### PR TITLE
Otbn skip reseed

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -70,6 +70,17 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "SecSkipUrndReseedAtStart"
+      type:    "bit"
+      default: "0"
+      desc: '''
+        If enabled (1), URND reseed is skipped at the start of an operation.
+        Disabled (0) by default.
+        Useful for SCA measurements only.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
     { name: "RndCnstOtbnKey",
       type: "otp_ctrl_pkg::otbn_key_t",
       desc: '''

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -67,9 +67,10 @@ module otbn_top_sim (
   logic secure_wipe_running;
 
   otbn_core #(
-    .ImemSizeByte ( ImemSizeByte ),
-    .DmemSizeByte ( DmemSizeByte ),
-    .SecMuteUrnd  ( 1'b0         )
+    .ImemSizeByte             ( ImemSizeByte ),
+    .DmemSizeByte             ( DmemSizeByte ),
+    .SecMuteUrnd              ( 1'b0         ),
+    .SecSkipUrndReseedAtStart ( 1'b0         )
   ) u_otbn_core (
     .clk_i                       ( IO_CLK                     ),
     .rst_ni                      ( IO_RST_N                   ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -19,8 +19,10 @@ module otbn
   // Default seed for URND PRNG
   parameter urnd_prng_seed_t RndCnstUrndPrngSeed = RndCnstUrndPrngSeedDefault,
 
-   // Disable URND reseed and advance when not in use. Useful for SCA only.
+  // Disable URND advance when not in use. Useful for SCA only.
   parameter bit SecMuteUrnd = 1'b0,
+  // Skip URND re-seed at the start of an operation. Useful for SCA only.
+  parameter bit SecSkipUrndReseedAtStart = 1'b0,
 
   // Default seed and nonce for scrambling
   parameter otp_ctrl_pkg::otbn_key_t   RndCnstOtbnKey   = RndCnstOtbnKeyDefault,
@@ -1077,7 +1079,8 @@ module otbn
     .DmemSizeByte(DmemSizeByte),
     .ImemSizeByte(ImemSizeByte),
     .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed),
-    .SecMuteUrnd(SecMuteUrnd)
+    .SecMuteUrnd(SecMuteUrnd),
+    .SecSkipUrndReseedAtStart(SecSkipUrndReseedAtStart)
   ) u_otbn_core (
     .clk_i,
     .rst_ni                      (rst_n),

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -28,6 +28,7 @@ module otbn_core
 
   // Disable URND reseed and advance when not in use. Useful for SCA only.
   parameter bit SecMuteUrnd = 1'b0,
+  parameter bit SecSkipUrndReseedAtStart = 1'b0,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
@@ -277,7 +278,8 @@ module otbn_core
   // Start stop control start OTBN execution when requested and deals with any pre start or post
   // stop actions.
   otbn_start_stop_control #(
-    .SecMuteUrnd(SecMuteUrnd)
+    .SecMuteUrnd(SecMuteUrnd),
+    .SecSkipUrndReseedAtStart(SecSkipUrndReseedAtStart)
   ) u_otbn_start_stop_control (
     .clk_i,
     .rst_ni,

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -27,7 +27,9 @@ module otbn_start_stop_control
   import prim_mubi_pkg::*;
 #(
   // Disable URND advance when not in use. Useful for SCA only.
-  parameter bit SecMuteUrnd = 1'b0
+  parameter bit SecMuteUrnd = 1'b0,
+  // Skip URND re-seed at the start of the operation. Useful for SCA only.
+  parameter bit SecSkipUrndReseedAtStart = 1'b0
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -66,8 +68,9 @@ module otbn_start_stop_control
 
   import otbn_pkg::*;
 
-  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  // Create lint errors to reduce the risk of accidentally enabling these features.
   `ASSERT_STATIC_LINT_ERROR(OtbnSecMuteUrndNonDefault, SecMuteUrnd == 0)
+  `ASSERT_STATIC_LINT_ERROR(OtbnSecSkipUrndReseedAtStartNonDefault, SecSkipUrndReseedAtStart == 0)
 
   otbn_start_stop_state_e state_q, state_d;
   logic init_sec_wipe_done_q, init_sec_wipe_done_d;
@@ -77,6 +80,7 @@ module otbn_start_stop_control
   logic mubi_err_q, mubi_err_d;
   logic urnd_reseed_err_q, urnd_reseed_err_d;
   logic secure_wipe_error_q, secure_wipe_error_d;
+  logic skip_reseed_q;
 
   logic addr_cnt_inc;
   logic [5:0] addr_cnt_q, addr_cnt_d;
@@ -102,6 +106,24 @@ module otbn_start_stop_control
   assign rma_request   = mubi4_test_true_strict(rma_req_i);
   assign stop          = esc_request | rma_request | secure_wipe_req_i;
   assign should_lock_d = should_lock_q | esc_request | rma_request;
+
+  // Only if SecSkipUrndReseedAtStart is set, the controller start pulse is sent
+  // one cycle after leaving the Halt state.
+  if (SecSkipUrndReseedAtStart) begin: gen_skip_reseed
+    logic skip_reseed_d;
+
+    assign skip_reseed_d = ((state_q == OtbnStartStopStateHalt) & start_i & ~stop);
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        skip_reseed_q <= 1'b0;
+      end else begin
+        skip_reseed_q <= skip_reseed_d;
+      end
+    end
+  end else begin: gen_reseed
+    assign skip_reseed_q = 1'b0;
+  end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -165,14 +187,14 @@ module otbn_start_stop_control
         if (stop && !rma_request) begin
           state_d = OtbnStartStopStateLocked;
         end else if (start_i || rma_request) begin
-          urnd_reseed_req_o = 1'b1;
+          urnd_reseed_req_o = ~SecSkipUrndReseedAtStart | rma_request;
           ispr_init_o       = 1'b1;
           state_reset_o     = 1'b1;
           state_d           = OtbnStartStopStateUrndRefresh;
         end
       end
       OtbnStartStopStateUrndRefresh: begin
-        urnd_reseed_req_o = 1'b1;
+        urnd_reseed_req_o = ~skip_reseed_q;
         if (stop) begin
           if (mubi4_test_false_strict(wipe_after_urnd_refresh_q) && !rma_request) begin
             // We are told to stop and don't have to wipe after the current URND refresh is ack'd,
@@ -192,7 +214,7 @@ module otbn_start_stop_control
           if (mubi4_test_false_strict(wipe_after_urnd_refresh_q)) begin
             // We are not stopping and we don't have to wipe after the current URND refresh is
             // ack'd, so we wait for the ACK and then start executing.
-            if (urnd_reseed_ack_i) begin
+            if (urnd_reseed_ack_i || skip_reseed_q) begin
               state_d = OtbnStartStopStateRunning;
             end
           end else begin
@@ -338,9 +360,10 @@ module otbn_start_stop_control
                                 init_sec_wipe_done_q; // keep
 
   // Logic separate from main FSM code to avoid false combinational loop warning from verilator
-  assign controller_start_o = (state_q == OtbnStartStopStateUrndRefresh) &
-                              mubi4_test_false_strict(wipe_after_urnd_refresh_q) &
-                              urnd_reseed_ack_i;
+  assign controller_start_o =
+    // The controller start pulse is fired when finishing the initial URND reseed.
+    ((state_q == OtbnStartStopStateUrndRefresh) & (urnd_reseed_ack_i | skip_reseed_q) &
+      mubi4_test_false_strict(wipe_after_urnd_refresh_q));
 
   assign done_o = ((state_q == OtbnStartStopSecureWipeComplete && init_sec_wipe_done_q) ||
                    (stop && (state_q == OtbnStartStopStateUrndRefresh) &&

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5910,6 +5910,19 @@
           name_top: SecOtbnMuteUrnd
         }
         {
+          name: SecSkipUrndReseedAtStart
+          desc:
+            '''
+            If enabled (1), URND reseed is skipped at the start of an operation.
+            Disabled (0) by default.
+            Useful for SCA measurements only.
+            '''
+          type: bit
+          default: "0"
+          expose: "true"
+          name_top: SecOtbnSkipUrndReseedAtStart
+        }
+        {
           name: RndCnstOtbnKey
           desc: Compile-time random reset value for IMem/DMem scrambling key.
           type: otp_ctrl_pkg::otbn_key_t

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1000,6 +1000,7 @@ module chip_earlgrey_cw310 #(
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .SecOtbnMuteUrnd(1'b1),
+    .SecOtbnSkipUrndReseedAtStart(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .UsbdevRcvrWakeTimeUs(10000),
     .RomCtrlBootRomInitFile(BootRomInitFile),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -74,6 +74,7 @@ module top_earlgrey #(
   parameter bit OtbnStub = 0,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
   parameter bit SecOtbnMuteUrnd = 0,
+  parameter bit SecOtbnSkipUrndReseedAtStart = 0,
   // parameters for keymgr
   parameter bit KeymgrKmacEnMasking = 1,
   // parameters for csrng
@@ -2272,6 +2273,7 @@ module top_earlgrey #(
     .RegFile(OtbnRegFile),
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
     .SecMuteUrnd(SecOtbnMuteUrnd),
+    .SecSkipUrndReseedAtStart(SecOtbnSkipUrndReseedAtStart),
     .RndCnstOtbnKey(RndCnstOtbnOtbnKey),
     .RndCnstOtbnNonce(RndCnstOtbnOtbnNonce)
   ) u_otbn (

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1081,6 +1081,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .SecOtbnMuteUrnd(1'b1),
+    .SecOtbnSkipUrndReseedAtStart(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .UsbdevRcvrWakeTimeUs(10000),
 % elif target["name"] == "cw305":


### PR DESCRIPTION
Skip URND re-seed at the start of the application.
The purpose of this change is to reduce noise for side-channel analysis of OTBN.
This feature is hidden behind a parameter SecSkipUrndReseedAtStart and should be used only for generating bitstreams for CW310.

This PR is dependent on #17195