### PR TITLE
[util] refactor flash image pre-processing script to enable scrambling

### DIFF
--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -33,6 +33,7 @@ py_binary(
     srcs = ["scramble_image.py"],
     deps = [
         ":mem",
+        "//util/design:prince",
         "//util/design:secded_gen",
         requirement("hjson"),
         requirement("pycryptodome"),

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -17,6 +17,9 @@ pyyaml==6.0
 tabulate==0.8.10
 typer==0.6.1
 
+# Dependencies: gen-flash-img.py
+pyfinite==1.9.1
+
 # Dependencies: dv_sim
 enlighten==1.10.2
 mistletoe==0.9.0

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -453,7 +453,9 @@ def _scramble_flash_vmem_impl(ctx):
             ctx.executable._tool,
         ],
         arguments = [
+            "--infile",
             ctx.file.vmem.path,
+            "--outfile",
             scrambled_vmem.path,
         ],
         executable = ctx.executable._tool,

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -8,6 +8,11 @@ load("@rules_python//python:defs.bzl", "py_binary")
 package(default_visibility = ["//visibility:public"])
 
 py_library(
+    name = "prince",
+    srcs = ["prince.py"],
+)
+
+py_library(
     name = "secded_gen",
     srcs = ["secded_gen.py"],
     data = ["//util/design/data:secded_cfg.hjson"],

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -22,7 +22,10 @@ py_library(
 py_binary(
     name = "gen-flash-img",
     srcs = ["gen-flash-img.py"],
-    deps = [":secded_gen"],
+    deps = [
+        ":secded_gen",
+        requirement("pyfinite"),
+    ],
 )
 
 py_binary(

--- a/util/design/gen-flash-img.py
+++ b/util/design/gen-flash-img.py
@@ -2,79 +2,133 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-r"""Takes a compiled vmem image and processes it for flash.
-    Long term this should include both layers of ECC and scrambling,
-    The first version has only the truncated plaintext ECC.
+r"""Takes a compiled VMEM image and processes it for loading into flash.
+
+    Specifically, this takes a raw flash image and adds both layers of ECC
+    (integrity and reliablity), and optionally, scrambles the data using the
+    same XEX scrambling scheme used in the flash controller. This enables
+    backdoor loading the flash on simulation platforms (e.g., DV and Verilator).
 """
 
 import argparse
-import math
+import functools
+import logging
 import re
+import sys
 from pathlib import Path
-from typing import Dict, Any
+from typing import List
 
+from pyfinite import ffield
+
+import prince
 import secded_gen
 
+FLASH_WORD_SIZE = 64  # bits
+FLASH_ADDR_SIZE = 16  # bits
+FLASH_INTEGRITY_ECC_SIZE = 4  # bits
+FLASH_RELIABILITY_ECC_SIZE = 8  # bits
+GF_OPERAND_B_MASK = (2**FLASH_WORD_SIZE) - 1
+GF_OPERAND_A_MASK = (GF_OPERAND_B_MASK &
+                     ~(0xffff <<
+                       (FLASH_WORD_SIZE - FLASH_ADDR_SIZE))) << FLASH_WORD_SIZE
+PRINCE_NUM_HALF_ROUNDS = 5
 
-def _add_intg_ecc(config: Dict[str, Any], in_val: int) -> str:
-    result, m = secded_gen.ecc_encode(config, "hamming", 64, in_val)
-
-    m_nibbles = math.ceil(m / 4)
-    result = format(result, '0' + str(16 + m_nibbles) + 'x')
-
-    # due to lack of storage space, the first nibble of the ECC is truncated
-    return result[1:]
-
-
-def _add_reliability_ecc(config: Dict[str, Any], in_val: int) -> str:
-    result, m = secded_gen.ecc_encode(config, "hamming", 68, in_val)
-
-    m_nibbles = math.ceil((68 + m) / 4)
-    result = format(result, '0' + str(m_nibbles) + 'x')
-
-    # return full result
-    return result
+# Create GF(2^64) with irreducible_polynomial = x^64 + x^4 + x^3 + x + 1
+GF_2_64 = ffield.FField(64,
+                        gen=((0x1 << 64) | (0x1 << 4) | (0x1 << 3) |
+                             (0x1 << 1) | 0x1))
 
 
-def main():
+@functools.lru_cache(maxsize=None)
+def _xex_scramble(data: int, word_addr: int, flash_addr_key: int,
+                  flash_data_key: int) -> int:
+    operand_a = ((flash_addr_key & GF_OPERAND_A_MASK) >>
+                 (FLASH_WORD_SIZE - FLASH_ADDR_SIZE)) | word_addr
+    operand_b = flash_addr_key & GF_OPERAND_B_MASK
+    mask = GF_2_64.Multiply(operand_a, operand_b)
+    masked_data = data ^ mask
+    return prince.prince(masked_data, flash_data_key,
+                         PRINCE_NUM_HALF_ROUNDS) ^ mask
+
+
+def main(argv: List[str]):
+    # Parse command line args.
     parser = argparse.ArgumentParser()
-    parser.add_argument('infile')
-    parser.add_argument('outfile')
-    args = parser.parse_args()
+    parser.add_argument("--infile",
+                        "-i",
+                        type=str,
+                        help="Input VMEM file to reformat.")
+    parser.add_argument("--outfile", "-o", type=str, help="Output VMEM file.")
+    parser.add_argument("--scramble",
+                        "-s",
+                        action="store_true",
+                        help="Whether to scramble data or not.")
+    parser.add_argument("--address-key",
+                        type=str,
+                        help="Flash address scrambling key.")
+    parser.add_argument("--data-key",
+                        type=str,
+                        help="Flash address scrambling key.")
+    args = parser.parse_args(argv)
 
-    # open original vmem and extract relevant content
+    # Validate command line args.
+    if args.scramble:
+        if args.address_key is None or args.data_key is None:
+            logging.error(
+                "Address and data keys must be provided when scrambling is"
+                "requested.")
+
+    # Open original VMEM for processing.
     try:
-        vmem_orig = Path(args.infile).read_text()
+        orig_vmem = Path(args.infile).read_text()
     except IOError:
         raise Exception(f"Unable to open {args.infile}")
 
-    # search only for lines that contain data, skip all other comments
-    result = re.findall(r"^@.*$", vmem_orig, flags=re.MULTILINE)
+    # Search for lines that contain data, skipping other comment lines.
+    orig_vmem_lines = re.findall(r"^@.*$", orig_vmem, flags=re.MULTILINE)
 
+    # Load project SECDED configuration.
     config = secded_gen.load_secded_config()
 
-    output = []
-    for line in result:
-        items = line.split()
-        result = ""
-        for item in items:
+    reformatted_vmem_lines = []
+    for line in orig_vmem_lines:
+        line_items = line.split()
+        reformatted_line = ""
+        address = None
+        data = None
+        for item in line_items:
+            # Process the address first.
             if re.match(r"^@", item):
-                result += item
+                reformatted_line += item
+                address = int(item.lstrip("@"), 16)
+            # Process the data words.
             else:
-                data_w_intg_ecc = _add_intg_ecc(config, int(item, 16))
-                full_ecc = _add_reliability_ecc(config, int(data_w_intg_ecc, 16))
-                result += f' {full_ecc}'
+                data = int(item, 16)
+                # `data_w_intg_ecc` will be in format {ECC bits, data bits}.
+                data_w_intg_ecc, _ = secded_gen.ecc_encode(
+                    config, "hamming", FLASH_WORD_SIZE, data)
+                # Due to storage constraints the first nibble of ECC is dropped.
+                data_w_intg_ecc &= 0xFFFFFFFFFFFFFFFFF
+                if args.scramble:
+                    intg_ecc = data_w_intg_ecc & (0xF << FLASH_WORD_SIZE)
+                    data = _xex_scramble(data, address, args.flash_addr_key,
+                                         args.flash_data_key)
+                    data_w_intg_ecc = intg_ecc | data
+                # `data_w_full_ecc` will be in format {reliablity ECC bits,
+                # integrity ECC bits, data bits}.
+                data_w_full_ecc, _ = secded_gen.ecc_encode(
+                    config, "hamming",
+                    FLASH_WORD_SIZE + FLASH_INTEGRITY_ECC_SIZE,
+                    data_w_intg_ecc)
+                reformatted_line += f" {data_w_full_ecc:x}"
 
-        # add processed element to output
-        output.append(result)
+        # Append reformatted line to what will be the new output VMEM file.
+        reformatted_vmem_lines.append(reformatted_line)
 
-    # open output file
-    outfile = open(args.outfile, "w")
-
-    # write processed content
-    for entry in output:
-        outfile.write(entry + "\n")
+    # Write re-formatted output file.
+    with open(args.outfile, "w") as of:
+        of.writelines(reformatted_vmem_lines)
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/util/design/prince.py
+++ b/util/design/prince.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+'''Implementation of PRINCE cipher for use in ROM/FLASH scrambling scripts.'''
+
+from typing import List
+
+PRINCE_SBOX4 = [
+    0xb, 0xf, 0x3, 0x2,
+    0xa, 0xc, 0x9, 0x1,
+    0x6, 0x7, 0x8, 0x0,
+    0xe, 0x5, 0xd, 0x4
+]
+
+PRINCE_SBOX4_INV = [
+    0xb, 0x7, 0x3, 0x2,
+    0xf, 0xd, 0x8, 0x9,
+    0xa, 0x6, 0x4, 0x0,
+    0x5, 0xe, 0xc, 0x1
+]
+
+PRINCE_SHIFT_ROWS64 = [
+    0x4, 0x9, 0xe, 0x3,
+    0x8, 0xd, 0x2, 0x7,
+    0xc, 0x1, 0x6, 0xb,
+    0x0, 0x5, 0xa, 0xf
+]
+
+PRINCE_SHIFT_ROWS64_INV = [
+    0xc, 0x9, 0x6, 0x3,
+    0x0, 0xd, 0xa, 0x7,
+    0x4, 0x1, 0xe, 0xb,
+    0x8, 0x5, 0x2, 0xf
+]
+
+PRINCE_ROUND_CONSTS = [
+    0x0000000000000000,
+    0x13198a2e03707344,
+    0xa4093822299f31d0,
+    0x082efa98ec4e6c89,
+    0x452821e638d01377,
+    0xbe5466cf34e90c6c,
+    0x7ef84f78fd955cb1,
+    0x85840851f1ac43aa,
+    0xc882d32f25323c54,
+    0x64a51195e0e3610d,
+    0xd3b5a399ca0c2399,
+    0xc0ac29b7c97c50dd
+]
+
+PRINCE_SHIFT_ROWS_CONSTS = [0x7bde, 0xbde7, 0xde7b, 0xe7bd]
+
+
+def sbox(data: int, width: int, coeffs: List[int]) -> int:
+    assert 0 <= width
+    assert 0 <= data < (1 << width)
+
+    full_mask = (1 << width) - 1
+    sbox_mask = (1 << (4 * (width // 4))) - 1
+
+    ret = data & (full_mask & ~sbox_mask)
+    for i in range(width // 4):
+        nibble = (data >> (4 * i)) & 0xf
+        sb_nibble = coeffs[nibble]
+        ret |= sb_nibble << (4 * i)
+
+    return ret
+
+
+def prince_nibble_red16(data: int) -> int:
+    assert 0 <= data < (1 << 16)
+    nib0 = (data >> 0) & 0xf
+    nib1 = (data >> 4) & 0xf
+    nib2 = (data >> 8) & 0xf
+    nib3 = (data >> 12) & 0xf
+    return nib0 ^ nib1 ^ nib2 ^ nib3
+
+
+def prince_mult_prime(data: int) -> int:
+    assert 0 <= data < (1 << 64)
+    ret = 0
+    for blk_idx in range(4):
+        data_hw = (data >> (16 * blk_idx)) & 0xffff
+        start_sr_idx = 0 if blk_idx in [0, 3] else 1
+        for nibble_idx in range(4):
+            sr_idx = (start_sr_idx + 3 - nibble_idx) % 4
+            sr_const = PRINCE_SHIFT_ROWS_CONSTS[sr_idx]
+            nibble = prince_nibble_red16(data_hw & sr_const)
+            ret |= nibble << (16 * blk_idx + 4 * nibble_idx)
+    return ret
+
+
+def prince_shiftrows(data: int, inv: bool) -> int:
+    assert 0 <= data < (1 << 64)
+    shifts = PRINCE_SHIFT_ROWS64_INV if inv else PRINCE_SHIFT_ROWS64
+
+    ret = 0
+    for nibble_idx in range(64 // 4):
+        src_nibble_idx = shifts[nibble_idx]
+        src_nibble = (data >> (4 * src_nibble_idx)) & 0xf
+        ret |= src_nibble << (4 * nibble_idx)
+    return ret
+
+
+def prince_fwd_round(rc: int, key: int, data: int) -> int:
+    assert 0 <= rc < (1 << 64)
+    assert 0 <= key < (1 << 64)
+    assert 0 <= data < (1 << 64)
+
+    data = sbox(data, 64, PRINCE_SBOX4)
+    data = prince_mult_prime(data)
+    data = prince_shiftrows(data, False)
+    data ^= rc
+    data ^= key
+    return data
+
+
+def prince_inv_round(rc: int, key: int, data: int) -> int:
+    assert 0 <= rc < (1 << 64)
+    assert 0 <= key < (1 << 64)
+    assert 0 <= data < (1 << 64)
+
+    data ^= key
+    data ^= rc
+    data = prince_shiftrows(data, True)
+    data = prince_mult_prime(data)
+    data = sbox(data, 64, PRINCE_SBOX4_INV)
+    return data
+
+
+def prince(data: int, key: int, num_rounds_half: int) -> int:
+    '''Run the PRINCE cipher
+
+    This uses the new keyschedule proposed by Dinur in "Cryptanalytic
+    Time-Memory-Data Tradeoffs for FX-Constructions with Applications to PRINCE
+    and PRIDE".
+
+    '''
+    assert 0 <= data < (1 << 64)
+    assert 0 <= key < (1 << 128)
+    assert 0 <= num_rounds_half <= 5
+
+    k1 = key & ((1 << 64) - 1)
+    k0 = key >> 64
+
+    k0_rot1 = ((k0 & 1) << 63) | (k0 >> 1)
+    k0_prime = k0_rot1 ^ (k0 >> 63)
+
+    data ^= k0
+    data ^= k1
+    data ^= PRINCE_ROUND_CONSTS[0]
+
+    for hri in range(num_rounds_half):
+        round_idx = 1 + hri
+        rc = PRINCE_ROUND_CONSTS[round_idx]
+        rk = k0 if round_idx & 1 else k1
+        data = prince_fwd_round(rc, rk, data)
+
+    data = sbox(data, 64, PRINCE_SBOX4)
+    data = prince_mult_prime(data)
+    data = sbox(data, 64, PRINCE_SBOX4_INV)
+
+    for hri in range(num_rounds_half):
+        round_idx = 11 - num_rounds_half + hri
+        rc = PRINCE_ROUND_CONSTS[round_idx]
+        rk = k1 if round_idx & 1 else k0
+        data = prince_inv_round(rc, rk, data)
+
+    data ^= PRINCE_ROUND_CONSTS[11]
+    data ^= k1
+
+    data ^= k0_prime
+
+    return data


### PR DESCRIPTION
This PR contains several commits that refactors the `gen-flash-img.py` script to enabling pre-scrambling flash images for backdoor loading in DV. This is needed to run top-level tests that enable flash scrambling in the ROM.

This partially addresses #9322.

Note, this does not yet wire up the `gen-flash-img.py` script to use the new scrambling feature, that will come in a follow on PR that will pass the flash scrambling seeds that are generated by the OTP image generation script to this script.

Also note: this required adding the `pyfinite` python module to the list of required modules.