### PR TITLE
bug fix

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -53,7 +53,7 @@ module pwrmgr_sec_cm_checker_assert
 
   `ASYNC_ASSERT(RomIntgChkDisFalse_A,
                 rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |->
-                (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On),
+                (lc_dft_en_i !== lc_ctrl_pkg::On || lc_hw_debug_en_i !== lc_ctrl_pkg::On),
                 (rom_intg_chk_dis | lc_dft_en_i | lc_hw_debug_en_i), reset_or_disable)
 
   // check rom_intg_chk_ok


### PR DESCRIPTION
Signed-off-by: Yehuda Bahar <yehuda.bachar@nuvoton.com>

The original assertion code is:
rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |-> (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On)

In simulation with UPF, VCMAIN when power is off, either net lc_dft_en_i or net lc_hw_debug_en_i may be 'X',
so the RHS expression will evaluate to 'X' which is false.
We want the RHS to evaluate to true if these nets not equal lc_ctrl_pkg::On.
