### PR TITLE
[coverage] Use non-instrumented test ROM

### DIFF
--- a/util/coverage/common.py
+++ b/util/coverage/common.py
@@ -257,9 +257,14 @@ def measure_coverage(*, log_level: LogLevel, out_root_dir: Path,
         test_targets_query(bazel_test_type),
     )
     test_targets = test_targets_fn(test_targets_all)
+    # Instrumented ROM overflows the space allocated for ROM. `test_targets_fn` for
+    # functional tests programs the FPGA with the non-instrumented test ROM and we skip
+    # bitstream loading during tests.
     run(
         BAZEL,
         "coverage",
+        "--define",
+        "bitstream=skip",
         f"--config={config}",
         "--test_output=all",
         *test_targets,

--- a/util/coverage/common.py
+++ b/util/coverage/common.py
@@ -10,6 +10,7 @@ from typing import (
     List,
 )
 import logging as log
+import os
 from pathlib import Path, PurePath
 from pprint import pformat
 import subprocess
@@ -74,6 +75,7 @@ def run(*args) -> List[str]:
     log.debug(f"command: {' '.join(args)}")
     try:
         res = subprocess.run(args,
+                             env=os.environ.copy(),
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              encoding='ascii',

--- a/util/coverage/common_test.py
+++ b/util/coverage/common_test.py
@@ -26,12 +26,19 @@ class AnyStringWith(str):
         return self in other
 
 
+class AnyDict(dict):
+
+    def __eq__(self, other):
+        return True
+
+
 class TestCommon(unittest.TestCase):
 
     RUN_ARGS = {
         "check": True,
         "encoding": "ascii",
         "errors": "ignore",
+        "env": AnyDict(),
         "stderr": subprocess.PIPE,
         "stdout": subprocess.PIPE,
     }
@@ -260,9 +267,10 @@ class TestCommon(unittest.TestCase):
             calls_run[1][0],
             (common.BAZEL, "query", AnyStringWith(bazel_test_type.value)))
         mock_test_targets_fn.assert_called_once_with(test_targets_all)
-        self.assertEqual(calls_run[2][0],
-                         (common.BAZEL, "coverage", f"--config={config}",
-                          "--test_output=all", *test_targets))
+        self.assertEqual(
+            calls_run[2][0],
+            (common.BAZEL, "coverage", "--define", "bitstream=skip",
+             f"--config={config}", "--test_output=all", *test_targets))
         mock_get_test_logs_dir.assert_called_once_with(test_targets)
         mock_test_log_dirs_fn.assert_called_once_with(test_log_dirs)
         self.assertEqual(calls_run[3][0],

--- a/util/coverage/functest_coverage.py
+++ b/util/coverage/functest_coverage.py
@@ -4,12 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from pathlib import Path
+from pathlib import Path, PurePath
 from pprint import pformat
 from typing import List
 
 from device_profile_data import extract_profile_data
 from common import (
+    BAZEL,
     LLD_TARGET,
     BazelTestType,
     CoverageParams,
@@ -18,6 +19,9 @@ from common import (
 
 # Commands that this script uses
 LLVM_PROFDATA = "llvm-profdata"
+
+# Bazel target for locally spliced test ROM bitstream
+BITSTREAM_TARGET = "//hw/bitstream:gcp_spliced_test_rom"
 
 
 def handle_libs(device_libs_all: List[str]) -> List[str]:
@@ -44,7 +48,7 @@ def handle_objs(merged_library: Path, obj_files: List[str]) -> None:
         obj_files: A list of object files.
     """
     # Note: We allow unresolved symbols and multiple definitions because this library is
-    # used only for generating a coverage report and we link only and all intrumented
+    # used only for generating a coverage report and we link only and all instrumented
     # object files.
     # TODO(#16761): Try to remove these flags.
     run(LLD_TARGET, "--warn-unresolved-symbols", "-zmuldefs", "-o",
@@ -54,7 +58,10 @@ def handle_objs(merged_library: Path, obj_files: List[str]) -> None:
 def handle_test_targets(test_targets: List[str]) -> List[str]:
     """Choose cw310_test_rom tests from the given list of tests.
 
-    This function also filters wycheproof tests since they take a long time to run.
+    This function also
+    - Programs the FPGA with the non-instrumented test ROM since the instrumented one
+      overflows the ROM memory, and
+    - Filters wycheproof tests since they take a long time to run.
 
     Args:
         test_targets: A list of test targets.
@@ -62,6 +69,15 @@ def handle_test_targets(test_targets: List[str]) -> List[str]:
     Returns:
         cw310_test_rom tests without wycheproof tests.
     """
+    # Instrumented ROM overflows the space allocated for ROM. Program the fpga with the
+    # non-instrumented test ROM and skip bitstream loading during tests.
+    run(BAZEL, "build", BITSTREAM_TARGET)
+    [workspace] = run(BAZEL, "info", "workspace")
+    [bitstream] = run(BAZEL, "cquery", "--output=starlark", "--starlark:expr",
+                      "target.files.to_list()[0].path", BITSTREAM_TARGET)
+    bitstream_path = PurePath(workspace) / PurePath(bitstream)
+    run(BAZEL, "run", "//sw/host/opentitantool", "--", "fpga",
+        "load-bitstream", str(bitstream_path))
     return [
         t for t in test_targets
         if "cw310_test_rom" in t and "wycheproof" not in t


### PR DESCRIPTION
Due to the recent changes in bazel targets, we now splice locally built ROMs into the bitstreams from the bitstream cache by default. However, when coverage is enabled, the instrumented test ROM overflows the space allocated for ROM. This PR
- Passes the environment to subprocess for splicing, 
- Modifies `handle_test_targets()` for functional tests so that the FPGA is programmed with the non-instrumented test ROM before the instrumented tests are executed, and
- Modifies `measure_coverage()` so that we don't program the FPGA while running the tests.