### PR TITLE
[dv/alert_handler] alert_handler esc assertions missing cov

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -122,6 +122,8 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
                      $sformatf("escalation protocol_%0d is not set", i));
       end
     end
+    // Let the simulation wait a few clock cycles before reset to make sure assertions are checked.
+    cfg.clk_rst_vif.wait_clks($urandom_range(2, 10));
   endtask
 
   virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -122,6 +122,8 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
                      $sformatf("escalation protocol_%0d is not set", i));
       end
     end
+    // Let the simulation wait a few clock cycles before reset to make sure assertions are checked.
+    cfg.clk_rst_vif.wait_clks($urandom_range(2, 10));
   endtask
 
   virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);


### PR DESCRIPTION
The fsm error state assertions are missing coverage in nightly regression because the sec_cm test immediately reset after the error checks are done. This won't give enough time for assertions to finish checking.
So this PR waited a few random clock cycles before issuing reset to make sure all assertions have time to check.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>