### PR TITLE
[hw,doc] Add one-paragraph descriptions to all blocks

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -3,6 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 { name:               "adc_ctrl",
   one_line_desc:      "Low-power control interface for a dual-channel ADC with filtering and debouncing capability",
+  one_paragraph_desc: '''
+  The Analog to Digital Converter (ADC) Control Interface hardware block provides a simple front-end to an analog block that allows filtering and debouncing of the sampled data.
+  The ADC controller supports 2 ADC channels and 8 filters on the values from the channels.
+  It has debounce timers on the filter output and supports ADCs with 10-bit output.
+  To enable usage while the device is sleeping, it runs on a slow always-on clock.
+  In addition, it has a low power periodic scan mode for monitoring ADC channels.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -6,6 +6,15 @@
 {
   name:               "aes",
   one_line_desc:      "AES encryption and decryption engine with SCA and FI countermeasures",
+  one_paragraph_desc: '''
+  [Advanced Encryption Standard (AES)][nist-aes] is the primary symmetric encryption and decryption mechanism used in OpenTitan protocols.
+  The OpenTitan AES hardware block supports encryption/decryption using AES-128/192/256 in ECB, CBC, CFB, OFB, and CTR block cipher modes.
+  The cipher core uses first-order domain-oriented masking (DOM) to deter side-channel analysis (SCA).
+  To save area, the masking can optionally be disabled using a compile-time Verilog parameter.
+  In addition, the block features several countermeasures to deter fault injection (FI) attacks on the control path.
+
+  [nist-aes]: https://www.nist.gov/publications/advanced-encryption-standard-aes
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -5,6 +5,13 @@
 {
   name:               "aon_timer",
   one_line_desc:      "Wakeup and watchdog timers running on a low-power, always-on clock",
+  one_paragraph_desc: '''
+  Always-on Timer (AON Timer) is the main timer hardware block of OpenTitan.
+  It includes two 32-bit up-counting timers, one of which functions as a wakeup timer and the other as a watchdog timer.
+  The watchdog timer has two thresholds: a 'bark' threshold that generates an interrupt and a 'bite' threshold that resets the system.
+  The wakeup timer has a 12-bit pre-scaler to enable very long timeouts and also generates an interrupt to the core.
+  The timers run on a ~200 kHz AON clock and have a maximum timeout window of roughly ~6 hours for the watchdog timer and ~1000 days with the use of the pre-scaler for the wakeup timer.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/clkmgr/data/clkmgr.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.hjson
@@ -11,6 +11,13 @@
 {
   name:               "clkmgr",
   one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
+  one_paragraph_desc: '''
+  The OpenTitan clock manager derives on-chip clocks from root clock signals provided by the Analog Sensor Top (AST).
+  Input and output clocks may be asynchronous to each other.
+  During clock derivation, the clock manager can divide clocks to lower frequencies and gate clocks based on control signals from the power manager and to a limited extent from software.
+  For example, the idle status of relevant hardware blocks is tracked and clock gating requests from software are ignored as long these blocks are active.
+  Further security features include switchable clock jitter, continuous monitoring of clock frequencies, and various countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -7,6 +7,13 @@
 {
   name:               "clkmgr",
   one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
+  one_paragraph_desc: '''
+  The OpenTitan clock manager derives on-chip clocks from root clock signals provided by the Analog Sensor Top (AST).
+  Input and output clocks may be asynchronous to each other.
+  During clock derivation, the clock manager can divide clocks to lower frequencies and gate clocks based on control signals from the power manager and to a limited extent from software.
+  For example, the idle status of relevant hardware blocks is tracked and clock gating requests from software are ignored as long these blocks are active.
+  Further security features include switchable clock jitter, continuous monitoring of clock frequencies, and various countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -3,6 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 { name:               "csrng",
   one_line_desc:      "Takes entropy bits to produce cryptographically secure random numbers for consumption by hardware blocks and by software",
+  one_paragraph_desc: '''
+  The OpenTitan Cryptographically Secure Random Number Generator (CSRNG) consumes random seeds from the entropy source and generates random numbers for separate application interface contexts, such as multiple entropy distribution networks and software.
+  When used in fully deterministic mode, the random numbers are generated just based on seeds provided by the application input.
+  The CSRNG targets compliance with [BSI's AIS31 recommendations for Common Criteria (CC)][bsi-ais31] as well as NIST's [SP 800-90A][nist-sp-800-90a] and [SP 800-90C][nist-sp-800-90c].
+  Internally, it uses the CTR_DRBG construction with a security strength of 256 bits as specified by [SP 800-90A][nist-sp-800-90a].
+
+  [bsi-ais31]: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Zertifizierung/Interpretationen/AIS_31_Functionality_classes_for_random_number_generators_e.pdf
+  [nist-sp-800-90a]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf
+  [nist-sp-800-90c]: https://csrc.nist.gov/CSRC/media/Publications/sp/800-90c/draft/documents/sp800_90c_second_draft.pdf
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -4,6 +4,12 @@
 {
   name:               "edn",
   one_line_desc:      "Distributes random numbers produced by CSRNG to hardware blocks",
+  one_paragraph_desc: '''
+  The OpenTitan Entropy Distribution Network (EDN) interfaces various hardware blocks consuming random numbers to CSRNG.
+  Besides adapting bus widths, it provides a set of registers for firmware to manage the corresponding CSRNG application interface.
+  This allows configuring EDN to automatically send reseed and generate commands to the connected CSRNG context in order to continuously supply consumers with entropy of defined quality.
+  Additionally, EDN supports a boot-time request mode, in which it supplies a limited amount of potentially lower-quality entropy with less firmware interaction immediately at boot-time or after reset.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -3,6 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 { name:               "entropy_src",
   one_line_desc:      "Filters and checks raw entropy bits from a random noise source and forwards them to CSRNG",
+  one_paragraph_desc: '''
+  The OpenTitan entropy source hardware block (entropy_src) takes bits from a physically random noise source (external to this block) and produces random values in a manner that is compliant both with FIPS (through [NIST SP 800-90B][nist-sp-800-90b]) and [CC (AIS31)][bsi-ais31] recommendations.
+  The random values produced by entropy_src serve as non-deterministic seeds for CSRNG.
+  Depending on the mode of operation, entropy_src can apply a secure hash function to the raw noise bits for conditioning.
+  To detect statistical defects in the raw noise bits, entropy_src performs multiple health checks.
+
+  [bsi-ais31]: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Zertifizierung/Interpretationen/AIS_31_Functionality_classes_for_random_number_generators_e.pdf
+  [nist-sp-800-90b]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90B.pdf
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -7,6 +7,13 @@
 {
   name:               "flash_ctrl",
   one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
+  one_paragraph_desc: '''
+  The OpenTitan flash controller interfaces the integrated, non-volatile flash memory with software and other hardware components in the system, such as life cycle controller, key manager, and OTP controller.
+  It consists of the open source flash controller that interfaces with a third party flash module.
+  The protocol controller handles read, program, and erase requests, as well as life cycle RMA entry.
+  It supports differentiation between informational and data flash partitions, flash memory protection at page boundaries, and the handling of key manager secrets inaccessible to software.
+  The actual physical controller is highly parameterized (number of banks, number of pages for each bank, number of words and word size for each page, and number of read buffers) and supports XEX scrambling configurable by software, as well as two types of ECC support configurable on a page boundary.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -18,6 +18,13 @@
 {
   name:               "flash_ctrl",
   one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
+  one_paragraph_desc: '''
+  The OpenTitan flash controller interfaces the integrated, non-volatile flash memory with software and other hardware components in the system, such as life cycle controller, key manager, and OTP controller.
+  It consists of the open source flash controller that interfaces with a third party flash module.
+  The protocol controller handles read, program, and erase requests, as well as life cycle RMA entry.
+  It supports differentiation between informational and data flash partitions, flash memory protection at page boundaries, and the handling of key manager secrets inaccessible to software.
+  The actual physical controller is highly parameterized (number of banks, number of pages for each bank, number of words and word size for each page, and number of read buffers) and supports XEX scrambling configurable by software, as well as two types of ECC support configurable on a page boundary.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -4,6 +4,12 @@
 {
   name:               "gpio",
   one_line_desc:      "General-purpose I/O pin control interface for software",
+  one_paragraph_desc: '''
+  The GPIO hardware block allows software to communicate through general purpose I/O pins in a flexible manner.
+  It supports up to 32 GPIO ports and each of these ports can be written as peripheral outputs in two modes: either with direct access to each GPIO value using direct write, allowing software to control all GPIO ports simultaneously, or with masked writes to half of the bits at a time, allowing software to affect the output value of a subset of the bits without requiring a read-modify-write.
+  In the input direction, software can read the contents of any of the GPIO peripheral inputs, and it can request the detection of an interrupt event for any of the 32 bits in a configurable manner for detecting rising edge, falling edge, or active low/high input.
+  A noise filter is available through configuration for any of the inputs.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -4,6 +4,13 @@
 {
   name:               "hmac",
   one_line_desc:      "Accelerator for SHA-256-based keyed hash message authentication code and the SHA-256 hash function",
+  one_paragraph_desc: '''
+  The OpenTitan HMAC hardware block is a keyed hash based message authentication code generator using [SHA-256][nist-fips-180-4] to check the integrity of an incoming message and optionally a signature signed with the same secret key.
+  This HMAC implementation is not hardened against side-channel analysis (SCA) or fault injection (FI) attacks; it is meant purely for hashing acceleration.
+  If hardened MAC operations are required, either the KMAC hardware block or a software implementation should be used.
+
+  [nist-fips-180-4]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -5,6 +5,12 @@
 {
   name:               "i2c",
   one_line_desc:      "I2C interface for host and device mode, supporting up to 1 Mbaud data rates",
+  one_paragraph_desc: '''
+  The I2C hardware block provides the interface for the I2C serial communication protocol.
+  It can be configured in host (master) or device (slave) mode and supports standard data rate (100 kbaud), fast data rate (400 kbaud), and fast plus data rate (1 Mbaud).
+  In addition to supporting all mandatory I2C features, this block supports clock stretching in host mode and automatic clock stretching in device mode.
+  This block uses a 7-bit address space and it is compatible with any device covered by I2C specification operating at speeds up to 1 Mbaud.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -4,6 +4,15 @@
 {
   name:               "keymgr",
   one_line_desc:      "Managing identities and root keys; shielding confidential assets from software; providing a key derivation interface for software",
+  one_paragraph_desc: '''
+  The OpenTitan key manager hardware block implements the hardware component of the identities and root keys strategy of OpenTitan.
+  It shields confidential assets from direct software access and provides an interface for software to use derived keys and identity outputs.
+  The key derivation functionality interfaces KMAC.
+  keymgr provides AES, OTBN, and KMAC with confidential keys over sideload interfaces that are not accessible from software.
+  In addition, it supports the [Open Profile for DICE][pigweed-open-dice].
+
+  [pigweed-open-dice]: https://pigweed.googlesource.com/open-dice/+/HEAD/docs/specification.md#Open-Profile-for-DICE
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -5,6 +5,16 @@
 {
   name:               "kmac",
   one_line_desc:      "Accelerator for Keccak-based keyed hash message authentication code and SHA-3 hash functions; with SCA and FI countermeasures",
+  one_paragraph_desc: '''
+  OpenTitan protocols use [Keccak/SHA-3][nist-fips-202]-based cryptographic primitives for data authentication, integrity checking, and key derivation.
+  The OpenTitan KMAC hardware block is a hardware accelerator that supports Keccak-based Message Authentication Code (KMAC) and the SHA3-derived functions SHAKE and cSHAKE as defined in [NIST SP 800-185][nist-sp-800-185].
+  The Keccak core uses first-order domain-oriented masking (DOM) to deter side-channel analysis (SCA).
+  To save area, the masking can optionally be disabled using a compile-time Verilog parameter.
+  In addition, this block features several countermeasures to deter fault injection (FI) attacks.
+
+  [nist-fips-202]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
+  [nist-sp-800-185]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -4,6 +4,10 @@
 {
   name:               "lc_ctrl",
   one_line_desc:      "Manages device life cycle states and transitions, and controls key manager, flash, OTP, and debug access",
+  one_paragraph_desc: '''
+  The OpenTitan life cycle controller is responsible for handling and guarding transitions between different device life cycle states, concurrently decoding the current life cycle state and redundantly broadcasting encoded life cycle qualification signals across the system, e.g., to control the behavior of key manager, flash controller, OTP controller, and debug infrastructure.
+  In addition, it features an escalation receiver for the alert system to invalidate the life cycle state as part of an escalation sequence.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -4,6 +4,16 @@
 {
   name:               "otbn",
   one_line_desc:      "OpenTitan Big Number accelerator, programmable coprocessor for asymmetric cryptography with SCA and FI countermeasures",
+  one_paragraph_desc: '''
+  The OpenTitan Big Number accelerator (OTBN) is a programmable coprocessor for asymmetric cryptographic algorithms such as RSA or elliptic curve cryptography (ECC).
+  Such algorithms are dominated by wide integer arithmetic, which are executed on OTBN's 256-bit-wide data path.
+  The data OTBN processes is often security sensitive, and OTBN is designed to reduce the attack surface by
+  (1) keeping the instruction set and the processor design as simple as possible to aid verification,
+  (2) minimizing control flow and clearly separating it from data flow,
+  (3) limiting OTBN's instruction fetch and data memory accesses to separate, dedicated on-chip memories,
+  (4) giving OTBN software direct access to cryptographically secure random numbers,
+  and (5) implementing various hardware countermeasures to deter side-channel analysis (SCA) and fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -11,6 +11,11 @@
 {
   name:               "otp_ctrl",
   one_line_desc:      "Interfaces integrated one-time programmable memory, supports scrambling, integrity and secure wipe",
+  one_paragraph_desc: '''
+  The OTP controller provides an open source abstraction interface for software and other hardware components such as life cycle controller and key manager to interact with an integrated, closed source, proprietary one-time-programmable (OTP) memory.
+  On top of defensive features provided by the proprietary OTP memory to deter side-channel analysis (SCA), fault injection (FI) attacks, and visual and electrical probing, the open source OTP controller features high-level logical security protection such as integrity checks and scrambling, as well as software isolation for when OTP contents are readable and programmable.
+  It features multiple individually-lockable logical partitions, periodic / persistent checking of OTP values, and a separate partition and interface for the life cycle controller.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -24,6 +24,11 @@
 {
   name:               "otp_ctrl",
   one_line_desc:      "Interfaces integrated one-time programmable memory, supports scrambling, integrity and secure wipe",
+  one_paragraph_desc: '''
+  The OTP controller provides an open source abstraction interface for software and other hardware components such as life cycle controller and key manager to interact with an integrated, closed source, proprietary one-time-programmable (OTP) memory.
+  On top of defensive features provided by the proprietary OTP memory to deter side-channel analysis (SCA), fault injection (FI) attacks, and visual and electrical probing, the open source OTP controller features high-level logical security protection such as integrity checks and scrambling, as well as software isolation for when OTP contents are readable and programmable.
+  It features multiple individually-lockable logical partitions, periodic / persistent checking of OTP values, and a separate partition and interface for the life cycle controller.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -5,6 +5,12 @@
 {
   name:               "pattgen",
   one_line_desc:      "Transmission of short time-dependent data patterns on two clock-parallel output channels",
+  one_paragraph_desc: '''
+  The pattern generator hardware block transmits short time-dependent data patterns on two clock-parallel channels.
+  Each channel consists of one clock and one data line.
+  The channels are configured using the following parameters: clock divider ratio, clock polarity, pattern length, pattern data, and repetition count.
+  Effectively, this block outputs the pattern data a specified number of times with the corresponding clock and then raises an interrupt when it is done.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -5,6 +5,11 @@
 {
   name:               "pinmux",
   one_line_desc:      "Multiplexes between on-chip hardware blocks and pins; can be configured at runtime",
+  one_paragraph_desc: '''
+  The OpenTitan pin multiplexer connects on-chip hardware blocks to IC pins and controls the attributes of the pin drivers (such as pull-up/down, open-drain, and drive strength).
+  Large parts of its functionality can be controlled by software through registers.
+  Further features include per-pin programmable sleep behavior and wakeup pattern detectors as well as support for life-cycle-based JTAG (TAP) isolation and muxing.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -17,6 +17,11 @@
 {
   name:               "pinmux",
   one_line_desc:      "Multiplexes between on-chip hardware blocks and pins, and can be configured at runtime",
+  one_paragraph_desc: '''
+  The OpenTitan pin multiplexer connects on-chip hardware blocks to IC pins and controls the attributes of the pin drivers (such as pull-up/down, open-drain, and drive strength).
+  Large parts of its functionality can be controlled by software through registers.
+  Further features include per-pin programmable sleep behavior and wakeup pattern detectors as well as support for life-cycle-based JTAG (TAP) isolation and muxing.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -4,6 +4,11 @@
 {
   name:               "pwm",
   one_line_desc:      "Transmission of pulse-width modulated output signals with adjustable duty cycle",
+  one_paragraph_desc: '''
+  This hardware block creates pulse-width modulated (PWM) signals with adjustable duty cycle.
+  It is suitable for general-purpose use, but primarily designed for control of LEDs.
+  All outputs are programmable with frequency, phase, and duty cycle.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -10,6 +10,12 @@
 {
   name:               "pwrmgr",
   one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
+  one_paragraph_desc: '''
+  The OpenTitan power manager sequences on-chip power, clocks, and reset signals on power-on reset (aka cold boot), low power entry and exit, and non-power-on resets.
+  To this end, it can turn power domains on and off, control root resets with the reset manager, and control root clock enables with the AST and the clock manager.
+  During power up, it is responsible for triggering OTP sensing, initiating the life cycle controller, coordinating with the ROM controller for the startup ROM check, and eventually releasing software to execute.
+  It features several countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -9,6 +9,12 @@
 {
   name:               "pwrmgr",
   one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
+  one_paragraph_desc: '''
+  The OpenTitan power manager sequences on-chip power, clocks, and reset signals on power-on reset (aka cold boot), low power entry and exit, and non-power-on resets.
+  To this end, it can turn power domains on and off, control root resets with the reset manager, and control root clock enables with the AST and the clock manager.
+  During power up, it is responsible for triggering OTP sensing, initiating the life cycle controller, coordinating with the ROM controller for the startup ROM check, and eventually releasing software to execute.
+  It features several countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -4,6 +4,12 @@
 {
   name:               "rom_ctrl",
   one_line_desc:      "Interfaces scrambled boot ROM with system bus and KMAC for initial health check after reset",
+  one_paragraph_desc: '''
+  The ROM controller interfaces between the system bus and the scrambled ROM.
+  The controller is responsible for descrambling on memory fetches.
+  It also has a checker block that interfaces KMAC to perform a cryptographic hash of the ROM contents at boot to detect any malicious changes to the ROM itself while in reset.
+  The ROM controller also has status registers for ROM integrity errors or checker block FSM glitches.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -9,6 +9,13 @@
 {
   name:               "rstmgr",
   one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
+  one_paragraph_desc: '''
+  The OpenTitan reset manager controls the on-chip reset.
+  It receives one root power-on reset signal for each power domain from the AST and feeds one reset signal for each on-chip reset domain to the OpenTitan hardware blocks.
+  Resets can be requested by the power manager, which internally arbitrates peripheral resets, e.g., from AON timer and alert handler, the RISC-V debug module, and to a limited extent by software.
+  Through always-on registers, software can get information on the reset cause, as well as alert and CPU status prior to a triggered reset (crash dump).
+  To deter fault injection (FI) attacks, several countermeasures are implemented, including consistency checks of leaf resets and support for shadow resets.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -21,6 +21,13 @@
 {
   name:               "rstmgr",
   one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
+  one_paragraph_desc: '''
+  The OpenTitan reset manager controls the on-chip reset.
+  It receives one root power-on reset signal for each power domain from the AST and feeds one reset signal for each on-chip reset domain to the OpenTitan hardware blocks.
+  Resets can be requested by the power manager, which internally arbitrates peripheral resets, e.g., from AON timer and alert handler, the RISC-V debug module, and to a limited extent by software.
+  Through always-on registers, software can get information on the reset cause, as well as alert and CPU status prior to a triggered reset (crash dump).
+  To deter fault injection (FI) attacks, several countermeasures are implemented, including consistency checks of leaf resets and support for shadow resets.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -4,6 +4,14 @@
 {
   name:               "rv_core_ibex",
   one_line_desc:      "Dual-core lockstep 32-bit RISC-V processor running application and control software",
+  one_paragraph_desc: '''
+  Ibex is a production-quality open source 32-bit RISC-V CPU core serving as main processor onto which OpenTitan application and control software is deployed.
+  The configuration used in OpenTitan implements the RV32IMCB ISA with a 3-stage pipeline and a single-cycle multiplier, user and machine execution modes, PMP+Smepmp, and a 4 KiB instruction cache with 2 ways and low-latency scrambling.
+  Further security features include dual-core lockstep operation, bus and register file integrity, PC hardening, data independent timing, and dummy instruction insertion.
+  Ibex integrates into OpenTitan through the RISC-V core wrapper wrapping its data and instruction memory interfaces to TileLink Uncached Light (TL-UL) host interfaces and providing a set of configuration and status register for supporting simple address translation and access to random numbers provided by CSRNG.
+  In addition, the wrapper handles the forwarding of crash dump data.
+  Debug support is enabled through the RISC-V debug module.
+  '''
   design_spec:        "../doc",
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -4,6 +4,11 @@
 {
   name:               "rv_dm",
   one_line_desc:      "Enables debug support for Ibex, access protected by life cycle",
+  one_paragraph_desc: '''
+  The RISC-V Debug Module (rv_dm) provides a JTAG test access port (TAP) to interface the Ibex RISC-V core as well as hardware blocks attached to the TileLink on-chip interconnect.
+  The interface to Ibex is compliant with the RISC-V Debug Specification 0.13.2, which in turn is supported by debug software such as OpenOCD and GDB.
+  For security reasons, rv_dm is only active in life cycles that have hardware debug enabled.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -5,6 +5,10 @@
 {
   name:               "rv_timer",
   one_line_desc:      "Memory-mapped timer unit implementing RISC-V mtime and mtimecmp registers",
+  one_paragraph_desc: '''
+  The OpenTitan RISC-V Timer hardware block provides TileLink Uncached Light (TL-UL) memory-mapped registers `mtime` and `mtimecmp` which can be used as the machine-mode timer registers as defined in the RISC-V privileged spec v1.12.
+  Additional parameters can be used to add optional features, such as prescaler, step increment size, threshold-triggered interrupts, additional 64-bit timers, and support for multiple independent harts.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/rv_timer/data/rv_timer.hjson.tpl
+++ b/hw/ip/rv_timer/data/rv_timer.hjson.tpl
@@ -8,6 +8,10 @@
 {
   name:               "rv_timer",
   one_line_desc:      "Memory-mapped timer unit implementing RISC-V mtime and mtimecmp registers",
+  one_paragraph_desc: '''
+  The OpenTitan RISC-V Timer hardware block provides TileLink Uncached Light (TL-UL) memory-mapped registers `mtime` and `mtimecmp` which can be used as the machine-mode timer registers as defined in the RISC-V privileged spec v1.12.
+  Additional parameters can be used to add optional features, such as prescaler, step increment size, threshold-triggered interrupts, additional 64-bit timers, and support for multiple independent harts.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -4,6 +4,12 @@
 {
   name:               "spi_device",
   one_line_desc:      "Serial peripheral interface supporting different device modes, suitable for bulk-load of data into and out of the chip",
+  one_paragraph_desc: '''
+  The SPI Device is a configurable, versatile hardware block that implements a generic SPI device mode, plus three additional modes (SPI Flash emulation mode, SPI passthrough mode, and TPM over SPI mode) to support a variety of different applications.
+  For example, generic mode can be used in a raw data transfer protocol termed "Firmware Operation Mode", which is intended to be used to bulk-load data into and out of the chip.
+  TPM over SPI operates in compliance with TPM PC Client Platform, unloading this protocol from a software solution.
+  SPI Flash emulation mode supports many JEDEC standard commands such as Read Status, Read JEDEC ID, Read SFDP, EN4B/EX4B, and multiple other read commands, allowing OpenTitan to provide, for example, verified boot firmware to other external devices.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -4,6 +4,13 @@
 {
   name:               "spi_host",
   one_line_desc:      "Serial peripheral interface for host mode, suitable for interfacing external serial NOR flash devices",
+  one_paragraph_desc: '''
+  The SPI Host hardware block bridges communications from the TileLink Uncached Light (TL-UL) bus and off-chip devices by acting as a SPI interface bus master, primarily intended for communication with serial NOR flash devices and other low-speed devices.
+  While SPI is not a formal standard, this implementation aims to be general enough to support a variety of devices by providing a plethora of run-time configurable options.
+  Communication with each device on the bus uses an independent chip select (CS), and each transaction may be individually configured regarding endianness, polarity and phase (CPOL/ CPHA), and full-duplex/half-duplex commands in standard mode.
+  32-bit TL-UL registers interface with receive and transmit data FIFOs as well as a command FIFO for encoding multiple sequential 'segments' making up a larger SPI transaction.
+  This allows each segment to have an arbitrary byte-count, Std/Dual/Quad width, and direction, and it allows the CS to be managed automatically across multiple sequential segments.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -4,6 +4,12 @@
 {
   name:               "sram_ctrl",
   one_line_desc:      "Interfacing on-chip SRAM blocks with system bus, supports lightweight scrambling, integrity and secure wipe",
+  one_paragraph_desc: '''
+  The OpenTitan SRAM controller (sram_ctrl) instantiates on-chip SRAM and makes it accessible through the TileLink on-chip interconnect.
+  sram_ctrl includes a lightweight scrambling mechanism based on the PRINCE cipher to reduce the attack surface on the confidentiality and integrity of data stored in the SRAM.
+  For end-to-end data integrity protection, sram_ctrl stores the integrity bits alongside data words in memory and raises an alert if it detects an integrity fault.
+  sram_ctrl contains an LFSR-based initialization mechanism that overwrites the entire SRAM with pseudorandom data.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -4,6 +4,11 @@
 {
   name:               "sysrst_ctrl",
   one_line_desc:      "Manages board-level reset sequencing, interfaces reset and power manager",
+  one_paragraph_desc: '''
+  The OpenTitan System Reset Controller (sysrst_ctrl) provides basic board-level reset sequencing in response to trusted inputs.
+  It is programmable to accommodate actions triggered by presses of buttons and keyboard key combinations, to control the duration of reset pulses, and to trigger reset or wake-up requests that go to the OpenTitan reset and power manager hardware blocks.
+  sysrst_ctrl is part of the always-on power and clock domain.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -4,6 +4,13 @@
 {
   name:               "uart",
   one_line_desc:      "Full duplex serial communication interface, supports bit rates of up to 1 Mbit/s",
+  one_paragraph_desc: '''
+  The Universal Asynchronous Receiver/Transmitter (UART) hardware block provides industry standard serial communication with external devices via two wires at a programmable baud rate.
+  Its full duplex design supports simultaneous transmission and reception, and flow control may be achieved using software handshaking if required.
+  To reduce software load, the device includes hardware FIFOs and supports interrupt generation when the FIFO level reaches software-programmable thresholds.
+  For compatibility with a variety of different targets and applications, the baud rate is software programmable and bit rates of up to 1 Mbit/s are supported.
+  The data format is restricted to 8 bits, reducing the complexity and cost, with optional parity for robustness against transmission errors.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -4,6 +4,13 @@
 {
   name:               "usbdev",
   one_line_desc:      "USB 2.0 Full Speed device interface (12 Mbit/s)",
+  one_paragraph_desc: '''
+  The OpenTitan USB Device provides compatibility with the industry standard Universal Serial Bus by implementing a Full Speed device (12 Mbit/s) according to the USB 2.0 Specification.
+  The device supports up to 12 bidirectional endpoints which may be used to support all of the USB 2.0 transfer types, including Isochronous transfers.
+  Support for packet transmission and reception is provided in hardware, with the generation of interrupts for software to mediate the different stages of Control and Data Transfers.
+  The maximum packet size for transfers is configurable up to the specification limit of 64 bytes per packet, reducing the protocol overhead for Bulk transfers, and the inbuilt 2 KiB memory can accommodate 32 packets.
+  The device may be configured to use either a single-ended interface to an external differential transceiver or a differential input/output for more direct interfacing and reduced hardware complexity when prototyping.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -13,6 +13,13 @@
 {
   name:               "clkmgr",
   one_line_desc:      "Derives and monitors on-chip clock signals, handles clock gating requests from power manager and software",
+  one_paragraph_desc: '''
+  The OpenTitan clock manager derives on-chip clocks from root clock signals provided by the Analog Sensor Top (AST).
+  Input and output clocks may be asynchronous to each other.
+  During clock derivation, the clock manager can divide clocks to lower frequencies and gate clocks based on control signals from the power manager and to a limited extent from software.
+  For example, the idle status of relevant hardware blocks is tracked and clock gating requests from software are ignored as long these blocks are active.
+  Further security features include switchable clock jitter, continuous monitoring of clock frequencies, and various countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -13,6 +13,13 @@
 {
   name:               "flash_ctrl",
   one_line_desc:      "Interfaces and manages integrated non-volatile flash memory; supports scrambling, integrity, and secure wipe",
+  one_paragraph_desc: '''
+  The OpenTitan flash controller interfaces the integrated, non-volatile flash memory with software and other hardware components in the system, such as life cycle controller, key manager, and OTP controller.
+  It consists of the open source flash controller that interfaces with a third party flash module.
+  The protocol controller handles read, program, and erase requests, as well as life cycle RMA entry.
+  It supports differentiation between informational and data flash partitions, flash memory protection at page boundaries, and the handling of key manager secrets inaccessible to software.
+  The actual physical controller is highly parameterized (number of banks, number of pages for each bank, number of words and word size for each page, and number of read buffers) and supports XEX scrambling configurable by software, as well as two types of ECC support configurable on a page boundary.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv"
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -13,6 +13,11 @@
 {
   name:               "pinmux",
   one_line_desc:      "Multiplexes between on-chip hardware blocks and pins, and can be configured at runtime",
+  one_paragraph_desc: '''
+  The OpenTitan pin multiplexer connects on-chip hardware blocks to IC pins and controls the attributes of the pin drivers (such as pull-up/down, open-drain, and drive strength).
+  Large parts of its functionality can be controlled by software through registers.
+  Further features include per-pin programmable sleep behavior and wakeup pattern detectors as well as support for life-cycle-based JTAG (TAP) isolation and muxing.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -10,6 +10,12 @@
 {
   name:               "pwrmgr",
   one_line_desc:      "Sequences on-chip power, clocks, and resets through different reset and power states",
+  one_paragraph_desc: '''
+  The OpenTitan power manager sequences on-chip power, clocks, and reset signals on power-on reset (aka cold boot), low power entry and exit, and non-power-on resets.
+  To this end, it can turn power domains on and off, control root resets with the reset manager, and control root clock enables with the AST and the clock manager.
+  During power up, it is responsible for triggering OTP sensing, initiating the life cycle controller, coordinating with the ROM controller for the startup ROM check, and eventually releasing software to execute.
+  It features several countermeasures to deter fault injection (FI) attacks.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -15,6 +15,13 @@
 {
   name:               "rstmgr",
   one_line_desc:      "Controls the on-chip reset signals, records reset cause and CPU crash dump for software",
+  one_paragraph_desc: '''
+  The OpenTitan reset manager controls the on-chip reset.
+  It receives one root power-on reset signal for each power domain from the AST and feeds one reset signal for each on-chip reset domain to the OpenTitan hardware blocks.
+  Resets can be requested by the power manager, which internally arbitrates peripheral resets, e.g., from AON timer and alert handler, the RISC-V debug module, and to a limited extent by software.
+  Through always-on registers, software can get information on the reset cause, as well as alert and CPU status prior to a triggered reset (crash dump).
+  To deter fault injection (FI) attacks, several countermeasures are implemented, including consistency checks of leaf resets and support for shadow resets.
+  '''
   design_spec:        "../doc",
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -57,6 +57,7 @@ REQUIRED_FIELDS = {
 
 OPTIONAL_FIELDS = {
     'one_line_desc': ['s', "one-line description of the component"],
+    'one_paragraph_desc': ['s', "one-paragraph description of the component"],
     # Note: this revision list may be deprecated in the future.
     'revisions': ['l', "list with revision records"],
     'design_spec':


### PR DESCRIPTION
This commit adds one-paragraph descriptions to all hardware blocks under `hw/ip` that have a `data/<name>.hjson` file except `trial1`.

These one-paragraph descriptions are intended for use as high-level summary and should describe the main elements and intentions of a hardware block.

For blocks that have their `.hjson` generated from a template (`.hjson.tpl`), this commit updates the template and the generated `.hjson`.  This commit also updates the `.hjson`s of the top-level-specific blocks.

The new field that contains the one-paragraph description, `one_paragraph_desc`, is added to `util/reggen` as optional.

This is a collaborative effort, and co-authors are listed in the commit message.