### PR TITLE
[dv/verilator] Get '-c' flag of Verilator simulator working

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -76,6 +76,7 @@ static bool read_ul_arg(unsigned long *arg_val, const char *arg_name,
     bad_fmt = true;
   } else {
     char *txt_end;
+    errno = 0;
     *arg_val = strtoul(arg_text, &txt_end, 0);
 
     // If txt_end doesn't point at a \0 then we didn't read the entire


### PR DESCRIPTION
At them moment, passing the '-c' flat to the Verilator sim always leads to a bogus error about the arg value being too large for an unsigned long.

The reason is that `read_ul_arg` calls `strtoul` and then checks `errno` without resetting `errno` first. This causes the error handling code to interpret the stale `errno` value (set by some previous call) as a strtoul parser failure.