### PR TITLE
[ci] Increase timeout for earlgrey verilator tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,7 +192,7 @@ jobs:
 - job: sw_build
   displayName: Earl Grey SW Build & Test
   # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
@@ -287,7 +287,7 @@ jobs:
   displayName: Fast Verilated Earl Grey tests
   # Build and run fast tests on sim_verilator
   pool: ci-public
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   dependsOn: lint
   steps:
   - template: ci/checkout-template.yml


### PR DESCRIPTION
The tests were already close to the limit before and are now timing out a lot more often. Add an extra hour to both jobs.