### PR TITLE
[top-test] Increase timeout of `csrng_edn_concurrency_reduced_freq`

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1724,7 +1724,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20_000_000", "+rng_srate_value_min=15",
+      run_opts: ["+sw_test_timeout_ns=30_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20", "+cal_sys_clk_70mhz=1", "+en_jitter=1"]
       run_timeout_mins: 240
     }


### PR DESCRIPTION
The current constraint on the simulated runtime (20 ms) of the `csrng_edn_concurrency_reduced_freq` test is too tight.  When that test is run with

    ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson \
        -i chip_sw_csrng_edn_concurrency_reduced_freq \
        --build-seed 4232114340 --fixed-seed 534783176

it would pass in 21.485 ms.  This commit increases the simulation timeout to 30 ms to fix this and leave some headroom.

This should resolve issue #16757 (though not automatically close it as per our procedures).