### PR TITLE
[test] enable flash scrambling and ECC in power virus test

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_creator_sw_cfg.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_creator_sw_cfg.hjson
@@ -33,7 +33,10 @@
                 },
                 {
                     name: "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG",
-                    // Default value for flash scramble / ecc / he_en
+                    // Default values for flash scramble / ecc / he_en. This OTP
+                    // word contains byte-aligned, packed, 4-bit mubi values.
+                    // See the flash_ctrl driver bitfield definitions in
+                    // sw/device/silicon_creator/lib/drivers/flash_ctrl.h.
                     value: "0x0",
                 },
                 {

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -62,6 +62,7 @@ cc_library(
     name = "earl_grey_test_rom_lib",
     deps = [
         "//sw/device/lib/dif:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/rom:bootstrap",
     ],
 )

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -24,6 +24,7 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/lib/testing/test_rom/chip_info.h"  // Generated.
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
@@ -176,16 +177,16 @@ bool rom_test_main(void) {
       TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
       OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET);
 
-  // TODO: This section needs to be updated based on the discussion in #15035
   if (otp_val != 0) {
-    LOG_INFO("Default flash settings have been supplied through otp 0x%x",
-             otp_val);
-
     dif_flash_ctrl_region_properties_t default_properties;
     CHECK_DIF_OK(dif_flash_ctrl_get_default_region_properties(
         &flash_ctrl, &default_properties));
-    default_properties.scramble_en = bitfield_field32_read(
-        otp_val, FLASH_CTRL_DEFAULT_REGION_SCRAMBLE_EN_FIELD);
+    default_properties.scramble_en =
+        bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_SCRAMBLING);
+    default_properties.ecc_en =
+        bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_ECC);
+    default_properties.high_endurance_en =
+        bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_HE);
     CHECK_DIF_OK(dif_flash_ctrl_set_default_region_properties(
         &flash_ctrl, default_properties));
   }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -133,10 +133,9 @@ typedef enum flash_ctrl_info_page {
 #define FLASH_CTRL_OTP_FIELD_HE \
   (bitfield_field32_t) { .mask = UINT8_MAX, .index = CHAR_BIT * 2 }
 
-
 /**
- * The following constants represent the expected number of sec_mmio register
- * writes performed by functions in provided in this module. See
+ * The following constants represent the expected number of sec_mmio
+ * register writes performed by functions in provided in this module. See
  * `SEC_MMIO_WRITE_INCREMENT()` for more details.
  *
  * Example:
@@ -155,8 +154,6 @@ enum {
   kFlashCtrlSecMmioBankErasePermsSet = 1,
   kFlashCtrlSecMmioInit = 3,
 };
-
-
 
 /**
  * Value of a word in flash after erase.
@@ -385,7 +382,7 @@ void flash_ctrl_data_default_perms_set(flash_ctrl_perms_t perms);
  * @param perms New permissions.
  */
 void flash_ctrl_info_perms_set(flash_ctrl_info_page_t info_page,
-                            flash_ctrl_perms_t perms);
+                               flash_ctrl_perms_t perms);
 
 /**
  * A struct for flash configuration settings.
@@ -424,13 +421,14 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg);
  * Sets configuration settings for an info page.
  *
  * The caller is responsible for calling
- * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgSet)` when sec_mmio is being
- * used to check expectations.
+ * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgSet)` when sec_mmio is
+ * being used to check expectations.
  *
  * @param info_page An information page.
  * @param cfg New configuration settings.
  */
