### PR TITLE
[doc,dv] Fix links to nightly results

### DIFF
--- a/hw/ip/adc_ctrl/doc/dv/index.md
+++ b/hw/ip/adc_ctrl/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "ADC_CTRL DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/adc_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/adc_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on ADC_CTRL design features, please see the [ADC_CTRL HWIP technical specification]().

--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "AES DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/report.html)
 
 ## Design features
 For detailed information on AES design features, please see the [AES HWIP Technical Specification]({{< relref ".." >}}).

--- a/hw/ip/aon_timer/doc/dv/index.md
+++ b/hw/ip/aon_timer/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "AON Timer DV Document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/report.html)
 
 ## Design features
 

--- a/hw/ip/clkmgr/doc/dv/index.md
+++ b/hw/ip/clkmgr/doc/dv/index.md
@@ -13,7 +13,7 @@ title: "CLKMGR DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/report.html)
 
 ## Design features
 The detailed information on CLKMGR design features is at [CLKMGR HWIP technical specification]({{< relref "hw/ip/clkmgr/doc" >}}).

--- a/hw/ip/csrng/doc/dv/index.md
+++ b/hw/ip/csrng/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "CSRNG DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
 * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/csrng/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/csrng/dv/latest/report.html)
 
 ## Design features
 For detailed information on CSRNG design features, please see the [CSRNG HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/edn/doc/dv/index.md
+++ b/hw/ip/edn/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "EDN DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/edn/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/edn/dv/latest/report.html)
 
 ## Design features
 For detailed information on EDN design features, please see the [EDN HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/entropy_src/doc/dv/index.md
+++ b/hw/ip/entropy_src/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "ENTROPY_SRC DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/report.html)
 
 ## Design features
 For detailed information on ENTROPY_SRC design features, please see the [ENTROPY_SRC HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/flash_ctrl/doc/dv/index.md
+++ b/hw/ip/flash_ctrl/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "FLASH_CTRL DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on `flash_ctrl` design features, please see the [`flash_ctrl` HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/gpio/doc/dv/index.md
+++ b/hw/ip/gpio/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "GPIO DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/gpio/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/gpio/dv/latest/report.html)
 
 ## Design features
 For detailed information on GPIO design features, please see the [GPIO design specification]({{< relref ".." >}}).

--- a/hw/ip/hmac/doc/dv/index.md
+++ b/hw/ip/hmac/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "HMAC DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/hmac/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/hmac/dv/latest/report.html)
 
 ## Design features
 For detailed information on HMAC design features, please see the

--- a/hw/ip/keymgr/doc/dv/index.md
+++ b/hw/ip/keymgr/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "KEYMGR DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/keymgr/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/keymgr/dv/latest/report.html)
 
 ## Design features
 For detailed information on KEYMGR design features, please see the [KEYMGR HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "KMAC DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/kmac/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/kmac/dv/latest/report.html)
 
 ## Design features
 For detailed information on KMAC design features, please see the [KMAC HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "LC_CTRL DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on LC_CTRL design features, please see the [LC_CTRL HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/otp_ctrl/doc/dv/index.md
+++ b/hw/ip/otp_ctrl/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "OTP_CTRL DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on OTP_CTRL design features, please see the [OTP_CTRL HW IP technical specification]({{< relref ".." >}}).

--- a/hw/ip/pattgen/doc/dv/index.md
+++ b/hw/ip/pattgen/doc/dv/index.md
@@ -13,7 +13,7 @@ title: "PATTGEN DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/pattgen/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/pattgen/dv/latest/report.html)
 
 ## Design features
 * Two independent programmable channels generating serial data

--- a/hw/ip/pwm/doc/dv/index.md
+++ b/hw/ip/pwm/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "PWM DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/pwm/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/pwm/dv/latest/report.html)
 
 ## Design features
 For detailed information on PWM design features, please see the

--- a/hw/ip/pwrmgr/doc/dv/index.md
+++ b/hw/ip/pwrmgr/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "PWRMGR DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw/ip/pwrmgr/doc/checklist" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/report.html)
 
 ## Design features
 For detailed information on PWRMGR design features, please see the [PWRMGR HWIP technical specification]({{< relref "hw/ip/pwrmgr/doc" >}}).

--- a/hw/ip/rom_ctrl/doc/dv/index.md
+++ b/hw/ip/rom_ctrl/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "ROM Controller DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/rom_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/rom_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on `rom_ctrl` design features, please see the [ROM Controller HWIP technical specification]({{< relref "hw/ip/rom_ctrl/doc" >}}).

--- a/hw/ip/rstmgr/doc/dv/index.md
+++ b/hw/ip/rstmgr/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "RSTMGR DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/report.html)
 
 ## Design features
 For detailed information on RSTMGR design features, please see the [RSTMGR HWIP technical specification]({{< relref "hw/ip/rstmgr/doc" >}}).

--- a/hw/ip/rv_dm/doc/dv/index.md
+++ b/hw/ip/rv_dm/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "RV_DM DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/rv_dm/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/rv_dm/dv/latest/report.html)
 
 ## Design features
 

--- a/hw/ip/rv_timer/doc/dv/index.md
+++ b/hw/ip/rv_timer/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "RV_TIMER DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/report.html)
 
 ## Design features
 For detailed information on RV_TIMER design features, please see the [RV_TIMER design specification]({{< relref ".." >}}).

--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -13,7 +13,7 @@ title: "SPI Device DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/spi_device/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/spi_device/dv/latest/report.html)
 
 ## Design features
 For detailed information on SPI Device design features, please see the [SPI_device design specification]({{< relref ".." >}}).

--- a/hw/ip/spi_host/doc/dv/index.md
+++ b/hw/ip/spi_host/doc/dv/index.md
@@ -12,7 +12,7 @@ title: "SPI_HOST DV Document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/spi_host/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/spi_host/dv/latest/report.html)
 
 ## Design features
 For detailed information on SPI_HOST design features, please see the

--- a/hw/ip/sram_ctrl/doc/dv/index.md
+++ b/hw/ip/sram_ctrl/doc/dv/index.md
@@ -19,7 +19,7 @@ Only toggle coverage on the IOs of these sub-modules is enabled for coverage col
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/sram_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/sram_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on SRAM_CTRL design features, please see the [SRAM_CTRL HWIP technical specification]({{< relref ".." >}}).

--- a/hw/ip/sysrst_ctrl/doc/dv/index.md
+++ b/hw/ip/sysrst_ctrl/doc/dv/index.md
@@ -21,7 +21,7 @@ applicable. Once done, remove this comment before making a PR. -->
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/sysrst_ctrl/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/sysrst_ctrl/dv/latest/report.html)
 
 ## Design features
 For detailed information on SYSRST_CTRL design features, please see the [SYSRST_CTRL HWIP technical specification]({{< relref "hw/ip/sysrst_ctrl/doc" >}}).

--- a/hw/ip/tlul/doc/dv/index.md
+++ b/hw/ip/tlul/doc/dv/index.md
@@ -13,7 +13,7 @@ title: "TLUL XBAR DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/keymgr/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/keymgr/dv/latest/report.html)
 
 ## Design features
 For detailed information on TLUL design features, please see the [TLUL design specification]({{< relref ".." >}}).

--- a/hw/ip/uart/doc/dv/index.md
+++ b/hw/ip/uart/doc/dv/index.md
@@ -13,7 +13,7 @@ title: "UART DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/uart/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/uart/dv/latest/report.html)
 
 ## Design features
 For detailed information on UART design features, please see the [UART design specification]({{< relref ".." >}}).

--- a/hw/ip/usbdev/doc/dv/index.md
+++ b/hw/ip/usbdev/doc/dv/index.md
@@ -14,7 +14,7 @@ title: "USBDEV DV document"
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
   * [HW development stages]({{< relref "doc/project/development_stages" >}})
-* [Simulation results](https://reports.opentitan.org/hw/ip/usbdev/dv/latest/results.html)
+* [Simulation results](https://reports.opentitan.org/hw/ip/usbdev/dv/latest/report.html)
 
 ## Design features
 For detailed information on USBDEV design features, please see the [USBDEV HWIP technical specification]({{< relref ".." >}}).


### PR DESCRIPTION
Previous links were pointing to `results.html` but the nightlies are currently published at `report.html`.