### PR TITLE
[hw,i2c] Add missing entries in testplan

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -143,7 +143,7 @@
               - Ensure receving correct number of fmt_fifo and rx_fifo watermark interrupts
             '''
       stage: V2
-      tests: ["i2c_host_fifo_watermark"]
+      tests: [""]
     }
     {
       name: host_fifo_overflow
@@ -303,7 +303,7 @@
               - Ensure reset is handled correctly
             '''
       stage: V3
-      tests: [""]
+      tests: ["i2c_target_stress_all_with_rand_reset"]
     }
     {
       name: target_perf

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -202,6 +202,20 @@
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
     }
+    {
+      name: "i2c_host_stress_all_with_rand_reset"
+      uvm_test_seq: "i2c_common_vseq"
+      run_opts: ["+run_stress_all_with_rand_reset",
+                 "+stress_seq=i2c_host_stress_all_vseq"]
+      run_timeout_mins: 20
+    }
+    {
+      name: "i2c_target_stress_all_with_rand_reset"
+      uvm_test_seq: "i2c_common_vseq"
+      run_opts: ["+run_stress_all_with_rand_reset",
+                 "+stress_seq=i2c_target_stress_all_vseq"]
+      run_timeout_mins: 20
+    }
   ]
 
   // List of regressions.
@@ -215,7 +229,7 @@
       tests: ["i2c_host_smoke", "i2c_host_override", "i2c_host_perf",
               "i2c_host_fifo_threshold", "i2c_host_fifo_overflow", "i2c_host_fifo_reset_fmt",
               "i2c_host_rx_oversample",  "i2c_host_stretch_timeout",
-              "i2c_host_fifo_fmt_empty", "i2c_host_fifo_reset_rx", "i2c_host_timeout",
+              "i2c_host_fifo_fmt_empty", "i2c_host_fifo_reset_rx", "i2c_host_stretch_timeout",
               "i2c_host_fifo_full",
               "i2c_host_error_intr"]
     }


### PR DESCRIPTION
Testplan has `i2c_<host/target>_stress_all_with_rand_reset`, but these not present in sim config json. Update the entries in simconfig and testplan
Testplan has fifo_watermark test which is not present in sequence lib. Add placeholder sequence for this test

This change fixes the errors shown in snapshot
![image](https://user-images.githubusercontent.com/124047397/225283533-3c65df16-11ec-4d9c-95e9-bf56b246b66b.png)
