### PR TITLE
[bazel,dvsim] enable passing `--data-perm` flag through dvsim/bazel

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -101,6 +101,9 @@ ifneq (${sw_images},)
 				bazel_opts+=" --//hw/ip/otp_ctrl/data:lc_seed=${build_seed}"; \
 				bazel_opts+=" --//hw/ip/otp_ctrl/data:otp_seed=${build_seed}"; \
 			fi; \
+			if [[ -n $${BAZEL_OTP_DATA_PERM_FLAG} ]]; then \
+				bazel_opts+=" --//hw/ip/otp_ctrl/data:data_perm=$${BAZEL_OTP_DATA_PERM_FLAG}"; \
+			fi; \
 			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
 				echo "Building \"$${bazel_label}\" on network connected machine."; \
 				bazel_cmd="./bazelisk.sh"; \

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -5,15 +5,15 @@
 load("//rules:autogen.bzl", "autogen_hjson_header")
 load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
-load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
-# These configurations expose the OTP image generation tool's seed override
-# command line arguments to enable dvsim to pass this through Bazel to the
-# underlying OTP image generation tool. This is required to enable dvsim to
-# invoke OTP image generation as part of the Bazel build process, while still
-# enabling the use of multiple seeds needed to achieve DV coverage.
+# These configurations expose the OTP image generation tool's command line
+# arguments to enable dvsim to pass this through Bazel to the underlying OTP
+# image generation script. This is required to enable dvsim to invoke OTP image
+# generation as part of the Bazel build process, while still enabling the use of
+# multiple seeds needed to achieve DV coverage.
 int_flag(
     name = "img_seed",
     build_setting_default = 0,
@@ -27,6 +27,11 @@ int_flag(
 int_flag(
     name = "otp_seed",
     build_setting_default = 0,
+)
+
+string_flag(
+    name = "data_perm",
+    build_setting_default = "",
 )
 
 # This package must be kept in sync with get_otp_images() from //rules:otp.bzl.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -128,11 +128,14 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 3
 
-  // Uncomment if using manufacturer tests / test hooks that live somewhere else
-  // on your system, outside of $REPO_TOP. See
-  // sw/device/tests/closed_source/README.md for more details.
   // exports: [
-  //   {MANUFACTURER_HOOKS_DIR: "/path/to/manufacturer_hooks_dir"}
+  //   Uncomment if using manufacturer tests / test hooks that live somewhere
+  //   else on your system, outside of $REPO_TOP. See
+  //   sw/device/tests/closed_source/README.md for more details.
+  //   {MANUFACTURER_HOOKS_DIR: "/path/to/manufacturer_hooks_dir"},
+  //   Uncomment if you are using the `--data-perm` OTP image generation flag,
+  //   when building OTP images with Bazel.
+  //   {BAZEL_OTP_DATA_PERM_FLAG: "[15:0],[23:16]"},
   // ]
 
   // Default UVM test and seq class name.

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -161,6 +161,8 @@ def _otp_image(ctx):
         args.add("--lc-seed", ctx.attr.lc_seed[BuildSettingInfo].value)
     if ctx.attr.otp_seed:
         args.add("--otp-seed", ctx.attr.otp_seed[BuildSettingInfo].value)
+    if ctx.attr.data_perm:
+        args.add("--data-perm", ctx.attr.data_perm[BuildSettingInfo].value)
     args.add("--img-cfg", ctx.file.src)
     args.add_all(ctx.files.overlays, before_each = "--add-cfg")
     args.add("--out", "{}/{}.BITWIDTH.vmem".format(output.dirname, ctx.attr.name))
@@ -208,6 +210,10 @@ otp_image = rule(
         "otp_seed": attr.label(
             default = "//hw/ip/otp_ctrl/data:otp_seed",
             doc = "Configuration override seed used to randomize OTP netlist constants.",
+        ),
+        "data_perm": attr.label(
+            default = "//hw/ip/otp_ctrl/data:data_perm",
+            doc = "Post-processing option to trigger permuting bit positions in memfile.",
         ),
         "verbose": attr.bool(
             default = False,


### PR DESCRIPTION
This enables passing the `--data-perm` flag of the `gen-otp-img.py` script through dvsim and Bazel to allow setting this parameter for top-level tests that make use of the Bazel-generated OTP image by setting the `OtpTypeCustom` flag in the `chip_sim_cfg.hjson` file.

To use this flag, users must simply set the `BAZEL_OTP_DATA_PERM_FLAG` environment variable on the dvsim run-stage machine (i.e., the machine that invokes Bazel to build the top-level test SW images). This can be done by setting environment variables in the `chip_sim_cfg.hjson` dvsim config file directly using the `exports` [list](https://cs.opensource.google/opentitan/opentitan/+/master:hw/top_earlgrey/dv/chip_sim_cfg.hjson;drc=303543449838578c1e95b3ef6ef7afdef411142d;l=134).