### PR TITLE
[chip/dv] added OTP images for additional 5 LC states

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_test_locked0.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_test_locked0.hjson
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name: "CREATOR_SW_CFG_ROM_EXEC_EN",
+                    // ROM execution is enabled if this item is set to a
+                    // non-zero value.
+                    value: "0xffffffff",
+                },
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "TEST_LOCKED0",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: 2
+        }
+    ]
+}

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_test_locked1.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_test_locked1.hjson
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name: "CREATOR_SW_CFG_ROM_EXEC_EN",
+                    // ROM execution is enabled if this item is set to a
+                    // mnon-zero value.
+                    value: "0xffffffff",
+                },
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "TEST_LOCKED1",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: 2
+        }
+    ]
+}

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked1.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked1.hjson
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name: "CREATOR_SW_CFG_ROM_EXEC_EN",
+                    // ROM execution is enabled if this item is set to a
+                    // non-zero value.
+                    value: "0xffffffff",
+                },
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "TEST_UNLOCKED1",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: 3
+        }
+    ]
+}

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked2.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_test_unlocked2.hjson
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Use the gen-otp-img.py script to convert this configuration into
+// a MEM file for preloading the OTP in FPGA synthesis or simulation.
+//
+
+{
+    // Seed to be used for generation of partition randomized values.
+    // Can be overridden on the command line with the --seed switch.
+    seed: 01931961561863975174
+
+    // The partition and item names must correspond with the OTP memory map.
+    partitions: [
+        {
+            name:  "CREATOR_SW_CFG",
+            items: [
+                {
+                    name: "CREATOR_SW_CFG_ROM_EXEC_EN",
+                    // ROM execution is enabled if this item is set to a
+                    // non-zero value.
+                    value: "0xffffffff",
+                },
+            ],
+        }
+        {
+            name:  "LIFE_CYCLE",
+            // Can be one of the following strings:
+            // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP
+            state: "TEST_UNLOCKED2",
+            // Can range from 0 to 16.
+            // Note that a value of 0 is only permissible in RAW state.
+            count: 4
+        }
+    ]
+}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -239,6 +239,30 @@
               --out {run_dir}/otp_ctrl_img_test_unlocked0.vmem \
               {gen_otp_images_cmd_opts}
         ''',
+        '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_test_unlocked1.hjson \
+              --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_hw_cfg.hjson \
+              --out {run_dir}/otp_ctrl_img_test_unlocked1.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
+        '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_test_unlocked2.hjson \
+              --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_hw_cfg.hjson \
+              --out {run_dir}/otp_ctrl_img_test_unlocked2.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
+        '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_test_locked0.hjson \
+              --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_hw_cfg.hjson \
+              --out {run_dir}/otp_ctrl_img_test_locked0.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
+        '''{gen_otp_images_cmd} \
+              --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_test_locked1.hjson \
+              --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_hw_cfg.hjson \
+              --out {run_dir}/otp_ctrl_img_test_locked1.vmem \
+              {gen_otp_images_cmd_opts}
+        ''',
          '''{gen_otp_images_cmd} \
               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_dev.hjson \
               --add-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_creator_sw_cfg.hjson \

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -198,6 +198,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     otp_images[OtpTypeLcStProd] = "otp_ctrl_img_prod.vmem";
     otp_images[OtpTypeLcStRma] = "otp_ctrl_img_rma.vmem";
     otp_images[OtpTypeLcStTestUnlocked0] = "otp_ctrl_img_test_unlocked0.vmem";
+    otp_images[OtpTypeLcStTestUnlocked1] = "otp_ctrl_img_test_unlocked1.vmem";
+    otp_images[OtpTypeLcStTestUnlocked2] = "otp_ctrl_img_test_unlocked2.vmem";
+    otp_images[OtpTypeLcStTestLocked0] = "otp_ctrl_img_test_locked0.vmem";
+    otp_images[OtpTypeLcStTestLocked1] = "otp_ctrl_img_test_locked1.vmem";
     otp_images[OtpTypeCustom] = "";
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -111,6 +111,10 @@ package chip_env_pkg;
     OtpTypeLcStProd,          // Base OTP image in Prod lifecycle state.
     OtpTypeLcStRma,           // Base OTP image in RMA lifecycle state.
     OtpTypeLcStTestUnlocked0, // Base OTP image in TestUnlocked0 lifecycle state.
+    OtpTypeLcStTestUnlocked1, // Base OTP image in TestUnlocked1 lifecycle state.
+    OtpTypeLcStTestUnlocked2, // Base OTP image in TestUnlocked2 lifecycle state.
+    OtpTypeLcStTestLocked0, // Base OTP image in TestUnlocked0 lifecycle state.
+    OtpTypeLcStTestLocked1, // Base OTP image in TestUnlocked0 lifecycle state.
     OtpTypeCustom             // Custom OTP image specified via `sw_images` plusarg.
   } otp_type_e;
 


### PR DESCRIPTION
This PR adds OTP preloaded images for {TEST_LOCKED0-1, TEST_UNLOCKED1-2} states.

Added items and modifications:
- Hjson files for new images 
- modification of `chip_env_pkg::otp_type_e` to include said LC states