### PR TITLE
[doc] Fix some broken links the documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -37,7 +37,6 @@
   - [Pinmux Targets](./hw/top_earlgrey/ip/pinmux/doc/autogen/targets.md)
     - [ASIC Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_asic.md)
     - [CW310 Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_cw310.md)
-    - [NEXYSVIDEO Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_nexysvideo.md)
 
 - [Cores](./hw/doc/cores.md)
   - [Ibex RISC-V Core Wrapper](./hw/ip/rv_core_ibex/README.md)

--- a/doc/contributing/hw/comportability/README.md
+++ b/doc/contributing/hw/comportability/README.md
@@ -54,7 +54,7 @@ All files that use the default copyright and license should therefore include th
 // SPDX-License-Identifier: Apache-2.0
 ```
 
-The project has adopted [Hjson](https://hjson.org) for JSON files, extending JSON to allow comments.
+The project has adopted [Hjson](https://hjson.github.io/) for JSON files, extending JSON to allow comments.
 Thus the Hjson files can include the header above.
 If pure JSON must be used for some reason, the "SPDX-License-Identifier:" can be added as the first key after the opening "{".
 Tools developed by the project should accept and ignore this key.

--- a/doc/contributing/style_guides/asm_coding_style.md
+++ b/doc/contributing/style_guides/asm_coding_style.md
@@ -21,7 +21,7 @@ As such, no advice is provided for other RISC-V extensions, though this style gu
 
 ***When referring to a RISC-V register, they must be referred to by their ABI names.***
 
-See the [psABI Reference](https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#register-convention) for a reference to these names.
+See the [psABI Reference](https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#register-convention) for a reference to these names.
 
 Example:
 ```S

--- a/doc/contributing/style_guides/hjson_usage_style.md
+++ b/doc/contributing/style_guides/hjson_usage_style.md
@@ -5,7 +5,7 @@
 ### Summary
 
 Json files are used to provide input data to many of the tools.
