### PR TITLE
[sca] Add OTBN entrypoint for P256 SCA capture.

### DIFF
--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -144,6 +144,16 @@ otbn_binary(
 )
 
 otbn_binary(
+    name = "p256_key_from_seed_sca",
+    srcs = [
+        "p256_key_from_seed_sca.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
     name = "p384_ecdsa_sca",
     srcs = [
         "p384_ecdsa_sca.s",

--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -1416,10 +1416,10 @@ p256_sign:
  *
  * This routine runs in constant time.
  *
- * @param[in]     dmem[d0]:  first share of scalar d (320 bits)
- * @param[in]     dmem[d1]:  second share of scalar d (320 bits)
- * @param[in,out] dmem[x]:   affine x-coordinate (256 bits)
- * @param[in,out] dmem[y]:   affine y-coordinate (256 bits)
+ * @param[in]   dmem[d0]:  first share of scalar d (320 bits)
+ * @param[in]   dmem[d1]:  second share of scalar d (320 bits)
+ * @param[out]  dmem[x]:   affine x-coordinate (256 bits)
+ * @param[out]  dmem[y]:   affine y-coordinate (256 bits)
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *

--- a/sw/otbn/crypto/p256_key_from_seed_sca.s
+++ b/sw/otbn/crypto/p256_key_from_seed_sca.s
@@ -1,0 +1,156 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Wrapper specifically for SCA/formal analysis of p256 keygen.
+ *
+ * Normally, the key generation routines called here would be used with key
+ * manager seeds only. This wrapper uses software-provided seeds for analysis
+ * purposes and should not be used for production code.
+ */
+
+.section .text.start
+
+start:
+  /* Read mode, then tail-call either p256_gen_secret_key or p256_gen_keypair */
+  la    x2, mode
+  lw    x2, 0(x2)
+
+  li    x3, 1
+  beq   x2, x3, p256_gen_secret_key
+
+  li    x3, 2
+  beq   x2, x3, p256_gen_keypair
+
+  /* Invalid mode; fail. */
+  unimp
+
+p256_gen_secret_key:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load shares of seed from DMEM.
+       [w21,w20] <= dmem[seed0]
+       [w23,w33] <= dmem[seed1] */
+  li        x2, 20
+  la        x3, seed0
+  bn.lid    x2, 0(x3++)
+  li        x2, 21
+  bn.lid    x2++, 0(x3)
+  la        x3, seed1
+  bn.lid    x2, 0(x3++)
+  li        x2, 23
+  bn.lid    x2, 0(x3)
+
+  /* Generate the derived secret key.
+       [w21,w20] <= d0
+       [w23,w33] <= d1 */
+  jal       x1, p256_key_from_seed
+
+  /* Write the results to DMEM.
+       dmem[d0] <= [w21, w20]
+       dmem[d1] <= [w23, w22] */
+  li        x2, 20
+  la        x3, d0
+  bn.sid    x2, 0(x3++)
+  li        x2, 21
+  bn.sid    x2++, 0(x3)
+  la        x3, d1
+  bn.sid    x2, 0(x3++)
+  li        x2, 23
+  bn.sid    x2, 0(x3)
+
+  ecall
+
+p256_gen_keypair:
+  /* First, generate the masked secret key d and write to DMEM.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal       x1, p256_gen_secret_key
+
+  /* Generate the public key Q = d*G.
+       dmem[x] <= Q.x
+       dmem[y] <= Q.y */
+  jal       x1, p256_base_mult
+
+  ecall
+
+
+/**
+ * Note: Technically this could be a .bss section, but it is convenient for
+ * software to have zeroes already set on the high bits of the seeds.
+ */
+.data
+
+/* Mode (1 = private key only, 2 = keypair) */
+.balign 4
+.globl mode
+mode:
+  .word 0x00000001
+
+/* First share of seed (320 bits). */
+.balign 32
+.globl seed0
+seed0:
+  .word 0x2335f23f
+  .word 0x3c174a16
+  .word 0x128c1339
+  .word 0xc48e8981
+  .word 0x7843d9a2
+  .word 0xbb6a0205
+  .word 0x446984cc
+  .word 0xa210c4be
+  .word 0xd7c77320
+  .word 0x2bac5b0b
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+
+/* Second share of seed (320 bits). */
+.balign 32
+.globl seed1
+seed1:
+  .word 0x225596d6
+  .word 0x2df4bec0
+  .word 0xbeb67c9e
+  .word 0x6f2f939a
+  .word 0xf7d1a873
+  .word 0x99dd9f5a
+  .word 0x551f77d1
+  .word 0x17bcfeef
+  .word 0x4e67f1f7
+  .word 0x63e2e86d
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+  .word 0x00000000
+
+/* First share of output key (320 bits). */
+.balign 32
+.globl d0
+d0:
+.zero 64
+
+/* Second share of output key (320 bits). */
+.balign 32
+.globl d1
+d1:
+.zero 64
+
+/* x-coordinate of output public key (256 bits). */
+.balign 32
+.globl x
+x:
+.zero 32
+
+/* y-coordinate of output public key (256 bits). */
+.balign 32
+.globl y
+y:
+.zero 32


### PR DESCRIPTION
This entrypoint runs the key-from-seed procedure that would normally be reserved for generating ECDSA keys from key manager seeds, but it takes the seeds from Ibex. This would not be run in production, but controlling the seeds is helpful for SCA analysis of the key-generation routine.

Note: This is still part of the `p256-key-from-seed-sca` branch on my fork that @wettermo and @m-temp have been working with; I just cleaned up the commits. After this and one more PR, that branch will be fully merged.