### PR TITLE
[opentitantool] High resolution detection of GPIO pulses

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -7,7 +7,7 @@ pub mod command;
 pub mod config;
 
 use crate::io::emu::Emulator;
-use crate::io::gpio::{GpioPin, PinMode, PullMode};
+use crate::io::gpio::{GpioMonitoring, GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
@@ -335,6 +335,20 @@ impl TransportWrapper {
             return Ok(Rc::new(NullPin::new(name)));
         }
         self.transport.borrow().gpio_pin(resolved_pin_name.as_str())
+    }
+
+    /// Convenience method, returns a number of [`GpioPin`] implementations.
+    pub fn gpio_pins(&self, names: &[String]) -> Result<Vec<Rc<dyn GpioPin>>> {
+        let mut result = Vec::new();
+        for name in names {
+            result.push(self.gpio_pin(name)?);
+        }
+        Ok(result)
+    }
+
+    /// Returns a [`GpioMonitoring`] implementation.
+    pub fn gpio_monitoring(&self) -> Result<Rc<dyn GpioMonitoring>> {
+        self.transport.borrow().gpio_monitoring()
     }
 
     /// Returns a [`Emulator`] implementation.

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -92,4 +92,81 @@ pub trait GpioPin {
         }
         Ok(())
     }
+
+    /// Not meant for API clients, this method returns the pin name as it is known to the
+    /// transport (which may have been through one or more alias mappings from the name provided
+    /// by the API client.)  This method is used by implementations of `GpioMonitoring`.
+    fn get_internal_pin_name(&self) -> Option<&str> {
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Edge {
+    Rising,
+    Falling,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ClockNature {
+    /// Unix time can be computed as (t + offset) / resolution, where t is a 64-bit timestamp
+    /// value from `MonitoringEvent`.
+    Wallclock {
+        /// If resolution is microseconds, `resolution` will be 1_000_000.
+        resolution: u64,
+        /// Offset relative to Unix epoch, measured according to above resolution.
+        offset: Option<u64>,
+    },
+    /// The 64-bit timestamp values could be emulator clock counts, or some other measure that
+    /// increases monotonically, but not necessarily uniformly in relation to wall clock time.
+    Unspecified,
+}
+
+/// Represents an edge detected on the GPIO pin.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct MonitoringEvent {
+    /// Identification of the signal that had an event, in the form of an index into the array
+    /// originally passed to `monitoring_read()`.
+    pub signal_index: u8,
+    /// Rising or falling edge
+    pub edge: Edge,
+    /// Timestamp of the edge, resolution and epoch is transport-specific, more information in
+    /// `ClockNature`.
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MonitoringStartResponse {
+    /// Transport timestamp at the time monitoring started.
+    pub timestamp: u64,
+    /// Initial logic level for each of the given pins.
+    pub initial_levels: Vec<bool>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MonitoringReadResponse {
+    /// List of events having occurred since the start or the last read.
+    pub events: Vec<MonitoringEvent>,
+    /// All events at or before this timestamp are guaranteed to be included.
+    pub timestamp: u64,
+}
+
+/// A trait implemented by transports which support advanced edge-detection on GPIO pins.  This
+/// trait allows monitoring a set of pins, and getting a stream of "events" (rising and falling
+/// edges with timestamps) for any change among the set.
+pub trait GpioMonitoring {
+    fn get_clock_nature(&self) -> Result<ClockNature>;
+
+    /// Set up edge trigger detection on the given set of pins, transport will buffer the list
+    /// internally, return the initial level of each of the given pins.
+    fn monitoring_start(&self, pins: &[&dyn GpioPin]) -> Result<MonitoringStartResponse>;
+
+    /// Retrieve list of events detected thus far, optionally stopping the possibly expensive edge
+    /// detection.  Buffer overrun will be reported as an `Err`, and result in the stopping of the
+    /// edge detection irrespective of the parameter value.
+    fn monitoring_read(
+        &self,
+        pins: &[&dyn GpioPin],
+        continue_monitoring: bool,
+    ) -> Result<MonitoringReadResponse>;
 }

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -71,4 +71,5 @@ pub enum TransportInterfaceType {
     I2c,
     Emulator,
     ProxyOps,
+    GpioMonitoring,
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -3,9 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
 use std::rc::Rc;
 
-use crate::io::gpio::{GpioPin, PinMode, PullMode};
+use crate::io::gpio::{
+    ClockNature, Edge, GpioMonitoring, GpioPin, MonitoringEvent, MonitoringReadResponse,
+    MonitoringStartResponse, PinMode, PullMode,
+};
 use crate::transport::hyperdebug::Inner;
 use crate::transport::TransportError;
 
@@ -113,5 +118,125 @@ impl GpioPin for HyperdebugGpioPin {
                 }
                 Ok(())
             })
+    }
+
+    fn get_internal_pin_name(&self) -> Option<&str> {
+        Some(&self.pinname)
+    }
+}
+
+pub struct HyperdebugGpioMonitoring {
+    inner: Rc<Inner>,
+}
+
+impl HyperdebugGpioMonitoring {
+    pub fn open(inner: &Rc<Inner>) -> Result<Self> {
+        Ok(Self {
+            inner: Rc::clone(inner),
+        })
+    }
+}
+
+impl GpioMonitoring for HyperdebugGpioMonitoring {
+    fn get_clock_nature(&self) -> Result<ClockNature> {
+        Ok(ClockNature::Wallclock {
+            resolution: 1_000_000,
+            offset: None,
+        })
+    }
+
+    /// Set up edge trigger detection on the given set of pins, transport will buffer the list
+    /// internally.
+    fn monitoring_start(&self, pins: &[&dyn GpioPin]) -> Result<MonitoringStartResponse> {
+        let mut pin_names = Vec::new();
+        for pin in pins {
+            pin_names.push(
+                pin.get_internal_pin_name()
+                    .ok_or(TransportError::InvalidOperation)?,
+            );
+        }
+        lazy_static! {
+            pub static ref START_TIME_REGEX: Regex = Regex::new("^ +@([0-9]+)").unwrap();
+            pub static ref SIGNAL_REGEX: Regex = Regex::new("^ +([0-9]+) ([^ ])+ ([01])").unwrap();
+        }
+        let mut start_time: u64 = 0;
+        let mut signals = Vec::new();
+        self.inner.execute_command(
+            &format!("gpio monitoring start {}", pin_names.join(" ")),
+            |line| {
+                if let Some(captures) = START_TIME_REGEX.captures(line) {
+                    start_time = captures.get(1).unwrap().as_str().parse().unwrap();
+                } else if let Some(captures) = SIGNAL_REGEX.captures(line) {
+                    signals.push(captures.get(3).unwrap().as_str() != "0");
+                } else {
+                    log::error!("Unexpected HyperDebug output: {}\n", line);
+                };
+            },
+        )?;
+        Ok(MonitoringStartResponse {
+            timestamp: start_time,
+            initial_levels: signals,
+        })
+    }
+
+    /// Retrieve list of events detected thus far, optionally stopping the possibly expensive edge
+    /// detection.  Buffer overrun will be reported as an `Err`, and result in the stopping of the
+    /// edge detection irrespective of the parameter value.
+    fn monitoring_read(
+        &self,
+        pins: &[&dyn GpioPin],
+        continue_monitoring: bool,
+    ) -> Result<MonitoringReadResponse> {
+        let mut pin_names = Vec::new();
+        for pin in pins {
+            pin_names.push(
+                pin.get_internal_pin_name()
+                    .ok_or(TransportError::InvalidOperation)?,
+            );
+        }
+        lazy_static! {
+            pub static ref START_TIME_REGEX: Regex = Regex::new("^ +@([0-9]+)").unwrap();
+            pub static ref EDGE_REGEX: Regex = Regex::new("^ +([0-9]+) (-?[0-9]+) ([RF])").unwrap();
+        }
+        let mut reference_time: u64 = 0;
+        let mut events = Vec::new();
+        loop {
+            let mut more_data = false;
+            self.inner.execute_command(
+                &format!("gpio monitoring read {}", pin_names.join(" ")),
+                |line| {
+                    if let Some(captures) = START_TIME_REGEX.captures(line) {
+                        reference_time = captures.get(1).unwrap().as_str().parse().unwrap();
+                    } else if let Some(captures) = EDGE_REGEX.captures(line) {
+                        events.push(MonitoringEvent {
+                            signal_index: captures.get(1).unwrap().as_str().parse().unwrap(),
+                            edge: if captures.get(3).unwrap().as_str() == "R" {
+                                Edge::Rising
+                            } else {
+                                Edge::Falling
+                            },
+                            timestamp: (reference_time as i64
+                                + captures.get(2).unwrap().as_str().parse::<i64>().unwrap())
+                                as u64,
+                        });
+                    } else if line == "Warning: more data" {
+                        more_data = true;
+                    } else {
+                        log::error!("Unexpected HyperDebug output: {}\n", line);
+                    }
+                },
+            )?;
+            if !more_data {
+                break;
+            }
+        }
+        if !continue_monitoring {
+            self.inner
+                .cmd_no_output(&format!("gpio monitoring stop {}", pin_names.join(" ")))?;
+        }
+        Ok(MonitoringReadResponse {
+            events,
+            timestamp: reference_time, // TODO: adjust in case of event later than this timestamp
+        })
     }
 }

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 
 use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::Emulator;
