### PR TITLE
Usbutils mods

### DIFF
--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -14,6 +14,78 @@
 static dif_usbdev_t usbdev;
 static dif_usbdev_buffer_pool_t buffer_pool;
 
+// Internal function to create the packet that will form the next part of a
+// larger buffer transfer
+static bool usb_testutils_part_prepare(usb_testutils_ctx_t *ctx,
+                                       usb_testutils_transfer_t *transfer,
+                                       dif_usbdev_buffer_t *next_part,
+                                       bool *last) {
+  CHECK(ctx && transfer && last);
+
+  // Allocate and fill a packet buffer
+  dif_result_t result =
+      dif_usbdev_buffer_request(ctx->dev, ctx->buffer_pool, next_part);
+  if (result != kDifOk) {
+    return false;
+  }
+
+  // Determine the maximum bytes/packet
+  unsigned max_packet = USBDEV_MAX_PACKET_SIZE;
+  if (transfer->flags & kUsbTestutilsXfrMaxPacketSupplied) {
+    max_packet = (unsigned)(transfer->flags & kUsbTestutilsXfrMaxPacketMask);
+  }
+
+  // How much are we sending this time?
+  unsigned part_len = transfer->length - transfer->offset;
+  if (part_len > max_packet) {
+    part_len = max_packet;
+  }
+  size_t bytes_written = 0U;
+  if (part_len) {
+    CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, next_part,
+                                         &transfer->buffer[transfer->offset],
+                                         part_len, &bytes_written));
+  }
+  //  Is this the last packet?
+  uint32_t next_offset = transfer->offset + bytes_written;
+  *last = true;
+  if (bytes_written == max_packet) {
+    if (next_offset < transfer->length ||
+        (transfer->flags & kUsbTestutilsXfrEmployZLP)) {
+      *last = false;
+    }
+  } else {
+    CHECK(bytes_written < max_packet);
+  }
+
+  transfer->offset = next_offset;
+  return true;
+}
+
+// Internal function to perform the next part of a larger buffer transfer
+static bool usb_testutils_transfer_next_part(
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_t *transfer) {
+  // Do we need to prepare a packet?
+  if (!transfer->next_valid &&
+      !usb_testutils_part_prepare(ctx, transfer, &transfer->next_part,
+                                  &transfer->last)) {
+    return false;
+  }
+
+  // Send the existing prepared packet
+  CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ep, &transfer->next_part));
+  transfer->next_valid = false;
+
+  // If we're double-buffering, request and fill another buffer immediately;
+  // we'll then be able to supply it much more promptly later...
+  if ((transfer->flags & kUsbTestutilsXfrDoubleBuffered) && !transfer->last) {
+    transfer->next_valid = usb_testutils_part_prepare(
+        ctx, transfer, &transfer->next_part, &transfer->last);
+  }
+
+  return true;
+}
+
 void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
   uint32_t istate;
 
@@ -21,16 +93,7 @@ void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
   CHECK_DIF_OK(dif_usbdev_irq_get_state(ctx->dev, &istate));
 
   if (!istate) {
-    // Nothing new to do right now, but keep buffers available for reception
-    CHECK_DIF_OK(dif_usbdev_fill_available_fifo(ctx->dev, ctx->buffer_pool));
     return;
-  }
-
-  // Record bus frame
-  if ((istate & (1u << kDifUsbdevIrqFrame))) {
-    // The first bus frame is 1
-    CHECK_DIF_OK(dif_usbdev_status_get_frame(ctx->dev, &ctx->frame));
-    ctx->got_frame = true;
   }
 
   // Process IN completions first so we get the fact that send completed
@@ -40,28 +103,47 @@ void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
     uint16_t sentep;
     CHECK_DIF_OK(dif_usbdev_get_tx_sent(ctx->dev, &sentep));
     TRC_C('a' + sentep);
