### PR TITLE
[cdc] Update waiver path

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -180,5 +180,5 @@ set_rule_status -rule {W_CNTL} -status {Waived}                           \
   -comment {PAD driving to I2C. PADs are not clock bounded}
 
 set_rule_status -rule {W_CNTL} -status {Waived}                           \
-  -expression {(Signal=~"top_earlgrey.*.u_reg.*_cdc.u_arb.*_sync.dst_ack_q") && (ReceivingFlop=~"top_earlgrey.*.u_sync_1.gen_generic.u_impl_generic.q_o*")} \
+  -expression {(Signal=~"top_earlgrey.*.u_reg.*_cdc.u_arb.*_sync.*.dst_ack_q") && (ReceivingFlop=~"top_earlgrey.*.u_sync_1.gen_generic.u_impl_generic.q_o*")} \
   -comment {PAD driving to I2C. PADs are not clock bounded}


### PR DESCRIPTION
The prim_sync_reqack module recently added a new layer with PR #16483 to support the RZ variant.
This PR updates the cdc waiver to include this new laywer.