### PR TITLE
[bazel] Bump OpenOCD to 0.12.0 from 0.12.0-rc1

### DIFF
--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -5,12 +5,12 @@
 load("//rules:repo.bzl", "http_archive_or_local")
 
 def openocd_repos(local = None):
-    OPENOCD_VERSION = "0.12.0-rc1"
+    OPENOCD_VERSION = "0.12.0"
     http_archive_or_local(
         name = "openocd",
         local = local,
         url = "https://sourceforge.net/projects/openocd/files/openocd/{version}/openocd-{version}.tar.gz".format(version = OPENOCD_VERSION),
         strip_prefix = "openocd-" + OPENOCD_VERSION,
         build_file = "//third_party/openocd:BUILD.openocd.bazel",
-        sha256 = "cdd3654a6c2fd046fe766de5ed897d75467138be9b9c271229bbd7409eb902a5",
+        sha256 = "bb367fd19ab96a65ee5b269b60326d9f36bca1c64d9865cc36985d3651aba563",
     )


### PR DESCRIPTION
This is not urgent, but the stable 0.12.0 release has been out for a little while. Assuming the experimental JTAG tests pass CI, I'd feel good about merging this.