### PR TITLE
[hw,i2c] Add support for Xcelium

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -954,7 +954,7 @@ class i2c_base_vseq extends cip_base_vseq #(
         read_acq_fifo(0, acq_fifo_empty);
       end else begin
         for (int i = 0; i < NumI2cIntr; i++) begin
-          i2c_intr_e my_intr = i;
+          i2c_intr_e my_intr = i2c_intr_e'(i);
           if (!expected_intr.exists(my_intr)) begin
             if (cfg.intr_vif.pins[i] !== 0) begin
               `uvm_error("process_target_interrupts",

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -49,7 +49,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
       expected_intr[AcqFull] = 1;
       expected_intr[TxStretch] = 1;
       expected_intr[CmdComplete] = 1;
-      for (int i = 0; i < NumI2cIntr; i++) intr_q.push_back(i);
+      for (int i = 0; i < NumI2cIntr; i++) intr_q.push_back(i2c_intr_e'(i));
     end
     if (cfg.bad_addr_pct > 0) cfg.m_i2c_agent_cfg.allow_bad_addr = 1;
   endtask


### PR DESCRIPTION
Xcelium errors out in cases where enum variable is assigned with non-enum variable.
Add explicit cast to fix the issue in I2C sequences