### PR TITLE
[rdc] EN_SYNC to EN Latch in ClkMgr

### DIFF
--- a/hw/top_earlgrey/rdc/rdc_waivers.tcl
+++ b/hw/top_earlgrey/rdc/rdc_waivers.tcl
@@ -149,3 +149,30 @@ set_rule_status -rule W_ASYNC_RST_FLOPS -status Waived \
   -expression {(DrivingSignal=~"*.u_rv_dm.u_pm_en_sync.*")} \
   -comment {LifeCycle HW Debug Enable signal is static and determined \
     at boot time.}
+
+# EN sync to EN Latch in CG
+# (io_div4|io_div2|io|usb)_root_ctrl
+create_view_criteria -name PorNRootCtrlCg -rule E_RST_METASTABILITY \
+  -criteria {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.*root_ctrl*") && \
+    (MetaStableFlop=~"*.u_*_root_ctrl.u_cg*")}
+set_rule_status -rule E_RST_METASTABILITY -status Waived \
+  -expression {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.u_main_root_ctrl.u_cg*") && \
+    (MetaStableFlop=~"*.u_clkmgr_aon.u_main_root_ctrl.u_cg*")}
+set_rule_status -rule E_RST_METASTABILITY -status Waived \
+  -expression {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.u_io_div4_root_ctrl.u_cg*") && \
+    (MetaStableFlop=~"*.u_clkmgr_aon.u_io_div4_root_ctrl.u_cg*")}
+set_rule_status -rule E_RST_METASTABILITY -status Waived \
+  -expression {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.u_io_div2_root_ctrl.u_cg*") && \
+    (MetaStableFlop=~"*.u_clkmgr_aon.u_io_div2_root_ctrl.u_cg*")}
+set_rule_status -rule E_RST_METASTABILITY -status Waived \
+  -expression {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.u_io_root_ctrl.u_cg*") && \
+    (MetaStableFlop=~"*.u_clkmgr_aon.u_io_root_ctrl.u_cg*")}
+set_rule_status -rule E_RST_METASTABILITY -status Waived \
+  -expression {(SourceReset=="POR_N") && \
+    (ResetFlop=~"*.u_clkmgr_aon.u_usb_root_ctrl.u_cg*") && \
+    (MetaStableFlop=~"*.u_clkmgr_aon.u_usb_root_ctrl.u_cg*")}


### PR DESCRIPTION
When POR_N is asserted, clocks are back to reset state and the IPs under top_earlgrey are reset. CG enable glitch won't affect the design.

This PR creates a criteria view to review the waived clock en paths if the logic receiving clocks are in reset or not.