### PR TITLE
[dv/otp] Fix regression cov issue

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -66,7 +66,7 @@
   overrides: [
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+      value: "-cm_hier {proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg+{dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
     }
   ]
 


### PR DESCRIPTION
When PR #17380 merged, I missed adding one common exclusion file to the override function.
This causes the nightly regression to have low coverage. This PR adds back the missing common coverage exclusion cfg.