### PR TITLE
[dv/alert_handler] Fix fcov holes

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -10,9 +10,15 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     class_index_cp: coverpoint class_index {
       bins class_index[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
     }
+    // Due to the limited simulation time, this only collect accum coverage until 2000. For the
+    // saturation case, design has assertions to cover that.
     accum_cnt_cp: coverpoint cnt {
-      bins accum_cnt[10] = {[0:'hffff]};
-      bins saturate_cnt  = {'hffff};
+      bins accum_cnt_0    = {0};
+      bins accum_cnt_10   = {[1:10]};
+      bins accum_cnt_50   = {[11:50]};
+      bins accum_cnt_100  = {[51:100]};
+      bins accum_cnt_1000 = {[101:1000]};
+      bins accum_cnt_2000 = {[1001:2000]};
     }
     class_cnt_cross: cross class_index_cp, accum_cnt_cp;
   endgroup : accum_cnt_cg

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -10,9 +10,15 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     class_index_cp: coverpoint class_index {
       bins class_index[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
     }
+    // Due to the limited simulation time, this only collect accum coverage until 2000. For the
+    // saturation case, design has assertions to cover that.
     accum_cnt_cp: coverpoint cnt {
-      bins accum_cnt[10] = {[0:'hffff]};
-      bins saturate_cnt  = {'hffff};
+      bins accum_cnt_0    = {0};
+      bins accum_cnt_10   = {[1:10]};
+      bins accum_cnt_50   = {[11:50]};
+      bins accum_cnt_100  = {[51:100]};
+      bins accum_cnt_1000 = {[101:1000]};
+      bins accum_cnt_2000 = {[1001:2000]};
     }
     class_cnt_cross: cross class_index_cp, accum_cnt_cp;
   endgroup : accum_cnt_cg


### PR DESCRIPTION
Accum count is hard to reach its max value 'hFFFF due to long simulation time.
We decide to reduce the range to 2000 because:
1). There is a direct test that force the accum count to a large value
  to begin with, then check if it will overflow.
2). There are design assertions to check if the counter reaches its max
  value.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>