### PR TITLE
[site] Fix vertical alignment of header between pages

### DIFF
--- a/site/landing/assets/scss/_main-header.scss
+++ b/site/landing/assets/scss/_main-header.scss
@@ -43,6 +43,7 @@
   width: 12.5em;
   max-height: 2.375em;
   min-width: 12.5em;
+  margin: 0;
   order: 1;
   flex-grow: 1;
   flex-basis: calc((40em - 100%) * 999);


### PR DESCRIPTION
This PR fixes the vertical alignment of the site's header changing between the landing and documentation pages.

Caused by `_reset.scss` setting `h1` margins to `0` which we undo for the documentation page. The logo is a `<h1>` so gets a `margin: 0` on the landing page, and the default margin elsewhere.

Test by going to `site/landing` and running `hugo serve`. You can flick between the landing page and documentation page at `https://localhost:1313` to see the fixed alignment.