### PR TITLE
[doc] Add markdown renderer for reggen

### DIFF
--- a/util/mdbook_reggen.py
+++ b/util/mdbook_reggen.py
@@ -17,8 +17,8 @@ from typing import List
 
 from mdbook import utils as md_utils
 from reggen.ip_block import IpBlock
-import reggen.gen_cfg_html as gen_cfg_html
-import reggen.gen_html as gen_html
+import reggen.gen_cfg_md as gen_cfg_md
+import reggen.gen_md as gen_md
 
 REGREF_PATTERN = re.compile(r"\{\{#regref\s+?(.+?)\s*?\}\}")
 
@@ -31,13 +31,13 @@ def main() -> None:
     book_root = context["root"]
 
     try:
-        ip_cfg_str = context["config"]["preprocessor"]["reggen"]["ip-cfg-py-regex"]
+        ip_cfg_str = context["config"]["preprocessor"]["reggen"][
+            "ip-cfg-py-regex"]
         ip_cfg_pattern = re.compile(ip_cfg_str)
     except KeyError:
         sys.exit(
             "No RegEx pattern given in book.toml to identify ip block configuration files.\n"
-            "Provide regex as preprocessor.reggen.ip-cfg-py-regex .",
-        )
+            "Provide regex as preprocessor.reggen.ip-cfg-py-regex .", )
 
     cfg_files: List[Path] = []
     for chapter in md_utils.chapters(book["sections"]):
@@ -46,16 +46,14 @@ def main() -> None:
             continue
 
         block = IpBlock.from_text(
-            chapter["content"],
-            [],
-            "file at {}/{}".format(context["root"], chapter["source_path"])
-        )
+            chapter["content"], [],
+            "file at {}/{}".format(context["root"], chapter["source_path"]))
         buffer = io.StringIO()
         buffer.write("# Hardware Interfaces and Registers\n")
         buffer.write("## Interfaces\n")
-        gen_cfg_html.gen_cfg_html(block, buffer)
+        gen_cfg_md.gen_cfg_md(block, buffer)
         buffer.write("\n## Registers\n")
-        gen_html.gen_html(block, buffer)
+        gen_md.gen_md(block, buffer)
         chapter["content"] = buffer.getvalue()
 
         cfg_files.append(Path(src_path))

