### PR TITLE
[usbdpi] DPI changes for additional usbdev testing

### DIFF
--- a/hw/dv/dpi/usbdpi/usb_monitor.h
+++ b/hw/dv/dpi/usbdpi/usb_monitor.h
@@ -12,25 +12,67 @@
  */
 typedef struct usb_monitor_ctx usb_monitor_ctx_t;
 
-/**
- * Create and initialise a USB monitor instance
- */
-usb_monitor_ctx_t *usb_monitor_init(const char *filename);
+// USB data callback types
+typedef enum {
+  UsbMon_DataType_Sync,
+  UsbMon_DataType_PID,
+  UsbMon_DataType_Byte,
+  UsbMon_DataType_EOP
+} usbmon_data_type_t;
 
 /**
- * Finalise a USB monitor
+ * Callback function for USB data
+ */
+typedef void (*usb_monitor_data_callback_t)(void *ctx_v,
+                                            usbmon_data_type_t type, uint8_t d);
+
+/**
+ * Create and initialize a USB monitor instance
+ *
+ * @param  filename  Filename to be used for log file
+ * @param  data_cb   USB data callback function
+ * @param  data_ctx  Context for data callback
+ * @return           USB monitor context
+ */
+usb_monitor_ctx_t *usb_monitor_init(const char *filename,
+                                    usb_monitor_data_callback_t data_cb,
+                                    void *data_ctx);
+
+/**
+ * Finalize a USB monitor
+ *
+ * @param mon        USB monitor context
  */
 void usb_monitor_fin(usb_monitor_ctx_t *mon);
 
 /**
  * Append a formatted message to the USB monitor log file
+ *
+ * @param mon        USB monitor context
+ * @param fmt        Format specifier for message
  */
 void usb_monitor_log(usb_monitor_ctx_t *mon, const char *fmt, ...);
 
 /**
  * Per-cycle monitoring of the USB
+ *
+ * @param mon        USB monitor context
+ * @param loglevel   Level of logging information required
+ * @param tick_bits  Elapsed simulation time in USB bit intervals (12Mbps)
+ * @param hdrive     Indicates whether the host is driving the bus
+ * @param d2p        Signals from USBDEV to DPI model
+ * @param p2d        Signals from DPI model to USBDEV
+ * @param lastpid    Receives the most-recently decoded PID (either direction)
  */
-void usb_monitor(usb_monitor_ctx_t *mon, int log, int tick, bool hdrive,
-                 uint32_t p2d, uint32_t d2p, uint8_t *lastpid);
+void usb_monitor(usb_monitor_ctx_t *mon, int log, uint32_t tick_bits,
+                 bool hdrive, uint32_t p2d, uint32_t d2p, uint8_t *lastpid);
+
+/**
+ * Export diagnostic state for waveform viewing
+ *
+ * @param mon        USB monitor context
+ * @return           Diagnostic state information (see usbdpi.sv)
+ */
+uint32_t usb_monitor_diags(usb_monitor_ctx_t *mon);
 
 #endif  // OPENTITAN_HW_DV_DPI_USBDPI_USB_MONITOR_H_

--- a/hw/dv/dpi/usbdpi/usb_utils.c
+++ b/hw/dv/dpi/usbdpi/usb_utils.c
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "usb_utils.h"
+
+#include <stdio.h>
+
+static const char *pid_names[] = {
+    "Rsvd",     //         0000b
+    "OUT",      //         0001b
+    "ACK",      //         0010b
+    "DATA0",    //         0011b
+    "PING",     //         0100b
+    "SOF",      //         0101b
+    "NYET",     //         0110b
+    "DATA2",    //         0111b
+    "SPLIT",    //         1000b
+    "IN",       //         1001b
+    "NAK",      //         1010b
+    "DATA1",    //         1011b
+    "PRE/ERR",  //         1100b
+    "SETUP",    //         1101b
+    "STALL",    //         1110b
+    "MDATA"     //         1111b
+};
+
+// Decode a PID and return its textual name, iff valid
+const char *decode_pid(uint8_t pid) {
+  // Valid PIDs are formed from two complementary nibbles
+  return (((pid ^ 0xf0u) >> 4) ^ (pid & 0xfu)) ? "???" : pid_names[pid & 0xfu];
+}
+
+// Dump a sequence of bytes as hexadecimal and AsCII for diagnostic purposes
+void dump_bytes(FILE *out, const char *prefix, const uint8_t *data, size_t n,
+                uint32_t flags) {
+  static const char hex_digits[] = "0123456789abcdef";
+  const unsigned ncols = 0x10u;
+  char buf[ncols * 4u + 2u];
+
+  if (!prefix) {
+    prefix = "";
+  }
+
+  // Note: we have no generic printf functionality and must use LOG_INFO()
+  while (n > 0u) {
+    const unsigned chunk = (n > ncols) ? ncols : (unsigned)n;
+    const uint8_t *row = data;
+    unsigned idx = 0u;
+    char *dp = buf;
+
+    // Columns of hexadecimal bytes
+    while (idx < chunk) {
+      dp[0] = hex_digits[row[idx] >> 4];
+      dp[1] = hex_digits[row[idx++] & 0xfu];
+      dp[2] = ' ';
+      dp += 3;
+    }
+    while (idx++ < ncols) {
+      dp[2] = dp[1] = dp[0] = ' ';
+      dp += 3;
+    }
+
+    // Printable ASCII characters
+    for (unsigned idx = 0u; idx < chunk; idx++) {
+      char ch = row[idx];
+      *dp++ = (ch < ' ' || ch >= 0x80u) ? '.' : ch;
+    }
+    *dp = '\0';
+    fprintf(out, "%s%s\n", prefix, buf);
+    data += chunk;
+    n -= chunk;
+  }
+}
+
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
+extern uint16_t get_le16(const uint8_t *dp);
+extern uint32_t get_le32(const uint8_t *dp);
+extern uint8_t *set_le16(uint8_t *dp, uint16_t n);
+extern uint8_t *set_le32(uint8_t *dp, uint32_t n);

--- a/hw/dv/dpi/usbdpi/usb_utils.h
+++ b/hw/dv/dpi/usbdpi/usb_utils.h
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_DPI_USBDPI_USB_UTILS_H_
+#define OPENTITAN_HW_DV_DPI_USBDPI_USB_UTILS_H_
+#include <stdint.h>
+#include <stdio.h>
+
+/**
+ * Decode a PID and return its textual name, iff valid
+ *
+ * @param pid        Packet IDentifier to be decoded
+ * @return           Textual name of PID (or "???")
+ */
+const char *decode_pid(uint8_t pid);
+
+/**
+ * Dump a sequence of bytes as hexadecimal and AsCII for diagnostic purposes
+ *
+ * @param file       Handle of output file
+ * @param prefix     Optional prefix for each output line
+ * @param data       First byte of data to be output
+ * @param n          Number of bytes
+ * @param flags      Formatting flags (reserved, SBZ)
+ */
+void dump_bytes(FILE *out, const char *prefix, const uint8_t *data, size_t n,
+                uint32_t flags);
+
+/**
+ * Utility function that reads a 16-bit value from a byte stream in little
+ * endian order, as per USB convention
+ *
+ * @param  dp        Pointer to first byte in stream
+ * @return           Value read
+ */
+inline uint16_t get_le16(const uint8_t *dp) { return dp[0] | (dp[1] << 8); }
+
+/**
+ * Utility function that reads a 32-bit value from a byte stream in little
+ * endian order, as per USB convention
+ *
+ * @param  dp        Pointer to first byte in stream
+ * @return           Value read
+ */
+inline uint32_t get_le32(const uint8_t *dp) {
+  return dp[0] | ((uint32_t)dp[1] << 8) | ((uint32_t)dp[2] << 16) |
+         ((uint32_t)dp[3] << 24);
+}
+
+/**
+ * Utility function that writes a 16-bit value into a byte stream in little
+ * endian order, as per USB convention
+ *
+ * @param  dp        Pointer into stream to receive first byte
+ * @param  n         Value to be written
+ * @return           Pointer beyond the bytes written
+ */
+inline uint8_t *set_le16(uint8_t *dp, uint16_t n) {
+  dp[0] = (uint8_t)n;
+  dp[1] = (uint8_t)(n >> 8);
+  return dp + 2;
+}
+
+/**
+ * Utility function that writes a 32-bit value into a byte stream in little
+ * endian order, as per USB convention
+ *
+ * @param  dp        Pointer into stream to receive first byte
+ * @param  n         Value to be written
+ * @return           Pointer beyond the bytes written
+ */
+inline uint8_t *set_le32(uint8_t *dp, uint32_t n) {
+  dp[0] = (uint8_t)n;
+  dp[1] = (uint8_t)(n >> 8);
+  dp[2] = (uint8_t)(n >> 16);
+  dp[3] = (uint8_t)(n >> 24);
+  return dp + 4;
+}
+
+#endif  // OPENTITAN_HW_DV_DPI_USBDPI_USB_UTILS_H_

--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifdef __linux__
-#include <pty.h>
-#elif __APPLE__
-#include <util.h>
-#endif
+#include "usbdpi.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -20,59 +16,65 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "usbdpi.h"
+#include "usb_utils.h"
+#include "usbdpi_test.h"
 
-// Next DATAx PID to be used (transmission) or expected (reception)
-#define DATA_TOGGLE_ADVANCE(pid) \
-  ((pid) == USB_PID_DATA1 ? USB_PID_DATA0 : USB_PID_DATA1)
-
-// Historically the simulation started too fast to connect to all
-// the fifos and terminals without loss of output. So a delay was added.
-// Today the startup is slow enough this does not seem to be needed.
-// In case things change again Im going to leave this behind a define
-// for now, but if this continues not to be needed the code can be deleted.
-// Uncomment next line if you need the delay
-// #define NEED_SLEEP
-
-// TODO - introduce setting of device configuration; initially we're refactoring
-//        without changing/extending behaviour
-// #define SET_DEV_CONFIG
-
+// Indexed directly by ctx->state (ST_)
 static const char *st_states[] = {"ST_IDLE 0", "ST_SEND 1", "ST_GET 2",
                                   "ST_SYNC 3", "ST_EOP 4",  "ST_EOP0 5"};
 
+// Indexed directly by ct-x>hostSt (HS_)
 static const char *hs_states[] = {
     "HS_STARTFRAME 0", "HS_WAITACK 1",   "HS_SET_DATASTAGE 2", "HS_DS_RXDATA 3",
     "HS_DS_SENDACK 4", "HS_DONEDADR 5",  "HS_REQDATA 6",       "HS_WAITDATA 7",
     "HS_SENDACK 8",    "HS_WAIT_PKT 9",  "HS_ACKIFDATA 10",    "HS_SENDHI 11",
-    "HS_EMPTYDATA 12", "HS_WAITACK2 13", "HS_NEXTFRAME 14"};
+    "HS_EMPTYDATA 12", "HS_WAITACK2 13", "HS_STREAMOUT 14",    "HS_STREAMIN 15",
+    "HS_NEXTFRAME 16"};
 
-static void pollRX(usbdpi_ctx_t *ctx, uint8_t endpoint, uint8_t pid,
-                   bool bSendHi, bool bNakData);
+static const char *decode_usb[] = {"SE0", "0-K", "1-J", "SE1"};
 
-// Get Baud
-static void readBaud(usbdpi_ctx_t *ctx);
+// Optionally invert the signals the host is driving, according to bus
+// configuration
+static uint32_t inv_driving(usbdpi_ctx_t *ctx, uint32_t d2p);
+
+// Request IN transfer. Get back NAK or DATA0/DATA1.
+static void pollRX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool send_hi,
+                   bool nak_data);
+// Get Baud (Vendor-specific)
+static void readBaud(usbdpi_ctx_t *ctx, uint8_t endpoint);
+
+// Get Test Configuration (Vendor-specific)
+static void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len);
 
 // Get Descriptor
-static void readDescriptor(usbdpi_ctx_t *ctx);
-
-// Set Baud
-static void setBaud(usbdpi_ctx_t *ctx);
+static void getDescriptor(usbdpi_ctx_t *ctx, uint8_t desc_type,
+                          uint8_t desc_idx, uint16_t desc_len);
+// Set Baud (Vendor-specific)
+static void setBaud(usbdpi_ctx_t *ctx, uint8_t endpoint);
 
 // Set device address (with null data stage)
 static void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr);
 
 // Set device configuration
-#if SET_DEVICE_CONFIG
-static void setDeviceConfiguration(usbdpi_ctx_t *ctx);
-#endif
+static void setDeviceConfiguration(usbdpi_ctx_t *ctx, uint8_t config);
+
+// Set test status, reporting progress/success/failure (Vendor-specific)
+static void setTestStatus(usbdpi_ctx_t *ctx, uint32_t status, const char *msg);
+
+// Change DP and DN outputs from host
+static uint32_t set_driving(usbdpi_ctx_t *ctx, uint32_t d2p, uint32_t newval);
 
 // Try to send OUT transfer. Optionally expect Status packet (eg. ACK|NAK) in
 // response
 static void tryTX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool bExpectStatus);
+
 // Test the ischronous transfers (without ACKs)
 // static void testIso(usbdpi_ctx_t *ctx);
 #define testIso(ctx) tryTX((ctx), ENDPOINT_ISOCHRONOUS, false)
