### PR TITLE
[dvsim] Disable automatic timeout in gui mode

### DIFF
--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -104,7 +104,7 @@ class LocalLauncher(Launcher):
         self.job_runtime_secs = elapsed_time.total_seconds()
         if self.process.poll() is None:
             if self.timeout_secs and (self.job_runtime_secs >
-                                      self.timeout_secs):
+                                      self.timeout_secs) and not self.deploy.gui:
                 self._kill()
                 timeout_message = 'Job timed out after {} minutes'.format(
                     self.deploy.get_timeout_mins())

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -431,7 +431,9 @@ def parse_args():
                         type=int,
                         metavar="MINUTES",
                         help=('Wall-clock timeout for builds in minutes: if '
-                              'the build takes longer it will be killed.'))
+                              'the build takes longer it will be killed. If '
+                              'GUI mode is enabled, this timeout mechanism will '
+                              'be disabled.'))
 
     disg.add_argument("--gui",
                       action='store_true',
@@ -491,7 +493,9 @@ def parse_args():
                       type=int,
                       metavar="MINUTES",
                       help=('Wall-clock timeout for runs in minutes: if '
-                            'the run takes longer it will be killed.'))
+                            'the run takes longer it will be killed. If '
+                            'GUI mode is enabled, this timeout mechanism will '
+                            'be disabled.'))
 
     rung.add_argument("--run-timeout-multiplier",
                       type=float,


### PR DESCRIPTION
As suggested in issue #17028, it makes sense to never timeout if in GUI mode.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>