### PR TITLE
[util,bazel] integrate flash scrambling with bazel

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -379,10 +379,22 @@ def opentitan_functest(
         if slot not in _FLASH_SLOTS:
             fail("Invalid slot: {}. Valid slots are: silicon_creator_{a,b,virtual}".format(slot))
         deps += _FLASH_SLOTS[slot]
+
+        # Get OTP image for sim targets. We need to pass the OTP image to the
+        # flash scrambling script since it contains the seeds to derive the
+        # scrambling keys. No need to worry about flash image scrambling for
+        # FPGA targets as the flash is loaded through bootstrap (i.e., the front
+        # door), unlike the sim targets which load via backdoor.
+        sim_otp_ = None
+        if "sim_dv" in target_params:
+            sim_otp_ = target_params["sim_dv"]["otp"]
+        elif "sim_verilator" in target_params:
+            sim_otp_ = target_params["sim_verilator"]["otp"]
         ot_flash_binary = name + "_prog"
         opentitan_flash_binary(
             name = ot_flash_binary,
             signed = signed,
+            sim_otp = sim_otp_,
             deps = deps,
             devices = devices_to_build_for,
             manifest = manifest,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2138,6 +2138,9 @@ opentitan_functest(
             "--bootstrap=\"$(location {flash})\"",
         ],
     ),
+    dv = dv_params(
+        otp = ":power_virus_systemtest_otp_img_rma",
+    ),
     targets = [
         # TODO(#14814): add more targets
         "cw310_test_rom",

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -24,6 +24,7 @@ py_binary(
     srcs = ["gen-flash-img.py"],
     deps = [
         ":secded_gen",
+        "//util/design/lib:present",
         requirement("pyfinite"),
     ],
 )


### PR DESCRIPTION
This integrates the flash scrambling script with Bazel to enable pre-scrambling flash images before they are backdoor loaded in DV and Verilator simulations.

A key feature to enable such is to pass the OTP VMEM image to the flash scrambling script so the flash scrambling key seeds, and enablement flag, can be read out and decoded for use.

While this commit reads out the scrambling key seeds, they still must be processed to produce the actual scrambling keys (as is done in HW). Additionally, the scrambling enablement flag must be read to determine whether or not to enabling scrambling within the pre-preprocessing script. These will both happen in a follow up.