### PR TITLE
[ci] Copy bitstream files from cache without splicing

### DIFF
--- a/ci/scripts/prepare-cached-bitstream.sh
+++ b/ci/scripts/prepare-cached-bitstream.sh
@@ -12,11 +12,10 @@ set -ex
 readonly TOPLEVEL=top_earlgrey
 readonly TOPLEVEL_BIN_DIR="${BIN_DIR}/hw/${TOPLEVEL}"
 readonly TARGETS=(
-  //hw/bitstream:test_rom
-  //hw/bitstream:rom
-  //hw/bitstream:rom_otp_dev
-  //hw/bitstream:rom_mmi
-  //hw/bitstream:otp_mmi
+  @bitstreams//:bitstream_test_rom
+  @bitstreams//:bitstream_rom
+  @bitstreams//:rom_mmi
+  @bitstreams//:otp_mmi
 )
 readonly BAZEL_OPTS=(
   "--define"


### PR DESCRIPTION
Avoid file name mismatches by copying files directly from the cache, so
the bazel rules don't affect the names. We no longer need to create new
cache entries for software changes, but that change is deferred to
another commit.