### PR TITLE
[crypto] Simplify DMEM interface for RSA.

### DIFF
--- a/sw/device/lib/testing/otbn_testutils.c
+++ b/sw/device/lib/testing/otbn_testutils.c
@@ -26,16 +26,18 @@ void otbn_testutils_wait_for_done(const dif_otbn_t *otbn,
     busy = status != kDifOtbnStatusIdle && status != kDifOtbnStatusLocked;
   }
 
-  // Error out if OTBN is locked.
-  CHECK(status == kDifOtbnStatusIdle, "OTBN is locked.");
-
-  // Get instruction count so that, if error bits are unexpected, we can print
-  // it to help with debugging.
+  // Get instruction count so that we can print them to help with debugging.
   uint32_t instruction_count;
   CHECK_DIF_OK(dif_otbn_get_insn_cnt(otbn, &instruction_count));
 
   dif_otbn_err_bits_t err_bits;
   CHECK_DIF_OK(dif_otbn_get_err_bits(otbn, &err_bits));
+
+  // Error out if OTBN is locked.
+  CHECK(status == kDifOtbnStatusIdle, "OTBN is locked. Error bits: 0x%08x",
+        err_bits);
+
+  // Error out if error bits do not match expectations.
   CHECK(err_bits == expected_err_bits,
         "OTBN error bits: got: 0x%08x, expected: 0x%08x.\nInstruction count: "
         "0x%08x",

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -412,6 +412,7 @@ otbn_consttime_test(
 
 otbn_sim_test(
     name = "rsa_1024_dec_test",
+    timeout = "long",
     srcs = [
         "rsa_1024_dec_test.s",
     ],


### PR DESCRIPTION
Previously, RSA code expected very specific formatting of DMEM, including a lot of loads from hardcoded memory addresses and indirect pointers. Now that we have a .bss directive for OTBN, there's no need to rely on this type of access. This change will make it easier to use the existing RSA lib for key generation, and generally make the code more flexible. Similar to this P256 change from a while back: https://github.com/lowRISC/opentitan/pull/14971

Also includes a minor improvement to the OTBN testutils, so that we print the error bits if OTBN fails a test because it became locked.