### PR TITLE
[hw,sysrst_ctrl] Update bounds for expected_wakeup counter

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
@@ -64,7 +64,10 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
     cfg.vif.ac_present = 1;
     for (int i = 0; i < ac_cycles; i++) begin
       cfg.clk_aon_rst_vif.wait_clks(1);
-      if (exp_z3_wakeup == 0 && enable_ulp && i > (get_ac_timer + 1)) exp_z3_wakeup = 1;
+      if (exp_z3_wakeup == 0 && enable_ulp && i > get_ac_timer) begin
+        `uvm_info(`gfn, "z3_wakeup assertion expected for a HIGH level on ac_present_i", UVM_LOW)
+        exp_z3_wakeup = 1;
+      end
     end
     cfg.vif.ac_present = 0;
    endtask
@@ -75,7 +78,10 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
     cfg.vif.pwrb_in = 0;
     for (int i = 0; i < pwrb_cycles; i++) begin
       cfg.clk_aon_rst_vif.wait_clks(1);
-      if (exp_z3_wakeup == 0 && enable_ulp && i > (get_pwrb_timer + 1)) exp_z3_wakeup = 1;
+      if (exp_z3_wakeup == 0 && enable_ulp && i > get_pwrb_timer) begin
+        exp_z3_wakeup = 1;
+        `uvm_info(`gfn, "z3_wakeup assertion expected for a H2L transition on pwrb_in_i", UVM_LOW)
+      end
     end
     cfg.vif.pwrb_in = 1;
    endtask
@@ -86,7 +92,10 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
     cfg.vif.lid_open = 1;
     for (int i = 0; i < lid_cycles; i++) begin
       cfg.clk_aon_rst_vif.wait_clks(1);
-      if (exp_z3_wakeup == 0 && enable_ulp && i > (get_lid_timer + 1)) exp_z3_wakeup = 1;
+      if (exp_z3_wakeup == 0 && enable_ulp && i > get_lid_timer) begin
+        exp_z3_wakeup = 1;
+        `uvm_info(`gfn, "z3_wakeup assertion expected for a L2H transition on lid_open_i", UVM_LOW)
+      end
     end
     cfg.vif.lid_open = 0;
    endtask


### PR DESCRIPTION
For cases where, `(ac/pwrb/lid)_cycles == get_(ac/pwrb/lid)_timer + 2`, ULP test sequence doesnt not update exp_z3_wakeup, because `i` value starts from 0 which itself indicates one cycle of transition/change in input level

Update bound value to fix this issue

Also, add `uvm_info` to indicate which level transition/change is detected by ULP block