### PR TITLE
[otbn] Synchronize clearing of the error bits

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -23,6 +23,7 @@ module otbn_controller
 
   input  logic start_i,   // start the processing at address zero
   output logic locking_o, // Controller is in or is entering the locked state
+  input  logic err_bit_clear_i,
 
   input prim_mubi_pkg::mubi4_t fatal_escalate_en_i,
   input prim_mubi_pkg::mubi4_t recov_escalate_en_i,
@@ -623,7 +624,7 @@ module otbn_controller
     if (!rst_ni) begin
       err_bits_q <= '0;
     end else begin
-      if (start_i && !locking_o) begin
+      if (err_bit_clear_i && !locking_o) begin
         err_bits_q <= '0;
       end else begin
         err_bits_q <= err_bits_q | err_bits_d;

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -412,8 +412,9 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .start_i      (controller_start),
+    .start_i         (controller_start),
     .locking_o,
+    .err_bit_clear_i (start_i),
 
     .fatal_escalate_en_i(controller_fatal_escalate_en),
     .recov_escalate_en_i(controller_recov_escalate_en),

--- a/sw/device/tests/keymgr_sideload_otbn_test.c
+++ b/sw/device/tests/keymgr_sideload_otbn_test.c
@@ -112,12 +112,8 @@ static void test_otbn_with_sideloaded_key(dif_keymgr_t *keymgr,
       keymgr, sideload_params);  // Regenerate the sideload key.
   LOG_INFO("Keymgr generated HW output for OTBN.");
   uint32_t post_clear_salt_result[8];
-  // TODO (issue #16653) - fix the function call below
-  // and send in kErrBitsOk (error is actually not expected) and uncomment the
-  // equality check on outputs afterwards.
-  run_x25519_app(otbn, post_clear_salt_result, kOtbnInvalidKeyErr);
-  // TODO (issue #16653) - uncomment the equality check on output below.
-  // CHECK_ARRAYS_EQ(result, post_clear_salt_result, ARRAYSIZE(result));
+  run_x25519_app(otbn, post_clear_salt_result, kErrBitsOk);
+  CHECK_ARRAYS_EQ(result, post_clear_salt_result, ARRAYSIZE(result));
 
   // Change the salt to generate a different key.
   sideload_params.salt[0] = ~sideload_params.salt[0];


### PR DESCRIPTION
Currently error bits in otbn_controller and otbn_core are not cleared at the same time.
This commit introduces an err_bit_clear signal to synchronize the clearing of error bits.

Closes #16653

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>