### PR TITLE
[ci] Adjust timeout values

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,7 +190,7 @@ jobs:
 - job: sw_build
   displayName: Earl Grey SW Build & Test
   # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
@@ -285,7 +285,7 @@ jobs:
   displayName: Fast Verilated Earl Grey tests
   # Build and run fast tests on sim_verilator
   pool: ci-public
-  timeoutInMinutes: 240
+  timeoutInMinutes: 120
   dependsOn: lint
   steps:
   - template: ci/checkout-template.yml


### PR DESCRIPTION
Earl Grey SW Build & Test jobs are still occasionally taking 3h+ so increase the timeout to 4h. The Fast Verilated test jobs are much more stable now so reduce the timeout to 2h.