### PR TITLE
[chip] Define visibility as public

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -12,6 +12,8 @@ load(
     "verilator_params",
 )
 
+package(default_visibility = ["//visibility:public"])
+
 # TODO(lowRISC:opentitan#13180): this is a temporary solution to enable writing
 # manufacturer specific tests in the `manufacturer_test_hooks` repository that
 # use open source test code. Specifically, this enables defining an


### PR DESCRIPTION
When trying to build chip level test with hooks in closed source environment, the build fail since it cant fined the  otbn_randomness_impl files.
Signed-off-by: Ariel Cohen <ariel.cohen@nuvoton.com>