### PR TITLE
[site] Centre block diagram on documentation page

### DIFF
--- a/site/landing/assets/scss/_block-diagram.scss
+++ b/site/landing/assets/scss/_block-diagram.scss
@@ -1,0 +1,3 @@
+.diagram {
+    margin: 2em auto;
+}

--- a/site/landing/assets/scss/single.scss
+++ b/site/landing/assets/scss/single.scss
@@ -3,6 +3,7 @@
 @import "base";
 @import "content-body";
 @import "boxes";
+@import "block-diagram";
 @import "main-header";
 @import "scheme-toggle";
 @import "footer";


### PR DESCRIPTION
This PR centres the block diagram in the middle of the documentation page.

Previously, the diagram was left aligned.

![image](https://user-images.githubusercontent.com/105280833/225377065-eaee4fff-ea3b-44e5-9d9a-6f8b0a191b2a.png)
