### PR TITLE
[opentitanlib] add jtag io trait

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -72,6 +72,7 @@ rust_library(
         "src/io/emu.rs",
         "src/io/gpio.rs",
         "src/io/i2c.rs",
+        "src/io/jtag.rs",
         "src/io/mod.rs",
         "src/io/spi.rs",
         "src/io/uart.rs",

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -9,6 +9,7 @@ pub mod config;
 use crate::io::emu::Emulator;
 use crate::io::gpio::{GpioMonitoring, GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
+use crate::io::jtag::Jtag;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 use crate::transport::{
@@ -322,6 +323,13 @@ impl TransportWrapper {
     /// transport object.
     pub fn capabilities(&self) -> Result<crate::transport::Capabilities> {
         self.transport.borrow().capabilities()
+    }
+
+    /// Returns a [`Jtag`] implementation.
+    pub fn jtag(&self, _openocd: &str, _openocd_adapter_config: &str) -> Result<Rc<dyn Jtag>> {
+        self.transport
+            .borrow()
+            .jtag(_openocd, _openocd_adapter_config)
     }
 
     /// Returns a SPI [`Target`] implementation.

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use structopt::StructOpt;
+use thiserror::Error;
+
+use crate::app::TransportWrapper;
+use crate::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use crate::impl_serializable_error;
+
+#[derive(Debug, StructOpt)]
+pub struct JtagParams {
+    #[structopt(long, help = "OpenOCD binary path.", default_value = "openocd")]
+    pub openocd: String,
+
+    #[structopt(long, help = "Path to OpenOCD JTAG adapter config file.")]
+    openocd_adapter_config: String,
+}
+
+impl JtagParams {
+    pub fn create(&self, transport: &TransportWrapper) -> Result<Rc<dyn Jtag>> {
+        let jtag = transport.jtag(&self.openocd, &self.openocd_adapter_config)?;
+        Ok(jtag)
+    }
+}
+
+/// Errors related to the JTAG interface.
+#[derive(Error, Debug, Deserialize, Serialize)]
+pub enum JtagError {
+    #[error("JTAG timeout")]
+    Timeout,
+    #[error("JTAG busy")]
+    Busy,
+    #[error("Generic error {0}")]
+    Generic(String),
+}
+impl_serializable_error!(JtagError);
+
+/// Represents an OpenOCD command sent over JTAG.
+pub enum OpenOcdCmd {
+    ReadLcCtrlReg(LcCtrlReg),
+    WriteLcCtrlReg(LcCtrlReg, u32),
+    // ReadCpuReg(IbexReg),
+    // WriteCpuReg(IbexReg, u32),
+    ReadMemory { addr: u32 },
+    WriteMemory { addr: u32, value: u32 },
+    Halt,
+    Resume,
+    Shutdown,
+    Version,
+}
+
+/// Represents a (higher complexity) OpenOCD command sequence.
+pub enum OpenOcdCmdSeq {
+    /// Exits with a non-zero status when the register does not contain the
+    /// given value.
+    AssertLcCtrlRegEq(LcCtrlReg, u32),
+
+    /// Polls the lc_ctrl register a finite number of times until its value
+    /// matches the expectation.
+    PollUntilLcCtrlRegEq(LcCtrlReg, u32),
+
+    /// Performs a lifecycle state transition to the target lifecycle state.
+    PerformLcTransition(DifLcCtrlState),
+}
+
+/// A trait which represents a JTAG interface.
+pub trait Jtag {
+    /// Starts an OpenOCD server to connect to the OpenTitan JTAG interface.
+    fn start_openocd_server<'a>(
+        &self,
+        openocd: &'a str,
+        openocd_adapter_config: &'a str,
+    ) -> Result<()>;
+
+    /// Stops the running OpenOCD server process.
+    fn stop_openocd_server(&self) -> Result<()>;
+
+    /// Runs an OpenOCD command over the JTAG interface.
+    fn exec_openocd_cmd(&self, cmd: OpenOcdCmd) -> Result<()>;
+
+    /// Runs a (higher complexity) OpenOCD command sequence.
+    fn exec_openocd_cmd_seq(&self, cmd_seq: OpenOcdCmdSeq) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -6,5 +6,6 @@ pub mod eeprom;
 pub mod emu;
 pub mod gpio;
 pub mod i2c;
+pub mod jtag;
 pub mod spi;
 pub mod uart;

--- a/sw/host/opentitanlib/src/proxy/errors.rs
+++ b/sw/host/opentitanlib/src/proxy/errors.rs
@@ -115,6 +115,7 @@ impl From<anyhow::Error> for SerializedError {
             crate::io::emu::EmuError,
             crate::io::gpio::GpioError,
             crate::io::i2c::I2cError,
+            crate::io::jtag::JtagError,
             crate::io::spi::SpiError,
             crate::io::uart::UartError,
             crate::transport::TransportError,

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -69,6 +69,7 @@ pub enum TransportInterfaceType {
     Uart,
     Spi,
     I2c,
+    Jtag,
     Emulator,
     ProxyOps,
     GpioMonitoring,

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -13,6 +13,7 @@ use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::Emulator;
 use crate::io::gpio::{GpioMonitoring, GpioPin};
 use crate::io::i2c::Bus;
+use crate::io::jtag::Jtag;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
@@ -37,6 +38,7 @@ bitflags! {
         const SPI = 0x00000002;
         const GPIO = 0x00000004;
         const I2C = 0x00000008;
+        const JTAG = 0x0000000A;
         const PROXY = 0x00000010;
         const EMULATOR = 0x00000020;
         const GPIO_MONITORING = 0x00000040; // Logic analyzer functionality
@@ -101,6 +103,10 @@ pub trait Transport {
         Ok(())
     }
 
+    /// Returns a [`Jtag`] implementation.
+    fn jtag(&self, _openocd: &str, _openocd_adapter_config: &str) -> Result<Rc<dyn Jtag>> {
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Jtag).into())
+    }
     /// Returns a SPI [`Target`] implementation.
     fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
         Err(TransportError::InvalidInterface(TransportInterfaceType::Spi).into())


### PR DESCRIPTION
This adds a JTAG IO trait to define the basic functionality we aim to implement for each transport.

This partially addresses #17490.