### PR TITLE
[opentitantool] Use StagedProgressBar everywhere

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/eeprom.rs
+++ b/sw/host/opentitanlib/src/bootstrap/eeprom.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, UpdateProtocol};
 use crate::spiflash::SpiFlash;
-use crate::transport::Capability;
+use crate::transport::{Capability, ProgressIndicator};
 
 /// Implements the SPI EEPROM bootstrap protocol.
 pub struct Eeprom;
@@ -42,7 +42,7 @@ impl UpdateProtocol for Eeprom {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
-        progress: &dyn Fn(u32, u32),
+        progress: &dyn ProgressIndicator,
     ) -> Result<()> {
         let spi = container.spi_params.create(transport, "BOOTSTRAP")?;
         let flash = SpiFlash::from_spi(&*spi)?;

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -11,12 +11,12 @@ use structopt::clap::arg_enum;
 use structopt::StructOpt;
 use thiserror::Error;
 
-use crate::app::TransportWrapper;
+use crate::app::{NoProgressBar, TransportWrapper};
 use crate::impl_serializable_error;
 use crate::io::gpio::GpioPin;
 use crate::io::spi::SpiParams;
 use crate::io::uart::UartParams;
-use crate::transport::Capability;
+use crate::transport::{Capability, ProgressIndicator};
 
 mod eeprom;
 mod legacy;
@@ -70,7 +70,7 @@ trait UpdateProtocol {
         container: &Bootstrap,
         transport: &TransportWrapper,
         payload: &[u8],
-        progress: &dyn Fn(u32, u32),
+        progress: &dyn ProgressIndicator,
     ) -> Result<()>;
 }
 
@@ -122,7 +122,7 @@ impl<'a> Bootstrap<'a> {
         options: &BootstrapOptions,
         payload: &[u8],
     ) -> Result<()> {
-        Self::update_with_progress(transport, options, payload, |_, _| {})
+        Self::update_with_progress(transport, options, payload, &NoProgressBar)
     }
 
     /// Perform the update, sending the firmware `payload` to a SPI or UART target depending on
