### PR TITLE
[dvsim] Generate report as json

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -722,6 +722,7 @@ class CovReport(Deploy):
         # Keep track of coverage results, once the job is finished.
         self.cov_total = ""
         self.cov_results = ""
+        self.cov_results_dict = dict()
 
     def post_finish(self, status):
         """Extract the coverage results summary for the dashboard.
@@ -741,6 +742,8 @@ class CovReport(Deploy):
                                     headers="firstrow",
                                     tablefmt="pipe",
                                     colalign=colalign)
+        for tup in zip(*results):
+            self.cov_results_dict[tup[0]] = tup[1]
 
 
 class CovAnalyze(Deploy):

--- a/util/dvsim/JobTime.py
+++ b/util/dvsim/JobTime.py
@@ -12,15 +12,16 @@ class JobTime:
     units = ["h", "m", "s", "ms", "us", "ns", "ps", "fs"]
     dividers = [60.0, ] * 3 + [1000.0, ] * 5
 
-    def __init__(self, time: float = 0.0, unit: str = "s"):
-        self.set(time, unit)
+    def __init__(self, time: float = 0.0, unit: str = "s", normalize: bool = True):
+        self.set(time, unit, normalize)
 
-    def set(self, time: float, unit: str):
+    def set(self, time: float, unit: str, normalize: bool = True):
         """Public API to set the instance variables time, unit."""
         self.__time = time
         self.__unit = unit
         assert self.__unit in self.units
-        self._normalize()
+        if normalize:
+            self._normalize()
 
     def get(self) -> Tuple[float, str]:
         """Returns the time and unit as a tuple."""

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -6,13 +6,17 @@ Class describing simulation configuration object
 """
 
 import collections
+from datetime import datetime, timezone
 import fnmatch
+import json
 import logging as log
 import os
+import re
 import subprocess
 import sys
 from collections import OrderedDict
 from pathlib import Path
+from typing import Optional
 
 from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
 from FlowCfg import FlowCfg
@@ -20,7 +24,7 @@ from Modes import BuildModes, Modes, Regressions, RunModes, Tests
 from SimResults import SimResults
 from tabulate import tabulate
 from Testplan import Testplan
-from utils import VERBOSE, rm_path
+from utils import TS_FORMAT, VERBOSE, rm_path
 
 # This affects the bucketizer failure report.
 _MAX_UNIQUE_TESTS = 5
@@ -529,6 +533,176 @@ class SimCfg(FlowCfg):
         for item in self.cfgs:
             item._cov_unr()
 