-The preference is to use [Hjson](https://hjson.org/), which is a variation of regular JSON that is easier to write.
+The preference is to use [Hjson](https://hjson.github.io), which is a variation of regular JSON that is easier to write.
 In particular, it allows the quote marks to be left off the key names, it allows a single string to be quoted with triple quote marks and flow over multiple lines (which is often needed in text descriptions) and it allows comments using the # or // style.
 
 This guide covers the enhancements provided by Hjson that are used in the project along with a recommended style.
@@ -42,7 +42,7 @@ It is always okay to deviate from the style guide by necessity, as long as that 
 
 Hjson is a variation of regular JSON that is easier to write.
 There are parsers in a number of languages and the tools make extensive use of the `hjson` package provided for Python 3.
-A full description can be found on the [Hjson website](https://hjson.org/), but the main features that make it convenient are that it keeps files cleaner by allowing the quote marks to be left off the key names, it enables long descriptive text by allowing a single string to flow over multiple lines and it allows comments using the # or // style.
+A full description can be found on the [Hjson website](https://hjson.github.io), but the main features that make it convenient are that it keeps files cleaner by allowing the quote marks to be left off the key names, it enables long descriptive text by allowing a single string to flow over multiple lines and it allows comments using the # or // style.
 
 For example:
 

--- a/doc/contributing/style_guides/python_coding_style.md
+++ b/doc/contributing/style_guides/python_coding_style.md
@@ -155,7 +155,7 @@ Exceptions:
 
 Use spaces to indent or align text.
 
-To convert tabs to spaces on any file, you can use the [UNIX `expand`](http://linux.die.net/man/1/expand) utility.
+To convert tabs to spaces on any file, you can use the [UNIX `expand`](https://linux.die.net/man/1/expand) utility.
 
 #### No Trailing Spaces
 

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -40,7 +40,7 @@ For questions about how the project is organized, see the [project](./project_go
 ## Repository Structure
 
 The underlying
-[repo](http://www.github.com/lowrisc/opentitan)
+[repo](https://www.github.com/lowrisc/opentitan)
 is set up as a monolithic repository to contain RTL, helper scripts, technical documentation, and other software necessary to produce our hardware designs.
 
 Unless otherwise noted, everything in the repository is covered by the Apache License, Version 2.0. See the [LICENSE](https://github.com/lowRISC/opentitan/blob/master/LICENSE) file and [repository README](https://github.com/lowRISC/opentitan/blob/master/README.md) for more information on licensing and see the user guides below for more information on development methodology.

--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -361,7 +361,7 @@ A functional coverage shell object has been created - this may not contain cover
 
 ### TB_LINT_SETUP
 
-[VeribleLint](https://google.github.io/verible/verilog_lint.html) for the testbench is [set up](../../../hw/lint/README.md) to run in nightly regression, with appropriate waivers.
+[VeribleLint](https://chipsalliance.github.io/verible/verilog_lint.html) for the testbench is [set up](../../../hw/lint/README.md) to run in nightly regression, with appropriate waivers.
 * For a constrained random testbench, an entry has been added to `hw/<top-level-design>/lint/<top-level-design>_dv_lint_cfgs.hjson`
 * For an FPV testbench, an entry has been added to `hw/<top-level-design>/lint/<top-level-design>_fpv_lint_cfgs.hjson`
 

--- a/doc/project_governance/development_stages.md
+++ b/doc/project_governance/development_stages.md
@@ -45,7 +45,7 @@ See the _Versioning_ section of the document for more discussion.
 Signed-off fully-functioning (read: not buggy) designs stay in the "Signed-Off" life stage as an available complete IP, with an associated revision ID.
 
 There exists a [template for IP checklists](https://github.com/lowRISC/opentitan/blob/master/util/uvmdvgen/checklist.md.tpl).
-The DIF stages use a separate, [software-specific checklist](https://github.com/lowRISC/opentitan/blob/master/doc/project/sw_checklist.md.tpl).
+The DIF stages use a separate, [software-specific checklist](https://github.com/lowRISC/opentitan/blob/master/doc/project_governance/checklist/sw_checklist.md.tpl).
 All the checklist items are listed in the [Sign-off Checklist](./checklist/README.md).
 
 | **Stage** | **Name** | **Definition** |

--- a/hw/dv/dpi/dmidpi/README.md
+++ b/hw/dv/dpi/dmidpi/README.md
@@ -1,7 +1,7 @@
 DMI DPI module for OpenOCD remote_bitbang driver
 ================================================
 
-This DPI module provides a "virtual" JTAG connection between a simulated chip and [OpenOCD](http://openocd.org/).
+This DPI module provides a "virtual" JTAG connection between a simulated chip and [OpenOCD](https://openocd.org/).
 It makes use of the `remote_bitbang` JTAG driver shipped with OpenOCD, which forwards JTAG requests over TCP to a remote server.
 The `dmidpi` module is instantiated in the hardware simulation to receive the JTAG requests from OpenOCD and drive DMI pins directly.
 

--- a/hw/dv/dpi/jtagdpi/README.md
+++ b/hw/dv/dpi/jtagdpi/README.md
@@ -2,7 +2,7 @@ JTAG DPI module for OpenOCD remote_bitbang driver
 =================================================
 
 This DPI module provides a "virtual" JTAG connection between an simulated chip
-and [OpenOCD](http://openocd.org/). It makes use of the `remote_bitbang` JTAG
+and [OpenOCD](https://openocd.org/). It makes use of the `remote_bitbang` JTAG
 driver shipped with OpenOCD, which forwards JTAG requests over TCP to a remote
 server. The `jtagdpi` module is instantiated in the hardware simulation to
 receive the JTAG requests from OpenOCD and drive the JTAG pins (TCK, TMS, TDI,

--- a/hw/dv/tools/ralgen/README.md
+++ b/hw/dv/tools/ralgen/README.md
@@ -1,7 +1,7 @@
 # `ralgen`: A FuseSoC generator for UVM RAL package
 
 The `ralgen.py` script is implemented as a
-[FuseSoC generator](https://fusesoc.readthedocs.io/en/master/user/generators.html).
+[FuseSoC generator](https://fusesoc.readthedocs.io/en/stable/user/build_system/generators.html).
 which enables the automatic creation of the SystemVerilog UVM RAL package and
 its insertion into the dependency tree when compiling the DV testbench.
 
@@ -78,7 +78,7 @@ the `ip_hjson` or `top_hjson` parameter is supplied.
 
 In addition, the `ralgen.py` script also creates a FuseSoC core file. It uses
 the `name` parameter to derive the
-[VLNV](https://fusesoc.readthedocs.io/en/master/user/overview.html#core-naming-rules)
+[VLNV](https://fusesoc.readthedocs.io/en/stable/user/build_system/core_files.html#naming-the-core-file)
 name for the generated core file.
 
 The generated core file adds **`lowrisc:dv:dv_base_reg`** as a dependency for

--- a/hw/ip/aes/dv/README.md
+++ b/hw/ip/aes/dv/README.md
@@ -10,7 +10,8 @@
 ## Current status
 * [Design & verification stage](../../../README.md)
   * [HW development stages](../../../../doc/project_governance/development_stages.md)
-* [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/report.html)
+* [Simulation results for Masked AES](https://reports.opentitan.org/hw/ip/aes_masked/dv/latest/report.html)
+* [Simulation results for Unmasked AES](https://reports.opentitan.org/hw/ip/aes_unmasked/dv/latest/report.html)
 
 ## Design features
 For detailed information on AES design features, please see the [AES HWIP Technical Specification](../README.md).

--- a/hw/ip/flash_ctrl/doc/programmers_guide.md
+++ b/hw/ip/flash_ctrl/doc/programmers_guide.md
@@ -9,7 +9,7 @@ To issue a flash read, the programmer must
 *  Set the 'START' bit for the operation to begin
 
 The above fields can be set in the [`CONTROL`](../data/flash_ctrl.hjson#control) and [`ADDR`](../data/flash_ctrl.hjson#addr) registers.
-See [library code](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/flash_ctrl.c) for implementation.
+See [library code](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/dif/dif_flash_ctrl.c) for implementation.
 
 It is acceptable for total number of flash words to be significantly greater than the depth of the read FIFO.
 In this situation, the read FIFO will fill up (or hit programmable fill value), pause the flash read and trigger an interrupt to software.

--- a/hw/ip/kmac/doc/programmers_guide.md
+++ b/hw/ip/kmac/doc/programmers_guide.md
@@ -78,7 +78,7 @@ It could restore the previous hashing state later and continue the operation.
 
 [SHA3 specification, FIPS 202]: https://csrc.nist.gov/publications/detail/fips/202/final
 [NIST SP 800-185]: https://csrc.nist.gov/publications/detail/sp/800-185/final
-[Domain-Oriented Masking (DOM)]: https://eprint.iacr.org/2017/395.pdf../data/kmac.hjson#entropy_seed_0cation
+[Domain-Oriented Masking (DOM)]: https://eprint.iacr.org/2017/395.pdf
 
 # Overview
 

--- a/hw/ip/kmac/dv/README.md
+++ b/hw/ip/kmac/dv/README.md
@@ -10,7 +10,8 @@
 ## Current status
 * [Design & verification stage](../../../README.md)
   * [HW development stages](../../../../doc/project_governance/development_stages.md)
-* [Simulation results](https://reports.opentitan.org/hw/ip/kmac/dv/latest/report.html)
+* [Simulation results for Masked KMAC](https://reports.opentitan.org/hw/ip/kmac_masked/dv/latest/report.html)
+* [Simulation results for Unmasked KMAC](https://reports.opentitan.org/hw/ip/kmac_unmasked/dv/latest/report.html)
 
 ## Design features
 For detailed information on KMAC design features, please see the [KMAC HWIP technical specification](../README.md).

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -1442,6 +1442,6 @@ Code snippets giving examples of 256x256 and 384x384 multiplies can be found in 
 
 # References
 
-<a name="ref-chen08">[CHEN08]</a> L. Chen, "Hsiao-Code Check Matrices and Recursively Balanced Matrices," arXiv:0803.1217 [cs], Mar. 2008 [Online]. Available: http://arxiv.org/abs/0803.1217
+<a name="ref-chen08">[CHEN08]</a> L. Chen, "Hsiao-Code Check Matrices and Recursively Balanced Matrices," arXiv:0803.1217 [cs], Mar. 2008 [Online]. Available: https://arxiv.org/abs/0803.1217
 
 <a name="ref-symbiotic21">[SYMBIOTIC21]</a> RISC-V Bitmanip Extension v0.93 Available: https://github.com/riscv/riscv-bitmanip/releases/download/v0.93/bitmanip-0.93.pdf

--- a/hw/ip/sram_ctrl/dv/README.md
+++ b/hw/ip/sram_ctrl/dv/README.md
@@ -17,7 +17,8 @@ Only toggle coverage on the IOs of these sub-modules is enabled for coverage col
 ## Current status
 * [Design & verification stage](../../../README.md)
   * [HW development stages](../../../../doc/project_governance/development_stages.md)
-* [Simulation results](https://reports.opentitan.org/hw/ip/sram_ctrl/dv/latest/report.html)
+* [Simulation results for SRAM](https://reports.opentitan.org/hw/ip/sram_ctrl_main/dv/latest/report.html)
+* [Simulation results for retention SRAM](https://reports.opentitan.org/hw/ip/sram_ctrl_ret/dv/latest/report.html)
 
 ## Design features
 For detailed information on SRAM_CTRL design features, please see the [SRAM_CTRL HWIP technical specification](../README.md).

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -249,7 +249,7 @@ Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | N/A         |
 Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Waived      | Revisit later. Tool setup in progress
 Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | N/A         |
 Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Done        |
-Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        |[common_cov_excl.el][], [uart_cov_excl.el][]
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Done        |[common_cov_excl.cfg][], [uart_cov_excl.el][]
 Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Done        |
 Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | N/A         |
 Coverage      | [FPV_COI_COVERAGE_AT_100][]       | N/A         |
@@ -275,5 +275,5 @@ Review        | Signoff date                      | Done        | 2019-11-01
 [PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
 [NO_ISSUES_PENDING]:             ../../../../doc/project_governance/checklist/README.md#no_issues_pending
 
-[common_cov_excl.el]:https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/vcs/common_cov_excl.el
+[common_cov_excl.cfg]:https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/vcs/common_cov_excl.cfg
 [uart_cov_excl.el]:  https://github.com/lowRISC/opentitan/blob/04bb36e0ae1430262b048d400102b0fed43377ac/hw/ip/uart/dv/cov/uart_cov_excl.el

--- a/hw/ip/usbdev/doc/theory_of_operation.md
+++ b/hw/ip/usbdev/doc/theory_of_operation.md
@@ -1,6 +1,6 @@
 # Theory of Operation
 
-A useful quick reference for USB Full-Speed is [USB Made Simple, Part 3 - Data Flow.](http://www.usbmadesimple.co.uk/ums_3.htm)
+A useful quick reference for USB Full-Speed is [USB Made Simple, Part 3 - Data Flow.](https://www.usbmadesimple.co.uk/ums_3.htm)
 
 The block diagram shows a high level view of the USB device including the main register access paths.
 

--- a/hw/top_earlgrey/doc/design/README.md
+++ b/hw/top_earlgrey/doc/design/README.md
@@ -6,7 +6,7 @@ For an overview, refer to the [OpenTitan Earl Grey Chip Datasheet](../specificat
 # Theory of Operations
 
 The netlist `chip_earlgrey_asic` contains the features listed above and is intended for ASIC synthesis, whereas the netlist `chip_earlgrey_cw310` provides an emulation environment for the `cw310` FPGA board.
-The code for Ibex is developed in its own [lowRISC repo](http://github.com/lowrisc/ibex), and is [*vendored in*](../../../../doc/contributing/hw/vendor.md) to this repository.
+The code for Ibex is developed in its own [lowRISC repo](https://github.com/lowrisc/ibex), and is [*vendored in*](../../../../doc/contributing/hw/vendor.md) to this repository.
 Surrounding Ibex is a suite of *Comportable* peripherals that follow the [Comportability Guidelines](../../../../doc/contributing/hw/comportability/README.md) for lowRISC peripheral IP.
 Each of these IP has its own specification.
 See the table produced in the [hardware documentation page](../../../README.md) for links to those specifications.

--- a/site/doxygen/main_page.md
+++ b/site/doxygen/main_page.md
@@ -1,11 +1,11 @@
 # OpenTitan Software APIs
 
-This part of the [Opentitan Documentation](../..) contains API documentation for the
+This part of the [Opentitan Documentation](/book) contains API documentation for the
 Software APIs that are part of OpenTitan.
 
 The documentation can be browsed using the tabs above, or there are API listings
 for the relevant DIFs in each Comportable Hardware IP specification.
 
-[Return to OpenTitan Software Documentation](../README.md)
+[Return to OpenTitan Software Documentation](/book/sw)
 
-[Return to OpenTitan Documentation](../..)
+[Return to OpenTitan Documentation](/book)

--- a/site/landing/content/privacy-policy.md
+++ b/site/landing/content/privacy-policy.md
@@ -135,7 +135,7 @@ rights free of charge. In summary, those include rights to:
 For further information on each of those rights, including the circumstances in
 which they apply, see the [Guidance from the UK Information Commissioner's
 Office (ICO) on individuals rights under the General Data Protection
-Regulation](http://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/).
+Regulation](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/).
 
 If you would like to exercise any of those rights, please:
 
@@ -149,7 +149,7 @@ on the 'unsubscribe' button at the bottom of the email newsletter. It may take
 up to seven days for this to take place.
 
 The [General Data Protection
-Regulation](http://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679&from=EN)
+Regulation](https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679&from=EN)
 also gives you right to lodge a complaint with a supervisory authority, in
 particular in the European Union (or European Economic Area) state where you
 work, normally live or where any alleged infringement of data protection laws

--- a/sw/README.md
+++ b/sw/README.md
@@ -57,4 +57,4 @@ See [Vendor Tool User Guide](../util/doc/vendor.md)
 
 * [CoreMark](https://github.com/eembc/coremark)
 * [Cryptoc](https://chromium.googlesource.com/chromiumos/third_party/cryptoc/)
-* [LLVM's Compiler-RT Coverage Profiling Library](https://github.com/llvm/llvm-project/tree/master/compiler-rt)
+* [LLVM's Compiler-RT Coverage Profiling Library](https://github.com/llvm/llvm-project/tree/main/compiler-rt)

--- a/sw/device/README.md
+++ b/sw/device/README.md
@@ -16,7 +16,7 @@ There are also some other standalone firmware images in the repository, which ar
 
 - [`sw/device/tests`](./tests/README.md) contains several categories of chip-level tests, including smoke, IP integration, and system-level (use case) tests.
 
-- [`sw/device/benchmarks/coremark`](https://github.com/lowRISC/opentitan/tree/master/sw/device/benchmarks/coremark) contains infrastructure for running the [CoreMark](https://github.com/eembc/coremark) benchmark suite on the OpenTitan device.
+- [`sw/vendor/eembc_coremark`](https://github.com/lowRISC/opentitan/tree/master/sw/vendor/eembc_coremark) contains infrastructure for running the [CoreMark](https://github.com/eembc/coremark) benchmark suite on the OpenTitan device.
 - `sw/device/riscv_compliance_support` contains infrastructure so we can run the [RISC-V Compliance](https://github.com/riscv/riscv-compliance) tests on the OpenTitan core.
 - `sw/device/sca` contains on-device software used for Side-Channel Analysis.
 - `sw/device/prebuilt` contains pre-built Tock images, which may not be up-to-date.

--- a/sw/device/lib/testing/test_framework/README.md
+++ b/sw/device/lib/testing/test_framework/README.md
@@ -6,8 +6,8 @@
 
 [Chip-level tests](../../../tests/README.md) are designed to be executed across all OpenTitan verification targets DV simulation, Verilator simulation, FPGA, and (eventually) silicon, using host-side test initiation tools, and an on-device test framework, as shown in the figure above.
 On the _host_ side, two main tools are used to initiate tests on the device. For the DV simulation target, the [dvsim.py](https://github.com/lowRISC/opentitan/blob/master/util/dvsim/dvsim.py) tool is used, while for Verilator and FPGA targets, Bazel (and `opentitantool`) is used.
-Focusing on the _device_ side, for all three targets, the [on-device test framework](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/test_main.c) is used to provide a uniform execution environment for chip-level tests.
-The [on-device test framework](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/test_main.c) provides boilerplate setup code that configures the UART for communicating messages and test results back to the host.
+Focusing on the _device_ side, for all three targets, the [on-device test framework](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/ottf_main.c) is used to provide a uniform execution environment for chip-level tests.
+The [on-device test framework](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/ottf_main.c) provides boilerplate setup code that configures the UART for communicating messages and test results back to the host.
 
 # Writing a Chip-Level Test
 To write a chip-level test that uses this framework, one must create a new C file for the test (see [Chip-Level Tests](../../../tests/README.md) for where to place this test) and follow the steps below.
@@ -33,7 +33,7 @@ Check out the [rv\_timer smoke test](https://github.com/lowRISC/opentitan/blob/m
 ## Signaling the end of test and self-checking mechanism
 It is mandatory to invoke the target-agnostic API `test_status_set()` to explicitly signal the end of the test based on whether it passed or failed.
 When invoked, the API calls `abort()` at the end to stop the core from executing any further.
-Please see [`sw/device/lib/testing/test_framework/test_status.h`](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/test_status.h) for documentation and usage.
+Please see [`sw/device/lib/testing/test_framework/status.h`](https://github.com/lowRISC/opentitan/blob/master/sw/device/lib/testing/test_framework/status.h) for documentation and usage.
 
 ### Non-DV Targets
 In non-DV targets (Verilator simulation, FPGA, or silicon), the signal is a message written to the console.

--- a/util/dvsim/README.md
+++ b/util/dvsim/README.md
@@ -25,7 +25,7 @@ DVSim is located at `$REPO_TOP/util/dvsim/dvsim.py`.
 DVSim relies on the following third-party Python libraries:
 * **[Hjson](https://hjson.github.io/)**: to parse the Hjson DUT configuration data.
 * **[Enlighten](https://python-enlighten.readthedocs.io/en/stable/)**: to track the progress of the EDA tool flows on the console in a readable way.
-* **[Mistletoe](https://pypi.org/project/mistletoe/0.-1/)**: to convert Markdown format to HTML, used for testplan descriptions and EDA tool flow reports.
+* **[Mistletoe](https://pypi.org/project/mistletoe)**: to convert Markdown format to HTML, used for testplan descriptions and EDA tool flow reports.
 * **[Premailer](https://pypi.org/project/premailer/)**: to inline a block of CSS into the generated HTML report.
 * **[Tabulate](https://pypi.org/project/tabulate/)**: to pretty-print tabular data when displaying the report on the console.
 

--- a/util/dvsim/doc/design_doc.md
+++ b/util/dvsim/doc/design_doc.md
@@ -222,7 +222,7 @@ DVSim, hence, also uses Hjson as the language for storing data.
 ### Makefile based approach
 
 RTL simulations were the first to be developed at the commencement of the OpenTitan project.
-The initial setup used a [Makefile-based approach](https://github.com/lowRISC/stwg-base/blob/master/hw/dv/tools/README.md), which sequenced the various steps that are required to be invoked to successfully run a simulation.
+The initial setup used a Makefile-based approach, which sequenced the various steps that are required to be invoked to successfully run a simulation.
 As the number of DUTs and the number of tests for each DUT grew, and as the list of our requirements grew, the Makefile-based approach became harder to read and follow and maintain.
 It became clear that a better system was needed, one that scaled well with our growing list of requirements.
 

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -290,7 +290,7 @@ provided by `-hi` and `-ha` respectively. By default, these are set to 'False'
 * `i2c_host_dv_doc.md`
 
   This is the initial DV document that will describe the entire testbench. This
-  is equivalent to the template available [here](https://github.com/lowRISC/opentitan/blob/master/hw/dv/doc/dv_template.md).
+  is equivalent to the template available [here](https://github.com/lowRISC/opentitan/blob/master/hw/dv/doc/dv_doc_template.md).
 
 The [VLNV](https://fusesoc.readthedocs.io/en/master/user/overview.html#core-naming-rules)
 name in the generated FuseSoC core files is set using the `--vendor` switch for

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -292,7 +292,7 @@ provided by `-hi` and `-ha` respectively. By default, these are set to 'False'
   This is the initial DV document that will describe the entire testbench. This
   is equivalent to the template available [here](https://github.com/lowRISC/opentitan/blob/master/hw/dv/doc/dv_doc_template.md).
 
-The [VLNV](https://fusesoc.readthedocs.io/en/master/user/overview.html#core-naming-rules)
+The [VLNV](https://fusesoc.readthedocs.io/en/stable/user/build_system/core_files.html#naming-the-core-file)
 name in the generated FuseSoC core files is set using the `--vendor` switch for
 the 'vendor' field. By default, it is set to "lowrisc". It can be overridden
 by supplying the `--vendor <vendor-name>` switch on the command line.


### PR DESCRIPTION
This is a follow up PR to https://github.com/lowRISC/opentitan/pull/17656, holding fewer mainly external link fixes.

I've captured the links I couldn't fix, in  https://github.com/lowRISC/opentitan/issues/17658