### PR TITLE
[tlul,dv] Add random invalid data to host driver

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -134,6 +134,20 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // Added to allow some TLUL checks to be ignored on certain scenarios.
   bit check_tl_errs = 1'b1;
 
+  // Invalidate drive option
+  // Setting these to '1', make driver send 'x' during invalidate cycle.
+  // Setting these to '0', make driver send 'random value' during invalidate cycle.
+  rand bit invalidate_a_x;
+  rand bit invalidate_d_x;
+
+  constraint invalidate_a_channel_op_c {
+    invalidate_a_x dist { 1 := 7, 0 := 3};
+  }
+  constraint invalidate_d_channel_op_c {
+    invalidate_d_x dist { 1 := 7, 0 := 3};
+  }
+
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)

--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -113,15 +113,22 @@ class tl_device_driver extends tl_base_driver;
   endtask : d_channel_thread
 
   function void invalidate_d_channel();
-    cfg.vif.d2h_int.d_opcode <= tlul_pkg::tl_d_op_e'('x);
-    cfg.vif.d2h_int.d_param <= '{default:'x};
-    cfg.vif.d2h_int.d_size <= '{default:'x};
-    cfg.vif.d2h_int.d_source <= '{default:'x};
-    cfg.vif.d2h_int.d_sink <= '{default:'x};
-    cfg.vif.d2h_int.d_data <= '{default:'x};
-    cfg.vif.d2h_int.d_user <= '{default:'x};
-    cfg.vif.d2h_int.d_error <= 1'bx;
-    cfg.vif.d2h_int.d_valid <= 1'b0;
+    if (cfg.invalidate_d_x) begin
+      cfg.vif.d2h_int.d_opcode <= tlul_pkg::tl_d_op_e'('x);
+      cfg.vif.d2h_int.d_param <= '{default:'x};
+      cfg.vif.d2h_int.d_size <= '{default:'x};
+      cfg.vif.d2h_int.d_source <= '{default:'x};
+      cfg.vif.d2h_int.d_sink <= '{default:'x};
+      cfg.vif.d2h_int.d_data <= '{default:'x};
+      cfg.vif.d2h_int.d_user <= '{default:'x};
+      cfg.vif.d2h_int.d_error <= 1'bx;
+      cfg.vif.d2h_int.d_valid <= 1'b0;
+    end else begin // if (cfg.invalidate_d_x)
+      tlul_pkg::tl_d2h_t d2h;
+      `DV_CHECK_STD_RANDOMIZE_FATAL(d2h)
+      d2h.d_valid = 1'b0;
+      cfg.vif.d2h_int <= d2h;
+    end
   endfunction : invalidate_d_channel
 
 endclass

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -234,17 +234,24 @@ class tl_host_driver extends tl_base_driver;
   endfunction
 
   function void invalidate_a_channel();
-    cfg.vif.h2d_int.a_opcode <= tlul_pkg::tl_a_op_e'('x);
-    cfg.vif.h2d_int.a_param <= '{default:'x};
-    cfg.vif.h2d_int.a_size <= '{default:'x};
-    cfg.vif.h2d_int.a_source <= '{default:'x};
-    cfg.vif.h2d_int.a_address <= '{default:'x};
-    cfg.vif.h2d_int.a_mask <= '{default:'x};
-    cfg.vif.h2d_int.a_data <= '{default:'x};
-    // The assignment to tl_type must have a cast since the LRM doesn't allow enum assignment of
-    // values not belonging to the enumeration set.
-    cfg.vif.h2d_int.a_user <= '{instr_type:prim_mubi_pkg::mubi4_t'('x), default:'x};
-    cfg.vif.h2d_int.a_valid <= 1'b0;
+    if (cfg.invalidate_a_x) begin
+      cfg.vif.h2d_int.a_opcode <= tlul_pkg::tl_a_op_e'('x);
+      cfg.vif.h2d_int.a_param <= '{default:'x};
+      cfg.vif.h2d_int.a_size <= '{default:'x};
+      cfg.vif.h2d_int.a_source <= '{default:'x};
+      cfg.vif.h2d_int.a_address <= '{default:'x};
+      cfg.vif.h2d_int.a_mask <= '{default:'x};
+      cfg.vif.h2d_int.a_data <= '{default:'x};
+      // The assignment to tl_type must have a cast since the LRM doesn't allow enum assignment of
+      // values not belonging to the enumeration set.
+      cfg.vif.h2d_int.a_user <= '{instr_type:prim_mubi_pkg::mubi4_t'('x), default:'x};
+      cfg.vif.h2d_int.a_valid <= 1'b0;
+    end else begin
+      tlul_pkg::tl_h2d_t h2d;
+      `DV_CHECK_STD_RANDOMIZE_FATAL(h2d)
+      h2d.a_valid = 1'b0;
+      cfg.vif.h2d_int <= h2d;
+    end
   endfunction : invalidate_a_channel
 
 endclass : tl_host_driver


### PR DESCRIPTION
host driver was driving 'x' during invalid period, which is good for test.
Some of coverage holes require 'wiggles' in some fields during a_valid = 0, so add option 
to drive random for some tests.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>