### PR TITLE
[base] Correct error in declaring module ids

### DIFF
--- a/sw/device/lib/base/internal/status.h
+++ b/sw/device/lib/base/internal/status.h
@@ -69,13 +69,12 @@ extern "C" {
  * - The kStatusModuleId can simply be ORed in when constucting a `status_t`.
  * - The value of MAKE_MODULE_ID can be used in constructing constants for
  *   types compatible with `status_t`.
+ *
+ * To declare a module-id in one of your own files:
+ * #define MODULE_ID MAKE_MODULE_ID('a', 'b', 'c')
  */
 #define MAKE_MODULE_ID(a, b, c) \
   (ASCII_5BIT(a) << 16) | (ASCII_5BIT(b) << 21) | (ASCII_5BIT(c) << 26)
-// A module that uses DECLARE_MODULE_ID shadows the global constant value with
-// its own local value.
-#define DECLARE_MODULE_ID(a, b, c) \
-  static const uint32_t kStatusModuleId = MAKE_MODULE_ID(a, b, c)
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -9,7 +9,7 @@
 
 #include "sw/device/lib/base/bitfield.h"
 
-const uint32_t kStatusModuleId = 0;
+const uint32_t MODULE_ID = 0;
 
 static const char *basename(const char *file) {
   const char *f = file;

--- a/sw/device/lib/base/status.h
+++ b/sw/device/lib/base/status.h
@@ -79,7 +79,7 @@ typedef struct status {
     } else if (__builtin_types_compatible_p(typeof(ex_), dif_result_t)) {      \
       absl_status_t code;                                                      \
       memcpy(&code, &ex_, sizeof(code));                                       \
-      status_ = status_create(code, kStatusModuleId, __FILE__,                 \
+      status_ = status_create(code, MODULE_ID, __FILE__,                       \
                               code == kOk ? 0 : __LINE__);                     \
     }                                                                          \
     status_;                                                                   \
@@ -105,7 +105,10 @@ typedef struct status {
   })
 
 // This global constant is available to all modules and is the constant zero.
-extern const uint32_t kStatusModuleId;
+// This name intentionally violates the constant naming convention of
+// `kModuleId` because users are expected to provide an override in the form
+// of a preprocessor defintion: `#define MODULE_ID MAKE_MODULE_ID(...)`.
+extern const uint32_t MODULE_ID;
 
 // Operations on status codes:
 /**
@@ -155,12 +158,11 @@ OT_ALWAYS_INLINE absl_status_t status_err(status_t s) {
 // Create a status with an optional argument.
 // TODO(cfrantz, alphan): Figure out how we want to create statuses in
 // silicon_creator code.
-#define STATUS_CREATE(s_, ...)                            \
-  ({                                                      \
-    static_assert(OT_VA_ARGS_COUNT(_, __VA_ARGS__) <= 2,  \
-                  "status macros take 0 or 1 arguments"); \
-    status_create(s_, kStatusModuleId, __FILE__,          \
-                  OT_GET_LAST_ARG(__VA_ARGS__));          \
+#define STATUS_CREATE(s_, ...)                                            \
+  ({                                                                      \
+    static_assert(OT_VA_ARGS_COUNT(_, __VA_ARGS__) <= 2,                  \
+                  "status macros take 0 or 1 arguments");                 \
+    status_create(s_, MODULE_ID, __FILE__, OT_GET_LAST_ARG(__VA_ARGS__)); \
   })
 
 // Helpers for creating statuses of various kinds.

--- a/sw/device/lib/base/status_unittest.cc
+++ b/sw/device/lib/base/status_unittest.cc
@@ -62,5 +62,27 @@ TEST(Status, ErrorValues) {
   EXPECT_EQ(std::string(mod_id), "STA");
 }
 
+TEST(Status, ErrorValuesInModule) {
+  int32_t arg;
+  status_t status;
+  bool err;
+  const char *message;
+  char mod_id[4]{};
+
+  // Normally, MODULE_ID should be defined at the top of your file, thus
+  // causing all uses of the error creation macros to substitute in your
+  // module ID.  In this test, we're doing it here to override the
+  // value for this test.
+#define MODULE_ID MAKE_MODULE_ID('z', 'z', 'z')
+  status = UNKNOWN();
+  int32_t expected_line = __LINE__ - 1;
+  err = status_extract(status, &message, &arg, mod_id);
+  EXPECT_EQ(status_ok(status), false);
+  EXPECT_EQ(status_err(status), absl_status_t::kUnknown);
+  EXPECT_EQ(err, true);
+  EXPECT_EQ(arg, expected_line);
+  EXPECT_EQ(std::string(mod_id), "ZZZ");
+}
+
 }  // namespace
 }  // namespace status_unittest

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -22,19 +22,19 @@ extern "C" {
  * minimized.
  */
 #define OTCRYPTO_OK HARDENED_OK_STATUS
-#define OTCRYPTO_RECOV_ERR                                      \
-  ((status_t){.value = (int32_t)(0x80000000 | kStatusModuleId | \
+#define OTCRYPTO_RECOV_ERR                                \
+  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kAborted)})
-#define OTCRYPTO_FATAL_ERR                                 \
-  ((status_t){.value =                                     \
-                  (int32_t)(0x80000000 | kStatusModuleId | \
+#define OTCRYPTO_FATAL_ERR                           \
+  ((status_t){.value =                               \
+                  (int32_t)(0x80000000 | MODULE_ID | \
                             ((__LINE__ & 0x7ff) << 5) | kFailedPrecondition)})
-#define OTCRYPTO_BAD_ARGS                                  \
-  ((status_t){.value =                                     \
-                  (int32_t)(0x80000000 | kStatusModuleId | \
+#define OTCRYPTO_BAD_ARGS                            \
+  ((status_t){.value =                               \
+                  (int32_t)(0x80000000 | MODULE_ID | \
                             ((__LINE__ & 0x7ff) << 5) | kInvalidArgument)})
-#define OTCRYPTO_ASYNC_INCOMPLETE                               \
-  ((status_t){.value = (int32_t)(0x80000000 | kStatusModuleId | \
+#define OTCRYPTO_ASYNC_INCOMPLETE                         \
+  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
 
 /**

--- a/sw/device/lib/crypto/impl/status_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_unittest.cc
@@ -72,7 +72,7 @@ TEST(Status, TryInterpretErrors) {
 }
 
 constexpr char kTestModId[3] = {'X', 'Y', 'Z'};
-DECLARE_MODULE_ID(kTestModId[0], kTestModId[1], kTestModId[2]);
+#define MODULE_ID MAKE_MODULE_ID(kTestModId[0], kTestModId[1], kTestModId[2])
 
 TEST(Status, ExtractStatusFieldsBadArgs) {
   const char *code = NULL;


### PR DESCRIPTION
The `status.h` module declared `kStatusModuleId` as an global and intended users to use `DECLARE_MODULE_ID` to create a local override with `static` scope that would shadow the global.  Embarrassingly, I never wrote an explicit test for this override behavior and the compiler complains that a variable cannot be declared both `extern` and `static`.

In order to permit this shadowing behavior, I've updated the code to name the default module ID as:
```
extern const uint32_t MODULE_ID;
```

and then permit users to `#define` their own MODULE_IDs to provide the relevant constant (preprocessor substitutions always win):

```
 #define MODULE_ID MAKE_MODULE_ID('a', 'b', 'c')
```

Signed-off-by: Chris Frantz <cfrantz@google.com>