### PR TITLE
[dv/sysrst_ctrl] Fix null pointer when not enable --cov option

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_pin_override_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_pin_override_vseq.sv
@@ -138,29 +138,31 @@ class sysrst_ctrl_pin_override_vseq extends sysrst_ctrl_base_vseq;
       perform_checks(en_override_z3_wakeup, override_val_z3_wakeup,
           allowed_z3_wakeup_1, allowed_z3_wakeup_0, cfg.vif.z3_wakeup, 0);
 
-      cov.pin_cfg_cg["bat_disable"].pin_cfg_cg.sample (en_override_bat_disable,
-          override_val_bat_disable, allowed_bat_disable_0, allowed_bat_disable_1);
+      if (cfg.en_cov) begin
+        cov.pin_cfg_cg["bat_disable"].pin_cfg_cg.sample (en_override_bat_disable,
+            override_val_bat_disable, allowed_bat_disable_0, allowed_bat_disable_1);
 
-      cov.pin_cfg_cg["ec_rst_l"].pin_cfg_cg.sample (en_override_ec_rst_l_out,
-          override_val_ec_rst_l_out, allowed_ec_rst_l_out_0, allowed_ec_rst_l_out_1);
+        cov.pin_cfg_cg["ec_rst_l"].pin_cfg_cg.sample (en_override_ec_rst_l_out,
+            override_val_ec_rst_l_out, allowed_ec_rst_l_out_0, allowed_ec_rst_l_out_1);
 
-      cov.pin_cfg_cg["pwrb_out"].pin_cfg_cg.sample (en_override_pwrb_out,
-          override_val_pwrb_out, allowed_pwrb_out_0, allowed_pwrb_out_1);
+        cov.pin_cfg_cg["pwrb_out"].pin_cfg_cg.sample (en_override_pwrb_out,
+            override_val_pwrb_out, allowed_pwrb_out_0, allowed_pwrb_out_1);
 
-      cov.pin_cfg_cg["key0_out"].pin_cfg_cg.sample (en_override_key0_out,
-          override_val_key0_out, allowed_key0_out_0, allowed_key0_out_1);
+        cov.pin_cfg_cg["key0_out"].pin_cfg_cg.sample (en_override_key0_out,
+            override_val_key0_out, allowed_key0_out_0, allowed_key0_out_1);
 
-      cov.pin_cfg_cg["key1_out"].pin_cfg_cg.sample (en_override_key1_out,
-          override_val_key1_out, allowed_key1_out_0, allowed_key1_out_1);
+        cov.pin_cfg_cg["key1_out"].pin_cfg_cg.sample (en_override_key1_out,
+            override_val_key1_out, allowed_key1_out_0, allowed_key1_out_1);
 
-      cov.pin_cfg_cg["key2_out"].pin_cfg_cg.sample (en_override_key2_out,
-          override_val_key2_out, allowed_key2_out_0, allowed_key2_out_1);
+        cov.pin_cfg_cg["key2_out"].pin_cfg_cg.sample (en_override_key2_out,
+            override_val_key2_out, allowed_key2_out_0, allowed_key2_out_1);
 
-      cov.pin_cfg_cg["z3_wakeup"].pin_cfg_cg.sample (en_override_z3_wakeup,
-          override_val_z3_wakeup, allowed_z3_wakeup_0, allowed_z3_wakeup_1);
+        cov.pin_cfg_cg["z3_wakeup"].pin_cfg_cg.sample (en_override_z3_wakeup,
+            override_val_z3_wakeup, allowed_z3_wakeup_0, allowed_z3_wakeup_1);
 
-      cov.pin_cfg_cg["flash_wp_l"].pin_cfg_cg.sample (en_override_flash_wp,
-          override_val_flash_wp, allowed_flash_wp_0, allowed_flash_wp_1);
+        cov.pin_cfg_cg["flash_wp_l"].pin_cfg_cg.sample (en_override_flash_wp,
+            override_val_flash_wp, allowed_flash_wp_0, allowed_flash_wp_1);
+      end
     end
 
   endtask : body

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
@@ -160,13 +160,15 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
       csr_rd_check(ral.ulp_status, .compare_value(0));
      end
      // Sample the wakeup event covergroup before clearing the status register
-     cov.wakeup_event.sysrst_ctrl_wkup_event_cg.sample(
-       get_field_val(ral.wkup_status.wakeup_sts, wkup_sts_rdata),
-       cfg.vif.pwrb_in,
-       cfg.vif.lid_open,
-       cfg.vif.ac_present,
-       cfg.intr_vif.pins
-     );
+     if (cfg.en_cov) begin
+       cov.wakeup_event.sysrst_ctrl_wkup_event_cg.sample(
+         get_field_val(ral.wkup_status.wakeup_sts, wkup_sts_rdata),
+         cfg.vif.pwrb_in,
+         cfg.vif.lid_open,
+         cfg.vif.ac_present,
+         cfg.intr_vif.pins
+       );
+     end
      cfg.clk_aon_rst_vif.wait_clks(10);
     end
    endtask : body


### PR DESCRIPTION
The `cov` object is only created if we enabled --cov option in simulation. So the `cov.XXX` statement should only be called if the --cov option is enabled, otherwise we will get a runtime error saying `.cov` is a NULL pointer.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>