### PR TITLE
[dv/sysrst] Update the time to set aon_timer_freq

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -51,8 +51,8 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task dut_init(string reset_kind = "HARD");
     cfg.vif.reset_signals();
-    super.dut_init();
     set_aon_clk_freq();
+    super.dut_init();
     if (do_sysrst_ctrl_init) sysrst_ctrl_init();
     add_delay_after_reset_before_csrs_access();
   endtask


### PR DESCRIPTION
Based on issue #17234, the aon_clk's frequency is set to a different value during the simulation after reset, that causes the testbench timer (which checks the actual ec_rst_l set time) to be inaccurate. This PR fixes it by setting the aon_clk frequency right before the reset.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>