-void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page, flash_ctrl_cfg_t cfg);
+void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
+                             flash_ctrl_cfg_t cfg);
 
 /**
  * Set bank erase permissions for both flash banks.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -11,6 +11,8 @@ load(
     "opentitan_functest",
     "verilator_params",
 )
+load("//rules:splice.bzl", "bitstream_splice")
+load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_image", "otp_json", "otp_partition")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -2051,10 +2053,41 @@ opentitan_functest(
     ],
 )
 
+otp_json(
+    name = "power_virus_systemtest_otp_overlay",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "power_virus_systemtest_otp_img_rma",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":power_virus_systemtest_otp_overlay"],
+    visibility = ["//visibility:private"],
+)
+
+bitstream_splice(
+    name = "power_virus_systemtest_bitstream",
+    src = "//hw/bitstream:test_rom",
+    data = ":power_virus_systemtest_otp_img_rma",
+    meminfo = "//hw/bitstream:otp_mmi",
+    tags = ["vivado"],
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+
 opentitan_functest(
     name = "power_virus_systemtest",
     srcs = ["power_virus_systemtest.c"],
     cw310 = cw310_params(
+        bitstream = ":power_virus_systemtest_bitstream",
+        tags = ["vivado"],
         test_cmds = [
             "--rom-kind={rom_kind}",
             "--bitstream=\"$(location {bitstream})\"",
@@ -2080,12 +2113,14 @@ opentitan_functest(
         "//hw/ip/uart/data:uart_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
+        "//sw/device/lib/base:multibits",
         "//sw/device/lib/dif:adc_ctrl",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/dif:csrng",
         "//sw/device/lib/dif:csrng_shared",
         "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:hmac",
         "//sw/device/lib/dif:i2c",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2054,11 +2054,19 @@ opentitan_functest(
 opentitan_functest(
     name = "power_virus_systemtest",
     srcs = ["power_virus_systemtest.c"],
+    cw310 = cw310_params(
+        test_cmds = [
+            "--rom-kind={rom_kind}",
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
     targets = [
         # TODO(#14814): add more targets
         "cw310_test_rom",
         "dv",
     ],
+    test_harness = "//sw/host/tests/chip/power_virus",
     deps = [
         "//hw/ip/adc_ctrl/data:adc_ctrl_regs",
         "//hw/ip/aes:model",

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -45,6 +45,7 @@
 #include "uart_regs.h"     // Generated.
 
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
+                        .enable_uart_flow_control = true,
                         .can_clobber_uart = false, );
 
 /**

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -580,13 +580,6 @@ static void configure_kmac(void) {
       .msg_mask = false,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, kmac_cfg));
-
-  dif_kmac_customization_string_t kmac_customization_string;
-  CHECK_DIF_OK(dif_kmac_customization_string_init("Power Virus Test", 16,
-                                                  &kmac_customization_string));
-  CHECK_DIF_OK(dif_kmac_mode_kmac_start(
-      &kmac, &kmac_operation_state, kDifKmacModeKmacLen256, kKmacDigestLength,
-      &kKmacKey, &kmac_customization_string));
 }
 
 static void configure_uart(dif_uart_t *uart) {
@@ -701,6 +694,12 @@ static void crypto_data_load_task(void *task_parameters) {
   hmac_testutils_check_message_length(&hmac, sizeof(kHmacRefData) * 8);
 
   // Load data into KMAC block.
+  dif_kmac_customization_string_t kmac_customization_string;
+  CHECK_DIF_OK(dif_kmac_customization_string_init("Power Virus Test", 16,
+                                                  &kmac_customization_string));
+  CHECK_DIF_OK(dif_kmac_mode_kmac_start(
+      &kmac, &kmac_operation_state, kDifKmacModeKmacLen256, kKmacDigestLength,
+      &kKmacKey, &kmac_customization_string));
   CHECK_DIF_OK(dif_kmac_absorb(&kmac, &kmac_operation_state, kKmacMessage,
                                kKmacMessageLength, NULL));
 

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -33,7 +33,7 @@ pub enum ExitStatus {
     ExitFailure,
 }
 
-// Creates a vtable for impementors of Read and AsRawFd traits.
+// Creates a vtable for implementors of Read and AsRawFd traits.
 pub trait ReadAsRawFd: Read + AsRawFd {}
 impl<T: Read + AsRawFd> ReadAsRawFd for T {}
 

--- a/sw/host/tests/chip/power_virus/BUILD
+++ b/sw/host/tests/chip/power_virus/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "power_virus",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/chip/power_virus/BUILD
+++ b/sw/host/tests/chip/power_virus/BUILD
@@ -16,6 +16,7 @@ rust_binary(
         "//third_party/rust/crates:anyhow",
         "//third_party/rust/crates:humantime",
         "//third_party/rust/crates:log",
+        "//third_party/rust/crates:regex",
         "//third_party/rust/crates:structopt",
     ],
 )

--- a/sw/host/tests/chip/power_virus/src/main.rs
+++ b/sw/host/tests/chip/power_virus/src/main.rs
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "600s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    Ok(())
+}

--- a/sw/host/tests/chip/power_virus/src/main.rs
+++ b/sw/host/tests/chip/power_virus/src/main.rs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use regex::Regex;
 use std::time::Duration;
 use structopt::StructOpt;
 
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::uart::console::UartConsole;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
 
 #[derive(Debug, StructOpt)]
 struct Opts {
@@ -22,13 +25,52 @@ struct Opts {
     timeout: Duration,
 }
 
+fn power_virus_systemtest(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Below is temporary until this test implements the command / response
+    // ujson framework.
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let result = console.interact(&*uart, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let opts = Opts::from_args();
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
-
     let uart = transport.uart("console")?;
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
+    execute_test!(power_virus_systemtest, &opts, &transport);
     Ok(())
 }

--- a/sw/host/tests/chip/power_virus/src/main.rs
+++ b/sw/host/tests/chip/power_virus/src/main.rs
@@ -69,6 +69,7 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
     let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
     execute_test!(power_virus_systemtest, &opts, &transport);


### PR DESCRIPTION
This PR contains a few commits that:
1. add a host side Rust component for the power virus test (to enable future bringup on HyperDebug platform),
2. fixes the test ROM and silicon_creator flash_ctrl driver to read the correctly sized fields from OTP when configuring the flash_ctrl's scrambling and ECC enables, and
3. enables flash scrambling and ECC via the proper OTP bits for the power virus test