### PR TITLE
[ci] Revert change to use local runner for Earl Grey SW Build & Test and increase timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -285,7 +285,7 @@ jobs:
   displayName: Fast Verilated Earl Grey tests
   # Build and run fast tests on sim_verilator
   pool: ci-public
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   dependsOn: lint
   steps:
   - template: ci/checkout-template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ jobs:
   timeoutInMinutes: 180
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool: ci-public-general
+  pool: ci-public
   variables:
     - name: bazelCacheGcpKeyPath
       value: ''


### PR DESCRIPTION
Running the Earl Grey Software Build & Test on frank is affecting the reliability of the FPGA tests running on that machine so revert back to using GCP. Also, increase the timeout of the Early Grey SW Build & Test job to give more headroom since the job is sometimes taking about 3 hours on GCP.