### PR TITLE
[kmac] Zero capacity of KMAC against SW (sideload only)

### DIFF
--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -90,6 +90,14 @@ package sha3_pkg;
      576/MsgWidth   //  9 depth := (1600 - 512*2)
   };
 
+  parameter int unsigned KeccakBitCapacity [5] = '{
+    2 * 128, // capacity for L128
+    2 * 224, // capacity for L224
+    2 * 256, // capacity for L256
+    2 * 384, // capacity for L384
+    2 * 512  // capacity for L512
+  };
+
   parameter int unsigned MaxBlockSize = KeccakRate[0];
 
   parameter int unsigned KeccakEntries = 1600/MsgWidth;


### PR DESCRIPTION
One possible low-cost way to fix #17508. At the end of KMAC operation, it zeroes the capacity part of Keccak state that is passed to TL-UL primitives.

Few questions that I'm asking myself about this PR and the main issue:

- Is `kmac_app` is the right submodule to do this?
- Should we also try to raise an error if SW tries to read from capacity? At the moment, I do not see a good error flow to realize this, so I felt this would be a high effort. I also do not see any security benefit.
- Should we harden this zeroing mechanism? With FI, one can flip the select signal that goes into MUX. Plus, this signal propagates all the way from registers into this MUX circuit, so there is a large exposure.
