### PR TITLE
[release] Add step to create a new release on Github

### DIFF
--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -31,6 +31,7 @@ variables:
     # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
   VIVADO_VERSION: "2020.2"
+  RELEASE_DATE: $[format('{0:yyyyMMdd}', pipeline.startTime)]
 
 jobs:
 - job: checkout
@@ -97,6 +98,22 @@ jobs:
       echo "Implementation log"
       cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug-release/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
     displayName: "Display hyperdebug bitstream synth and impl logs"
+
+  - task: GithubRelease@1
+    displayName: "Publish release to Github"
+    inputs:
+      gitHubConnection: "opentitan-github-connection" # TODO(milesdai): create the service connection before merging this PR
+      repositoryName: "$(Build.Repository.Name)"
+      action: "create"
+      target: "$(Build.SourceVersion)"
+      tagSource: "userSpecifiedTag"
+      tag: "snapshot-$(RELEASE_DATE)"
+      releaseNotesSource: "inline"
+      releaseNotesInline: "Nightly release"
+      assets: "$(Build.SourcesDirectory)/$(pkg_path)"
+      isDraft: true
+      isPreRelease: true
+      addChangeLog: true
 
   - publish: $(pkg_path)
     artifact: opentitan-release


### PR DESCRIPTION
This PR sets up the last step of the release process which is to create the release on Github.
Authentication is (will be) performed using an OAuth-based service connection between Azure and Github.
The release itself is performed using the [`GithubReleases@1`](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/github-release-v1?view=azure-pipelines) Azure task.

Addresses #15007 