### PR TITLE
[keymgr, dv] Fix operator precedence issue in `CheckKmacKey` assertion

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -555,7 +555,7 @@ interface keymgr_if(input clk, input rst_n);
     `ASSERT(NAME, SEQ, clk, !rst_n || keymgr_en_sync2 != lc_ctrl_pkg::On || !en_chk)
 
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKey, is_kmac_key_good && kmac_key_exp.valid ->
-                           kmac_key[0] ^ kmac_key[1] == kmac_key_exp[0] ^ kmac_key_exp[1])
+                           (kmac_key[0] ^ kmac_key[1]) == (kmac_key_exp[0] ^ kmac_key_exp[1]))
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKeyValid, is_kmac_key_good ->
                            kmac_key_exp.valid == kmac_key.valid)
 


### PR DESCRIPTION
Because `==` has higher precedence than `^`, #17509 introduced a bug/typo into `CheckKmacKey` assertion. Therefore the equality check `kmac_key[0] ^ kmac_key[1] == kmac_key_exp[0] ^ kmac_key_exp[1]` is parsed as follows

![image](https://user-images.githubusercontent.com/7850700/225955404-981ef836-aa36-4f26-8ec6-329747ca258e.png)

This PR fixes it.
