### PR TITLE
[dv/flash] Add knob to control wait for init

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -106,6 +106,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Enable/Disable the Secret Seeds and Keys during Initialisation
   bit en_init_keys_seeds;
 
+  // States whether to wait for the flash_init to finish before starting the actual sequence.
+  bit wait_init_done;
+
   // Enable/Disable the Random Flash Inititlisation After Reset
   bit disable_flash_init;
 
@@ -203,6 +206,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
     erase_timeout_ns = 120_000_000;  // 120ms
 
     en_init_keys_seeds = 1'b0;  // Off
+
+    // By default, wait for flash to finish initializing process before sending transactions
+    //  requests.
+    wait_init_done = 1'b1;
 
     disable_flash_init = 1'b0;  // Off
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -134,8 +134,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     update_secret_partition();
 
     // Wait for flash_ctrl to finish initializing on every reset
-    // We probably need a parameter to skip this for certain tests
-    csr_spinwait(.ptr(ral.status.init_wip), .exp_data(1'b0));
+    if (cfg.seq_cfg.wait_init_done) csr_spinwait(.ptr(ral.status.init_wip), .exp_data(1'b0));
   endtask : reset_flash
 
   // Apply a Reset to the DUT, then do some additional required actions with callback_vseq


### PR DESCRIPTION
Hi,
This PR is adding knob to allow to not wait for the initiation process to finish before starting the sequence.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>