### PR TITLE
[earlgrey/dv] Remove outdated TODO comment

### DIFF
--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -25,7 +25,6 @@
       sw_images: ["//sw/device/tests:clkmgr_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
     {
      name: chip_sw_csrng_smoketest
      uvm_test_seq: chip_sw_base_vseq


### PR DESCRIPTION
A known answer test for CSRNG that includes the generated bits has been added in PR #13341.  We thus know there is no mismatch there.  The referenced issue (#7505) has already been closed.