### PR TITLE
[AST] encapsulate pad2ast bus

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -9,6 +9,17 @@
 `else
 `define __AST_PKG_SV
 
+`define PAD2AST_WIRES     \
+{ manual_in_ast_misc,     \
+  mio_in_raw[MioPadIoc3], \
+  mio_in_raw[MioPadIoc2], \
+  mio_in_raw[MioPadIoc1], \
+  mio_in_raw[MioPadIob2], \
+  mio_in_raw[MioPadIob1], \
+  mio_in_raw[MioPadIob0], \
+  mio_in_raw[MioPadIoa5], \
+  mio_in_raw[MioPadIoa4] }
+
 package ast_pkg;
 
 parameter int unsigned NumIoRails = 2;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -202,12 +202,15 @@ module chip_earlgrey_asic #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
+  logic [24-1:0]                       dio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
 
   logic unused_mio_in_raw;
+  logic unused_dio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
+  assign unused_dio_in_raw = ^dio_in_raw;
 
   // Manual pads
   logic manual_in_por_n, manual_out_por_n, manual_oe_por_n;
@@ -479,7 +482,7 @@ module chip_earlgrey_asic #(
   // This is only used for scan and DFT purposes
     .clk_scan_i   ( ast_base_clks.clk_sys ),
     .scanmode_i   ( scanmode              ),
-    .dio_in_raw_o ( ),
+    .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({
       AST_MISC,
@@ -841,16 +844,7 @@ module chip_earlgrey_asic #(
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,
-                     mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIoc2],
-                     mio_in_raw[MioPadIoc1],
-                     mio_in_raw[MioPadIob2],
-                     mio_in_raw[MioPadIob1],
-                     mio_in_raw[MioPadIob0],
-                     mio_in_raw[MioPadIoa5],
-                     mio_in_raw[MioPadIoa4]
-                   };
+  assign pad2ast = `PAD2AST_WIRES ;
 
   // AST does not use all clocks / resets forwarded to it
   logic unused_slow_clk_en;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -212,12 +212,15 @@ module chip_earlgrey_cw310 #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
+  logic [24-1:0]                       dio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
 
   logic unused_mio_in_raw;
+  logic unused_dio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
+  assign unused_dio_in_raw = ^dio_in_raw;
 
   // Manual pads
   logic manual_in_por_n, manual_out_por_n, manual_oe_por_n;
@@ -355,7 +358,7 @@ module chip_earlgrey_cw310 #(
   // This is only used for scan and DFT purposes
     .clk_scan_i   ( 1'b0                  ),
     .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
-    .dio_in_raw_o ( ),
+    .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({
       IO_TRIGGER,

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -188,12 +188,15 @@ module chip_${top["name"]}_${target["name"]} #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
+  logic [24-1:0]                       dio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
 
   logic unused_mio_in_raw;
+  logic unused_dio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
+  assign unused_dio_in_raw = ^dio_in_raw;
 
   // Manual pads
 % for pad in dedicated_pads:
@@ -307,7 +310,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .clk_scan_i   ( 1'b0                  ),
     .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
   % endif
-    .dio_in_raw_o ( ),
+    .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({
 % for pad in list(reversed(dedicated_pads)):
@@ -628,16 +631,7 @@ module chip_${top["name"]}_${target["name"]} #(
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,
-                     mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIoc2],
-                     mio_in_raw[MioPadIoc1],
-                     mio_in_raw[MioPadIob2],
-                     mio_in_raw[MioPadIob1],
-                     mio_in_raw[MioPadIob0],
-                     mio_in_raw[MioPadIoa5],
-                     mio_in_raw[MioPadIoa4]
-                   };
+  assign pad2ast = `PAD2AST_WIRES ;
 
   // AST does not use all clocks / resets forwarded to it
   logic unused_slow_clk_en;


### PR DESCRIPTION
Currently the pad2ast is hardwired. In order for the vendor to change it, the top level template and sv files should be modified. Adding  a macro in ast_pkg.sv that defines the pad2ast allows the vendor to modify this macro in the vendor's ast_pkg.sv



