### PR TITLE
[spi_host/doc] Fix documentation related to CONFIGOPTS.CPOL_0 bit

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -260,7 +260,7 @@
             name: "CPOL",
             desc: '''The polarity of the sck clock signal.  When CPOL is 0,
                      sck is low when idle, and emits high pulses.   When CPOL
-                     is low, sck is high when idle, and emits a series of low
+                     is 1, sck is high when idle, and emits a series of low
                      pulses.
                      '''
             resval: "0x0"


### PR DESCRIPTION
sck is high on idle when CPOL_0 bit is 1 / high (not low).

Signed-off-by: Shawn Nematbakhsh <shawn@rivosinc.com>