### PR TITLE
[keymgr] XOR OTP root key with fresh randomness

### DIFF
--- a/hw/ip/keymgr/README.md
+++ b/hw/ip/keymgr/README.md
@@ -88,11 +88,7 @@ The key used for all 3 functions is the `CreatorRootKey`.
 
 The advancement from `CreatorRootKey` to the `OwnerIntermediateKey` is irreversible during the current power cycle.
 
-While in the CreatorRootKey state, the key from OTP is continuously captured and sensed.
-This provides some security benefit as the key is constantly background checked by the OTP.
-When an operation begins, the sampling is stopped.
-If at the conclusion of the operation the key manager stays in the same state, sampling begins again.
-If on the other hand key manager transitions to another state, OTP sampling is stopped until reset.
+Keymgr reads the root key from OTP in a single clock cycle. It assumes that when keymgr's internal FSM reaches to this clock cycle, OTP root key is already available (`valid` is set to 1). Otherwise, keymgr skips loading the root key.
 
 ### OwnerIntermediateKey
 

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -555,7 +555,7 @@ interface keymgr_if(input clk, input rst_n);
     `ASSERT(NAME, SEQ, clk, !rst_n || keymgr_en_sync2 != lc_ctrl_pkg::On || !en_chk)
 
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKey, is_kmac_key_good && kmac_key_exp.valid ->
-                           kmac_key == kmac_key_exp)
+                           kmac_key[0] ^ kmac_key[1] == kmac_key_exp[0] ^ kmac_key_exp[1])
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKeyValid, is_kmac_key_good ->
                            kmac_key_exp.valid == kmac_key.valid)
 


### PR DESCRIPTION
Implements the masking improvement suggested at #7614.

It also:

- Removes continuous OTP loading behavior. Therefore, loading of OTP root key happens in a single clock cycle.
- This and prior to this PR, `keymgr` assumes that when it reaches to OTP root key flopping stage, OTP key is already available. Otherwise key loading is skipped ( I do not know if there is a error reporting for this).
- Made small changes to DV side so that `kmac_key` comparison is made on the XOR result.
- Small doc update