### PR TITLE
Quote shell variables (shellcheck SC2086)

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -52,8 +52,8 @@ function prepare() {
     local url="https://github.com/bazelbuild/bazelisk/releases/download/${release}/bazelisk-${target}"
 
     mkdir -p "$bindir"
-    echo "Downloading bazelisk ${release} (${url})." >> $bindir/bazelisk.log
-    curl ${CURL_FLAGS} --location "$url" --output "$file"
+    echo "Downloading bazelisk ${release} (${url})." >> "$bindir"/bazelisk.log
+    curl "${CURL_FLAGS}" --location "$url" --output "$file"
     chmod +x "$file"
 }
 

--- a/ci/bazelisk.sh
+++ b/ci/bazelisk.sh
@@ -31,7 +31,7 @@ fi
 # See #14695 for more information.
 echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -ds)\"" >> "${GCP_BAZELRC}"
 
-"$(dirname $0)"/../bazelisk.sh \
+"$(dirname "$0")"/../bazelisk.sh \
   --bazelrc="${GCP_BAZELRC}" \
-  --bazelrc="$(dirname $0)"/.bazelrc \
+  --bazelrc="$(dirname "$0")"/.bazelrc \
   "$@"

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -121,20 +121,20 @@ tar -C /tools/verible -xf "$verible_tar" --strip-components=1
 export PATH=/tools/verible/bin:$PATH
 
 # Install verilator
-if [ $lsb_sr = "18.04" ]; then
+if [ "$lsb_sr" = "18.04" ]; then
   UBUNTU_SUFFIX="-u18"
 fi
 
 VERILATOR_TARBALL=verilator"$UBUNTU_SUFFIX-v$VERILATOR_VERSION".tar.gz
 VERILATOR_URL=https://storage.googleapis.com/verilator-builds/$VERILATOR_TARBALL
-echo "Fetching verilator tarball" $VERILATOR_URL
+echo "Fetching verilator tarball" "$VERILATOR_URL"
 curl -f -Ls -o "$VERILATOR_TARBALL" "$VERILATOR_URL" || {
     error "Failed to download verilator from ${VERILATOR_URL}"
 }
 
 sudo mkdir -p /tools/verilator
 sudo chmod 777 /tools/verilator
-tar -C /tools/verilator -xvzf $VERILATOR_TARBALL
+tar -C /tools/verilator -xvzf "$VERILATOR_TARBALL"
 export PATH=/tools/verilator/v$VERILATOR_VERSION/bin:$PATH
 
 # Install Rust

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -30,10 +30,10 @@ echo "### Display environment information"
 ci/scripts/show-env.sh
 
 echo -e "\n### Check commit metadata"
-ci/scripts/lint-commits.sh $tgt_branch
+ci/scripts/lint-commits.sh "$tgt_branch"
 
 echo -e "\n### Check Licence Headers"
-ci/scripts/check-licence-headers.sh $tgt_branch
+ci/scripts/check-licence-headers.sh "$tgt_branch"
 
 echo -e "\n### Check executable bits"
 ci/scripts/exec-check.sh
@@ -42,21 +42,21 @@ echo -e "\n### Check for non-ASCII characters in source code"
 ci/scripts/check-ascii.sh
 
 echo -e "\n### Run Python lint (flake8)"
