### PR TITLE
[site] Collapse navbar into a dropdown on mobile

### DIFF
--- a/site/landing/assets/scss/_intro.scss
+++ b/site/landing/assets/scss/_intro.scss
@@ -9,7 +9,7 @@
   background-size: 140em 23em;
   background-position: center bottom -1em;
   background-repeat: repeat-x;
-  padding: 3em $m-s 13.75em;
+  padding: 0 $m-s 13.75em;
 
   &__content {
     max-width: $max-width-m;

--- a/site/landing/assets/scss/_main-header.scss
+++ b/site/landing/assets/scss/_main-header.scss
@@ -28,14 +28,16 @@
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
+}
 
-  &:after {
+/* Desktop specific styling */
+@media (min-width: $max-width-s) {
+  .main-header:after {
     content: "";
     display: block;
     flex-grow: 9999;
     height: 1em;
     order: 2;
-    flex-basis: calc((40em - 100%) * 999);
   }
 }
 
@@ -46,7 +48,6 @@
   min-width: 12.5em;
   order: 1;
   flex-grow: 1;
-  flex-basis: calc((40em - 100%) * 999);
 
   svg {
     width: 12.5em;
@@ -64,6 +65,65 @@
   }
 }
 
+/* Mobile specific styling */
+@media (max-width: $max-width-s) {
+  /* Place the theme toggle after the logo */
+  .main-header {
+    .user-toggle {
+      order: 2;
+    }
+  }
+
+  /* Hide the checkbox and only show its SVG label */
+  .main-nav-toggle {
+    display: none;
+  }
+
+  .main-nav-toggle-label {
+    display: block;
+    width: 2em;
+    height: 1.6em;
+    cursor: pointer;
+  }
+
+  /* Hide nav when closed */
+  .main-nav-toggle:not(:checked) ~ .main-nav {
+    display: none;
+  }
+
+  .main-nav {
+    /* Move margin from below to above the nav */
+    margin-bottom: -3em;
+    margin-top: 3em;
+
+    &__list {
+      flex-direction: column;
+      align-items: center;
+      font-size: 1.5rem;
+      gap: 0;
+    }
+  }
+}
+/* Desktop specific styling */
+@media (min-width: $max-width-s) {
+  /* Hide hamburger nav toggle on desktop */
+  .main-nav-toggle {
+    display: none;
+  }
+
+  .main-header {
+    .user-toggle {
+      order: 4;
+    }
+  }
+
+  .main-nav {
+    &__list {
+      gap: calc(0.25em + 1.56vw);
+    }
+  }
+}
+
 .main-nav {
   order: 3;
   flex-grow: 1;
@@ -75,10 +135,6 @@
   }
 
   &__item {
-    & + & {
-      margin-left: calc(0.25em + 1.56vw);
-    }
-
     a {
       color: $white;
       color: var(--text-white);

--- a/site/landing/assets/scss/_main-header.scss
+++ b/site/landing/assets/scss/_main-header.scss
@@ -12,7 +12,7 @@
   transition: top .1s linear;
   text-decoration: none;
 
-  &:focus, 
+  &:focus,
   &:focus-visible {
     top: 0;
     color: $dark-purple;

--- a/site/landing/assets/scss/_main-header.scss
+++ b/site/landing/assets/scss/_main-header.scss
@@ -21,6 +21,7 @@
 
 .main-header {
   margin: 0 auto;
+  margin-bottom: 3em;
   max-width: $max-width-m;
   padding: 1.75em $m-s;
   display: flex;

--- a/site/landing/assets/scss/_main-header.scss
+++ b/site/landing/assets/scss/_main-header.scss
@@ -86,6 +86,15 @@
     cursor: pointer;
   }
 
+  /* Hide burger when open */
+  .main-nav-toggle:checked ~ .main-nav-toggle-label #burger {
+    display: none;
+  }
+  /* Hide cross when closed */
+  .main-nav-toggle:not(:checked) ~ .main-nav-toggle-label #cross {
+    display: none;
+  }
+
   /* Hide nav when closed */
   .main-nav-toggle:not(:checked) ~ .main-nav {
     display: none;

--- a/site/landing/layouts/index.html
+++ b/site/landing/layouts/index.html
@@ -37,10 +37,14 @@
 
     <input id="main-nav-toggle" class="main-nav-toggle" type="checkbox">
     <label class="main-nav-toggle-label" for="main-nav-toggle">
-      <svg viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg" fill="white">
-          <rect width="20" height="2" y="1"></rect>
-          <rect width="20" height="2" y="7"></rect>
-          <rect width="20" height="2" y="13"></rect>
+      <svg id="burger" viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg" fill="white">
+        <rect width="20" height="2" y="1"></rect>
+        <rect width="20" height="2" y="7"></rect>
+        <rect width="20" height="2" y="13"></rect>
+      </svg>
+      <svg id="cross" viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg" stroke="white" stroke-width="2">
+        <line x1="2" y1="0" x2="16" y2="16" />
+        <line x1="2" y1="16" x2="16" y2="0" />
       </svg>
     </label>
 

--- a/site/landing/layouts/index.html
+++ b/site/landing/layouts/index.html
@@ -35,6 +35,15 @@
       </a>
     </h1>
 
+    <input id="main-nav-toggle" class="main-nav-toggle" type="checkbox">
+    <label class="main-nav-toggle-label" for="main-nav-toggle">
+      <svg viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg" fill="white">
+          <rect width="20" height="2" y="1"></rect>
+          <rect width="20" height="2" y="7"></rect>
+          <rect width="20" height="2" y="13"></rect>
+      </svg>
+    </label>
+
     <nav id="main-nav" class="main-nav" aria-label="Main">
       <ul id="menu" class="main-nav__list">
         <li class="main-nav__item">
@@ -49,17 +58,18 @@
         <li class="main-nav__item">
           <a href="{{ .Site.Params.one_year_url }}">Blog</a>
         </li>
-        <li class="main-nav__item user-toggle">
-          <button class="[ toggle-button ] [ js-mode-toggle ]" aria-label="Switch light and dark theme">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path fill="currentColor"
-                d="M12 2a10 10 0 01.3 20H12a10 10 0 110-20zm0 2a8 8 0 100 16v-3a5 5 0 010-10V4zm0 4v8a4 4 0 100-8z"
-                fill-rule="evenodd" />
-            </svg>
-          </button>
-        </li>
       </ul>
     </nav>
+
+    <div class="user-toggle">
+      <button class="[ toggle-button ] [ js-mode-toggle ]" aria-label="Switch light and dark theme">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path fill="currentColor"
+            d="M12 2a10 10 0 01.3 20H12a10 10 0 110-20zm0 2a8 8 0 100 16v-3a5 5 0 010-10V4zm0 4v8a4 4 0 100-8z"
+            fill-rule="evenodd" />
+        </svg>
+      </button>
+    </div>
   </header>
 
   <main id="main" role="main">


### PR DESCRIPTION
## Summary

This PR arranges the site's header navbar into a vertical list and adds a hamburger toggle to show and hide it.

Based on the hamburger menu being added to the mdbook theme. Would be good to use the same header on both the site and book for consistency.

This dropdown isn't animated at all, is that something we want? If so I'll copy over the mdbook animations.

I'm really not precious about how this looks, so any feedback on that is appreciated.

## Screenshots

<details>
<summary>Before these changes</summary>

![Before changes](https://user-images.githubusercontent.com/105280833/222490721-4e6e56e4-755c-41a9-a20f-6bb447178c94.png)

</details>

With these changes:

<div style="display: flex;">
<img width="360px" src="https://user-images.githubusercontent.com/105280833/222491070-1cd3fa1e-ad29-4d1f-a793-6b07a719dce8.png" />
 <img width="360px" src="https://user-images.githubusercontent.com/105280833/222491401-32348e91-b096-4a87-adb2-0b3f5b4f350e.png" />
</div>