### PR TITLE
[otbn,sw] Fix initialization of WDRs in barrett384

### DIFF
--- a/sw/otbn/code-snippets/barrett384.s
+++ b/sw/otbn/code-snippets/barrett384.s
@@ -230,9 +230,9 @@ wrap_barrett384:
   /* Initialize all-zero register. */
   bn.xor w31, w31, w31
   /* Initialise WDRs before using them */
-  bn.xor w14, w14, w14
-  bn.xor w15, w15, w15
   bn.xor w16, w16, w16
+  bn.xor w17, w17, w17
+  bn.xor w18, w18, w18
   /* load first operand from dmem to [w9, w8] */
   li x4, 8
   la x5, inp_a


### PR DESCRIPTION
`w14` and `w15` get initialized later by loading from memory, so they don't have to be initialized with XORs.  `w17` and `w18`, on the other hand, are first used in `mulqacc.so` operations, which update only half of the destination WDR.  Not initializing them causes mismatches compared to the ISS.