-use crate::io::gpio::GpioPin;
+use crate::io::gpio::{GpioMonitoring, GpioPin};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
@@ -39,6 +39,7 @@ bitflags! {
         const I2C = 0x00000008;
         const PROXY = 0x00000010;
         const EMULATOR = 0x00000020;
+        const GPIO_MONITORING = 0x00000040; // Logic analyzer functionality
     }
 }
 
@@ -109,6 +110,10 @@ pub trait Transport {
     /// Returns a [`GpioPin`] implementation.
     fn gpio_pin(&self, _instance: &str) -> Result<Rc<dyn GpioPin>> {
         Err(TransportError::InvalidInterface(TransportInterfaceType::Gpio).into())
+    }
+    /// Returns a [`GpioMonitoring`] implementation, for logic analyzer functionality.
+    fn gpio_monitoring(&self) -> Result<Rc<dyn GpioMonitoring>> {
+        Err(TransportError::InvalidInterface(TransportInterfaceType::GpioMonitoring).into())
     }
     /// Returns a [`Emulator`] implementation.
     fn emulator(&self) -> Result<Rc<dyn Emulator>> {

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -51,6 +51,8 @@ rust_binary(
         "//third_party/rust/crates:hex",
         "//third_party/rust/crates:humantime",
         "//third_party/rust/crates:log",
+        "//third_party/rust/crates:mio",
+        "//third_party/rust/crates:mio_signals",
         "//third_party/rust/crates:nix",
         "//third_party/rust/crates:raw_tty",
         "//third_party/rust/crates:regex",

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -3,14 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use nix::unistd::isatty;
+use raw_tty::TtyModeGuard;
 use serde_annotate::Annotate;
 use std::any::Any;
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::unix::io::AsRawFd;
+use std::rc::Rc;
+use std::time::Duration;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::io::gpio::{PinMode, PullMode};
+use opentitanlib::io::gpio::{ClockNature, Edge, GpioPin, PinMode, PullMode};
 use opentitanlib::transport::Capability;
+use opentitanlib::util::file;
 
 #[derive(Debug, StructOpt)]
 /// Reads a GPIO pin.
@@ -168,6 +177,296 @@ impl CommandDispatch for GpioApplyStrapping {
     }
 }
 
+#[derive(Debug, StructOpt, CommandDispatch)]
+pub enum GpioMonitoringCommand {
+    Start(GpioMonitoringStart),
+    Read(GpioMonitoringRead),
+    Vcd(GpioMonitoringVcd),
+}
+
+#[derive(Debug, StructOpt)]
+/// Begin logic-analyzer style monitoring of a set of pins.
+pub struct GpioMonitoringStart {
+    #[structopt(
+        name = "PINS",
+        help = "The list of GPIO pins to monitor (space separated)"
+    )]
+    pub pins: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct InitialLevel {
+    pub signal_name: String,
+    pub value: bool,
+}
+
+#[derive(serde::Serialize)]
+pub struct GpioMonitoringStartResult {
+    pub clock_nature: ClockNature,
+    pub timestamp: u64,
+    pub initial_levels: Vec<InitialLevel>,
+}
+
+impl CommandDispatch for GpioMonitoringStart {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport
+            .capabilities()?
+            .request(Capability::GPIO | Capability::GPIO_MONITORING)
+            .ok()?;
+        let gpio_monitoring = transport.gpio_monitoring()?;
+        let gpio_pins = transport.gpio_pins(&self.pins)?;
+        let clock_nature = gpio_monitoring.get_clock_nature()?;
+        let resp = gpio_monitoring.monitoring_start(
+            &gpio_pins
+                .iter()
+                .map(Rc::borrow)
+                .collect::<Vec<&dyn GpioPin>>(),
+        )?;
+        Ok(Some(Box::new(GpioMonitoringStartResult {
+            clock_nature,
+            initial_levels: resp
+                .initial_levels
+                .into_iter()
+                .enumerate()
+                .map(|(i, l)| InitialLevel {
+                    signal_name: self.pins[i].clone(),
+                    value: l,
+                })
+                .collect(),
+            timestamp: resp.timestamp,
+        })))
+    }
+}
+
+#[derive(Debug, StructOpt)]
+/// Retrieve logic-analyzer style monitoring events detected so far, on a set of pins.  Optionally
+/// continue monitoring, in which case `monitoring read` must be called again later.
+pub struct GpioMonitoringRead {
+    #[structopt(
+        name = "PINS",
+        help = "The list of GPIO pins being monitored (space separated)"
+    )]
+    pub pins: Vec<String>,
+
+    #[structopt(long, case_insensitive = true)]
+    pub continue_monitoring: bool,
+}
+
+#[derive(serde::Serialize)]
+pub struct MonitoringEvent {
+    pub signal_name: String,
+    pub edge: Edge,
+    /// Timestamp of the edge, resolution and epoch is transport-specific.
+    pub timestamp: u64,
+}
+
+#[derive(serde::Serialize)]
+pub struct GpioMonitoringReadResult {
+    /// List of events that has happened since last queried.
+    pub events: Vec<MonitoringEvent>,
+    /// Timestamp of the reading, all events happening before this time are guaranteed to be
+    /// included in the list above.
+    pub timestamp: u64,
+}
+
+impl CommandDispatch for GpioMonitoringRead {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport
+            .capabilities()?
+            .request(Capability::GPIO | Capability::GPIO_MONITORING)
+            .ok()?;
+        let gpio_monitoring = transport.gpio_monitoring()?;
+        let gpio_pins = transport.gpio_pins(&self.pins)?;
+        let resp = gpio_monitoring.monitoring_read(
+            &gpio_pins
+                .iter()
+                .map(Rc::borrow)
+                .collect::<Vec<&dyn GpioPin>>(),
+            self.continue_monitoring,
+        )?;
+        Ok(Some(Box::new(GpioMonitoringReadResult {
+            events: resp
+                .events
+                .into_iter()
+                .map(|e| MonitoringEvent {
+                    signal_name: self.pins[e.signal_index as usize].clone(),
+                    edge: e.edge,
+                    timestamp: e.timestamp,
+                })
+                .collect(),
+            timestamp: resp.timestamp,
+        })))
+    }
+}
+
+#[derive(Debug, StructOpt)]
+/// Whereas `monitoring start` and `monitoring read` are meant for use by scripts, this
+/// `monitoring vcd` is intended for manual use by an operator.  It will stay in the foreground,
+/// collecting events until the user presses Ctrl-C.  A transcript will be written in the industry
+/// standard VCD format, which can be loaded into e.g. Pulseview (or probably also Saleae
+/// software), to get a logic analyzer view of what transpired.
+pub struct GpioMonitoringVcd {
+    #[structopt(
+        name = "PINS",
+        help = "The list of GPIO pins to monitor (space separated)"
+    )]
+    pub pins: Vec<String>,
+
+    #[structopt(short, long, help = "Output file")]
+    outfile: String,
+
+    #[structopt(short, long, help = "Do not print start end exit messages.")]
+    quiet: bool,
+}
+
+impl CommandDispatch for GpioMonitoringVcd {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport
+            .capabilities()?
+            .request(Capability::GPIO | Capability::GPIO_MONITORING)
+            .ok()?;
+        let gpio_monitoring = transport.gpio_monitoring()?;
+        let gpio_pins = transport.gpio_pins(&self.pins)?;
+        let mut file = File::create(&self.outfile)?;
+
+        if !self.quiet {
+            eprintln!("Dumping events to {}", &self.outfile);
+            eprint!("[CTRL+C] to exit  ");
+        }
+        // Putting the terminal input into raw mode is the only way we can catch Ctrl-C.  (This is
+        // not ideal, it would have been better to catch the SIGINT signal, but the mio_signals
+        // package is not compatible with the way that our rusb library uses background threads.)
+        // The tty guard will restore the console settings when it goes out of scope.
+        let mut stdin = std::io::stdin();
+        let _stdin_guard = if isatty(stdin.as_raw_fd())? {
+            let mut guard = TtyModeGuard::new(stdin.as_raw_fd())?;
+            guard.set_raw_mode()?;
+            Some(guard)
+        } else {
+            None
+        };
+
+        // Inform the transport that we want to monitor a set of pins, and write a file header
+        // with the names of each of the monitored signals.
+        let clock_nature = gpio_monitoring.get_clock_nature()?;
+        let initial = gpio_monitoring.monitoring_start(
+            &gpio_pins
+                .iter()
+                .map(Rc::borrow)
+                .collect::<Vec<&dyn GpioPin>>(),
+        )?;
+        writeln!(&mut file, "$version")?;
+        let properties = super::version::get_volatile_status();
+        writeln!(
+            &mut file,
+            "   opentitantool {} {} {}",
+            properties.get("BUILD_GIT_VERSION").unwrap(),
+            properties.get("BUILD_SCM_STATUS").unwrap(),
+            properties.get("BUILD_TIMESTAMP").unwrap().parse::<i64>()?
+        )?;
+        writeln!(&mut file, "$end")?;
+        match clock_nature {
+            ClockNature::Wallclock { resolution, .. } => {
+                writeln!(
+                    &mut file,
+                    "$timescale {}ps $end",
+                    1000000000000u64 / resolution
+                )?;
+            }
+            ClockNature::Unspecified => (),
+        }
+        writeln!(&mut file, "$scope module logic $end")?;
+        for (n, pin) in self.pins.iter().enumerate() {
+            writeln!(&mut file, "$var wire 1 '{} {} $end", n, pin)?;
+        }
+        writeln!(&mut file, "$upscope $end")?;
+        writeln!(&mut file, "$enddefinitions $end")?;
+        writeln!(&mut file, "#{}", initial.timestamp)?;
+        for (n, v) in initial.initial_levels.iter().enumerate() {
+            writeln!(&mut file, "{}'{}", if *v { 1 } else { 0 }, n)?;
+        }
+
+        // Now loop indefinitely, retrieving events from the internal queue of the transport and
+        // printing them to the output file.
+        let mut loop_count: usize = 0;
+        'event_loop: loop {
+            let resp = gpio_monitoring.monitoring_read(
+                &gpio_pins
+                    .iter()
+                    .map(Rc::borrow)
+                    .collect::<Vec<&dyn GpioPin>>(),
+                true,
+            )?;
+            for event in &resp.events {
+                writeln!(&mut file, "#{}", event.timestamp)?;
+                writeln!(
+                    &mut file,
+                    "{}'{}",
+                    match event.edge {
+                        Edge::Rising => 1,
+                        Edge::Falling => 0,
+                    },
+                    event.signal_index
+                )?;
+            }
+            eprint!("\u{8}{}", ['/', '-', '\\', '|'][loop_count & 3usize]);
+            let delay = if resp.events.is_empty() {
+                Duration::from_millis(10)
+            } else {
+                Duration::from_millis(0)
+            };
+            if file::wait_fd_read_timeout(stdin.as_raw_fd(), delay).is_ok() {
+                let mut buf = [0u8; 1];
+                let len = stdin.read(&mut buf)?;
+                if len == 1 && buf[0] == 3 {
+                    // CtrlC
+                    break 'event_loop;
+                }
+            }
+            loop_count += 1;
+        }
+
+        // Make one final reading to fetch any events that may have happened just before user
+        // requested to end monitoring.
+        let resp = gpio_monitoring.monitoring_read(
+            &gpio_pins
+                .iter()
+                .map(Rc::borrow)
+                .collect::<Vec<&dyn GpioPin>>(),
+            false,
+        )?;
+        for event in &resp.events {
+            writeln!(&mut file, "#{}", event.timestamp)?;
+            writeln!(
+                &mut file,
+                "{}'{}",
+                match event.edge {
+                    Edge::Rising => 1,
+                    Edge::Falling => 0,
+                },
+                event.signal_index
+            )?;
+        }
+        // Output timestamp of final reading (all signals remained stable from the last edge until
+        // this time.)
+        writeln!(&mut file, "#{}", resp.timestamp)?;
+        eprintln!("\r");
+        Ok(None)
+    }
+}
+
 #[derive(Debug, StructOpt)]
 /// Remove a configuration-named pin strapping
 pub struct GpioRemoveStrapping {
@@ -187,6 +486,22 @@ impl CommandDispatch for GpioRemoveStrapping {
     }
 }
 
