### PR TITLE
[sysrst_ctrl,dv] Consolidate combo detection crosses

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
@@ -224,6 +224,22 @@ class sysrst_ctrl_combo_detect_vseq extends sysrst_ctrl_base_vseq;
               get_field_val(ral.com_pre_sel_ctl[i].pwrb_in_sel, get_trigger_combo_pre[i]),
               get_field_val(ral.com_pre_sel_ctl[i].ac_present_sel, get_trigger_combo_pre[i])
             );
+            cov.combo_key_combinations.sysrst_ctrl_combo_key_combinations_cg.sample(
+              current_bat_act,
+              intr_actions[i],
+              current_ec_act,
+              current_rst_act,
+              get_field_val(ral.com_sel_ctl[i].key0_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].key1_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].key2_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].pwrb_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].ac_present_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key0_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key1_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key2_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].pwrb_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].ac_present_sel, get_trigger_combo_pre[i])
+            );
           end
 
           if (get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i])) begin

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
@@ -151,6 +151,7 @@ class sysrst_ctrl_combo_detect_vseq extends sysrst_ctrl_base_vseq;
 
     repeat (num_trans) begin
       bit bat_act_triggered, ec_act_triggered, rst_act_triggered;
+      bit current_bat_act, current_ec_act, current_rst_act;
       bit [3:0] intr_actions, intr_actions_pre_reset;
       int ec_act_occur_cyc = 0;
       repeat ($urandom_range(1, 2)) begin
@@ -199,16 +200,19 @@ class sysrst_ctrl_combo_detect_vseq extends sysrst_ctrl_base_vseq;
       for (int i = 0; i <= 3; i++) begin
         if (cycles > (get_duration[i] + set_key_timer) && triggered[i]) begin
           intr_actions[i]    = get_field_val(ral.com_out_ctl[i].interrupt, get_action[i]);
-          bat_act_triggered |= get_field_val(ral.com_out_ctl[i].bat_disable, get_action[i]);
-          ec_act_triggered  |= get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i]);
-          rst_act_triggered |= get_field_val(ral.com_out_ctl[i].rst_req, get_action[i]);
+          current_bat_act    = get_field_val(ral.com_out_ctl[i].bat_disable, get_action[i]);
+          current_ec_act     = get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i]);
+          current_rst_act    = get_field_val(ral.com_out_ctl[i].rst_req, get_action[i]);
+          bat_act_triggered |= current_bat_act;
+          ec_act_triggered  |= current_ec_act;
+          rst_act_triggered |= current_rst_act;
 
           if (cfg.en_cov) begin
             cov.combo_detect_action[i].sysrst_ctrl_combo_detect_action_cg.sample(
-              bat_act_triggered,
+              current_bat_act,
               intr_actions[i],
-              ec_act_triggered,
-              rst_act_triggered,
+              current_ec_act,
+              current_rst_act,
               get_field_val(ral.com_sel_ctl[i].key0_in_sel, get_trigger_combo[i]),
               get_field_val(ral.com_sel_ctl[i].key1_in_sel, get_trigger_combo[i]),
               get_field_val(ral.com_sel_ctl[i].key2_in_sel, get_trigger_combo[i]),

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_vseq.sv
@@ -198,31 +198,28 @@ class sysrst_ctrl_combo_detect_vseq extends sysrst_ctrl_base_vseq;
       // NOTE: The interrupt will only raise if the interrupt combo action is set.
       for (int i = 0; i <= 3; i++) begin
         if (cycles > (get_duration[i] + set_key_timer) && triggered[i]) begin
-          intr_actions[i] = get_field_val(ral.com_out_ctl[i].interrupt, get_action[i]);
+          intr_actions[i]    = get_field_val(ral.com_out_ctl[i].interrupt, get_action[i]);
           bat_act_triggered |= get_field_val(ral.com_out_ctl[i].bat_disable, get_action[i]);
-          ec_act_triggered |= get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i]);
+          ec_act_triggered  |= get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i]);
           rst_act_triggered |= get_field_val(ral.com_out_ctl[i].rst_req, get_action[i]);
 
           if (cfg.en_cov) begin
