### PR TITLE
[otbn, pre_sca] Improve tool options and otbn_top_coco.v

### DIFF
--- a/hw/ip/otbn/pre_sca/alma/README.md
+++ b/hw/ip/otbn/pre_sca/alma/README.md
@@ -193,11 +193,14 @@ tutorial](https://github.com/IAIK/coco-alma/tree/hw-verif#usage)
       --top-module otbn_top_coco \
       --label tmp/labels_updated.txt \
       --vcd tmp/circuit.vcd \
+      --checking-mode per-location \
       --rst-name rst_sys_n \
       --rst-phase 0 \
       --rst-cycles 2 \
       --init-delay 139 \
       --cycles 25 \
+      --excluded-signals u_otbn_core.u_otbn_controller.rf_bignum_intg_err_i[0] \
+      --glitch-behavior loose \
       --mode stable
    ```
 

--- a/hw/ip/otbn/pre_sca/alma/README.md
+++ b/hw/ip/otbn/pre_sca/alma/README.md
@@ -201,6 +201,7 @@ tutorial](https://github.com/IAIK/coco-alma/tree/hw-verif#usage)
       --cycles 25 \
       --excluded-signals u_otbn_core.u_otbn_controller.rf_bignum_intg_err_i[0] \
       --glitch-behavior loose \
+      --dbg-signals otbn_cycle_cnt_o \
       --mode stable
    ```
 

--- a/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
@@ -32,13 +32,16 @@ examples/otbn/labels/generate_bignum_rf_labels.py \
   -o tmp/labels_updated.txt -w 1 -s 0
 
 # Verify
-python3 verify.py --json tmp/circuit.json \
-  --top-module otbn_top_coco \
-  --label tmp/labels_updated.txt \
-  --vcd tmp/circuit.vcd \
-  --rst-name rst_sys_n \
-  --rst-phase 0 \
-  --rst-cycles 2 \
-  --init-delay 139 \
-  --cycles 25 \
-  --mode stable
+  python3 verify.py --json tmp/circuit.json \
+    --top-module otbn_top_coco \
+    --label tmp/labels_updated.txt \
+    --vcd tmp/circuit.vcd \
+    --checking-mode per-location \
+    --rst-name rst_sys_n \
+    --rst-phase 0 \
+    --rst-cycles 2 \
+    --init-delay 139 \
+    --cycles 25 \
+    --excluded-signals u_otbn_core.u_otbn_controller.rf_bignum_intg_err_i[0] \
+    --glitch-behavior loose \
+    --mode stable

--- a/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
@@ -32,16 +32,17 @@ examples/otbn/labels/generate_bignum_rf_labels.py \
   -o tmp/labels_updated.txt -w 1 -s 0
 
 # Verify
-  python3 verify.py --json tmp/circuit.json \
-    --top-module otbn_top_coco \
-    --label tmp/labels_updated.txt \
-    --vcd tmp/circuit.vcd \
-    --checking-mode per-location \
-    --rst-name rst_sys_n \
-    --rst-phase 0 \
-    --rst-cycles 2 \
-    --init-delay 139 \
-    --cycles 25 \
-    --excluded-signals u_otbn_core.u_otbn_controller.rf_bignum_intg_err_i[0] \
-    --glitch-behavior loose \
-    --mode stable
+python3 verify.py --json tmp/circuit.json \
+  --top-module otbn_top_coco \
+  --label tmp/labels_updated.txt \
+  --vcd tmp/circuit.vcd \
+  --checking-mode per-location \
+  --rst-name rst_sys_n \
+  --rst-phase 0 \
+  --rst-cycles 2 \
+  --init-delay 139 \
+  --cycles 25 \
+  --excluded-signals u_otbn_core.u_otbn_controller.rf_bignum_intg_err_i[0] \
+  --glitch-behavior loose \
+  --dbg-signals otbn_cycle_cnt_o \
+  --mode stable

--- a/hw/ip/otbn/rtl/otbn_rf_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum.sv
@@ -160,8 +160,21 @@ module otbn_rf_bignum
     );
   end
 
-  assign intg_err_o = ((|rd_data_a_err) & rd_en_a_i) |
-                      ((|rd_data_b_err) & rd_en_b_i);
+  logic intg_err_unbuf, intg_err_buf;
+
+  assign intg_err_unbuf = ((|rd_data_a_err) & rd_en_a_i) |
+                          ((|rd_data_b_err) & rd_en_b_i);
+
+  // This primitive is used to place a constraint for synthesis. It is required to
+  // ensure that the signal name will be available in the synthesized netlist.
+  prim_buf #(
+    .Width(1)
+  ) u_prim_buf (
+    .in_i(intg_err_unbuf),
+    .out_o(intg_err_buf)
+  );
+
+  assign intg_err_o = intg_err_buf;
 
   `ASSERT(BlankingBignumRegReadA_A,
           !rd_en_a_i |->  rd_data_a_intg_o == '0,


### PR DESCRIPTION
Add buffer for rf_bignum.intg_err_o signal so Yosys do not optimize this signal in the netlist. We are excluding this signal from formal masking analysis. Update verify commands to exclude this signal.

Add cycle counter in testbench to easily inspect waves and associate those waves with tool output. The counter is reset with the start pulse being sent. Update verify commands to print this cycle counter.
    
Output RND and URND signals so that we can place a `volatile_random` label on these inputs.

