### PR TITLE
[opentitantool] Re-introduce non-cw310 hyperdebug

### DIFF
--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::app::config::process_config_file;
 use crate::app::{TransportWrapper, TransportWrapperBuilder};
 use crate::transport::hyperdebug::c2d2::C2d2Flavor;
-use crate::transport::hyperdebug::CW310Flavor;
+use crate::transport::hyperdebug::{CW310Flavor, StandardFlavor};
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 
@@ -79,6 +79,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
             hyperdebug::create::<CW310Flavor>(args)?,
             Some(Path::new("/__builtin__/hyperdebug_cw310.json")),
         ),
+        "hyperdebug" => (hyperdebug::create::<StandardFlavor>(args)?, None),
         "hyperdebug_dfu" => (hyperdebug::create_dfu(args)?, None),
         "c2d2" => (
             hyperdebug::create::<C2d2Flavor>(args)?,


### PR DESCRIPTION
Google uses hyperdebug with non-cw310, non-OpenTitan development boards, and would like to continue to be able to do so using the `--interface=hyperdebug` argument.
