### PR TITLE
[dv/sysrst_ctrl] Fix constraints and reduce reseed number

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -61,6 +61,8 @@
     {
       name: sysrst_ctrl_combo_detect_ec_rst
       uvm_test_seq: sysrst_ctrl_combo_detect_ec_rst_vseq
+      // This is a directed test with very few random values.
+      reseed: 5
     }
     {
       name: sysrst_ctrl_pin_access_test


### PR DESCRIPTION
This pr:
1). Fix a constraint in combo_detect directed test.
    The wait_cycles_c are evaluated in decimal but debounce_timer and
    detect timer are in hex.
    So I updated them to all use decimal numbers.
2). Reduce nightly reseed for the direct test.
3). Make a task virtual so it can be reused in pre-condition test

Signed-off-by: Cindy Chen <chencindy@opentitan.org>