+#[derive(Debug, StructOpt)]
+pub struct GpioMonitoring {
+    #[structopt(subcommand)]
+    command: GpioMonitoringCommand,
+}
+
+impl CommandDispatch for GpioMonitoring {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        self.command.run(context, transport)
+    }
+}
+
 /// Commands for manipulating GPIO pins.
 #[derive(Debug, StructOpt, CommandDispatch)]
 pub enum GpioCommand {
@@ -197,4 +512,5 @@ pub enum GpioCommand {
     SetMode(GpioSetMode),
     SetPullMode(GpioSetPullMode),
     Set(GpioSet),
+    Monitoring(GpioMonitoring),
 }

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -19,7 +19,7 @@ use opentitanlib::app::TransportWrapper;
 ///
 /// At runtime, this string is parsed into key/value pairs, which are returned.  (It would have
 /// been desirable to perform the parsing at compile time as well.)
-fn get_volatile_status() -> BTreeMap<&'static str, &'static str> {
+pub fn get_volatile_status() -> BTreeMap<&'static str, &'static str> {
     let volatile_status = include_str!("../../../../../bazel-out/volatile-status.txt");
     let re = Regex::new(r"([A-Z_]+) ([^\n]+)\n").unwrap();
     let mut properties: BTreeMap<&'static str, &'static str> = BTreeMap::new();


### PR DESCRIPTION
For feature request #17067, this PR introduces new a new `GpioMonitoring` trait, allowing clients to request simple "logic analyzer" functionality on one or more GPIO pins at a time.

The user would first execute e.g. `opentitantool gpio monitoring start IOC0 IOC1`, then do whatever to stimulate some action of the device under test, and finally run `opentitantool gpio monitoring read IOC0 IOC1` to get a list of events such as "rising edge on IOC1 at such and such time", "falling edge at ...", ...

The debugger devices may restrict which pins or combinations of pins can be monitored this way, which will be reported as errors from monitoring start, and will have some limit on the number of events that can be queued. Overflow will be reported by monitoring read.

For continuous streaming monitoring of a pin, `opentitantool gpio monitoring read IOC0 IOC1 --continue` can be used, which must be followed by another call to monitoring read (which could again continue, or stop the monitoring by omitting the flag.)