### PR TITLE
[opentitantool] Consider interface field in conf files 

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -139,7 +139,6 @@ impl SpiConfiguration {
 }
 
 pub struct TransportWrapperBuilder {
-    transport: RefCell<Box<dyn Transport>>,
     pin_alias_map: HashMap<String, String>,
     uart_map: HashMap<String, String>,
     spi_map: HashMap<String, String>,
@@ -164,9 +163,8 @@ pub struct TransportWrapper {
 }
 
 impl TransportWrapperBuilder {
-    pub fn new(transport: Box<dyn crate::transport::Transport>) -> Self {
+    pub fn new() -> Self {
         Self {
-            transport: RefCell::new(transport),
             pin_alias_map: HashMap::new(),
             uart_map: HashMap::new(),
             spi_map: HashMap::new(),
@@ -292,7 +290,10 @@ impl TransportWrapperBuilder {
         Ok(result_spi_conf_map)
     }
 
-    pub fn build(self) -> Result<TransportWrapper> {
+    pub fn build(
+        self,
+        transport: Box<dyn crate::transport::Transport>,
+    ) -> Result<TransportWrapper> {
         let pin_conf_map =
             Self::consolidate_pin_conf_map(&self.pin_alias_map, &self.pin_conf_list)?;
         let mut strapping_conf_map: HashMap<String, HashMap<String, PinConfiguration>> =
@@ -305,7 +306,7 @@ impl TransportWrapperBuilder {
         }
         let spi_conf_map = Self::consolidate_spi_conf_map(&self.spi_map, &self.spi_conf_list)?;
         Ok(TransportWrapper {
-            transport: self.transport,
+            transport: RefCell::new(transport),
             pin_map: self.pin_alias_map,
             uart_map: self.uart_map,
             spi_map: self.spi_map,

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -60,12 +60,12 @@ pub enum Error {
 /// Creates the requested backend interface according to [`BackendOpts`].
 pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
     let interface = args.interface.as_str();
-    let mut env = TransportWrapperBuilder::new();
+    let mut env = TransportWrapperBuilder::new(interface.to_string());
 
     for conf_file in &args.conf {
         process_config_file(&mut env, conf_file.as_ref())?
     }
-    let (backend, default_conf) = match interface {
+    let (backend, default_conf) = match env.get_interface() {
         "" => (create_empty_transport()?, None),
         "proxy" => (proxy::create(&args.proxy_opts)?, None),
         "verilator" => (

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -59,6 +59,8 @@ pub enum TransportError {
     MissingCapabilities(Capability, Capability),
     #[error("Inconsistent configuration for {0:?} instance {1}")]
     InconsistentConf(TransportInterfaceType, String),
+    #[error("Inconsistent configuration of transport interface {0} vs. {1}")]
+    InconsistentInterfaceConf(String, String),
 }
 impl_serializable_error!(TransportError);
 


### PR DESCRIPTION
Opentitantool takes an `--interface` flag specifying the backend interface, and uses a default configuration file depending on the interface.

At times, the user wants to use one or more alternative configuration files, in such cases, these files usually apply to one particular backend transport, which can even be declared in an "interface" field inside the configuration files.  If such a file is specified using `--conf`, the interface could be inferred.

This change makes opentitantool take the interface from either the command line, or the configuration files, (raising an error if different values are given between command line and configuration file, or among several configuration files.)