### PR TITLE
[fpv/edn] Fix sec_cm failures

### DIFF
--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -116,6 +116,9 @@ module edn_ack_sm (
   // The following assertion ensures the Error state is stable until reset.
   // With `FpvSecCm` prefix, this assertion will added to weekly FPV sec_cm regression.
   `ASSERT(FpvSecCmErrorStEscalate_A, state_q == Error |-> local_escalate_i)
-  `ASSERT(FpvSecCmErrorStStable_A,   state_q == Error |=> $stable(state_q))
+
+  // This assertion does not have `FpvSecCm` prefix because the sec_cm FPV environment will
+  // blackbox the `prim_sparse_fsm` `state_q` output.
+  `ASSERT(AckSmErrorStStable_A,   state_q == Error |=> $stable(state_q))
 
 endmodule

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -247,5 +247,8 @@ module edn_main_sm import edn_pkg::*; #(
   // The following assertion ensures the Error state is stable until reset.
   // With `FpvSecCm` prefix, this assertion will added to weekly FPV sec_cm regression.
   `ASSERT(FpvSecCmErrorStEscalate_A, state_q == Error |-> local_escalate_i)
-  `ASSERT(FpvSecCmErrorStStable_A,   state_q == Error |=> $stable(state_q))
+
+  // This assertion does not have `FpvSecCm` prefix because the sec_cm FPV environment will
+  // blackbox the `prim_sparse_fsm` `state_q` output.
+  `ASSERT(ErrorStStable_A, state_q == Error |=> $stable(state_q))
 endmodule


### PR DESCRIPTION
This PR fixes the nightly regression FPV sec_cm failure. The assertion is absolutely correct, but the FPV sec_cm env will blackbox the `prim_sparse_fsm`. Thus the state_q output will be random values. So this environment will break the assertion.
For the solution, I removed the sec_cm prefix, so the assertion will only run in normal FPV or DV environment.