### PR TITLE
[doc/spi_device] Update spi_device doc to not support mode 3

### DIFF
--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -693,7 +693,7 @@ CPOL controls clock polarity and CPHA controls the clock phase.
 For further details, please refer to this diagram from Wikipedia:
 [File:SPI_timing_diagram2.svg](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#/media/File:SPI_timing_diagram2.svg)
 
-This version of SPI_DEVICE HWIP supports mode 0 (CPHA and CPOL as 0) and mode 3 (CPHA and CPOL as 1) for Generic, Flash, and Passthrough modes.
+This version of SPI_DEVICE HWIP supports mode 0 (CPHA and CPOL as 0) for Generic, Flash, and Passthrough modes. Mode 3 (CPHA and CPOL as 1) is not supported in the current version.
 SW should configure the SPI_DEVICE to mode 0 to enable TPM mode along with other modes.
 
 ## SPI Device Firmware Operation Mode


### PR DESCRIPTION
This PR updates document to not support mode 3 for SPI_DEVICE. 
The current design has issue #16339, and we check most cases does not use mode 3.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>