### PR TITLE
[pwrmgr] changed clamp and clamp_env reset value

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -110,10 +110,9 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     if (!rst_ni) begin
       cause_q        <= Por;
       cause_toggle_q <= 1'b0;
-      // pwrmgr resets assuming main power domain is already ready
       pd_nq          <= 1'b1;
-      pwr_clamp_q    <= 1'b0;
-      pwr_clamp_env_q <= 1'b0;
+      pwr_clamp_q    <= 1'b1;
+      pwr_clamp_env_q <= 1'b1;
       core_clk_en_q  <= 1'b0;
       io_clk_en_q    <= 1'b0;
       usb_clk_en_q   <= 1'b0;


### PR DESCRIPTION
fixes [17164](https://github.com/lowRISC/opentitan/issues/17164)

The original design assumed MAIN power domain is active. However when chip is in deep sleep and por_n arrives, it takes time for the chip to wake up.
Setting clamp reset value to '1', will keep all signals going from main pd to aon pd to remain isolated.
