### PR TITLE
[crypto] Add SPHINCS+ tweakable hash function.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
@@ -15,6 +15,24 @@ cc_library(
 )
 
 cc_library(
+    name = "context",
+    hdrs = ["context.h"],
+)
+
+cc_library(
     name = "params",
     hdrs = ["params.h"],
+)
+
+cc_library(
+    name = "thash",
+    srcs = ["thash_shake_simple.c"],
+    hdrs = ["thash.h"],
+    deps = [
+        ":address",
+        ":context",
+        ":params",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/drivers:kmac",
+    ],
 )

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/context.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_CONTEXT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_CONTEXT_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Context object for the SPHINCS+ operation.
+ *
+ * The reference implementation has more fields here: `sk_seed` and
+ * hash-specific precomputed values for Haraka and SHA2 hash functions. Since
+ * we are only using SHAKE-based SPHINCS+ in this context, and only performing
+ * verification, all we need is the public key seed.
+ */
+typedef struct spx_ctx {
+  uint32_t pub_seed[kSpxNWords];
+} spx_ctx_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_CONTEXT_H_

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/thash.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_THASH_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_THASH_H_
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Tweakable hash function.
+ *
+ * Produces a digest of length `kSpxN` bytes based on the input buffer,
+ * address, and public key seed from `ctx`. The exact construction depends on
+ * the SPHINCS+ parameters.
+ *
+ * For details on tweakable hash constructions for SPHINCS+, see the
+ * paper: https://sphincs.org/data/sphincs+-paper.pdf
+ *
+ * @param in Input buffer.
+ * @param inblocks Number of `kSpxN`-byte blocks in input buffer.
+ * @param ctx Context object.
+ * @param addr Hypertree address.
+ * @param[out] out Output buffer (at least `kSpxN` bytes).
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t thash(const unsigned char *in, size_t inblocks,
+                  const spx_ctx_t *ctx, const spx_addr_t *addr, uint32_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_THASH_H_

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/thash_shake_simple.h
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
+
+rom_error_t thash(const unsigned char *in, size_t inblocks,
+                  const spx_ctx_t *ctx, const spx_addr_t *addr, uint32_t *out) {
+  // Uses the "simple" thash construction (Construction 7 in the SPHINCS+
+  // paper): H(pk_seed, addr, in).
+  HARDENED_RETURN_IF_ERROR(kmac_shake256_start());
+  kmac_shake256_absorb_words(ctx->pub_seed, kSpxNWords);
+  kmac_shake256_absorb_words(addr->addr, ARRAYSIZE(addr->addr));
+  kmac_shake256_absorb(in, inblocks * kSpxN);
+  kmac_shake256_squeeze_start();
+  return kmac_shake256_squeeze_end(out, kSpxNWords);
+}


### PR DESCRIPTION
This PR implements the "tweakable hash" (thash) function for SPHINCS+. For an input `in`, `thash` is `SHAKE-256(<public key seed> || <hypertree address> || in)`.

For ROM we will only implement the "simple" variant from the paper, not the "robust" one; they provide similar security (same number of bits of security but with different security proofs). However, "robust" is significantly slower.