### PR TITLE
[sysrst_ctrl] removed redundant sample call

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/cov/sysrst_ctrl_cov_if.sv
+++ b/hw/ip/sysrst_ctrl/dv/cov/sysrst_ctrl_cov_if.sv
@@ -142,9 +142,7 @@ interface sysrst_ctrl_cov_if
     int index,
     bit [31:0] detection_timer
   );
-    foreach (combo_detect_det_cg_inst[i]) begin
-      combo_detect_det_cg_inst[index].sample(detection_timer);
-    end
+    combo_detect_det_cg_inst[index].sample(detection_timer);
   endfunction
 
   function automatic void cg_auto_block_sample (


### PR DESCRIPTION
foreach loop is not required as the index of covergroup is provided as input to sampling function

Signed-off-by: Raviteja Chatta <crteja@lowrisc.org>