### PR TITLE
[entropy_src/dv] Separate external health test (XHT) verification from V2 tests

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -118,6 +118,15 @@
       stage: V2
       tests: ["entropy_src_functional_errors"]
     }
+    {
+      name: external_health_tests
+      desc: '''
+            Verify the external health test (XHT) interface and functionality, including continuous
+            and windowed functionality and different high/low thresholds and watermarks.
+            '''
+      stage: V3
+      tests: ["entropy_src_rng_with_xht_rsps"], // TODO(#16276): Complete XHT verification
+    }
   ]
   covergroups: [
     {

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -74,6 +74,13 @@
     }
 
     {
+      name: entropy_src_rng_with_xht_rsps
+      uvm_test: entropy_src_rng_test
+      uvm_test_seq: entropy_src_rng_vseq
+      run_opts: ["+xht_only_default_rsp=0"]
+    }
+
+    {
       name: entropy_src_stress_all
       uvm_test: entropy_src_stress_all_test
       uvm_test_seq: entropy_src_stress_all_vseq

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -112,6 +112,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // alert within alert_max_delay clock cycles.
   int      alert_max_delay;
 
+  // Whether to keep the default response on the XHT interface at all time.
+  bit xht_only_default_rsp = 0;
+
   ///////////////////////
   // Randomized fields //
   ///////////////////////

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -113,7 +113,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   int      alert_max_delay;
 
   // Whether to keep the default response on the XHT interface at all time.
-  bit xht_only_default_rsp = 0;
+  bit xht_only_default_rsp = 1;
 
   ///////////////////////
   // Randomized fields //

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -183,6 +183,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
         process_interrupts();
         process_fifo_exceptions();
         health_test_scoring_thread();
+        process_xht();
       join_none
     end
   endtask
@@ -1103,6 +1104,21 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
         if (new_intrs[i]) begin
           `uvm_info(`gfn, $sformatf("INTERRUPT RECEIVED: %0s", i.name), UVM_FULL)
         end
+      end
+    end
+  endtask
+
+  task process_xht();
+    // Process XHT transactions.
+    forever begin
+      @(cfg.m_xht_agent_cfg.vif.mon_cb);
+      if (cfg.under_reset) continue;
+
+      if (cfg.xht_only_default_rsp) begin
+        // If the environment is configured to maintain the default XHT response at all time, ensure
+        // that this is really the case.
+        `DV_CHECK_EQ(cfg.m_xht_agent_cfg.vif.mon_cb.rsp,
+                     entropy_src_pkg::ENTROPY_SRC_XHT_RSP_DEFAULT)
       end
     end
   endtask

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -425,7 +425,9 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     fork
         m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
         m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);
-        m_xht_seq.start(p_sequencer.xht_sequencer);
+        if (!cfg.xht_only_default_rsp) begin
+          m_xht_seq.start(p_sequencer.xht_sequencer);
+        end
     join_none
   endtask
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -27,6 +27,13 @@ class entropy_src_base_test extends cip_base_test #(
   // Overrides should happen in the specific testcase.
 
   virtual function void configure_env();
+    // Take plusargs into account.
+    bit xht_only_default_rsp;
+    if ($value$plusargs("xht_only_default_rsp=%0b", xht_only_default_rsp)) begin
+      `uvm_info(`gfn, $sformatf("+xht_only_default_rsp specified"), UVM_MEDIUM)
+      cfg.xht_only_default_rsp = xht_only_default_rsp;
+    end
+
     // seed_cnt only used by smoke test
     // so there is no need to randomize it.
     cfg.seed_cnt                       = 1;


### PR DESCRIPTION
As described in #17358, the current instantiation of `entropy_src` in the Earlgrey top-level design has the XHT response input tied off to a default value, but the `entropy_src_rng` block-level test had time-varying, non-default XHT responses.

This PR changes that in three commits as follows:
1. Add a config knob that tells tests to only drive the default XHT response.
2. Add a scoreboard check to ensure that the knob is respected.
3. Separate `entropy_src_rng` with time-varying XHT responses to a new `entropy_src_rng_with_xht_rsps` test and change `entropy_src_rng` to only drive default XHT responses.

This resolves #17358.