### PR TITLE
[opentitantool] Use VERSION_FILE env variable to define opentitantool version

### DIFF
--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -32,9 +32,15 @@ rust_binary(
         "src/command/version.rs",
         "src/main.rs",
     ],
+    compile_data = [
+        "//util:full_version.txt",
+    ],
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],
+    rustc_env = {
+        "VERSION_FILE": "$(location //util:full_version.txt)",
+    },
     # stamping is necessary because opentitantool builds version.rs that needs it
     stamp = 1,
     tags = [

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -20,7 +20,7 @@ use opentitanlib::app::TransportWrapper;
 /// At runtime, this string is parsed into key/value pairs, which are returned.  (It would have
 /// been desirable to perform the parsing at compile time as well.)
 pub fn get_volatile_status() -> BTreeMap<&'static str, &'static str> {
-    let volatile_status = include_str!("../../../../../bazel-out/volatile-status.txt");
+    let volatile_status = include_str!(env!("VERSION_FILE"));
     let re = Regex::new(r"([A-Z_]+) ([^\n]+)\n").unwrap();
     let mut properties: BTreeMap<&'static str, &'static str> = BTreeMap::new();
     for cap in re.captures_iter(volatile_status) {

--- a/util/BUILD
+++ b/util/BUILD
@@ -19,7 +19,7 @@ genrule(
 genrule(
     name = "full_version_file",
     outs = ["full_version.txt"],
-    cmd = """cp bazel-out/volatile-status.txt $@""",
+    cmd = """cp -f bazel-out/volatile-status.txt $@""",
     stamp = 1,  # this provides volatile-status.txt
 )
 


### PR DESCRIPTION
The version file path is configurable instead of a hard-coded path in version.rs.

There is an existing bazel label to grab the OT version information.