### PR TITLE
[dv/alert_handler] move lpg coverage with ping outside of alert_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
@@ -39,11 +39,6 @@ covergroup alert_esc_trans_cg with function sample(alert_esc_trans_type_e trans)
   }
 endgroup : alert_esc_trans_cg
 
-covergroup alert_ping_lpg_cg with function sample(bit alert_lpg_en);
-  option.per_instance = 1;
-  cp_alert_ping_lpg: coverpoint alert_lpg_en;
-endgroup
-
 covergroup alert_lpg_cg with function sample(bit alert_lpg_en);
   option.per_instance = 1;
   cp_alert_lpg: coverpoint alert_lpg_en;
@@ -57,7 +52,6 @@ class alert_esc_agent_cov extends dv_base_agent_cov #(alert_esc_agent_cfg);
   esc_handshake_complete_cg   m_esc_handshake_complete_cg;
   alert_esc_trans_cg          m_alert_trans_cg;
   alert_esc_trans_cg          m_esc_trans_cg;
-  alert_ping_lpg_cg           m_alert_ping_lpg_cg;
   alert_lpg_cg                m_alert_lpg_cg;
 
   `uvm_component_utils(alert_esc_agent_cov)
@@ -70,7 +64,6 @@ class alert_esc_agent_cov extends dv_base_agent_cov #(alert_esc_agent_cfg);
       else m_esc_trans_cg = new();
     end
     if (cfg.en_lpg_cov && cfg.is_alert) begin
-      m_alert_ping_lpg_cg = new();
       m_alert_lpg_cg = new();
     end
     if (cfg.is_alert)    m_alert_handshake_complete_cg = new();

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -80,9 +80,6 @@ class alert_monitor extends alert_esc_base_monitor;
     bit ping_p, alert_p;
     forever @(cfg.vif.monitor_cb) begin
       if (ping_p != cfg.vif.monitor_cb.alert_rx_final.ping_p) begin
-        if (cfg.en_lpg_cov && cfg.en_cov) begin
-          cov.m_alert_ping_lpg_cg.sample(cfg.en_alert_lpg);
-        end
         if (!cfg.en_alert_lpg) begin
           cfg.under_ping_handshake = 1;
           req = alert_esc_seq_item::type_id::create("req");

--- a/hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson
+++ b/hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson
@@ -5,18 +5,13 @@
 // This DV coverplan documents additional alert agent covergroups.
 // To enable these covergroups, please ensure the following variables are enabled:
 // `cfg.en_ping_cov` and `cfg.en_lpg_cov`
+// Note that if LPG is enabled, the alert ping request handshake won't be initiated, so we cannot
+// collect that coverage in this agent.
 {
   covergroups: [
     {
       name:  alert_trans_cg
       desc: '''Cover if the transaction is a ping request or an actual alert request.'''
-    }
-    {
-      name:  alert_ping_lpg_cg
-      desc: '''Covers alert lpg status during a ping request.
-
-      Cover if its lower-power-group (lpg) is enabled or disabled during a ping request.
-      '''
     }
     {
       name:  alert_lpg_cg

--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -276,6 +276,10 @@
       name: cycles_bwtween_pings_cg
       desc: '''Covers how many cycles are there between two ping requests.'''
     }
+    {
+      name: alert_ping_with_lpg_wrap_cg
+      desc: '''Covers ping requests are initiated with LPG enabled or disabled.'''
+    }
 
   ]
 }

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -2,8 +2,25 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+class alert_ping_with_lpg_cg_wrap;
+  covergroup alert_ping_with_lpg_cg(string name) with function sample (bit lpg_en);
+    option.per_instance = 1;
+    option.name         = name;
+    lpg_cg: coverpoint lpg_en {
+      bins lpg_en  = {1};
+      bins lpg_dis = {0};
+    }
+  endgroup
+
+  function new(string name);
+    alert_ping_with_lpg_cg = new(name);
+  endfunction
+endclass
+
 class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_cfg));
   `uvm_component_utils(alert_handler_env_cov)
+
+  alert_ping_with_lpg_cg_wrap ping_with_lpg_cg_wrap[NUM_ALERTS];
 
   // covergroups
   covergroup accum_cnt_cg with function sample(int class_index, int cnt);