+    def _gen_json_results(self, run_results):
+        """Returns the run results as json-formatted dictionary.
+        """
+
+        def _empty_str_as_none(s: str) -> Optional[str]:
+            """Map an empty string to None and retain the value of a non-empty
+            string.
+
+            This is intended to clearly distinguish an empty string, which may
+            or may not be an valid value, from an invalid value.
+            """
+            return s if s != "" else None
+
+        def _pct_str_to_float(s: str) -> Optional[float]:
+            """Map a percentage value stored in a string with ` %` suffix to a
+            float or to None if the conversion to Float fails.
+            """
+            try:
+                return float(s[:-2])
+            except ValueError:
+                return None
+
+        def _test_result_to_dict(tr) -> dict:
+            """Map a test result entry to a dict."""
+            job_time_s = (tr.job_runtime.with_unit('s').get()[0]
+                          if tr.job_runtime is not None
+                          else None)
+            sim_time_us = (tr.simulated_time.with_unit('us').get()[0]
+                           if tr.simulated_time is not None
+                           else None)
+            pass_rate = tr.passing * 100.0 / tr.total if tr.total > 0 else 0
+            return {
+                'name': tr.name,
+                'max_runtime_s': job_time_s,
+                'simulated_time_us': sim_time_us,
+                'passing_runs': tr.passing,
+                'total_runs': tr.total,
+                'pass_rate': pass_rate,
+            }
+
+        results = dict()
+
+        # Describe name of hardware block targeted by this run and optionally
+        # the variant of the hardware block.
+        results['block_name'] = self.name.lower()
+        results['block_variant'] = _empty_str_as_none(self.variant.lower())
+
+        # The timestamp for this run has been taken with `utcnow()` and is
+        # stored in a custom format.  Store it in standard ISO format with
+        # explicit timezone annotation.
+        timestamp = datetime.strptime(self.timestamp, TS_FORMAT)
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+        results['report_timestamp'] = timestamp.isoformat()
+
+        # Extract Git properties.
+        m = re.search(r'https://github.com/.+?/tree/([0-9a-fA-F]+)',
+                      self.revision)
+        results['git_revision'] = m.group(1) if m else None
+        results['git_branch_name'] = _empty_str_as_none(self.branch)
+
+        # Describe type of report and tool used.
+        results['report_type'] = 'simulation'
+        results['tool'] = self.tool.lower()
+
+        # Create dictionary to store results.
+        results['results'] = {
+            'testpoints': [],
+            'unmapped_tests': [],
+            'testplan_stage_summary': [],
+            'coverage': dict(),
+            'failure_buckets': [],
+        }
+
+        # If the testplan does not yet have test results mapped to testpoints,
+        # map them now.
+        sim_results = SimResults(self.deploy, run_results)
+        if not self.testplan.test_results_mapped:
+            self.testplan.map_test_results(test_results=sim_results.table)
+
+        # Extract results of testpoints and tests into the `testpoints` field.
+        for tp in self.testplan.testpoints:
+
+            # Ignore testpoints that contain unmapped tests, because those will
+            # be handled separately.
+            if tp.name in ["Unmapped tests", "N.A."]:
+                continue
+
+            # Extract test results for this testpoint.
+            tests = []
+            for tr in tp.test_results:
+
+                # Ignore test results with zero total runs unless we are told
+                # to "map the full testplan".
+                if tr.total == 0 and not self.map_full_testplan:
+                    continue
+
+                # Map test result metrics and append it to the collecting list.
+                tests.append(_test_result_to_dict(tr))
+
+            # Ignore testpoints for which no tests have been run unless we are
+            # told to "map the full testplan".
+            if len(tests) == 0 and not self.map_full_testplan:
+                continue
+
+            # Append testpoint to results.
+            results['results']['testpoints'].append({
+                'name': tp.name,
+                'stage': tp.stage,
+                'tests': tests,
+            })
+
+        # Extract unmapped tests.
+        unmapped_trs = [tr for tr in sim_results.table if not tr.mapped]
+        for tr in unmapped_trs:
+            results['results']['unmapped_tests'].append(
+                _test_result_to_dict(tr))
+
+        # Extract summary of testplan stages.
+        if self.map_full_testplan:
+            for k, d in self.testplan.progress.items():
+                results['results']['testplan_stage_summary'].append({
+                    'name': k,
+                    'total_tests': d['total'],
+                    'written_tests': d['written'],
+                    'passing_tests': d['passing'],
+                    'pass_rate': _pct_str_to_float(d['progress']),
+                })
+
+        # Extract coverage results if coverage has been collected in this run.
+        if self.cov_report_deploy is not None:
+            cov = self.cov_report_deploy.cov_results_dict
+            for k, v in cov.items():
+                results['results']['coverage'][k.lower()] = _pct_str_to_float(v)
+
+        # Extract failure buckets.
+        if sim_results.buckets:
+            by_tests = sorted(sim_results.buckets.items(),
+                              key=lambda i: len(i[1]),
+                              reverse=True)
+            for bucket, tests in by_tests:
+                unique_tests = collections.defaultdict(list)
+                for (test, line, context) in tests:
+                    if not isinstance(test, RunTest):
+                        continue
+                    unique_tests[test.name].append((test, line, context))
+                fts = []
+                for test_name, test_runs in unique_tests.items():
+                    frs = []
+                    for test, line, context in test_runs:
+                        frs.append({
+                            'seed': test.seed,
+                            'failure_message': {
+                                'log_file_path': test.get_log_path(),
+                                'log_file_line_num': line,
+                                'text': ''.join(context),
+                            },
+                        })
+                    fts.append({
+                        'name': test_name,
+                        'failing_runs': frs,
+                    })
+
+                results['results']['failure_buckets'].append({
+                    'identifier': bucket,
+                    'failing_tests': fts,
+                })
+
+        # Return the `results` dictionary as json string.
+        return json.dumps(results)
+
     def _gen_results(self, run_results):
         '''
         The function is called after the regression has completed. It collates the
@@ -634,7 +808,8 @@ class SimCfg(FlowCfg):
 
         else:
             # Map regr results to the testplan entries.
-            self.testplan.map_test_results(test_results=results.table)
+            if not self.testplan.test_results_mapped:
+                self.testplan.map_test_results(test_results=results.table)
 
             results_str += self.testplan.get_test_results_table(
                 map_full_testplan=self.map_full_testplan)

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -700,8 +700,11 @@ class SimCfg(FlowCfg):
                     'failing_tests': fts,
                 })
 
+        # Store the `results` dictionary in this object.
+        self.results_dict = results
+
         # Return the `results` dictionary as json string.
-        return json.dumps(results)
+        return json.dumps(self.results_dict)
 
     def _gen_results(self, run_results):
         '''


### PR DESCRIPTION
This PR extends dvsim to generate reports in machine-readable json format, in addition to the existing human-readable formats.

## TODOs
- [x] Report failure buckets.
- [x] Cleanly convert `JobTime` objects to numeric values with a target unit.
- [x] Report unmapped tests.
- [x] Publish JSON results to the webserver.

The *testplan stage summary* is implemented, but it is only output when the simulation configuration has the `map_full_testplan` attribute set (as with the HTML output). Similarly, coverage only gets reported when dvsim is run with `-c`, which matches the behavior of the HTML report generation.