### PR TITLE
Add missing dependencies

### DIFF
--- a/hw/ip/prim/prim_and2.core
+++ b/hw/ip/prim/prim_and2.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_buf.core
+++ b/hw/ip/prim/prim_buf.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
-
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_clock_buf.core
+++ b/hw/ip/prim/prim_clock_buf.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
-
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_flop.core
+++ b/hw/ip/prim/prim_flop.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_sec_anchor.core
+++ b/hw/ip/prim/prim_sec_anchor.core
@@ -10,8 +10,9 @@ filesets:
     files:
         - rtl/prim_sec_anchor_buf.sv
         - rtl/prim_sec_anchor_flop.sv
-
     file_type: systemVerilogSource
+    depend:
+        - lowrisc:prim:assert
 
 targets:
   default:

--- a/hw/ip/prim/prim_subreg.core
+++ b/hw/ip/prim/prim_subreg.core
@@ -16,6 +16,8 @@ filesets:
       - rtl/prim_subreg_ext.sv
       - rtl/prim_subreg_shadow.sv
     file_type: systemVerilogSource
+    depend:
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
-
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_xnor2.core
+++ b/hw/ip/prim/prim_xnor2.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/prim_xor2.core
+++ b/hw/ip/prim/prim_xor2.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:


### PR DESCRIPTION
There are a few cores that use
```
`include "prim_assert.sv"
```
and do *not* list `lowrisc:prim:assert` as their dependency, so I'm adding this here.