### PR TITLE
[spi_passthru] Test the jedec_id

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -139,6 +139,7 @@ RUST_TARGETS = [
     "//sw/host/tests/rom/e2e_bootstrap_entry:e2e_bootstrap_entry",
     "//sw/host/tests/rom/e2e_chip_specific_startup:e2e_chip_specific_startup",
     "//sw/host/tests/rom/sw_strap_value:sw_strap_value",
+    "//sw/host/tests/chip/spi_passthru:spi_passthru",
 ]
 
 rustfmt_test(

--- a/sw/device/lib/testing/json/BUILD
+++ b/sw/device/lib/testing/json/BUILD
@@ -53,3 +53,10 @@ cc_library(
         "//sw/device/lib/ujson",
     ],
 )
+
+cc_library(
+    name = "spi_passthru",
+    srcs = ["spi_passthru.c"],
+    hdrs = ["spi_passthru.h"],
+    deps = ["//sw/device/lib/ujson"],
+)

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -15,6 +15,7 @@ extern "C" {
     value(_, GpioSet) \
     value(_, GpioGet) \
     value(_, PinmuxConfig) \
+    value(_, SpiConfigureJedecId) \
     value(_, SwStrapRead)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);
 

--- a/sw/device/lib/testing/json/spi_passthru.c
+++ b/sw/device/lib/testing/json/spi_passthru.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sw/device/lib/testing/json/spi_passthru.h"

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SPI_PASSTHRU_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SPI_PASSTHRU_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+#define STRUCT_CONFIG_JEDEC_ID(field, string) \
+    field(device_id, uint16_t) \
+    field(manufacturer_id, uint8_t) \
+    field(continuation_code, uint8_t) \
+    field(continuation_len, uint8_t)
+UJSON_SERDE_STRUCT(ConfigJedecId, config_jedec_id_t, STRUCT_CONFIG_JEDEC_ID);
+
+// clang-format on
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SPI_PASSTHRU_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2189,3 +2189,32 @@ opentitan_functest(
         "//sw/device/tests/crypto:rsa_3072_verify_testvectors_hardcoded_header",
     ],
 )
+
+opentitan_functest(
+    name = "spi_passthru_test",
+    srcs = ["spi_passthru_test.c"],
+    cw310 = cw310_params(
+        # This test will need hyperdebug once we start using multi-lane
+        # SPI modes.
+        #interface = "hyper310",
+        #tags = ["manual"],
+        test_cmds = [
+            "--rom-kind=testrom",
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
+    targets = [
+        "cw310_test_rom",
+    ],
+    test_harness = "//sw/host/tests/chip/spi_passthru",
+    deps = [
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:spi_passthru",
+        "//sw/device/lib/testing/test_framework:ottf_flow_control",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+    ],
+)

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/json/spi_passthru.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_spi_device_handle_t spid;
+
+status_t configure_jedec_id(ujson_t *uj, dif_spi_device_handle_t *spid) {
+  config_jedec_id_t config;
+  TRY(ujson_deserialize_config_jedec_id_t(uj, &config));
+  dif_spi_device_flash_id_t id = {
+      .device_id = config.device_id,
+      .manufacturer_id = config.manufacturer_id,
+      .continuation_code = config.continuation_code,
+      .num_continuation_code = config.continuation_len,
+  };
+  TRY(dif_spi_device_set_flash_id(spid, id));
+
+  dif_spi_device_flash_command_t read_id = {
+      .opcode = 0x9F,
+      .address_type = kDifSpiDeviceFlashAddrDisabled,
+      .dummy_cycles = 0,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .passthrough_swap_address = false,
+      .payload_dir_to_host = true,
+      .payload_swap_enable = false,
+      .upload = false,
+      .set_busy_status = false,
+  };
+  TRY(dif_spi_device_set_flash_command_slot(spid, 3, kDifToggleEnabled,
+                                            read_id));
+  return RESP_OK_STATUS(uj);
+}
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandSpiConfigureJedecId:
+        RESP_ERR(uj, configure_jedec_id(uj, &spid));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  // We should never reach here.
+  return INTERNAL();
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_spi_device_init_handle(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spid));
+
+  dif_spi_device_config_t dev_cfg = {
+      .clock_polarity = kDifSpiDeviceEdgePositive,
+      .data_phase = kDifSpiDeviceEdgeNegative,
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .device_mode = kDifSpiDeviceModePassthrough,
+  };
+  CHECK_DIF_OK(dif_spi_device_configure(&spid, dev_cfg));
+
+  dif_spi_device_passthrough_intercept_config_t passthru_cfg = {
+      .status = true,
+      .jedec_id = true,
+      .sfdp = true,
+      .mailbox = false,
+  };
+  CHECK_DIF_OK(
+      dif_spi_device_set_passthrough_intercept_config(&spid, passthru_cfg));
+
+  ujson_t uj = ujson_ottf_console();
+  status_t s = command_processor(&uj);
+  LOG_INFO("status = %r", s);
+  return status_ok(s);
+}

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -25,6 +25,12 @@ ujson_rust(
     defines = ["opentitanlib=crate"],
 )
 
