### PR TITLE
[dv/chip] fix adc_ctrl chip level test failure

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
@@ -184,15 +184,17 @@ class chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq extends chip_sw_base_vseq;
     // Fork tasks for detecting edges.
     powerdown_count = 0;
     powerdown_count_enabled = 1;
-    fork
-      wait_for_adc_valid_falling_edge();
-      detect_powerdown_rising_edge();
-    join_none
+    fork begin : isolation_fork
+      fork
+        wait_for_adc_valid_falling_edge();
+        detect_powerdown_rising_edge();
+      join_none
 
-    // Generate a sequence of ADC data.
-    generate_adc_data();
+      // Generate a sequence of ADC data.
+      generate_adc_data();
 
-    disable fork;
+      disable fork;
+    end join
   endtask
 
 endclass


### PR DESCRIPTION
Fix chip level adc_ctrl test failure because the disable fork statement is not wrapped with an isolation fork join statement.
This cause the base level chip_sw_base_vseq's fork none nonblocking statement is killed as well.
Fix issue #17619 