### PR TITLE
[sysrst_ctrl] Minor documentation improvements

### DIFF
--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -648,7 +648,7 @@
       ],
     }
     { name: "AUTO_BLOCK_OUT_CTL",
-      desc: "confiure the key outputs to auto-override and their value",
+      desc: "configure the key outputs to auto-override and their value",
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "REGWEN",

--- a/hw/ip/sysrst_ctrl/doc/_index.md
+++ b/hw/ip/sysrst_ctrl/doc/_index.md
@@ -6,7 +6,7 @@ title: "System Reset Control Technical Specification"
 
 This document specifies the functionality of the System Reset Controller (`sysrst_ctrl`) that provides programmable hardware-level responses to trusted IOs and basic board-level reset sequencing capabilities.
 These capabilities include keyboard and button combination-triggered actions, reset stretching for system-level reset signals, and internal reset / wakeup requests that go to the OpenTitan reset and power manager blocks.
-This module conforms to the [Comportable guideline for peripheral functionality.]({{< relref "doc/rm/comportability_specification" >}}).
+This module conforms to the [Comportable guideline for peripheral functionality]({{< relref "doc/rm/comportability_specification" >}}).
 See that document for integration overview within the broader top level system.
 
 ## Features


### PR DESCRIPTION
Two minor typo corrections from a first read of the `sysrst_ctrl` documentation.