### PR TITLE
[opentitantool] Add analog support to `Gpio` trait

### DIFF
--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -15,10 +15,14 @@ pub struct PinConfiguration {
     pub name: String,
     /// The input/output mode of the GPIO pin.
     pub mode: Option<PinMode>,
-    /// The default/initial level of the pin (true means high).
+    /// The default/initial level of the pin (true means high), has effect only in `PushPull` and
+    /// `OpenDrain` modes.
     pub level: Option<bool>,
     /// Whether the pin has pullup/down resistor enabled.
     pub pull_mode: Option<PullMode>,
+    /// The default/initial analog level of the pin in Volts, has effect only in `AnalogOutput`
+    /// mode.
+    pub volts: Option<f32>,
     /// Name of a pin defined by the transport (or a lower level
     /// PinConfiguration).
     pub alias_of: Option<String>,

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -41,8 +41,7 @@ impl GpioPin for CW310GpioPin {
         match mode {
             PinMode::Input => usb.pin_set_output(&self.pinname, false)?,
             PinMode::PushPull => usb.pin_set_output(&self.pinname, true)?,
-            PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
-            PinMode::Alternate => return Err(GpioError::UnsupportedPinMode(mode).into()),
+            _ => return Err(GpioError::UnsupportedPinMode(mode).into()),
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/transport/ti50emulator/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/gpio.rs
@@ -373,7 +373,7 @@ impl GpioPin for Ti50GpioPin {
             gpio::PinMode::Input => state.pin_mode = Some(PinMode::Input),
             gpio::PinMode::OpenDrain => state.pin_mode = Some(PinMode::OpenDrain),
             gpio::PinMode::PushPull => state.pin_mode = Some(PinMode::PushPull),
-            gpio::PinMode::Alternate => return Err(GpioError::UnsupportedPinMode(mode).into()),
+            _ => return Err(GpioError::UnsupportedPinMode(mode).into()),
         }
         self.host_state.set(state);
         Ok(())

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -91,8 +91,7 @@ impl GpioPin for UltradebugGpioPin {
         let direction = match mode {
             PinMode::Input => false,
             PinMode::PushPull => true,
-            PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode(mode).into()),
-            PinMode::Alternate => return Err(GpioError::UnsupportedPinMode(mode).into()),
+            _ => return Err(GpioError::UnsupportedPinMode(mode).into()),
         };
         self.device
             .borrow_mut()

--- a/sw/host/opentitanlib/src/transport/verilator/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/gpio.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::verilator::transport::Inner;
+use crate::transport::TransportError;
 use crate::util::file;
 
 pub struct VerilatorGpioPin {
@@ -71,7 +72,11 @@ impl GpioPin for VerilatorGpioPin {
         mode: Option<PinMode>,
         value: Option<bool>,
         pull: Option<PullMode>,
+        analog_value: Option<f32>,
     ) -> Result<()> {
+        if analog_value.is_some() {
+            return Err(TransportError::UnsupportedOperation.into());
+        }
         if let Some(mode) = mode {
             self.pinmode.set(mode);
         }

--- a/sw/host/tests/rom/sw_strap_value/src/main.rs
+++ b/sw/host/tests/rom/sw_strap_value/src/main.rs
@@ -47,6 +47,7 @@ fn sw_strap_set(transport: &TransportWrapper, value: u8) -> Result<()> {
             Some(settings[pinval].0),
             Some(settings[pinval].1),
             Some(settings[pinval].2),
+            None,
         )?;
     }
     Ok(())


### PR DESCRIPTION
Add declarations of `analog_read()` and `analog_write()` methods to the `Gpio` trait, along with analog pin modes and configuration support, allowing e.g. strappings to specify precise analog voltages to apply (which will be useful for the USB CC pins).
