### PR TITLE
[ci] Increase timeout for Fast Verilated Earl Grey Tests

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -9,7 +9,7 @@ set -e
 
 ci/bazelisk.sh test \
     --build_tests_only=true \
-    --test_timeout=2400,2400,3600,-1 \
+    --test_timeout=2400,2400,5400,-1 \
     --local_test_jobs=4 \
     --local_cpu_resources=4 \
     --test_tag_filters=verilator,-broken \


### PR DESCRIPTION
Sometimes CI fails due to the timeout of
`watchdog_functest_sim_verilator`.

This commit increases timeout from 3600 s to 5400 s.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>