### PR TITLE
[dv/otp] Change the order of cfg files

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -66,7 +66,7 @@
   overrides: [
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg+{dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cover.cfg"
     }
   ]
 


### PR DESCRIPTION
Looks like the order of the CFG coverage configureation files affect the coverage results.
The customized otp_ctrl_cover.cfg needs to be at the end.