### PR TITLE
[dv/chip] otp inject prim_otp_error

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -37,8 +37,8 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     '{"*lc_ctrl*state_regs*", TopEarlgreyAlertIdLcCtrlFatalStateError},
     '{"*lc_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdLcCtrlFatalBusIntegError},
     '{"*otbn*prim_reg_we_check*", TopEarlgreyAlertIdOtbnFatal},
-    // TODO TopEarlgreyAlertIdOtpCtrlFatalMacroError,
-    // TODO TopEarlgreyAlertIdOtpCtrlFatalPrimOtpAlert.
+    // TopEarlgreyAlertIdOtpCtrlFatalMacroError: done in chip_sw_otp_ctrl_escalation_vseq
+    '{"*otp_ctrl.u_otp.*u_state_regs", TopEarlgreyAlertIdOtpCtrlFatalPrimOtpAlert},
     '{"*otp_ctrl*u_otp_ctrl_dai*", TopEarlgreyAlertIdOtpCtrlFatalCheckError},
     '{"*otp_ctrl*prim_reg_we_check*", TopEarlgreyAlertIdOtpCtrlFatalBusIntegError},
     '{"*pattgen*prim_reg_we_check*", TopEarlgreyAlertIdPattgenFatalFault},


### PR DESCRIPTION
This PR injects prim_otp_fatal error in chip level test. 
The prim_otp_error won't affect any open source registers. 
It only triggers alert.
Todos from issue #15649