+
+// Callback for USB data detection
+static void usbdpi_data_callback(void *ctx_v, usbmon_data_type_t type,
+                                 uint8_t d);
 
 /**
  * Create a USB DPI instance, returning a 'chandle' for later use
@@ -82,36 +84,32 @@ void *usbdpi_create(const char *name, int loglevel) {
   usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)calloc(1, sizeof(usbdpi_ctx_t));
   assert(ctx);
 
-  // Note: calloc has initialised most of the fields for us
+  // Note: calloc has initialized most of the fields for us
   // ctx->tick = 0;
   // ctx->tick_bits = 0;
   // ctx->frame = 0;
   // ctx->framepend = 0;
-  // ctx->lastframe = 0;
+  // ctx->frame_start = 0;
   // ctx->last_pu = 0;
   // ctx->driving = 0;
   // ctx->baudrate_set_successfully = 0;
 
-  // First DATAx received shall be DATA0
-  ctx->rx_next_data = USB_PID_DATA0;
+  // Initialize state for each endpoint and direction
+  for (unsigned ep = 0U; ep < USBDPI_MAX_ENDPOINTS; ep++) {
+    // First DATAx received shall be DATA0
+    ctx->ep_in[ep].next_data = USB_PID_DATA0;
 
-  // First DATAx transmitted shall be DATA0 because it must follow a SETUP
-  // transaction
-  ctx->tx_next_data = USB_PID_DATA0;
-
-  // Note: we hold off polling for IN transfers until after we've
-  //       performed some basic iniitalisation and the polling-based host
-  //       software is ready to respond
-  //
-  // TODO - change this to a proper state machine to sequence the traffic
-  ctx->inframe = 4U;
+    // First DATAx transmitted shall be DATA0 because it must follow a SETUP
+    // transaction
+    ctx->ep_out[ep].next_data = USB_PID_DATA0;
+  }
 
   ctx->state = ST_IDLE;
   ctx->hostSt = HS_NEXTFRAME;
   ctx->loglevel = loglevel;
 
-  // NOTE: it would perhaps be preferable to move the file handling into the
-  //       monitor itself, but at the moment we use its file handle here...
+  ctx->step = STEP_BUS_RESET;
+
   char cwd[FILENAME_MAX];
   char *cwd_rv;
   cwd_rv = getcwd(cwd, sizeof(cwd));
@@ -121,7 +119,7 @@ void *usbdpi_create(const char *name, int loglevel) {
   int rv = snprintf(ctx->mon_pathname, FILENAME_MAX, "%s/%s.log", cwd, name);
   assert(rv <= FILENAME_MAX && rv > 0);
 
-  ctx->mon = usb_monitor_init(ctx->mon_pathname);
+  ctx->mon = usb_monitor_init(ctx->mon_pathname, usbdpi_data_callback, ctx);
 
   // Prepare the transfer descriptors for use
   usb_transfer_setup(ctx);
@@ -129,51 +127,14 @@ void *usbdpi_create(const char *name, int loglevel) {
   return (void *)ctx;
 }
 
-const char *decode_usb[] = {"SE0", "0-K", "1-J", "SE1"};
-
 void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
-  int d2p = usb_d2p[0];
-  int dp, dn;
-
   usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)ctx_void;
   assert(ctx);
 
-  char raw_str[D2P_BITS + 1];
-  {
-    int i;
-    for (i = 0; i < D2P_BITS; i++) {
-      raw_str[D2P_BITS - i - 1] = d2p & (1 << i) ? '1' : '0';
-    }
-  }
-  raw_str[D2P_BITS] = 0;
-
-  if (d2p & (D2P_DP_EN | D2P_DN_EN | D2P_D_EN)) {
-    if (ctx->state == ST_SEND) {
-      printf(
-          "[usbdpi] frame 0x%x tick_bits 0x%x error state %s hs %s and device "
-          "drives\n",
-          ctx->frame, ctx->tick_bits, st_states[ctx->state],
-          hs_states[ctx->hostSt]);
-    }
-    ctx->state = ST_GET;
-  } else {
-    if (ctx->state == ST_GET) {
-      ctx->state = ST_IDLE;
-    }
-  }
-
-  if ((d2p & D2P_DNPU) && (d2p & D2P_DPPU)) {
-    printf("[usbdpi] frame 0x%x tick_bits 0x%x error both pullups are driven\n",
-           ctx->frame, ctx->tick_bits);
-  }
-  if ((d2p & D2P_PU) != ctx->last_pu) {
-    usb_monitor_log(ctx->mon, "%4x %8d Pullup change to %s%s%s\n", ctx->frame,
-                    ctx->tick, (d2p & D2P_DPPU) ? "DP Pulled up " : "",
-                    (d2p & D2P_DNPU) ? "DN Pulled up " : "",
-                    (d2p & D2P_TX_USE_D_SE0) ? "SingleEnded" : "Differential");
-
-    ctx->last_pu = d2p & D2P_PU;
-  }
+  // Ascertain the state of the D+/D- signals from the device
+  // TODO - migrate to a simple function
+  uint32_t d2p = usb_d2p[0];
+  unsigned dp, dn;
   if (d2p & D2P_TX_USE_D_SE0) {
     // Single-ended mode uses D and SE0
     if (d2p & D2P_D_EN) {
@@ -192,7 +153,7 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
   } else {
     // Normal D+/D- mode
     if (d2p & D2P_DNPU) {
-      // DN pullup would say DP and DN are swapped
+      // Assertion of DN pullup suggests DP and DN are swapped
       dp = ((d2p & D2P_DN_EN) && (d2p & D2P_DN)) ||
            (!(d2p & D2P_DN_EN) && (d2p & D2P_DNPU));
       dn = (d2p & D2P_DP_EN) && (d2p & D2P_DP);
@@ -204,7 +165,73 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
     }
   }
 
+  // TODO - check the timing of the device responses to ensure compliance with
+  // the specification; the response time of acknowledgements, for example, has
+  // a hard real time requirement that is specified in terms of bit intervals
+  if (d2p & (D2P_DP_EN | D2P_DN_EN | D2P_D_EN)) {
+    switch (ctx->state) {
+      // Host to device transmission
+      case ST_SYNC:
+      case ST_SEND:
+      case ST_EOP:
+      case ST_EOP0:
+        printf(
+            "[usbdpi] frame 0x%x tick_bits 0x%x error state %s hs %s and "
+            "device "
+            "drives\n",
+            ctx->frame, ctx->tick_bits, st_states[ctx->state],
+            hs_states[ctx->hostSt]);
+        break;
+
+      // Device to host transmission; collect the bits
+      case ST_GET:
+        // TODO - perform bit-level decoding and packet construction here rather
+        // than relying upon usb_monitor to do that
+        // TODO - synchronize with the device transmission and check that the
+        // signals remain stable across all 4 cycles of the bit interval
+        break;
+
+      case ST_IDLE:
+        // Nothing to do
+        break;
+
+      default:
+        assert(!"Invalid/unknown state");
+        break;
+    }
+
+    ctx->state = ST_GET;
+  } else {
+    if (ctx->state == ST_GET) {
+      ctx->state = ST_IDLE;
+    }
+  }
+
+  if ((d2p & D2P_DNPU) && (d2p & D2P_DPPU)) {
+    printf("[usbdpi] frame 0x%x tick_bits 0x%x error both pullups are driven\n",
+           ctx->frame, ctx->tick_bits);
+  }
+  if ((d2p & D2P_PU) != ctx->last_pu) {
+    usb_monitor_log(ctx->mon, "0x%-3x 0x%-8x Pullup change to %s%s%s\n",
+                    ctx->frame, ctx->tick_bits,
+                    (d2p & D2P_DPPU) ? "DP Pulled up " : "",
+                    (d2p & D2P_DNPU) ? "DN Pulled up " : "",
+                    (d2p & D2P_TX_USE_D_SE0) ? "SingleEnded" : "Differential");
+
+    ctx->last_pu = d2p & D2P_PU;
+  }
+
+  // TODO - prime candidate for a function
   if (ctx->loglevel & LOG_BIT) {
+    char raw_str[D2P_BITS + 1];
+    {
+      int i;
+      for (i = 0; i < D2P_BITS; i++) {
+        raw_str[D2P_BITS - i - 1] = d2p & (1 << i) ? '1' : '0';
+      }
+    }
+    raw_str[D2P_BITS] = 0;
+
     const char *pullup = (d2p & D2P_PU) ? "PU" : "  ";
     const char *state =
         (ctx->state == ST_GET) ? decode_usb[dp << 1 | dn] : "ZZ ";
@@ -213,8 +240,9 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
   }
 
   // Device-to-Host EOP
-  if (ctx->state == ST_GET && dp == 0 && dp == 0) {
+  if (ctx->state == ST_GET && dp == 0 && dn == 0) {
     switch (ctx->bus_state) {
+      // Control Transfers
       case kUsbControlSetup:
         ctx->bus_state = kUsbControlSetupAck;
         break;
@@ -230,13 +258,84 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
       case kUsbControlStatusOut:
         ctx->bus_state = kUsbControlStatusOutAck;
         break;
+
+      // Bulk Transfers
       case kUsbBulkOut:
         ctx->bus_state = kUsbBulkOutAck;
         break;
       case kUsbBulkInToken:
         ctx->bus_state = kUsbBulkInData;
-      default:;
+        break;
+
+      default:
+        break;
     }
+  }
+}
+
+// Callback for USB data detection
+// - the DPI host model presently does not duplicate the bit-level decoding and
+//   packet construction of the usb_monitor, so we piggyback on its decoding and
+//   trust it to be neutral.
+//
+// Note: this is invoked for any byte transferred over the USB; both
+// host-to-device and device-to-host traffic
+void usbdpi_data_callback(void *ctx_v, usbmon_data_type_t type, uint8_t d) {
+  usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)ctx_v;
+  assert(ctx);
+  if (!ctx->recving) {
+    ctx->recving = transfer_alloc(ctx);
+  }
+
+  // We are interested only in the packets from device to host
+  if (ctx->state != ST_GET) {
+    return;
+  }
+
+  usbdpi_transfer_t *tr = ctx->recving;
+  // TODO - commute to run time error indicating buffer exhaustion
+  assert(tr);
+  if (tr) {
+    if (false) {  // ctx->loglevel & LOG_MON) {
+      printf("[usbdpi] data type %u d 0x%02x\n", type, d);
+    }
+
+    bool ok = false;
+    switch (type) {
+      case UsbMon_DataType_Sync:
+        // Initialize/rewind the received transfer
+        transfer_init(tr);
+        ok = true;
+        break;
+      case UsbMon_DataType_EOP:
+        ok = true;
+        break;
+      // Collect the PID and any subsequent data bytes
+      case UsbMon_DataType_PID:
+        switch (d) {
+          case USB_PID_DATA0:
+          case USB_PID_DATA1: {
+            // TODO - this records the start of the data field with the
+            // current transfer descriptors
+            uint8_t *dp = transfer_data_start(tr, d, 0U);
+            ok = (dp != NULL);
+          } break;
+          default:
+            ok = transfer_append(tr, &d, 1);
+            break;
+        }
+        break;
+      // Collect data field
+      case UsbMon_DataType_Byte:
+        ok = transfer_append(tr, &d, 1);
+        break;
+      default:
+        assert(!"Unknown/unhandled rx type from monitor");
+        break;
+    }
+
+    // TODO - commute to run time error indicating excessive packet length
+    assert(ok);
   }
 }
 
@@ -258,7 +357,7 @@ void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr) {
       dp[2] = dev_addr;  // device address
       dp[3] = 0;
       // Trigger bitstuffing, technically the device
-      // behaviour is unspecified with wIndex != 0
+      // behavior is unspecified with wIndex != 0
       dp[4] = 0xFF;  // wIndex = 0xFF00
       dp[5] = 0;
       dp[6] = 0;  // wLength = 0
@@ -269,7 +368,6 @@ void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr) {
         dp[9] ^= 0x01u;
       }
       transfer_send(ctx, tr);
-
       ctx->bus_state = kUsbControlSetup;
       ctx->hostSt = HS_WAITACK;
       break;
@@ -282,7 +380,6 @@ void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr) {
           ctx->tick_bits >= ctx->wait) {
         transfer_token(tr, USB_PID_IN, 0, 0);
         transfer_send(ctx, tr);
-
         ctx->bus_state = kUsbControlStatusInToken;
         ctx->hostSt = HS_DS_RXDATA;
       }
@@ -297,6 +394,10 @@ void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr) {
         transfer_status(ctx, tr, USB_PID_ACK);
         ctx->bus_state = kUsbIdle;
         ctx->hostSt = HS_NEXTFRAME;
+
+        // Remember the assigned device address
+        ctx->dev_address = dev_addr;
+
         printf("[usbdpi] setDeviceAddress done\n");
       }
       break;
@@ -305,27 +406,22 @@ void setDeviceAddress(usbdpi_ctx_t *ctx, uint8_t dev_addr) {
   }
 }
 
-#if SET_DEV_CONFIG
 // Set device configuration
-void setDeviceConfiguration(uspdpi_ctx_t *ctx) {}
-#endif
-
-// Get Descriptor
-void readDescriptor(usbdpi_ctx_t *ctx) {
+void setDeviceConfiguration(usbdpi_ctx_t *ctx, uint8_t config) {
   usbdpi_transfer_t *tr = ctx->sending;
   uint8_t *dp;
   switch (ctx->hostSt) {
     case HS_STARTFRAME:
       transfer_token(tr, USB_PID_SETUP, ctx->dev_address, ENDPOINT_ZERO);
 
-      dp = transfer_data_start(tr, USB_PID_DATA0, 0);
-      dp[0] = 0x80;  // d2h, std, device
-      dp[1] = USB_REQ_GET_DESCRIPTOR;
-      dp[2] = 0;  // index 0
-      dp[3] = 1;  // type device
+      dp = transfer_data_start(tr, USB_PID_DATA0, 8);
+      dp[0] = 0;  // h2d, std, device
+      dp[1] = USB_REQ_SET_CONFIGURATION;
+      dp[2] = config;
+      dp[3] = 0;
       dp[4] = 0;  // wIndex = 0
       dp[5] = 0;
-      dp[6] = 0x12;  // wLength = 18
+      dp[6] = 0;  // wLength = 0
       dp[7] = 0;
       transfer_data_end(tr, dp + 8);
 
@@ -335,11 +431,57 @@ void readDescriptor(usbdpi_ctx_t *ctx) {
       break;
     case HS_WAITACK:
       ctx->wait = ctx->tick_bits + 532;  // HACK
+      ctx->hostSt = HS_SET_DATASTAGE;
+      break;
+    case HS_SET_DATASTAGE:
+      if (ctx->bus_state == kUsbControlSetupAck &&
+          ctx->tick_bits >= ctx->wait) {
+        transfer_token(tr, USB_PID_IN, ctx->dev_address, ENDPOINT_ZERO);
+        transfer_send(ctx, tr);
+        ctx->bus_state = kUsbControlStatusInToken;
+        ctx->hostSt = HS_DS_RXDATA;
+      }
+      break;
+    case HS_DS_RXDATA:
+      ctx->wait = ctx->tick_bits + 24;  // HACK -- 2 bytes
+      ctx->hostSt = HS_DS_SENDACK;
+      break;
+    case HS_DS_SENDACK:
+      if (ctx->bus_state == kUsbControlStatusInData ||
+          ctx->tick_bits >= ctx->wait) {
+        transfer_status(ctx, tr, USB_PID_ACK);
+        ctx->bus_state = kUsbIdle;
+        ctx->hostSt = HS_NEXTFRAME;
+        printf("[usbdpi] setDeviceConfiguration done\n");
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+// Get Descriptor
+void getDescriptor(usbdpi_ctx_t *ctx, uint8_t desc_type, uint8_t desc_idx,
+                   uint16_t desc_len) {
+  usbdpi_transfer_t *tr = ctx->sending;
+  uint8_t *dp;
+  switch (ctx->hostSt) {
+    case HS_STARTFRAME: {
+      // TODO - build the bmRequestType by ORing values
+      const uint8_t bmRequestType = 0x80;  // d2h, vendor, endpoint
+      uint16_t wValue = (desc_type << 8) | (uint8_t)desc_idx;
+      transfer_setup(ctx, tr, bmRequestType, USB_REQ_GET_DESCRIPTOR, wValue, 0U,
+                     desc_len);
+    } break;
+    case HS_WAITACK:
+      ctx->wait = ctx->tick_bits + 1164;  // HACK
       ctx->hostSt = HS_REQDATA;
       break;
     case HS_REQDATA:
-      if (ctx->bus_state == kUsbControlSetupAck &&
-          ctx->tick_bits >= ctx->wait) {
+      // TODO - we must wait before trying the IN because we currently
+      // do not retry after a NAK response, but the CPU software can be tardy
+      if (ctx->tick_bits >= ctx->wait &&
+          ctx->bus_state == kUsbControlSetupAck) {
         transfer_token(tr, USB_PID_IN, ctx->dev_address, ENDPOINT_ZERO);
 
         transfer_send(ctx, tr);
@@ -352,40 +494,85 @@ void readDescriptor(usbdpi_ctx_t *ctx) {
       ctx->hostSt = HS_SENDACK;
       break;
     case HS_SENDACK:
-      if (ctx->tick_bits >= ctx->wait) {
-        printf("[usbdpi] Timed out waiting for device\n");
-        ctx->hostSt = HS_NEXTFRAME;
-        ctx->bus_state = kUsbIdle;
-      }
       if (ctx->bus_state == kUsbControlDataInData) {
+        if (ctx->step == STEP_GET_CONFIG_DESCRIPTOR) {
+          // Check the GET_DESCRIPTOR response
+          assert(ctx->recving);
+
+          // TODO - detect when the returned data falls short of the requested
+          // transfer length
+          uint8_t *dp = transfer_data_field(ctx->recving);
+          assert(dp);
+          // Collect the returned values
+          // uint8_t  bLength = dp[0];
+          // uint8_t  bDescriptorType = dp[1];
+          uint16_t wTotalLength = dp[2] | (dp[3] << 8);
+          // uint8_t  bNumInterfaces = dp[4];
+
+          ctx->cfg_desc_len = wTotalLength;
+        }
+
         transfer_token(tr, USB_PID_ACK, ctx->dev_address, ENDPOINT_ZERO);
 
         transfer_send(ctx, tr);
-
         ctx->bus_state = kUsbControlDataInAck;
         ctx->hostSt = HS_WAIT_PKT;
 
         ctx->wait = ctx->tick_bits + 200;  // HACK
+      } else if (ctx->tick_bits >= ctx->wait) {
+        printf("[usbdpi] Timed out waiting for device\n");
+        ctx->hostSt = HS_NEXTFRAME;
+        ctx->bus_state = kUsbIdle;
       }
       break;
     case HS_WAIT_PKT:
+      // TODO - introduce support for multiple packets when we've requested
+      // longer transfers
       if (ctx->tick_bits >= ctx->wait) {
         ctx->hostSt = HS_EMPTYDATA;
       }
       break;
     case HS_EMPTYDATA:
-      // Transmit OUT transaction with no DATA packet
+      // Status stage of Control Read
+      // Transmit zero-length data packet and await handshake
       transfer_token(tr, USB_PID_OUT, ctx->dev_address, ENDPOINT_ZERO);
 
+      dp = transfer_data_start(tr, USB_PID_DATA1, 0);
+      transfer_data_end(tr, dp);
       transfer_send(ctx, tr);
       ctx->bus_state = kUsbControlStatusOut;
       ctx->hostSt = HS_WAITACK2;
-
       ctx->wait = ctx->tick_bits + 200;  // HACK
       break;
     case HS_WAITACK2:
-      if (ctx->tick_bits >= ctx->wait ||
-          ctx->bus_state == kUsbControlStatusOutAck) {
+      if (ctx->bus_state == kUsbControlStatusOutAck) {
+        switch (ctx->lastrxpid) {
+          case USB_PID_ACK:
+            ctx->ep_out[ENDPOINT_ZERO].next_data =
+                DATA_TOGGLE_ADVANCE(ctx->ep_out[ENDPOINT_ZERO].next_data);
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+
+          case USB_PID_NAK:
+            // TODO - this means that the device is still busy
+            ctx->hostSt = HS_WAITACK2;
+            ctx->wait = ctx->tick_bits + 200;  // HACK
+            break;
+
+          // TODO - commute these other responses into test failures
+          case USB_PID_STALL:
+            printf("[usbdpi] Device stalled\n");
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+          default:
+            printf("[usbdpi] Unexpected handshake response 0x%02x\n",
+                   ctx->lastrxpid);
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+        }
+      } else if (ctx->tick_bits >= ctx->wait) {
+        printf(
+            "[usbdpi] Time out waiting for device response in Status Stage\n");
         ctx->hostSt = HS_NEXTFRAME;
       }
       break;
@@ -394,13 +581,172 @@ void readDescriptor(usbdpi_ctx_t *ctx) {
   }
 }
 
-// Get Baud
-void readBaud(usbdpi_ctx_t *ctx) {
+// Get Test Configuration (Vendor-specific)
+void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len) {
+  usbdpi_transfer_t *tr = ctx->sending;
+  uint8_t *dp;
+  assert(tr);
+  switch (ctx->hostSt) {
+    case HS_STARTFRAME: {
+      const uint8_t bmRequestType = 0xc2;  // d2h, vendor, endpoint
+      transfer_setup(ctx, tr, bmRequestType, USBDPI_VENDOR_TEST_CONFIG, 0U, 0U,
+                     desc_len);
+    } break;
+    case HS_WAITACK:
+      ctx->wait = ctx->tick_bits + 1164;  // HACK
+      ctx->hostSt = HS_REQDATA;
+      break;
+    case HS_REQDATA:
+      // TODO - we must wait before trying the IN because we currently
+      // do not retry after a NAK response, but the CPU software can be tardy
+      if (ctx->tick_bits >= ctx->wait &&
+          ctx->bus_state == kUsbControlSetupAck) {
+        transfer_token(tr, USB_PID_IN, ctx->dev_address, ENDPOINT_ZERO);
+
+        transfer_send(ctx, tr);
+        ctx->bus_state = kUsbControlDataInToken;
+        ctx->hostSt = HS_WAITDATA;
+      }
+      break;
+    case HS_WAITDATA:
+      ctx->wait = ctx->tick_bits + 2000;  // HACK
+      ctx->hostSt = HS_SENDACK;
+      break;
+    case HS_SENDACK:
+      if (ctx->bus_state == kUsbControlDataInData) {
+        switch (ctx->lastrxpid) {
+          case USB_PID_DATA1: {
+            usbdpi_transfer_t *rx = ctx->recving;
+            assert(rx);
+            // TODO - check the length of the received data field!
+            uint8_t *dp = transfer_data_field(rx);
+            assert(dp);
+            // Validate the first part of the test descriptor
+            printf("[usbdpi] Test descriptor 0x%.8X\n", get_le32(dp));
+
+            transfer_dump(rx, stdout);
+
+            // Check the header signature
+            const uint8_t test_sig_head[] = {0x7eu, 0x57u, 0xc0u, 0xf1u};
+            const uint8_t test_sig_tail[] = {0x1fu, 0x0cu, 0x75u, 0xe7u};
+            if (!memcmp(dp, test_sig_head, 4) && 0x10 == get_le16(&dp[4]) &&
+                !memcmp(&dp[12], test_sig_tail, 4)) {
+              ctx->test_number = get_le16(&dp[6]);
+              ctx->test_arg[0] = dp[8];
+              ctx->test_arg[1] = dp[9];
+              ctx->test_arg[2] = dp[10];
+              ctx->test_arg[3] = dp[11];
+
+              printf("[usbdpi] Test number 0x%04x args %02x %02x %02x %02x\n",
+                     ctx->test_number, ctx->test_arg[0], ctx->test_arg[1],
+                     ctx->test_arg[2], ctx->test_arg[3]);
+
+              usbdpi_test_init(ctx);
+            } else {
+              printf(
+                  "[usbdpi] Invalid/unrecognised test descriptor received\n");
+              assert(!"Cannot proceed without test descriptor");
+            }
+          } break;
+
+          case USB_PID_NAK:
+            // TODO - we should retry the request in this case
+            printf("[usbdpi] Unable to retrieve test config\n");
+            assert(!"DPI is unable to retrieve test config");
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+
+          case USB_PID_STALL:
+            printf("[usbdpi] Device stalled\n");
+            assert(!"Device is stalled");
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+          default:
+            printf("[usbdpi] Unexpected handshake response 0x%02x\n",
+                   ctx->lastrxpid);
+            assert(!"Unexpected handshake response");
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+        }
+        transfer_token(tr, USB_PID_ACK, ctx->dev_address, ENDPOINT_ZERO);
+
+        transfer_send(ctx, tr);
+        ctx->bus_state = kUsbControlDataInAck;
+        ctx->hostSt = HS_WAIT_PKT;
+
+        ctx->wait = ctx->tick_bits + 200;  // HACK
+      } else if (ctx->tick_bits >= ctx->wait) {
+        printf("[usbdpi] Timed out waiting for device\n");
+        ctx->hostSt = HS_NEXTFRAME;
+        ctx->bus_state = kUsbIdle;
+      }
+      break;
+    case HS_WAIT_PKT:
+      if (ctx->tick_bits >= ctx->wait) {
+        ctx->hostSt = HS_EMPTYDATA;
+      }
+      break;
+    case HS_EMPTYDATA:
+      // Status stage of Control Read
+      // Transmit zero-length data packet and await handshake
+      transfer_token(tr, USB_PID_OUT, ctx->dev_address, ENDPOINT_ZERO);
+
+      dp = transfer_data_start(tr, USB_PID_DATA1, 0);
+      transfer_data_end(tr, dp);
+      transfer_send(ctx, tr);
+      ctx->bus_state = kUsbControlStatusOut;
+      ctx->hostSt = HS_WAITACK2;
+      ctx->wait = ctx->tick_bits + 200;  // HACK
+      break;
+    case HS_WAITACK2:
+      if (ctx->bus_state == kUsbControlStatusOutAck) {
+        switch (ctx->lastrxpid) {
+          case USB_PID_ACK:
+            ctx->ep_out[ENDPOINT_ZERO].next_data =
+                DATA_TOGGLE_ADVANCE(ctx->ep_out[ENDPOINT_ZERO].next_data);
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+
+          case USB_PID_NAK:
+            // TODO - this means that the device is still busy
+            ctx->hostSt = HS_WAITACK2;
+            ctx->wait = ctx->tick_bits + 200;  // HACK
+            break;
+
+          // TODO - commute these other responses into test failures
+          case USB_PID_STALL:
+            printf("[usbdpi] Device stalled\n");
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+          default:
+            printf("[usbdpi] Unexpected handshake response 0x%02x\n",
+                   ctx->lastrxpid);
+            ctx->hostSt = HS_NEXTFRAME;
+            break;
+        }
+      } else if (ctx->tick_bits >= ctx->wait) {
+        printf(
+            "[usbdpi] Time out waiting for device response in Status Stage\n");
+        ctx->hostSt = HS_NEXTFRAME;
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+// Set Test Status, reporting progress/success/failure (Vendor-specific)
+void setTestStatus(usbdpi_ctx_t *ctx, uint32_t status, const char *msg) {
+  // TODO - placeholder for reporting of test status reporting and termination
+}
+
+// Get Baud (Vendor-specific)
+void readBaud(usbdpi_ctx_t *ctx, uint8_t endpoint) {
   usbdpi_transfer_t *tr = ctx->sending;
   uint8_t *dp;
   switch (ctx->hostSt) {
     case HS_STARTFRAME:
-      transfer_token(tr, USB_PID_SETUP, ctx->dev_address, ENDPOINT_ZERO);
+      transfer_token(tr, USB_PID_SETUP, ctx->dev_address, endpoint);
 
       dp = transfer_data_start(tr, USB_PID_DATA0, 0);
       dp[0] = 0xc2;  // d2h, vendor, endpoint
@@ -413,8 +759,8 @@ void readBaud(usbdpi_ctx_t *ctx) {
       dp[7] = 0;
       transfer_data_end(tr, dp + 8);
 
-      // TODO - why are we not setting bus_state here too?
       transfer_send(ctx, tr);
+      ctx->bus_state = kUsbControlSetup;
       ctx->hostSt = HS_WAITACK;
       break;
     case HS_WAITACK:
@@ -423,7 +769,10 @@ void readBaud(usbdpi_ctx_t *ctx) {
       break;
     case HS_REQDATA:
       if (ctx->tick_bits >= ctx->wait) {
-        transfer_token(tr, USB_PID_IN, ctx->dev_address, ENDPOINT_ZERO);
+        // NOTE: This IN request produces a NAK from the device because there is
+        //       nothing available, at which point a REAL host should surely
+        //       retry the request at a later time!
+        transfer_token(tr, USB_PID_IN, ctx->dev_address, endpoint);
 
         transfer_send(ctx, tr);
         ctx->hostSt = HS_WAITDATA;
@@ -434,6 +783,7 @@ void readBaud(usbdpi_ctx_t *ctx) {
       ctx->hostSt = HS_SENDACK;
       break;
     case HS_SENDACK:
+      // TODO - are we not ACKing the NAK at this point?
       if (ctx->tick_bits >= ctx->wait) {
         transfer_status(ctx, tr, USB_PID_ACK);
         ctx->hostSt = HS_EMPTYDATA;
@@ -441,14 +791,14 @@ void readBaud(usbdpi_ctx_t *ctx) {
       break;
     case HS_EMPTYDATA:
       // Transmit OUT transaction with zero-length DATA packet
-      transfer_token(tr, USB_PID_OUT, ctx->dev_address, ENDPOINT_ZERO);
+      transfer_token(tr, USB_PID_OUT, ctx->dev_address, endpoint);
       if (INSERT_ERR_DATA_TOGGLE) {
         // NOTE: This raises a LinkOutErr on the USBDEV because it is expecting
         //       DATA0
-        // TODO - uint8_t bad_pid = DATA_TOGGLE_ADVANCE(ctx->tx_next_data);
-        dp = transfer_data_start(tr, USB_PID_DATA1, 0);
+        uint8_t bad_pid = DATA_TOGGLE_ADVANCE(ctx->ep_out[endpoint].next_data);
+        dp = transfer_data_start(tr, bad_pid, 0);
       } else {
-        dp = transfer_data_start(tr, USB_PID_DATA0, 0);
+        dp = transfer_data_start(tr, ctx->ep_out[endpoint].next_data, 0);
       }
       transfer_data_end(tr, dp);
 
@@ -462,7 +812,8 @@ void readBaud(usbdpi_ctx_t *ctx) {
       if (ctx->tick_bits >= ctx->wait ||
           ctx->bus_state == kUsbControlStatusOutAck) {
         if (ctx->lastrxpid == USB_PID_ACK) {
-          ctx->rx_next_data = DATA_TOGGLE_ADVANCE(ctx->rx_next_data);
+          ctx->ep_out[endpoint].next_data =
+              DATA_TOGGLE_ADVANCE(ctx->ep_out[endpoint].next_data);
         }
         ctx->hostSt = HS_NEXTFRAME;
         printf("[usbdpi] readBaud done\n");
@@ -473,13 +824,13 @@ void readBaud(usbdpi_ctx_t *ctx) {
   }
 }
 
-// Set Baud
-void setBaud(usbdpi_ctx_t *ctx) {
+// Set Baud (Vendor-specific)
+void setBaud(usbdpi_ctx_t *ctx, uint8_t endpoint) {
   usbdpi_transfer_t *tr = ctx->sending;
   uint8_t *dp;
   switch (ctx->hostSt) {
     case HS_STARTFRAME:
-      transfer_token(tr, USB_PID_SETUP, ctx->dev_address, ENDPOINT_ZERO);
+      transfer_token(tr, USB_PID_SETUP, ctx->dev_address, endpoint);
 
       dp = transfer_data_start(tr, USB_PID_DATA0, 0);
       dp[0] = 0x42;  // h2d, vendor, endpoint
@@ -493,6 +844,7 @@ void setBaud(usbdpi_ctx_t *ctx) {
       transfer_data_end(tr, dp + 8);
 
       transfer_send(ctx, tr);
+      ctx->bus_state = kUsbControlSetup;
       ctx->hostSt = HS_WAITACK;
       break;
     case HS_WAITACK:
@@ -501,7 +853,7 @@ void setBaud(usbdpi_ctx_t *ctx) {
       break;
     case HS_REQDATA:
       if (ctx->tick_bits >= ctx->wait) {
-        transfer_token(tr, USB_PID_IN, ctx->dev_address, ENDPOINT_ZERO);
+        transfer_token(tr, USB_PID_IN, ctx->dev_address, endpoint);
 
         transfer_send(ctx, tr);
         ctx->hostSt = HS_WAITDATA;
@@ -524,29 +876,24 @@ void setBaud(usbdpi_ctx_t *ctx) {
   }
 }
 
-// Try OUT transfer to the device, optionally expecting a Status
+// Try an OUT transfer to the device, optionally expecting a Status
 //   packet (eg. ACK|NAK) in response; this is not expected for
 //   Isochronous transfers
 void tryTX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool bExpectStatus) {
+  const uint8_t pattern[] = {
+      "AbCdEfGhIjKlMnOpQrStUvWxYz+0123456789-aBcDeFgHiJkLmNoPqRsTuVwXyZ"};
   usbdpi_transfer_t *tr = ctx->sending;
   uint8_t *dp;
   switch (ctx->hostSt) {
     case HS_STARTFRAME:
       transfer_token(tr, USB_PID_OUT, ctx->dev_address, endpoint);
 
-      dp = transfer_data_start(tr, USB_PID_DATA0, 0);
-      // TODO - introduce something more sensible here?
-      dp[0] = 0x42;  // h2d, vendor, endpoint
-      dp[1] = 3;     // set baud
-      dp[2] = 96;    // index 0
-      dp[3] = 0;     // type device
-      dp[4] = 0;     // wIndex = 0
-      dp[5] = 0;
-      dp[6] = 0;  // wLength = 0
-      dp[7] = 0;
-      transfer_data_end(tr, dp + 8);
+      dp = transfer_data_start(tr, ctx->ep_out[endpoint].next_data, 0);
+      memcpy(dp, pattern, sizeof(pattern));
+      transfer_data_end(tr, dp + sizeof(pattern));
 
       transfer_send(ctx, tr);
+      ctx->bus_state = kUsbBulkOut;
       ctx->hostSt = HS_WAITACK;
       break;
     case HS_WAITACK:  // no actual ACK if Isochronous transfer
@@ -555,8 +902,11 @@ void tryTX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool bExpectStatus) {
       break;
     case HS_REQDATA:
       if (ctx->tick_bits >= ctx->wait) {
+        // Note: Isochronous transfers are not acknowledged and do not employ
+        //       Data Toggle Synchronization
         if (bExpectStatus && ctx->lastrxpid == USB_PID_ACK) {
-          ctx->tx_next_data = DATA_TOGGLE_ADVANCE(ctx->tx_next_data);
+          ctx->ep_out[endpoint].next_data =
+              DATA_TOGGLE_ADVANCE(ctx->ep_out[endpoint].next_data);
         }
 
         transfer_token(tr, USB_PID_IN, ctx->dev_address, endpoint);
@@ -574,19 +924,11 @@ void tryTX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool bExpectStatus) {
   }
 }
 
-/**
- * Request IN data from endpoint. Receive DATA0/DATA1, if available,
- * to which we optionally send a NAK rather than ACK response.
- * Optionally then send an OUT data packet.
- *
- * @param ctx        USB DPI context
- * @param endpoint   Endpoint from which to read
- * @param pid        DATAx PID to be used for subsequent OUT
- * @param bSendHi    also send OUT packet
- * @param bNakData   send NAK instead of ACK if there is data
- */
-void pollRX(usbdpi_ctx_t *ctx, uint8_t endpoint, uint8_t pid, bool bSendHi,
-            bool bNakData) {
+// Request IN. Get back DATA0/DATA1 or NAK.
+//
+// send_hi  -> also send OUT packet
+// nak_data -> send NAK instead of ACK if there is data
+void pollRX(usbdpi_ctx_t *ctx, uint8_t endpoint, bool send_hi, bool nak_data) {
   usbdpi_transfer_t *tr = ctx->sending;
   uint8_t *dp;
   switch (ctx->hostSt) {
@@ -604,39 +946,49 @@ void pollRX(usbdpi_ctx_t *ctx, uint8_t endpoint, uint8_t pid, bool bSendHi,
       ctx->hostSt = HS_ACKIFDATA;
       break;
     case HS_ACKIFDATA:
-      if (ctx->tick_bits >= ctx->wait) {
-        printf("[usbdpi] Timed out waiting for IN response\n");
-        ctx->hostSt = HS_SENDHI;
-      } else if (ctx->bus_state == kUsbBulkInData) {
+      if (ctx->bus_state == kUsbBulkInData) {
+        // TODO - have we got a LFSR-generated data packet?
         if (ctx->lastrxpid != USB_PID_NAK) {
-          // device sent data so ACK it
-          // TODO check DATA0 vs DATA1
-          transfer_status(ctx, tr, bNakData ? USB_PID_NAK : USB_PID_ACK);
+          transfer_status(ctx, tr, nak_data ? USB_PID_NAK : USB_PID_ACK);
         }
+        ctx->hostSt = HS_SENDHI;
+      } else if (ctx->tick_bits >= ctx->wait) {
+        printf("[usbdpi] Timed out waiting for IN response\n");
         ctx->hostSt = HS_SENDHI;
       }
       break;
     case HS_SENDHI:
-      if (bSendHi) {
+      if (send_hi) {
         transfer_token(tr, USB_PID_OUT, ctx->dev_address, endpoint);
 
-        dp = transfer_data_start(tr, pid, 0);
+        dp = transfer_data_start(tr, ctx->ep_out[endpoint].next_data, 0);
         dp[0] = 0x48;  // "H"
         dp[1] = 0x69;  // "i"
         dp[2] = 0x21;  // "!"
         transfer_data_end(tr, dp + 3);
 
         transfer_send(ctx, tr);
+        ctx->wait = ctx->tick_bits + 532;  // HACK
+        ctx->hostSt = HS_WAITACK;
+      } else {
+        ctx->hostSt = HS_NEXTFRAME;
       }
-      ctx->inframe = ctx->frame;
-      ctx->hostSt = HS_NEXTFRAME;  // Device will ACK
+      break;
+    case HS_WAITACK:
+      if (ctx->tick_bits >= ctx->wait) {
+        if (ctx->lastrxpid == USB_PID_ACK) {
+          ctx->ep_out[endpoint].next_data =
+              DATA_TOGGLE_ADVANCE(ctx->ep_out[endpoint].next_data);
+        }
+        ctx->hostSt = HS_NEXTFRAME;
+      }
       break;
     default:
       break;
   }
 }
 
-// Test behaviour in (non-)response to other device and unimplemented endpoints
+// Test behavior in (non-)response to other device and unimplemented endpoints
 void testUnimplEp(usbdpi_ctx_t *ctx, uint8_t pid, uint8_t device,
                   uint8_t endpoint) {
   usbdpi_transfer_t *tr = ctx->sending;
@@ -652,7 +1004,7 @@ void testUnimplEp(usbdpi_ctx_t *ctx, uint8_t pid, uint8_t device,
         dp[2] = 2;  // device address
         dp[3] = 0;
         // Trigger bitstuffing, technically the device
-        // behaviour is unspecified with wIndex != 0
+        // behavior is unspecified with wIndex != 0
         dp[4] = 0xFF;  // wIndex = 0xFF00
         dp[5] = 0;
         dp[6] = 0;  // wLength = 0
@@ -695,9 +1047,9 @@ void testUnimplEp(usbdpi_ctx_t *ctx, uint8_t pid, uint8_t device,
 }
 
 // Change DP and DN outputs from host
-int set_driving(usbdpi_ctx_t *ctx, int d2p, int newval) {
+uint32_t set_driving(usbdpi_ctx_t *ctx, uint32_t d2p, uint32_t newval) {
   // Always maintain the current state of VBUS
-  int driving = ctx->driving & P2D_SENSE;
+  uint32_t driving = ctx->driving & P2D_SENSE;
   if (d2p & D2P_DNPU) {
     // Have dn pull-up, so must be flipping pins
     if (newval & P2D_DP) {
@@ -715,7 +1067,9 @@ int set_driving(usbdpi_ctx_t *ctx, int d2p, int newval) {
   return driving;
 }
 
-int inv_driving(usbdpi_ctx_t *ctx, int d2p) {
+// Optionally invert the signals the host is driving, according to bus
+// configuration
+uint32_t inv_driving(usbdpi_ctx_t *ctx, uint32_t d2p) {
   // works for either orientation
   return ctx->driving ^ (P2D_DP | P2D_DN | P2D_D);
 }
@@ -728,26 +1082,19 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
   int force_stat = 0;
   int dat;
 
-  if (ctx->tick == 0) {
-#ifdef NEED_SLEEP
-    int i;
-    for (i = 7; i > 0; i--) {
-      printf("USBDPI Sleep %d...\n", i);
-      sleep(1);
-    }
-#endif
-  }
-  ctx->tick++;
-
   // The 48MHz clock runs at 4 times the bus clock for a full speed (12Mbps)
   // device
+  //
+  // TODO - vary the phase over the duration of the test to check device
+  //        synchronization
+  ctx->tick++;
   ctx->tick_bits = ctx->tick >> 2;
   if (ctx->tick & 3) {
     return ctx->driving;
   }
 
   // Monitor, analyse and record USB bus activity
-  usb_monitor(ctx->mon, ctx->loglevel, ctx->tick,
+  usb_monitor(ctx->mon, ctx->loglevel, ctx->tick_bits,
               (ctx->state != ST_IDLE) && (ctx->state != ST_GET), ctx->driving,
               d2p, &(ctx->lastrxpid));
 
@@ -761,12 +1108,12 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
   }
 
   if (ctx->tick < ctx->recovery_time) {
-    ctx->lastframe = ctx->tick_bits;
+    ctx->frame_start = ctx->tick_bits;
     return ctx->driving;
   }
 
   // Time to commence a new bus frame?
-  if ((ctx->tick_bits - ctx->lastframe) >= FRAME_INTERVAL) {
+  if ((ctx->tick_bits - ctx->frame_start) >= FRAME_INTERVAL) {
     if (ctx->state != ST_IDLE) {
       if (ctx->framepend == 0) {
         printf(
@@ -782,14 +1129,12 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       }
       ctx->framepend = 0;
       ctx->frame++;
-      ctx->lastframe = ctx->tick_bits;
+      ctx->frame_start = ctx->tick_bits;
 
-      // TODO - modify this accordingly when separating the frame number and the
-      //        STEP_ state machine
-      if (ctx->frame >= 20 && ctx->frame < 30) {
-        // Test suspend
+      if (ctx->step >= STEP_IDLE_START && ctx->step < STEP_IDLE_END) {
+        // Test suspend behavior by dropping the SOF signalling
         ctx->state = ST_IDLE;
-        printf("Idle frame 0x%x\n", ctx->frame);
+        printf("[usbdpi] idle frame 0x%x\n", ctx->frame);
       } else {
         // Ensure that a buffer is available for constructing a transfer
         usbdpi_transfer_t *tr = ctx->sending;
@@ -805,12 +1150,20 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       }
       printf("[usbdpi] frame 0x%x tick_bits 0x%x CRC5 0x%x\n", ctx->frame,
              ctx->tick, CRC5(ctx->frame, 11));
+
       if (ctx->hostSt == HS_NEXTFRAME) {
+        ctx->step = usbdpi_test_seq_next(ctx, ctx->step);
         ctx->hostSt = HS_STARTFRAME;
+      } else {
+        // TODO - this surely means that something went wrong;
+        // but what shall we do at this point?!
+        assert(!"DPI Host not ready to start new frame");
       }
     }
   }
+
   switch (ctx->state) {
+    // Host state machine advances when the bit-level activity is idle
     case ST_IDLE: {
       // Ensure that a buffer is available for constructing a transfer
       usbdpi_transfer_t *tr = ctx->sending;
@@ -820,26 +1173,55 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
         ctx->sending = tr;
       }
 
-      // TODO - test step remains equivalent to the frame number for now; fixed
-      //        timing, not yet responsive to the device/sw behaviour
-      ctx->step = ctx->frame;
-
       switch (ctx->step) {
         case STEP_SET_DEVICE_ADDRESS:
           setDeviceAddress(ctx, USBDEV_ADDRESS);
-          ctx->dev_address = USBDEV_ADDRESS;
           break;
 
-        case STEP_READ_DESCRIPTOR:
-          readDescriptor(ctx);
-          break;
+          // TODO - an actual host issues a number of GET_DESCRIPTOR control/
+          //        transfers to read descriptions of the configurations,
+          //        interfaces and endpoints
 
-          // TODO: Should have SET_CONFIGURATION here, else non-default
-          // endpoints should be disabled.
+        case STEP_GET_DEVICE_DESCRIPTOR:
+          // Initially we fetch just the minimal descriptor length of 0x12U
+          // bytes and the returned information will indicate the full length
           //
-          // case STEP_SET_DEVICE_CONFIG:
-          //   setDeviceConfiguration(ctx);
-          //   break;
+          // TODO - Set the descriptor length to the minimum because the DPI
+          // model does not yet catch and report errors properly
+          ctx->cfg_desc_len = 12U;
+          getDescriptor(ctx, USB_DESC_TYPE_DEVICE, 0U, 0x12U);
+          break;
+
+        case STEP_GET_CONFIG_DESCRIPTOR:
+          getDescriptor(ctx, USB_DESC_TYPE_CONFIGURATION, 0U, 0x9U);
+          break;
+
+        case STEP_GET_FULL_CONFIG_DESCRIPTOR: {
+          uint16_t wLength = ctx->cfg_desc_len;
+          if (wLength >= USBDEV_MAX_PACKET_SIZE) {
+            // Note: getDescriptor cannot yet receive multiple packets
+            wLength = USBDEV_MAX_PACKET_SIZE;
+          }
+          getDescriptor(ctx, USB_DESC_TYPE_CONFIGURATION, 0U, wLength);
+        } break;
+
+          // TODO - we must receive and respond to test configuration at some
+          //        point; perhaps we can make the software advertise itself
+          //        with different vendor/device combinations to indicate the
+          //        testing we must do
+
+        case STEP_SET_DEVICE_CONFIG:
+          setDeviceConfiguration(ctx, 1);
+          break;
+
+        // Test configuration and status
+        case STEP_GET_TEST_CONFIG:
+          getTestConfig(ctx, 0x10U);
+          break;
+
+        case STEP_SET_TEST_STATUS:
+          setTestStatus(ctx, ctx->test_status, ctx->test_msg);
+          break;
 
           // These should be at 3 and 4 but the read needs the host
           // not to be sending (until skip fifo is implemented in in_pe engine)
@@ -847,20 +1229,19 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
           // hello_world to not use the uart until frame 4)
 
         case STEP_FIRST_READ:
-          pollRX(ctx, ENDPOINT_SERIAL0, USB_PID_DATA0, true, true);
+          pollRX(ctx, ENDPOINT_SERIAL0, true, true);
           break;
         case STEP_READ_BAUD:
-          readBaud(ctx);
+          readBaud(ctx, ENDPOINT_ZERO);
           break;
-
         case STEP_SECOND_READ:
-          pollRX(ctx, ENDPOINT_SERIAL0, USB_PID_DATA1, true, false);
+          pollRX(ctx, ENDPOINT_SERIAL0, true, false);
           break;
         case STEP_SET_BAUD:
-          setBaud(ctx);
+          setBaud(ctx, ENDPOINT_ZERO);
           break;
         case STEP_THIRD_READ:
-          pollRX(ctx, ENDPOINT_SERIAL0, USB_PID_DATA0, false, true);
+          pollRX(ctx, ENDPOINT_SERIAL0, false, true);
           break;
         case STEP_TEST_ISO1:
           testIso(ctx);
@@ -887,14 +1268,10 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
           break;
 
         default:
-          if (ctx->frame > ctx->inframe &&
-              !(ctx->frame >= STEP_IDLE_START && ctx->frame < STEP_IDLE_END)) {
-            uint8_t pid = USB_PID_DATA1;
-            if ((ctx->frame - STEP_IDLE_END) & 1) {
-              pid = USB_PID_DATA0;
-            }
-            pollRX(ctx, ENDPOINT_SERIAL0, pid, false, false);
+          if (ctx->step < STEP_IDLE_START || ctx->step >= STEP_IDLE_END) {
+            pollRX(ctx, ENDPOINT_SERIAL0, false, false);
           }
+          break;
       }
     } break;
 
@@ -965,7 +1342,16 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       }
       ctx->bit <<= 1;
       break;
+
+    case ST_GET:
+      // Device is driving the bus; nothing to do here
+      break;
+
+    default:
+      assert(!"Unknown/invalid USBDPI drive state");
+      break;
   }
+
   if ((ctx->loglevel & LOG_BIT) &&
       (force_stat || (ctx->driving != last_driving))) {
     usb_monitor_log(
@@ -981,7 +1367,17 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
 void usbdpi_diags(void *ctx_void, svBitVecVal *diags) {
   usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)ctx_void;
 
-  diags[1] = (ctx->bus_state << 20) | (ctx->tick_bits >> 12);
+  // Check for overflow, which would cause confusion in waveform interpretation;
+  // if an assertion fires, the mapping from fields to svBitVecVal will need
+  // to be changed, both here and in usbdpi.sv
+  assert(ctx->state <= 0xfU);
+  assert(ctx->hostSt <= 0x1fU);
+  assert(ctx->bus_state <= 0x3fU);
+  assert(ctx->step <= 0x7fU);
+
+  diags[2] = usb_monitor_diags(ctx->mon);
+  diags[1] =
+      (ctx->step << 25) | (ctx->bus_state << 20) | (ctx->tick_bits >> 12);
   diags[0] = (ctx->tick_bits << 20) | ((ctx->frame & 0x7ffU) << 9) |
              ((ctx->hostSt & 0x1fU) << 4) | (ctx->state & 0xfU);
 }

--- a/hw/dv/dpi/usbdpi/usbdpi.core
+++ b/hw/dv/dpi/usbdpi/usbdpi.core
@@ -10,13 +10,16 @@ filesets:
     files:
       - usbdpi.sv: { file_type: systemVerilogSource }
       - usbdpi.c: { file_type: cppSource }
+      - usbdpi_test.c: { file_type: cppSource }
       - usb_crc.c: { file_type: cppSource }
-      - usb_transfer.c: { file_type: cppSource }
       - usb_monitor.c: { file_type: cppSource }
+      - usb_transfer.c: { file_type: cppSource }
+      - usb_utils.c: { file_type: cppSource }
       - usbdpi.h: { file_type: cppSource, is_include_file: true }
+      - usbdpi_test.h: { file_type: cppSource, is_include_file: true }
       - usb_monitor.h: { file_type: cppSource, is_include_file: true }
       - usb_transfer.h: { file_type: cppSource, is_include_file: true }
-
+      - usb_utils.h: { file_type: cppSource, is_include_file: true }
 
 targets:
   default:

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -19,16 +19,25 @@ typedef uint32_t svBitVecVal;
 #else
 #include <svdpi.h>
 #endif
-
 #include "usb_monitor.h"
 #include "usb_transfer.h"
+
+// Shall we employ a proper simulation of the frame interval (1ms)?
+// TODO - until such time as we can perform multiple control transfers in a
+//        single bus frame, this is impractical because the simulation takes too
+//        long and is apt to time out
+#define FULL_FRAME 0
 
 // How many bits in our frame
 //
 //   (frames on a Full Speed USB link are 1ms, with 12Mbps signalling, but the
 //    USB device supports only data transfers of up to 64 bytes, so a 1ms
 //    frame interval makes the simulation needlessly long)
-#define FRAME_INTERVAL 256 * 8  // 0.17ms, more than enough for our transfers
+#if FULL_FRAME
+#define FRAME_INTERVAL 12000  // 12Mbps, 1ms frame time
+#else
+#define FRAME_INTERVAL 6000  // 0.5ms
+#endif
 
 // How many bits after start to assert VBUS
 #define SENSE_AT 20 * 8
@@ -46,10 +55,8 @@ typedef uint32_t svBitVecVal;
 // Endpoints used during top-level tests
 #define ENDPOINT_ZERO 0         // Endpoint Zero (for the Default Control Pipe)
 #define ENDPOINT_SERIAL0 1      // For basic serial communications test
-#define ENDPOINT_STREAM_IN 2    // For streaming LFSR data (IN to host)
 #define ENDPOINT_SERIAL1 2      // Second serial channel
 #define ENDPOINT_ISOCHRONOUS 3  // For basic testing of Isochronous transfers
-#define ENDPOINT_STREAM_OUT 4   // For streaming LFSR data (OUT from host)
 #define ENDPOINT_UNIMPLEMENTED \
   15  // For testing of response to unimplemented
       // endpoints
@@ -74,39 +81,10 @@ typedef uint32_t svBitVecVal;
 #define P2D_DP 4
 #define P2D_D 8
 
-#define ST_IDLE 0
-#define ST_SEND 1
-#define ST_GET 2
-#define ST_SYNC 3
-#define ST_EOP 4
-#define ST_EOP0 5
-
-/* Test steps */
-// TODO - these are simply bus frame numbers at present, but the DPI
-//        shall be changed to respond to the device to avoid assuming the
-//        speed/timing of the SW/CPU/USBDEV activity should not be assumed
-#define STEP_SET_DEVICE_ADDRESS 1U
-#define STEP_READ_DESCRIPTOR 2U
-#define STEP_SET_DEVICE_CONFIG 3U
-// TODO - these should be advanced once we respond to device
-#define STEP_FIRST_READ 9U
-#define STEP_READ_BAUD 10U
-#define STEP_SECOND_READ 14U
-#define STEP_SET_BAUD 15U
-#define STEP_THIRD_READ 16U
-#define STEP_TEST_ISO1 17U
-#define STEP_TEST_ISO2 18U
-#define STEP_ENDPT_UNIMPL_SETUP 20U
-#define STEP_ENDPT_UNIMPL_OUT 21U
-#define STEP_ENDPT_UNIMPL_IN 22U
-#define STEP_DEVICE_UK_SETUP 23U
-#define STEP_IDLE_START 23U
-#define STEP_IDLE_END 33U
-
 /* Remember these go LSB first */
 
 /* Sync is KJKJKJKK */
-#define USB_SYNC 0x2a
+#define USB_SYNC 0x2AU
 
 /* USB Packet IDentifiers */
 #define USB_PID_OUT 0xE1U
@@ -134,22 +112,15 @@ typedef uint32_t svBitVecVal;
 #define USB_REQ_SET_INTERFACE 0x0BU
 #define USB_REQ_SYNCH_FRAME 0x0CU
 
-/* Host states */
-#define HS_STARTFRAME 0
-#define HS_WAITACK 1
-#define HS_SET_DATASTAGE 2
-#define HS_DS_RXDATA 3
-#define HS_DS_SENDACK 4
-#define HS_DONEDADR 5
-#define HS_REQDATA 6
-#define HS_WAITDATA 7
-#define HS_SENDACK 8
-#define HS_WAIT_PKT 9
-#define HS_ACKIFDATA 10
-#define HS_SENDHI 11
-#define HS_EMPTYDATA 12
-#define HS_WAITACK2 13
-#define HS_NEXTFRAME 14
+/* USB Descriptor Types */
+#define USB_DESC_TYPE_DEVICE 0x01U
+#define USB_DESC_TYPE_CONFIGURATION 0x02U
+#define USB_DESC_TYPE_STRING 0x03U
+#define USB_DESC_TYPE_INTERFACE 0x04U
+#define USB_DESC_TYPE_ENDPOINT 0x05U
+#define USB_DESC_TYPE_DEVICE_QUALIFIER 0x06U
+#define USB_DESC_TYPE_OTHER_SPEED_CONFIG 0x07U
+#define USB_DESC_TYPE_INTERFACE_POWER 0x08U
 
 // Device address to be used for the USBDEV IP block
 #define USBDEV_ADDRESS 2
@@ -157,39 +128,130 @@ typedef uint32_t svBitVecVal;
 // Unknown device address (check USBDEV ignores traffic to other devices)
 #define UKDEV_ADDRESS 6
 
-// Special value that denotes that this transfer does not include a data stage
-#define USBDPI_NO_DATA_STAGE ((uint8_t)~0U)
+// Maximum number of endpoints implemented by the USBDEV IP
+#define USBDEV_MAX_ENDPOINTS 12U
+
+// Maximum number of endpoints supported by the DPI model
+#define USBDPI_MAX_ENDPOINTS 16U
 
 // Maximum number of simultaneous transfer descriptors
 //   (The host model may simply avoid polling for further IN transfers
 //    whilst there are no further desciptors available)
 #define USBDPI_MAX_TRANSFERS 0x10U
 
+// Time intervals for common transactions, in bits
+// (allowing for bit stuffing and bus turnaround etc; for setting timeouts)
+#define USBDPI_INTERVAL_SETUP_STAGE 200U
+
+// Return the time at which the given number of bit intervals shall have elapsed
+#define USBDPI_TIMEOUT(ctx, bits) ((ctx)->tick_bits + (bits))
+
+// Maximum length of test status message
+#define USBDPI_MAX_TEST_MSG_LEN 80U
+
+// Vendor-specific commands used for test framework
+#define USBDPI_VENDOR_TEST_CONFIG 0x7CU
+#define USBDPI_VENDOR_TEST_STATUS 0x7EU
+
+// Next DATAx PID to be used (transmission) or expected (reception)
+#define DATA_TOGGLE_ADVANCE(pid) \
+  ((pid) == USB_PID_DATA1 ? USB_PID_DATA0 : USB_PID_DATA1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// state numbers are annotated purely to add waveform comprehension
+// USBDPI driver states
+typedef enum {
+  ST_IDLE = 0,
+  ST_SEND = 1,
+  ST_GET = 2,
+  ST_SYNC = 3,
+  ST_EOP = 4,
+  ST_EOP0 = 5
+} usbdpi_drv_state_t;
+
+// Test steps
+typedef enum {
+
+  STEP_BUS_RESET = 0u,
+  STEP_SET_DEVICE_ADDRESS,
+  STEP_GET_DEVICE_DESCRIPTOR,
+  STEP_GET_CONFIG_DESCRIPTOR,
+  STEP_GET_FULL_CONFIG_DESCRIPTOR,
+  STEP_SET_DEVICE_CONFIG,
+
+  // Read test configuration
+  // This is a bespoke 'vendor' command via which we inquire of the CPU
+  // software what behaviour is required
+  STEP_GET_TEST_CONFIG,
+  // Report test status (pass/failure) to the CPU software
+  STEP_SET_TEST_STATUS,
+
+  // usbdev_test
+  STEP_FIRST_READ,
+  STEP_READ_BAUD,
+  STEP_SECOND_READ,
+  STEP_SET_BAUD,
+  STEP_THIRD_READ,
+  STEP_TEST_ISO1,
+  STEP_TEST_ISO2,
+  STEP_ENDPT_UNIMPL_SETUP,
+  STEP_ENDPT_UNIMPL_OUT,
+  STEP_ENDPT_UNIMPL_IN,
+  STEP_DEVICE_UK_SETUP,
+  STEP_IDLE_START,
+  STEP_IDLE_END = STEP_IDLE_START + 4,
+
+  // usbdev_stream_test
+  STEP_STREAM_SERVICE = 0x20u,
+
+  // Disconnect the device and stop
+  STEP_BUS_DISCONNECT = 0x7fu
+} usbdpi_test_step_t;
+
+// Host states
+typedef enum {
+  HS_STARTFRAME = 0,
+  HS_WAITACK = 1,
+  HS_SET_DATASTAGE = 2,
+
+  HS_DS_RXDATA = 3,
+  HS_DS_SENDACK = 4,
+  HS_DONEDADR = 5,
+  HS_REQDATA = 6,
+  HS_WAITDATA = 7,
+  HS_SENDACK = 8,
+  HS_WAIT_PKT = 9,
+  HS_ACKIFDATA = 10,
+  HS_SENDHI = 11,
+  HS_EMPTYDATA = 12,
+  HS_WAITACK2 = 13,
+  HS_STREAMOUT = 14,
+  HS_STREAMIN = 15,
+  HS_NEXTFRAME = 16
+} usbdpi_host_state_t;
+
 typedef enum usbdpi_bus_state {
   kUsbIdle = 0,
   kUsbControlSetup,
   kUsbControlSetupAck,
   kUsbControlDataOut,
-  kUsbControlDataOutAck,  // 4
+  kUsbControlDataOutAck,
   kUsbControlStatusInToken,
   kUsbControlStatusInData,
   kUsbControlStatusInAck,
 
-  kUsbControlDataInToken,  // 8
+  kUsbControlDataInToken,
   kUsbControlDataInData,
   kUsbControlDataInAck,
   kUsbControlStatusOut,
-  kUsbControlStatusOutAck,  // 0xc
+  kUsbControlStatusOutAck,
   kUsbIsoToken,
   kUsbIsoDataIn,
   kUsbIsoDataOut,
 
-  kUsbBulkOut,  // 0x10
+  kUsbBulkOut,
   kUsbBulkOutAck,
   kUsbBulkInToken,
   kUsbBulkInData,
@@ -206,16 +268,41 @@ struct usbdpi_ctx {
   int linebits;
   int bit;
   int byte;
+  /**
+   * Test number, retrieved from the software
+   */
+  uint16_t test_number;
+  /**
+   * Test-specific arguments
+   */
+  uint8_t test_arg[4];
+  /**
+   * Test status
+   * TODO - introduce enum indicating the test status, or borrow from
+   *        the existing source tree; we indicate progress too in other places
+   */
+  uint32_t test_status;
+  char test_msg[USBDPI_MAX_TEST_MSG_LEN];
 
   /**
-   * Next DATAx (DATA0 or DATA1) to be transmitted; advanced when ACKed
-   * and reset after SETUP packet transmitted
+   * Context for IN endpoints
    */
-  uint8_t tx_next_data;
+  struct {
+    /**
+     * Next DATAx PID (DATA0 or DATA1) expected from device
+     */
+    uint8_t next_data;
+  } ep_in[USBDPI_MAX_ENDPOINTS];
   /**
-   * Next DATAx PID (DATA0 or DATA1) expected from device
+   * Context for OUT endpoints
    */
-  uint8_t rx_next_data;
+  struct {
+    /**
+     * Next DATAx (DATA0 or DATA1) to be transmitted; advanced when ACKed
+     * and reset after SETUP packet transmitted
+     */
+    uint8_t next_data;
+  } ep_out[USBDPI_MAX_ENDPOINTS];
 
   // Diagnostic logging and bus monitoring
   int loglevel;
@@ -229,39 +316,54 @@ struct usbdpi_ctx {
   /**
    * Host controller state
    */
-  int hostSt;
+  usbdpi_host_state_t hostSt;
+  /**
+   * Transfer currently being received from the DUT (NULL iff none)
+   */
+  usbdpi_transfer_t *recving;
   /***
    * Transfer currently being sent to the DUT (NULL iff none)
    */
   usbdpi_transfer_t *sending;
 
-  /***
-   * Received transfers
-   */
-  usbdpi_transfer_t *received;
-
-  // TODO - introduce response detection and retrying
-  int retries;
-
   int last_pu;
   uint8_t lastrxpid;
-  int tick;
-  int tick_bits;
+
+  /**
+   * Count of clock cycles
+   */
+  uint32_t tick;
+  /**
+   * Current time in USB bit intervals
+   */
+  uint32_t tick_bits;
+
   int recovery_time;
 
   /**
    * Test step number
    */
-  uint16_t step;
+  usbdpi_test_step_t step;
 
   // Bus framing
-  // Note: USB frames are transmitted as 11-bit fields [0,0x7ffU]
+  // Note: USB frame numbers are transmitted as 11-bit fields [0,0x7ffU]
   uint16_t frame;
   uint16_t framepend;
-  uint16_t lastframe;
-  uint16_t inframe;
-  int state;
-  int wait;
+
+  /**
+   * Time at which the current frame started (bit intervals)
+   */
+  uint32_t frame_start;
+
+  /**
+   * Wait timeout for current operation (bit intervals)
+   */
+  uint32_t wait;
+
+  /**
+   * DPI driver state
+   */
+  usbdpi_drv_state_t state;
 
   int baudrate_set_successfully;
 
@@ -269,7 +371,10 @@ struct usbdpi_ctx {
    * Device address currently assigned to the DUT
    */
   uint8_t dev_address;
-
+  /**
+   * Length of configuration descriptor
+   */
+  uint16_t cfg_desc_len;
   /**
    * Linked-list of free transfer descriptors
    */

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -46,7 +46,7 @@ module usbdpi #(
     byte usbdpi_host_to_device(input chandle ctx, input bit [10:0] d2p);
 
   import "DPI-C" function
-    void usbdpi_diags(input chandle ctx, output bit [63:0] diags);
+    void usbdpi_diags(input chandle ctx, output bit [95:0] diags);
 
   chandle ctx;
 
@@ -59,14 +59,142 @@ module usbdpi #(
     usbdpi_close(ctx);
   end
 
-  // Make C diagnostic information viewable in waveforms
-  wire  [11:0] c_bus_state;  // only 5 bits used
-  wire  [31:0] c_tickbits;
-  wire  [10:0] c_frame;
-  wire  [4:0]  c_hostSt;
-  wire  [3:0]  c_state;
+  // USB Packet IDentifier values, for waveform viewing
+  typedef enum bit [7:0] {
+    OUT = 8'hE1,
+    IN = 8'h69,
+    SOF = 8'hA5,
+    SETUP = 8'h2D,
+    DATA0 = 8'hC3,
+    DATA1 = 8'h4B,
+    ACK = 8'hD2,
+    NAK = 8'h5A,
+    STALL = 8'h1E,
+    NYET = 8'h96,
+    PING = 8'hB4
+  } usb_pid_t;
+
+  // Host state
+  // Note: MUST be kept consistent with usbdpi_host_state_t in usbdpi.h
+  typedef enum bit [4:0] {
+    HS_STARTFRAME = 0,
+    HS_WAITACK = 1,
+    HS_SET_DATASTAGE = 2,
+    HS_DS_RXDATA = 3,
+    HS_DS_SENDACK = 4,
+    HS_DONEDADR = 5,
+    HS_REQDATA = 6,
+    HS_WAITDATA = 7,
+    HS_SENDACK = 8,
+    HS_WAIT_PKT = 9,
+    HS_ACKIFDATA = 10,
+    HS_SENDHI = 11,
+    HS_EMPTYDATA = 12,
+    HS_WAITACK2 = 13,
+    HS_STREAMOUT = 14,
+    HS_STREAMIN = 15,
+    HS_NEXTFRAME = 16
+  } usbdpi_host_state_t;
+
+  // Bus state
+  // Note: MUST be kept consistent with usbdpi_bus_state in usbdpi.h
+  typedef enum bit [4:0] {
+    kUsbIdle = 0,
+    kUsbControlSetup,
+    kUsbControlSetupAck,
+    kUsbControlDataOut,
+    kUsbControlDataOutAck,  // 4
+    kUsbControlStatusInToken,
+    kUsbControlStatusInData,
+    kUsbControlStatusInAck,
+
+    kUsbControlDataInToken,  // 8
+    kUsbControlDataInData,
+    kUsbControlDataInAck,
+    kUsbControlStatusOut,
+    kUsbControlStatusOutAck,  // 0xc
+    kUsbIsoToken,
+    kUsbIsoDataIn,
+    kUsbIsoDataOut,
+
+    kUsbBulkOut,  // 0x10
+    kUsbBulkOutAck,
+    kUsbBulkInToken,
+    kUsbBulkInData,
+    kUsbBulkInAck
+  } usbdpi_bus_state_t;
+
+  // USB monitor state
+  // Note: MUST be kept consistent with usbdpi_monitor_state_t in usb_monitor.c
+  typedef enum bit [1:0] {
+    MS_IDLE = 0,
+    MS_GET_PID,
+    MS_GET_BYTES
+  } usb_monitor_state_t;
+
+  // USB driver state
+  // Note: MUST be kept consistent with usbdpi_drv_state_t in usbdpi.h
+  typedef enum bit [3:0] {
+    ST_IDLE = 0,
+    ST_SEND = 1,
+    ST_GET = 2,
+    ST_SYNC = 3,
+    ST_EOP = 4,
+    ST_EOP0 = 5
+  } usbdpi_drv_state_t;
+
+  // Test steps
+  typedef enum bit [6:0] {
+
+    STEP_BUS_RESET = 0,
+    STEP_SET_DEVICE_ADDRESS,
+    STEP_GET_DEVICE_DESCRIPTOR,
+    STEP_GET_CONFIG_DESCRIPTOR,
+    STEP_GET_FULL_CONFIG_DESCRIPTOR,
+    STEP_SET_DEVICE_CONFIG,
+
+    STEP_GET_TEST_CONFIG,
+    STEP_SET_TEST_STATUS,
+
+    // usbdev_test
+    STEP_FIRST_READ,
+    STEP_READ_BAUD,
+    STEP_SECOND_READ,
+    STEP_SET_BAUD,
+    STEP_THIRD_READ,
+    STEP_TEST_ISO1,
+    STEP_TEST_ISO2,
+    STEP_ENDPT_UNIMPL_SETUP,
+    STEP_ENDPT_UNIMPL_OUT,
+    STEP_ENDPT_UNIMPL_IN,
+    STEP_DEVICE_UK_SETUP,
+    STEP_IDLE_START,
+    STEP_IDLE_END = STEP_IDLE_START + 4,
+
+    // usbdev_stream_test
+    STEP_STREAM_SERVICE = 'h20,
+
+    // Disconnect the device and stop
+    STEP_BUS_DISCONNECT = 'h7f
+  } usbdpi_test_step_t;
+
+  // Make usb_monitor diagnostic information viewable in waveforms
+  bit [9:0] c_spare1;
+  usb_monitor_state_t c_mon_state;
+  bit [3:0] c_mon_bits;
+  bit [7:0] c_mon_byte;
+  usb_pid_t c_mon_pid;
+  // Make usbdpi diagnostic information viewable in waveforms
+  usbdpi_test_step_t c_step;
+  usbdpi_bus_state_t c_bus_state;
+  bit [31:0] c_tickbits;
+  bit [10:0] c_frame;
+  usbdpi_host_state_t c_hostSt;
+  usbdpi_drv_state_t c_state;
   always @(posedge clk_48MHz_i)
-    usbdpi_diags(ctx, {c_bus_state, c_tickbits, c_frame, c_hostSt, c_state});
+    usbdpi_diags(ctx, {c_spare1, c_mon_state, c_mon_bits, c_mon_byte, c_mon_pid,
+                       c_step, c_bus_state, c_tickbits, c_frame, c_hostSt,
+                       c_state});
 
   logic [10:0] d2p;
   logic [10:0] d2p_r;
@@ -76,7 +204,8 @@ module usbdpi #(
   logic       dp_int, dn_int, d_last;
   logic       flip_detect, pullup_detect, rx_enable;
 
-  // Detect a request to flip pins by the DN resistor being applied
+  // Detect a request to flip pins by the DN resistor being applied;
+  //   it's a full speed device so the pullup resistor is on the D+ signal
   assign flip_detect = pullupdn_d2p;
   assign pullup_detect = pullupdp_d2p || pullupdn_d2p;
   assign rx_enable = rx_enable_d2p;

--- a/hw/dv/dpi/usbdpi/usbdpi_test.c
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.c
@@ -1,0 +1,151 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "usbdpi_test.h"
+
+#include <assert.h>
+
+// Test-specific initialization
+void usbdpi_test_init(usbdpi_ctx_t *ctx) {
+  // Test-specific initialization code
+  bool bOK = false;
+  switch (ctx->test_number) {
+    case 0:
+      // The simple smoke test (usbdev_test) does not require any parameters
+      // or special initialization at present
+      bOK = true;
+      break;
+
+    default:
+      assert(!"Unrecognised/unsupported test in USBDPI");
+      break;
+  }
+
+  // TODO - commute this to a proper test failure at run time
+  assert(bOK);
+}
+
+// Return the next step in the test sequence
+usbdpi_test_step_t usbdpi_test_seq_next(usbdpi_ctx_t *ctx,
+                                        usbdpi_test_step_t step) {
+  // Default to disconnecting and stopping
+  usbdpi_test_step_t next_step = STEP_BUS_DISCONNECT;
+
+  switch (step) {
+    // Bus reset (VBUS newly present...)
+    case STEP_BUS_RESET:
+      next_step = STEP_SET_DEVICE_ADDRESS;
+      break;
+    // Standard device set up sequence
+    case STEP_SET_DEVICE_ADDRESS:
+      next_step = STEP_GET_DEVICE_DESCRIPTOR;
+      break;
+    case STEP_GET_DEVICE_DESCRIPTOR:
+      next_step = STEP_GET_CONFIG_DESCRIPTOR;
+      break;
+    case STEP_GET_CONFIG_DESCRIPTOR:
+      next_step = STEP_GET_FULL_CONFIG_DESCRIPTOR;
+      break;
+    case STEP_GET_FULL_CONFIG_DESCRIPTOR:
+      next_step = STEP_SET_DEVICE_CONFIG;
+      break;
+      // TODO - a real host issues additional GET_DESCRIPTOR commands at
+      // this point, reading device qualifier and endpoint information
+
+    case STEP_SET_DEVICE_CONFIG:
+      next_step = STEP_GET_TEST_CONFIG;
+      break;
+
+    case STEP_SET_TEST_STATUS:
+      next_step = STEP_BUS_DISCONNECT;
+      break;
+
+    case STEP_BUS_DISCONNECT:
+      // deassert VBUS
+      ctx->driving &= ~P2D_SENSE;
+      break;
+
+    // At this point we have discovered which test we are to perform
+    default:
+      switch (ctx->test_number) {
+        // Streaming test (usbdev_stream_test)
+        case 1:
+          switch (next_step) {
+            case STEP_GET_TEST_CONFIG:
+              next_step = STEP_STREAM_SERVICE;
+              break;
+
+            default:
+              // The single state that keeps aggressively polling for IN
+              // packets, processing them and pushing them OUT to the
+              // device. The device test software is responsible for
+              // terminating the test and reporting its status
+              next_step = STEP_STREAM_SERVICE;
+              break;
+          }
+          break;
+
+        // Default behavior; usbdev_test
+        default:
+          // TODO - for now we're just maintaining the existing timing
+          // sequence
+          switch (step) {
+            case STEP_GET_TEST_CONFIG:
+              next_step = STEP_FIRST_READ;
+              break;
+
+            case STEP_FIRST_READ:
+              next_step = STEP_READ_BAUD;
+              break;
+            // case STEP_READ_BAUD:
+            //   next_step = STEP_SECOND_READ;
+            //   break;
+            case STEP_SECOND_READ:
+              next_step = STEP_SET_BAUD;
+              break;
+            case STEP_SET_BAUD:
+              next_step = STEP_THIRD_READ;
+              break;
+            case STEP_THIRD_READ:
+              next_step = STEP_TEST_ISO1;
+              break;
+            case STEP_TEST_ISO1:
+              next_step = STEP_TEST_ISO2;
+              break;
+            // case STEP_TEST_ISO2:
+            //   next_step = STEP_ENDPT_UNIMPL_SETUP;
+            //   break;
+            case STEP_ENDPT_UNIMPL_SETUP:
+              next_step = STEP_ENDPT_UNIMPL_SETUP;
+              break;
+            case STEP_ENDPT_UNIMPL_OUT:
+              next_step = STEP_ENDPT_UNIMPL_IN;
+              break;
+            case STEP_ENDPT_UNIMPL_IN:
+              next_step = STEP_DEVICE_UK_SETUP;
+              break;
+            case STEP_DEVICE_UK_SETUP:
+              next_step = STEP_IDLE_START;
+              break;
+
+            case STEP_IDLE_END:
+              // Final resting state
+              next_step = STEP_IDLE_END;
+              break;
+
+            // TODO - for now this is still required to advance through
+            // the test steps
+            case STEP_IDLE_START:
+            case STEP_TEST_ISO2:
+            case STEP_READ_BAUD:
+            default:
+              next_step = (usbdpi_test_step_t)((unsigned)step + 1U);
+              break;
+          }
+          break;
+      }
+      break;
+  }
+  return next_step;
+}

--- a/hw/dv/dpi/usbdpi/usbdpi_test.h
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.h
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_
+#define OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_
+#include "usbdpi.h"
+
+// Test-specific initialization
+void usbdpi_test_init(usbdpi_ctx_t *ctx);
+
+// Return the next step in the test sequence
+usbdpi_test_step_t usbdpi_test_seq_next(usbdpi_ctx_t *ctx,
+                                        usbdpi_test_step_t step);
+
+#endif  // OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -215,7 +215,7 @@ void _ottf_main(void) {
                      differential_xcvr && !uphy);
 
   usb_testutils_controlep_init(&usbdev_control, &usbdev, 0, config_descriptors,
-                               sizeof(config_descriptors));
+                               sizeof(config_descriptors), NULL, 0);
   while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
     usb_testutils_poll(&usbdev);
   }

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -369,6 +369,7 @@ cc_library(
     hdrs = [
         "usb_testutils.h",
         "usb_testutils_controlep.h",
+        "usb_testutils_diags.h",
     ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -47,6 +47,12 @@ typedef enum usb_setup_req {
   kUsbSetupReqSynchFrame = 12
 } usb_setup_req_t;
 
+// Vendor-specific requests defined by our device/test framework
+typedef enum vendor_setup_req {
+  kVendorSetupReqTestConfig = 0x7C,
+  kVendorSetupReqTestStatus = 0x7E
+} vendor_setup_req_t;
+
 typedef enum usb_req_type {  // bmRequestType
   kUsbReqTypeRecipientMask = 0x1f,
   kUsbReqTypeDevice = 0,
@@ -54,14 +60,25 @@ typedef enum usb_req_type {  // bmRequestType
   kUsbReqTypeEndpoint = 2,
   kUsbReqTypeOther = 3,
   kUsbReqTypeTypeMask = 0x60,
-  KUsbReqTypeStandard = 0,
-  KUsbReqTypeClass = 0x20,
-  KUsbReqTypeVendor = 0x40,
-  KUsbReqTypeReserved = 0x60,
+  kUsbReqTypeStandard = 0,
+  kUsbReqTypeClass = 0x20,
+  kUsbReqTypeVendor = 0x40,
+  kUsbReqTypeReserved = 0x60,
   kUsbReqTypeDirMask = 0x80,
   kUsbReqTypeDirH2D = 0x00,
   kUsbReqTypeDirD2H = 0x80,
 } usb_req_type_t;
+
+typedef enum usb_desc_type {  // Descriptor type (wValue hi)
+  kUsbDescTypeDevice = 1,
+  kUsbDescTypeConfiguration,
+  kUsbDescTypeString,
+  kUsbDescTypeInterface,
+  kUsbDescTypeEndpoint,
+  kUsbDescTypeDeviceQualifier,
+  kUsbDescTypeOtherSpeedConfiguration,
+  kUsbDescTypeInterfacePower,
+} usb_desc_type_t;
 
 typedef enum usb_feature_req {
   kUsbFeatureEndpointHalt = 0,        // recipient is endpoint
@@ -86,8 +103,9 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
   uint32_t stat;
   int zero, type;
   size_t bytes_written;
+  // Endpoint for SetFeature/ClearFeature/GetStatus requests
   dif_usbdev_endpoint_id_t endpoint = {
-      .number = bmRequestType & 0x0f,
+      .number = (uint8_t)wIndex,
       .direction = bmRequestType & 0x80,
   };
   dif_usbdev_buffer_t buffer;
@@ -118,17 +136,24 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       return kUsbTestutilsCtError;  // unknown
 
     case kUsbSetupReqSetAddress:
+      TRC_S("SA");
       ctctx->new_dev = wValue & 0x7f;
       // send zero length packet for status phase
       CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtAddrStatIn;
 
     case kUsbSetupReqSetConfiguration:
+      TRC_S("SC");
       // only ever expect this to be 1 since there is one config descriptor
       ctctx->usb_config = wValue;
       // send zero length packet for status phase
       CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
-      ctctx->device_state = kUsbTestutilsDeviceConfigured;
+      if (wValue) {
+        ctctx->device_state = kUsbTestutilsDeviceConfigured;
+      } else {
+        // Device deconfigured
+        ctctx->device_state = kUsbTestutilsDeviceAddressed;
+      }
       return kUsbTestutilsCtStatIn;
 
     case kUsbSetupReqGetConfiguration:
@@ -214,6 +239,29 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       return kUsbTestutilsCtWaitIn;
 
     default:
+      // We implement a couple of bespoke, vendor-defined Setup requests to
+      // allow the DPI model to access the test configuration (Control Read) and
+      // to report the test status (Control Write)
+      if ((bmRequestType & kUsbReqTypeTypeMask) == kUsbReqTypeVendor &&
+          ctctx->test_dscr) {
+        switch ((vendor_setup_req_t)bRequest) {
+          case kVendorSetupReqTestConfig: {
+            TRC_S("TC");
+            // Test config descriptor
+            len = ctctx->test_dscr_len;
+            if (wLength < len) {
+              len = wLength;
+            }
+            CHECK_DIF_OK(dif_usbdev_buffer_write(
+                ctx->dev, &buffer, ctctx->test_dscr, len, &bytes_written));
+            CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
+            return kUsbTestutilsCtWaitIn;
+          } break;
+          case kVendorSetupReqTestStatus: {
+            // TODO - pass the received test status to the OTTF directly?
+          } break;
+        }
+      }
       return kUsbTestutilsCtError;
   }
   return kUsbTestutilsCtError;
@@ -230,9 +278,8 @@ static void ctrl_tx_done(void *ctctx_v) {
       CHECK_DIF_OK(dif_usbdev_address_set(ctx->dev, ctctx->new_dev));
       TRC_I(ctctx->new_dev, 8);
       ctctx->ctrlstate = kUsbTestutilsCtIdle;
-      // Should be kUsbTestutilsDeviceAddressed only, but test controller is
-      // borked ctctx->device_state = kUsbTestutilsDeviceAddressed;
-      ctctx->device_state = kUsbTestutilsDeviceConfigured;
+      // We now have a device address on the USB
+      ctctx->device_state = kUsbTestutilsDeviceAddressed;
       return;
     case kUsbTestutilsCtStatIn:
       ctctx->ctrlstate = kUsbTestutilsCtIdle;
@@ -240,6 +287,7 @@ static void ctrl_tx_done(void *ctctx_v) {
     case kUsbTestutilsCtWaitIn:
       ctctx->ctrlstate = kUsbTestutilsCtStatOut;
       return;
+
     default:
       break;
   }
@@ -278,6 +326,11 @@ static void ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
         if (ctctx->ctrlstate != kUsbTestutilsCtError) {
           return;
         }
+
+        TRC_C(':');
+        for (int i = 0; i < packet_info.length; i++) {
+          TRC_I(bp[i], 8);
+        }
       }
       break;
 
@@ -307,12 +360,9 @@ static void ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
   CHECK_DIF_OK(
       dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint, kDifToggleEnabled));
   TRC_S("USB: unCT ");
-  TRC_I((ctctx->ctrlstate << 24) | setup << 16 | size, 32);
-  TRC_C(':');
-  for (int i = 0; i < packet_info.length; i++) {
-    TRC_I(bp[i], 8);
-    TRC_C(' ');
-  }
+  TRC_I((ctctx->ctrlstate << 24) | ((int)packet_info.is_setup << 16) |
+            packet_info.length,
+        32);
   if (buffer.type != kDifUsbdevBufferTypeStale) {
     // Return the unused buffer.
     CHECK_DIF_OK(dif_usbdev_buffer_return(ctx->dev, ctx->buffer_pool, &buffer));
@@ -329,8 +379,9 @@ static void ctrl_reset(void *ctctx_v) {
 
 void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
                                   usb_testutils_ctx_t *ctx, int ep,
-                                  const uint8_t *cfg_dscr,
-                                  size_t cfg_dscr_len) {
+                                  const uint8_t *cfg_dscr, size_t cfg_dscr_len,
+                                  const uint8_t *test_dscr,
+                                  size_t test_dscr_len) {
   ctctx->ctx = ctx;
   usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutMessage, ctctx, ctrl_tx_done,
                                ctrl_rx, NULL, ctrl_reset);
@@ -338,6 +389,8 @@ void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
   ctctx->ctrlstate = kUsbTestutilsCtIdle;
   ctctx->cfg_dscr = cfg_dscr;
   ctctx->cfg_dscr_len = cfg_dscr_len;
+  ctctx->test_dscr = test_dscr;
+  ctctx->test_dscr_len = test_dscr_len;
   CHECK_DIF_OK(dif_usbdev_interface_enable(ctx->dev, kDifToggleEnabled));
   ctctx->device_state = kUsbTestutilsDeviceDefault;
 }

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -14,8 +14,8 @@ typedef enum usb_testutils_ctstate {
   kUsbTestutilsCtIdle,
   kUsbTestutilsCtWaitIn,      // Queued IN data stage, waiting ack
   kUsbTestutilsCtStatOut,     // Waiting for OUT status stage
-  kUsbTestutilsCtAddrStatIn,  // Queued status stage, waiting ack afterwhich set
-                              // dev_addr
+  kUsbTestutilsCtAddrStatIn,  // Queued status stage, waiting ack.
+                              // After which, set dev_addr
   kUsbTestutilsCtStatIn,      // Queued status stage, waiting ack
   kUsbTestutilsCtError        // Something bad
 } usb_testutils_ctstate_t;
@@ -36,8 +36,16 @@ typedef struct usb_testutils_controlep_ctx {
   usb_testutils_device_state_t device_state;
   uint32_t new_dev;
   uint8_t usb_config;
+  /**
+   * USB configuration descriptor
+   */
   const uint8_t *cfg_dscr;
   size_t cfg_dscr_len;
+  /**
+   * Optional test descriptor, or NULL
+   */
+  const uint8_t *test_dscr;
+  size_t test_dscr_len;
 } usb_testutils_controlep_ctx_t;
 
 /**
@@ -48,14 +56,18 @@ typedef struct usb_testutils_controlep_ctx {
  * @param ep endpoint (if this is other than 0 make sure you know why)
  * @param cfg_dscr configuration descriptor for the device
  * @param cfg_dscr_len length of cfg_dscr
+ * @param test_dscr optional test descriptor, or NULL
+ * @param test_dscr_len length of test_dscr
  */
 void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
                                   usb_testutils_ctx_t *ctx, int ep,
-                                  const uint8_t *cfg_dscr, size_t cfg_dscr_len);
+                                  const uint8_t *cfg_dscr, size_t cfg_dscr_len,
+                                  const uint8_t *test_dscr,
+                                  size_t test_dscr_len);
 
-/********************************************************************/
-/* Below this point are macros used to construct the USB descriptor */
-/* Use them to initialize a uint8_t array for cfg_dscr              */
+/***********************************************************************/
+/* Below this point are macros used to construct the USB configuration */
+/* descriptor. Use them to initialize a uint8_t array for cfg_dscr     */
 
 #define USB_CFG_DSCR_LEN 9
 #define USB_CFG_DSCR_HEAD(total_len, nint)                                   \
@@ -65,7 +77,7 @@ void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
       (total_len)&0xff, /* wTotalLength[0]                           */      \
       (total_len) >> 8, /* wTotalLength[1]                           */      \
       (nint),           /* bNumInterfaces                            */      \
-      1,                /* bConfigurationValu                        */      \
+      1,                /* bConfigurationValue                       */      \
       0,                /* iConfiguration                            */      \
       0xC0,             /* bmAttributes: must-be-one, self-powered   */      \
       50 /* bMaxPower                                 */ /* MUST be followed \
@@ -94,6 +106,17 @@ void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
 // KEEP BLANK LINE ABOVE, it is in the macro!
 
 #define USB_EP_DSCR_LEN 7
+#define USB_EP_DSCR(in, ep, attr, maxsize, interval)                          \
+  /* endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13   */       \
+  USB_EP_DSCR_LEN,                 /* bLength                              */ \
+      5,                           /* bDescriptorType                      */ \
+      (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
+      attr,                        /* bmAttributes                         */ \
+      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
+      (interval)                   /* bInterval                            */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
 #define USB_BULK_EP_DSCR(in, ep, maxsize, interval)                           \
   /* endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13   */       \
   USB_EP_DSCR_LEN,                 /* bLength                              */ \
@@ -103,6 +126,21 @@ void usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
       (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
+
+/***********************************************************************/
+/* Below this point are macros used to construct the test descriptor   */
+/* Use them to initialize a uint8_t array for test_dscr                */
+#define USB_TESTUTILS_TEST_DSCR_LEN 0x10u
+#define USB_TESTUTILS_TEST_DSCR(num, arg0, arg1, arg2, arg3)            \
+  0x7e, 0x57, 0xc0, 0xf1u,                /* Header signature        */ \
+      (USB_TESTUTILS_TEST_DSCR_LEN)&0xff, /* Descriptor length[0]    */ \
+      (USB_TESTUTILS_TEST_DSCR_LEN) >> 8, /* Descriptor length[1]    */ \
+      (num)&0xff,                         /* Test number[0]          */ \
+      (num) >> 8,                         /* Test number[1]          */ \
+      (arg0), (arg1), (arg2), (arg3),     /* Test-specific arugments */ \
+      0x1fu, 0x0cu, 0x75, 0xe7u           /* Tail signature */
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 

--- a/sw/device/lib/testing/usb_testutils_diags.h
+++ b/sw/device/lib/testing/usb_testutils_diags.h
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_DIAGS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_DIAGS_H_
+// Diagnostic, testing and performance measurements utilities for verification
+// of usbdev and development of the usb_testutils support software; the
+// requirements of this software are peculiar in that the USBDPI model used in
+// top-level requires packet responses very promptly, so the introduction of
+// logging/tracing code can substantially alter behavior and cause malfunction
+
+// Used for tracing what is going on. This may impact timing which is critical
+// when simulating with the USB DPI module.
+#define USBUTILS_ENABLE_TRC 0
+
+#if USBUTILS_ENABLE_TRC
+// May be useful on FPGA CW310
+#include "sw/device/lib/runtime/log.h"
+#define TRC_S(s) LOG_INFO("%s", s)
+#define TRC_I(i, b) LOG_INFO("0x%x", i)
+#define TRC_C(c) LOG_INFO("%c", c)
+#else
+#define TRC_S(s)
+#define TRC_I(i, b)
+#define TRC_C(c)
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_DIAGS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1900,13 +1900,20 @@ opentitan_functest(
 opentitan_functest(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
-    targets = ["verilator"],
+    cw310 = cw310_params(
+        tags = ["skip_in_ci"],  # Requires DPI model
+    ),
+    targets = [
+        "verilator",
+        "cw310_test_rom",
+    ],
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:pinmux_testutils",

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -32,7 +32,7 @@
 /**
  * Configuration values for USB.
  */
-static uint8_t config_descriptors[] = {
+static const uint8_t config_descriptors[] = {
     USB_CFG_DSCR_HEAD(
         USB_CFG_DSCR_LEN + 2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
         2),
@@ -43,6 +43,12 @@ static uint8_t config_descriptors[] = {
     USB_BULK_EP_DSCR(0, 2, 32, 0),
     USB_BULK_EP_DSCR(1, 2, 32, 4),
 };
+
+/**
+ * Test descriptor
+ */
+static const uint8_t test_descriptor[] = {
+    USB_TESTUTILS_TEST_DSCR(0, 0, 0, 0, 0)};
 
 /**
  * USB device context types.
@@ -91,9 +97,10 @@ static void usb_receipt_callback(uint8_t c) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK(kDeviceType == kDeviceSimVerilator,
+  CHECK(kDeviceType == kDeviceSimVerilator || kDeviceType == kDeviceFpgaCw310,
         "This test is not expected to run on platforms other than the "
-        "Verilator simulation. It needs the USB DPI model.");
+        "Verilator simulation or CW310 FPGA. It needs the USB DPI model "
+        "or host application.");
 
   LOG_INFO("Running USBDEV test");
 
@@ -110,7 +117,8 @@ bool test_main(void) {
   usb_testutils_init(&usbdev, /*pinflip=*/false, /*en_diff_rcvr=*/false,
                      /*tx_use_d_se0=*/false);
   usb_testutils_controlep_init(&usbdev_control, &usbdev, 0, config_descriptors,
-                               sizeof(config_descriptors));
+                               sizeof(config_descriptors), test_descriptor,
+                               sizeof(test_descriptor));
   while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
     usb_testutils_poll(&usbdev);
   }


### PR DESCRIPTION
Substantial further work on the DPI model to exercise the device much more thoroughly, fixing a number of issues in its original implementation, and extending it with a view to supporting control transfers properly and exercising abnormal conditions such as bus errors, disconnects etc.
Coding style migrating incrementally towards standard.
Inclusion of symbol diags in waveforms
OTTF software specifies test configuration to DPI model, so a single chip build can run additional (more to be added).

Please provide comments/feedback on structure/style/readability etc; nothing is expected wrt USB knowledge or reproducing test passes etc.

Supersedes #17228 
Thanks -A

Updated: integration of usbdev_stream_test deferred
