### PR TITLE
[opentitantool]: Proxy forwarding of strappings

### DIFF
--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -277,6 +277,14 @@ impl<'a> TransportCommandHandler<'a> {
                     Bootstrap::update(self.transport, options, payload)?;
                     Ok(Response::Proxy(ProxyResponse::Bootstrap))
                 }
+                ProxyRequest::ApplyPinStrapping { strapping_name } => {
+                    self.transport.apply_pin_strapping(strapping_name)?;
+                    Ok(Response::Proxy(ProxyResponse::ApplyPinStrapping))
+                }
+                ProxyRequest::RemovePinStrapping { strapping_name } => {
+                    self.transport.remove_pin_strapping(strapping_name)?;
+                    Ok(Response::Proxy(ProxyResponse::RemovePinStrapping))
+                }
             },
         }
     }

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -200,9 +200,17 @@ pub enum ProxyRequest {
         options: BootstrapOptions,
         payload: Vec<u8>,
     },
+    ApplyPinStrapping {
+        strapping_name: String,
+    },
+    RemovePinStrapping {
+        strapping_name: String,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
 pub enum ProxyResponse {
     Bootstrap,
+    ApplyPinStrapping,
+    RemovePinStrapping,
 }

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -140,6 +140,8 @@ pub trait Transport {
 /// Methods available only on the Proxy implementation of the Transport trait.
 pub trait ProxyOps {
     fn bootstrap(&self, options: &BootstrapOptions, payload: &[u8]) -> Result<()>;
+    fn apply_pin_strapping(&self, strapping_name: &str) -> Result<()>;
+    fn remove_pin_strapping(&self, strapping_name: &str) -> Result<()>;
 }
 
 /// Used by Transport implementations dealing with emulated OpenTitan

--- a/sw/host/opentitanlib/src/transport/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/mod.rs
@@ -138,7 +138,25 @@ impl ProxyOps for ProxyOpsImpl {
             payload: payload.to_vec(),
         })? {
             ProxyResponse::Bootstrap => Ok(()),
-            //_ => bail!(ProxyError::UnexpectedReply()), // Enable when second option is added
+            _ => bail!(ProxyError::UnexpectedReply()), // Enable when second option is added
+        }
+    }
+
+    fn apply_pin_strapping(&self, strapping_name: &str) -> Result<()> {
+        match self.execute_command(ProxyRequest::ApplyPinStrapping {
+            strapping_name: strapping_name.to_string(),
+        })? {
+            ProxyResponse::ApplyPinStrapping => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()), // Enable when second option is added
+        }
+    }
+
+    fn remove_pin_strapping(&self, strapping_name: &str) -> Result<()> {
+        match self.execute_command(ProxyRequest::RemovePinStrapping {
+            strapping_name: strapping_name.to_string(),
+        })? {
+            ProxyResponse::RemovePinStrapping => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()), // Enable when second option is added
         }
     }
 }


### PR DESCRIPTION
When using `opentitansession`, often the session process will be provided with configuration files on startup, and the individual `opentitantool` invocation may or may not get any configuration file arguments.

To handle all cases, `gpio apply` should check if either the session process knows a strapping by the name, and in that case have the session process apply it, or check if local files declare a strapping by the name, and in that case instruct the session process to individually configure every pin mentioned in the strapping.