### PR TITLE
[hw,sysrst_ctrl] Debounce must check trigger active

### DIFF
--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
@@ -158,8 +158,8 @@ module sysrst_ctrl_detect
       // detection stage, otherwise we fall back.
       DebounceSt: begin
         cnt_en = 1'b1;
-        // Unconditionally go back to idle if the detector is disabled.
-        if (!cfg_enable_i) begin
+        // Go back to idle if the detector is disabled or if trigger is deactivated.
+        if (!cfg_enable_i || !trigger_active) begin
           state_d = IdleSt;
           cnt_clr = 1'b1;
         end else if (cnt_done) begin


### PR DESCRIPTION
Based on my previous investigation, I think that the debounce in the system reset control is not behaving properly:
https://github.com/lowRISC/opentitan/issues/17238#issuecomment-1431523457

Namely during the debounce state it does not check whether the trigger stays active.