### PR TITLE
Revert "[fusesoc] Use bazel-provided python to run fusesoc"

### DIFF
--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@nonhermetic//:env.bzl", "ENV")
-load("@ot_python_deps//:requirements.bzl", "entry_point")
 
 """Rules for running FuseSoC.
 
@@ -72,9 +71,9 @@ def _fusesoc_build_impl(ctx):
     ctx.actions.run(
         mnemonic = "FuseSoC",
         outputs = outputs,
-        inputs = ctx.files.srcs + ctx.files.cores + ctx.files._fusesoc,
+        inputs = ctx.files.srcs + ctx.files.cores,
         arguments = [args],
-        executable = ctx.executable._fusesoc,
+        executable = "fusesoc",
         use_default_shell_env = False,
         execution_requirements = {
             "no-sandbox": "",
@@ -104,10 +103,5 @@ fusesoc_build = rule(
         ),
         "verilator_options": attr.label(),
         "make_options": attr.label(),
-        "_fusesoc": attr.label(
-            default = entry_point("fusesoc"),
-            executable = True,
-            cfg = "exec",
-        ),
     },
 )


### PR DESCRIPTION
This reverts commit db7e744e5aae42b391bd9ab082f655da6b88d6a9.