### PR TITLE
[opentitantool] Gpio monitoring via proxy

### DIFF
--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 
 use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::{EmuState, EmuValue};
-use crate::io::gpio::{PinMode, PullMode};
+use crate::io::gpio::{
+    ClockNature, MonitoringReadResponse, MonitoringStartResponse, PinMode, PullMode,
+};
 use crate::io::spi::{MaxSizes, TransferMode};
 use crate::proxy::errors::SerializedError;
 use crate::transport::Capabilities;
@@ -24,6 +26,7 @@ pub enum Request {
     GetCapabilities,
     ApplyDefaultConfiguration,
     Gpio { id: String, command: GpioRequest },
+    GpioMonitoring { command: GpioMonRequest },
     Uart { id: String, command: UartRequest },
     Spi { id: String, command: SpiRequest },
     I2c { id: String, command: I2cRequest },
@@ -36,6 +39,7 @@ pub enum Response {
     GetCapabilities(Capabilities),
     ApplyDefaultConfiguration,
     Gpio(GpioResponse),
+    GpioMonitoring(GpioMonResponse),
     Uart(UartResponse),
     Spi(SpiResponse),
     I2c(I2cResponse),
@@ -57,6 +61,25 @@ pub enum GpioResponse {
     Read { value: bool },
     SetMode,
     SetPullMode,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum GpioMonRequest {
+    GetClockNature,
+    Start {
+        pins: Vec<String>,
+    },
+    Read {
+        pins: Vec<String>,
+        continue_monitoring: bool,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum GpioMonResponse {
+    GetClockNature { resp: ClockNature },
+    Start { resp: MonitoringStartResponse },
+    Read { resp: MonitoringReadResponse },
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -6,8 +6,13 @@ use anyhow::{bail, Result};
 use std::rc::Rc;
 
 use super::ProxyError;
-use crate::io::gpio::{GpioPin, PinMode, PullMode};
-use crate::proxy::protocol::{GpioRequest, GpioResponse, Request, Response};
+use crate::io::gpio::{
+    ClockNature, GpioMonitoring, GpioPin, MonitoringReadResponse, MonitoringStartResponse, PinMode,
+    PullMode,
+};
+use crate::proxy::protocol::{
+    GpioMonRequest, GpioMonResponse, GpioRequest, GpioResponse, Request, Response,
+};
 use crate::transport::proxy::{Inner, Proxy};
 
 pub struct ProxyGpioPin {
@@ -63,6 +68,71 @@ impl GpioPin for ProxyGpioPin {
     fn set_pull_mode(&self, pull: PullMode) -> Result<()> {
         match self.execute_command(GpioRequest::SetPullMode { pull })? {
             GpioResponse::SetPullMode => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn get_internal_pin_name(&self) -> Option<&str> {
+        Some(&self.pinname)
+    }
+}
+
+pub struct GpioMonitoringImpl {
+    inner: Rc<Inner>,
+}
+
+impl GpioMonitoringImpl {
+    pub fn new(proxy: &Proxy) -> Result<Self> {
+        Ok(Self {
+            inner: Rc::clone(&proxy.inner),
+        })
+    }
+
+    // Convenience method for issuing GPIO monitoring commands via proxy protocol.
+    fn execute_command(&self, command: GpioMonRequest) -> Result<GpioMonResponse> {
+        match self
+            .inner
+            .execute_command(Request::GpioMonitoring { command })?
+        {
+            Response::GpioMonitoring(resp) => Ok(resp),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+}
+
+impl GpioMonitoring for GpioMonitoringImpl {
+    fn get_clock_nature(&self) -> Result<ClockNature> {
+        match self.execute_command(GpioMonRequest::GetClockNature)? {
+            GpioMonResponse::GetClockNature { resp } => Ok(resp),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn monitoring_start(&self, pins: &[&dyn GpioPin]) -> Result<MonitoringStartResponse> {
+        let pins = pins
+            .iter()
+            .map(|p| p.get_internal_pin_name().unwrap().to_string())
+            .collect::<Vec<String>>();
+        match self.execute_command(GpioMonRequest::Start { pins })? {
+            GpioMonResponse::Start { resp } => Ok(resp),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn monitoring_read(
+        &self,
+        pins: &[&dyn GpioPin],
+        continue_monitoring: bool,
+    ) -> Result<MonitoringReadResponse> {
+        let pins = pins
+            .iter()
+            .map(|p| p.get_internal_pin_name().unwrap().to_string())
+            .collect::<Vec<String>>();
+        match self.execute_command(GpioMonRequest::Read {
+            pins,
+            continue_monitoring,
+        })? {
+            GpioMonResponse::Read { resp } => Ok(resp),
             _ => bail!(ProxyError::UnexpectedReply()),
         }
     }

--- a/sw/host/opentitanlib/src/transport/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/mod.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::bootstrap::BootstrapOptions;
 use crate::impl_serializable_error;
 use crate::io::emu::Emulator;
-use crate::io::gpio::GpioPin;
+use crate::io::gpio::{GpioMonitoring, GpioPin};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
@@ -197,6 +197,11 @@ impl Transport for Proxy {
     // Create GpioPin instance, or return one from a cache of previously created instances.
     fn gpio_pin(&self, pinname: &str) -> Result<Rc<dyn GpioPin>> {
         Ok(Rc::new(gpio::ProxyGpioPin::open(self, pinname)?))
+    }
+
+    // Create ProxyOps instance.
+    fn gpio_monitoring(&self) -> Result<Rc<dyn GpioMonitoring>> {
+        Ok(Rc::new(gpio::GpioMonitoringImpl::new(self)?))
     }
 
     // Create Emulator instance, or return one from a cache of previously created instances.


### PR DESCRIPTION
The logic analyser functionality was accidentally left out of the proxy protocol.  This PR adds the protocol declarations to be able to pass the few additional method calls.