@@ -161,6 +178,9 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     num_checked_pings_cg = new();
     cycles_between_pings_cg = new();
 
+    foreach (ping_with_lpg_cg_wrap[i]) begin
+      ping_with_lpg_cg_wrap[i] = new($sformatf("ping_with_lpg_cg_wrap[%0d]", i));
+    end
   endfunction : new
 
 endclass

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -515,8 +515,15 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
   virtual task check_ping_triggered_cycles();
     int ping_wait_cycs;
     while (ping_wait_cycs <= MAX_PING_WAIT_CYCLES * 2) begin
-      if (cfg.alert_handler_vif.alert_ping_reqs > 0) break;
-      if (cfg.alert_handler_vif.esc_ping_reqs > 0) break;
+    if (cfg.alert_handler_vif.alert_ping_reqs > 0) begin
+      if (cfg.en_cov) begin
+        int alert_id = $clog2(cfg.alert_handler_vif.alert_ping_reqs);
+        cov.ping_with_lpg_cg_wrap[alert_id].alert_ping_with_lpg_cg.sample(
+            cfg.alert_host_cfg[alert_id].en_alert_lpg);
+      end
+      break;
+    end
+    if (cfg.alert_handler_vif.esc_ping_reqs > 0) break;
       cfg.clk_rst_vif.wait_clks(1);
       ping_wait_cycs++;
     end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -276,6 +276,10 @@
       name: cycles_bwtween_pings_cg
       desc: '''Covers how many cycles are there between two ping requests.'''
     }
+    {
+      name: alert_ping_with_lpg_wrap_cg
+      desc: '''Covers ping requests are initiated with LPG enabled or disabled.'''
+    }
 
   ]
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -2,8 +2,25 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+class alert_ping_with_lpg_cg_wrap;
+  covergroup alert_ping_with_lpg_cg(string name) with function sample (bit lpg_en);
+    option.per_instance = 1;
+    option.name         = name;
+    lpg_cg: coverpoint lpg_en {
+      bins lpg_en  = {1};
+      bins lpg_dis = {0};
+    }
+  endgroup
+
+  function new(string name);
+    alert_ping_with_lpg_cg = new(name);
+  endfunction
+endclass
+
 class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_cfg));
   `uvm_component_utils(alert_handler_env_cov)
+
+  alert_ping_with_lpg_cg_wrap ping_with_lpg_cg_wrap[NUM_ALERTS];
 
   // covergroups
   covergroup accum_cnt_cg with function sample(int class_index, int cnt);
@@ -161,6 +178,9 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     num_checked_pings_cg = new();
     cycles_between_pings_cg = new();
 
+    foreach (ping_with_lpg_cg_wrap[i]) begin
+      ping_with_lpg_cg_wrap[i] = new($sformatf("ping_with_lpg_cg_wrap[%0d]", i));
+    end
   endfunction : new
 
 endclass

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -515,8 +515,15 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
   virtual task check_ping_triggered_cycles();
     int ping_wait_cycs;
     while (ping_wait_cycs <= MAX_PING_WAIT_CYCLES * 2) begin
-      if (cfg.alert_handler_vif.alert_ping_reqs > 0) break;
-      if (cfg.alert_handler_vif.esc_ping_reqs > 0) break;
+    if (cfg.alert_handler_vif.alert_ping_reqs > 0) begin
+      if (cfg.en_cov) begin
+        int alert_id = $clog2(cfg.alert_handler_vif.alert_ping_reqs);
+        cov.ping_with_lpg_cg_wrap[alert_id].alert_ping_with_lpg_cg.sample(
+            cfg.alert_host_cfg[alert_id].en_alert_lpg);
+      end
+      break;
+    end
+    if (cfg.alert_handler_vif.esc_ping_reqs > 0) break;
       cfg.clk_rst_vif.wait_clks(1);
       ping_wait_cycs++;
     end


### PR DESCRIPTION
If LPG is enabled and ping request is triggered, it won't start the alert ping handshake because the ping_ok signal is internally routed back by prim_alert_receiver.
So alert agent will never see a ping request handshake on the alert channel.
To check the coverage, the alert_handler testbench needs to manually probe internal design signal.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>