### PR TITLE
[ast] Bypass logic for clk_ext in FPGA targets

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -107,4 +107,4 @@ set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_a
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from [get_clocks clk_usb_48mhz] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]

--- a/hw/top_earlgrey/ip/ast/lint/ast.waiver
+++ b/hw/top_earlgrey/ip/ast/lint/ast.waiver
@@ -64,6 +64,22 @@ waive -rules CLOCK_MUX -location {ast_clks_byp.sv} \
       -regexp {Clock '(clk_ast_ext_scn|clk_ext_scn|clk_src_ext_usb|clk_ext_aon)' is driven by a multiplexer here, used as a clock} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {Assignment to 'clk_ast_ext_scn' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {'prim_clock_buf' instance 'u_clk_ext_buf' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {'prim_clock_div' instance 'u_no_scan_clk_(ext_d1ord2|usb_div240_div)' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {'prim_clock_gating' instance 'u_clk_ext_io_ckgt' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
 waive -rules CLOCK_MUX -location {ast.sv} \
       -regexp {Clock 'clk_aon_n' is driven by a multiplexer here, used as a clock} \
       -comment {This clock inverter has a DFT mux.}


### PR DESCRIPTION
Bypass the dividers and derived clock generation for the external clock (IOC6) when using the FPGA. Instead, reuse the clocks generated within the FPGA, which bypassed the oscillator modeling of the AST.

This connects clocks for tests that switch to the external clock on IOC6. Previously, the external clock tree was not driven.