### PR TITLE
[otbn] Stop OTBN URND when it is not used

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -58,6 +58,17 @@
       randcount: "256",
       randtype:  "data"
     },
+    { name:    "SecMuteUrnd"
+      type:    "bit"
+      default: "0"
+      desc: '''
+        If enabled (1), URND is advanced only when data is needed.
+        Disabled (0) by default.
+        Useful for SCA measurements only.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
     { name: "RndCnstOtbnKey",
       type: "otp_ctrl_pkg::otbn_key_t",
       desc: '''

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -68,7 +68,8 @@ module otbn_top_sim (
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
-    .DmemSizeByte ( DmemSizeByte )
+    .DmemSizeByte ( DmemSizeByte ),
+    .SecMuteUrnd  ( 1'b0         )
   ) u_otbn_core (
     .clk_i                       ( IO_CLK                     ),
     .rst_ni                      ( IO_RST_N                   ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -19,6 +19,9 @@ module otbn
   // Default seed for URND PRNG
   parameter urnd_prng_seed_t RndCnstUrndPrngSeed = RndCnstUrndPrngSeedDefault,
 
+   // Disable URND reseed and advance when not in use. Useful for SCA only.
+  parameter bit SecMuteUrnd = 1'b0,
+
   // Default seed and nonce for scrambling
   parameter otp_ctrl_pkg::otbn_key_t   RndCnstOtbnKey   = RndCnstOtbnKeyDefault,
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnNonce = RndCnstOtbnNonceDefault
@@ -1073,7 +1076,8 @@ module otbn
     .RegFile(RegFile),
     .DmemSizeByte(DmemSizeByte),
     .ImemSizeByte(ImemSizeByte),
-    .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
+    .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed),
+    .SecMuteUrnd(SecMuteUrnd)
   ) u_otbn_core (
     .clk_i,
     .rst_ni                      (rst_n),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5897,6 +5897,19 @@
           randwidth: 256
         }
         {
+          name: SecMuteUrnd
+          desc:
+            '''
+            If enabled (1), URND is advanced only when data is needed.
+            Disabled (0) by default.
+            Useful for SCA measurements only.
+            '''
+          type: bit
+          default: "0"
+          expose: "true"
+          name_top: SecOtbnMuteUrnd
+        }
+        {
           name: RndCnstOtbnKey
           desc: Compile-time random reset value for IMem/DMem scrambling key.
           type: otp_ctrl_pkg::otbn_key_t

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -999,6 +999,7 @@ module chip_earlgrey_cw310 #(
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
+    .SecOtbnMuteUrnd(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .UsbdevRcvrWakeTimeUs(10000),
     .RomCtrlBootRomInitFile(BootRomInitFile),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -73,6 +73,7 @@ module top_earlgrey #(
   // parameters for otbn
   parameter bit OtbnStub = 0,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
+  parameter bit SecOtbnMuteUrnd = 0,
   // parameters for keymgr
   parameter bit KeymgrKmacEnMasking = 1,
   // parameters for csrng
@@ -2270,6 +2271,7 @@ module top_earlgrey #(
     .Stub(OtbnStub),
     .RegFile(OtbnRegFile),
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
+    .SecMuteUrnd(SecOtbnMuteUrnd),
     .RndCnstOtbnKey(RndCnstOtbnOtbnKey),
     .RndCnstOtbnNonce(RndCnstOtbnOtbnNonce)
   ) u_otbn (

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1080,6 +1080,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
+    .SecOtbnMuteUrnd(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .UsbdevRcvrWakeTimeUs(10000),
 % elif target["name"] == "cw305":


### PR DESCRIPTION
Stop initial re-seed of OTBN's URND pseaudo-random number generator after reset and stop advancing URND when data is not required by the program. The purpose of this change is to reduce noise for side-channel analysis of OTBN.

This feature is hidden behind a parameter SecMuteURND and it should be used only for generating bitstreams for side-channel analysis. Assertion is added to ensure that this feature is not enabled by accident.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>