### PR TITLE
[hw,dv_utils] Fix macro substitution issue with Xcelium

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -457,12 +457,12 @@
 `define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
   begin \
     string str; \
-    if ($value$plusargs("``PLUSARG_``=%0s", str)) begin \
+    if ($value$plusargs(`"``PLUSARG_``=%0s`", str)) begin \
       if (!uvm_enum_wrapper#(ENUM_)::from_name(str, VAR_)) begin \
-        `uvm_fatal(ID_, $sformatf("Cannot find %s from enum ``ENUM_``", VAR_.name())) \
+        `uvm_fatal(ID_, $sformatf(`"Cannot find %s from enum ``ENUM_```", VAR_.name())) \
       end \
     end else if (CHECK_EXISTS_) begin \
-      `uvm_fatal(ID_, "Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>") \
+      `uvm_fatal(ID_, `"Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>`") \
     end \
   end
 `endif
@@ -480,10 +480,10 @@
 `define DV_GET_QUEUE_PLUSARG(QUEUE_, PLUSARG_, DELIMITER_ = ",", CHECK_EXISTS_ = 0, ID_ = `gfn) \
   begin \
     string str; \
-    if ($value$plusargs("``PLUSARG_``=%0s", str)) begin \
+    if ($value$plusargs(`"``PLUSARG_``=%0s`", str)) begin \
       str_split(str, QUEUE_, DELIMITER_); \
     end else if (CHECK_EXISTS_) begin \
-      `uvm_fatal(ID_, "Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>") \
+      `uvm_fatal(ID_, `"Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>`") \
     end \
   end
 `endif


### PR DESCRIPTION
As per System Verilog standard, to create macro strings using macro arguments use `` `" `` instead of `"`.
Update the macros processing `valueplusargs` arguments. Other macros has this change.
![image](https://user-images.githubusercontent.com/124047397/225325431-18643c10-4bd8-4008-8e12-2aa2f015f07e.png)
