### PR TITLE
[dv/clkmgr] Fix unr file name in clkmgr_cfg

### DIFF
--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -47,7 +47,7 @@
   reseed: 50
 
   // CLKMGR exclusion files.
-  vcs_cov_excl_files: ["{proj_root}/hw/ip/clkmgr/dv/cov/clkmgr_manual_cov_unr_excl.el",
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/clkmgr/dv/cov/clkmgr_cov_manual_excl.el",
                        "{proj_root}/hw/ip/clkmgr/dv/cov/clkmgr_cov_unr_excl.el"]
 
   // Default UVM test and seq class name.


### PR DESCRIPTION
This PR fixes the UNR file name in the clkmgr_cfg.hjson file.
Fixes issue #17201.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>