### PR TITLE
[dv/cip] Fix csr_rw corner cases

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -506,9 +506,12 @@ class cip_base_vseq #(
       int check_cycles = $urandom_range(max_alert_handshake_cycles,
                                         max_alert_handshake_cycles * 3);
 
-      // This task allows recoverable alerts to fire, or fatal alert being triggered once by
-      // `alert_test` register.
+      // This task wait for recoverable alerts handshake to complete, or fatal alert being
+      // triggered once by `alert_test` register.
       cfg.clk_rst_vif.wait_clks(max_alert_handshake_cycles);
+      foreach (cfg.m_alert_agent_cfgs[alert_name]) begin
+        `DV_SPINWAIT(cfg.m_alert_agent_cfgs[alert_name].vif.wait_ack_complete();)
+      end
 
       repeat(check_cycles) begin
         cfg.clk_rst_vif.wait_clks(1);


### PR DESCRIPTION
Due to the async clock config, alert receiver and sender domain can have different clock frequencies.
The cip_base_vseq intend to check there is no fatal alert at the end of the simulation, and allow recoverable alert to fire due to alert_test reg.
The current wait cycles method does not handle the different clock domain very well. This new method will just wait until the first alert handshake is done.