### PR TITLE
[build] Downgrade OpenOCD to v0.11.0

### DIFF
--- a/third_party/openocd/BUILD
+++ b/third_party/openocd/BUILD
@@ -45,6 +45,8 @@ configure_make(
     ],
     configure_in_place = True,
     configure_options = [
+        "--disable-wextra",  # Needed to build v0.11.0
+        "--disable-werror",  # Needed to build v0.11.0
         "--enable-ftdi",
         "--enable-verbose-jtag-io",
         "--disable-vsllink",

--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -5,12 +5,12 @@
 load("//rules:repo.bzl", "http_archive_or_local")
 
 def openocd_repos(local = None):
-    OPENOCD_VERSION = "0.12.0-rc1"
+    OPENOCD_VERSION = "0.11.0"
     http_archive_or_local(
         name = "openocd",
         local = local,
         url = "https://sourceforge.net/projects/openocd/files/openocd/{version}/openocd-{version}.tar.gz".format(version = OPENOCD_VERSION),
         strip_prefix = "openocd-" + OPENOCD_VERSION,
         build_file = "//third_party/openocd:BUILD.openocd.bazel",
-        sha256 = "cdd3654a6c2fd046fe766de5ed897d75467138be9b9c271229bbd7409eb902a5",
+        sha256 = "242ecb0956d117f79dfec6f807e0ef8c0083e262ff0520f13063f4caa3ad82d9",
     )


### PR DESCRIPTION
The archive for v0.12.0-rc1 disappeared from SourceForge today. We cannot use the GitHub archive because it doesn't include sources for OpenOCD's third-party dependencies.

Signed-off-by: Dan McArdle <dmcardle@google.com>