-ci/scripts/python-lint.sh $tgt_branch || {
+ci/scripts/python-lint.sh "$tgt_branch" || {
     echo "(ignoring python lint errors)"
 }
 
 echo -e "\n### Run Python lint (mypy)"
-ci/scripts/mypy.sh $tgt_branch
+ci/scripts/mypy.sh "$tgt_branch"
 
 echo -e "\n### Use clang-format to check C/C++ coding style"
-ci/scripts/clang-format.sh $tgt_branch
+ci/scripts/clang-format.sh "$tgt_branch"
 
 echo -e "\n### Check formatting on header guards"
-ci/scripts/include-guard.sh $tgt_branch
+ci/scripts/include-guard.sh "$tgt_branch"
 
 echo -e "\n### Use rustfmt to check Rust coding style"
-ci/scripts/rust-format.sh $tgt_branch
+ci/scripts/rust-format.sh "$tgt_branch"
 
 echo -e "\n### Run shellcheck on all shell scripts"
 ci/scripts/run-shellcheck.sh
@@ -68,4 +68,4 @@ echo -e "\n### Render landing site"
 ci/scripts/build-site.sh
 
 echo -e "\n### Check what kinds of changes the PR contains"
-ci/scripts/get-build-type.sh $tgt_branch PullRequest
+ci/scripts/get-build-type.sh "$tgt_branch" PullRequest

--- a/ci/scripts/build-bitstream-vivado.sh
+++ b/ci/scripts/build-bitstream-vivado.sh
@@ -100,7 +100,7 @@ fusesoc --verbose --cores-root=. \
   --build-root="$OBJ_DIR/hw" \
   "$CORE_NAME" \
   --BootRomInitFile="$BOOTROM_VMEM" \
-  $OTP_ARG
+  "$OTP_ARG"
 
 BITSTREAM_FNAME="lowrisc_systems_chip_${FLAVOUR}_${TARGET}_0.1.bit"
 BITSTREAM_PATH="$OBJ_DIR/hw/synth-vivado/$BITSTREAM_FNAME"

--- a/ci/scripts/check-licence-headers.sh
+++ b/ci/scripts/check-licence-headers.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/clang-format.sh
+++ b/ci/scripts/clang-format.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/get-bitstream-strategy.sh
+++ b/ci/scripts/get-bitstream-strategy.sh
@@ -33,19 +33,19 @@ else
 fi
 
 # Retrieve the most recent bitstream at or before HEAD.
-BITSTREAM="--refresh HEAD" ./bazelisk.sh build ${bitstream_target}
+BITSTREAM="--refresh HEAD" ./bazelisk.sh build "${bitstream_target}"
 
 # The directory containing the bitstream is named after the git hash.
-bitstream_file=$(ci/scripts/target-location.sh ${bitstream_target})
-bitstream_commit=$(basename "$(dirname ${bitstream_file})")
+bitstream_file=$(ci/scripts/target-location.sh "${bitstream_target}")
+bitstream_commit=$(basename "$(dirname "${bitstream_file}")")
 
 echo "Checking for changes against pre-built bitstream from ${bitstream_commit}"
 echo "Files changed:"
-git diff --stat --name-only ${bitstream_commit}
+git diff --stat --name-only "${bitstream_commit}"
 echo
 echo "Changed files after exclusions applied:"
 # Use the cached bitstream if no changed files remain.
-if git diff --exit-code --stat --name-only ${bitstream_commit} -- "${excluded_files[@]}"; then
+if git diff --exit-code --stat --name-only "${bitstream_commit}" -- "${excluded_files[@]}"; then
   bitstream_strategy=cached
 else
   bitstream_strategy=build

--- a/ci/scripts/get-build-type.sh
+++ b/ci/scripts/get-build-type.sh
@@ -23,7 +23,7 @@ only_cdc_changes=0
 if [[ "$build_reason" = "PullRequest" ]]; then
     # Conservative way of checking for documentation-only and OTBN changes.
     # Only relevant for pipelines triggered from pull requests
-    merge_base="$(git merge-base HEAD origin/$tgt_branch)" || {
+    merge_base="$(git merge-base HEAD origin/"$tgt_branch")" || {
         echo >&2 "Failed to find fork point for origin/$tgt_branch."
         exit 1
     }

--- a/ci/scripts/include-guard.sh
+++ b/ci/scripts/include-guard.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/lint-commits.sh
+++ b/ci/scripts/lint-commits.sh
@@ -14,7 +14,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/python-lint.sh
+++ b/ci/scripts/python-lint.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }
@@ -44,7 +44,7 @@ lintpy_cmd="util/lintpy.py --tools flake8 -f"
 set -o pipefail
 git diff -z --name-only --diff-filter=ACMRTUXB "$merge_base" -- \
   "${pathspec_args[@]}" | \
-    xargs -0 -r $lintpy_cmd || {
+    xargs -0 -r "$lintpy_cmd" || {
     echo -n "##vso[task.logissue type=error]"
     echo "Python lint failed."
     exit 1

--- a/ci/scripts/run-english-breakfast-verilator-tests.sh
+++ b/ci/scripts/run-english-breakfast-verilator-tests.sh
@@ -28,7 +28,7 @@ bazel-bin/sw/host/opentitantool/opentitantool \
     --rcfile="" \
     --logging=info \
     --interface=verilator \
-    --verilator-bin=$BIN_DIR/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator \
+    --verilator-bin="$BIN_DIR"/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator \
     --verilator-rom="$(find bazel-out/* -name 'test_rom_sim_verilator.32.vmem')" \
     --verilator-flash="$(find bazel-out/* -name 'aes_smoketest_prog_sim_verilator.64.scr.vmem')" \
     console \

--- a/ci/scripts/rust-format.sh
+++ b/ci/scripts/rust-format.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -30,8 +30,8 @@ then
   REDIR='/dev/null'
 fi
 
-REL_PATH=$(${REPO_TOP}/bazelisk.sh outquery "$@" 2>$REDIR)
+REL_PATH=$("${REPO_TOP}"/bazelisk.sh outquery "$@" 2>$REDIR)
 readonly REL_PATH
-REPO_EXECROOT=$(${REPO_TOP}/bazelisk.sh info --show_make_env execution_root)
+REPO_EXECROOT=$("${REPO_TOP}"/bazelisk.sh info --show_make_env execution_root)
 readonly REPO_EXECROOT
 echo "${REPO_EXECROOT}/${REL_PATH}"

--- a/ci/scripts/whitespace.sh
+++ b/ci/scripts/whitespace.sh
@@ -16,7 +16,7 @@ if [ $# != 1 ]; then
 fi
 tgt_branch="$1"
 
-merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+merge_base="$(git merge-base origin/"$tgt_branch" HEAD)" || {
     echo >&2 "Failed to find fork point for origin/$tgt_branch."
     exit 1
 }

--- a/hw/ip/aes/pre_sca/alma/verify_aes.sh
+++ b/hw/ip/aes/pre_sca/alma/verify_aes.sh
@@ -27,8 +27,8 @@ fi
 echo "Verifying ${TOP_MODULE} using Alma"
 
 # Parse
-./parse.py --top-module ${TOP_MODULE} \
---source ${REPO_TOP}/hw/ip/aes/pre_syn/syn_out/latest/generated/${TOP_MODULE}.alma.v \
+./parse.py --top-module "${TOP_MODULE}" \
+--source "${REPO_TOP}"/hw/ip/aes/pre_syn/syn_out/latest/generated/"${TOP_MODULE}".alma.v \
 --netlist tmp/circuit.v --log-yosys
 
 # Label
@@ -37,13 +37,13 @@ sed -i 's/\(mask_i\s\[\)\([0-9]\+:0\)\(\]\s=\s\)unimportant/\1\2\3secret \2/g' t
 sed -i 's/\(prd_i\s\[[0-9]\+:0\]\s=\s\)unimportant/\1random/g' tmp/labels.txt
 
 # Trace
-./trace.py --testbench ${REPO_TOP}/hw/ip/aes/pre_sca/alma/cpp/verilator_tb_${TESTBENCH}.cpp \
+./trace.py --testbench "${REPO_TOP}"/hw/ip/aes/pre_sca/alma/cpp/verilator_tb_"${TESTBENCH}".cpp \
 --netlist tmp/circuit.v -o tmp/circuit
 
 # Verify
 ./verify.py --json tmp/circuit.json \
    --label tmp/labels.txt \
-   --top-module ${TOP_MODULE} \
+   --top-module "${TOP_MODULE}" \
    --vcd tmp/tmp.vcd \
    --rst-name rst_ni --rst-phase 0 \
    --probe-duration once --mode transient \

--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -90,7 +90,7 @@ OT_DEP_PACKAGES=(
 
 # Convert OpenTitan dependency sources.
 for file in "${OT_DEP_SOURCES[@]}"; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -101,26 +101,26 @@ for file in "${OT_DEP_SOURCES[@]}"; do
         --define=SYNTHESIS --define=YOSYS \
         "${OT_DEP_PACKAGES[@]}" \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 # Rename the prim_sparse_fsm_flop module. For some reason, sv2v decides to append a suffix.
 sed -i 's/module prim_sparse_fsm_flop_.*/module prim_sparse_fsm_flop \(/g' \
-    $LR_SYNTH_OUT_DIR/generated/prim_sparse_fsm_flop.v
+    "$LR_SYNTH_OUT_DIR"/generated/prim_sparse_fsm_flop.v
 
 # Get and convert core sources.
 for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -132,26 +132,26 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
         "${OT_DEP_PACKAGES[@]}" \
         "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Rename prim_sparse_fsm_flop instances. For some reason, sv2v decides to append a suffix.
     sed -i 's/prim_sparse_fsm_flop_.*/prim_sparse_fsm_flop \#(/g' \
-        $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
-    sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT_aes_pkg.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT(logic \[.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i '/\.StateEnumT_aes_pkg.*(.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 #-------------------------------------------------------------------------
@@ -175,4 +175,4 @@ fi
 #-------------------------------------------------------------------------
 # report kGE number
 #-------------------------------------------------------------------------
-python/get_kge.py $LR_SYNTH_CELL_LIBRARY_PATH $LR_SYNTH_OUT_DIR/reports/area.rpt
+python/get_kge.py "$LR_SYNTH_CELL_LIBRARY_PATH" "$LR_SYNTH_OUT_DIR"/reports/area.rpt

--- a/hw/ip/aes/pre_syn/translate_timing_rpts.sh
+++ b/hw/ip/aes/pre_syn/translate_timing_rpts.sh
@@ -4,8 +4,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-./python/build_translated_names.py $LR_SYNTH_TOP_MODULE ./$LR_SYNTH_OUT_DIR/generated ./$LR_SYNTH_OUT_DIR/reports/timing/*.csv.rpt
+./python/build_translated_names.py "$LR_SYNTH_TOP_MODULE" ./"$LR_SYNTH_OUT_DIR"/generated ./"$LR_SYNTH_OUT_DIR"/reports/timing/*.csv.rpt
 
 for file in ./$LR_SYNTH_OUT_DIR/reports/timing/*.csv.rpt; do
-    ./python/translate_timing_csv.py $file ./$LR_SYNTH_OUT_DIR/generated
+    ./python/translate_timing_csv.py "$file" ./"$LR_SYNTH_OUT_DIR"/generated
 done

--- a/hw/ip/kmac/pre_sca/alma/verify_kmac.sh
+++ b/hw/ip/kmac/pre_sca/alma/verify_kmac.sh
@@ -25,8 +25,8 @@ fi
 echo "Verifying ${TOP_MODULE} using Alma"
 
 ## Parse
-./parse.py --top-module ${TOP_MODULE} \
---source ${REPO_TOP}/hw/ip/kmac/pre_syn/syn_out/latest/generated/${TOP_MODULE}.alma.v \
+./parse.py --top-module "${TOP_MODULE}" \
+--source "${REPO_TOP}"/hw/ip/kmac/pre_syn/syn_out/latest/generated/"${TOP_MODULE}".alma.v \
 --netlist tmp/circuit.v --log-yosys
 
 # Label
@@ -44,13 +44,13 @@ S_I=$"s_i [$WIDTH_MIN_1:0] = secret $WIDTH_MIN_1:0\ns_i [$((WIDTH*2-1)):$WIDTH] 
 sed -i "s/\(s_i\s\[\)\([0-9]\+:0\)\(\]\s=\s\)unimportant/${S_I}/g" tmp/labels.txt
 
 # Trace
-./trace.py --testbench ${REPO_TOP}/hw/ip/kmac/pre_sca/alma/cpp/verilator_tb_${TESTBENCH}.cpp \
+./trace.py --testbench "${REPO_TOP}"/hw/ip/kmac/pre_sca/alma/cpp/verilator_tb_"${TESTBENCH}".cpp \
 --netlist tmp/circuit.v -o tmp/circuit
 
 # Verify
 ./verify.py --json tmp/circuit.json \
    --label tmp/labels.txt \
-   --top-module ${TOP_MODULE} \
+   --top-module "${TOP_MODULE}" \
    --vcd tmp/tmp.vcd \
    --rst-name rst_ni --rst-phase 0 \
    --probe-duration once --mode transient \

--- a/hw/ip/kmac/pre_syn/syn_yosys.sh
+++ b/hw/ip/kmac/pre_syn/syn_yosys.sh
@@ -107,7 +107,7 @@ OT_DEP_PACKAGES=(
 
 # Convert OpenTitan dependency sources.
 for file in "${OT_DEP_SOURCES[@]}"; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -118,26 +118,26 @@ for file in "${OT_DEP_SOURCES[@]}"; do
         --define=SYNTHESIS --define=YOSYS \
         "${OT_DEP_PACKAGES[@]}" \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 # Rename the prim_sparse_fsm_flop module. For some reason, sv2v decides to append a suffix.
 sed -i 's/module prim_sparse_fsm_flop_.*/module prim_sparse_fsm_flop \(/g' \
-    $LR_SYNTH_OUT_DIR/generated/prim_sparse_fsm_flop.v
+    "$LR_SYNTH_OUT_DIR"/generated/prim_sparse_fsm_flop.v
 
 # Get and convert core sources.
 for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -149,26 +149,26 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
         "${OT_DEP_PACKAGES[@]}" \
         "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Rename prim_sparse_fsm_flop instances. For some reason, sv2v decides to append a suffix.
     sed -i 's/prim_sparse_fsm_flop_.*/prim_sparse_fsm_flop \#(/g' \
-        $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
-    sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT.*StateWidth.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT(logic \[.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i '/\.StateEnumT.*StateWidth.*(.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 #-------------------------------------------------------------------------
@@ -192,4 +192,4 @@ fi
 #-------------------------------------------------------------------------
 # report kGE number
 #-------------------------------------------------------------------------
-python/get_kge.py $LR_SYNTH_CELL_LIBRARY_PATH $LR_SYNTH_OUT_DIR/reports/area.rpt
+python/get_kge.py "$LR_SYNTH_CELL_LIBRARY_PATH" "$LR_SYNTH_OUT_DIR"/reports/area.rpt

--- a/hw/ip/otbn/dv/smoke/run_smoke.sh
+++ b/hw/ip/otbn/dv/smoke/run_smoke.sh
@@ -23,16 +23,16 @@ source "$UTIL_DIR/build_consts.sh"
 SMOKE_BIN_DIR=$BIN_DIR/otbn/smoke_test
 SMOKE_SRC_DIR=$REPO_TOP/hw/ip/otbn/dv/smoke
 
-mkdir -p $SMOKE_BIN_DIR
+mkdir -p "$SMOKE_BIN_DIR"
 
 OTBN_UTIL=$REPO_TOP/hw/ip/otbn/util
 
-$OTBN_UTIL/otbn_as.py -o $SMOKE_BIN_DIR/smoke_test.o $SMOKE_SRC_DIR/smoke_test.s || \
+"$OTBN_UTIL"/otbn_as.py -o "$SMOKE_BIN_DIR"/smoke_test.o "$SMOKE_SRC_DIR"/smoke_test.s || \
     fail "Failed to assemble smoke_test.s"
-$OTBN_UTIL/otbn_ld.py -o $SMOKE_BIN_DIR/smoke.elf $SMOKE_BIN_DIR/smoke_test.o || \
+"$OTBN_UTIL"/otbn_ld.py -o "$SMOKE_BIN_DIR"/smoke.elf "$SMOKE_BIN_DIR"/smoke_test.o || \
     fail "Failed to link smoke_test.o"
 
-(cd $REPO_TOP;
+(cd "$REPO_TOP";
  fusesoc --cores-root=. run --target=sim --setup --build \
          lowrisc:ip:otbn_top_sim || fail "HW Sim build failed")
 
@@ -42,8 +42,8 @@ readonly RUN_LOG
 trap "rm -rf $RUN_LOG" EXIT
 
 timeout 5s \
-  $REPO_TOP/build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim \
-  --load-elf=$SMOKE_BIN_DIR/smoke.elf -t | tee $RUN_LOG
+  "$REPO_TOP"/build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim \
+  --load-elf="$SMOKE_BIN_DIR"/smoke.elf -t | tee "$RUN_LOG"
 
 if [ $? -eq 124 ]; then
   fail "Simulation timeout"
@@ -54,7 +54,7 @@ if [ $? -ne 0 ]; then
 fi
 
 had_diff=0
-grep -A 74 "Call Stack:" $RUN_LOG | diff -U3 $SMOKE_SRC_DIR/smoke_expected.txt - || had_diff=1
+grep -A 74 "Call Stack:" "$RUN_LOG" | diff -U3 "$SMOKE_SRC_DIR"/smoke_expected.txt - || had_diff=1
 
 if [ $had_diff == 0 ]; then
   echo "OTBN SMOKE PASS"

--- a/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
+++ b/hw/ip/otbn/pre_sca/alma/verify_otbn.sh
@@ -9,9 +9,9 @@ echo "Verifying OTBN using Alma"
 
 # Parse
 python3 parse.py --keep --top-module otbn_top_coco --log-yosys \
-  --source ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v \
-  ${REPO_TOP}/hw/ip/otbn/pre_syn/syn_out/latest/generated/otbn_core.alma.v \
-  ${REPO_TOP}/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
+  --source "${REPO_TOP}"/hw/ip/otbn/pre_sca/alma/rtl/ram_1p.v \
+  "${REPO_TOP}"/hw/ip/otbn/pre_syn/syn_out/latest/generated/otbn_core.alma.v \
+  "${REPO_TOP}"/hw/ip/otbn/pre_sca/alma/rtl/otbn_top_coco.v
 
 # Assemble the program
 program=isw_and

--- a/hw/ip/otbn/pre_syn/syn_yosys.sh
+++ b/hw/ip/otbn/pre_syn/syn_yosys.sh
@@ -116,7 +116,7 @@ OT_DEP_PACKAGES=(
 
 # Convert OpenTitan dependency sources.
 for file in "${OT_DEP_SOURCES[@]}"; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -127,31 +127,31 @@ for file in "${OT_DEP_SOURCES[@]}"; do
         --define=SYNTHESIS --define=SYNTHESIS_MEMORY_BLACK_BOXING --define=YOSYS \
         "${OT_DEP_PACKAGES[@]}" \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_and2/prim_xilinx_and2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_and2/prim_xilinx_and2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Remove calls to $value$plusargs(). Yosys doesn't seem to support this.
-    sed -i '/$value$plusargs(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/$value$plusargs(.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 # Rename the prim_sparse_fsm_flop module. For some reason, sv2v decides to append a suffix.
 sed -i 's/module prim_sparse_fsm_flop_.*/module prim_sparse_fsm_flop \(/g' \
-    $LR_SYNTH_OUT_DIR/generated/prim_sparse_fsm_flop.v
+    "$LR_SYNTH_OUT_DIR"/generated/prim_sparse_fsm_flop.v
 
 # Get and convert core sources.
 for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
-    module=`basename -s .sv $file`
+    module=`basename -s .sv "$file"`
 
     # Skip packages
     if echo "$module" | grep -q '_pkg$'; then
@@ -163,28 +163,28 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
         "${OT_DEP_PACKAGES[@]}" \
         "$LR_SYNTH_SRC_DIR"/rtl/*_pkg.sv \
         -I"$LR_SYNTH_SRC_DIR"/../prim/rtl \
-        $file \
-        > $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$file" \
+        > "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Make sure auto-generated primitives are resolved to generic or Xilinx-specific primitives
     # where available.
-    sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_and2/prim_xilinx_and2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_flop/prim_xilinx_flop/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xilinx_flop_2sync/prim_flop_2sync/g'  "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_buf/prim_xilinx_buf/g'                "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_xor2/prim_xilinx_xor2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_and2/prim_xilinx_and2/g'              "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i 's/prim_ram_1p/prim_generic_ram_1p/g'         "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Rename prim_sparse_fsm_flop instances. For some reason, sv2v decides to append a suffix.
     sed -i 's/prim_sparse_fsm_flop_.*/prim_sparse_fsm_flop \#(/g' \
-        $LR_SYNTH_OUT_DIR/generated/${module}.v
+        "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
-    sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT_otbn_pkg.*Width.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT(logic \[.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
+    sed -i '/\.StateEnumT_otbn_pkg.*Width.*(.*/d' "$LR_SYNTH_OUT_DIR"/generated/"${module}".v
 done
 
 #-------------------------------------------------------------------------
@@ -208,4 +208,4 @@ fi
 #-------------------------------------------------------------------------
 # report kGE number
 #-------------------------------------------------------------------------
-python/get_kge.py $LR_SYNTH_CELL_LIBRARY_PATH $LR_SYNTH_OUT_DIR/reports/area.rpt
+python/get_kge.py "$LR_SYNTH_CELL_LIBRARY_PATH" "$LR_SYNTH_OUT_DIR"/reports/area.rpt

--- a/hw/ip/prim/pre_dv/prim_crc32/run_predv.sh
+++ b/hw/ip/prim/pre_dv/prim_crc32/run_predv.sh
@@ -21,7 +21,7 @@ source "$UTIL_DIR/build_consts.sh"
 
 PREDV_DIR=$REPO_TOP/hw/ip/prim/pre_dv/prim_crc32
 
-(cd $REPO_TOP || exit;
+(cd "$REPO_TOP" || exit;
  fusesoc --cores-root=. run --target=sim --setup --build \
          lowrisc:prim:crc32_sim || fail "HW Sim build failed")
 
@@ -31,8 +31,8 @@ readonly RUN_LOG
 trap "rm -rf $RUN_LOG" EXIT
 
 timeout 5s \
-  $REPO_TOP/build/lowrisc_prim_crc32_sim_0/sim-verilator/Vprim_crc32_sim | \
-  tee $RUN_LOG
+  "$REPO_TOP"/build/lowrisc_prim_crc32_sim_0/sim-verilator/Vprim_crc32_sim | \
+  tee "$RUN_LOG"
 
 if [ $? -eq 124 ]; then
   fail "Simulation timeout"
@@ -42,7 +42,7 @@ if [ $? -ne 0 ]; then
   fail "Simulator run failed"
 fi
 
-grep -A 97 "00000000" $RUN_LOG | diff $PREDV_DIR/predv_expected.txt -
+grep -A 97 "00000000" "$RUN_LOG" | diff "$PREDV_DIR"/predv_expected.txt -
 
 if [ $? -eq 0 ]; then
   echo "PRE-DV PASS"

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
@@ -58,16 +58,16 @@ cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-flip-diff.log
 
 echo "Check No Flip Single Ended against expected logs"
 diff $VFILE_DIR/usb-noflip-se.log $EXPECT_USB
-diff $IGNORE_EX_UART $VFILE_DIR/uart-noflip-se.log $EXPECT_UART
+diff "$IGNORE_EX_UART" $VFILE_DIR/uart-noflip-se.log $EXPECT_UART
 
 echo "Check Flipped Single Ended against No Flip Single Ended"
-diff $IGNORE_USB $VFILE_DIR/usb-flip-se.log $VFILE_DIR/usb-noflip-se.log
-diff $IGNORE_UART $VFILE_DIR/uart-flip-se.log $VFILE_DIR/uart-noflip-se.log
+diff "$IGNORE_USB" $VFILE_DIR/usb-flip-se.log $VFILE_DIR/usb-noflip-se.log
+diff "$IGNORE_UART" $VFILE_DIR/uart-flip-se.log $VFILE_DIR/uart-noflip-se.log
 
 echo "Check No Flip differential against No Flip Single Ended"
-diff $IGNORE_USB $VFILE_DIR/usb-noflip-diff.log $VFILE_DIR/usb-noflip-se.log
-diff $IGNORE_UART $VFILE_DIR/uart-noflip-diff.log $VFILE_DIR/uart-noflip-se.log
+diff "$IGNORE_USB" $VFILE_DIR/usb-noflip-diff.log $VFILE_DIR/usb-noflip-se.log
+diff "$IGNORE_UART" $VFILE_DIR/uart-noflip-diff.log $VFILE_DIR/uart-noflip-se.log
 
 echo "Check Flipped differential against No Flip Single Ended"
-diff $IGNORE_USB $VFILE_DIR/usb-flip-diff.log $VFILE_DIR/usb-noflip-se.log
-diff $IGNORE_UART $VFILE_DIR/uart-flip-diff.log $VFILE_DIR/uart-noflip-se.log
+diff "$IGNORE_USB" $VFILE_DIR/usb-flip-diff.log $VFILE_DIR/usb-noflip-se.log
+diff "$IGNORE_UART" $VFILE_DIR/uart-flip-diff.log $VFILE_DIR/uart-noflip-se.log

--- a/rules/scripts/clang_format.template.sh
+++ b/rules/scripts/clang_format.template.sh
@@ -11,9 +11,9 @@ clang_format=$(realpath "$CLANG_FORMAT")
 
 if [[ ! -z "${WORKSPACE}" ]]; then
     REPO="$(dirname "$(realpath ${WORKSPACE})")"
-    cd ${REPO} || exit 1
+    cd "${REPO}" || exit 1
 elif [[ ! -z "${BUILD_WORKSPACE_DIRECTORY+is_set}" ]]; then
-    cd ${BUILD_WORKSPACE_DIRECTORY} || exit 1
+    cd "${BUILD_WORKSPACE_DIRECTORY}" || exit 1
 else
     echo "Neither WORKSPACE nor BUILD_WORKSPACE_DIRECTORY were set."
     echo "If this is a test rule, add 'workspace = \"//:WORKSPACE\"' to your rule."
@@ -34,13 +34,13 @@ case "$MODE" in
     diff)
         RESULT=0
         for f in $FILES; do
-            diff -Naur "$f" <(${clang_format} ${f})
+            diff -Naur "$f" <(${clang_format} "${f}")
             RESULT=$(($RESULT | $?))
         done
         exit $RESULT
         ;;
     fix)
-        echo "$FILES" | xargs ${clang_format} -i
+        echo "$FILES" | xargs "${clang_format}" -i
         ;;
     *)
         echo "Unknown mode: $MODE"

--- a/third_party/python/gen_requirements.sh
+++ b/third_party/python/gen_requirements.sh
@@ -12,8 +12,8 @@ WHEEL_DIR="./"
 OUTPUT_FILE="sanitized_requirements.txt"
 
 for wheel in $(ls -1 ${WHEEL_DIR}/*.whl); do
-  wheel_basename=$(echo ${wheel} | tr '\n' '\0' | xargs -0 -n 1 basename)
-  IFS='-' read -ra WHEEL_NAME_ARRAY <<< ${wheel_basename}
+  wheel_basename=$(echo "${wheel}" | tr '\n' '\0' | xargs -0 -n 1 basename)
+  IFS='-' read -ra WHEEL_NAME_ARRAY <<< "${wheel_basename}"
   PACKAGE_NAME=${WHEEL_NAME_ARRAY[0]}
   PACKAGE_VERSION=${WHEEL_NAME_ARRAY[1]}
   echo "${PACKAGE_NAME}==${PACKAGE_VERSION}" >> ${OUTPUT_FILE}

--- a/util/fpga/splice_rom.sh
+++ b/util/fpga/splice_rom.sh
@@ -134,10 +134,10 @@ updatemem -force --meminfo "${FPGA_BIN_DIR}/rom.mmi" \
   --out "${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.splice.bit" \
   --debug
 
-mv ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit.orig
+mv "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".bit "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".bit.orig
 
 # Rename to the canonical bitstream output name to simplify interaction with
 # other tools, and create a copy with a .splice suffix to be able to
 # export the artifact in CI.
-mv ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.splice.bit ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit
-cp ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit.splice
+mv "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".splice.bit "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".bit
+cp "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".bit "${FPGA_BIN_DIR}"/"${FPGA_BIT_NAME}".bit.splice

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -86,21 +86,21 @@ if [[ -d ${BAZEL_AIRGAPPED_DIR} ]]; then
     while true; do
       read -p "Airgapped directory exists, rebuild? [Y/n]" yn
       case $yn in
-          "") rm -rf ${BAZEL_AIRGAPPED_DIR}; break;;
-          [Yy]*) rm -rf ${BAZEL_AIRGAPPED_DIR}; break;;
+          "") rm -rf "${BAZEL_AIRGAPPED_DIR}"; break;;
+          [Yy]*) rm -rf "${BAZEL_AIRGAPPED_DIR}"; break;;
           [Nn]*) exit;;
           *) echo "Please enter [Yy] or [Nn]."
       esac
     done
   else
-    rm -rf ${BAZEL_AIRGAPPED_DIR}
+    rm -rf "${BAZEL_AIRGAPPED_DIR}"
   fi
 fi
 
 ################################################################################
 # Setup the airgapped directory.
 ################################################################################
-mkdir -p ${BAZEL_AIRGAPPED_DIR}
+mkdir -p "${BAZEL_AIRGAPPED_DIR}"
 
 ################################################################################
 # Prepare the distdir.
@@ -109,10 +109,10 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
       ${AIRGAPPED_DIR_CONTENTS} == "DISTDIR" ]]; then
   echo $LINE_SEP
   echo "Preparing bazel offline distdir ..."
-  mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_DISTDIR}
-  cd ${BAZEL_AIRGAPPED_DIR}
+  mkdir -p "${BAZEL_AIRGAPPED_DIR}"/"${BAZEL_DISTDIR}"
+  cd "${BAZEL_AIRGAPPED_DIR}"
   curl --silent --location \
-    https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64 \
+    https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-linux-x86_64 \
     --output bazel
   chmod +x bazel
   git clone -b "${BAZEL_VERSION}" --depth 1 https://github.com/bazelbuild/bazel bazel-repo
@@ -134,12 +134,12 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
       ${AIRGAPPED_DIR_CONTENTS} == "CACHE" ]]; then
   echo $LINE_SEP
   echo "Preparing bazel offline cachedir ..."
-  cd ${REPO_TOP}
-  mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR}
+  cd "${REPO_TOP}"
+  mkdir -p "${BAZEL_AIRGAPPED_DIR}"/"${BAZEL_CACHEDIR}"
   # Make bazel forget everything it knows, then download everything.
   ${BAZELISK} clean --expunge
   ${BAZELISK} fetch \
-    --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
+    --repository_cache="${BAZEL_AIRGAPPED_DIR}"/"${BAZEL_CACHEDIR}" \
     //... \
     @bindgen_clang_linux//... \
     @rules_rust_bindgen__bindgen-0.60.1//... \
@@ -154,11 +154,11 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rules_foreign_cc//toolchains/... \
     @rust_analyzer_1.67.0_tools//... \
     @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//...
-  cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
-    ${BAZEL_AIRGAPPED_DIR}/
+  cp -R "$(${BAZELISK} info output_base)"/external/"${BAZEL_PYTHON_WHEEL_REPO}" \
+    "${BAZEL_AIRGAPPED_DIR}"/
   # We don't need all bitstreams in the cache, we just need the latest one so
   # that the cache is "initialized" and "offline" mode will work correctly.
-  mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHEDIR}
+  mkdir -p "${BAZEL_AIRGAPPED_DIR}"/"${BAZEL_BITSTREAMS_CACHEDIR}"
   readonly SYSTEM_BITSTREAM_CACHE="${HOME}/.cache/opentitan-bitstreams"
   readonly SYSTEM_BITSTREAM_CACHEDIR="${SYSTEM_BITSTREAM_CACHE}/cache"
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"

--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -175,6 +175,6 @@ if [ "$command" = "serve" ] || [ "$command" = "serve-proxy" ]; then
   echo "Website being served at : ${base_url}"
   echo
   echo "--------------------------------------------"
-  python3 -m http.server -d "$build_dir" ${serve_port:1}
+  python3 -m http.server -d "$build_dir" "${serve_port:1}"
                                          # strip leading :
 fi

--- a/util/site/deploy.sh
+++ b/util/site/deploy.sh
@@ -89,7 +89,7 @@ deploy_site_builder () {
     gcloud config set project ${PROJECT}
     # Build the image locally using podman for speed
     tag="gcr.io/${PROJECT}/builder" # https://cloud.google.com/container-registry/docs/pushing-and-pulling#tag
-    pushd ${proj_root}
+    pushd "${proj_root}"
     podman build -t "${tag}" -f "${proj_root}/util/site/site-builder/builder.Dockerfile" .
     popd
     gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin gcr.io && \
@@ -99,25 +99,25 @@ deploy_site_builder () {
 deploy_staging () {
     # "Build the site for staging and deploy it to the staging bucket hosted at staging.opentitan.org"
     PROJECT="${OPENTITAN_ORG_ID}"
-    rm -rf ${build_dir}
-    ${proj_root}/util/site/build-docs.sh build-staging
+    rm -rf "${build_dir}"
+    "${proj_root}"/util/site/build-docs.sh build-staging
     remove_cruft
-    gcloud storage cp -R --gzip-in-flight-all ${build_dir}/* gs://${PROJECT}-staging
+    gcloud storage cp -R --gzip-in-flight-all "${build_dir}"/* gs://${PROJECT}-staging
 }
 
 deploy_prod () {
     # DO_NOT_USE
     # "Build the site for production and deploy it to the production bucket hosted at opentitan.org"
     PROJECT="${OPENTITAN_ORG_ID}"
-    rm -rf ${build_dir}
-    ${proj_root}/util/site/build-docs.sh build
+    rm -rf "${build_dir}"
+    "${proj_root}"/util/site/build-docs.sh build
     remove_cruft
-    gcloud storage cp -R --gzip-in-flight-all ${build_dir}/* gs://${PROJECT}-prod
+    gcloud storage cp -R --gzip-in-flight-all "${build_dir}"/* gs://${PROJECT}-prod
 }
 
 # Remove additional files from build directory that we don't need
 # TODO remove this when we are ready for .mdbookignore (https://github.com/rust-lang/mdBook/pull/1908)
-remove_cruft () { rm -rf ${build_dir}/book/.git ${build_dir}/book/.github ${build_dir}/book/build-site ${build_dir}/book/site ; }
+remove_cruft () { rm -rf "${build_dir}"/book/.git "${build_dir}"/book/.github "${build_dir}"/book/build-site "${build_dir}"/book/site ; }
 
 #######
 # CLI #

--- a/util/syn_yosys.sh
+++ b/util/syn_yosys.sh
@@ -56,7 +56,7 @@ sv2v -DSYNTHESIS *.sv +RTS -N4 > combined.v
 modules=`cat combined.v | grep "^module" | sed -e "s/^module //" | sed -e "s/ (//"`
 echo "$modules" > modules.txt  # for debugging
 for module in $modules; do
-  sed -n "/^module $module /,/^endmodule/p" < combined.v > $module.v
+  sed -n "/^module $module /,/^endmodule/p" < combined.v > "$module".v
 done
 rm combined.v
 
@@ -100,17 +100,17 @@ for module in "${modules[@]}"; do
   # run Conformal LEC
   lec -xl -nogui -nobanner \
     -dofile  ../../hw/formal/lec_sv2v.do \
-    -logfile lec_${module}.log \
+    -logfile lec_"${module}".log \
     <<< "exit -force" > /dev/null 2>&1
 
   # summarize results
-  result=`grep "Compare Results" lec_${module}.log 2>&1`
+  result=`grep "Compare Results" lec_"${module}".log 2>&1`
   if [ $? -ne 0 ]; then
     result="CRASH"
   else
-    result=`echo $result | awk '{ print $4 }'`
+    result=`echo "$result" | awk '{ print $4 }'`
   fi
-  printf "%-25s %s\n" $module $result
+  printf "%-25s %s\n" "$module" "$result"
 done
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
This fixes `shellcheck` diagnostic SC2086: Double quote to prevent globbing and word splitting.

Three additional shell scripts in the `hw/vendor` directory were not included:

- `hw/vendor/pulp_riscv_dbg/ci/get-openocd.sh`
- `hw/vendor/pulp_riscv_dbg/ci/install-verilator.sh`
- `hw/vendor/pulp_riscv_dbg/tb/jtag_dmi/run_vsim_xilinx.sh`

**Note**: these are the automatic transformations applied by `shellcheck`. If people agree with the overall PR, we can consider cleaning up things like `"$LR_SYNTH_OUT_DIR"/generated/"${module}".v` into `"${LR_SYNTH_OUT_DIR}/generated/${module}.v"`.