### PR TITLE
[dv/sysrst_ctrl] Fix nightly failure

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_edge_detect_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_edge_detect_vseq.sv
@@ -49,7 +49,7 @@ class sysrst_ctrl_edge_detect_vseq extends sysrst_ctrl_base_vseq;
      bit l2h_detected;
 
      fork
-       if (edge_detect_l2h.en_l2h)
+       if (edge_detect_l2h.en_l2h) begin
          forever begin
            @(posedge cfg.vif.sysrst_ctrl_inputs[index]);
              if (!edge_detect_l2h.l2h_triggered) begin
@@ -57,7 +57,8 @@ class sysrst_ctrl_edge_detect_vseq extends sysrst_ctrl_base_vseq;
                l2h_detected = 1;
              end
          end
-       if (edge_detect_h2l.en_h2l)
+       end
+       if (edge_detect_h2l.en_h2l) begin
          forever begin
            @(negedge cfg.vif.sysrst_ctrl_inputs[index]);
              if (!edge_detect_h2l.h2l_triggered) begin
@@ -65,7 +66,7 @@ class sysrst_ctrl_edge_detect_vseq extends sysrst_ctrl_base_vseq;
                h2l_detected = 1;
              end
          end
-
+       end
        // after h2l_detected is set, check the input stay low for enought time
        forever begin
          bit h2l_timer_reached;
@@ -145,7 +146,7 @@ class sysrst_ctrl_edge_detect_vseq extends sysrst_ctrl_base_vseq;
        for (int i = 0; i < NumInputs; i++) begin
          automatic int local_i = i;
          edge_detect_h2l[i].en_h2l = get_input[i];
-         edge_detect_l2h[i].en_l2h = get_input[NumInputs + i + 1];
+         edge_detect_l2h[i].en_l2h = get_input[NumInputs + i];
          fork
            monitor_input_edge(sysrst_input_idx_e'(local_i), edge_detect_h2l[local_i],
                   edge_detect_l2h[local_i]);


### PR DESCRIPTION
This PR fixes sysrst_ctrl nightly failure because an index issue. According to `key_intr_ctl` register, the first set is index 0 to 6, the second set is index 7 to 13.
So in a for loop, if the first set is `i`, the second set should be `i+7`, but the implementation is `i+7+1`.
This PR removed the `+1` and also add two begin end to improve the readability.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>