### PR TITLE
[WIP] [rv_dm] Fix xprop instrumentation

### DIFF
--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -330,7 +330,7 @@ module dm_csrs #(
           // Handle ranges of addresses in the default statement instead of with range clauses
           // (`[:]`) in a `unique case inside` construct.  The reason is that not all tools
           // support ranges in `case inside` constructs.
-          if (dm_csr_addr >= dm::Data0 && dm_csr_addr <= DataEnd) begin
+          unique if (dm_csr_addr >= dm::Data0 && dm_csr_addr <= DataEnd) begin
             resp_queue_inp.data = data_q[$clog2(dm::DataCount)'(autoexecdata_idx)];
             if (!cmdbusy_i) begin
               // check whether we need to re-execute the command (just give a cmd_valid)
@@ -342,8 +342,7 @@ module dm_csrs #(
                 cmderr_d = dm::CmdErrBusy;
               end
             end
-          end
-          if (dm_csr_addr >= dm::ProgBuf0 && dm_csr_addr <= ProgBufEnd) begin
+          end else if (dm_csr_addr >= dm::ProgBuf0 && dm_csr_addr <= ProgBufEnd) begin
             resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
             if (!cmdbusy_i) begin
               // check whether we need to re-execute the command (just give a cmd_valid)
@@ -357,6 +356,8 @@ module dm_csrs #(
                 cmderr_d = dm::CmdErrBusy;
               end
             end
+          end else begin
+            // Workaround for `unique0 if` not being supported in some commercial simulators.
           end
         end
       endcase
@@ -473,7 +474,7 @@ module dm_csrs #(
           // Handle ranges of addresses in the default statement instead of with range clauses
           // (`[:]`) in a `unique case inside` construct.  The reason is that not all tools
           // support ranges in `case inside` constructs.
-          if (dm_csr_addr >= dm::Data0 && dm_csr_addr <= DataEnd) begin
+          unique if (dm_csr_addr >= dm::Data0 && dm_csr_addr <= DataEnd) begin
             if (dm::DataCount > 0) begin
               // attempts to write them while busy is set does not change their value
               if (!cmdbusy_i) begin
@@ -488,8 +489,7 @@ module dm_csrs #(
                 end
               end
             end
-          end
-          if (dm_csr_addr >= dm::ProgBuf0 && dm_csr_addr <=ProgBufEnd) begin
+          end else if (dm_csr_addr >= dm::ProgBuf0 && dm_csr_addr <=ProgBufEnd) begin
             // attempts to write them while busy is set does not change their value
             if (!cmdbusy_i) begin
               progbuf_d[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]] = dmi_req_i.data;
@@ -505,6 +505,8 @@ module dm_csrs #(
                 cmderr_d = dm::CmdErrBusy;
               end
             end
+          end else begin
+            // Workaround for `unique0 if` not being supported in some commercial simulators.
           end
         end
       endcase

--- a/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
@@ -228,6 +228,9 @@ module dm_mem #(
     assign rdata_o = (word_enable32_q) ? word_mux[32 +: 32] : word_mux[0 +: 32];
   end
 
+  logic [DbgAddressBits-1:0] addr;
+  assign addr = addr_i[DbgAddressBits-1:0];
+
   // read/write logic
   logic [dm::DataCount-1:0][31:0] data_bits;
   logic [7:0][7:0] rdata;
@@ -254,7 +257,7 @@ module dm_mem #(
     if (req_i) begin
       // this is a write
       if (we_i) begin
-        unique case (addr_i[DbgAddressBits-1:0]) inside
+        unique case (addr) inside
           HaltedAddr: begin
             halted_aligned[wdata_hartsel] = 1'b1;
             halted_d_aligned[wdata_hartsel] = 1'b1;
@@ -295,7 +298,7 @@ module dm_mem #(
 
       // this is a read
       end else begin
-        unique case (addr_i[DbgAddressBits-1:0]) inside
+        unique case (addr) inside
           // variable ROM content
           WhereToAddr: begin
             // variable jump to abstract cmd, program_buffer or resume
@@ -384,7 +387,7 @@ module dm_mem #(
   always_comb begin
     err_d = 1'b0;
     if (req_i) begin
-      unique case (addr_i[DbgAddressBits-1:0]) inside
+      unique case (addr) inside
         WhereToAddr:                              err_d = gen_wr_err(we_i, be_i, FullRegMask);
         HaltedAddr:                               err_d = gen_wr_err(we_i, be_i, HartSelMask);
         GoingAddr:                                err_d = gen_wr_err(we_i, be_i, OneBitMask);


### PR DESCRIPTION
A few code constructs in `rv_dm` (actually in `hw/vendor/pulp_riscv_dbg`) are unsupported in VCS xprop instrumentation; see #17131. This PR refactors the code to remove the unsupported constructs while preserving the synthesis semantics (and most of the simulation semantics). This resolves #17131.

**Do not merge this draft PR.** It currently modifies vendored files directly, but that will be replaced by an update of the vendored code if we can get the patch into the upstream repo or an OT-specific patch if we can't get the patch upstreamed.

## TODOs
- [ ] Resolve upstream PR https://github.com/pulp-platform/riscv-dbg/pull/150
- [ ] Potentially get lint fixes upstreamed as well (reducing our patches).
- [ ] Re-vendor and update patch files, especially those that add `unique case inside` code
- [ ] Add additional patches to remove `&& addr <= RomEndAddr` in `dm_mem`, because that causes lint errors as the inequality is always true.