-            cov.combo_detect_action[i].sysrst_ctrl_combo_detect_action_cg.sample(bat_act_triggered,
-                            intr_actions[i],
-                            ec_act_triggered,
-                            rst_act_triggered,
-                            get_field_val(ral.com_sel_ctl[i].key0_in_sel, get_trigger_combo[i]),
-                            get_field_val(ral.com_sel_ctl[i].key1_in_sel, get_trigger_combo[i]),
-                            get_field_val(ral.com_sel_ctl[i].key2_in_sel, get_trigger_combo[i]),
-                            get_field_val(ral.com_sel_ctl[i].pwrb_in_sel, get_trigger_combo[i]),
-                            get_field_val(ral.com_sel_ctl[i].ac_present_sel,get_trigger_combo[i]),
-                            get_field_val(ral.com_pre_sel_ctl[i].key0_in_sel,
-                                                             get_trigger_combo_pre[i]),
-                            get_field_val(ral.com_pre_sel_ctl[i].key1_in_sel,
-                                                             get_trigger_combo_pre[i]),
-                            get_field_val(ral.com_pre_sel_ctl[i].key2_in_sel,
-                                                             get_trigger_combo_pre[i]),
-                            get_field_val(ral.com_pre_sel_ctl[i].pwrb_in_sel,
-                                                             get_trigger_combo_pre[i]),
-                            get_field_val(ral.com_pre_sel_ctl[i].ac_present_sel,
-                                                             get_trigger_combo_pre[i]));
+            cov.combo_detect_action[i].sysrst_ctrl_combo_detect_action_cg.sample(
+              bat_act_triggered,
+              intr_actions[i],
+              ec_act_triggered,
+              rst_act_triggered,
+              get_field_val(ral.com_sel_ctl[i].key0_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].key1_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].key2_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].pwrb_in_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_sel_ctl[i].ac_present_sel, get_trigger_combo[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key0_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key1_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].key2_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].pwrb_in_sel, get_trigger_combo_pre[i]),
+              get_field_val(ral.com_pre_sel_ctl[i].ac_present_sel, get_trigger_combo_pre[i])
+            );
           end
 
           if (get_field_val(ral.com_out_ctl[i].ec_rst, get_action[i])) begin
@@ -233,6 +230,7 @@ class sysrst_ctrl_combo_detect_vseq extends sysrst_ctrl_base_vseq;
           end
         end
       end
+
       if (ec_act_triggered) begin
         // We don't check ec_rst_pulse right after it occurs. past_cycles indicates how many
         // cycles the pulse has been active.

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
@@ -100,95 +100,6 @@ class sysrst_ctrl_combo_detect_action_obj extends uvm_object;
     cp_precondition_key2_in_sel:    coverpoint precondition_key2_in_sel;
     cp_precondition_pwrb_in_sel:    coverpoint precondition_pwrb_in_sel;
     cp_precondition_ac_present_sel: coverpoint precondition_ac_present_sel;
