### PR TITLE
[flash_ctrl] fix incorrect `IPoly` parameter in flash scrambler

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__flash.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__flash.sv
@@ -11,17 +11,11 @@ localparam int unsigned FlashKeySize = flash_phy_pkg::KeySize;
 localparam int unsigned FlashNumRoundsHalf = crypto_dpi_prince_pkg::NumRoundsHalf;
 localparam int unsigned FlashAddrWidth = 16;
 
-localparam bit[FlashDataWidth-1:0] IPoly = FlashDataWidth'(1'b1) << 15 |
-                                           FlashDataWidth'(1'b1) << 9  |
-                                           FlashDataWidth'(1'b1) << 7  |
-                                           FlashDataWidth'(1'b1) << 4  |
-                                           FlashDataWidth'(1'b1) << 3  |
-                                           FlashDataWidth'(1'b1) << 0;
-
 function bit [FlashDataWidth-1:0] flash_gf_mult2(bit [FlashDataWidth-1:0] operand);
   bit [FlashDataWidth-1:0] mult_out;
 
-  mult_out = operand[FlashDataWidth-1] ? (operand << 1) ^ IPoly : (operand << 1);
+  mult_out = operand[FlashDataWidth-1] ? (operand << 1) ^
+    flash_phy_pkg::ScrambleIPoly : (operand << 1);
   return mult_out;
 endfunction
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -346,17 +346,11 @@ package flash_ctrl_env_pkg;
   // remove bank select
   localparam int unsigned FlashByteAddrWidth = flash_ctrl_pkg::BusAddrByteW - 1;
 
-  localparam bit [FlashDataWidth-1:0] IPoly = FlashDataWidth'(1'b1) << 15 |
-                                      FlashDataWidth'(1'b1) << 9  |
-                                      FlashDataWidth'(1'b1) << 7  |
-                                      FlashDataWidth'(1'b1) << 4  |
-                                      FlashDataWidth'(1'b1) << 3  |
-                                      FlashDataWidth'(1'b1) << 0;
-
   function automatic bit [FlashDataWidth-1:0] flash_gf_mult2(bit [FlashDataWidth-1:0] operand);
     bit [FlashDataWidth-1:0]          mult_out;
 
-    mult_out = operand[FlashDataWidth-1] ? (operand << 1) ^ IPoly : (operand << 1);
+    mult_out = operand[FlashDataWidth-1] ? (operand << 1) ^
+      flash_phy_pkg::ScrambleIPoly : (operand << 1);
     return mult_out;
   endfunction
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -52,6 +52,17 @@ package flash_phy_pkg;
   // If this value is greater than 1, constraints must be updated for multicycle paths
   parameter int unsigned CipherCycles  = 2;
 
+  // GF(2) irreducible polynomial for flash XEX scrambling scheme.
+  // We use the NIST 800-38B recommendation for block cipher modes of operation.
+  // See Section "5.3 Subkeys" on page 6:
+  // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38B.pdf
+  // Specifically, we use the polynomial: x^64 + x^4 + x^3 + x + 1. Note, the
+  // MSB get clipped off below.
+  parameter bit[DataWidth-1:0] ScrambleIPoly = DataWidth'(1'b1) << 4 |
+                                               DataWidth'(1'b1) << 3 |
+                                               DataWidth'(1'b1) << 1 |
+                                               DataWidth'(1'b1) << 0;
+
   // Read buffer metadata
   typedef enum logic [1:0] {
     Invalid     = 2'h0,

--- a/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
@@ -53,10 +53,12 @@ module flash_phy_scramble import flash_phy_pkg::*; #(
   assign unused_key = muxed_addr_key[KeySize-1 -: UnusedWidth];
 
   // Galois Multiply portion
+  // Note: Degree of IPoly and width parameters must match (leading MSB of IPoly is dropped).
   if (SecScrambleEn) begin : gen_gf_mult
     prim_gf_mult # (
       .Width(DataWidth),
-      .StagesPerCycle(DataWidth / GfMultCycles)
+      .StagesPerCycle(DataWidth / GfMultCycles),
+      .IPoly(ScrambleIPoly)
     ) u_mult (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
While working on #9322, I noticed the degree of the GF(2) irreducible polynomial used for the flash scrambling scheme was incorrect. It did not match the flash data word width, which is another parameter of the `prim_gf_mult` module.

Since the flash data width is 64, I believe the degree of the irreducible polynomial should also be 64. This updates the `IPoly` parameter of the `prim_gf_mult` module to use the Conway polynomial with degree 64, listed here:
http://www.math.rwth-aachen.de/~Frank.Luebeck/data/ConwayPol/CP2.html

Once updating this, I was able to compute the scrambling XEX mask using GF(2^64) multiplication in the [`galois`](https://galois.readthedocs.io/en/v0.0.21/index.html) Python package to confirm the HW GF(2^64) multiplication implementation is correct.