### PR TITLE
[test] Add passthrough address translation test

### DIFF
--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -25,6 +25,7 @@ extern "C" {
     value(_, SpiFlashEraseSector) \
     value(_, SpiFlashEmulator) \
     value(_, SpiFlashWrite) \
+    value(_, SpiPassthruSetAddressMap) \
     value(_, SwStrapRead)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);
 

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -61,6 +61,11 @@ UJSON_SERDE_STRUCT(SpiFlashEraseSector, spi_flash_erase_sector_t, STRUCT_SPI_FLA
     field(length, uint16_t)
 UJSON_SERDE_STRUCT(SpiFlashWrite, spi_flash_write_t, STRUCT_SPI_FLASH_WRITE);
 
+#define STRUCT_SPI_PASSTHRU_SWAP_MAP(field, string) \
+    field(mask, uint32_t) \
+    field(value, uint32_t)
+UJSON_SERDE_STRUCT(SpiPassthruSwapMap, spi_passthru_swap_map_t, STRUCT_SPI_PASSTHRU_SWAP_MAP);
+
 // clang-format on
 #ifdef __cplusplus
 }

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -134,6 +134,14 @@ status_t spi_flash_write(ujson_t *uj, dif_spi_host_t *spih,
   return RESP_OK_STATUS(uj);
 }
 
+status_t spi_passthru_set_address_map(ujson_t *uj,
+                                      dif_spi_device_handle_t *spid) {
+  spi_passthru_swap_map_t swap;
+  TRY(ujson_deserialize_spi_passthru_swap_map_t(uj, &swap));
+  TRY(dif_spi_device_set_flash_address_swap(spid, swap.mask, swap.value));
+  return RESP_OK_STATUS(uj);
+}
+
 status_t command_processor(ujson_t *uj) {
   while (true) {
     test_command_t command;
@@ -168,6 +176,9 @@ status_t command_processor(ujson_t *uj) {
         break;
       case kTestCommandSpiFlashEmulator:
         RESP_ERR(uj, spi_flash_emulator(&spih, &spid));
+        break;
+      case kTestCommandSpiPassthruSetAddressMap:
+        RESP_ERR(uj, spi_passthru_set_address_map(uj, &spid));
         break;
 
       default:

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -90,3 +90,12 @@ impl SpiFlashWrite {
         Ok(())
     }
 }
+
+impl SpiPassthruSwapMap {
+    pub fn apply_address_swap(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiPassthruSetAddressMap.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Test address translation for SPI passthrough. Add different data to two different sectors, and check that reads to each address pull the correct data. Then, map one sector to another, and check that the read of the virtualized address pulls the other sector's data.