### PR TITLE
[rtl/prim] Fix prim_alert_receiver SVA for CDC

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -318,7 +318,7 @@ module prim_alert_receiver
         state_q == Idle &&
         !ping_pending_q
         |->
-        alert_o,
+        ##[0:1] alert_o,
         clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
   end else begin : gen_sync_assert
     // signal integrity check propagation


### PR DESCRIPTION
The CDC synchronizer in prim_diff_decode causes an extra cycle of delay setting alert_o. This causes test failures with CDC instrumentation enabled.

Partially addresses #16689

Signed-off-by: Guillermo Maturana <maturana@google.com>