### PR TITLE
[spi_passthru] Test status-modifying opcodes 

### DIFF
--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -16,6 +16,8 @@ extern "C" {
     value(_, GpioGet) \
     value(_, PinmuxConfig) \
     value(_, SpiConfigureJedecId) \
+    value(_, SpiReadStatus) \
+    value(_, SpiWriteStatus) \
     value(_, SwStrapRead)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);
 

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -17,6 +17,11 @@ extern "C" {
     field(continuation_len, uint8_t)
 UJSON_SERDE_STRUCT(ConfigJedecId, config_jedec_id_t, STRUCT_CONFIG_JEDEC_ID);
 
+#define STRUCT_STATUS_REGISTER(field, string) \
+    field(status, uint32_t) \
+    field(addr_4b, bool)
+UJSON_SERDE_STRUCT(StatusRegister, status_register_t, STRUCT_STATUS_REGISTER);
+
 // clang-format on
 #ifdef __cplusplus
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2195,7 +2195,9 @@ opentitan_functest(
 
 opentitan_functest(
     name = "spi_passthru_test",
-    srcs = ["spi_passthru_test.c"],
+    srcs = [
+        "spi_passthru_test.c",
+    ],
     cw310 = cw310_params(
         # This test will need hyperdebug once we start using multi-lane
         # SPI modes.
@@ -2214,6 +2216,7 @@ opentitan_functest(
     deps = [
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/testing:spi_device_testutils",
         "//sw/device/lib/testing/json:command",
         "//sw/device/lib/testing/json:spi_passthru",
         "//sw/device/lib/testing/test_framework:ottf_flow_control",

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -23,7 +24,7 @@ OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
 static dif_spi_device_handle_t spid;
 
-status_t configure_jedec_id(ujson_t *uj, dif_spi_device_handle_t *spid) {
+static status_t configure_jedec_id(ujson_t *uj, dif_spi_device_handle_t *spid) {
   config_jedec_id_t config;
   TRY(ujson_deserialize_config_jedec_id_t(uj, &config));
   dif_spi_device_flash_id_t id = {
@@ -33,21 +34,26 @@ status_t configure_jedec_id(ujson_t *uj, dif_spi_device_handle_t *spid) {
       .num_continuation_code = config.continuation_len,
   };
   TRY(dif_spi_device_set_flash_id(spid, id));
-
-  dif_spi_device_flash_command_t read_id = {
-      .opcode = 0x9F,
-      .address_type = kDifSpiDeviceFlashAddrDisabled,
-      .dummy_cycles = 0,
-      .payload_io_type = kDifSpiDevicePayloadIoSingle,
-      .passthrough_swap_address = false,
-      .payload_dir_to_host = true,
-      .payload_swap_enable = false,
-      .upload = false,
-      .set_busy_status = false,
-  };
-  TRY(dif_spi_device_set_flash_command_slot(spid, 3, kDifToggleEnabled,
-                                            read_id));
   return RESP_OK_STATUS(uj);
+}
+
+static status_t write_status_register(ujson_t *uj,
+                                      dif_spi_device_handle_t *spid) {
+  status_register_t sr;
+  TRY(ujson_deserialize_status_register_t(uj, &sr));
+  TRY(dif_spi_device_set_flash_status_registers(spid, sr.status));
+  return RESP_OK_STATUS(uj);
+}
+
+static status_t read_status_register(ujson_t *uj,
+                                     dif_spi_device_handle_t *spid) {
+  status_register_t sr;
+  dif_toggle_t addr_4b;
+  TRY(dif_spi_device_get_flash_status_registers(spid, &sr.status));
+  TRY(dif_spi_device_get_4b_address_mode(spid, &addr_4b));
+  sr.addr_4b = addr_4b;
+  RESP_OK(ujson_serialize_status_register_t, uj, &sr);
+  return OK_STATUS();
 }
 
 status_t command_processor(ujson_t *uj) {
@@ -57,6 +63,12 @@ status_t command_processor(ujson_t *uj) {
     switch (command) {
       case kTestCommandSpiConfigureJedecId:
         RESP_ERR(uj, configure_jedec_id(uj, &spid));
+        break;
+      case kTestCommandSpiReadStatus:
+        RESP_ERR(uj, read_status_register(uj, &spid));
+        break;
+      case kTestCommandSpiWriteStatus:
+        RESP_ERR(uj, write_status_register(uj, &spid));
         break;
       default:
         LOG_ERROR("Unrecognized command: %d", command);
@@ -71,14 +83,12 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_spi_device_init_handle(
       mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spid));
 
-  dif_spi_device_config_t dev_cfg = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
-      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-      .device_mode = kDifSpiDeviceModePassthrough,
-  };
-  CHECK_DIF_OK(dif_spi_device_configure(&spid, dev_cfg));
+  // We want to block passthru of the first 5 read commands, corresponding to
+  // ReadStatus{1,2,3}, ReadJedecID and ReadSfdp.
+  // We also block all write commands.
+  spi_device_testutils_configure_passthrough(&spid,
+                                             /*filters=*/0x1F,
+                                             /*upload_write_commands=*/true);
 
   dif_spi_device_passthrough_intercept_config_t passthru_cfg = {
       .status = true,

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -21,3 +21,17 @@ impl ConfigJedecId {
         Ok(())
     }
 }
+
+impl StatusRegister {
+    pub fn read(uart: &dyn Uart) -> Result<Self> {
+        TestCommand::SpiReadStatus.send(&*uart)?;
+        StatusRegister::recv(uart, Duration::from_secs(300), false)
+    }
+
+    pub fn write(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiWriteStatus.send(&*uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
1. Test EN4B, EX4B, WREN and WRDI.
2. Test reading the extended status register.

Signed-off-by: Chris Frantz <cfrantz@google.com>