### PR TITLE
[util,test] fix bug in flash scrambling script and add flash scrambling smoketest

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3518,7 +3518,7 @@
       in #14095 for more details on how to approach the implementation.
       '''
       stage: V3
-      tests: []
+      tests: ["chip_sw_power_virus"]
     }
     {
       name: chip_sw_power_idle_load

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3349,6 +3349,7 @@
               "chip_sw_rstmgr_smoketest",
               "chip_sw_sram_ctrl_smoketest",
               "chip_sw_uart_smoketest",
+              "chip_sw_flash_scrambling_smoketest",
             ]
     }
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1802,6 +1802,17 @@
       ]
       run_timeout_mins: 300
     }
+    {
+      name: chip_sw_flash_scrambling_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/tests:flash_scrambling_smoketest:1",
+        "//sw/device/tests:flash_scrambling_smoketest_otp_img_rma:4",
+      ]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeCustom"]
+      run_timeout_mins: 10
+    }
   ]
 
   // List of regressions.
@@ -1822,6 +1833,7 @@
               "chip_sw_spi_device_pass_through",
               "chip_sw_i2c_host_tx_rx",
               "chip_sw_i2c_device_tx_rx",
+              "chip_sw_flash_scrambling_smoketest",
               "chip_plic_all_irqs",
               "chip_sw_example_flash",
               "chip_sw_example_rom",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2229,3 +2229,37 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
     ],
 )
+
+otp_json(
+    name = "flash_scrambling_smoketest_otp_overlay",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                # Enable flash scrambling and ECC.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "flash_scrambling_smoketest_otp_img_rma",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":flash_scrambling_smoketest_otp_overlay"],
+    visibility = ["//visibility:private"],
+)
+
+opentitan_functest(
+    name = "flash_scrambling_smoketest",
+    srcs = ["example_test_from_flash.c"],
+    dv = dv_params(
+        otp = ":flash_scrambling_smoketest_otp_img_rma",
+    ),
+    targets = [
+        "dv",
+    ],
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2100,10 +2100,8 @@ otp_json(
         otp_partition(
             name = "CREATOR_SW_CFG",
             items = {
-                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090909",
-                # TODO(#14814): enable flash scrambling / ECC by replacing above
-                # with below.
-                #"CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+                # Enable flash scrambling and ECC.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
             },
         ),
     ],

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -1157,8 +1157,8 @@ static void check_otp_csr_configs(void) {
   dif_flash_ctrl_region_properties_t default_properties;
   CHECK_DIF_OK(dif_flash_ctrl_get_default_region_properties(
       &flash_ctrl, &default_properties));
-  CHECK(default_properties.scramble_en == kMultiBitBool4False);
-  CHECK(default_properties.ecc_en == kMultiBitBool4False);
+  CHECK(default_properties.scramble_en == kMultiBitBool4True);
+  CHECK(default_properties.ecc_en == kMultiBitBool4True);
   CHECK(default_properties.high_endurance_en == kMultiBitBool4False);
 }
 


### PR DESCRIPTION
This PR:
1. fixes a bug in the flash scrambling script that resulted in an incorrect computation of the XEX scrambling mask,
2. enables flash scrambling and ECC in the power virus test,
3. consolidates all flash_ctrl configurations in the test ROM (made debugging easier and better aligns with ROM),
4. adds a simple flash scrambling smoke test as a presubmit check in private-CI

This completes all tasks, and fixes #9322.

This also partially addresses #14814. 