### PR TITLE
[ci] Increase timeout of failing jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ jobs:
 - job: sw_build
   displayName: Earl Grey SW Build & Test
   # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
@@ -287,7 +287,7 @@ jobs:
   displayName: Fast Verilated Earl Grey tests
   # Build and run fast tests on sim_verilator
   pool: ci-public
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: lint
   steps:
   - template: ci/checkout-template.yml


### PR DESCRIPTION
Some CI jobs currently time out even though there does not seem to be anything fundamentally wrong with them (see #17187).  Until the issue has been resolved, this commit increases the timeout of those jobs, so that we can keep using CI checks.