### PR TITLE
[pwrmgr, rtl] Fix ndmreset handling in pwrmgr_fsm

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -452,7 +452,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
                                        direct_rst_req |
                                        sw_rst_req) |
                                       (ndmreset_req &
-                                       lc_ctrl_pkg::lc_tx_test_false_loose(lc_dft_en_i))}};
+                                       lc_ctrl_pkg::lc_tx_test_false_loose(lc_hw_debug_en_i))}};
 
 
         state_d = FastPwrStateResetWait;


### PR DESCRIPTION
A system reset should be requested when an ndmreset is requested when the life cycle controller hasn't enabled debug. The logic to handle this was mistakenly wired into the DFT state.

Fixes #17377