### PR TITLE
[dv/flash] Add timeout value and flash path variables to seq_cfg

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -103,6 +103,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Timeout for read transaction
   uint read_timeout_ns;
 
+  // Timeout for LC state transition
+  uint state_wait_timeout_ns;
+
   // Enable/Disable the Secret Seeds and Keys during Initialisation
   bit en_init_keys_seeds;
 
@@ -111,6 +114,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   // Enable/Disable the Random Flash Inititlisation After Reset
   bit disable_flash_init;
+
+  // Path to flash wrapper hierarchy.
+  string flash_path_str;
 
   `uvm_object_new
 
@@ -205,6 +211,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     erase_timeout_ns = 120_000_000;  // 120ms
 
+    state_wait_timeout_ns = 500_000; // 500us
+
     en_init_keys_seeds = 1'b0;  // Off
 
     // By default, wait for flash to finish initializing process before sending transactions
@@ -212,6 +220,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     wait_init_done = 1'b1;
 
     disable_flash_init = 1'b0;  // Off
+
+    flash_path_str = "tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic";
 
     set_partition_pc();
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -10,7 +10,6 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
   task body();
     jtag_pkg::jtag_req_t jtag_src_req, jtag_dst_req;
     jtag_pkg::jtag_rsp_t jtag_src_rsp, jtag_dst_rsp;
-    string   flash_path = "tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic";
     string   dut_path = "tb.dut";
     bit      lc_nvm_debug_en;
     ast_pkg::ast_obs_ctrl_t obs_src, obs_dst;
@@ -29,7 +28,7 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     `DV_CHECK(uvm_hdl_force(mystr, jtag_src_req.tms))
     mystr = {dut_path, ".cio_tdi_i"};
     `DV_CHECK(uvm_hdl_force(mystr, jtag_src_req.tdi))
-    mystr = {flash_path, ".tdo_o"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".tdo_o"};
     `DV_CHECK(uvm_hdl_force(mystr, jtag_src_rsp.tdo))
     // tdo_oe : dut.eflash
     $assertoff(0, "prim_lc_sync");
@@ -39,11 +38,11 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
 
     // takes dealy to propagate lc_nvm_debug_en
     cfg.clk_rst_vif.wait_clks(5);
-    mystr = {flash_path, ".tck_i"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".tck_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tck))
-    mystr = {flash_path, ".tms_i"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".tms_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tms))
-    mystr = {flash_path, ".tdi_i"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".tdi_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tdi))
     mystr = {dut_path, ".cio_tdo_o"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_rsp.tdo))
@@ -65,15 +64,15 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     `DV_CHECK(uvm_hdl_force(mystr, obs_src.obmsl))
     mystr = {dut_path, ".obs_ctrl_i.obmen"};
     `DV_CHECK(uvm_hdl_force(mystr, obs_src.obmen))
-    mystr = {flash_path, ".fla_obs_o"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".fla_obs_o"};
     `DV_CHECK(uvm_hdl_force(mystr, fla_src))
 
     cfg.clk_rst_vif.wait_clks(1);
-    mystr = {flash_path, ".obs_ctrl_i.obgsl"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".obs_ctrl_i.obgsl"};
     `DV_CHECK(uvm_hdl_read(mystr, obs_dst.obgsl))
-    mystr = {flash_path, ".obs_ctrl_i.obmsl"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".obs_ctrl_i.obmsl"};
     `DV_CHECK(uvm_hdl_read(mystr, obs_dst.obmsl))
-    mystr = {flash_path, ".obs_ctrl_i.obmen"};
+    mystr = {cfg.seq_cfg.flash_path_str, ".obs_ctrl_i.obmen"};
     `DV_CHECK(uvm_hdl_read(mystr, obs_dst.obmen))
     mystr = {dut_path, ".fla_obs_o"};
     `DV_CHECK(uvm_hdl_read(mystr, fla_dst))

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
@@ -18,12 +18,11 @@ class flash_ctrl_hw_prog_rma_wipe_err_vseq extends flash_ctrl_err_base_vseq;
 
   // fatal_std_err
   task run_error_event();
-     int state_wait_timeout_ns = 500_000; // 500 us
      int event_idx = $urandom_range(0, 3);
 
     `uvm_info(`gfn, $sformatf("event_idx :%0d", event_idx), UVM_MEDIUM)
      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == StRmaWordSel);,
-                  , state_wait_timeout_ns)
+                  , cfg.seq_cfg.state_wait_timeout_ns)
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
     cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -94,12 +94,11 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
         end
       end
       begin
-        int state_wait_timeout_ns = 500_000; // 500 us
         string path = {"tb.dut.u_eflash.gen_flash_cores[0].u_core.gen_prog_data",
                        ".u_prog.pack_data[31:0]"};
 
         `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == StRmaEraseWait);,
-                     , state_wait_timeout_ns)
+                     , cfg.seq_cfg.state_wait_timeout_ns)
         flip_2bits(path);
         cfg.clk_rst_vif.wait_clks(10);
         `DV_CHECK(uvm_hdl_release(path))

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -35,7 +35,6 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
 
   task body();
     logic [RmaSeedWidth-1:0] rma_seed;
-    int                      state_wait_timeout_ns = 500_000; // 500 us
     bit                      rma_done = 0;
     bit                      flash_dis = 0;
     // INITIALIZE FLASH REGIONS
@@ -58,7 +57,7 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
           `uvm_info("Test", $sformatf("Reset index: %s", reset_state_index.name), UVM_LOW)
           `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rma_state == dv2rma_st(reset_state_index));,
                        $sformatf("Timed out waiting for rma_state: %s", reset_state_index.name),
-                       state_wait_timeout_ns)
+                       cfg.seq_cfg.state_wait_timeout_ns)
           // Give more cycles for long stages
           // to trigger reset in the middle of the state.
           if (reset_state_index inside {StRmaRdVerify, StRmaErase}) cfg.clk_rst_vif.wait_clks(10);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -38,7 +38,6 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
   endtask
 
   task body();
-    int state_wait_timeout_ns = 50000; // 50 us
     int long_wait_timeout_ns = 5000000; // 5ms
     int wait_time;
     string path;
@@ -55,7 +54,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
             otp_model();
             `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
                          "Timed out waiting for rd_buf_en",
-                         state_wait_timeout_ns)
+                         cfg.seq_cfg.state_wait_timeout_ns)
             `uvm_info("Test", "RMA REQUEST START", UVM_LOW)
             rma_seed = $urandom;  // Random RMA Seed
             send_rma_req(rma_seed);
@@ -76,7 +75,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
             `uvm_info("Test", $sformatf("index: %s exception_mode: %0d",
                                         reset_index.name, exception_mode), UVM_LOW)
             if (reset_index == DVWaitRmaRsp) wait_time = long_wait_timeout_ns;
-            else wait_time = state_wait_timeout_ns;
+            else wait_time = cfg.seq_cfg.state_wait_timeout_ns;
 
             `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.lcmgr_state == dv2rtl_st(reset_index));,
                          $sformatf("Timed out waiting for %s", reset_index.name),
@@ -149,7 +148,7 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
       otp_model();
       `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.rd_buf_en == 1);,
                    "Timed out waiting for rd_buf_en",
-                   state_wait_timeout_ns)
+                   cfg.seq_cfg.state_wait_timeout_ns)
 
       apply_reset();
       cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::On;


### PR DESCRIPTION
Hi,
This PR is adding some variables to seq_cfg so they could be overriden by extending env. Required for specific tests.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>