### PR TITLE
[spi_host] Test more spi host functionality 

### DIFF
--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -316,8 +316,13 @@ static void issue_address(const dif_spi_host_t *spi_host,
 
 static void issue_dummy(const dif_spi_host_t *spi_host,
                         dif_spi_host_segment_t *segment, bool last_segment) {
-  write_command_reg(spi_host, segment->dummy.length, segment->dummy.width,
-                    kDifSpiHostDirectionDummy, last_segment);
+  if (segment->dummy.length > 0) {
+    // We only want to program a dummy segment if the number of cycles is
+    // greater than zero.  Programming a zero to the hardware results in a
+    // dummy segment of 512 bits.
+    write_command_reg(spi_host, segment->dummy.length, segment->dummy.width,
+                      kDifSpiHostDirectionDummy, last_segment);
+  }
 }
 
 static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -22,40 +22,17 @@ enum {
   kJedecContCodeCount = 12,
   // A density of 24 corresponds to 16MiB (1<<24 bytes).
   kJedecDensity = 24,
-  // The standard SFDP signature value.
-  kSfdpSignature = 0x50444653,
 };
-
-typedef struct sfdp_header {
-  uint32_t signature;
-  uint8_t minor;
-  uint8_t major;
-  uint8_t nph;
-  uint8_t reserved;
-} sfdp_header_t;
-
-typedef struct parameter_header {
-  uint8_t param_id;
-  uint8_t minor;
-  uint8_t major;
-  uint8_t length;
-  uint8_t table_pointer[3];
-  uint8_t pad;
-} parameter_header_t;
 
 typedef struct bfpt {
   uint32_t data[9];
 } bfpt_t;
 
 typedef struct sfdp {
-  sfdp_header_t header;
-  parameter_header_t param;
+  spi_flash_testutils_sfdp_header_t header;
+  spi_flash_testutils_parameter_header_t param;
   bfpt_t bfpt;
 } sfdp_t;
-
-// JESD216F, section 6.4.18:
-// The Quad Enable mechanism is bits 20:23 of the 15th dword.
-#define QUAD_ENABLE ((bitfield_field32_t){.mask = 7, .index = 20})
 
 // This function prepares the downstream-visible SFDP table.
 // Out of convenience, it also checks the quad-enable mechanism from
@@ -120,7 +97,7 @@ static status_t read_and_prepare_sfdp(dif_spi_host_t *spih,
     // JESD216F, section 6.4.18:
     // The Quad Enable mechanism is bits 20:23 of the 15th dword.
     quad_enable = read_32(data + offset + 14 * sizeof(uint32_t));
-    quad_enable = bitfield_field32_read(quad_enable, QUAD_ENABLE);
+    quad_enable = bitfield_field32_read(quad_enable, SPI_FLASH_QUAD_ENABLE);
   }
   return OK_STATUS(quad_enable);
 }

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -303,14 +303,8 @@ void spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
               },
       },
   };
-  size_t tlen = ARRAYSIZE(transaction);
-  if (dummy == 0) {
-    // If there are no dummy cycles, then get rid of the dummy segment in
-    // the transaction.
-    memcpy(&transaction[2], &transaction[3], sizeof(dif_spi_host_segment_t));
-    tlen -= 1;
-  }
-  CHECK_DIF_OK(dif_spi_host_transaction(spih, /*csid=*/0, transaction, tlen));
+  CHECK_DIF_OK(dif_spi_host_transaction(spih, /*csid=*/0, transaction,
+                                        ARRAYSIZE(transaction)));
 }
 
 status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -46,7 +46,7 @@ void spi_flash_testutils_read_id(dif_spi_host_t *spih,
 }
 
 void spi_flash_testutils_read_sfdp(dif_spi_host_t *spih, uint32_t address,
-                                   uint8_t *buffer, size_t length) {
+                                   void *buffer, size_t length) {
   CHECK(spih != NULL);
   CHECK(buffer != NULL);
 
@@ -209,7 +209,7 @@ void spi_flash_testutils_erase_sector(dif_spi_host_t *spih, uint32_t address,
 }
 
 void spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
-                                    uint8_t *payload, size_t length,
+                                    const void *payload, size_t length,
                                     uint32_t address, bool addr_is_4b) {
   CHECK(spih != NULL);
   CHECK(payload != NULL);
@@ -249,7 +249,7 @@ void spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
   spi_flash_testutils_wait_until_not_busy(spih);
 }
 
