### PR TITLE
[spi_passthru] Simplest implementation of SPI passthru 

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -364,8 +364,14 @@ cc_library(
 
 cc_library(
     name = "spi_flash_testutils",
-    srcs = ["spi_flash_testutils.c"],
-    hdrs = ["spi_flash_testutils.h"],
+    srcs = [
+        "spi_flash_emulator.c",
+        "spi_flash_testutils.c",
+    ],
+    hdrs = [
+        "spi_flash_emulator.h",
+        "spi_flash_testutils.h",
+    ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":spi_device_testutils",

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -355,7 +355,9 @@ cc_library(
     hdrs = ["spi_device_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/testing/json:spi_passthru",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -23,6 +23,7 @@ extern "C" {
     value(_, SpiFlashReadId) \
     value(_, SpiFlashReadSfdp) \
     value(_, SpiFlashEraseSector) \
+    value(_, SpiFlashEmulator) \
     value(_, SpiFlashWrite) \
     value(_, SwStrapRead)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -35,6 +35,8 @@ typedef enum spi_device_flash_opcode {
   kSpiDeviceFlashOpPageProgram = 0x02,
   kSpiDeviceFlashOpEnter4bAddr = 0xb7,
   kSpiDeviceFlashOpExit4bAddr = 0xe9,
+  kSpiDeviceFlashOpResetEnable = 0x66,
+  kSpiDeviceFlashOpReset = 0x99,
 } spi_device_flash_opcode_t;
 
 /**

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -8,7 +8,9 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/testing/json/spi_passthru.h"
 
 /**
  * A set of typical opcodes for named flash commands.
@@ -73,5 +75,19 @@ enum spi_device_command_slot {
 void spi_device_testutils_configure_passthrough(
     dif_spi_device_handle_t *spi_device, uint32_t filters,
     bool upload_write_commands);
+
+/**
+ * Wait for a spi command upload.
+ *
+ * Upon detecting a spi command upload, the `info` block will be populated
+ * with the opcode, address and data phases of the uploaded command.
+ *
+ * @param spid A spid_device DIF handle.
+ * @param info Pointer to an upload_info_t.
+ * @return A status_t indicating success or failure in receving the uploaded
+ *         command.
+ */
+status_t spi_device_testutils_wait_for_upload(dif_spi_device_handle_t *spid,
+                                              upload_info_t *info);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_DEVICE_TESTUTILS_H_

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -1,0 +1,158 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/spi_flash_emulator.h"
+
+#include <stdalign.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
+
+enum {
+  // JEDEC standard continuation code.
+  kJedecContCode = 0x7f,
+  // JEDEC ID of lowRISC.
+  kJedecManufacturer = 0xEF,
+  // lowRISC is on page 12 of JEDEC IDs.
+  kJedecContCodeCount = 12,
+  // A density of 24 corresponds to 16MiB (1<<24 bytes).
+  kJedecDensity = 24,
+  // The standard SFDP signature value.
+  kSfdpSignature = 0x50444653,
+};
+
+typedef struct sfdp_header {
+  uint32_t signature;
+  uint8_t minor;
+  uint8_t major;
+  uint8_t nph;
+  uint8_t reserved;
+} sfdp_header_t;
+
+typedef struct parameter_header {
+  uint8_t param_id;
+  uint8_t minor;
+  uint8_t major;
+  uint8_t length;
+  uint8_t table_pointer[3];
+  uint8_t pad;
+} parameter_header_t;
+
+typedef struct bfpt {
+  uint32_t data[9];
+} bfpt_t;
+
+typedef struct sfdp {
+  sfdp_header_t header;
+  parameter_header_t param;
+  bfpt_t bfpt;
+} sfdp_t;
+
+static status_t prepare_sfdp(dif_spi_host_t *spih,
+                             dif_spi_device_handle_t *spid) {
+  alignas(uint32_t) uint8_t data[256];
+  spi_flash_testutils_read_sfdp(spih, 0, data, sizeof(data));
+
+  // TODO: present a better SFDP table.  This table is as simple
+  // as possible and copies only a few bits of relevant data
+  // from the backend EEPROM's table.
+  sfdp_t sfdp = {
+      .header = {.signature = kSfdpSignature,
+                 .minor = 0,
+                 .major = 1,
+                 .nph = 0,
+                 .reserved = 0xFF},
+      .param =
+          {
+              .param_id = 0x00,
+              .minor = 0,
+              .major = 1,
+              .length = sizeof(bfpt_t) / sizeof(uint32_t),
+              .table_pointer = {(uint8_t)offsetof(sfdp_t, bfpt)},
+              .pad = 0xFF,
+          },
+      .bfpt = {0},
+  };
+
+  uint32_t offset =
+      read_32(data + offsetof(sfdp_t, param.table_pointer)) & 0x00FFFFFF;
+  if (offset >= sizeof(data)) {
+    return INVALID_ARGUMENT();
+  }
+
+  // We want to copy SFDP word 0 from the eeprom and preserve the
+  // block_erase_size, write_granularity, write_en_required, write_en_opcode,
+  // erase_opcode, support_fast_read_112, address_modes and
+  // support_fast_read_114 fields.
+  sfdp.bfpt.data[0] = read_32(data + offset);
+  sfdp.bfpt.data[0] &= 0x0047FFFF;
+  // Preserve the entire density field.
+  sfdp.bfpt.data[1] = read_32(data + offset + 1 * sizeof(uint32_t));
+  // Preserve the 1-1-4 parameters, discard the 1-4-4 parameters.
+  sfdp.bfpt.data[2] = read_32(data + offset + 2 * sizeof(uint32_t));
+  sfdp.bfpt.data[2] &= 0xFFFF0000;
+  // Preserve the sector erase information.
+  sfdp.bfpt.data[7] = read_32(data + offset + 7 * sizeof(uint32_t));
+  sfdp.bfpt.data[8] = read_32(data + offset + 8 * sizeof(uint32_t));
+
+  TRY(dif_spi_device_write_flash_buffer(spid, kDifSpiDeviceFlashBufferTypeSfdp,
+                                        0, sizeof(sfdp), (uint8_t *)&sfdp));
+  return OK_STATUS();
+}
+
+static status_t prepare_jedec_id(dif_spi_device_handle_t *spid) {
+  dif_spi_device_flash_id_t id = {
+      // TODO: configure a density that reflects the backend eeprom.
+      .device_id = kJedecDensity << 8,
+      .manufacturer_id = kJedecManufacturer,
+      .continuation_code = kJedecContCode,
+      .num_continuation_code = kJedecContCodeCount,
+  };
+  TRY(dif_spi_device_set_flash_id(spid, id));
+  return OK_STATUS();
+}
+
+status_t spi_flash_emulator(dif_spi_host_t *spih,
+                            dif_spi_device_handle_t *spid) {
+  // TODO: add a mode that uses spi_device address translation.
+  LOG_INFO("Configuring spi_flash_emulator.");
+  TRY(dif_spi_device_set_passthrough_mode(spid, kDifToggleDisabled));
+  TRY(prepare_sfdp(spih, spid));
+  TRY(prepare_jedec_id(spid));
+  TRY(dif_spi_device_set_passthrough_mode(spid, kDifToggleEnabled));
+  LOG_INFO("Starting spi_flash_emulator.");
+
+  bool running = true;
+  while (running) {
+    upload_info_t info = {0};
+    TRY(spi_device_testutils_wait_for_upload(spid, &info));
+
+    TRY(dif_spi_device_set_passthrough_mode(spid, kDifToggleDisabled));
+    switch (info.opcode) {
+      // TODO: process the alternate erase opcodes from the BFPT.
+      case kSpiDeviceFlashOpChipErase:
+        spi_flash_testutils_erase_chip(spih);
+        break;
+      case kSpiDeviceFlashOpSectorErase:
+        spi_flash_testutils_erase_sector(spih, info.address, info.addr_4b);
+        break;
+      case kSpiDeviceFlashOpPageProgram:
+        spi_flash_testutils_program_page(spih, info.data, info.data_len,
+                                         info.address, info.addr_4b);
+        break;
+      case kSpiDeviceFlashOpReset:
+        running = false;
+        break;
+      default:
+        LOG_ERROR("Unknown SPI op: %02x", info.opcode);
+    }
+    TRY(dif_spi_device_set_passthrough_mode(spid, kDifToggleEnabled));
+    TRY(dif_spi_device_set_flash_status_registers(spid, 0));
+  }
+  LOG_INFO("Exiting spi_flash_emulator.");
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/spi_flash_emulator.h
+++ b/sw/device/lib/testing/spi_flash_emulator.h
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_EMULATOR_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_EMULATOR_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+
+/**
+ * Emulate a SPI eeprom.
+ *
+ * @param spih A SPI host handle.
+ * @param spid A SPI device handle.
+ * @return A status.
+ */
+status_t spi_flash_emulator(dif_spi_host_t *spih,
+                            dif_spi_device_handle_t *spid);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_EMULATOR_H_

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -69,56 +69,10 @@ static status_t write_sfdp_data(ujson_t *uj, dif_spi_device_handle_t *spid) {
 }
 
 static status_t wait_for_upload(ujson_t *uj, dif_spi_device_handle_t *spid) {
-  // Wait for a SPI transaction cause an upload.
-  bool upload_pending;
-  do {
-    // The UploadCmdfifoNotEmpty interrupt status is updated after the SPI
-    // transaction completes.
-    TRY(dif_spi_device_irq_is_pending(
-        &spid->dev, kDifSpiDeviceIrqUploadCmdfifoNotEmpty, &upload_pending));
-  } while (!upload_pending);
-
   upload_info_t info = {0};
-  uint8_t occupancy;
-
-  // Get the SPI opcode.
-  TRY(dif_spi_device_get_flash_command_fifo_occupancy(spid, &occupancy));
-  if (occupancy != 1) {
-    // Cannot have an uploaded command without an opcode.
-    return INTERNAL();
-  }
-  TRY(dif_spi_device_pop_flash_command_fifo(spid, &info.opcode));
-  // Get the flash_status register.
-  TRY(dif_spi_device_get_flash_status_registers(spid, &info.flash_status));
-
-  // Get the SPI address (if available).
-  TRY(dif_spi_device_get_flash_address_fifo_occupancy(spid, &occupancy));
-  if (occupancy) {
-    dif_toggle_t addr_4b;
-    TRY(dif_spi_device_get_4b_address_mode(spid, &addr_4b));
-    info.addr_4b = addr_4b;
-    TRY(dif_spi_device_pop_flash_address_fifo(spid, &info.address));
-    info.has_address = true;
-  }
-
-  // Get the SPI data payload (if available).
-  uint32_t start;
-  TRY(dif_spi_device_get_flash_payload_fifo_occupancy(spid, &info.data_len,
-                                                      &start));
-  if (info.data_len) {
-    if (info.data_len > sizeof(info.data)) {
-      // We aren't expecting more than 256 bytes of data.
-      return INVALID_ARGUMENT();
-    }
-    TRY(dif_spi_device_read_flash_buffer(spid,
-                                         kDifSpiDeviceFlashBufferTypePayload,
-                                         start, info.data_len, info.data));
-  }
-
-  // Finished: ack the IRQ and clear the busy bit (and all other bits)
-  // in flash_status.
-  TRY(dif_spi_device_irq_acknowledge(&spid->dev,
-                                     kDifSpiDeviceIrqUploadCmdfifoNotEmpty));
+  TRY(spi_device_testutils_wait_for_upload(spid, &info));
+  // Clear the bits in flash_status to signal the end of processing of an
+  // uploaded command.
   TRY(dif_spi_device_set_flash_status_registers(spid, 0));
   RESP_OK(ujson_serialize_upload_info_t, uj, &info);
   return OK_STATUS();

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -14,6 +14,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/json/command.h"
 #include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_emulator.h"
 #include "sw/device/lib/testing/spi_flash_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
@@ -164,6 +165,9 @@ status_t command_processor(ujson_t *uj) {
         break;
       case kTestCommandSpiFlashWrite:
         RESP_ERR(uj, spi_flash_write(uj, &spih, &spid));
+        break;
+      case kTestCommandSpiFlashEmulator:
+        RESP_ERR(uj, spi_flash_emulator(&spih, &spid));
         break;
 
       default:


### PR DESCRIPTION
1. Create a SPI flash emulator to processes uploaded commands.
   Currently, the emulator understands ChipErase, SectorErase and
   PageProgram.

Signed-off-by: Chris Frantz <cfrantz@google.com>