### PR TITLE
[dv/otp] all escalation_test add otp_check_fatal_alert

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -37,8 +37,8 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     '{"*lc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
     '{"*otbn*prim_reg_we_check*", TopEarlgreyAlertIdOtbnFatal},
     // TODO TopEarlgreyAlertIdOtpCtrlFatalMacroError,
-    // TODO TopEarlgreyAlertIdOtpCtrlFatalCheckError
     // TODO TopEarlgreyAlertIdOtpCtrlFatalPrimOtpAlert.
+    '{"*otp_ctrl*u_otp_ctrl_dai*", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
     '{"*otp_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
     '{"*pattgen*prim_reg_we_check*", TopEarlgreyAlertIdPattgenFatalFault},
     '{"*pinmux*prim_reg_we_check*", TopEarlgreyAlertIdPinmuxAonFatalFault},


### PR DESCRIPTION
This PR inject faults to trigger otp_ctrl_check_fatal_alert. This PR implements a TODO in issue #15649