### PR TITLE
[dv/kmac] Fix nightly regression error

### DIFF
--- a/hw/ip/kmac/dv/cov/kmac_cov.core
+++ b/hw/ip/kmac/dv/cov/kmac_cov.core
@@ -15,6 +15,7 @@ filesets:
     files:
       - kmac_cov_if.sv
       - kmac_cov_bind.sv
+      - sha3pad_assert_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
+++ b/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
@@ -16,9 +16,18 @@ module kmac_cov_bind;
     .mubi   (sha3_done)
   );
 
-    bind kmac cip_mubi_cov_if #(.Width(4)) kmac_sha3_absorb_mubi_cov_if (
+  bind kmac cip_mubi_cov_if #(.Width(4)) kmac_sha3_absorb_mubi_cov_if (
     .rst_ni (rst_ni),
     .mubi   (sha3_absorbed)
+  );
+
+  bind kmac sha3pad_assert_if #(.EnMasking(u_sha3.u_pad.EnMasking)) sha3pad_assert_cov_if (
+    .clk_i (clk_i),
+    .rst_ni (rst_ni),
+    .process_i (u_sha3.u_pad.process_i),
+    .keccak_complete_i (u_sha3.u_pad.keccak_complete_i),
+    .keccak_run_o (u_sha3.u_pad.keccak_run_o),
+    .lc_escalate_en_i (u_sha3.u_pad.lc_escalate_en_i)
   );
 
 endmodule

--- a/hw/ip/kmac/dv/cov/sha3pad_assert_if.sv
+++ b/hw/ip/kmac/dv/cov/sha3pad_assert_if.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface implements liveness assertions for sha3pad.
+interface sha3pad_assert_if # (
+    parameter bit EnMasking = 1
+  )(
+    input                      clk_i,
+    input                      rst_ni,
+    input logic                process_i,
+    input logic                keccak_complete_i,
+    input logic                keccak_run_o,
+    input lc_ctrl_pkg::lc_tx_t lc_escalate_en_i
+   );
+
+  localparam int Share = (EnMasking) ? 2 : 1;
+
+  // If `process_i` is asserted, eventually sha3pad trigger run signal
+  `ASSERT(ProcessToRun_A, process_i |-> strong(##[2:$] keccak_run_o),
+    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
+
+  // Keccak control interface
+  // Keccak run triggered -> completion should come
+  `ASSUME(RunThenComplete_M,
+    keccak_run_o |-> strong(##[24*Share:$] keccak_complete_i),
+    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
+endinterface

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -829,9 +829,6 @@ module sha3pad
     $rose(process_latched) && (!end_of_block && !sent_blocksize )
     && !(st inside {StPrefixWait, StMessageWait}) |-> ##[1:5] keccak_valid_o,
     clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
-  // If `process_i` is asserted, eventually sha3pad trigger run signal
-  `ASSERT(ProcessToRun_A, process_i |-> strong(##[2:$] keccak_run_o),
-    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
 
   // If process_i asserted, completion shall be asserted shall be asserted
   //`ASSERT(ProcessToAbsorbed_A, process_i |=> strong(##[24*Share:$] absorbed_o))
@@ -845,12 +842,6 @@ module sha3pad
       (mode_i == Sha3 && (strength_i inside {L224, L256, L384, L512})) ||
       ((mode_i == Shake || mode_i == CShake) && (strength_i inside {L128, L256})),
     clk_i, !rst_ni)
-
-  // Keccak control interface
-  // Keccak run triggered -> completion should come
-  `ASSUME(RunThenComplete_M,
-    keccak_run_o |-> strong(##[24*Share:$] keccak_complete_i),
-    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
 
   // No partial write is allowed for Message FIFO interface
   `ASSUME(NoPartialMsgFifo_M,


### PR DESCRIPTION
This PR fix issue #17094.

The strong liveness assertions in sha3pad module are written to ensure a kmac request/transaction must finish. However, in chip level testbench, it is not necessary to wait for all kmac transactions to finish. A recent update in VCS will flag these unfinished strong assertions as failures.
So the solution here is to move these assertions to block level testbench, using an interface with binding method. This gives user flexibility to choose whether they want to enable these strong assertions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>