### PR TITLE
[dv/common] Fix Xcelium enum type issue

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -91,13 +91,6 @@ package dv_utils_pkg;
     ClkFreqDiffAny
   } clk_freq_diff_e;
 
-  // Enum representing reset scheme
-  typedef enum bit [1:0] {
-    RstAssertSyncDeassertSync,
-    RstAssertAsyncDeassertSync,
-    RstAssertAsyncDeassertASync
-  } rst_scheme_e;
-
   string msg_id = "dv_utils_pkg";
 
   // return the smaller value of 2 inputs

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -44,7 +44,8 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
             // design.
             int dly_ps = $urandom_range(0, cfg.clk_rst_vif.clk_period_ps);
             #(dly_ps * 1ps);
-            cfg.clk_aon_rst_vif.apply_reset(.rst_n_scheme(0)); // AON reset.
+            cfg.clk_aon_rst_vif.apply_reset(.rst_n_scheme(
+                common_ifs_pkg::RstAssertSyncDeassertSync)); // AON reset.
           end
           begin
             super.apply_reset(kind); // CORE reset,

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -87,7 +87,7 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
         cfg.clk_aon_rst_vif.apply_reset(.pre_reset_dly_clks(0),
                                         .reset_width_clks(400),
                                         .post_reset_dly_clks(0),
-                                        .rst_n_scheme(0));
+                                        .rst_n_scheme(common_ifs_pkg::RstAssertSyncDeassertSync));
       join
     end
   endtask  // apply_reset


### PR DESCRIPTION
This PR fixes two issues reported in #17200
1. Declared two enum `rst_scheme_e`. Since dv_utils includes commoin_if, so I delete the enum in dv_utils.
2. Xcelium will report error if a function declares an enum type as input, but the use of the function inputs a integer instead of the actual enum. This is fixed by explicitely declare the enum.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>