### PR TITLE
[ci] Increase timeout for CW310 Hyperdebug bitstream

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -451,7 +451,7 @@ jobs:
     - lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'), eq(variables['Build.SourceBranchName'], 'master'))
   pool: ci-public
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml


### PR DESCRIPTION
The build time for FPGA bitstreams currently varies quite much, see issue #17187.  PR #17216 addressed this problem for the CW310 bitstream without Hyperdebug.

This commit increases the timeout for the CW310 Earl Grey *with Hyperdebug* bitstream.  CI currently skips this check for PRs but runs it after the merge, where it fails on `master` (again, see issue #17187 for further information).