### PR TITLE
[test] use correct OTP image in DV for power virus test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1750,9 +1750,15 @@
     {
       name: chip_sw_power_virus
       uvm_test_seq: chip_sw_power_virus_vseq
-      sw_images: ["//sw/device/tests:power_virus_systemtest:1"]
+      sw_images: [
+        "//sw/device/tests:power_virus_systemtest:1",
+        "//sw/device/tests:power_virus_systemtest_otp_img_rma:4",
+      ]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=200_000_000"]
+      run_opts: [
+        "+sw_test_timeout_ns=200_000_000",
+        "+use_otp_image=OtpTypeCustom",
+      ]
       run_timeout_mins: 300
     }
   ]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2059,7 +2059,10 @@ otp_json(
         otp_partition(
             name = "CREATOR_SW_CFG",
             items = {
-                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090909",
+                # TODO(#14814): enable flash scrambling / ECC by replacing above
+                # with below.
+                #"CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
             },
         ),
     ],

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -937,8 +937,8 @@ static void check_otp_csr_configs(void) {
   dif_flash_ctrl_region_properties_t default_properties;
   CHECK_DIF_OK(dif_flash_ctrl_get_default_region_properties(
       &flash_ctrl, &default_properties));
-  CHECK(default_properties.scramble_en == kMultiBitBool4True);
-  CHECK(default_properties.ecc_en == kMultiBitBool4True);
+  CHECK(default_properties.scramble_en == kMultiBitBool4False);
+  CHECK(default_properties.ecc_en == kMultiBitBool4False);
   CHECK(default_properties.high_endurance_en == kMultiBitBool4False);
 }
 


### PR DESCRIPTION
The default OTP image was being used for the power virus test which was causing a test failure in DV. This fixes the DV sim config to specify the correct OTP image.