@@ -132,7 +132,7 @@ impl<'a> Bootstrap<'a> {
         transport: &TransportWrapper,
         options: &BootstrapOptions,
         payload: &[u8],
-        progress: impl Fn(u32, u32),
+        progress: &dyn ProgressIndicator,
     ) -> Result<()> {
         if transport
             .capabilities()?
@@ -164,7 +164,7 @@ impl<'a> Bootstrap<'a> {
             reset_pin: transport.gpio_pin("RESET")?,
             reset_delay: options.reset_delay,
         }
-        .do_update(updater, transport, payload, &progress)
+        .do_update(updater, transport, payload, progress)
     }
 
     fn do_update(
@@ -172,7 +172,7 @@ impl<'a> Bootstrap<'a> {
         updater: Box<dyn UpdateProtocol>,
         transport: &TransportWrapper,
         payload: &[u8],
-        progress: &dyn Fn(u32, u32),
+        progress: &dyn ProgressIndicator,
     ) -> Result<()> {
         updater.verify_capabilities(self, transport)?;
         let perform_bootstrap_reset = updater.uses_common_bootstrap_reset();

--- a/sw/host/opentitanlib/src/test_utils/bootstrap.rs
+++ b/sw/host/opentitanlib/src/test_utils/bootstrap.rs
@@ -7,7 +7,7 @@ use serde_annotate::Annotate;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
-use crate::app::{self, TransportWrapper};
+use crate::app::{StagedProgressBar, TransportWrapper};
 use crate::bootstrap::{self, BootstrapOptions};
 
 /// Load a program into the chip.
@@ -30,15 +30,8 @@ impl Bootstrap {
 
     pub fn load(&self, transport: &TransportWrapper, file: &Path) -> Result<()> {
         let payload = std::fs::read(file)?;
-        let progress = app::progress_bar(payload.len() as u64);
-        bootstrap::Bootstrap::update_with_progress(
-            transport,
-            &self.options,
-            &payload,
-            |_, chunk| {
-                progress.inc(chunk as u64);
-            },
-        )?;
+        let progress = StagedProgressBar::new();
+        bootstrap::Bootstrap::update_with_progress(transport, &self.options, &payload, &progress)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use structopt::StructOpt;
 
-use crate::app::{self, TransportWrapper};
+use crate::app::{StagedProgressBar, TransportWrapper};
 use crate::transport::common::fpga::FpgaProgram;
 use crate::util::rom_detect::RomKind;
 
@@ -47,16 +47,13 @@ impl LoadBitstream {
     ) -> Result<Option<Box<dyn Annotate>>> {
         log::info!("Loading bitstream: {:?}", file);
         let payload = std::fs::read(file)?;
-        let progress = app::progress_bar(payload.len() as u64);
-        let pfunc = Box::new(move |_, chunk| {
-            progress.inc(chunk as u64);
-        });
+        let progress = StagedProgressBar::new();
         let operation = FpgaProgram {
             bitstream: payload,
             rom_kind: self.rom_kind,
             rom_reset_pulse: self.rom_reset_pulse,
             rom_timeout: self.rom_timeout,
-            progress: Some(pfunc),
+            progress: Box::new(progress),
         };
         transport.dispatch(&operation)
     }

--- a/sw/host/opentitanlib/src/transport/common/fpga.rs
+++ b/sw/host/opentitanlib/src/transport/common/fpga.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use crate::io::gpio::GpioPin;
 use crate::io::uart::Uart;
+use crate::transport::ProgressIndicator;
 use crate::util::rom_detect::{RomDetect, RomKind};
 
 /// Command for Transport::dispatch().
@@ -21,7 +22,7 @@ pub struct FpgaProgram<'a> {
     pub rom_timeout: Duration,
     /// A progress function to provide user feedback.
     /// Will be called with the address and length of each chunk sent to the target device.
-    pub progress: Option<Box<dyn Fn(u32, u32) + 'a>>,
+    pub progress: Box<dyn ProgressIndicator + 'a>,
 }
 
 impl FpgaProgram<'_> {

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -200,10 +200,7 @@ impl Transport for CW310 {
             log::info!("Programming the FPGA bitstream.");
             let usb = self.device.borrow();
             usb.spi1_enable(false)?;
-            usb.fpga_program(
-                &fpga_program.bitstream,
-                fpga_program.progress.as_ref().map(Box::as_ref),
-            )?;
+            usb.fpga_program(&fpga_program.bitstream, fpga_program.progress.as_ref())?;
             Ok(None)
         } else if action.downcast_ref::<ResetSam3x>().is_some() {
             self.device.borrow().reset_sam3x()?;

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -583,7 +583,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
                 &mut self.inner.usb_device.borrow_mut(),
                 self.current_firmware_version.as_deref(),
                 &update_firmware_action.firmware,
-                &update_firmware_action.progress,
+                update_firmware_action.progress.as_ref(),
                 update_firmware_action.force,
             )
         } else if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
@@ -710,10 +710,7 @@ impl Flavor for CW310Flavor {
         log::info!("Programming the FPGA bitstream.");
         let usb = cw310.device.borrow();
         usb.spi1_enable(false)?;
-        usb.fpga_program(
-            &fpga_program.bitstream,
-            fpga_program.progress.as_ref().map(Box::as_ref),
-        )?;
+        usb.fpga_program(&fpga_program.bitstream, fpga_program.progress.as_ref())?;
         Ok(())
     }
     fn clear_bitstream(_clear: &ClearBitstream) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -160,12 +160,13 @@ pub struct Bootstrap {
     pub image_path: PathBuf,
 }
 
-pub enum Progress {
-    /// Declares that a stage of the operation is starting, giving the total number of bytes to be
-    /// processed in this stage.  If only a single stage, `name` may be the empty string.
-    Stage { name: String, total: u32 },
-    /// Informs about progress within the current state, `pos` is absolute number of bytes so far.
-    Progress { pos: u32 },
+pub trait ProgressIndicator {
+    // Begins a new stage, indicating "size" of this stage in bytes.  `name` can be the empty
+    // string, for instance if the operation has only a single stage.
+    fn new_stage(&self, name: &str, total: usize);
+    // Indicates how far towards the previously declared `total`.  Operation will be shown as
+    // complete, once the parameter value to this method equals `total`.
+    fn progress(&self, absolute: usize);
 }
 
 /// Command for Transport::dispatch().
@@ -175,7 +176,7 @@ pub struct UpdateFirmware<'a> {
     /// trait implementation knows how to download such.
     pub firmware: Option<Vec<u8>>,
     /// A progress function to provide user feedback, see details of the `Progress` struct.
-    pub progress: Option<Box<dyn Fn(Progress) + 'a>>,
+    pub progress: Box<dyn ProgressIndicator + 'a>,
     /// Should updating be attempted, even if the current firmware version matches that of the
     /// image to be updated to.
     pub force: bool,

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::app::{self, TransportWrapper};
+use opentitanlib::app::{StagedProgressBar, TransportWrapper};
 use opentitanlib::bootstrap::{Bootstrap, BootstrapOptions, BootstrapProtocol};
 use opentitanlib::image::image::ImageAssembler;
 use opentitanlib::transport;
@@ -83,15 +83,8 @@ impl CommandDispatch for BootstrapCommand {
         }
 
         let payload = self.payload()?;
-        let progress = app::progress_bar(payload.len() as u64);
-        Bootstrap::update_with_progress(
-            transport,
-            &self.bootstrap_options,
-            &payload,
-            |_, chunk| {
-                progress.inc(chunk as u64);
-            },
-        )?;
+        let progress = StagedProgressBar::new();
+        Bootstrap::update_with_progress(transport, &self.bootstrap_options, &payload, &progress)?;
         Ok(None)
     }
 }

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -8,11 +8,10 @@ use std::any::Any;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::time::Instant;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::app::{self, TransportWrapper};
+use opentitanlib::app::{StagedProgressBar, TransportWrapper};
 use opentitanlib::io::eeprom::{AddressMode, Transaction, MODE_111};
 use opentitanlib::io::spi::{SpiParams, Transfer};
 use opentitanlib::spiflash::SpiFlash;
@@ -175,13 +174,8 @@ impl CommandDispatch for SpiRead {
         flash.set_address_mode_auto(&*spi)?;
 
         let mut buffer = vec![0u8; self.length];
-        let progress = app::progress_bar(self.length as u64);
-        let t0 = Instant::now();
-        flash.read_with_progress(&*spi, self.start, &mut buffer, |_, chunk| {
-            progress.inc(chunk as u64);
-        })?;
-        progress.finish();
-        let duration = t0.elapsed().as_secs_f64();
+        let progress = StagedProgressBar::new();
+        flash.read_with_progress(&*spi, self.start, &mut buffer, &progress)?;
 
         if self.filename.to_str() == Some("-") {
             self.write_file(io::stdout(), &buffer)?;
@@ -191,7 +185,7 @@ impl CommandDispatch for SpiRead {
             self.write_file(file, &buffer)?;
             Ok(Some(Box::new(SpiReadResponse {
                 length: buffer.len(),
-                bytes_per_second: buffer.len() as f64 / duration,
+                bytes_per_second: progress.bytes_per_second(),
             })))
         }
     }
@@ -224,17 +218,12 @@ impl CommandDispatch for SpiErase {
         let mut flash = SpiFlash::from_spi(&*spi)?;
         flash.set_address_mode_auto(&*spi)?;
 
-        let progress = app::progress_bar(self.length as u64);
-        let t0 = Instant::now();
-        flash.erase_with_progress(&*spi, self.start, self.length, |_, chunk| {
-            progress.inc(chunk as u64);
-        })?;
-        progress.finish();
-        let duration = t0.elapsed().as_secs_f64();
+        let progress = StagedProgressBar::new();
+        flash.erase_with_progress(&*spi, self.start, self.length, &progress)?;
 
         Ok(Some(Box::new(SpiEraseResponse {
             length: self.length,
-            bytes_per_second: self.length as f64 / duration,
+            bytes_per_second: progress.bytes_per_second(),
         })))
     }
 }
@@ -267,17 +256,12 @@ impl CommandDispatch for SpiProgram {
         flash.set_address_mode_auto(&*spi)?;
 
         let buffer = fs::read(&self.filename)?;
-        let progress = app::progress_bar(buffer.len() as u64);
-        let t0 = Instant::now();
-        flash.program_with_progress(&*spi, self.start, &buffer, |_, chunk| {
-            progress.inc(chunk as u64);
-        })?;
-        progress.finish();
-        let duration = t0.elapsed().as_secs_f64();
+        let progress = StagedProgressBar::new();
+        flash.program_with_progress(&*spi, self.start, &buffer, &progress)?;
 
         Ok(Some(Box::new(SpiProgramResponse {
             length: buffer.len(),
-            bytes_per_second: buffer.len() as f64 / duration,
+            bytes_per_second: progress.bytes_per_second(),
         })))
     }
 }

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -68,7 +68,7 @@ impl CommandDispatch for TransportUpdateFirmware {
         let progress = StagedProgressBar::new();
         let operation = UpdateFirmware {
             firmware,
-            progress: Some(progress.pfunc()),
+            progress: Box::new(progress),
             force: self.force,
         };
         transport.dispatch(&operation)


### PR DESCRIPTION
In particular the rescue bootstrap protocol, and also bitstream loading may transfer a number of bytes that is different from the size of the binary input file.  The `StagedProgressBar` allows the sub-routines to indicate how many bytes are actually expected to be transferred, so that the progress bar renders correctly.