-
-    cross_bat_disable_combo_sel: cross cp_bat_disable, cp_key0_in_sel, cp_key1_in_sel,
-      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel, cp_precondition_key0_in_sel,
-      cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-      illegal_bins invalid_bat_disable = binsof(cp_key0_in_sel)    intersect {0} &&
-                                         binsof(cp_key1_in_sel)    intersect {0} &&
-                                         binsof(cp_key2_in_sel)    intersect {0} &&
-                                         binsof(cp_pwrb_in_sel)    intersect {0} &&
-                                         binsof(cp_ac_present_sel) intersect {0} &&
-                                         binsof(cp_bat_disable)    intersect {1};
-      ignore_bins invalid_combinations_key_0_sel =
-        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_1_sel =
-        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_2_sel =
-        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
-      ignore_bins invalid_combinations_pwrb_sel =
-        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
-      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-        binsof(cp_precondition_ac_present_sel) intersect {1};
-      ignore_bins key_trigger_disabled = binsof (cp_bat_disable) intersect {0};
-    }
-    cross_interrupt_combo_sel: cross cp_interrupt, cp_key0_in_sel, cp_key1_in_sel,
-      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-      illegal_bins invalid_interrupt = binsof(cp_key0_in_sel)    intersect {0} &&
-                                       binsof(cp_key1_in_sel)    intersect {0} &&
-                                       binsof(cp_key2_in_sel)    intersect {0} &&
-                                       binsof(cp_pwrb_in_sel)    intersect {0} &&
-                                       binsof(cp_ac_present_sel) intersect {0} &&
-                                       binsof(cp_interrupt)      intersect {1};
-      ignore_bins invalid_combinations_key_0_sel =
-        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_1_sel =
-        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_2_sel =
-        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
-      ignore_bins invalid_combinations_pwrb_sel =
-        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
-      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-        binsof(cp_precondition_ac_present_sel) intersect {1};
-      ignore_bins key_trigger_disabled = binsof (cp_interrupt) intersect {0};
-    }
-    cross_ec_rst_combo_sel: cross cp_ec_rst, cp_key0_in_sel, cp_key1_in_sel,
-      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-      illegal_bins invalid_ec_rst = binsof(cp_key0_in_sel)    intersect {0} &&
-                                    binsof(cp_key1_in_sel)    intersect {0} &&
-                                    binsof(cp_key2_in_sel)    intersect {0} &&
-                                    binsof(cp_pwrb_in_sel)    intersect {0} &&
-                                    binsof(cp_ac_present_sel) intersect {0} &&
-                                    binsof(cp_ec_rst)         intersect {1};
-      ignore_bins invalid_combinations_key_0_sel =
-        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_1_sel =
-        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_2_sel =
-        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
-      ignore_bins invalid_combinations_pwrb_sel =
-        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
-      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-        binsof(cp_precondition_ac_present_sel) intersect {1};
-      ignore_bins key_trigger_disabled = binsof (cp_ec_rst) intersect {0};
-    }
-    cross_rst_req_combo_sel: cross cp_rst_req, cp_key0_in_sel, cp_key1_in_sel,
-      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-      illegal_bins invalid_rst_req = binsof(cp_key0_in_sel)    intersect {0} &&
-                                     binsof(cp_key1_in_sel)    intersect {0} &&
-                                     binsof(cp_key2_in_sel)    intersect {0} &&
-                                     binsof(cp_pwrb_in_sel)    intersect {0} &&
-                                     binsof(cp_ac_present_sel) intersect {0} &&
-                                     binsof(cp_rst_req)        intersect {1};
-      ignore_bins invalid_combinations_key_0_sel =
-        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_1_sel =
-        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
-      ignore_bins invalid_combinations_key_2_sel =
-        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
-      ignore_bins invalid_combinations_pwrb_sel =
-        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
-      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-        binsof(cp_precondition_ac_present_sel) intersect {1};
-      ignore_bins key_trigger_disabled = binsof (cp_rst_req) intersect {0};
-    }
   endgroup  // sysrst_ctrl_combo_detect_action_cg
 
   function new(string name = "sysrst_ctrl_combo_detect_action_obj");
@@ -196,6 +107,68 @@ class sysrst_ctrl_combo_detect_action_obj extends uvm_object;
     sysrst_ctrl_combo_detect_action_cg = new(name);
   endfunction : new
 endclass : sysrst_ctrl_combo_detect_action_obj
