### PR TITLE
[spi_passthru] Test flash erase opcodes 

### DIFF
--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -17,6 +17,7 @@ extern "C" {
     value(_, PinmuxConfig) \
     value(_, SpiConfigureJedecId) \
     value(_, SpiReadStatus) \
+    value(_, SpiWaitForUpload) \
     value(_, SpiWriteStatus) \
     value(_, SpiWriteSfdp) \
     value(_, SwStrapRead)

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -26,6 +26,16 @@ UJSON_SERDE_STRUCT(StatusRegister, status_register_t, STRUCT_STATUS_REGISTER);
     field(data, uint8_t, 256)
 UJSON_SERDE_STRUCT(SfdpData, sfdp_data_t, STRUCT_SFDP_DATA);
 
+#define STRUCT_UPLOAD_INFO(field, string) \
+    field(opcode, uint8_t) \
+    field(has_address, bool) \
+    field(addr_4b, bool) \
+    field(data_len, uint16_t) \
+    field(flash_status, uint32_t) \
+    field(address, uint32_t) \
+    field(data, uint8_t, 256)
+UJSON_SERDE_STRUCT(UploadInfo, upload_info_t, STRUCT_UPLOAD_INFO);
+
 // clang-format on
 #ifdef __cplusplus
 }

--- a/sw/host/opentitanlib/src/spiflash/flash.rs
+++ b/sw/host/opentitanlib/src/spiflash/flash.rs
@@ -64,6 +64,10 @@ impl SpiFlash {
     // Winbond parts use 0x35 and 0x15 for extended status reads.
     pub const READ_STATUS2: u8 = 0x35;
     pub const READ_STATUS3: u8 = 0x15;
+    pub const WRITE_STATUS: u8 = 0x01;
+    // Winbond parts use 0x31 and 0x11 for extended status writes.
+    pub const WRITE_STATUS2: u8 = 0x31;
+    pub const WRITE_STATUS3: u8 = 0x11;
     pub const READ_ID: u8 = 0x9f;
     pub const ENTER_4B: u8 = 0xb7;
     pub const EXIT_4B: u8 = 0xe9;

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -38,9 +38,9 @@ pub mod status;
 #[macro_export]
 macro_rules! execute_test {
     ($test:path, $($args:tt)*) => {
-        println!("Starting test {}...", stringify!($test));
+        println!("{}:Starting test {}...", line!(), stringify!($test));
         let result = $test($($args)*);
-        println!("Finished test {}: {:?}", stringify!($test), result);
+        println!("{}:Finished test {}: {:?}", line!(), stringify!($test), result);
         let _ = result?;
     };
 }

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -25,7 +25,7 @@ impl ConfigJedecId {
 impl StatusRegister {
     pub fn read(uart: &dyn Uart) -> Result<Self> {
         TestCommand::SpiReadStatus.send(&*uart)?;
-        StatusRegister::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false)
     }
 
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
@@ -42,5 +42,16 @@ impl SfdpData {
         self.send(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
+    }
+}
+
+impl UploadInfo {
+    pub fn execute<F>(uart: &dyn Uart, f: F) -> Result<Self>
+    where
+        F: FnOnce() -> Result<()>,
+    {
+        TestCommand::SpiWaitForUpload.send(&*uart)?;
+        f()?;
+        Self::recv(uart, Duration::from_secs(300), false)
     }
 }


### PR DESCRIPTION
1. Add a ujson struct for communication information about uploaded
   commands.
2. Test the chip_erase opcode.
3. Test the sector_erase opcode.

Signed-off-by: Chris Frantz <cfrantz@google.com>