### PR TITLE
[entropy_src] Don't push to input FIFO unless indicating ready to AST

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -988,7 +988,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   );
 
   // fifo controls
-  assign sfifo_esrng_push = (es_enable_fo[5] && es_delayed_enable && es_rng_src_valid);
+  assign sfifo_esrng_push = es_enable_fo[5] && es_delayed_enable && es_rng_src_valid &&
+                            rng_enable_q;
 
   assign sfifo_esrng_clr   = ~es_delayed_enable;
   assign sfifo_esrng_wdata = es_rng_bus;


### PR DESCRIPTION
In lowRISC/OpenTitan#16732 we started registering the rng_enable output to AST to make the signal glitch free for closing CDC. As a result of the introduced register, it became now possible for entropy_src to push entropy from AST into the input FIFO despite indicating not being ready. While this might not have been a big issue for the actual chip, it led to large amount of failures in block-level DV due to the push-pull agent on the AST interface, the scoreboard and the RTL becoming out of sync whenever re-enabling entropy_src while AST provided valid input data.

This can be fixed by only pushing valid data from AST into the input FIFO if entropy_src is indeed indicating ready to AST. The behavior during disabling of entropy_src isn't affected by this fix.

This resolves lowRISC/OpenTitan#17236.