### PR TITLE
[dv/otp_ctrl] Update exclusion file regarding prim_sec_inv*

### DIFF
--- a/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg
+++ b/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// The modules below are preverified in FPV testbench.
+// There are many conditional coverage and hard to them all.
+-moduletree prim_secded_inv_72_64_dec
+-moduletree prim_secded_inv_72_64_enc
+
+begin tgl
+  +module prim_secded_inv_72_64_dec
+  +module prim_secded_inv_72_64_enc
+end

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -63,6 +63,13 @@
   vcs_cov_excl_files: ["{proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_unr_excl.el",
                        "{proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_fsm_unr_excl.el"]
 
+  overrides: [
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+    }
+  ]
+
   // Default UVM test and seq class name.
   uvm_test: otp_ctrl_base_test
   uvm_test_seq: otp_ctrl_base_vseq


### PR DESCRIPTION
This PR updates the coverage config file to only cover toggle coverage on prim_sec_inv* files. The main coverage issue is the massive condition coverage inside these prim_sec_inv* files. It is very hard to hit all of them.

This PR will fix issue #17362