-void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
+void spi_flash_testutils_program_page(dif_spi_host_t *spih, const void *payload,
                                       size_t length, uint32_t address,
                                       bool addr_is_4b) {
   spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageProgram, payload,
@@ -257,9 +257,9 @@ void spi_flash_testutils_program_page(dif_spi_host_t *spih, uint8_t *payload,
 }
 
 void spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
-                                 uint8_t *payload, size_t length,
-                                 uint32_t address, bool addr_is_4b,
-                                 uint8_t width, uint8_t dummy) {
+                                 void *payload, size_t length, uint32_t address,
+                                 bool addr_is_4b, uint8_t width,
+                                 uint8_t dummy) {
   CHECK(spih != NULL);
   CHECK(payload != NULL);
   CHECK(length <= 256);  // Length must be less than a page size.

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -321,16 +321,16 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
       status = TRY(spi_flash_testutils_read_status(
           spih, kSpiDeviceFlashOpReadStatus1, 2));
       status = bitfield_bit32_write(status, 9, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus1, status, enabled ? 2 : 1));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus1,
+                                           status, enabled ? 2 : 1));
       break;
     case 2:
       // QE is bit6 of status reg 1.
       status = TRY(spi_flash_testutils_read_status(
           spih, kSpiDeviceFlashOpReadStatus1, 1));
       status = bitfield_bit32_write(status, 6, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus1, status, 1));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus1,
+                                           status, 1));
       break;
     case 3:
       // QE is bit7 of status reg 2.
@@ -338,8 +338,8 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
       status = TRY(spi_flash_testutils_read_status(
           spih, kSpiDeviceFlashOpReadStatus2, 1));
       status = bitfield_bit32_write(status, 7, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus2, status, 1));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus2,
+                                           status, 1));
       break;
     case 4:
       // QE is bit1 of status reg 2.
@@ -348,8 +348,8 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
       status = TRY(spi_flash_testutils_read_status(
           spih, kSpiDeviceFlashOpReadStatus1, 2));
       status = bitfield_bit32_write(status, 9, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus1, status, 2));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus1,
+                                           status, 2));
       break;
     case 5:
       // QE is bit1 of status reg 2.
@@ -361,8 +361,8 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
                     spih, kSpiDeviceFlashOpReadStatus2, 1))
                 << 8;
       status = bitfield_bit32_write(status, 9, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus1, status, 2));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus1,
+                                           status, 2));
       break;
     case 6:
       // QE is bit1 of status reg 2.
@@ -371,8 +371,8 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
       status = TRY(spi_flash_testutils_read_status(
           spih, kSpiDeviceFlashOpReadStatus2, 1));
       status = bitfield_bit32_write(status, 1, enabled);
