### PR TITLE
[test] re-enable I2C checking in power virus test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1883,6 +1883,7 @@
               "chip_sw_kmac_mode_kmac",
               "chip_sw_kmac_mode_kmac_jitter_en",
               "chip_sw_sleep_pin_mio_dio_val",
+              "chip_sw_power_virus",
               // TODO: uncomment when these run with Xcelium.
               // "chip_sw_lc_walkthrough_dev",
               // "chip_sw_lc_walkthrough_prod",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
@@ -31,18 +31,16 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
       cfg.m_i2c_agent_cfgs[i].if_mode = Device;
     end
 
-    // Wait for test_main() to start
+    // Wait for test_main() to start and configurations to be computed.
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Computed peripheral clock period.");
-    // Backdoor read I2C configuration parameters.
-    i2c_scl_period_ns = sw_symbol_backdoor_read32("kI2cSclPeriodNs");
-    // Hard-coded from
-    // https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/arch/device_sim_dv.c
+    // Hard-coded from `sw/device/lib/arch/device_sim_dv.c`.
     peripheral_clock_freq_hz = 24 * 1000 * 1000;
-    peripheral_clock_period_ns = 1000000000/peripheral_clock_freq_hz;
-    `uvm_info(`gfn, $sformatf("kI2cSclPeriodNs = %0d", i2c_scl_period_ns), UVM_LOW);
+    peripheral_clock_period_ns = 1_000_000_000 / peripheral_clock_freq_hz;
     `uvm_info(`gfn, $sformatf("peripheral_clock_period_ns = %0d", peripheral_clock_period_ns),
       UVM_LOW);
 
+    // Hard-coded from `sw/device/tests/power_virus_systemtest.c`.
+    i2c_scl_period_ns = 1000;
     half_cycles_in_i2c_period = ((int'(i2c_scl_period_ns) / 2 - 1) /
       int'(peripheral_clock_period_ns)) + 1;
     `uvm_info(`gfn, $sformatf("Half (peripheral) cycles in I2C clock period: %d",
@@ -51,7 +49,7 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
     // Enable I2C monitors.
     foreach (cfg.m_i2c_agent_cfgs[i]) begin
       cfg.m_i2c_agent_cfgs[i].en_monitor = 1'b1;
-      cfg.m_i2c_agent_cfgs[i].target_addr0 = i+1;
+      cfg.m_i2c_agent_cfgs[i].target_addr0 = i + 1;
       cfg.chip_vif.enable_i2c(.inst_num(i), .enable(1));
       cfg.m_i2c_agent_cfgs[i].timing_cfg.tClockLow = half_cycles_in_i2c_period - 2;
       cfg.m_i2c_agent_cfgs[i].timing_cfg.tClockPulse = half_cycles_in_i2c_period + 1;

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -136,6 +136,7 @@ enum {
   /**
    * I2C parameters.
    */
+  kI2cSclPeriodNs = 1000,
   kI2cSdaRiseFallTimeNs = 10,
   kI2cDeviceMask = 0x7f,
   kI2c0DeviceAddress0 = 0x11,
@@ -174,13 +175,6 @@ enum {
 };
 
 static uint32_t csrng_reseed_cmd_header;
-
-/**
- * These symbols are meant to be backdoor read by the testbench. Due to current
- * DV infrastructure limitations, these must be `volatile const` to be accessed
- * by the testbench.
- */
-static volatile const uint32_t kI2cSclPeriodNs = 1000;
 
 /**
  * The peripheral clock of I2C IP (in nanoseconds)
@@ -1184,7 +1178,7 @@ static void max_power_task(void *task_parameters) {
       for (size_t jj = 0; jj < I2C_PARAM_FIFO_DEPTH - 1; ++jj) {
         uint8_t byte;
         CHECK_DIF_OK(dif_i2c_read_byte(i2c_handles[ii], &byte));
-        /*CHECK(kI2cMessage[jj] == byte);*/
+        CHECK(kI2cMessage[jj] == byte);
       };
     };
   }


### PR DESCRIPTION
This PR contains a few commits that:
1. re-enables I2C RX checking after fixing a bug in the agent configuration reported in #17607,
2. cleans up I2C DIF calls, and
3. adds the power virus test to the list of tests run in pre-submit (note: this may be removed if the runtime is too long).