### PR TITLE
[opentitantool] Nonblocking UART methods

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -79,6 +79,7 @@ rust_library(
         "src/io/ioexpander.rs",
         "src/io/jtag.rs",
         "src/io/mod.rs",
+        "src/io/nonblocking_help.rs",
         "src/io/spi.rs",
         "src/io/uart.rs",
         "src/lib.rs",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -88,6 +88,7 @@ rust_library(
         "src/otp/lc_state.rs",
         "src/otp/mod.rs",
         "src/otp/otp_img.rs",
+        "src/proxy/nonblocking_uart.rs",
         "src/proxy/errors.rs",
         "src/proxy/handler.rs",
         "src/proxy/mod.rs",

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -11,6 +11,7 @@ use crate::io::gpio::{GpioMonitoring, GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
 use crate::io::ioexpander::IoExpander;
 use crate::io::jtag::{Jtag, JtagParams};
+use crate::io::nonblocking_help::NonblockingHelp;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 use crate::transport::{
@@ -551,6 +552,10 @@ impl TransportWrapper {
     /// Invoke non-standard functionality of some Transport implementations.
     pub fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
         self.transport.dispatch(action)
+    }
+
+    pub fn nonblocking_help(&self) -> Result<Rc<dyn NonblockingHelp>> {
+        self.transport.nonblocking_help()
     }
 
     /// Apply given configuration to a single pins.

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -9,5 +9,6 @@ pub mod gpio;
 pub mod i2c;
 pub mod ioexpander;
 pub mod jtag;
+pub mod nonblocking_help;
 pub mod spi;
 pub mod uart;

--- a/sw/host/opentitanlib/src/io/nonblocking_help.rs
+++ b/sw/host/opentitanlib/src/io/nonblocking_help.rs
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+/// In order to provide nonblocking functionality (e.g. in the `Uart` trait), some transport
+/// backends may need help from the main `mio` event loop.  This trait allows the transport to
+/// register its internal event sources with a poll registery used by the main loop, and the main
+/// loop will then be reponsible for calling `nonblocking_help` every time one of the transports
+/// internal sources become ready.
+pub trait NonblockingHelp {
+    fn register_nonblocking_help(
+        &self,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+    ) -> Result<()>;
+    fn nonblocking_help(&self) -> Result<()>;
+}
+
+/// Implementation to be used by backends which do not need to put any internal source into
+/// `mio::poll()` of the main event loop.
+pub struct NoNonblockingHelp;
+impl NonblockingHelp for NoNonblockingHelp {
+    fn register_nonblocking_help(
+        &self,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+    ) -> Result<()> {
+        Ok(())
+    }
+    fn nonblocking_help(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -4,29 +4,60 @@
 
 use anyhow::{bail, Result};
 use handler::TransportCommandHandler;
+use mio::event::Event;
 use mio::net::TcpListener;
+use mio::{Registry, Token};
+use nonblocking_uart::NonblockingUartRegistry;
 use protocol::Message;
-use socket_server::JsonSocketServer;
+use socket_server::{Connection, JsonSocketServer};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 
 use crate::app::TransportWrapper;
 
 pub mod errors;
 mod handler;
+mod nonblocking_uart;
 pub mod protocol;
 mod socket_server;
 
 /// Interface for handlers of protocol messages, responding to each message with a single
 /// instance of the same protocol message.
-pub trait CommandHandler<Msg> {
-    fn execute_cmd(&mut self, msg: &Msg) -> Result<Msg>;
+pub trait CommandHandler<Msg, E: ExtraEventHandler> {
+    fn execute_cmd(
+        &mut self,
+        conn_token: Token,
+        registry: &Registry,
+        extra_event_handler: &mut E,
+        msg: &Msg,
+    ) -> Result<Msg>;
+
+    fn register_nonblocking_help(
+        &self,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn nonblocking_help(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub trait ExtraEventHandler {
+    fn handle_poll_event(
+        &mut self,
+        event: &Event,
+        connection_map: &mut HashMap<Token, Connection>,
+    ) -> Result<bool>;
 }
 
 /// This is the main entry point for the session proxy.  This struct will either bind on a
 /// specified port, or find an available port from a range, before entering an event loop.
 pub struct SessionHandler<'a> {
     port: u16,
-    socket_server: JsonSocketServer<Message, TransportCommandHandler<'a>>,
+    socket_server: JsonSocketServer<Message, TransportCommandHandler<'a>, NonblockingUartRegistry>,
 }
 
 impl<'a> SessionHandler<'a> {
@@ -42,7 +73,11 @@ impl<'a> SessionHandler<'a> {
                 Err(_) => port += 1,
             }
         };
-        let socket_server = JsonSocketServer::new(TransportCommandHandler::new(transport), socket)?;
+        let socket_server = JsonSocketServer::new(
+            TransportCommandHandler::new(transport)?,
+            NonblockingUartRegistry::new(),
+            socket,
+        )?;
         // Configure all GPIO pins to default direction and level, according to
         // configuration files provided, and configures SPI port mode/speed, etc.
         transport.apply_default_configuration()?;

--- a/sw/host/opentitanlib/src/proxy/nonblocking_uart.rs
+++ b/sw/host/opentitanlib/src/proxy/nonblocking_uart.rs
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use mio::event::Event;
+use mio::{Registry, Token};
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::ptr::hash;
+use std::rc::Rc;
+use std::time::Duration;
+
+use super::socket_server::{get_next_token, Connection};
+use super::ExtraEventHandler;
+use crate::io::uart::Uart;
+
+pub struct NonblockingUartRegistry {
+    pub token_map: HashMap<Token, UartKey>,
+    // Set of Uart objects in "nonblocking read" mode.  Key is the address of the Uart object.
+    // Once switched to nonblocking mode, they do not go back.
+    pub nonblocking_uarts: HashMap<UartKey, NonblockingUart>,
+}
+
+impl NonblockingUartRegistry {
+    pub fn new() -> Self {
+        Self {
+            token_map: HashMap::new(),
+            nonblocking_uarts: HashMap::new(),
+        }
+    }
+
+    pub fn nonblocking_uart_init(
+        &mut self,
+        uart: &std::rc::Rc<dyn crate::io::uart::Uart>,
+        conn_token: Token,
+        registry: &Registry,
+    ) -> Result<u32> {
+        match self.nonblocking_uarts.entry(UartKey(uart.clone())) {
+            Vacant(entry) => {
+                let token = get_next_token();
+                self.token_map.insert(token, UartKey(uart.clone()));
+                uart.register_nonblocking_read(registry, token)?;
+
+                let mut nonblocking_uart = NonblockingUart::new(uart, token.0 as u32);
+                nonblocking_uart.add_connection(conn_token);
+                let channel = nonblocking_uart.channel;
+                entry.insert(nonblocking_uart);
+                Ok(channel)
+            }
+            Occupied(mut entry) => {
+                let nonblocking_uart = entry.get_mut();
+                nonblocking_uart.add_connection(conn_token);
+                Ok(nonblocking_uart.channel)
+            }
+        }
+    }
+}
+
+impl ExtraEventHandler for NonblockingUartRegistry {
+    fn handle_poll_event(
+        &mut self,
+        event: &Event,
+        connection_map: &mut HashMap<Token, Connection>,
+    ) -> Result<bool> {
+        match self.token_map.get(&event.token()) {
+            Some(uart_key) => {
+                if event.is_readable() {
+                    self.nonblocking_uarts
+                        .get_mut(uart_key)
+                        .unwrap()
+                        .process(connection_map)?;
+                }
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+}
+
+pub struct NonblockingUart {
+    conn_tokens: HashSet<Token>,
+    uart: std::rc::Rc<dyn crate::io::uart::Uart>,
+    channel: u32,
+}
+
+impl NonblockingUart {
+    pub fn new(uart: &std::rc::Rc<dyn crate::io::uart::Uart>, channel: u32) -> Self {
+        Self {
+            conn_tokens: HashSet::new(),
+            uart: uart.clone(),
+            channel,
+        }
+    }
+
+    pub fn add_connection(&mut self, conn_token: Token) {
+        self.conn_tokens.insert(conn_token);
+    }
+
+    fn process(&mut self, connection_map: &mut HashMap<Token, Connection>) -> Result<()> {
+        let mut buf = [0u8; 256];
+        // `mio` convention demands that we keep reading until a read returns zero bytes,
+        // otherwise next `poll()` is not guaranteed to notice more data.
+        loop {
+            let len = self.uart.read_timeout(&mut buf, Duration::from_millis(1))?;
+            if len == 0 {
+                return Ok(());
+            }
+            // Iterate through list of connections who "subscribe" to this UART instance, putting
+            // data into each of their outgoing buffers.  If any connection has been closed,
+            // remove the reference to it from `conn_tokens`.
+            let mut closed_connections = Vec::new();
+            for conn_token in &self.conn_tokens {
+                if let Some(conn) = connection_map.get_mut(conn_token) {
+                    conn.transmit_outgoing_msg(super::protocol::Message::Async {
+                        channel: self.channel,
+                        msg: super::protocol::AsyncMessage::UartData {
+                            data: buf[0..len].to_vec(),
+                        },
+                    })?
+                } else {
+                    // The particular TCP connection has been closed, and should be removed from the
+                    // list of subsribers to this `Uart`.  Keep its ID for removal when this
+                    // iteration is done.
+                    closed_connections.push(*conn_token);
+                }
+            }
+            for conn_token in closed_connections {
+                self.conn_tokens.remove(&conn_token);
+            }
+        }
+    }
+}
+
+/// Struct allowing `HashMap` to use `Uart` object identity as the key.
+#[derive(Clone)]
+pub struct UartKey(pub Rc<dyn Uart>);
+
+impl Hash for UartKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash(&*self.0, state)
+    }
+}
+impl PartialEq for UartKey {
+    /// Determines whether the two `Rc`s point to the same `Uart` instance.
+    #[allow(clippy::vtable_address_comparisons)]
+    fn eq(&self, other: &Self) -> bool {
+        Rc::as_ptr(&self.0) == Rc::as_ptr(&other.0)
+    }
+}
+
+impl Eq for UartKey {}

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -17,8 +17,18 @@ use crate::util::voltage::Voltage;
 
 #[derive(Serialize, Deserialize)]
 pub enum Message {
+    // Request/response pairs.  There is no explicit identifier to link a response to a request,
+    // as requests are processed and responses generated in the order they are received.
     Req(Request),
     Res(Result<Response, SerializedError>),
+    // An "asynchronos message" is one that is not a direct response to a request, but can be sent
+    // at any time, as part of a communication "channel" previously set up.
+    Async { channel: u32, msg: AsyncMessage },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum AsyncMessage {
+    UartData { data: Vec<u8> },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -95,6 +105,8 @@ pub enum UartRequest {
     Write {
         data: Vec<u8>,
     },
+    SupportsNonblockingRead,
+    RegisterNonblockingRead,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -103,6 +115,8 @@ pub enum UartResponse {
     SetBaudrate,
     Read { data: Vec<u8> },
     Write,
+    SupportsNonblockingRead { has_support: bool },
+    RegisterNonblockingRead { channel: u32 },
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -181,6 +181,20 @@ impl Uart for SerialPortUart {
         self.port.borrow_mut().clear(ClearBuffer::Input)?;
         Ok(())
     }
+
+    fn supports_nonblocking_read(&self) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn register_nonblocking_read(&self, registry: &mio::Registry, token: mio::Token) -> Result<()> {
+        let port: &mut TTYPort = &mut self.port.borrow_mut();
+        registry.register(
+            &mut mio::unix::SourceFd(&port.as_raw_fd()),
+            token,
+            mio::Interest::READABLE,
+        )?;
+        Ok(())
+    }
 }
 
 const PID_FILE_LEN: usize = 11;

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -137,7 +137,7 @@ impl CW310 {
 impl Transport for CW310 {
     fn capabilities(&self) -> Result<Capabilities> {
         Ok(Capabilities::new(
-            Capability::SPI | Capability::GPIO | Capability::UART,
+            Capability::SPI | Capability::GPIO | Capability::UART | Capability::UART_NONBLOCKING,
         ))
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -485,6 +485,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
     fn capabilities(&self) -> Result<Capabilities> {
         Ok(Capabilities::new(
             Capability::UART
+                | Capability::UART_NONBLOCKING
                 | Capability::GPIO
                 | Capability::GPIO_MONITORING
                 | Capability::SPI

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -14,6 +14,7 @@ use crate::io::emu::Emulator;
 use crate::io::gpio::{GpioMonitoring, GpioPin};
 use crate::io::i2c::Bus;
 use crate::io::jtag::{Jtag, JtagParams};
+use crate::io::nonblocking_help::{NoNonblockingHelp, NonblockingHelp};
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
@@ -44,6 +45,7 @@ bitflags! {
         const EMULATOR = 0x01 << 5;
         const GPIO_MONITORING = 0x01 << 6; // Logic analyzer functionality
         const JTAG = 0x01 << 7;
+        const UART_NONBLOCKING = 0x01 << 8;
     }
 }
 
@@ -142,6 +144,13 @@ pub trait Transport {
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn serde_annotate::Annotate>>> {
         Err(TransportError::UnsupportedOperation.into())
+    }
+
+    /// Before nonblocking operations can be used on `Uart` or other traits, this
+    /// `NonblockingHelp` object must be invoked, in order to get the `Transport` implementation a
+    /// chance to register its internal event sources with the main event loop.
+    fn nonblocking_help(&self) -> Result<Rc<dyn NonblockingHelp>> {
+        Ok(Rc::new(NoNonblockingHelp))
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use std::cell::Cell;
+use std::io::{ErrorKind, Read};
 use std::rc::Rc;
 use std::time::Duration;
 
 use super::ProxyError;
+use crate::io::nonblocking_help::NonblockingHelp;
 use crate::io::uart::Uart;
 use crate::proxy::protocol::{Request, Response, UartRequest, UartResponse};
 use crate::transport::proxy::{Inner, Proxy};
@@ -14,6 +17,7 @@ use crate::transport::proxy::{Inner, Proxy};
 pub struct ProxyUart {
     inner: Rc<Inner>,
     instance: String,
+    nonblocking_mode: Cell<bool>,
 }
 
 impl ProxyUart {
@@ -21,6 +25,7 @@ impl ProxyUart {
         let result = Self {
             inner: Rc::clone(&proxy.inner),
             instance: instance.to_string(),
+            nonblocking_mode: Cell::new(false),
         };
         Ok(result)
     }
@@ -33,6 +38,27 @@ impl ProxyUart {
         })? {
             Response::Uart(resp) => Ok(resp),
             _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn nonblocking_read(&self, buf: &mut [u8], timeout: Option<Duration>) -> Result<usize> {
+        let mut first_try = true;
+        loop {
+            {
+                let mut uarts = self.inner.uarts.borrow_mut();
+                let uart_record = uarts.get_mut(&self.instance).unwrap();
+                match uart_record.pipe_receiver.read(buf) {
+                    Ok(0) => (),
+                    Ok(n) => return Ok(n),
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => (),
+                    Err(e) => anyhow::bail!(e),
+                }
+            }
+            if !first_try && timeout.is_some() {
+                return Ok(0); // Timeout
+            }
+            self.inner.poll_for_async_data(timeout)?;
+            first_try = false;
         }
     }
 }
@@ -57,6 +83,9 @@ impl Uart for ProxyUart {
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// This function _may_ block.
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        if self.nonblocking_mode.get() {
+            return self.nonblocking_read(buf, None);
+        }
         match self.execute_command(UartRequest::Read {
             timeout_millis: None,
             len: buf.len() as u32,
@@ -73,6 +102,9 @@ impl Uart for ProxyUart {
     /// The `timeout` may be used to specify a duration to wait for data.
     /// If timeout expires without any data arriving `Ok(0)` will be returned, never `Err(_)`.
     fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        if self.nonblocking_mode.get() {
+            return self.nonblocking_read(buf, Some(timeout));
+        }
         match self.execute_command(UartRequest::Read {
             timeout_millis: Some(timeout.as_millis() as u32),
             len: buf.len() as u32,
@@ -91,5 +123,41 @@ impl Uart for ProxyUart {
             UartResponse::Write => Ok(()),
             _ => bail!(ProxyError::UnexpectedReply()),
         }
+    }
+
+    fn supports_nonblocking_read(&self) -> Result<bool> {
+        match self.execute_command(UartRequest::SupportsNonblockingRead)? {
+            UartResponse::SupportsNonblockingRead { has_support } => Ok(has_support),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+    fn register_nonblocking_read(&self, registry: &mio::Registry, token: mio::Token) -> Result<()> {
+        if !self.inner.nonblocking_help_enabled.get() {
+            bail!("Call register_nonblocking_help() before register_nonblocking_read()");
+        }
+        self.nonblocking_mode.set(true);
+        match self.execute_command(UartRequest::RegisterNonblockingRead)? {
+            UartResponse::RegisterNonblockingRead { channel } => {
+                self.inner
+                    .uart_channel_map
+                    .borrow_mut()
+                    .insert(channel, self.instance.clone());
+                let mut uarts = self.inner.uarts.borrow_mut();
+                let uart_record = uarts.get_mut(&self.instance).unwrap();
+                registry.register(
+                    &mut uart_record.pipe_receiver,
+                    token,
+                    mio::Interest::READABLE,
+                )?;
+                Ok(())
+            }
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn nonblocking_help(&self) -> Result<Rc<dyn NonblockingHelp>> {
+        Ok(Rc::new(super::ProxyNonblockingHelp {
+            inner: self.inner.clone(),
+        }))
     }
 }

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -78,6 +78,14 @@ impl UartConsole {
     where
         T: ConsoleDevice + ?Sized,
     {
+        if self.exit_success.as_ref().map(|rx| rx.is_match("")) == Some(true) {
+            // For compatibility with non-mio implementation, an `exit_success` regexp which
+            // matches the empty string will result in a single read to clear any buffered
+            // characters.
+            self.uart_read(device, Duration::from_millis(10), &mut stdout)?;
+            return Ok(ExitStatus::ExitSuccess);
+        }
+
         let mut poll = Poll::new()?;
         let transport_help_token = Self::get_next_token();
         let nonblocking_help = device.nonblocking_help()?;


### PR DESCRIPTION
Implementation of e.g. `opentitantool console` has suffered from having to take turns doing a short-timeout read from the uart and from stdin.  This became further ridiculous when using the proxy network protocol and remote `opentitansession`, as each 10ms-timeout read required a separate network request/response.

This PR introduces a way of registering a `Uart` instance to be used with `mio::poll()` for reading (writes are still blocking, as are all SPI and I2C operations.)