### PR TITLE
[spi_device/dv] Enable phase/polarity mode 3

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -321,8 +321,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     end else begin
       // flash mode only supports these 2 values.
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(sck_polarity_phase,
-          // TODO (#16339), add back 'b11 once this issue is fixed
-          sck_polarity_phase inside {0};)
+          sck_polarity_phase inside {0, 'b11};)
     end
     cfg.spi_host_agent_cfg.sck_polarity[0] = sck_polarity_phase[0];
     cfg.spi_host_agent_cfg.sck_phase[0] = sck_polarity_phase[1];

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -109,7 +109,7 @@ module tb;
   `CONNECT_SPI_IO(spi_if, sd_in, sd_out, sd_out_en, 2)
   `CONNECT_SPI_IO(spi_if, sd_in, sd_out, sd_out_en, 3)
 
-  assign spi_if_pass.sck = pass_out.sck;
+  assign spi_if_pass.sck = pass_out.sck & pass_out.sck_en;
   // if passthrough_en is low, set csb inactive as the whole passthrough interface is off
   assign spi_if_pass.csb[0] = pass_out.csb ||  !pass_out.passthrough_en;
   assign spi_if_pass.csb[1] = 1; // only 1 passthrough CSB


### PR DESCRIPTION
Designer is fixing the related bug #16339.

Also have a small update on sck_en. This clock gating is tied to 1 in the design, We'd better use it to gate the clock, in case that sck_en behavor is changed

Signed-off-by: Weicai Yang <weicai@google.com>