### PR TITLE
[dv/keymgr] Fix xor index

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -555,7 +555,8 @@ interface keymgr_if(input clk, input rst_n);
     `ASSERT(NAME, SEQ, clk, !rst_n || keymgr_en_sync2 != lc_ctrl_pkg::On || !en_chk)
 
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKey, is_kmac_key_good && kmac_key_exp.valid ->
-                           (kmac_key[0] ^ kmac_key[1]) == (kmac_key_exp[0] ^ kmac_key_exp[1]))
+                           (kmac_key.key[0] ^ kmac_key.key[1]) ==
+                           (kmac_key_exp.key[0] ^ kmac_key_exp.key[1]))
   `ASSERT_IFF_KEYMGR_LEGAL(CheckKmacKeyValid, is_kmac_key_good ->
                            kmac_key_exp.valid == kmac_key.valid)
 


### PR DESCRIPTION
This PR follows fix #17509 where we see assertion failures regarding `CheckKmacKey` in nightly.
The issue is that kmac RTL, and DV expected keys are stored in format `hw_key_req_t`. This structure https://cs.opensource.google/opentitan/opentitan/+/master:hw/ip/keymgr/rtl/keymgr_pkg.sv;l=233?q=hw_key_req_t&ss=opentitan%2Fopentitan also includes valid bit.
So if we directly using `kmac_key[0] ^ kmac_key[1]`, it won't xor two key shares, instead, it xor the first and second bits of the array.