+ujson_rust(
+    name = "spi_passthru",
+    srcs = ["//sw/device/lib/testing/json:spi_passthru"],
+    defines = ["opentitanlib=crate"],
+)
+
 filegroup(
     name = "config",
     srcs = glob(["src/app/config/*.json"]),
@@ -86,6 +92,7 @@ rust_library(
         "src/test_utils/e2e_command.rs",
         "src/test_utils/epmp.rs",
         "src/test_utils/gpio.rs",
+        "src/test_utils/spi_passthru.rs",
         "src/test_utils/init.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/mod.rs",
@@ -160,6 +167,7 @@ rust_library(
         ":gpio",
         ":e2e_command",
         ":pinmux_config",
+        ":spi_passthru",
         "@hyperdebug_firmware//file",
     ],
     crate_features = [
@@ -177,6 +185,7 @@ rust_library(
         "e2e_command": "$(location :e2e_command)",
         "gpio": "$(location :gpio)",
         "pinmux_config": "$(location :pinmux_config)",
+        "spi_passthru": "$(location :spi_passthru)",
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//file)",
     },
     deps = [

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -14,6 +14,7 @@ pub mod load_bitstream;
 pub mod pinmux_config;
 
 pub mod rpc;
+pub mod spi_passthru;
 pub mod status;
 
 /// The `execute_test` macro should be used in end-to-end tests to

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+include!(env!("spi_passthru"));
+
+impl ConfigJedecId {
+    pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiConfigureJedecId.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}

--- a/sw/host/tests/chip/spi_passthru/BUILD
+++ b/sw/host/tests/chip/spi_passthru/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "spi_passthru",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde_json",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/chip/spi_passthru/src/main.rs
+++ b/sw/host/tests/chip/spi_passthru/src/main.rs
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::spiflash::SpiFlash;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::spi_passthru::ConfigJedecId;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "600s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+
+    #[structopt(
+        long,
+        default_value = "BOOTSTRAP",
+        help = "Name of the debugger's SPI interface"
+    )]
+    spi: String,
+}
+
+fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let config = ConfigJedecId {
+        device_id: 0x1234,
+        manufacturer_id: 0x56,
+        continuation_code: 0x7f,
+        continuation_len: 3,
+    };
+    config.execute(&*uart)?;
+
+    let spi = transport.spi(&opts.spi)?;
+    let jedec_id = SpiFlash::read_jedec_id(&*spi, 16)?;
+    log::info!("jedec_id = {:x?}", jedec_id);
+    // Note: there is no specified bit pattern after the end of the JEDEC ID.
+    // OpenTitan returns zeros.  Some devices return 0xFF or repeat the byte sequence.
+    assert_eq!(
+        jedec_id,
+        [
+            0x7f, 0x7f, 0x7f, // 3 continuation codes of 0x7F.
+            0x56, // Manufacturer ID of 0x56.
+            0x34, 0x12, // Device ID 0x1234 (in little endian order).
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // All zeros up to read length.
+        ]
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    uart.clear_rx_buffer()?;
+
+    execute_test!(test_jedec_id, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
1. Create the basic framework for the spi_passthru test.
2. Test the JEDEC ID feature of thee spi_device.