### PR TITLE
[dv/sysrst_ctrl] fix stress_all_with_rand_reset issue

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -237,7 +237,8 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       "alert_test": begin
       end
       // TODO: need support pre-condition
-      "com_pre_sel_ctl_0", "com_pre_det_ctl_0": begin
+      "com_pre_sel_ctl_0", "com_pre_sel_ctl_1", "com_pre_sel_ctl_2", "com_pre_sel_ctl_3",
+      "com_pre_det_ctl_0", "com_pre_det_ctl_1", "com_pre_det_ctl_2", "com_pre_det_ctl_3": begin
       end
       default: begin
        `uvm_error(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))


### PR DESCRIPTION
Regression has error in stress_all_with_rand_reset saying `invalid csr: com_pre_sel_ctl_3`. This PR adds all pre-condition related CSRs to valid CSR list in scb.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>