### PR TITLE
[opentitantool] HyperDebug: Dynamic I2C port discovery

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,6 +114,6 @@ nonhermetic_repo(name = "nonhermetic")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 http_file(
     name = "hyperdebug_firmware",
-    urls = ["https://storage.googleapis.com/aoa-recovery-test-images/hyperdebug_v2.0.20491-956ccf530.bin"],
-    sha256 = "e9c93d2935b9b6a571b547f20fe6177c48a909535d87533b7a0c64fb049bd643",
+    urls = ["https://storage.googleapis.com/aoa-recovery-test-images/hyperdebug_v2.0.20634-ee78d5668.bin"],
+    sha256 = "c72c418bc56d673d4106af9a0973c6e4268d09fb18d363e7ad336a877a127be9",
 )

--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
-use crate::transport::TransportError;
+use crate::transport::{TransportError, TransportInterfaceType};
 
 /// The C2D2 (Case Closed Debugging Debugger) is used to bring up OT and EC chips sitting
 /// inside a computing device, such that those OT chips can provide Case Closed Debugging
@@ -26,6 +26,16 @@ impl Flavor for C2d2Flavor {
             return Ok(Rc::new(C2d2ResetPin::open(inner)?));
         }
         StandardFlavor::gpio_pin(inner, pinname)
+    }
+
+    fn spi_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, u8)> {
+        if instance == "0" {
+            return Ok((super::spi::USB_SPI_REQ_ENABLE, 0));
+        }
+        bail!(TransportError::InvalidInstance(
+            TransportInterfaceType::Spi,
+            instance.to_string()
+        ))
     }
 
     fn get_default_usb_vid() -> u16 {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -9,7 +9,7 @@ use zerocopy::{AsBytes, FromBytes};
 
 use crate::io::i2c::{Bus, I2cError, Transfer};
 use crate::transport::hyperdebug::{BulkInterface, Inner};
-use crate::transport::TransportError;
+use crate::transport::{TransportError, TransportInterfaceType};
 
 pub struct HyperdebugI2cBus {
     inner: Rc<Inner>,
@@ -67,6 +67,10 @@ impl RspTransfer {
 
 impl HyperdebugI2cBus {
     pub fn open(inner: &Rc<Inner>, i2c_interface: &BulkInterface, idx: u8) -> Result<Self> {
+        ensure!(
+            idx < 16,
+            TransportError::InvalidInstance(TransportInterfaceType::I2c, idx.to_string())
+        );
         let mut usb_handle = inner.usb_device.borrow_mut();
 
         // Exclusively claim I2C interface, preparing for bulk transfers.


### PR DESCRIPTION
Add support for more than one I2C port on HyperDebug.  Ports can either be given as a zero-base index (for backwards compatibility) or as an alphanumeric identifier, which HyperDebug firmware will translate into an index.

Also, remove some SPI name lookup code for compatibility with older HyperDebug firmwares.  The binary firmware already in this repository supports the "new" way.