### PR TITLE
[dv/lc_ctrl] Fix lc_ctrl testbench issues

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -122,15 +122,4 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
     return (this.test_phase);
   endfunction
 
-  // Use these functions to propagate in_reset to JTAG RISCV agents
-  virtual function void reset_asserted();
-    super.reset_asserted();
-    m_jtag_riscv_agent_cfg.in_reset = 1;
-  endfunction
-
-  virtual function void reset_deasserted();
-    super.reset_deasserted();
-    m_jtag_riscv_agent_cfg.in_reset = 0;
-  endfunction
-
 endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -18,21 +18,21 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
+  // In jtag_riscv_agent_cfg, setting the in_reset value to 1 will trigger the dmi_agent to reset.
   virtual task apply_reset(string kind = "HARD");
     if (kind == "HARD") begin
-      fork
-        cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
-        super.apply_reset(kind);
-      join
+      cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
+      super.apply_reset(kind);
+      cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
     end
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.escalate_injected = 0;
     cfg.otp_vendor_test_status = 0;
-    cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.trst_n = 0;
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
     super.apply_resets_concurrently(reset_duration_ps);
-    cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.trst_n = 1;
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
   endtask
 
   virtual task pre_start();

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -32,7 +32,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.


### PR DESCRIPTION
1). Remove duplicated imported cfg.
2). Simplify the reset cases.
When set the jtag_riscv_agent cfg `in_reset` to 1, the agent will trigger a reset for `jtag_agent`. So there is no need to directly drive the reset pins again.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>