### PR TITLE
[crypto] Add message hashing and utility functions for SPHINCS+.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
@@ -30,6 +30,19 @@ cc_library(
 )
 
 cc_library(
+    name = "hash",
+    srcs = ["hash_shake.c"],
+    hdrs = ["hash.h"],
+    deps = [
+        ":address",
+        ":context",
+        ":params",
+        ":utils",
+        "//sw/device/silicon_creator/lib/drivers:kmac",
+    ],
+)
+
+cc_library(
     name = "params",
     hdrs = ["params.h"],
 )
@@ -44,5 +57,18 @@ cc_library(
         ":params",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:kmac",
+    ],
+)
+
+cc_library(
+    name = "utils",
+    srcs = ["utils.c"],
+    hdrs = ["utils.h"],
+    deps = [
+        ":address",
+        ":params",
+        ":thash",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:error",
     ],
 )

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/hash.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_HASH_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_HASH_H_
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize the SPHINCS+ hash function.
+ *
+ * Hook for any precomputation or setup tasks the hash function needs to do
+ * before a SPHINCS+ operation takes place.
+ *
+ * Appears in reference code as `initialize_hash_function`.
+ *
+ * @param ctx Context object.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t spx_hash_initialize(spx_ctx_t *ctx);
+
+/**
+ * Hash the input message and derive the leaf index.
+ *
+ * Computes H(R, pk, m), where R is the random number included in the SPHINCS+
+ * signature and H is the underlying hash function (Hmsg in the SPHINCS+
+ * paper). Outputs the message digest and the index of the leaf. The index is
+ * split in the tree index and the leaf index, for convenient copying to an
+ * address.
+ *
+ * @param R Per-signature random number.
+ * @param pk Public key.
+ * @param m Input message.
+ * @param mlen Input message length.
+ * @param[out] digest Output buffer for message digest.
+ * @param[out] tree Tree index.
+ * @param[out] leaf_idx Leaf index.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t spx_hash_message(const uint8_t *R, const uint8_t *pk,
+                             const uint8_t *m, unsigned long long mlen,
+                             uint8_t *digest, uint64_t *tree,
+                             uint32_t *leaf_idx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_HASH_H_

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/hash_shake.c
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h"
+
+enum {
+  /**
+   * Number of bits needed to represent the `tree` field.
+   */
+  kSpxTreeBits = kSpxTreeHeight * (kSpxD - 1),
+  /**
+   * Number of bytes needed to represent the `tree` field.
+   */
+  kSpxTreeBytes = (kSpxTreeBits + 7) / 8,
+  /**
+   * Number of bits needed to represent a leaf index.
+   */
+  kSpxLeafBits = kSpxTreeHeight,
+  /**
+   * Number of bytes needed to represent a leaf index.
+   */
+  kSpxLeafBytes = (kSpxLeafBits + 7) / 8,
+  /**
+   * Number of bytes needed for the message digest.
+   */
+  kSpxDigestBytes = kSpxForsMsgBytes + kSpxTreeBytes + kSpxLeafBytes,
+  /**
+   * Number of 32-bit words needed for the message digest.
+   *
+   * Rounded up if necessary.
+   */
+  kSpxDigestWords = (kSpxDigestBytes + sizeof(uint32_t) - 1) / sizeof(uint32_t),
+};
+
+static_assert(
+    kSpxTreeBits <= 64,
+    "For given height and depth, 64 bits cannot represent all subtrees.");
+static_assert(
+    kSpxLeafBits <= 32,
+    "For the given height, 32 bits is not large enough for a leaf index.");
+
+rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
+  return kmac_shake256_configure();
+}
+
+rom_error_t spx_hash_message(const uint8_t *R, const uint8_t *pk,
+                             const uint8_t *m, unsigned long long mlen,
+                             uint8_t *digest, uint64_t *tree,
+                             uint32_t *leaf_idx) {
+  uint32_t buf[kSpxDigestWords] = {0};
+  unsigned char *bufp = (unsigned char *)buf;
+
+  HARDENED_RETURN_IF_ERROR(kmac_shake256_start());
+  kmac_shake256_absorb(R, kSpxN);
+  kmac_shake256_absorb(pk, kSpxPkBytes);
+  kmac_shake256_absorb(m, mlen);
+  kmac_shake256_squeeze_start();
+  HARDENED_RETURN_IF_ERROR(kmac_shake256_squeeze_end(buf, kSpxDigestWords));
+
+  memcpy(digest, bufp, kSpxForsMsgBytes);
+  bufp += kSpxForsMsgBytes;
+
+  if (kSpxTreeBits == 0) {
+    *tree = 0;
+  } else {
+    *tree = spx_utils_bytes_to_u64(bufp, kSpxTreeBytes);
+    *tree &= (~(uint64_t)0) >> (64 - kSpxTreeBits);
+    bufp += kSpxTreeBytes;
+  }
+
+  *leaf_idx = (uint32_t)spx_utils_bytes_to_u64(bufp, kSpxLeafBytes);
+  *leaf_idx &= (~(uint32_t)0) >> (32 - kSpxLeafBits);
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
@@ -35,8 +35,8 @@ extern "C" {
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t thash(const unsigned char *in, size_t inblocks,
-                  const spx_ctx_t *ctx, const spx_addr_t *addr, uint32_t *out);
+rom_error_t thash(const uint8_t *in, size_t inblocks, const spx_ctx_t *ctx,
+                  const spx_addr_t *addr, uint32_t *out);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
@@ -10,8 +10,8 @@
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
 
-rom_error_t thash(const unsigned char *in, size_t inblocks,
-                  const spx_ctx_t *ctx, const spx_addr_t *addr, uint32_t *out) {
+rom_error_t thash(const uint8_t *in, size_t inblocks, const spx_ctx_t *ctx,
+                  const spx_addr_t *addr, uint32_t *out) {
   // Uses the "simple" thash construction (Construction 7 in the SPHINCS+
   // paper): H(pk_seed, addr, in).
   HARDENED_RETURN_IF_ERROR(kmac_shake256_start());

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.c
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/utils.c
+
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
+
+uint64_t spx_utils_bytes_to_u64(const uint8_t *in, size_t inlen) {
+  uint64_t retval = 0;
+  for (size_t i = 0; i < inlen; i++) {
+    retval |= ((uint64_t)in[i]) << (8 * (inlen - 1 - i));
+  }
+  return retval;
+}
+
+rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
+                                   uint32_t idx_offset,
+                                   const uint8_t *auth_path,
+                                   uint8_t tree_height, const spx_ctx_t *ctx,
+                                   spx_addr_t *addr, uint32_t *root) {
+  // Initialize working buffer.
+  uint32_t buffer[2 * kSpxNWords];
+  // Pointer to second half of buffer for convenience.
+  uint32_t *buffer_second = &buffer[kSpxNWords];
+
+  // If leaf_idx is odd (last bit = 1), current path element is a right child
+  // and auth_path has to go left. Otherwise it is the other way around.
+  if (leaf_idx & 1) {
+    memcpy(buffer_second, leaf, kSpxN);
+    memcpy(buffer, auth_path, kSpxN);
+  } else {
+    memcpy(buffer, leaf, kSpxN);
+    memcpy(buffer_second, auth_path, kSpxN);
+  }
+  auth_path += kSpxN;
+
+  for (uint8_t i = 0; i < tree_height - 1; i++) {
+    leaf_idx >>= 1;
+    idx_offset >>= 1;
+    // Set the address of the node we're creating.
+    spx_addr_tree_height_set(addr, i + 1);
+    spx_addr_tree_index_set(addr, leaf_idx + idx_offset);
+
+    // Pick the right or left neighbor, depending on parity of the node.
+    uint32_t *hash_dst = (leaf_idx & 1) ? buffer_second : buffer;
+    uint32_t *auth_dst = (leaf_idx & 1) ? buffer : buffer_second;
+
+    // This is an inlined `thash` operation.
+    HARDENED_RETURN_IF_ERROR(kmac_shake256_start());
+    kmac_shake256_absorb_words(ctx->pub_seed, kSpxNWords);
+    kmac_shake256_absorb_words(addr->addr, ARRAYSIZE(addr->addr));
+    kmac_shake256_absorb_words(buffer, 2 * kSpxNWords);
+    kmac_shake256_squeeze_start();
+
+    // Copy the auth path while KMAC is processing for performance reasons.
+    memcpy(auth_dst, auth_path, kSpxN);
+    auth_path += kSpxN;
+
+    // Get the `thash` output.
+    HARDENED_RETURN_IF_ERROR(kmac_shake256_squeeze_end(hash_dst, kSpxNWords));
+  }
+
+  // The last iteration is exceptional; we do not copy an auth_path node.
+  leaf_idx >>= 1;
+  idx_offset >>= 1;
+  spx_addr_tree_height_set(addr, tree_height);
+  spx_addr_tree_index_set(addr, leaf_idx + idx_offset);
+  return thash((unsigned char *)buffer, 2, ctx, addr, root);
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/utils.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_UTILS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_UTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Convert from big-endian bytes to a 64-bit integer.
+ *
+ * It is the caller's responsibility to ensure the number of bytes is small
+ * enough to fit a 64-bit integer (i.e. `inlen` <= 8).
+ *
+ * Appears in the reference code as `bytes_to_ull`.
+ *
+ * @param in Input buffer
+ * @param inlen Size of input buffer (in bytes).
+ */
+uint64_t spx_utils_bytes_to_u64(const uint8_t *in, size_t inlen);
+
+/**
+ * Computes a root node of a subtree.
+ *
+ * Computes the root node based on the provided leaf and authentication path.
+ * Expects address to be complete other than the tree_height and tree_index.
+ *
+ * @param leaf Input leaf.
+ * @param leaf_idx Index of input leaf.
+ * @param idx_offset Leaf index offset.
+ * @param auth_path Input authentication path.
+ * @param tree_height Tree height.
+ * @param ctx Context object.
+ * @param addr Hypertree address.
+ * @param[out] root Resulting root node.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
+                                   uint32_t idx_offset,
+                                   const uint8_t *auth_path,
+                                   uint8_t tree_height, const spx_ctx_t *ctx,
+                                   spx_addr_t *addr, uint32_t *root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_UTILS_H_


### PR DESCRIPTION
This PR adds two more pieces of SPHINCS+:
- Hash initialization function (in our case, this configures the KMAC block)
- The function to hash the initial input message
  - computes `SHAKE256(R || public key || message)`, where `R` is taken from the signature)
- A few utility functions needed by the verification computation
  - converting bytes to `uint64_t`
  - computing the root of a subtree 