### PR TITLE
[ci] Use a selfhosted pool for SW B&T

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ jobs:
   timeoutInMinutes: 180
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool: ci-public
+  pool: ci-public-general
   variables:
     - name: bazelCacheGcpKeyPath
       value: ''


### PR DESCRIPTION
This PR moves the SW Build & Tests job to a selfhosted pool to avoid the long running jobs we see due to IOPS limitations in GCP.