### PR TITLE
[spi_passthru] Exted spi flash emulator

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -375,7 +375,9 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":spi_device_testutils",
+        "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -171,7 +171,23 @@ void spi_device_testutils_configure_passthrough(
           .set_busy_status = upload_write_commands,
       },
       {
-          // Slot 16: PageProgram
+          // Slot 16: BlockErase32k
+          .opcode = kSpiDeviceFlashOpBlockErase32k,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 17: BlockErase64k
+          .opcode = kSpiDeviceFlashOpBlockErase64k,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 18: PageProgram
           .opcode = kSpiDeviceFlashOpPageProgram,
           .address_type = kDifSpiDeviceFlashAddrCfg,
           .payload_io_type = kDifSpiDevicePayloadIoSingle,
@@ -179,6 +195,48 @@ void spi_device_testutils_configure_passthrough(
           .upload = upload_write_commands,
           .set_busy_status = upload_write_commands,
       },
+      {
+          // Slot 19: SectorErase4b
+          .opcode = kSpiDeviceFlashOpSectorErase4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 20: BlockErase32k4b
+          .opcode = kSpiDeviceFlashOpBlockErase32k4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 21: BlockErase64k4b
+          .opcode = kSpiDeviceFlashOpBlockErase64k4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 22: PageProgram4b
+          .opcode = kSpiDeviceFlashOpPageProgram4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+      {
+          // Slot 23: Reset
+          .opcode = kSpiDeviceFlashOpReset,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .payload_io_type = kDifSpiDevicePayloadIoNone,
+          .upload = upload_write_commands,
+          .set_busy_status = upload_write_commands,
+      },
+
   };
   for (int i = 0; i < ARRAYSIZE(write_commands); ++i) {
     uint8_t slot = i + kSpiDeviceWriteCommandSlotBase;

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -32,11 +32,17 @@ typedef enum spi_device_flash_opcode {
   kSpiDeviceFlashOpWriteStatus3 = 0x11,
   kSpiDeviceFlashOpChipErase = 0xc7,
   kSpiDeviceFlashOpSectorErase = 0x20,
+  kSpiDeviceFlashOpBlockErase32k = 0x52,
+  kSpiDeviceFlashOpBlockErase64k = 0xd8,
   kSpiDeviceFlashOpPageProgram = 0x02,
   kSpiDeviceFlashOpEnter4bAddr = 0xb7,
   kSpiDeviceFlashOpExit4bAddr = 0xe9,
   kSpiDeviceFlashOpResetEnable = 0x66,
   kSpiDeviceFlashOpReset = 0x99,
+  kSpiDeviceFlashOpSectorErase4b = 0x21,
+  kSpiDeviceFlashOpBlockErase32k4b = 0x5c,
+  kSpiDeviceFlashOpBlockErase64k4b = 0xdc,
+  kSpiDeviceFlashOpPageProgram4b = 0x12,
 } spi_device_flash_opcode_t;
 
 /**
@@ -66,7 +72,14 @@ enum spi_device_command_slot {
  *  - WriteStatus3
  *  - ChipErase
  *  - SectorErase
+ *  - BlockErase32k
+ *  - BlockErase64k
  *  - PageProgram
+ *  - SectorErase4b
+ *  - BlockErase32k4b
+ *  - BlockErase64k4b
+ *  - PageProgram4b
+ *  - Reset
  *  - Enter4bAddr
  *  - Exit4bAddr
  *

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/testing/spi_flash_testutils.h"
 
+#include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
 #include "sw/device/lib/testing/spi_device_testutils.h"
@@ -85,29 +86,65 @@ void spi_flash_testutils_read_sfdp(dif_spi_host_t *spih, uint32_t address,
                                         ARRAYSIZE(transaction)));
 }
 
+status_t spi_flash_testutils_read_status(dif_spi_host_t *spih, uint8_t opcode,
+                                         size_t length) {
+  CHECK(spih != NULL);
+  CHECK(length <= 3);
+  uint32_t status;
+  dif_spi_host_segment_t transaction[] = {
+      {
+          .type = kDifSpiHostSegmentTypeOpcode,
+          .opcode = opcode,
+      },
+      {
+          .type = kDifSpiHostSegmentTypeRx,
+          .rx =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .buf = &status,
+                  .length = length,
+              },
+      },
+  };
+  TRY(dif_spi_host_transaction(spih, /*csid=*/0, transaction,
+                               ARRAYSIZE(transaction)));
+  return OK_STATUS(status);
+}
+
+status_t spi_flash_testutils_write_status(dif_spi_host_t *spih, uint8_t opcode,
+                                          uint32_t status, size_t length) {
+  CHECK(spih != NULL);
+  CHECK(length <= 3);
+  spi_flash_testutils_issue_write_enable(spih);
+  dif_spi_host_segment_t transaction[] = {
+      {
+          .type = kDifSpiHostSegmentTypeOpcode,
+          .opcode = opcode,
+      },
+      {
+          .type = kDifSpiHostSegmentTypeTx,
+          .tx =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .buf = &status,
+                  .length = length,
+              },
+      },
+  };
+  TRY(dif_spi_host_transaction(spih, /*csid=*/0, transaction,
+                               ARRAYSIZE(transaction)));
+  return OK_STATUS();
+}
+
 void spi_flash_testutils_wait_until_not_busy(dif_spi_host_t *spih) {
   CHECK(spih != NULL);
-  uint8_t status;
+  status_t status;
 
   do {
-    dif_spi_host_segment_t transaction[] = {
-        {
-            .type = kDifSpiHostSegmentTypeOpcode,
-            .opcode = kSpiDeviceFlashOpReadStatus1,
-        },
-        {
-            .type = kDifSpiHostSegmentTypeRx,
-            .rx =
-                {
-                    .width = kDifSpiHostWidthStandard,
-                    .buf = &status,
-                    .length = 1,
-                },
-        },
-    };
-    CHECK_DIF_OK(dif_spi_host_transaction(spih, /*csid=*/0, transaction,
-                                          ARRAYSIZE(transaction)));
-  } while (status & kSpiFlashStatusBitWip);
+    status =
+        spi_flash_testutils_read_status(spih, kSpiDeviceFlashOpReadStatus1, 1);
+    CHECK_STATUS_OK(status);
+  } while (status.value & kSpiFlashStatusBitWip);
 }
 
 void spi_flash_testutils_issue_write_enable(dif_spi_host_t *spih) {
@@ -137,8 +174,8 @@ void spi_flash_testutils_erase_chip(dif_spi_host_t *spih) {
   spi_flash_testutils_wait_until_not_busy(spih);
 }
 
-void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
-                                      bool addr_is_4b) {
+void spi_flash_testutils_erase_op(dif_spi_host_t *spih, uint8_t opcode,
+                                  uint32_t address, bool addr_is_4b) {
   CHECK(spih != NULL);
   spi_flash_testutils_issue_write_enable(spih);
 
@@ -147,7 +184,7 @@ void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
   dif_spi_host_segment_t transaction[] = {
       {
           .type = kDifSpiHostSegmentTypeOpcode,
-          .opcode = kSpiDeviceFlashOpSectorErase,
+          .opcode = opcode,
       },
       {
           .type = kDifSpiHostSegmentTypeAddress,
@@ -165,9 +202,15 @@ void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
   spi_flash_testutils_wait_until_not_busy(spih);
 }
 
-void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
-                                      size_t length, uint32_t address,
+void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
                                       bool addr_is_4b) {
+  spi_flash_testutils_erase_op(spih, kSpiDeviceFlashOpSectorErase, address,
+                               addr_is_4b);
+}
+
+void spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
+                                    uint8_t *payload, size_t length,
+                                    uint32_t address, bool addr_is_4b) {
   CHECK(spih != NULL);
   CHECK(payload != NULL);
   CHECK(length <= 256);  // Length must be less than a page size.
@@ -179,7 +222,7 @@ void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
   dif_spi_host_segment_t transaction[] = {
       {
           .type = kDifSpiHostSegmentTypeOpcode,
-          .opcode = kSpiDeviceFlashOpPageProgram,
+          .opcode = opcode,
       },
       {
           .type = kDifSpiHostSegmentTypeAddress,
@@ -204,4 +247,143 @@ void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
                                         ARRAYSIZE(transaction)));
 
   spi_flash_testutils_wait_until_not_busy(spih);
+}
+
+void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
+                                      size_t length, uint32_t address,
+                                      bool addr_is_4b) {
+  spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageProgram, payload,
+                                 length, address, addr_is_4b);
+}
+
+void spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
+                                 uint8_t *payload, size_t length,
+                                 uint32_t address, bool addr_is_4b,
+                                 uint8_t width, uint8_t dummy) {
+  CHECK(spih != NULL);
+  CHECK(payload != NULL);
+  CHECK(length <= 256);  // Length must be less than a page size.
+  CHECK(width == 1 || width == 2 || width == 4);
+
+  dif_spi_host_addr_mode_t addr_mode =
+      addr_is_4b ? kDifSpiHostAddrMode4b : kDifSpiHostAddrMode3b;
+  dif_spi_host_width_t data_width = width == 1   ? kDifSpiHostWidthStandard
+                                    : width == 2 ? kDifSpiHostWidthDual
+                                                 : kDifSpiHostWidthQuad;
+
+  dif_spi_host_segment_t transaction[4] = {
+      {
+          .type = kDifSpiHostSegmentTypeOpcode,
+          .opcode = opcode,
+      },
+      {
+          .type = kDifSpiHostSegmentTypeAddress,
+          .address =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .mode = addr_mode,
+                  .address = address,
+              },
+      },
+      {
+          .type = kDifSpiHostSegmentTypeDummy,
+          .dummy =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .length = dummy,
+              },
+      },
+      {
+          .type = kDifSpiHostSegmentTypeRx,
+          .rx =
+              {
+                  .width = data_width,
+                  .buf = payload,
+                  .length = length,
+              },
+      },
+  };
+  size_t tlen = ARRAYSIZE(transaction);
+  if (dummy == 0) {
+    // If there are no dummy cycles, then get rid of the dummy segment in
+    // the transaction.
+    memcpy(&transaction[2], &transaction[3], sizeof(dif_spi_host_segment_t));
+    tlen -= 1;
+  }
+  CHECK_DIF_OK(dif_spi_host_transaction(spih, /*csid=*/0, transaction, tlen));
+}
+
+status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
+                                         bool enabled) {
+  uint32_t status;
+  switch (method) {
+    case 0:
+      // Device does not have a QE bit.
+      break;
+    case 1:
+      // QE is bit1 of status reg 2.
+      // Set/clear via two-byte reads/writes via SR1 opcodes.
+      // Writing only one byte to SR1 clears SR2.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus1, 2));
+      status = bitfield_bit32_write(status, 9, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus1, status, enabled ? 2 : 1));
+      break;
+    case 2:
+      // QE is bit6 of status reg 1.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus1, 1));
+      status = bitfield_bit32_write(status, 6, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus1, status, 1));
+      break;
+    case 3:
+      // QE is bit7 of status reg 2.
+      // Use "status register 2" opcodes.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus2, 1));
+      status = bitfield_bit32_write(status, 7, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus2, status, 1));
+      break;
+    case 4:
+      // QE is bit1 of status reg 2.
+      // Set/clear via two-byte reads/writes via SR1 opcodes.
+      // Writing only one byte to SR1 does not affcet SR2.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus1, 2));
+      status = bitfield_bit32_write(status, 9, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus1, status, 2));
+      break;
+    case 5:
+      // QE is bit1 of status reg 2.
+      // Requires reading status reg via SR1/SR2 opcodes.
+      // Set/clear via two-byte reads/writes via SR1 opcodes.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus1, 1));
+      status |= TRY(spi_flash_testutils_read_status(
+                    spih, kSpiDeviceFlashOpReadStatus2, 1))
+                << 8;
+      status = bitfield_bit32_write(status, 9, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus1, status, 2));
+      break;
+    case 6:
+      // QE is bit1 of status reg 2.
+      // Requires reading status reg via SR1/SR2/SR3 opcodes.
+      // Set/clear via one-byte writes via SR2 opcode.
+      status = TRY(spi_flash_testutils_read_status(
+          spih, kSpiDeviceFlashOpReadStatus2, 1));
+      status = bitfield_bit32_write(status, 1, enabled);
+      status = TRY(spi_flash_testutils_write_status(
+          spih, kSpiDeviceFlashOpWriteStatus2, status, 1));
+      break;
+    case 7:
+      // Reserved.
+      return INVALID_ARGUMENT();
+      break;
+  }
+  return OK_STATUS();
 }

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
 
 typedef struct spi_flash_testutils_jedec_id {
@@ -42,6 +43,36 @@ typedef enum spi_flash_status_bit {
 } spi_flash_status_bit_t;
 
 /**
+ * Perform a Read Status command.
+ *
+ * Issues a Read Status transaction using the requested opcode.
+ * In the case of a multi-byte status, the bytes are assembled and returned
+ * as a litte-endian word
+ *
+ * @param spih A SPI host handle.
+ * @param opcode The desired Read Status opcode.
+ * @param length The result length (1 to 3 bytes).
+ * @return status_t containing either the status register value or an error.
+ */
+status_t spi_flash_testutils_read_status(dif_spi_host_t *spih, uint8_t opcode,
+                                         size_t length);
+
+/**
+ * Perform a Write Status command.
+ *
+ * Issues a Write Status transaction using the requested opcode.
+ * In the case of a multi-byte status, the status word bytes are
+ * as a litte-endian word
+ *
+ * @param spih A SPI host handle.
+ * @param opcode The desired Write Status opcode.
+ * @param status The status register value to write.
+ * @param length The status length (1 to 3 bytes).
+ * @return status_t containing either OK or an error.
+ */
+status_t spi_flash_testutils_write_status(dif_spi_host_t *spih, uint8_t opcode,
+                                          uint32_t status, size_t length);
+/**
  * Spin wait until a Read Status command shows the downstream SPI flash is no
  * longer busy.
  */
@@ -63,10 +94,26 @@ void spi_flash_testutils_issue_write_enable(dif_spi_host_t *spih);
 void spi_flash_testutils_erase_chip(dif_spi_host_t *spih);
 
 /**
- * Perform full Sector Erase sequence, including the Write Enable and Sector
- * Erase commands, and poll the status registers in a loop until the WIP bit
- * clears.
+ * Perform full Sector Erase sequence via the requested opcode.
+ * The sequence includes the Write Enable and Sector Erase commands,
+ * and then polls the status registers in a loop until the WIP
+ * bit clears.
  *
+ * Does not return until the erase completes.
+ *
+ * @param spih A SPI host handle.
+ * @param opcode The desired erase opcode.
+ * @param address An address contained within the desired sector.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ */
+void spi_flash_testutils_erase_op(dif_spi_host_t *spih, uint8_t opcode,
+                                  uint32_t address, bool addr_is_4b);
+
+/**
+ * Perform full Sector Erase sequence via the standard Sector Erase opcode.
+ * The sequence includes the Write Enable and Sector Erase commands,
+ * and then polls the status registers in a loop until the WIP
+ * bit clears.
  * Does not return until the erase completes.
  *
  * @param spih A SPI host handle.
@@ -77,8 +124,31 @@ void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
                                       bool addr_is_4b);
 
 /**
- * Perform full Page Program sequence, including the Write Enable and Page
- * Program commands, and poll the status registers in a loop until the WIP bit
+ * Perform full Page Program sequence via the requested opcode.
+ * The sequence includes the Write Enable and Page Program commands,
+ * and then polls the status registers in a loop until the WIP bit
+ * clears.
+ *
+ * Does not return until the programming operation completes.
+ *
+ * @param spih A SPI host handle.
+ * @param opcode The desired program opcode.
+ * @param payload A pointer to the payload to be written to the page.
+ * @param length Number of bytes in the payload. Must be less than or equal to
+ *               256 bytes.
+ * @param address The start address where the payload programming should begin.
+ *                Note that an address + length that crosses a page boundary may
+ *                wrap around to the start of the page.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ */
+void spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
+                                    uint8_t *payload, size_t length,
+                                    uint32_t address, bool addr_is_4b);
+
+/**
+ * Perform full Page Program sequence via the standard page program opcode.
+ * The sequence includes the Write Enable and Page Program commands,
+ * and then polls the status registers in a loop until the WIP bit
  * clears.
  *
  * Does not return until the programming operation completes.
@@ -95,5 +165,36 @@ void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
 void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
                                       size_t length, uint32_t address,
                                       bool addr_is_4b);
+
+/**
+ * Perform a read via the requested opcode.
+ *
+ * @param spih A SPI host handle.
+ * @param opcode The desired read opcode.
+ * @param payload A pointer to the buffer to receive data from the device.
+ * @param length Number of bytes in the buffer. Must be less than or equal to
+ *               256 bytes.
+ * @param address The start address where the read should begin.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ * @param width The width of the read (1, 2 or 4 bits).
+ * @param dummy The number of dummy cycles required after the address phase.
+ */
+void spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
+                                 uint8_t *payload, size_t length,
+                                 uint32_t address, bool addr_is_4b,
+                                 uint8_t width, uint8_t dummy);
+
+/**
+ * Enable or disable Quad mode on the EEPROM according to the SFDP-described
+ * method.
+ *
+ * @param spih A SPI host handle.
+ * @param method The method to use to enable.  This value should come from the
+ *               SFDP quad-enable field described in JESD216 section 6.4.18.
+ * @param enable Whether to enable or disable quad mode.
+ * @return status_t containing either OK or an error.
+ */
+status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
+                                         bool enable);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_TESTUTILS_H_

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -145,7 +145,7 @@ void _ottf_main(void) {
     // Run `test_main()` in a FreeRTOS task, allowing other FreeRTOS tasks to
     // be spawned, if requested in the main test task. Note, we spawn the main
     // test task at a priority level of 0.
-    ottf_task_create(test_wrapper, "test_main", kOttfFreeRtosMinStackSize, 0);
+    ottf_task_create(test_wrapper, "test_main", /*task_stack_depth=*/1024, 0);
     vTaskStartScheduler();
   } else {
     // Otherwise, launch `test_main()` on bare-metal.


### PR DESCRIPTION
1. Adjust the filter for additional opcodes: Block Erase 32k/64k, and the 4-byte versions of PageProgram, SectorErase, and BlockErase.
2. Improve spi_flash_testutils to be able to issue the additional programming and erase opcodes to the eeprom.
3. Add processing of the additional opcodes in the main spi_flash_emulator loop.
4. Learn the quad-enable method from the SFDP and enable it on the back-end flash part.