### PR TITLE
[doc,site] Site/dashboard

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -20,10 +20,14 @@ additional-js = [
     "./util/mdbook/wavejson/default.js",
     "./util/mdbook/wavejson/wavedrom.min.js",
     "./util/mdbook/wavejson/wavejson.js",
+    "./util/site-dashboard/dashboard.js",
+    "./util/site-dashboard/ot-nightly-results.js",
+    "./util/site-dashboard/install-dashboards.js",
 ]
 
 additional-css = [
     "./util/mdbook/wavejson/wavejson.css",
+    "./util/site-dashboard/dashboard-mdbook-block.css",
 ]
 
 [preprocessor.readme2index]
@@ -53,3 +57,6 @@ command = "./util/mdbook_doxygen.py"
 out-dir = "build-site/gen"
 html-out-dir = "gen/doxy"
 dif-src-py-regex = 'dif_\S*\.h'
+
+[preprocessor.block-dashboard]
+command = "./util/mdbook-block-dashboard.py"

--- a/hw/ip/adc_ctrl/README.md
+++ b/hw/ip/adc_ctrl/README.md
@@ -1,5 +1,7 @@
 # Analog to Digital Converter Control Interface
 
+{{#block-dashboard adc_ctrl}}
+
 # Overview
 
 This document specifies the ADC controller IP functionality.

--- a/hw/ip/aes/README.md
+++ b/hw/ip/aes/README.md
@@ -1,5 +1,6 @@
 # AES HWIP Technical Specification
 
+{{#block-dashboard aes}}
 
 # Overview
 

--- a/hw/ip/aon_timer/README.md
+++ b/hw/ip/aon_timer/README.md
@@ -1,5 +1,7 @@
 # AON Timer Technical Specification
 
+{{#block-dashboard aon_timer}}
+
 # Overview
 
 This document specifies the Always-On ("AON") Timer IP functionality.

--- a/hw/ip/clkmgr/README.md
+++ b/hw/ip/clkmgr/README.md
@@ -1,5 +1,7 @@
 # Clock Manager HWIP Technical Specification
 
+{{#block-dashboard clkmgr}}
+
 # Overview
 
 This document specifies the functionality of the OpenTitan clock manager.

--- a/hw/ip/csrng/README.md
+++ b/hw/ip/csrng/README.md
@@ -1,5 +1,7 @@
 # CSRNG HWIP Technical Specification
 
+{{#block-dashboard csrng}}
+
 # Overview
 
 This document specifies the Cryptographically Secure Random Number Generator (CSRNG) hardware IP functionality.

--- a/hw/ip/edn/README.md
+++ b/hw/ip/edn/README.md
@@ -1,5 +1,7 @@
 # EDN HWIP Technical Specification
 
+{{#block-dashboard edn}}
+
 # Overview
 
 This document specifies EDN hardware IP functionality.

--- a/hw/ip/entropy_src/README.md
+++ b/hw/ip/entropy_src/README.md
@@ -1,5 +1,7 @@
 # ENTROPY_SRC HWIP Technical Specification
 
+{{#block-dashboard entropy_src}}
+
 # Overview
 
 This document specifies ENTROPY_SRC hardware IP functionality.

--- a/hw/ip/flash_ctrl/README.md
+++ b/hw/ip/flash_ctrl/README.md
@@ -1,5 +1,7 @@
 # Flash Controller HWIP Technical Specification
 
+{{#block-dashboard flash_ctrl}}
+
 # Overview
 
 This document describes the flash controller functionality.

--- a/hw/ip/gpio/README.md
+++ b/hw/ip/gpio/README.md
@@ -1,5 +1,7 @@
 # GPIO HWIP Technical Specification
 
+{{#block-dashboard gpio}}
+
 # Overview
 
 This document specifies GPIO hardware IP functionality. This

--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -1,5 +1,7 @@
 # HMAC HWIP Technical Specification
 
+{{#block-dashboard hmac}}
+
 # Overview
 
 This document specifies HMAC hardware IP functionality. This module conforms to

--- a/hw/ip/i2c/README.md
+++ b/hw/ip/i2c/README.md
@@ -1,5 +1,6 @@
 # I2C HWIP Technical Specification
 
+{{#block-dashboard i2c}}
 
 # Overview
 

--- a/hw/ip/keymgr/README.md
+++ b/hw/ip/keymgr/README.md
@@ -1,5 +1,7 @@
 # Key Manager HWIP Technical Specification
 
+{{#block-dashboard keymgr}}
+
 # Overview
 
 This document specifies the functionality of the OpenTitan key manager.

--- a/hw/ip/kmac/README.md
+++ b/hw/ip/kmac/README.md
@@ -1,5 +1,7 @@
 # KMAC HWIP Technical Specification
 
+{{#block-dashboard kmac}}
+
 # Overview
 
 This document specifies the Keccak Message Authentication Code (KMAC) and Secure Hashing Algorithm 3 (SHA3) hardware IP functionality.

--- a/hw/ip/lc_ctrl/README.md
+++ b/hw/ip/lc_ctrl/README.md
@@ -1,5 +1,6 @@
 # Life Cycle Controller Technical Specification
 
+{{#block-dashboard lc_ctrl}}
 
 # Overview
 

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -1,5 +1,7 @@
 # OpenTitan Big Number Accelerator (OTBN) Technical Specification
 
+{{#block-dashboard otbn}}
+
 # Overview
 
 This document specifies functionality of the OpenTitan Big Number Accelerator, or OTBN.

--- a/hw/ip/otp_ctrl/README.md
+++ b/hw/ip/otp_ctrl/README.md
@@ -1,5 +1,6 @@
 # OTP Controller Technical Specification
 
+{{#block-dashboard otp_ctrl}}
 
 # Overview
 

--- a/hw/ip/pattgen/README.md
+++ b/hw/ip/pattgen/README.md
@@ -1,5 +1,7 @@
 # Pattern Generator HWIP Technical Specification
 
+{{#block-dashboard pattgen}}
+
 # Overview
 
 This document specifies the functionality of the pattern generator hardware IP (HWIP).

--- a/hw/ip/pwm/README.md
+++ b/hw/ip/pwm/README.md
@@ -1,5 +1,7 @@
 # PWM HWIP Technical Specification
 
+{{#block-dashboard pwm}}
+
 # Overview
 
 This document specifies PWM hardware IP (HWIP) functionality.

--- a/hw/ip/pwrmgr/README.md
+++ b/hw/ip/pwrmgr/README.md
@@ -1,5 +1,7 @@
 # Power Manager HWIP Technical Specification
 
+{{#block-dashboard pwrmgr}}
+
 # Overview
 
 This document specifies the functionality of the OpenTitan power manager.

--- a/hw/ip/rom_ctrl/README.md
+++ b/hw/ip/rom_ctrl/README.md
@@ -1,5 +1,7 @@
 # ROM Controller Technical Specification
 
+{{#block-dashboard rom_ctrl}}
+
 # Overview
 
 This document describes the ROM controller (`rom_ctrl`).

--- a/hw/ip/rstmgr/README.md
+++ b/hw/ip/rstmgr/README.md
@@ -1,5 +1,7 @@
 # Reset Manager HWIP Technical Specification
 
+{{#block-dashboard rstmgr}}
+
 # Overview
 
 This document describes the functionality of the reset controller and its interaction with the rest of the OpenTitan system.

--- a/hw/ip/rv_dm/README.md
+++ b/hw/ip/rv_dm/README.md
@@ -1,5 +1,8 @@
 # RISC-V Debug System Wrapper Technical Specification
+
 # Overview
+
+{{#block-dashboard rv_dm}}
 
 This document specifies the RISC-V Debug System wrapper functionality.
 

--- a/hw/ip/rv_timer/README.md
+++ b/hw/ip/rv_timer/README.md
@@ -1,5 +1,7 @@
 # Timer HWIP Technical Specification
 
+{{#block-dashboard rv_timer}}
+
 # Overview
 
 This document specifies RISC-V Timer hardware IP functionality. This module

--- a/hw/ip/spi_device/README.md
+++ b/hw/ip/spi_device/README.md
@@ -1,7 +1,8 @@
 # SPI Device HWIP Technical Specification
 
-# Overview
+{{#block-dashboard spi_device}}
 
+# Overview
 
 ## Features
 

--- a/hw/ip/spi_host/README.md
+++ b/hw/ip/spi_host/README.md
@@ -1,5 +1,7 @@
 # SPI_HOST HWIP Technical Specification
 
+{{#block-dashboard spi_host}}
+
 # Overview
 
 This document specifies SPI_HOST hardware IP (HWIP) functionality.

--- a/hw/ip/sram_ctrl/README.md
+++ b/hw/ip/sram_ctrl/README.md
@@ -1,5 +1,6 @@
 # SRAM Controller Technical Specification
 
+{{#block-dashboard sram_ctrl}}
 
 # Overview
 

--- a/hw/ip/sysrst_ctrl/README.md
+++ b/hw/ip/sysrst_ctrl/README.md
@@ -1,5 +1,7 @@
 # System Reset Control Technical Specification
 
+{{#block-dashboard sysrst_ctrl}}
+
 # Overview
 
 This document specifies the functionality of the System Reset Controller (`sysrst_ctrl`) that provides programmable hardware-level responses to trusted IOs and basic board-level reset sequencing capabilities.

--- a/hw/ip/uart/README.md
+++ b/hw/ip/uart/README.md
@@ -1,5 +1,7 @@
 # UART HWIP Technical Specification
 
+{{#block-dashboard uart}}
+
 # Overview
 
 This document specifies UART hardware IP functionality. This module

--- a/hw/ip/usbdev/README.md
+++ b/hw/ip/usbdev/README.md
@@ -1,5 +1,7 @@
 # USB 2.0 Full-Speed Device HWIP Technical Specification
 
+{{#block-dashboard usbdev}}
+
 # Overview
 
 This document specifies the USB device hardware IP functionality.

--- a/hw/ip_templates/alert_handler/README.md
+++ b/hw/ip_templates/alert_handler/README.md
@@ -1,5 +1,6 @@
 # Alert Handler Technical Specification
 
+{{#block-dashboard alert_handler}}
 
 # Overview
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/README.md
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/README.md
@@ -1,5 +1,6 @@
 # Alert Handler Technical Specification
 
+{{#block-dashboard alert_handler}}
 
 # Overview
 

--- a/site/landing/content/dashboard.md
+++ b/site/landing/content/dashboard.md
@@ -1,0 +1,8 @@
++++
+  ExtraStyles = ["/css/dv-dashboard.css"]
+  Title = "Design Verification Dashboard"
++++
+
+This summarizes the results from our [nightly OpenTitan regression](https://reports.opentitan.org/hw/top_earlgrey/dv/summary/latest/report.html) which runs a wide variety of tests for each block as well as a chip-level tests.
+
+{{< all-blocks-dashboard >}}

--- a/site/landing/layouts/partials/header.html
+++ b/site/landing/layouts/partials/header.html
@@ -20,7 +20,7 @@
         <a href="/guides/getting_started#top">Getting Started</a>
       </li>
       <li class="main-nav__item">
-        <a href="https://reports.opentitan.org/hw/top_earlgrey/dv/summary/latest/report.html">Dashboard</a>
+        <a href="/dashboard#top">Dashboard</a>
       </li>
       <li class="main-nav__item">
         <a href="/book/doc/project_governance#top">About</a>

--- a/site/landing/layouts/shortcodes/all-blocks-dashboard.html
+++ b/site/landing/layouts/shortcodes/all-blocks-dashboard.html
@@ -1,0 +1,15 @@
+<div id="blocks-dashboard" class="dashboard-table"></div>
+<script src="/js/dashboard.js"></script>
+<script src="/js/ot-nightly-results.js"></script>
+<script>
+  function produce_results_table(results) {
+    let block_result_collection = new BlockLevelResultsCollection();
+    results.map((result) => block_result_collection.add_results(result));
+
+    var dashboard_table_toplevel = document.querySelector("#blocks-dashboard");
+    var results_table = block_result_collection.make_results_table();
+    results_table.render(dashboard_table_toplevel);
+  }
+
+  fetch_all_results().then(produce_results_table);
+</script>

--- a/site/landing/static/css/dv-dashboard.css
+++ b/site/landing/static/css/dv-dashboard.css
@@ -1,0 +1,29 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#blocks-dashboard {
+  padding: 0px;
+}
+
+.dashboard-table table {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.dashboard-table tr:nth-child(1) {
+  border-bottom: 1px solid;
+}
+
+.dashboard-table th, td {
+  padding: 5px;
+}
+
+.dashboard-table td {
+  border-radius: 5px;
+  text-align: center
+}
+
+.dashboard-table td:nth-child(1) {
+  background-color: #ccc;
+}

--- a/site/landing/static/js/dashboard.js
+++ b/site/landing/static/js/dashboard.js
@@ -1,0 +1,1 @@
+../../../../util/site-dashboard/dashboard.js

--- a/site/landing/static/js/ot-nightly-results.js
+++ b/site/landing/static/js/ot-nightly-results.js
@@ -1,0 +1,1 @@
+../../../../util/site-dashboard/ot-nightly-results.js

--- a/util/mdbook-block-dashboard.py
+++ b/util/mdbook-block-dashboard.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import sys
+import re
+
+from mdbook import utils as md_utils
+
+BLOCK_DASHBOARD_PATTERN = re.compile(r'{{#block-dashboard\s+(\w+)\s*}}')
+BLOCK_DASHBOARD_TEMPLATE = \
+    r"<div class='dv-dashboard block-dashboard-compact' data-block-name='\1'></div>"
+
+
+def main() -> None:
+    md_utils.supports_html_only()
+
+    # load both the context and the book from stdin
+    context, book = json.load(sys.stdin)
+
+    for chapter in md_utils.chapters(book["sections"]):
+        chapter["content"] = \
+            BLOCK_DASHBOARD_PATTERN.sub(BLOCK_DASHBOARD_TEMPLATE, chapter["content"])
+
+    # dump the book into stdout
+    print(json.dumps(book))
+
+
+if __name__ == "__main__":
+    main()

--- a/util/site-dashboard/dashboard-grid.css
+++ b/util/site-dashboard/dashboard-grid.css
@@ -1,0 +1,14 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.dashboard-grid-vertical {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.dashboard-grid-horizontal {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: 1fr 1fr;
+}

--- a/util/site-dashboard/dashboard-mdbook-block.css
+++ b/util/site-dashboard/dashboard-mdbook-block.css
@@ -35,7 +35,8 @@
   border-bottom: 1px solid;
 }
 
-.dashboard-table th, td {
+.dashboard-table th,
+.dashboard-table td {
   padding: 15px;
   font-size: 150%;
 }

--- a/util/site-dashboard/dashboard-mdbook-block.css
+++ b/util/site-dashboard/dashboard-mdbook-block.css
@@ -1,0 +1,53 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.block-dashboard-compact {
+  display: inline-grid;
+  grid-auto-flow: row;
+  grid-template-columns: repeat(9, minmax(5px, auto));;
+}
+
+.dashboard-title, .dashboard-label, .dashboard-value {
+  padding: 5px;
+  font-size: 80%;
+  margin-bottom: 5px;
+}
+
+.dashboard-title {
+  font-weight: bold;
+  text-align: left;
+}
+
+.dashboard-label {
+  color: #fff;
+  background-color: #444;
+  text-align: center;
+}
+
+.dashboard-value {
+  margin-right: 5px;
+  background-color: #0f0;
+  text-align: left;
+}
+
+.dashboard-table tr:nth-child(1) {
+  border-bottom: 1px solid;
+}
+
+.dashboard-table th, td {
+  padding: 15px;
+  font-size: 150%;
+}
+
+.dashboard-table td {
+  border-radius: 15px;
+}
+
+.dashboard-table td:nth-child(1) {
+  background-color: #ccc;
+}
+
+.dv-dashboard h1 {
+  text-align: center;
+}

--- a/util/site-dashboard/dashboard.js
+++ b/util/site-dashboard/dashboard.js
@@ -1,0 +1,303 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+const DashValueKindPlain = 0;
+const DashValueKindPctColoured = 1;
+const DashValueKindLink = 2;
+
+function render_dashboard_value(value, kind, node) {
+  if (value == null) {
+    node.textContent = "--";
+    return;
+  }
+
+  let value_text = "BAD KIND";
+
+  switch (kind) {
+    case DashValueKindPlain:
+      node.textContent = value.toString();
+      break;
+    case DashValueKindPctColoured:
+      value = value.toPrecision(3);
+      node.textContent = value.toString() + " %";
+
+      let r_colour = 0;
+      let g_colour = 0;
+
+      if (value >= 50) {
+        // Transition from green to yellow
+        r_colour = Math.round(255 * ((100 - value) / 50));
+        g_colour = 255;
+      } else {
+        // Transition from yellow to red
+        r_colour = 255;
+        g_colour = Math.round(255 * (value / 50));
+      }
+
+      let color_str = "rgb(" + r_colour.toString() + "," +
+        g_colour.toString() + ",0)";
+
+      node.style.backgroundColor = color_str;
+
+      break;
+    case DashValueKindLink:
+      value_link = document.createElement("a");
+      value_link.setAttribute("href", value[1]);
+      value_link.textContent = value[0];
+
+      node.appendChild(value_link);
+      break;
+    default:
+      node.textContent = "BAD KIND";
+  }
+}
+
+class DashboardSingleEntry {
+  constructor(label, value, kind) {
+    this.label = label;
+    this.value = value;
+    this.kind = kind;
+  }
+
+  render(node) {
+    let label_div = document.createElement("div");
+    label_div.setAttribute("class", "dashboard-label");
+    label_div.textContent = this.label;
+
+    let value_div = document.createElement("div");
+    value_div.setAttribute("class", "dashboard-value");
+
+    render_dashboard_value(this.value, this.kind, value_div);
+
+    node.appendChild(label_div);
+    node.appendChild(value_div);
+  }
+}
+
+class DashboardSingleEntryCollection {
+  constructor(entries, title = null, report_url = null) {
+    this.entries = entries;
+    this.report_url = report_url
+    this.title = title;
+  }
+
+  render(node) {
+    if (this.title != null) {
+      let title_node = document.createElement("div");
+      title_node.setAttribute("class", "dashboard-title");
+
+      if (this.report_url != null) {
+        let title_link = document.createElement("a");
+        title_link.setAttribute("href", this.report_url + "report.html");
+        title_link.textContent = this.title;
+        title_node.appendChild(title_link);
+      } else {
+        title_node.textContent = this.title;
+      }
+
+      node.appendChild(title_node);
+    }
+
+    this.entries.map(entry => entry.render(node));
+  }
+}
+
+class DashboardTable {
+  constructor(headings, values, kinds) {
+    this.headings = headings;
+    this.values = values;
+    this.kinds = kinds;
+  }
+
+  render(node) {
+    let table = document.createElement("table");
+
+    this.render_header(table);
+
+    for (let i = 0;i < this.values.length; i++) {
+      this.render_value_row(table, this.values[i]);
+    }
+
+    node.appendChild(table);
+  }
+
+  render_header(node) {
+    let header_row = document.createElement("tr");
+    for (let i = 0;i < this.headings.length; i++) {
+      let header_element = document.createElement("th");
+      header_element.textContent = this.headings[i];
+      header_row.appendChild(header_element);
+    }
+
+    node.appendChild(header_row);
+  }
+
+  render_value_row(node, values) {
+    let value_row = document.createElement("tr");
+    for (let i = 0;i < values.length; i++) {
+      let value_element = document.createElement("td");
+      render_dashboard_value(values[i], this.kinds[i], value_element);
+      value_row.appendChild(value_element);
+    }
+
+    node.appendChild(value_row);
+  }
+}
+
+class BlockLevelResults {
+  constructor(json, report_url) {
+    this.process_report(json);
+    this.report_url = report_url;
+  }
+
+  process_report(report) {
+    this.block_name = report.block_name;
+    if ("block_variant" in report && report.block_variant != null) {
+      this.block_name += '/' + report.block_variant;
+    }
+
+    this.coverage = report.results.coverage
+    this.calculate_summary_coverage(report.tool);
+
+    this.tests = 0;
+    this.passing_tests = 0;
+
+    // The report is given in terms of testpoints. Each testpoint may be mapped to
+    // multiple tests at a given test may be mapped to multiple testpoints.
+    // There may be an additional lists of unmapped tests as well (i.e. those
+    // without testpoits). We want a list of unique tests.
+    const tests_info = report.results.testpoints
+      .flatMap(t => t.tests)
+      .concat(report.results.unmapped_tests)
+      .filter((t, i, a) => a.findIndex(o => o.name === t.name) === i);
+
+    this.process_tests(tests_info);
+
+    this.passing_tests_pct = (this.passing_tests / this.tests) * 100;
+  }
+
+  process_tests(tests_info) {
+    this.tests = tests_info
+      .map(t => t.total_runs)
+      .reduce((acc, x) => acc + x, 0);
+
+    this.passing_tests = tests_info
+      .map(t => t.passing_runs)
+      .reduce((acc, x) => acc + x, 0);
+  }
+
+  calculate_summary_coverage(tool) {
+    this.summary_coverage = {
+      "functional": null,
+      "assertion": null,
+      "toggle": null,
+      "code": null
+    };
+
+    let code_coverage_vals = [];
+
+    // VCS and Xcelium have different category names for coverage. For code
+    // coverage there are a number of values to produce an average from for the
+    // other summary coverage categories we just need to extract the correct
+    // number.
+    if (tool == 'vcs') {
+        code_coverage_vals =
+          [this.coverage["line"],
+           this.coverage["cond"],
+           this.coverage["fsm"],
+           this.coverage["branch"]];
+
+        this.summary_coverage["functional"] = this.coverage["group"];
+        this.summary_coverage["assertion"] = this.coverage["assert"];
+        this.summary_coverage["toggle"] = this.coverage["toggle"];
+
+    } else if (tool == 'xcelium') {
+      code_coverage_vals =
+        [this.coverage["block"],
+         this.coverage["branch"],
+         this.coverage["statement"],
+         this.coverage["expression"],
+         this.coverage["fsm"]];
+
+      this.summary_coverage["functional"] = this.coverage["covergroup"];
+      this.summary_coverage["assertion"] = this.coverage["assertion"];
+      this.summary_coverage["toggle"] = this.coverage["toggle"];
+    }
+
+    let code_coverage_valid_vals = code_coverage_vals
+      .reduce((acc, x) => x != null ? acc + 1 : acc, 0);
+
+    if (code_coverage_valid_vals > 0) {
+      let avg_code_coverage = code_coverage_vals
+        .reduce((acc, x) => x != null ? acc + x : acc, 0);
+      avg_code_coverage /= code_coverage_valid_vals;
+
+      this.summary_coverage["code"] = avg_code_coverage;
+    }
+  }
+
+  make_block_summary_dashboard() {
+    return new DashboardSingleEntryCollection(
+      [new DashboardSingleEntry("Tests Running", this.tests, DashValueKindPlain),
+       new DashboardSingleEntry("Test Passing", this.passing_tests_pct, DashValueKindPctColoured),
+       new DashboardSingleEntry("Functional Coverage", this.summary_coverage["functional"], DashValueKindPctColoured),
+       new DashboardSingleEntry("Code Coverage", this.summary_coverage["code"], DashValueKindPctColoured)],
+      this.block_name,
+      this.report_url,
+    );
+  }
+}
+
+class BlockLevelResultsCollection {
+  constructor() {
+    this.results_collection = [];
+  }
+
+  add_results(results) {
+    this.results_collection.push(results);
+  }
+
+  make_results_table() {
+    let headings = [
+      "Block",
+      "Tests",
+      "Passing",
+      "Code Coverage",
+      "Toggle Coverage",
+      "Assert Coverage",
+      "Functional Coverage"
+    ]
+
+    let kinds = [
+      DashValueKindLink,
+      DashValueKindPlain,
+      DashValueKindPctColoured,
+      DashValueKindPctColoured,
+      DashValueKindPctColoured,
+      DashValueKindPctColoured,
+      DashValueKindPctColoured,
+      DashValueKindPctColoured,
+    ];
+
+    let values = [];
+
+    for (let i = 0; i < this.results_collection.length; i++) {
+      values.push(this.generate_table_values(this.results_collection[i]));
+    }
+
+    return new DashboardTable(headings, values, kinds);
+  }
+
+  generate_table_values(results) {
+    return [
+      [results.block_name, results.report_url + "report.html"],
+      results.tests,
+      results.passing_tests_pct,
+      results.summary_coverage["code"],
+      results.summary_coverage["toggle"],
+      results.summary_coverage["assertion"],
+      results.summary_coverage["functional"]
+    ];
+  }
+}

--- a/util/site-dashboard/install-dashboards.js
+++ b/util/site-dashboard/install-dashboards.js
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+const dashboards = document.getElementsByClassName("dv-dashboard");
+
+for (let i = 0;i < dashboards.length; i++) {
+  block_name = dashboards[i].getAttribute("data-block-name");
+  if (block_name != null) {
+    fetch_block_results(block_name)
+      .then(function (block_result_list) {
+        let dashboard_toplevel = dashboards[i];
+        block_result_list
+          .map(block_result =>
+            block_result.make_block_summary_dashboard().render(dashboard_toplevel));
+      });
+  }
+}

--- a/util/site-dashboard/ot-nightly-results.js
+++ b/util/site-dashboard/ot-nightly-results.js
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+const all_report_urls = [
+  ["adc_ctrl", ["https://reports.opentitan.org/hw/ip/adc_ctrl/dv/latest/"]],
+  ["aes", ["https://reports.opentitan.org/hw/ip/aes_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/aes_unmasked/dv/latest/"]],
+  ["alert_handler", ["https://reports.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/dv/latest/"]],
+  ["aon_timer", ["https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/"]],
+  ["clkmgr", ["https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/"]],
+  ["csrng", ["https://reports.opentitan.org/hw/ip/csrng/dv/latest/"]],
+  ["edn", ["https://reports.opentitan.org/hw/ip/edn/dv/latest/"]],
+  ["entropy_src", ["https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/"]],
+  ["flash_ctrl", ["https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/"]],
+  ["gpio", ["https://reports.opentitan.org/hw/ip/gpio/dv/latest/"]],
+  ["hmac", ["https://reports.opentitan.org/hw/ip/hmac/dv/latest/"]],
+  ["i2c", ["https://reports.opentitan.org/hw/ip/i2c/dv/latest/"]],
+  ["keymgr", ["https://reports.opentitan.org/hw/ip/keymgr/dv/latest/"]],
+  ["kmac", ["https://reports.opentitan.org/hw/ip/kmac_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/kmac_unmasked/dv/latest/"]],
+  ["lc_ctrl", ["https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/"]],
+  ["otbn", ["https://reports.opentitan.org/hw/ip/otbn/dv/uvm/latest/"]],
+  ["otp_ctrl", ["https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/"]],
+  ["pattgen", ["https://reports.opentitan.org/hw/ip/pattgen/dv/latest/"]],
+  ["prim_alert", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/"]],
+  ["prim_esc", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/"]],
+  ["prim_lfsr", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/"]],
+  ["prim_present", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/"]],
+  ["prim_prince", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/"]],
+  ["pwm", ["https://reports.opentitan.org/hw/ip/pwm/dv/latest/"]],
+  ["pwrmgr", ["https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/"]],
+  ["rom_ctrl", ["https://reports.opentitan.org/hw/ip/rom_ctrl/dv/latest/"]],
+  ["rstmgr", ["https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/"]],
+  ["rstmgr_cnsty_chk", ["https://reports.opentitan.org/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/latest/"]],
+  ["rv_dm", ["https://reports.opentitan.org/hw/ip/rv_dm/dv/latest/"]],
+  ["rv_timer", ["https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/"]],
+  ["spi_device", ["https://reports.opentitan.org/hw/ip/spi_device/dv/latest/"]],
+  ["spi_host", ["https://reports.opentitan.org/hw/ip/spi_host/dv/latest/"]],
+  ["sram_ctrl", ["https://reports.opentitan.org/hw/ip/sram_ctrl_main/dv/latest/", "https://reports.opentitan.org/hw/ip/sram_ctrl_ret/dv/latest/"]],
+  ["sysrst_ctrl", ["https://reports.opentitan.org/hw/ip/sysrst_ctrl/dv/latest/"]],
+  ["tl_agent", ["https://reports.opentitan.org/hw/dv/sv/tl_agent/dv/latest/"]],
+  ["uart", ["https://reports.opentitan.org/hw/ip/uart/dv/latest/"]],
+  ["usbdev", ["https://reports.opentitan.org/hw/ip/usbdev/dv/latest/"]],
+  ["xbar", ["https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_main/dv/autogen/latest/", "https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_peri/dv/autogen/latest/"]],
+  ["chip", ["https://reports.opentitan.org/hw/top_earlgrey/dv/latest/"]]
+];
+
+async function fetch_block_report(block_report_url) {
+  try {
+    let fetch_response = await fetch(block_report_url + "report.json");
+    let block_info = await fetch_response.json();
+    let block_results = new BlockLevelResults(block_info, block_report_url);
+
+    return block_results;
+  } catch (error) {
+    console.error(`Saw error whilst processing block URL ${block_report_url}`);
+    console.error(error);
+  }
+
+  return null;
+}
+
+async function fetch_results(block_report_urls) {
+  let report_promises = block_report_urls.map((url) => fetch_block_report(url));
+
+  let report_results = await Promise.allSettled(report_promises);
+
+  return report_results
+    .filter((report_result) =>
+      report_result.status == "fulfilled" && report_result.value != null)
+    .map((report_result) => report_result.value);
+}
+
+async function fetch_block_results(block_name) {
+  let block_report_urls = all_report_urls.find((block_info) => block_info[0] == block_name);
+
+  return fetch_results(block_report_urls[1]);
+}
+
+async function fetch_all_results() {
+  block_report_urls = all_report_urls.flatMap((url_info) => url_info[1]);
+
+  return fetch_results(block_report_urls);
+}

--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -129,6 +129,7 @@ book_env+=" MDBOOK_PREPROCESSOR__REGGEN__COMMAND=${proj_root}/util/mdbook_reggen
 book_env+=" MDBOOK_PREPROCESSOR__WAVEJSON__COMMAND=${proj_root}/util/mdbook_wavejson.py"
 book_env+=" MDBOOK_PREPROCESSOR__README2INDEX__COMMAND=${proj_root}/util/mdbook_readme2index.py"
 book_env+=" MDBOOK_PREPROCESSOR__DASHBOARD__COMMAND=${proj_root}/util/mdbook_dashboard.py"
+book_env+=" MDBOOK_PREPROCESSOR__BLOCK_DASHBOARD__COMMAND=${proj_root}/util/mdbook-block-dashboard.py"
 # ./doc/guides/getting_started/book.toml
 book_guides_env="env"
 book_guides_env+=" MDBOOK_PREPROCESSOR__TOOLVERSION__COMMAND=${proj_root}/util/mdbook_toolversion.py"


### PR DESCRIPTION
~~[Only consider the final 5 commits, this PR will be rebased once #17323 is merged, which makes up all but the last 5 commits here.]~~

~~REVIEW BUT DO NOT MERGE
_We want to coordinate the merge of new website changes, so that suitable precautions can be taken for a safe deployment._~~

Merge Notes.
~~The final 2 commits represent changes on top of #17400 and #17402 to add links to the top-level dashboard page, which is otherwise inaccessible from the links currently available. When rebasing this PR after those two have been merged, the final two commits should reduce to 1-line changes.~~

---

This PR consists of a top-level block dashboard and block-level HWIP mini-dashboards, both developed by @GregAC out-of-tree. These dashboards pull information from the reports.opentitan.org data, and present the information in a more targeted, concise and relevant way. 

The latest [staging.opentitan.org](https://staging.opentitan.org) site contains both the all-blocks dashboard [[1]](https://staging.opentitan.org/dashboard/#top) and the block-level dashboards (e.g. [[2]](https://staging.opentitan.org/book/hw/ip/aes/index.html)) as of this PR.

---

![image](https://user-images.githubusercontent.com/102029880/221871764-6b5a6c84-135a-4da7-961a-98aa8be74207.png)

![image](https://user-images.githubusercontent.com/102029880/221871675-a8522929-7a55-4b90-bcff-38851640894e.png)

