### PR TITLE
[hw,i2c,dv] I2C hrst test fixes

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -18,7 +18,7 @@ package i2c_agent_pkg;
   typedef enum logic [3:0] {
     None, DevAck, RdData, WrData,
     HostStart, HostRStart, HostData, HostAck,
-    HostNAck, HostStop
+    HostNAck, HostStop, HostDataGlitch
   } drv_type_e;
 
   // Driver phase


### PR DESCRIPTION
- Added a new `drv_state_e` enum to drive `Start`glitch during data byte transmission on a random bit.
- Modified test sequence to update the expected ACQ data in case of a start glitch
- Removed, logic to drive `Stop` glitch since, stop requires SDA to transition from LOW to HIGH, which is possible only in write request (since in write I2C agent will drive data bits to DUT)

These changes address most of the `i2c_target_hrst` test failures