-      status = TRY(spi_flash_testutils_write_status(
-          spih, kSpiDeviceFlashOpWriteStatus2, status, 1));
+      TRY(spi_flash_testutils_write_status(spih, kSpiDeviceFlashOpWriteStatus2,
+                                           status, 1));
       break;
     case 7:
       // Reserved.

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -58,7 +58,7 @@ void spi_flash_testutils_read_id(dif_spi_host_t *spih,
  * into the buffer.
  *
  * @param spih A SPI host handle.
- * @param buffer A pointer to a buffer that will hold the SFDP contents.
+ * @param[out] buffer A pointer to a buffer that will hold the SFDP contents.
  * @param length The number of bytes to write into `buffer`.
  */
 void spi_flash_testutils_read_sfdp(dif_spi_host_t *spih, uint32_t address,
@@ -74,7 +74,7 @@ typedef enum spi_flash_status_bit {
  *
  * Issues a Read Status transaction using the requested opcode.
  * In the case of a multi-byte status, the bytes are assembled and returned
- * as a litte-endian word
+ * as a litte-endian word.
  *
  * @param spih A SPI host handle.
  * @param opcode The desired Read Status opcode.
@@ -89,7 +89,7 @@ status_t spi_flash_testutils_read_status(dif_spi_host_t *spih, uint8_t opcode,
  *
  * Issues a Write Status transaction using the requested opcode.
  * In the case of a multi-byte status, the status word bytes are
- * as a litte-endian word
+ * as a litte-endian word.
  *
  * @param spih A SPI host handle.
  * @param opcode The desired Write Status opcode.
@@ -198,7 +198,7 @@ void spi_flash_testutils_program_page(dif_spi_host_t *spih, const void *payload,
  *
  * @param spih A SPI host handle.
  * @param opcode The desired read opcode.
- * @param payload A pointer to the buffer to receive data from the device.
+ * @param[out] payload A pointer to the buffer to receive data from the device.
  * @param length Number of bytes in the buffer. Must be less than or equal to
  *               256 bytes.
  * @param address The start address where the read should begin.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1724,6 +1724,8 @@ opentitan_functest(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -4,12 +4,15 @@
 #include <assert.h>
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -18,54 +21,136 @@
 static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
               "This test assumes the target platform is little endian.");
 
-#define SFDP_SIGNATURE 0x50444653
-
 OTTF_DEFINE_TEST_CONFIG();
 
-void read_sfdp(dif_spi_host_t *spi_host) {
-  uint8_t buf[256];
-  dif_spi_host_segment_t segments[] = {
-      {
-          .type = kDifSpiHostSegmentTypeOpcode,
-          .opcode = 0x5a,
-      },
-      {
-          .type = kDifSpiHostSegmentTypeAddress,
-          .address =
-              {
-                  .width = kDifSpiHostWidthStandard,
-                  .mode = kDifSpiHostAddrMode3b,
-                  .address = 0x0,
-              },
-      },
-      {
-          .type = kDifSpiHostSegmentTypeDummy,
-          .dummy =
-              {
-                  .width = kDifSpiHostWidthStandard,
-                  .length = 8,
-              },
-      },
-      {
-          .type = kDifSpiHostSegmentTypeRx,
-          .rx =
-              {
-                  .width = kDifSpiHostWidthStandard,
-                  .buf = buf,
-                  .length = sizeof(buf),
-              },
-      },
-  };
-  CHECK_DIF_OK(
-      dif_spi_host_transaction(spi_host, 0, segments, ARRAYSIZE(segments)));
+// A data pattern to program into the chip:
+// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
+static const char kGettysburgPrelude[256] =
+    "Four score and seven years ago our fathers brought forth on this "
+    "continent, a new nation, conceived in Liberty, and dedicated to the "
+    "proposition that all men are created equal.";
 
-  uint32_t sfdp = read_32(buf);
-  LOG_INFO("SFDP signature is 0x%08x", sfdp);
-  CHECK(sfdp == SFDP_SIGNATURE, "Expected to find the SFDP signature!");
+// The SFDP structure we'll read out of the chip.
+typedef struct sfdp {
+  union {
+    struct {
+      spi_flash_testutils_sfdp_header_t header;
+      spi_flash_testutils_parameter_header_t param;
+    };
+    uint8_t data[256];
+  };
+  uint32_t *bfpt;
+} sfdp_t;
+
+dif_spi_host_t spi_host;
+sfdp_t sfdp;
+
+status_t test_software_reset(void) {
+  // The software reset sequence is two transactions: RSTEN followed by RST.
+  dif_spi_host_segment_t op = {
+      .type = kDifSpiHostSegmentTypeOpcode,
+      .opcode = kSpiDeviceFlashOpResetEnable,
+  };
+  TRY(dif_spi_host_transaction(&spi_host, /*cs_id=*/0, &op, 1));
+
+  op.opcode = kSpiDeviceFlashOpResetEnable;
+  TRY(dif_spi_host_transaction(&spi_host, /*cs_id=*/0, &op, 1));
+  return OK_STATUS();
+}
+
+status_t test_read_sfdp(void) {
+  spi_flash_testutils_read_sfdp(&spi_host, 0, sfdp.data, sizeof(sfdp.data));
+  LOG_INFO("SFDP signature is 0x%08x", sfdp.header.signature);
+  CHECK(sfdp.header.signature == kSfdpSignature,
+        "Expected to find the SFDP signature!");
+
+  uint32_t bfpt_offset = sfdp.param.table_pointer[0] |
+                         sfdp.param.table_pointer[1] << 8 |
+                         sfdp.param.table_pointer[2] << 16;
+  sfdp.bfpt = (uint32_t *)(sfdp.data + bfpt_offset);
+  return OK_STATUS();
+}
+
+status_t test_chip_erase(void) {
+  spi_flash_testutils_erase_chip(&spi_host);
+
+  // Check that the first page of flash actually got erased.
+  uint8_t buf[256] = {0};
+  spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadNormal, buf,
+                              sizeof(buf),
+                              /*address=*/0,
+                              /*addr_is_4b=*/false,
+                              /*width=*/1,
+                              /*dummy=*/0);
+  uint8_t expected[256];
+  memset(expected, 0xFF, sizeof(expected));
+  CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
+  return OK_STATUS();
+}
+
+status_t test_enable_quad_mode(void) {
+  if (sfdp.param.length < 14) {
+    return INVALID_ARGUMENT();
+  }
+  uint8_t mech = bitfield_field32_read(sfdp.bfpt[14], SPI_FLASH_QUAD_ENABLE);
+  LOG_INFO("Setting the EEPROM's QE bit via mechanism %d", mech);
+  TRY(spi_flash_testutils_quad_enable(&spi_host, mech, /*enabled=*/true));
+  return OK_STATUS();
+}
+
+// Program a pattern into the flash part and read it back.
+status_t test_page_program(void) {
+  spi_flash_testutils_program_page(&spi_host, kGettysburgPrelude,
+                                   sizeof(kGettysburgPrelude),
+                                   /*address=*/0, /*addr_is_4b=*/0);
+
+  uint8_t buf[256];
+  spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadNormal, buf,
+                              sizeof(buf), 0,
+                              /*addr_is_4b=*/false,
+                              /*width=*/1,
+                              /*dummy=*/0);
+  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast read" opcode.
+status_t test_fast_read(void) {
+  uint8_t buf[256];
+  spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadFast, buf,
+                              sizeof(buf), 0,
+                              /*addr_is_4b=*/false,
+                              /*width=*/1,
+                              /*dummy=*/8);
+  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast dual read" opcode.
+status_t test_dual_read(void) {
+  uint8_t buf[256];
+  spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadDual, buf,
+                              sizeof(buf), 0,
+                              /*addr_is_4b=*/false,
+                              /*width=*/2,
+                              /*dummy=*/8);
+  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast quad read" opcode.
+status_t test_quad_read(void) {
+  uint8_t buf[256];
+  spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadQuad, buf,
+                              sizeof(buf), 0,
+                              /*addr_is_4b=*/false,
+                              /*width=*/4,
+                              /*dummy=*/8);
+  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
 }
 
 bool test_main(void) {
-  dif_spi_host_t spi_host;
   CHECK_DIF_OK(dif_spi_host_init(
       mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host));
 
@@ -78,6 +163,14 @@ bool test_main(void) {
                "SPI_HOST config failed!");
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(&spi_host, true));
 
-  read_sfdp(&spi_host);
-  return true;
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, test_software_reset);
+  EXECUTE_TEST(result, test_read_sfdp);
+  EXECUTE_TEST(result, test_chip_erase);
+  EXECUTE_TEST(result, test_enable_quad_mode);
+  EXECUTE_TEST(result, test_page_program);
+  EXECUTE_TEST(result, test_fast_read);
+  EXECUTE_TEST(result, test_dual_read);
+  EXECUTE_TEST(result, test_quad_read);
+  return status_ok(result);
 }


### PR DESCRIPTION
Add spi_host tests that exercise more features of the spi_host.  This
test now depends on several bits of EEPROM functionality; fortunately,
the IS25WP016 part on the CW310 board supports all of the operations.

1. Test single opcode transactions with no data phase (software_reset, chip_erase).
2. Test read transactions with dummy cycles (read_sfdp, fast_read).
3. Test read and write transactions without dummy cycles (page_program).
4. Test two-lane reads (dual_read).
5. Test four-lane reads (quad_read).

Note: this PR depends on #17615 and #17617.  You need only review the last 3 commits in this PR.