### PR TITLE
[crypto] Add top-level SPHINCS+ signature verification.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
@@ -86,6 +86,24 @@ cc_library(
 )
 
 cc_library(
+    name = "verify",
+    srcs = ["verify.c"],
+    hdrs = ["verify.h"],
+    deps = [
+        ":address",
+        ":context",
+        ":fors",
+        ":hash",
+        ":params",
+        ":thash",
+        ":utils",
+        ":wots",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+cc_library(
     name = "wots",
     srcs = ["wots.c"],
     hdrs = ["wots.h"],

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.c
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/sign.c
+
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/fors.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.h"
+
+static_assert(kSpxD <= UINT8_MAX, "kSpxD must fit into a uint8_t.");
+rom_error_t spx_verify(const uint8_t *sig, const uint8_t *m, size_t mlen,
+                       const uint8_t *pk, uint32_t *root) {
+  spx_ctx_t ctx;
+  memcpy(ctx.pub_seed, pk, kSpxN);
+
+  // This hook allows the hash function instantiation to do whatever
+  // preparation or computation it needs, based on the public seed.
+  HARDENED_RETURN_IF_ERROR(spx_hash_initialize(&ctx));
+
+  spx_addr_t wots_addr = {.addr = {0}};
+  spx_addr_t tree_addr = {.addr = {0}};
+  spx_addr_t wots_pk_addr = {.addr = {0}};
+  spx_addr_type_set(&wots_addr, kSpxAddrTypeWots);
+  spx_addr_type_set(&tree_addr, kSpxAddrTypeHashTree);
+  spx_addr_type_set(&wots_pk_addr, kSpxAddrTypeWotsPk);
+
+  // Derive the message digest and leaf index from R || PK || M.
+  // The additional kSpxN is a result of the hash domain separator.
+  uint8_t mhash[kSpxForsMsgBytes];
+  uint64_t tree;
+  uint32_t idx_leaf;
+  HARDENED_RETURN_IF_ERROR(
+      spx_hash_message(sig, pk, m, mlen, mhash, &tree, &idx_leaf));
+  sig += kSpxN;
+
+  // Layer correctly defaults to 0, so no need to set_layer_addr.
+  spx_addr_tree_set(&wots_addr, tree);
+  spx_addr_keypair_set(&wots_addr, idx_leaf);
+
+  HARDENED_RETURN_IF_ERROR(
+      fors_pk_from_sig(sig, mhash, &ctx, &wots_addr, root));
+  sig += kSpxForsBytes;
+
+  // For each subtree..
+  for (uint8_t i = 0; i < kSpxD; i++) {
+    spx_addr_layer_set(&tree_addr, i);
+    spx_addr_tree_set(&tree_addr, tree);
+
+    spx_addr_subtree_copy(&wots_addr, &tree_addr);
+    spx_addr_keypair_set(&wots_addr, idx_leaf);
+
+    spx_addr_keypair_copy(&wots_pk_addr, &wots_addr);
+
+    // The WOTS public key is only correct if the signature was correct.
+    // Initially, root is the FORS pk, but on subsequent iterations it is
+    // the root of the subtree below the currently processed subtree.
+    uint32_t wots_pk[kSpxWotsWords];
+    HARDENED_RETURN_IF_ERROR(wots_pk_from_sig(sig, (unsigned char *)root, &ctx,
+                                              &wots_addr, wots_pk));
+    sig += kSpxWotsBytes;
+
+    // Compute the leaf node using the WOTS public key.
+    uint32_t leaf[kSpxNWords];
+    HARDENED_RETURN_IF_ERROR(thash((unsigned char *)wots_pk, kSpxWotsLen, &ctx,
+                                   &wots_pk_addr, leaf));
+
+    // Compute the root node of this subtree.
+    HARDENED_RETURN_IF_ERROR(
+        spx_utils_compute_root((unsigned char *)leaf, idx_leaf, 0, sig,
+                               kSpxTreeHeight, &ctx, &tree_addr, root));
+    sig += kSpxTreeHeight * kSpxN;
+
+    // Update the indices for the next layer.
+    idx_leaf = (tree & ((1 << kSpxTreeHeight) - 1));
+    tree = tree >> kSpxTreeHeight;
+  }
+
+  return kErrorOk;
+}
+
+inline void spx_public_key_root(const uint8_t *pk, uint32_t *root) {
+  memcpy(root, pk + kSpxN, kSpxN);
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/ed15dd78658f63288c7492c00260d86154b84637/ref/api.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_VERIFY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_VERIFY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Size of SPHINCS+ root node.
+   */
+  kSpxVerifyRootNumWords = kSpxNWords,
+  /**
+   * Size of SPHINCS+ signature.
+   */
+  kSpxVerifySigBytes = kSpxBytes,
+  /**
+   * Size of SPHINCS+ public key.
+   */
+  kSpxVerifyPkBytes = kSpxPkBytes,
+};
+
+/**
+ * Computes the root for a signature and message under a given public key.
+ *
+ * The signature is valid if the computed root matches the root from the public
+ * key; the final comparison is left to the caller.
+ *
+ * @param sig Input signature (`kSpxVerifySigBytes` bytes long).
+ * @param m Input message.
+ * @param mlen Length of message (bytes).
+ * @param pk Public key (`kSpxVerifyPkBytes` bytes long).
+ * @param[out] root Buffer for computed tree root (`kSpxVerifyRootNumWords`
+ *                  words long).
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t spx_verify(const uint8_t *sig, const uint8_t *m, size_t mlen,
+                       const uint8_t *pk, uint32_t *root);
+
+/**
+ * Extract the public key root.
+ *
+ * @param pk Public key (`kSpxVerifyPkBytes` bytes long).
+ * @param[out] root Buffer for the public key root (`kSpxVerifyRootNumWords`
+ *                  words long).
+ */
+void spx_public_key_root(const uint8_t *pk, uint32_t *root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_VERIFY_H_


### PR DESCRIPTION
This commit finishes the ROM SPHINCS+ signature verification implementation :tada: It can now be called from the boot code in sigverify (although still TODO is updating the manifest format so it can hold SPHINCS+ signatures and adding the code that calls this verification depending on OTP settings).