### PR TITLE
[hw,doc] Add one-line descriptions to all blocks

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 { name:               "adc_ctrl",
+  one_line_desc:      "Low-power control interface for a dual-channel ADC with filtering and debouncing capability",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -5,6 +5,7 @@
 # AES register template
 {
   name:               "aes",
+  one_line_desc:      "AES encryption and decryption engine with SCA and FI countermeasures",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -4,6 +4,7 @@
 //
 {
   name:               "aon_timer",
+  one_line_desc:      "Wakeup and watchdog timers running on a low-power, always-on clock",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/clkmgr/data/clkmgr.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.hjson
@@ -10,6 +10,7 @@
 #
 {
   name:               "clkmgr",
+  one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -6,6 +6,7 @@
 #
 {
   name:               "clkmgr",
+  one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 { name:               "csrng",
+  one_line_desc:      "Takes entropy bits to produce cryptographically secure random numbers for consumption by hardware blocks and by software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "edn",
+  one_line_desc:      "Distributes random numbers produced by CSRNG to hardware blocks",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 { name:               "entropy_src",
+  one_line_desc:      "Filters and checks raw entropy bits from a random noise source and forwards them to CSRNG",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -6,6 +6,7 @@
 
 {
   name:               "flash_ctrl",
+  one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -17,6 +17,7 @@
 
 {
   name:               "flash_ctrl",
+  one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "gpio",
+  one_line_desc:      "General-purpose I/O pin control interface for software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "hmac",
+  one_line_desc:      "Accelerator for SHA-256-based keyed hash message authentication code and the SHA-256 hash function",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -4,6 +4,7 @@
 
 {
   name:               "i2c",
+  one_line_desc:      "I2C interface for host and device mode, supporting up to 1 Mbaud data rates",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "keymgr",
+  one_line_desc:      "Managing identities and root keys; shielding confidential assets from software; providing a key derivation interface for software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -4,6 +4,7 @@
 
 {
   name:               "kmac",
+  one_line_desc:      "Accelerator for Keccak-based keyed hash message authentication code and SHA-3 hash functions; with SCA and FI countermeasures",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "lc_ctrl",
+  one_line_desc:      "Manages device life cycle states and transitions, and controls key manager, flash, OTP, and debug access",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "otbn",
+  one_line_desc:      "OpenTitan Big Number accelerator, programmable coprocessor for asymmetric cryptography with SCA and FI countermeasures",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -10,6 +10,7 @@
 
 {
   name:               "otp_ctrl",
+  one_line_desc:      "Interfaces integrated one-time programmable memory, supports scrambling, integrity and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -23,6 +23,7 @@
 %>
 {
   name:               "otp_ctrl",
+  one_line_desc:      "Interfaces integrated one-time programmable memory, supports scrambling, integrity and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -4,6 +4,7 @@
 
 {
   name:               "pattgen",
+  one_line_desc:      "Transmission of short time-dependent data patterns on two clock-parallel output channels",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -4,6 +4,7 @@
 //
 {
   name:               "pinmux",
+  one_line_desc:      "Multiplexes between on-chip hardware blocks and pins; can be configured at runtime",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -16,6 +16,7 @@
 ##  - attr_dw:             Width of wakeup counters
 {
   name:               "pinmux",
+  one_line_desc:      "Multiplexes between on-chip hardware blocks and pins, and can be configured at runtime",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "pwm",
+  one_line_desc:      "Transmission of pulse-width modulated output signals with adjustable duty cycle",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "pwrmgr",
+  one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -8,6 +8,7 @@
 %>\
 {
   name:               "pwrmgr",
+  one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "rom_ctrl",
+  one_line_desc:      "Interfaces scrambled boot ROM with system bus and KMAC for initial health check after reset",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -8,6 +8,7 @@
 #
 {
   name:               "rstmgr",
+  one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -20,6 +20,7 @@
 #
 {
   name:               "rstmgr",
+  one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "rv_core_ibex",
+  one_line_desc:      "Dual-core lockstep 32-bit RISC-V processor running application and control software",
   design_spec:        "../doc",
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "rv_dm",
+  one_line_desc:      "Enables debug support for Ibex, access protected by life cycle",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -4,6 +4,7 @@
 //
 {
   name:               "rv_timer",
+  one_line_desc:      "Memory-mapped timer unit implementing RISC-V mtime and mtimecmp registers",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_timer/data/rv_timer.hjson.tpl
+++ b/hw/ip/rv_timer/data/rv_timer.hjson.tpl
@@ -7,6 +7,7 @@
 ##  - timers: number of timers in each hart
 {
   name:               "rv_timer",
+  one_line_desc:      "Memory-mapped timer unit implementing RISC-V mtime and mtimecmp registers",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "spi_device",
+  one_line_desc:      "Serial peripheral interface supporting different device modes, suitable for bulk-load of data into and out of the chip",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "spi_host",
+  one_line_desc:      "Serial peripheral interface for host mode, suitable for interfacing external serial NOR flash devices",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "sram_ctrl",
+  one_line_desc:      "Interfacing on-chip SRAM blocks with system bus, supports lightweight scrambling, integrity and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "sysrst_ctrl",
+  one_line_desc:      "Manages board-level reset sequencing, interfaces reset and power manager",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "uart",
+  one_line_desc:      "Full duplex serial communication interface, supports bit rates of up to 1 Mbit/s",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "usbdev",
+  one_line_desc:      "USB 2.0 Full Speed device interface (12 Mbit/s)",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -12,6 +12,7 @@
 #
 {
   name:               "clkmgr",
+  one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -12,6 +12,7 @@
 
 {
   name:               "flash_ctrl",
+  one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -12,6 +12,7 @@
 //
 {
   name:               "pinmux",
+  one_line_desc:      "Multiplexes between on-chip hardware blocks and pins, and can be configured at runtime",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name:               "pwrmgr",
+  one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -14,6 +14,7 @@
 #
 {
   name:               "rstmgr",
+  one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -56,6 +56,7 @@ REQUIRED_FIELDS = {
 }
 
 OPTIONAL_FIELDS = {
+    'one_line_desc': ['s', "one-line description of the component"],
     # Note: this revision list may be deprecated in the future.
     'revisions': ['l', "list with revision records"],
     'design_spec':


### PR DESCRIPTION
This PR adds one-line descriptions to all hardware blocks under `hw/ip` that have a `data/<name>.hjson` file except `trial1`.

These one-line descriptions are intended for use in summary tables or as subtitles.  As such, they should concisely convey the gist of a hardware block. (One-*paragraph* summaries follow in a later PR.)

For blocks that have their `.hjson` generated from a template (`.hjson.tpl`), this PR updates the template and the generated
`.hjson`.  This PR also updates the `.hjson`s of the top-level-specific blocks.

The new field that contains the one-line description, `one_line_desc`, is added to `util/reggen` as optional.