### PR TITLE
[test] power virus test: fix typo in spi_host1 pins

### DIFF
--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -543,9 +543,9 @@ static void configure_pinmux(void) {
   CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIor11,
                                         kTopEarlgreyPinmuxOutselSpiHost1Sd1));
   CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIor12,
-                                        kTopEarlgreyPinmuxOutselSpiHost1Sd1));
+                                        kTopEarlgreyPinmuxOutselSpiHost1Sd2));
   CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIor13,
-                                        kTopEarlgreyPinmuxOutselSpiHost1Sd1));
+                                        kTopEarlgreyPinmuxOutselSpiHost1Sd3));
   CHECK_DIF_OK(dif_pinmux_input_select(
       &pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd0,
       kTopEarlgreyPinmuxInselIoa2));


### PR DESCRIPTION
Fix a typo regarding the SD1-SD3 pins of the spi_host1