### PR TITLE
[test] Use correct TAP ID for lc_ctrl in e2e_bootstrap_rma

### DIFF
--- a/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
@@ -241,7 +241,7 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         //
         // [0]: https://docs.opentitan.org/hw/ip/lc_ctrl/doc/#life-cycle-tap-controller
         // [1]: See where `dmi_jtag_tap` is created in hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
-        // [2]: See where `dmi_jtag` is instantiated in hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+        // [2]: See the `IdcodeValue` for `lc_ctrl` in hw/top_earlgrey/data/top_earlgrey.hjson
         //
         // Because these commands are command-line args, they *must* end with
         // semicolons to satisfy the TCL lexer. When a TCL program is read from
@@ -250,7 +250,7 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
             "-c",
             "transport select jtag;",
             "-c",
-            "jtag newtap lc_ctrl tap -irlen 5 -expected-id 0x00000001 -ignore-bypass;",
+            "jtag newtap lc_ctrl tap -irlen 5 -expected-id 0x04f5484d -ignore-bypass;",
             "-c",
             &format!(
                 "target create {JTAG_TAP_NAME} riscv -chain-position lc_ctrl.tap -rtos hwthread;"


### PR DESCRIPTION
Prior to this change, the test warned that it found a TAP with an unexpected ID.

    Info : Hardware thread awareness created
    Info : clock speed 200 kHz
    Info : JTAG tap: lc_ctrl.tap tap/device found: 0x04f5484d (mfg: 0x426 (Google Inc), part: 0x4f54, ver: 0x0)
    Warn : JTAG tap: lc_ctrl.tap       UNEXPECTED: 0x04f5484d (mfg: 0x426 (Google Inc), part: 0x4f54, ver: 0x0)
    Error: JTAG tap: lc_ctrl.tap  expected 1 of 1: 0x00000001 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x0)
    Error: Trying to use configured scan chain anyway...
    Warn : Bypassing JTAG setup events due to errors
    Error: Debug Module did not become active. dmcontrol=0x0
    Warn : target lc_ctrl.tap.0 examination failed
    Info : starting gdb server for lc_ctrl.tap.0 on 3333
    Info : Listening on port 3333 for gdb connections

With this commit, the warning has disappeared and the ID matches the newly-hardcoded TAP ID.

    Info : Hardware thread awareness created
    Info : clock speed 200 kHz
    Info : JTAG tap: lc_ctrl.tap tap/device found: 0x04f5484d (mfg: 0x426 (Google Inc), part: 0x4f54, ver: 0x0)
    Error: Debug Module did not become active. dmcontrol=0x0
    Warn : target lc_ctrl.tap.0 examination failed
    Info : starting gdb server for lc_ctrl.tap.0 on 3333
    Info : Listening on port 3333 for gdb connections

Fixes #17634