### PR TITLE
[test, uj] Add mailbox manipulation commands

### DIFF
--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -25,6 +25,9 @@ extern "C" {
     value(_, SpiFlashEraseSector) \
     value(_, SpiFlashEmulator) \
     value(_, SpiFlashWrite) \
+    value(_, SpiMailboxMap) \
+    value(_, SpiMailboxUnmap) \
+    value(_, SpiMailboxWrite) \
     value(_, SpiPassthruSetAddressMap) \
     value(_, SwStrapRead)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -43,6 +43,18 @@ UJSON_SERDE_STRUCT(UploadInfo, upload_info_t, STRUCT_UPLOAD_INFO);
 UJSON_SERDE_STRUCT(SpiFlashReadId, spi_flash_read_id_t,
     STRUCT_SPI_FLASH_READ_ID);
 
+#define STRUCT_SPI_MAILBOX_MAP(field, string) \
+    field(address, uint32_t)
+UJSON_SERDE_STRUCT(SpiMailboxMap, spi_mailbox_map_t,
+    STRUCT_SPI_MAILBOX_MAP);
+
+#define STRUCT_SPI_MAILBOX_WRITE(field, string) \
+    field(offset, uint16_t) \
+    field(length, uint16_t) \
+    field(data, uint8_t, 256)
+UJSON_SERDE_STRUCT(SpiMailboxWrite, spi_mailbox_write_t,
+    STRUCT_SPI_MAILBOX_WRITE);
+
 #define STRUCT_SPI_FLASH_READ_SFDP(field, string) \
     field(address, uint32_t) \
     field(length, uint16_t)

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -99,3 +99,27 @@ impl SpiPassthruSwapMap {
         Ok(())
     }
 }
+
+impl SpiMailboxMap {
+    pub fn apply(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiMailboxMap.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+
+    pub fn disable(uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiMailboxUnmap.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}
+
+impl SpiMailboxWrite {
+    pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::SpiMailboxWrite.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add commands to map/unmap the mailbox and to write data to it.

Use the commands in the SPI passthrough test to demonstrate read interception when targeting a page with different data in mailbox vs. the external SPI flash.