+
+////////////////////////////////////////////////
+// Combo detect key combinations cover points //
+// Because there are many key combinations    //
+// and each combo block is the same we can    //
+// aggregate these statistics.                //
+////////////////////////////////////////////////
+class sysrst_ctrl_combo_key_combinations_obj extends uvm_object;
+  `uvm_object_utils(sysrst_ctrl_combo_key_combinations_obj)
+
+  covergroup sysrst_ctrl_combo_key_combinations_cg with function sample (
+    bit bat_disable,
+    bit interrupt,
+    bit ec_rst,
+    bit rst_req,
+    bit key0_in_sel,
+    bit key1_in_sel,
+    bit key2_in_sel,
+    bit pwrb_in_sel,
+    bit ac_present_sel,
+    bit precondition_key0_in_sel,
+    bit precondition_key1_in_sel,
+    bit precondition_key2_in_sel,
+    bit precondition_pwrb_in_sel,
+    bit precondition_ac_present_sel
+  );
+    option.per_instance = 1;
+    option.name = "sysrst_ctrl_combo_key_combinations_cg";
+
+    cp_key0_in_sel:    coverpoint key0_in_sel;
+    cp_key1_in_sel:    coverpoint key1_in_sel;
+    cp_key2_in_sel:    coverpoint key2_in_sel;
+    cp_pwrb_in_sel:    coverpoint pwrb_in_sel;
+    cp_ac_present_sel: coverpoint ac_present_sel;
+    cp_precondition_key0_in_sel:    coverpoint precondition_key0_in_sel;
+    cp_precondition_key1_in_sel:    coverpoint precondition_key1_in_sel;
+    cp_precondition_key2_in_sel:    coverpoint precondition_key2_in_sel;
+    cp_precondition_pwrb_in_sel:    coverpoint precondition_pwrb_in_sel;
+    cp_precondition_ac_present_sel: coverpoint precondition_ac_present_sel;
+
+    cross_key_combinations_combo_sel: cross cp_key0_in_sel, cp_key1_in_sel, cp_key2_in_sel,
+      cp_pwrb_in_sel, cp_ac_present_sel, cp_precondition_key0_in_sel, cp_precondition_key1_in_sel,
+      cp_precondition_key2_in_sel, cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel
+      iff (bat_disable || interrupt || ec_rst || rst_req) {
+      ignore_bins invalid_combinations_key_0_sel =
+        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_1_sel =
+        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_2_sel =
+        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
+      ignore_bins invalid_combinations_pwrb_sel =
+        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
+      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
+        binsof(cp_precondition_ac_present_sel) intersect {1};
+    }
+  endgroup  // sysrst_ctrl_combo_key_combinations_cg
+
+  function new(string name = "sysrst_ctrl_combo_key_combinations_obj");
+    super.new(name);
+    sysrst_ctrl_combo_key_combinations_cg = new();
+  endfunction : new
+endclass : sysrst_ctrl_combo_key_combinations_obj
 
 /////////////////////////////////////////////
 // Combo intr status register cover points //
@@ -305,6 +278,7 @@ class sysrst_ctrl_env_cov extends cip_base_env_cov #(
   sysrst_ctrl_pin_cfgs_obj pin_cfg_cg[string];
   sysrst_ctrl_debounce_timer_obj debounce_timer_cg[string];
   sysrst_ctrl_combo_detect_action_obj combo_detect_action[int];
+  sysrst_ctrl_combo_key_combinations_obj combo_key_combinations;
   sysrst_ctrl_combo_intr_status_obj combo_intr_status;
   sysrst_ctrl_wakeup_event_obj wakeup_event;
 
@@ -329,6 +303,7 @@ class sysrst_ctrl_env_cov extends cip_base_env_cov #(
       combo_detect_action[i] = new(i);
     end
 
+    combo_key_combinations = new();
     combo_intr_status = new();
     wakeup_event = new();
   endfunction : new

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
@@ -86,107 +86,108 @@ class sysrst_ctrl_combo_detect_action_obj extends uvm_object;
     option.per_instance = 1;
     option.name = $sformatf("sysrst_ctrl_combo_detect_action_cg_%0d", index);
 
-    cp_bat_disable: coverpoint bat_disable;
-    cp_interrupt:   coverpoint interrupt;
-    cp_ec_rst:      coverpoint ec_rst;
-    cp_rst_req:     coverpoint rst_req;
-    cp_key0_in_sel:   coverpoint key0_in_sel;
-    cp_key1_in_sel:   coverpoint key1_in_sel;
-    cp_key2_in_sel:   coverpoint key2_in_sel;
-    cp_pwrb_in_sel:   coverpoint pwrb_in_sel;
-    cp_ac_present_sel:coverpoint ac_present_sel;
-    cp_precondition_key0_in_sel: coverpoint precondition_key0_in_sel;
-    cp_precondition_key1_in_sel: coverpoint precondition_key1_in_sel;
-    cp_precondition_key2_in_sel: coverpoint precondition_key2_in_sel;
-    cp_precondition_pwrb_in_sel: coverpoint precondition_pwrb_in_sel;
+    cp_bat_disable:    coverpoint bat_disable;
+    cp_interrupt:      coverpoint interrupt;
+    cp_ec_rst:         coverpoint ec_rst;
+    cp_rst_req:        coverpoint rst_req;
+    cp_key0_in_sel:    coverpoint key0_in_sel;
+    cp_key1_in_sel:    coverpoint key1_in_sel;
+    cp_key2_in_sel:    coverpoint key2_in_sel;
+    cp_pwrb_in_sel:    coverpoint pwrb_in_sel;
+    cp_ac_present_sel: coverpoint ac_present_sel;
+    cp_precondition_key0_in_sel:    coverpoint precondition_key0_in_sel;
+    cp_precondition_key1_in_sel:    coverpoint precondition_key1_in_sel;
+    cp_precondition_key2_in_sel:    coverpoint precondition_key2_in_sel;
+    cp_precondition_pwrb_in_sel:    coverpoint precondition_pwrb_in_sel;
     cp_precondition_ac_present_sel: coverpoint precondition_ac_present_sel;
+
     cross_bat_disable_combo_sel: cross cp_bat_disable, cp_key0_in_sel, cp_key1_in_sel,
-         cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,cp_precondition_key0_in_sel,
-         cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-         cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-         illegal_bins invalid_bat_disable = binsof(cp_key0_in_sel) intersect {0} &&
-                                binsof(cp_key1_in_sel) intersect {0} &&
-                                binsof(cp_key2_in_sel) intersect {0} &&
-                                binsof(cp_pwrb_in_sel) intersect {0} &&
-                                binsof(cp_ac_present_sel) intersect {0} &&
-                                binsof(cp_bat_disable) intersect {1};
-         ignore_bins invalid_combinations_key_0_sel = binsof(cp_key0_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key0_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_1_sel = binsof(cp_key1_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key1_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_2_sel = binsof(cp_key2_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key2_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_pwrb_sel  = binsof(cp_pwrb_in_sel) intersect {1} &&
-                                binsof(cp_precondition_pwrb_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-                                binsof(cp_precondition_ac_present_sel) intersect {1};
-         ignore_bins key_trigger_disabled = binsof (cp_bat_disable) intersect {0};
+      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel, cp_precondition_key0_in_sel,
+      cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
+      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
+      illegal_bins invalid_bat_disable = binsof(cp_key0_in_sel)    intersect {0} &&
+                                         binsof(cp_key1_in_sel)    intersect {0} &&
+                                         binsof(cp_key2_in_sel)    intersect {0} &&
+                                         binsof(cp_pwrb_in_sel)    intersect {0} &&
+                                         binsof(cp_ac_present_sel) intersect {0} &&
+                                         binsof(cp_bat_disable)    intersect {1};
+      ignore_bins invalid_combinations_key_0_sel =
+        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_1_sel =
+        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_2_sel =
+        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
+      ignore_bins invalid_combinations_pwrb_sel =
+        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
+      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
+        binsof(cp_precondition_ac_present_sel) intersect {1};
+      ignore_bins key_trigger_disabled = binsof (cp_bat_disable) intersect {0};
     }
     cross_interrupt_combo_sel: cross cp_interrupt, cp_key0_in_sel, cp_key1_in_sel,
-         cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-         cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-         cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-         illegal_bins invalid_interrupt = binsof(cp_key0_in_sel) intersect {0} &&
-                                binsof(cp_key1_in_sel) intersect {0} &&
-                                binsof(cp_key2_in_sel) intersect {0} &&
-                                binsof(cp_pwrb_in_sel) intersect {0} &&
-                                binsof(cp_ac_present_sel) intersect {0} &&
-                                binsof(cp_interrupt) intersect {1};
-         ignore_bins invalid_combinations_key_0_sel = binsof(cp_key0_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key0_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_1_sel = binsof(cp_key1_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key1_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_2_sel = binsof(cp_key2_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key2_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_pwrb_sel  = binsof(cp_pwrb_in_sel) intersect {1} &&
-                                binsof(cp_precondition_pwrb_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-                                binsof(cp_precondition_ac_present_sel) intersect {1};
-         ignore_bins key_trigger_disabled = binsof (cp_interrupt) intersect {0};
+      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
+      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
+      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
+      illegal_bins invalid_interrupt = binsof(cp_key0_in_sel)    intersect {0} &&
+                                       binsof(cp_key1_in_sel)    intersect {0} &&
+                                       binsof(cp_key2_in_sel)    intersect {0} &&
+                                       binsof(cp_pwrb_in_sel)    intersect {0} &&
+                                       binsof(cp_ac_present_sel) intersect {0} &&
+                                       binsof(cp_interrupt)      intersect {1};
+      ignore_bins invalid_combinations_key_0_sel =
+        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_1_sel =
+        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_2_sel =
+        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
+      ignore_bins invalid_combinations_pwrb_sel =
+        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
+      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
+        binsof(cp_precondition_ac_present_sel) intersect {1};
+      ignore_bins key_trigger_disabled = binsof (cp_interrupt) intersect {0};
     }
     cross_ec_rst_combo_sel: cross cp_ec_rst, cp_key0_in_sel, cp_key1_in_sel,
-         cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-         cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-         cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-         illegal_bins invalid_ec_rst = binsof(cp_key0_in_sel) intersect {0} &&
-                                binsof(cp_key1_in_sel) intersect {0} &&
-                                binsof(cp_key2_in_sel) intersect {0} &&
-                                binsof(cp_pwrb_in_sel) intersect {0} &&
-                                binsof(cp_ac_present_sel) intersect {0} &&
-                                binsof(cp_ec_rst) intersect {1};
-         ignore_bins invalid_combinations_key_0_sel = binsof(cp_key0_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key0_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_1_sel = binsof(cp_key1_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key1_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_2_sel = binsof(cp_key2_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key2_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_pwrb_sel  = binsof(cp_pwrb_in_sel) intersect {1} &&
-                                binsof(cp_precondition_pwrb_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-                                binsof(cp_precondition_ac_present_sel) intersect {1};
-         ignore_bins key_trigger_disabled = binsof (cp_ec_rst) intersect {0};
+      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
+      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
+      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
+      illegal_bins invalid_ec_rst = binsof(cp_key0_in_sel)    intersect {0} &&
+                                    binsof(cp_key1_in_sel)    intersect {0} &&
+                                    binsof(cp_key2_in_sel)    intersect {0} &&
+                                    binsof(cp_pwrb_in_sel)    intersect {0} &&
+                                    binsof(cp_ac_present_sel) intersect {0} &&
+                                    binsof(cp_ec_rst)         intersect {1};
+      ignore_bins invalid_combinations_key_0_sel =
+        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_1_sel =
+        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_2_sel =
+        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
+      ignore_bins invalid_combinations_pwrb_sel =
+        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
+      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
+        binsof(cp_precondition_ac_present_sel) intersect {1};
+      ignore_bins key_trigger_disabled = binsof (cp_ec_rst) intersect {0};
     }
     cross_rst_req_combo_sel: cross cp_rst_req, cp_key0_in_sel, cp_key1_in_sel,
-         cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
-         cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
-         cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
-         illegal_bins invalid_rst_req = binsof(cp_key0_in_sel) intersect {0} &&
-                                binsof(cp_key1_in_sel) intersect {0} &&
-                                binsof(cp_key2_in_sel) intersect {0} &&
-                                binsof(cp_pwrb_in_sel) intersect {0} &&
-                                binsof(cp_ac_present_sel) intersect {0} &&
-                                binsof(cp_rst_req) intersect {1};
-         ignore_bins invalid_combinations_key_0_sel = binsof(cp_key0_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key0_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_1_sel = binsof(cp_key1_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key1_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_key_2_sel = binsof(cp_key2_in_sel) intersect {1} &&
-                                binsof(cp_precondition_key2_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_pwrb_sel  = binsof(cp_pwrb_in_sel) intersect {1} &&
-                                binsof(cp_precondition_pwrb_in_sel)    intersect {1};
-         ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
-                                binsof(cp_precondition_ac_present_sel) intersect {1};
-         ignore_bins key_trigger_disabled = binsof (cp_rst_req) intersect {0};
+      cp_key2_in_sel, cp_pwrb_in_sel, cp_ac_present_sel,
+      cp_precondition_key0_in_sel, cp_precondition_key1_in_sel, cp_precondition_key2_in_sel,
+      cp_precondition_pwrb_in_sel, cp_precondition_ac_present_sel {
+      illegal_bins invalid_rst_req = binsof(cp_key0_in_sel)    intersect {0} &&
+                                     binsof(cp_key1_in_sel)    intersect {0} &&
+                                     binsof(cp_key2_in_sel)    intersect {0} &&
+                                     binsof(cp_pwrb_in_sel)    intersect {0} &&
+                                     binsof(cp_ac_present_sel) intersect {0} &&
+                                     binsof(cp_rst_req)        intersect {1};
+      ignore_bins invalid_combinations_key_0_sel =
+        binsof(cp_key0_in_sel) intersect {1} && binsof(cp_precondition_key0_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_1_sel =
+        binsof(cp_key1_in_sel) intersect {1} && binsof(cp_precondition_key1_in_sel) intersect {1};
+      ignore_bins invalid_combinations_key_2_sel =
+        binsof(cp_key2_in_sel) intersect {1} && binsof(cp_precondition_key2_in_sel) intersect {1};
+      ignore_bins invalid_combinations_pwrb_sel =
+        binsof(cp_pwrb_in_sel) intersect {1} && binsof(cp_precondition_pwrb_in_sel) intersect {1};
+      ignore_bins invalid_combinations_ac_power_sel = binsof(cp_ac_present_sel) intersect {1} &&
+        binsof(cp_precondition_ac_present_sel) intersect {1};
+      ignore_bins key_trigger_disabled = binsof (cp_rst_req) intersect {0};
     }
   endgroup  // sysrst_ctrl_combo_detect_action_cg
 
@@ -228,25 +229,25 @@ class sysrst_ctrl_combo_intr_status_obj extends uvm_object;
     cp_ac_present_sel:coverpoint ac_present_sel;
     cp_interrupt:   coverpoint interrupt;
     cross_combo0: cross cp_combo0_h2l, cp_key0_in_sel, cp_key1_in_sel, cp_key2_in_sel,
-       cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
-       ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
+      cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
+      ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
                              binsof(cp_combo0_h2l) intersect {1};
-       }
+      }
     cross_combo1: cross cp_combo1_h2l, cp_key0_in_sel, cp_key1_in_sel, cp_key2_in_sel,
-       cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
-       ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
+      cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
+      ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
                              binsof(cp_combo1_h2l) intersect {1};
-       }
+      }
     cross_combo2: cross cp_combo2_h2l, cp_key0_in_sel, cp_key1_in_sel, cp_key2_in_sel,
-       cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
-       ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
+      cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
+      ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
                              binsof(cp_combo2_h2l) intersect {1};
-       }
+      }
     cross_combo3: cross cp_combo3_h2l, cp_key0_in_sel, cp_key1_in_sel, cp_key2_in_sel,
-       cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
-       ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
+      cp_pwrb_in_sel, cp_ac_present_sel, cp_interrupt {
+      ignore_bins invalid0 = binsof(cp_interrupt) intersect {0} &&
                              binsof(cp_combo3_h2l) intersect {1};
-       }
+      }
   endgroup // sysrst_ctrl_combo_intr_status_cg
 
   function new(string name = "sysrst_ctrl_combo_intr_status_obj");


### PR DESCRIPTION
In the previous implementation (https://github.com/lowRISC/opentitan/pull/17266), each of the four combo detection blocks required each combination of pre-condition and conditions to trigger each of the outputs. Since each of the detection blocks are essentially the same, this PR limits the per-block covergroup and moves the bigger cross point to a covergroup that aggregates all of the combo blocks. Additionally, we don't need each output to be hit by each key combination, so any output action should count towards the covergroup.

This decreases the crosses from 3,376 to 243.