--- a/util/reggen/gen_cfg_md.py
+++ b/util/reggen/gen_cfg_md.py
@@ -1,0 +1,126 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Generate Markdown documentation from Block
+"""
+
+from typing import TextIO
+
+from reggen.ip_block import IpBlock
+from reggen.md_helpers import url, italic, coderef, render_td, name_width, table
+
+
+def genout(outfile: TextIO, msg: str) -> None:
+    outfile.write(msg)
+
+def gen_kv(outfile: TextIO, key: str, value: str) -> None:
+    genout(outfile, f'- {italic(key)}: {value}\n')
+
+def gen_cfg_md(cfgs: IpBlock, outfile: TextIO) -> None:
+    rnames = cfgs.get_rnames()
+
+    ot_server = 'https://docs.opentitan.org'
+    comport_url = ot_server + '/doc/rm/comportability_specification'
+    comport_url = url("Comportable guideline for peripheral device functionality", comport_url)
+    genout(outfile,
+           f'Referring to the {comport_url}, the module '
+           f'{coderef(cfgs.name)} has the following hardware '
+           'interfaces defined\n')
+
+    # clocks
+    gen_kv(outfile,
+           'Primary Clock',
+           coderef(cfgs.clocking.primary.clock))
+    other_clocks = cfgs.clocking.other_clocks()
+    if other_clocks:
+        other_clocks_str = [coderef(clk) for clk in other_clocks]
+        gen_kv(outfile, 'Other Clocks', ', '.join(other_clocks_str))
+    else:
+        gen_kv(outfile, 'Other Clocks', italic("none"))
+
+    # bus interfaces
+    dev_ports = [coderef(port) for port in cfgs.bus_interfaces.get_port_names(False, True)]
+    assert dev_ports
+    gen_kv(outfile, 'Bus Device Interfaces (TL-UL)', ', '.join(dev_ports))
+
+    host_ports = [coderef(port) for port in cfgs.bus_interfaces.get_port_names(True, False)]
+    if host_ports:
+        gen_kv(outfile, 'Bus Host Interfaces (TL-UL)', ', '.join(host_ports))
+    else:
+        gen_kv(outfile, 'Bus Host Interfaces (TL-UL)', italic("none"))
+
+    # IO
+    ios = ([('input', x) for x in cfgs.xputs[1]] +
+           [('output', x) for x in cfgs.xputs[2]] +
+           [('inout', x) for x in cfgs.xputs[0]])
+    if ios:
+        gen_kv(outfile, "Peripheral Pins for Chip IO", "")
+        header = ["Pin name", "Direction", "Description"]
+        rows = []
+        for direction, x in ios:
+            rows.append([name_width(x), direction, render_td(x.desc, rnames)])
+        genout(outfile, "\n")
+        genout(outfile, table(header, rows))
+        genout(outfile, "\n")
+    else:
+        gen_kv(outfile, "Peripheral Pins for Chip IO", italic("none"))
+
+    # Inter-Module Signals
+    if not cfgs.inter_signals:
+        gen_kv(outfile, "Inter-Module Signals", italic("none"))
+    else:
+        gen_kv(outfile, "Inter-Module Signals",
+               url("Reference", "/doc/rm/comportability_specification/#inter-signal-handling"))
+        header = ["Port Name", "Package::Struct", "Type", "Act", "Width", "Description"]
+        rows = []
+        for ims in cfgs.inter_signals:
+            name = ims.name
+            pkg_struct = ims.package + "::" + ims.struct if ims.package is not None else ims.struct
+            sig_type = ims.signal_type
+            act = ims.act
+            width = str(ims.width) if ims.width is not None else "1"
+            desc = ims.desc if ims.desc is not None else ""
+            rows.append([name, pkg_struct, sig_type, act, width, desc])
+        genout(outfile, "\n")
+        genout(outfile, table(header, rows))
+        genout(outfile, "\n")
+
+    # Interrupts
+    if not cfgs.interrupts:
+        gen_kv(outfile, "Interrupts", italic("none"))
+    else:
+        gen_kv(outfile, "Interrupts", "")
+        header = ["Interrupt Name", "Type", "Description"]
+        rows = []
+        for x in cfgs.interrupts:
+            rows.append([name_width(x), x.intr_type.name, render_td(x.desc, rnames)])
+        genout(outfile, "\n")
+        genout(outfile, table(header, rows))
+        genout(outfile, "\n")
+
+    # Alerts
+    if not cfgs.alerts:
+        gen_kv(outfile, "Security Alerts", italic("none"))
+    else:
+        gen_kv(outfile, "Security Alerts", "")
+        header = ["Alert Name", "Description"]
+        rows = []
+        for x in cfgs.alerts:
+            rows.append([x.name, render_td(x.desc, rnames)])
+        genout(outfile, "\n")
+        genout(outfile, table(header, rows))
+        genout(outfile, "\n")
+
+    # countermeasures
+    if not cfgs.countermeasures:
+        gen_kv(outfile, "Security Countermeasures", italic("none"))
+    else:
+        gen_kv(outfile, "Security Countermeasures", "")
+        header = ["Countermeasure ID", "Description"]
+        rows = []
+        for cm in cfgs.countermeasures:
+            rows.append([cfgs.name.upper() + '.' + str(cm), render_td(cm.desc, rnames)])
+        genout(outfile, "\n")
+        genout(outfile, table(header, rows))
+        genout(outfile, "\n")

--- a/util/reggen/gen_md.py
+++ b/util/reggen/gen_md.py
@@ -1,0 +1,340 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Generate Markdown documentation from IpBlock
+"""
+
+from typing import List, Optional, Set, TextIO, Union
+
+import mistletoe as mk
+from reggen.ip_block import IpBlock
+from reggen.md_helpers import (bold, coderef, expand_paras, get_reg_link,
+                               italic, md_safe_for_table, render_td, table,
+                               title, url, wavejson)
+from reggen.multi_register import MultiRegister
+from reggen.reg_block import RegBlock
+from reggen.register import Register
+from reggen.window import Window
+
+
+def genout(outfile: TextIO, msg: str) -> None:
+    outfile.write(msg)
+
+def gen_md_reg_picture(outfile: TextIO, reg: Register, width: int) -> str:
+    # We use WaveDrom to generate the register since we already have a wavejson preprocessor,
+    # we just output a wavejson block
+    # bit-field is great but has some flaws that make it hard to draw nice
+    # picture. Notably, it does not automatically rotate fields that don't fit
+    # or increase the vertical space if necessary.
+    # As the result, the following code makes some assumptions to decide when to rotate and
+    # to compute the vertical space. Furthermore, we do not know the horizontal size so
+    # we have to fix it, which mean that the final result might be rescaled on the page
+    hspace = 640
+    vspace = 80
+    fontsize = 14
+    lanes = 1
+    margin = 10  # margin around text
+    # estimated size that a character takes
+    font_adv = 16
+    # size of each bit in the picture
+    bit_width = hspace * lanes / width
+
+    fields = []
+    next_bit = 0
+    for field in reg.fields:
+        fieldlsb = field.bits.lsb
+        # add an empty field if necessary
+        if fieldlsb > next_bit:
+            fields.append({"bits": fieldlsb - next_bit})
+        # we need to decide whether to rotate or not
+        # compute the size needed to draw
+        need_space = font_adv * len(field.name) + 2 * margin
+        # if this too large horizontally, rotate
+        # FIXME this does not account for splitting accross lanes
+        rotate = 0
+        if need_space > bit_width * field.bits.width():
+            rotate = -90
+            # increase vertical space if needed
+            vspace = max(vspace, need_space)
+
+        fields.append({
+            "name": field.name,
+            "bits": field.bits.width(),
+            "attr": [field.swaccess.key],
+            "rotate": rotate
+        })
+        next_bit = field.bits.msb + 1
+    # add an empty field if necessary
+    if width > next_bit:
+        fields.append({"bits": width - next_bit})
+    # wavedrom configuration, see https://github.com/wavedrom/bitfield
+    config = {"lanes": lanes, "fontsize": fontsize, "vspace": vspace}
+    genout(outfile, wavejson({"reg": fields, "config": config}))
+
+
+# Generation of markdown table with header, register picture and details
+def gen_kv(outfile: TextIO, key: str, value: str) -> None:
+    genout(outfile, f'- {key}: {value}\n')
+
+
+def gen_md_register_summary(outfile: TextIO, obj_list: List[Union[Window,
+                                                                  Register]],
+                            comp: str, width: int, rnames: Set[str]) -> None:
+
+    bytew = width // 8
+    genout(outfile, title("Summary", 4))
+
+    header = ["Name", "Offset", "Length", "Description"]
+    rows = []
+
+    for obj in obj_list:
+        obj_length = bytew if isinstance(obj, Register) else bytew * obj.items
+        desc_paras = expand_paras(obj.desc, rnames)
+        obj_desc = desc_paras[0]
+        rows.append([
+            f"{comp}.{get_reg_link(obj.name)}", f"{obj.offset:#x}",
+            f"{obj_length}", f"{obj_desc}"
+        ])
+
+    genout(outfile, table(header, rows))
+
+
+def gen_md_register(outfile: TextIO, reg: Register, comp: str, width: int,
+                    rnames: Set[str]) -> None:
+    rname = reg.name
+    desc_paras = expand_paras(reg.desc, rnames)
+    desc_head = desc_paras[0]
+    desc_body = desc_paras[1:]
+
+    genout(outfile, title(rname, 4))
+    genout(outfile, desc_head)
+    genout(outfile, "\n")
+    header = ["Offset", "Reset default", "Reset mask"]
+    row = [f"{reg.offset:#x}", f"{reg.resval:#x}", f"{reg.resmask:#x}"]
+    colalign = ["center", "center", "center"]
+    if reg.regwen is not None:
+        header.append("Register enable")
+        row.append(f"{get_reg_link(reg.regwen)}")
+        colalign.append("center")
+    genout(outfile, table(header, [row], colalign))
+    genout(outfile, "\n")
+    for p in desc_body:
+        genout(outfile, p)
+        genout(outfile, "\n")
+    # generate bit-field pictur
+    gen_md_reg_picture(outfile, reg, width)
+
+    # If this is the first register of a multireg,
+    # we also insert a label without the index so
+    # that unnumbered links from the register table
+    # descriptions and Hugo-generated docs are possible.
+    # FIXME TODO insert anchor for first register, mdbook might super this in the future
+    # https://github.com/rust-lang/mdBook/pull/2013
+    # if rname[-2:] == "0":
+    #     mr_anchor = ('id="{}"'
+    #                  .format(rname[:-2].lower()))
+    # else:
+    #     mr_anchor = ''
+    #
+    # # FIXME TODO generate register fields "overview" in Markdown
+
+    # table with fields
+    header = ["Bits", "Type", "Reset", "Name", "Description"]
+    colalign = ["center", "center", "center", "left", "left"]
+    rows = []
+    nextbit = width-1
+    fcount = 0
+
+    def maybe_add_reversed(msb):
+        nonlocal nextbit
+        nonlocal rows
+        # insert a row for reserved bits if any
+        if nextbit > msb:
+            tmp_row = []
+            if (nextbit == msb + 1):
+                tmp_row.append(str(nextbit))
+            else:
+                tmp_row.append(str(nextbit) + ":" + str(msb + 1))
+            tmp_row.extend(["", "", "", "Reserved"])
+            rows.append(tmp_row)
+            nextbit = msb
+
+    for field in reversed(reg.fields):
+        row = []
+        fcount += 1
+        fname = field.name
+
+        # insert a row for reserved bits if any
+        maybe_add_reversed(field.bits.msb)
+
+        row.append(field.bits.as_str())
+        row.append(field.swaccess.key)
+        row.append('x' if field.resval is None else hex(field.resval))
+        row.append(fname)
+
+        # Collect up any description and enum table
+        desc_parts = []
+
+        if field.desc is not None:
+            desc_parts += expand_paras(field.desc, rnames)
+
+        if field.enum is not None:
+            hex_width = 2 + ((field.bits.width() + 3) // 4)
+            for enum in field.enum:
+                enum_desc_paras = expand_paras(enum.desc, rnames)
+                # if there are several paragraph, we join them together in one
+                # many descriptions start by giving the value again which is redundant, ie
+                #  6’b00_0001: Electronic Codebook (ECB) mode.
+                # so we remove it
+                if enum_desc_paras[0].startswith(f"{field.bits.width()}'b"):
+                    idx = enum_desc_paras[0].find(':')
+                    if idx is not None:
+                        enum_desc_paras[0] = enum_desc_paras[0][idx + 1:]
+                desc_parts.append(
+                    coderef(f" {enum.value:#0{hex_width}x} = {enum.name}") +
+                    ": " + " ".join(enum_desc_paras))
+            if field.has_incomplete_enum():
+                desc_parts.append(coderef("Other values are reserved."))
+
+        row.append(md_safe_for_table(desc_parts))
+        rows.append(row)
+        nextbit = field.bits.lsb - 1
+    # insert a row for reserved bits if any
+    maybe_add_reversed(0)
+
+    genout(outfile, table(header, rows, colalign))
+
+
+def gen_window_row(outfile: TextIO, base_addr: int, validbits: int,
+                   regwidth: int, idx: Optional[int]) -> None:
+    '''Generate a row for a window
+
+    If idx is None, this is a row that shows we're skipping some addresses and
+    has a "...". If idx is not None, this gives an address and we show the bits
+    that are valid.
+    '''
+    assert 0 < validbits
+    assert 0 < regwidth
+    assert regwidth % 8 == 0
+    assert validbits <= regwidth
+
+    if idx is not None:
+        assert idx >= 0
+        addr = base_addr + idx * (regwidth // 8)
+        addr_td = f'<td class="regbits">+{addr:#x}</td>'
+        if validbits < regwidth:
+            pad = regwidth - validbits
+            unused_tds = f'<td class="unused" colspan="{pad}">&nbsp;</td>'
+        else:
+            unused_tds = ''
+        data_tds = f'<td class="fname" colspan="{validbits}">&nbsp;</td>'
+        tds = addr_td + unused_tds + data_tds
+    else:
+        tds = (f'<td>&nbsp;</td>'
+               f'<td align="center" colspan="{regwidth}">...</td>')
+
+    genout(outfile, f'<tr>{tds}</tr>')
+
+
+def gen_md_window(outfile: TextIO, win: Window, comp: str, regwidth: int,
+                  rnames: Set[str]) -> None:
+    wname = win.name or '(unnamed window)'
+    offset = win.offset
+    desc_paras = expand_paras(win.desc, rnames)
+    desc_head = desc_paras[0]
+    desc_body = desc_paras[1:]
+
+    genout(outfile, title(wname, 4))
+    genout(outfile, desc_head)
+    genout(outfile, "\n")
+    gen_kv(outfile, "Offset", f"{offset:#x}")
+    gen_kv(outfile, "Items", f"{win.items}")
+    gen_kv(outfile, "Access", f"{win.swaccess.key}")
+    gen_kv(outfile, "Byte writes",
+           'supported' if win.byte_write else 'NOT supported')
+    genout(outfile, "\n")
+    for p in desc_body:
+        genout(outfile, p)
+        genout(outfile, "\n")
+
+    # wid = win.validbits
+    #
+    # for x in range(regwidth - 1, -1, -1):
+    #     if x == regwidth - 1 or x == wid - 1 or x == 0:
+    #         genout(outfile, '<td class="bitnum">' + str(x) + '</td>')
+    #     else:
+    #         genout(outfile, '<td class="bitnum"></td>')
+    # genout(outfile, '</tr>')
+    #
+    # # We want to show the first and last two addresses, with a blank line in
+    # # between if we skip anything.
+    # assert win.items >= 1
+    # if win.items <= 4:
+    #     indices_0 = list(range(win.items))
+    #     indices_1 = []
+    # else:
+    #     indices_0 = [0, 1]
+    #     indices_1 = [win.items - 2, win.items - 1]
+    #
+    # for idx in indices_0:
+    #     gen_window_row(outfile, offset, win.validbits, regwidth, idx)
+    # if indices_1:
+    #     gen_window_row(outfile, offset, win.validbits, regwidth, None)
+    # for idx in indices_1:
+    #     gen_window_row(outfile, offset, win.validbits, regwidth, idx)
+    #
+    # genout(outfile, '</td></tr></table>')
+    # genout(outfile,
+    #        '<tr>{}</tr>'.format(render_td(win.desc, rnames, 'regde')))
+    # genout(outfile, "</table>\n<br>\n")
+
+
+def gen_md_reg_block(outfile: TextIO, rb: RegBlock, comp: str, width: int,
+                     rnames: Set[str]) -> None:
+    if len(rb.entries) == 0:
+        genout(outfile, 'This interface does not expose any registers.')
+    else:
+        # Generate overview table first.
+        obj_list: List[Union[Register, Window]] = []
+        for x in rb.entries:
+            if isinstance(x, MultiRegister):
+                for reg in x.regs:
+                    obj_list += [reg]
+            else:
+                assert isinstance(x, Window) or isinstance(x, Register)
+                obj_list += [x]
+        gen_md_register_summary(outfile, obj_list, comp, width, rnames)
+
+        # Generate detailed entries
+        for x in rb.entries:
+            if isinstance(x, Register):
+                gen_md_register(outfile, x, comp, width, rnames)
+            elif isinstance(x, MultiRegister):
+                for reg in x.regs:
+                    gen_md_register(outfile, reg, comp, width, rnames)
+            else:
+                assert isinstance(x, Window)
+                gen_md_window(outfile, x, comp, width, rnames)
+
+
+def gen_md(block: IpBlock, outfile: TextIO) -> int:
+    rnames = block.get_rnames()
+
+    assert block.reg_blocks
+    # Handle the case where there's just one interface
+    if len(block.reg_blocks) == 1:
+        rb = list(block.reg_blocks.values())[0]
+        gen_md_reg_block(outfile, rb, block.name, block.regwidth, rnames)
+        return 0
+
+    # Handle the case where there is more than one device interface and,
+    # correspondingly, more than one reg block.
+    for iface_name, rb in block.reg_blocks.items():
+        iface_desc = ('device interface <code>{}</code>'.format(iface_name)
+                      if iface_name is not None else
+                      'the unnamed device interface')
+        genout(outfile, title(f"Registers visible under {iface_desc}", 3))
+        gen_md_reg_block(outfile, rb, block.name, block.regwidth, rnames)
+
+    return 0

--- a/util/reggen/md_helpers.py
+++ b/util/reggen/md_helpers.py
@@ -1,0 +1,143 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import re
+from typing import List, Match, Optional, Set, Union
+
+import tabulate
+from reggen.signal import Signal
+
+
+def name_width(x: Signal) -> str:
+    if x.bits.width() == 1:
+        return x.name
+
+    return '{}[{}:0]'.format(x.name, x.bits.msb)
+
+
+def coderef(s: str) -> str:
+    '''Return markdown code to refer to some element in the code'''
+    return f"**`{s}`**"
+
+
+def italic(s: str) -> str:
+    '''Return markdown code to put a string in italic'''
+    return f"*{s}*"
+
+
+def bold(s: str) -> str:
+    '''Return markdown code to put a string in bold'''
+    return f"**{s}**"
+
+
+def url(text: str, url: str) -> str:
+    '''Return a markdown link to a URL'''
+    return f"[{text}]({url})"
+
+
+def get_reg_link(rname: str) -> str:
+    '''Return regname with a link to itself'''
+    return url(rname, "#" + rname.lower())
+
+
+def title(title: str, level: int) -> str:
+    '''return the markdown string that corresponds to a title of a certain level'''
+    assert level <= 6, "commonmark does not handle more than 6 levels of title"
+    return ('#' * level) + " " + title + '\n'
+
+
+def wavejson(json: str) -> str:
+    '''return the markdown code to embed a wavedrom bit-field register picture'''
+    return f"\n```wavejson\n{json}\n```\n"
+
+
+def split_paragraphs(s: str) -> List[str]:
+    '''split a pseudo-markdown code into paragraphs'''
+    return [paragraph.strip() for paragraph in re.split(r'\n(?:\s*\n)+', s)]
+
+
+def md_safe_for_table(s: Union[str, List[str]]) -> str:
+    '''
+    Transform (a subset of) markdown into something that can be put
+    in a markdown table cell. The input can either be a string (unsegmented
+    markdown code) or a list of paragraphs
+
+    Specifically, this function handle two corner cases:
+    - muliline paragraph: line returns are transformed in spaces
+    - paragraphs: new paragraphs are introduced using <br /> since it cannot be
+      done in standard CommonMark
+    '''
+    # Start by splitting into paragraphs. The regex matches a newline followed
+    # by one or more lines that just contain whitespace. Then in each
+    # paragraph, line returns (ie not empty lines) are replace with a space
+    # since they are a problem in tables where we must put everything on one line
+    paras = split_paragraphs(s) if isinstance(s, str) else s
+
+    paras = [re.sub(r"\n", " ", p) for p in paras]
+    return "<br />".join(paras)
+
+
+def table(header: List[str],
+          rows: List[List[str]],
+          colalign: Union[None, List[str]] = None) -> str:
+    '''
+    Return the markdown code for a table given a header and the rows.
+
+    This function handles markdown idiocracies like not being able to
+    handle multilines in tables and line braks (which are convert to <br />).
+    Ff colalign is not None, each entry is the list specifies the align of a
+    column and can be one of 'left', 'right' or 'center'
+    '''
+    header = [md_safe_for_table(x) for x in header]
+    rows = [[md_safe_for_table(x) for x in row] for row in rows]
+    # for some unknown reason, the "github" format of tabulate is "pipe" without
+    # the align specifiers, but alignment is part of the GitHub Markdown format...
+    return "\n" + tabulate.tabulate(rows, header, "pipe",
+                                    colalign=colalign) + "\n\n"
+
+
+def expand_paras(s: str, rnames: Set[str]) -> List[str]:
+    '''
+    Expand a description field to markdown.
+
+    We also generate links to registers when a name is prefixed with a double
+    exclamation mark. For example, if there is a register FOO then !!FOO or
+    !!FOO.field will generate a link to that register.
+
+    Returns a list of rendered paragraphs
+    '''
+
+    def fieldsub(match: Match[str]) -> str:
+        base = match.group(1).partition('.')[0].lower()
+        # If we do not find the register name, there is a chance that this
+        # is a multireg that spans more than one register entry.
+        # We check whether at least _0 and _1 exist (via a set intersection),
+        # and still insert the link if these names exist.
+        # Note that we do not have to modify the link name since we insert
+        # a link target without the index suffix right before the first multireg
+        # entry in the register table.
+        mr_names = set([base + "_0", base + "_1"])
+        if base in rnames or len(rnames & mr_names) == 2:
+            if match.group(1)[-1] == ".":
+                return ('<a href="#' + base + '"><code class=\"reg\">' +
+                        match.group(1)[:-1] + '</code></a>.')
+            else:
+                return ('<a href="#' + base + '"><code class=\"reg\">' +
+                        match.group(1) + '</code></a>')
+        log.warn('!!' + match.group(1).partition('.')[0] +
+                 ' not found in register list.')
+        return match.group(0)
+
+    # substitute reference to registers and fields
+    return [
+        re.sub(r"!!([A-Za-z0-9_.]+)", fieldsub, p) for p in split_paragraphs(s)
+    ]
+
+
+def render_td(s: str, rnames: Set[str]) -> str:
+    '''Expand a description field for use in a markdown table. See expand_paras for
+    details about the supported format.
+    '''
+    return md_safe_for_table(expand_paras(s, rnames))

--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -150,7 +150,7 @@ buildSite () {
     echo "Building doxygen..."
     pushd "${this_dir}" >/dev/null
     # shellcheck disable=SC2086
-    ${doxygen_env} doxygen ${doxygen_args}
+#     ${doxygen_env} doxygen ${doxygen_args}
     popd >/dev/null
     echo "Doxygen build complete."
 


### PR DESCRIPTION
The current generator uses HTML, this commit creates a new Markdown generator and switch mdbook-reggen to use it. The content is the same but there are a few changes compared to the HTML backend:
- The register fields now use a Markdown table instead of a HTML table (but still need to use <br /> to break paragraph in cells). Also the fields are listed from msb to lsb, instead of lsb to msb.
- The register field summary now uses wavedrom to draw instead of a custom HTML table (which was unreadable anyway).
- Some reset/mask/offset information is displayed a bit differently using a table instead of a list to make it more compact.