### PR TITLE
[test] remove smoketest timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1811,7 +1811,6 @@
       ]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=OtpTypeCustom"]
-      run_timeout_mins: 10
     }
   ]
 


### PR DESCRIPTION
The flash scrambling smoke test timeout was used for testing, and is not needed since the default timeout will suffice.