### PR TITLE
[aes, dv] FI test improvements

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
@@ -60,10 +60,11 @@ class aes_cipher_fi_vseq extends aes_base_vseq;
               // that state.
               clear_regs('{dataout: 1'b1, default: 1'b0});
               `DV_WAIT(cfg.aes_cipher_control_fi_vif[if_num].aes_cipher_ctrl_cs == await_state)
-            end else if (await_state == aes_pkg::CIPHER_CTRL_PRNG_RESEED) begin
-              // The PRNG Reseed state is also difficult to hit with a random delay. This writes the
-              // trigger register to bring the FSM into the PRNG Reseed state, and it waits until
-              // the FSM has reached that state.
+            end else if ((await_state == aes_pkg::CIPHER_CTRL_PRNG_RESEED) && `EN_MASKING) begin
+              // The PRNG Reseed state is also difficult to hit with a random delay, and completely
+              // unreachable for the unmasked implementation.
+              // This writes the trigger register to bring the FSM into the PRNG Reseed state, and
+              // waits until the FSM has reached that state.
               prng_reseed();
               `DV_WAIT(cfg.aes_cipher_control_fi_vif[if_num].aes_cipher_ctrl_cs == await_state)
             end else begin

--- a/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_cipher_fi_vseq.sv
@@ -13,7 +13,7 @@ class aes_cipher_fi_vseq extends aes_base_vseq;
   status_t aes_status;
   bit  finished_all_msgs = 0;
   bit  wait_for_alert_clear = 0;
-  bit  alert = 0;
+  bit  wait_for_alert_and_reset = 0;
 
   localparam bit FORCE   = 0;
   localparam bit RELEASE = 1;
@@ -70,12 +70,24 @@ class aes_cipher_fi_vseq extends aes_base_vseq;
             end else begin
               cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
             end
+            if (finished_all_msgs) begin
+              // As long as the DUT hasn't finished processing messages yet, the signal forcing
+              // will interrupt the message processing. The `basic` thread will notice this and
+              // as part of the recovery procedure wait for an alert, reset the DUT and then
+              // continue processing messages.
+              // Otherwise we have to try to detect the alert and to reset the DUT ourselves.
+              wait_for_alert_and_reset = 1;
+            end
             `uvm_info(`gfn, $sformatf("FORCING %h on if[%d]", force_value, if_num), UVM_MEDIUM)
             cfg.aes_cipher_control_fi_vif[if_num].force_signal(target, FORCE, force_value);
             wait_for_alert_clear = 1;
+            if (wait_for_alert_and_reset) begin
+              wait_for_fatal_alert_and_reset();
+            end
           end
           basic: begin
             send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+            finished_all_msgs = 1;
           end
         join_none
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_control_fi_vseq.sv
@@ -13,7 +13,7 @@ class aes_control_fi_vseq extends aes_base_vseq;
   status_t aes_status;
   bit  finished_all_msgs = 0;
   bit  wait_for_alert_clear = 0;
-  bit  alert = 0;
+  bit  wait_for_alert_and_reset = 0;
 
   localparam bit FORCE   = 0;
   localparam bit RELEASE = 1;
@@ -73,12 +73,24 @@ class aes_control_fi_vseq extends aes_base_vseq;
             end else begin
               cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
             end
+            if (finished_all_msgs) begin
+              // As long as the DUT hasn't finished processing messages yet, the signal forcing
+              // will interrupt the message processing. The `basic` thread will notice this and
+              // as part of the recovery procedure wait for an alert, reset the DUT and then
+              // continue processing messages.
+              // Otherwise we have to try to detect the alert and to reset the DUT ourselves.
+              wait_for_alert_and_reset = 1;
+            end
             `uvm_info(`gfn, $sformatf("FORCING %h on if[%d]", force_value, if_num), UVM_MEDIUM)
             cfg.aes_control_fi_vif[if_num].force_signal(target, FORCE, force_value);
             wait_for_alert_clear = 1;
+            if (wait_for_alert_and_reset) begin
+              wait_for_fatal_alert_and_reset();
+            end
           end
           basic: begin
             send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+            finished_all_msgs = 1;
           end
         join_none
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_ctr_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_ctr_fi_vseq.sv
@@ -13,7 +13,7 @@ class aes_ctr_fi_vseq extends aes_base_vseq;
   status_t aes_status;
   bit  finished_all_msgs = 0;
   bit  wait_for_alert_clear = 0;
-  bit  alert = 0;
+  bit  wait_for_alert_and_reset = 0;
 
   localparam bit FORCE   = 0;
   localparam bit RELEASE = 1;
@@ -60,12 +60,24 @@ class aes_ctr_fi_vseq extends aes_base_vseq;
             end else begin
               cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
             end
+            if (finished_all_msgs) begin
+              // As long as the DUT hasn't finished processing messages yet, the signal forcing
+              // will interrupt the message processing. The `basic` thread will notice this and
+              // as part of the recovery procedure wait for an alert, reset the DUT and then
+              // continue processing messages.
+              // Otherwise we have to try to detect the alert and to reset the DUT ourselves.
+              wait_for_alert_and_reset = 1;
+            end
             `uvm_info(`gfn, $sformatf("FORCING %h on if[%d]", force_value, if_num), UVM_MEDIUM)
             cfg.aes_ctr_fsm_fi_vif[if_num].force_signal(target, FORCE, force_value);
             wait_for_alert_clear = 1;
+            if (wait_for_alert_and_reset) begin
+              wait_for_fatal_alert_and_reset();
+            end
           end
           basic: begin
             send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+            finished_all_msgs = 1;
           end
         join_none
 


### PR DESCRIPTION
Some of the FI tests had a somewhat low pass rate for the unmasked implementation. I had a look at this and identified the following two main reasons:
1. Some FSM states are unreachable in the unmasked implementation (e.g. state for reseeding the cipher core internal PRNG which isn't implemented). Some tests would wait for the FSM to enter this state which simply never happens.
2. Sometimes, the message processing thread who is also responsible for resetting the DUT in case of fatal alerts finishes before the fault is inserted. In this case the test has to detect the alert and reset the DUT itself instead of relying on the message processing thread. This was happening far more frequently for the unmasked design due to the higher performance (lower processing time).

This PR fixes both these issues and pushes the overall pass rate up to around 96% (unmasked, previously 91% sometimes even below 90%) and 98% (masked, previously 97%) .