-    for (unsigned ep = 0; ep < USBDEV_NUM_ENDPOINTS; ep++) {
-      if (sentep & (1 << ep)) {
+    unsigned ep = 0u;
+    while (sentep && ep < USBDEV_NUM_ENDPOINTS) {
+      if (sentep & (1u << ep)) {
         // Free up the buffer and optionally callback
         CHECK_DIF_OK(
             dif_usbdev_clear_tx_status(ctx->dev, ctx->buffer_pool, ep));
 
-        if (ctx->in[ep].tx_done_callback) {
-          ctx->in[ep].tx_done_callback(ctx->in[ep].ep_ctx);
+        // If we have a larger transfer in progress, continue with that
+        usb_testutils_transfer_t *transfer = &ctx->in[ep].transfer;
+        usb_testutils_xfr_result_t res = kUsbTestutilsXfrResultOk;
+        bool done = true;
+        if (transfer->buffer) {
+          if (transfer->next_valid || !transfer->last) {
+            if (usb_testutils_transfer_next_part(ctx, ep, transfer)) {
+              done = false;
+            } else {
+              res = kUsbTestutilsXfrResultFailed;
+            }
+          }
+          if (done) {
+            // Larger buffer transfer now completed; forget the buffer
+            transfer->buffer = NULL;
+          }
         }
+        // Notify that we've sent the single packet, or larger buffer transfer
+        // is now complete
+        if (done && ctx->in[ep].tx_done_callback) {
+          ctx->in[ep].tx_done_callback(ctx->in[ep].ep_ctx, res);
+        }
+        sentep &= ~(1u << ep);
       }
+      ep++;
     }
-
-    // Clear the interrupt sooner so that we can respond more promptly to
-    // subsequent transmitted packets
-    CHECK_DIF_OK(dif_usbdev_irq_acknowledge(ctx->dev, kDifUsbdevIrqPktSent));
-    istate &= ~(1u << kDifUsbdevIrqPktSent);
   }
 
   // Keep buffers available for packet reception
   CHECK_DIF_OK(dif_usbdev_fill_available_fifo(ctx->dev, ctx->buffer_pool));
 
   if (istate & (1u << kDifUsbdevIrqPktReceived)) {
+    // TODO: we run the risk of starving the IN side here if the rx_callback(s)
+    // are time-consuming
     while (true) {
       bool is_empty;
       CHECK_DIF_OK(dif_usbdev_status_get_rx_fifo_empty(ctx->dev, &is_empty));
@@ -103,6 +185,13 @@ void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
 
   // Clear the interrupts that we've received and handled
   CHECK_DIF_OK(dif_usbdev_irq_acknowledge_state(ctx->dev, istate));
+
+  // Record bus frame
+  if ((istate & (1u << kDifUsbdevIrqFrame))) {
+    // The first bus frame is 1
+    CHECK_DIF_OK(dif_usbdev_status_get_frame(ctx->dev, &ctx->frame));
+    ctx->got_frame = true;
+  }
 
   // Note: LinkInErr will be raised in response to a packet being NAKed by the
   // host which is not expected behavior on a physical USB but this is something
@@ -158,10 +247,38 @@ void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
   // TODO Errors? What Errors?
 }
 
-void usb_testutils_in_endpoint_setup(usb_testutils_ctx_t *ctx, uint8_t ep,
-                                     void *ep_ctx, void (*tx_done)(void *),
-                                     void (*flush)(void *),
-                                     void (*reset)(void *)) {
+bool usb_testutils_transfer_send(usb_testutils_ctx_t *ctx, uint8_t ep,
+                                 const uint8_t *data, uint32_t length,
+                                 usb_testutils_xfr_flags_t flags) {
+  CHECK(ep < USBDEV_NUM_ENDPOINTS);
+
+  usb_testutils_transfer_t *transfer = &ctx->in[ep].transfer;
+  if (transfer->buffer) {
+    // If there is an in-progress transfer, then we cannot accept another
+    return false;
+  }
+
+  // Describe this transfer
+  transfer->buffer = data;
+  transfer->offset = 0U;
+  transfer->length = length;
+  transfer->flags = flags;
+  transfer->next_valid = false;
+
+  if (!usb_testutils_transfer_next_part(ctx, ep, transfer)) {
+    // Forget about the attempted transfer
+    transfer->buffer = NULL;
+    return false;
+  }
+
+  // Buffer transfer is underway...
+  return true;
+}
+
+void usb_testutils_in_endpoint_setup(
+    usb_testutils_ctx_t *ctx, uint8_t ep, void *ep_ctx,
+    void (*tx_done)(void *, usb_testutils_xfr_result_t), void (*flush)(void *),
+    void (*reset)(void *)) {
   ctx->in[ep].ep_ctx = ep_ctx;
   ctx->in[ep].tx_done_callback = tx_done;
   ctx->in[ep].flush = flush;
@@ -217,7 +334,7 @@ void usb_testutils_out_endpoint_setup(
 void usb_testutils_endpoint_setup(
     usb_testutils_ctx_t *ctx, uint8_t ep,
     usb_testutils_out_transfer_mode_t out_mode, void *ep_ctx,
-    void (*tx_done)(void *),
+    void (*tx_done)(void *, usb_testutils_xfr_result_t),
     void (*rx)(void *, dif_usbdev_rx_packet_info_t, dif_usbdev_buffer_t),
     void (*flush)(void *), void (*reset)(void *)) {
   usb_testutils_in_endpoint_setup(ctx, ep, ep_ctx, tx_done, flush, reset);

--- a/sw/device/lib/testing/usb_testutils.h
+++ b/sw/device/lib/testing/usb_testutils.h
@@ -69,13 +69,6 @@ struct usb_testutils_ctx {
   } out[USBDEV_NUM_ENDPOINTS];
 };
 
-/**
- * Call regularly to poll the usbdev interface
- *
- * @param ctx usbdev context pointer
- */
-void usb_testutils_poll(usb_testutils_ctx_t *ctx);
-
 typedef enum usb_testutils_out_transfer_mode {
   /**
    * The endpoint does not support OUT transactions.
@@ -128,7 +121,7 @@ void usb_testutils_out_endpoint_setup(
     void (*reset)(void *));
 
 /**
- * Call to set up a pairt of IN and OUT endpoints.
+ * Call to set up a pair of IN and OUT endpoints.
  *
  * @param ctx usbdev context pointer
  * @param ep endpoint number
@@ -140,13 +133,37 @@ void usb_testutils_out_endpoint_setup(
  * @param flush(void *ep_ctx) called every 16ms based USB host timebase
  * @param reset(void *ep_ctx) called when an USB link reset is detected
  */
-void usb_testutils_endpoint_setup(usb_testutils_ctx_t *ctx, int ep,
+void usb_testutils_endpoint_setup(usb_testutils_ctx_t *ctx, uint8_t ep,
                                   usb_testutils_out_transfer_mode_t out_mode,
                                   void *ep_ctx, void (*tx_done)(void *),
                                   void (*rx)(void *,
                                              dif_usbdev_rx_packet_info_t,
                                              dif_usbdev_buffer_t),
                                   void (*flush)(void *), void (*reset)(void *));
+
+/**
+ * Remove an IN endpoint.
+ *
+ * @param ctx usbdev context pointer
+ * @param ep endpoint number
+ */
+void usb_testutils_in_endpoint_remove(usb_testutils_ctx_t *ctx, uint8_t ep);
+
+/**
+ * Remove an OUT endpoint.
+ *
+ * @param ctx usbdev context pointer
+ * @param ep endpoint number
+ */
+void usb_testutils_out_endpoint_remove(usb_testutils_ctx_t *ctx, uint8_t ep);
+
+/**
+ * Remove a pair of IN and OUT endpoints
+ *
+ * @param ctx usbdev context pointer
+ * @param ep endpoint number
+ */
+void usb_testutils_endpoint_remove(usb_testutils_ctx_t *ctx, uint8_t ep);
 
 /**
  * Returns an indication of whether an endpoint is currently halted because
@@ -175,5 +192,19 @@ inline bool usb_testutils_endpoint_halted(usb_testutils_ctx_t *ctx,
  */
 void usb_testutils_init(usb_testutils_ctx_t *ctx, bool pinflip,
                         bool en_diff_rcvr, bool tx_use_d_se0);
+
+/**
+ * Call regularly to poll the usbdev interface
+ *
+ * @param ctx usbdev context pointer
+ */
+void usb_testutils_poll(usb_testutils_ctx_t *ctx);
+
+/**
+ * Finalize the usbdev interface
+ *
+ * @param ctx initialized usbdev context pointer
+ */
+void usb_testutils_fin(usb_testutils_ctx_t *ctx);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_H_

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -36,13 +36,6 @@
 #define STREAMS_MAX 11U
 #endif
 
-// TODO - currently we are unable to send the configuration descriptor
-// if we try to describe more than two bidirectional endpoints
-#if STREAMS_MAX > 2U
-#undef STREAMS_MAX
-#define STREAMS_MAX 2U
-#endif
-
 // Number of streams to be tested
 #ifndef NUM_STREAMS
 #define NUM_STREAMS STREAMS_MAX
@@ -216,15 +209,14 @@ struct usbdev_stream_test_ctx {
 
 /**
  * Configuration values for USB.
- * TODO - dynamically construct a config descriptor appropriate to the test;
- *        this would avoid creating unusable ports on the host and also provide
- *        a little more testing
  */
 static const uint8_t config_descriptors[] = {
     USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN + STREAMS_MAX * (USB_INTERFACE_DSCR_LEN +
                                                         2 * USB_EP_DSCR_LEN),
                       STREAMS_MAX),
 
+    // Up to 11 interfaces and STREAMS_MAX in the descriptor head specifies how
+    // many of the interfaces will be declared to the host
     VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
     USB_BULK_EP_DSCR(0, 1U, USBDEV_MAX_PACKET_SIZE, 0),
     USB_BULK_EP_DSCR(1, 1U, USBDEV_MAX_PACKET_SIZE, 0),
@@ -232,6 +224,42 @@ static const uint8_t config_descriptors[] = {
     VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
     USB_BULK_EP_DSCR(0, 2U, USBDEV_MAX_PACKET_SIZE, 0),
     USB_BULK_EP_DSCR(1, 2U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(2, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 3U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 3U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(3, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 4U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 4U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(4, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 5U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 5U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(5, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 6U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 6U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(6, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 7U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 7U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(7, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 8U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 8U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(8, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 9U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 9U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(9, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 10U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 10U, USBDEV_MAX_PACKET_SIZE, 0),
+
+    VEND_INTERFACE_DSCR(10, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 11U, USBDEV_MAX_PACKET_SIZE, 0),
+    USB_BULK_EP_DSCR(1, 11U, USBDEV_MAX_PACKET_SIZE, 0),
 };
 
 /**
@@ -414,7 +442,7 @@ static void buffer_check(usbdev_stream_test_ctx_t *ctx, usbdev_stream_t *s,
 }
 
 // Callback for successful buffer transmission
-static void strm_tx_done(void *stream_v) {
+static void strm_tx_done(void *stream_v, usb_testutils_xfr_result_t result) {
   usbdev_stream_t *s = (usbdev_stream_t *)stream_v;
   usbdev_stream_test_ctx_t *ctx = s->ctx;
   usb_testutils_ctx_t *usbdev = ctx->usbdev;


### PR DESCRIPTION
Changes to usb_testutils to support further testing and porting of TinyUSB device stack

- Separation of IN and OUT endpoints, required for higher layers, including TinyUSB device stack; I suspect this was always intended but not previously implemented

- Endpoint removal and finalization, required for usbdev_pincfg_test and others; this is a t-l test that cycles the usbdev through each permutation of pins/bus configuration in turn, checking differential vs single-ended, swapped vs unswapped etc. It removes the endpoints, finalizes the usb_testutils layer/DIF and then resets the usbdev IP block before starting anew

- Support larger data stages; required for more complex configuration descriptors such as usbdev_stream_test when it is 
streaming to/from all endpoints concurrently.

- Introduce usb_testutils_buffer_send() which supports the sending of larger buffers, with usb_testutils splitting the data stage across multiple packets, optionally including support for Zero Length Packets when the host does not know in advance how much data shall be sent.

- _buffer_send() functionality also permits the use of double-buffering for increased IN throughput by removing the RAM->CPU->usbdev data transfer from the pkt_sent interrupt response time; with a second usbdev buffer already preloaded with data, it becomes possible to supply the new buffer much more promptly.

Measurements on CW310 FPGA with 10MHz Ibex yield around 550KiB/s sustained IN data rate to the host under ideal conditions (no other interrupt handlers/delays in responding to usbdev interrupt state register, no heavy CPU load required to generate the packet data; this is just streaming pre-existing data from SRAM). This is a little shy of double what's previously been attained without double-buffering, and estimates suggest that we're sending 8-9 packets of 64 bytes apiece per one millisecond bus frame, so although we're definitely not achieving back-to-back IN performance and are NAKing requests, the host controller (Lenovo laptop) must be retrying at least fairly keenly.
