### PR TITLE
[ci] Remove references to the .splice bitstreams

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -418,7 +418,6 @@ jobs:
         # Rename bitstreams to be compatible with subsequent steps
         # TODO(#13807): replace this after choosing a naming scheme
         mv "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit" "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
-        mv "$BIN_DIR/$SUB_PATH/fpga_cw310_rom.bit" "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
       }
 
       . util/build_consts.sh

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -28,7 +28,6 @@ readonly BIT_SRC_DIR="${BIN_DIR}/hw/top_earlgrey"
 readonly BIT_NAME_PREFIX="lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
 mkdir -p "${BIT_CACHE_DIR}"
 cp "${BIT_SRC_DIR}/${BIT_NAME_PREFIX}.orig" \
-    "${BIT_SRC_DIR}/${BIT_NAME_PREFIX}.splice" \
     "${BIT_SRC_DIR}/otp.mmi"  \
     "${BIT_SRC_DIR}/rom.mmi" \
     "${BIT_CACHE_DIR}"


### PR DESCRIPTION
These are no longer cached and should not be used by the CI system.