### PR TITLE
[opentitantool] Add ability to use GSC as debugger for Chromebooks

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -117,6 +117,7 @@ rust_library(
         "src/transport/hyperdebug/i2c.rs",
         "src/transport/hyperdebug/mod.rs",
         "src/transport/hyperdebug/spi.rs",
+        "src/transport/hyperdebug/ti50.rs",
         "src/transport/mod.rs",
         "src/transport/proxy/emu.rs",
         "src/transport/proxy/gpio.rs",

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::app::config::process_config_file;
 use crate::app::{TransportWrapper, TransportWrapperBuilder};
-use crate::transport::hyperdebug::{C2d2Flavor, CW310Flavor, StandardFlavor};
+use crate::transport::hyperdebug::{C2d2Flavor, CW310Flavor, StandardFlavor, Ti50Flavor};
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 
@@ -89,6 +89,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
             hyperdebug::create::<C2d2Flavor>(args)?,
             Some(Path::new("/__builtin__/h1dx_devboard.json")),
         ),
+        "ti50" => (hyperdebug::create::<Ti50Flavor>(args)?, None),
         "cw310" => (
             cw310::create(args)?,
             Some(Path::new("/__builtin__/opentitan_cw310.json")),

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -9,8 +9,7 @@ use thiserror::Error;
 
 use crate::app::config::process_config_file;
 use crate::app::{TransportWrapper, TransportWrapperBuilder};
-use crate::transport::hyperdebug::c2d2::C2d2Flavor;
-use crate::transport::hyperdebug::{CW310Flavor, StandardFlavor};
+use crate::transport::hyperdebug::{C2d2Flavor, CW310Flavor, StandardFlavor};
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -131,9 +131,15 @@ impl<'a> TransportCommandHandler<'a> {
                         let number = instance.get_max_transfer_count()?;
                         Ok(Response::Spi(SpiResponse::GetMaxTransferCount { number }))
                     }
-                    SpiRequest::GetMaxChunkSize => {
-                        let size = instance.max_chunk_size()?;
-                        Ok(Response::Spi(SpiResponse::GetMaxChunkSize { size }))
+                    SpiRequest::GetMaxTransferSizes => {
+                        let sizes = instance.get_max_transfer_sizes()?;
+                        Ok(Response::Spi(SpiResponse::GetMaxTransferSizes { sizes }))
+                    }
+                    SpiRequest::GetEepromMaxTransferSizes => {
+                        let sizes = instance.get_eeprom_max_transfer_sizes()?;
+                        Ok(Response::Spi(SpiResponse::GetEepromMaxTransferSizes {
+                            sizes,
+                        }))
                     }
                     SpiRequest::SetVoltage { voltage } => {
                         instance.set_voltage(*voltage)?;

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::{EmuState, EmuValue};
 use crate::io::gpio::{PinMode, PullMode};
-use crate::io::spi::TransferMode;
+use crate::io::spi::{MaxSizes, TransferMode};
 use crate::proxy::errors::SerializedError;
 use crate::transport::Capabilities;
 use crate::util::voltage::Voltage;
@@ -111,7 +111,8 @@ pub enum SpiRequest {
         value: u32,
     },
     GetMaxTransferCount,
-    GetMaxChunkSize,
+    GetMaxTransferSizes,
+    GetEepromMaxTransferSizes,
     SetVoltage {
         voltage: Voltage,
     },
@@ -139,8 +140,11 @@ pub enum SpiResponse {
     GetMaxTransferCount {
         number: usize,
     },
-    GetMaxChunkSize {
-        size: usize,
+    GetMaxTransferSizes {
+        sizes: MaxSizes,
+    },
+    GetEepromMaxTransferSizes {
+        sizes: MaxSizes,
     },
     SetVoltage,
     RunTransaction {

--- a/sw/host/opentitanlib/src/spiflash/flash.rs
+++ b/sw/host/opentitanlib/src/spiflash/flash.rs
@@ -151,7 +151,7 @@ impl SpiFlash {
         loop {
             // READ_SFDP always takes a 3-byte address followed by a dummy byte regardless of
             // address mode.
-            let mut eeprom_transactions: Vec<Transaction> = Vec::new();
+            let mut eeprom_transactions = Vec::new();
             let read_size = spi.get_eeprom_max_transfer_sizes()?.read;
             for (i, transfer) in buf.chunks_mut(read_size).enumerate() {
                 eeprom_transactions.push(Transaction::Read(

--- a/sw/host/opentitanlib/src/transport/cw310/spi.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/spi.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::io::spi::{AssertChipSelect, SpiError, Target, Transfer, TransferMode};
+use crate::io::spi::{AssertChipSelect, MaxSizes, SpiError, Target, Transfer, TransferMode};
 use crate::transport::cw310::usb::Backend;
 use crate::transport::cw310::CW310;
 use crate::transport::TransportError;
@@ -89,8 +89,11 @@ impl Target for CW310Spi {
         Ok(42)
     }
 
-    fn max_chunk_size(&self) -> Result<usize> {
-        Ok(65536)
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        Ok(MaxSizes {
+            read: 65536,
+            write: 65536,
+        })
     }
 
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -34,10 +34,7 @@ impl GpioPin for HyperdebugGpioPin {
     fn read(&self) -> Result<bool> {
         let line = self
             .inner
-            .cmd_one_line_output(&format!("gpioget {}", &self.pinname))
-            .map_err(|_| {
-                TransportError::CommunicationError("No output from gpioget".to_string())
-            })?;
+            .cmd_one_line_output(&format!("gpioget {}", &self.pinname))?;
         Ok(line.trim_start().starts_with('1'))
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -38,6 +38,7 @@ pub mod gpio;
 pub mod i2c;
 pub mod spi;
 
+pub use c2d2::C2d2Flavor;
 pub use dfu::HyperdebugDfu;
 
 /// Implementation of the Transport trait for HyperDebug based on the

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -37,9 +37,11 @@ pub mod dfu;
 pub mod gpio;
 pub mod i2c;
 pub mod spi;
+pub mod ti50;
 
 pub use c2d2::C2d2Flavor;
 pub use dfu::HyperdebugDfu;
+pub use ti50::Ti50Flavor;
 
 /// Implementation of the Transport trait for HyperDebug based on the
 /// Nucleo-L552ZE-Q.
@@ -428,7 +430,7 @@ impl Inner {
                         if buf[i] == b'\n' {
                             // Found a complete line, process it
                             let mut line_end = i;
-                            if line_end > line_start && buf[line_end - 1] == 13 {
+                            while line_end > line_start && buf[line_end - 1] == 13 {
                                 line_end -= 1;
                             }
                             let line = std::str::from_utf8(&buf[line_start..line_end])

--- a/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::rc::Rc;
+
+use crate::io::gpio::GpioPin;
+use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::{TransportError, TransportInterfaceType};
+
+// The GSC has some capability to control GPIO lines inside a Chromebook, and to program the AP
+// firmware flash chip via SPI.  This "flavor" allows OpenTitanTool to access those capabilities.
+pub struct Ti50Flavor {}
+
+impl Ti50Flavor {
+    const PID_TI50: u16 = 0x504a;
+}
+
+impl Flavor for Ti50Flavor {
+    fn gpio_pin(inner: &Rc<Inner>, pinname: &str) -> Result<Rc<dyn GpioPin>> {
+        StandardFlavor::gpio_pin(inner, pinname)
+    }
+
+    fn spi_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, u8)> {
+        if instance == "AP" {
+            return Ok((super::spi::USB_SPI_REQ_ENABLE_AP, 0));
+        } else if instance == "EC" {
+            return Ok((super::spi::USB_SPI_REQ_ENABLE_EC, 0));
+        }
+        bail!(TransportError::InvalidInstance(
+            TransportInterfaceType::Spi,
+            instance.to_string()
+        ))
+    }
+
+    fn get_default_usb_vid() -> u16 {
+        VID_GOOGLE
+    }
+
+    fn get_default_usb_pid() -> u16 {
+        Self::PID_TI50
+    }
+}

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use super::ProxyError;
 use crate::io::spi::{
-    AssertChipSelect, SpiError, Target, TargetChipDeassert, Transfer, TransferMode,
+    AssertChipSelect, MaxSizes, SpiError, Target, TargetChipDeassert, Transfer, TransferMode,
 };
 use crate::proxy::protocol::{
     Request, Response, SpiRequest, SpiResponse, SpiTransferRequest, SpiTransferResponse,
@@ -89,9 +89,16 @@ impl Target for ProxySpi {
         }
     }
 
-    fn max_chunk_size(&self) -> Result<usize> {
-        match self.execute_command(SpiRequest::GetMaxChunkSize)? {
-            SpiResponse::GetMaxChunkSize { size } => Ok(size as usize),
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        match self.execute_command(SpiRequest::GetMaxTransferSizes)? {
+            SpiResponse::GetMaxTransferSizes { sizes } => Ok(sizes),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn get_eeprom_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        match self.execute_command(SpiRequest::GetEepromMaxTransferSizes)? {
+            SpiResponse::GetEepromMaxTransferSizes { sizes } => Ok(sizes),
             _ => bail!(ProxyError::UnexpectedReply()),
         }
     }

--- a/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use std::rc::Rc;
 
-use crate::io::spi::{AssertChipSelect, SpiError, Target, Transfer, TransferMode};
+use crate::io::spi::{AssertChipSelect, MaxSizes, SpiError, Target, Transfer, TransferMode};
 use crate::transport::TransportError;
 use crate::util::voltage::Voltage;
 
@@ -48,7 +48,7 @@ impl Target for Ti50Spi {
     }
 
     /// Maximum chunksize handled by this SPI device.
-    fn max_chunk_size(&self) -> Result<usize> {
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
         Err(TransportError::UnsupportedOperation.into())
     }
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -8,7 +8,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::spi::{
-    AssertChipSelect, ClockPolarity, SpiError, Target, TargetChipDeassert, Transfer, TransferMode,
+    AssertChipSelect, ClockPolarity, MaxSizes, SpiError, Target, TargetChipDeassert, Transfer,
+    TransferMode,
 };
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
@@ -103,10 +104,13 @@ impl Target for UltradebugSpi {
         Ok(42)
     }
 
-    fn max_chunk_size(&self) -> Result<usize> {
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
         // Size of the FTDI read buffer.  We can't perform a read larger than this;
         // the FTDI device simply won't read any more.
-        Ok(65536)
+        Ok(MaxSizes {
+            read: 65536,
+            write: 65536,
+        })
     }
 
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {


### PR DESCRIPTION
The GSC chip inside Chromebooks use mostly the same USB communication protocol as HyperDebug to control GPIOs and SPI busses inside the Chromebook during CCD debugging.
    
This CL allows e.g. flashing the AP firmware chip of a Chromebook with SuzyQ or Servo USB connection to the Ti50 GSC chip.

Mostly, I am proposing this as it will be useful for communication with a GSC being tested on a devboard connected to the host computer via USB (as well as via HyperDebug).