### PR TITLE
[doc] Fix broken internal documention links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,12 @@ involved.
 * Code review is not design review and doesn't remove the need for discussing
   implementation options. If you would like to make a large-scale change or
   discuss multiple implementation options, discuss on the mailing list.
-* Create pull requests from a fork rather than making new branches in 
+* Create pull requests from a fork rather than making new branches in
   `github.com/lowrisc/opentitan`.
 * Do not attempt to commit code with a non-Apache license without discussing
   first.
 * If a relevant bug or tracking issue exists, reference it in the pull request
   and commits.
 
-Please see [Contributing to
-OpenTitan](https://docs.opentitan.org/doc/project/contributing/) for more
-general guidance.
+Please see [Contributing to OpenTitan](https://opentitan.org/book/doc/contributing)
+for more general guidance.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and chip manufacturers.  OpenTitan is administered by [lowRISC
 CIC](https://www.lowrisc.org) as a collaborative project to produce high
 quality, open IP for instantiation as a full-featured product. See the
 [OpenTitan site](https://opentitan.org/) and [OpenTitan
-docs](https://docs.opentitan.org) for more information about the project.
+docs](https://opentitan.org/book) for more information about the project.
 
 ## About this repository
 
@@ -27,8 +27,8 @@ access it [online at docs.opentitan.org](https://docs.opentitan.org/).
 
 ## How to contribute
 
-Have a look at [CONTRIBUTING](https://github.com/lowRISC/opentitan/blob/master/CONTRIBUTING.md) and our [documentation on
-project organization and processes](https://docs.opentitan.org/doc/project/)
+Have a look at [CONTRIBUTING](CONTRIBUTING.md) and our [documentation on
+project organization and processes](./doc/project_governance/README.md)
 for guidelines on how to contribute code to this repository.
 
 ## Licensing

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Datasheet](./hw/top_earlgrey/doc/specification.md)
   - [Design](./hw/top_earlgrey/doc/design/README.md)
   - [Design Verification](./hw/top_earlgrey/dv/README.md)
+    - [Chip Testplan](./hw/top_earlgrey/data/chip_testplan.hjson)
   - [Analog Sensor Top](./hw/top_earlgrey/ip/ast/README.md)
   - [Alert Handler](./hw/top_earlgrey/ip_autogen/alert_handler/README.md)
     - [Theory of Operation](./hw/top_earlgrey/ip_autogen/alert_handler/doc/theory_of_operation.md)

--- a/doc/contributing/bazel_notes.md
+++ b/doc/contributing/bazel_notes.md
@@ -1,7 +1,7 @@
 # Bazel Notes
 
 Both OpenTitan hardware and software is built with Bazel.
-While our [Getting Started](https://docs.opentitan.org/doc/guides/getting_started/) guides detail some of the Bazel commands that can be used to build both types of artifacts, below are detailed notes on:
+While our [Getting Started](https://opentitan.org/guides/getting_started) guides detail some of the Bazel commands that can be used to build both types of artifacts, below are detailed notes on:
 * how Bazel is configured for our project, and
 * brief examples of Bazel commands that are useful for:
     * querying,
@@ -24,7 +24,7 @@ The `WORKSPACE` file controls external dependencies such that builds can be made
 Bazel loads specific external dependencies, such as various language toolchains.
 It uses them to build OpenTitan targets (like it does with bazel\_embedded) or to satisfy dependencies (as it does with abseil).
 To produce increasingly stable releases the external dependencies loaded in `WORKSPACE` file attempts to fix a all external `http_archive`s to a specific SHA.
-As we add more dependencies to the workspace, builds and tests will become less sensitive to external updates, and we will vastly simplify the [Getting Started](https://docs.opentitan.org/doc/guides/getting_started/) instructions.
+As we add more dependencies to the workspace, builds and tests will become less sensitive to external updates, and we will vastly simplify the [Getting Started](https://opentitan.org/guides/getting_started) instructions.
 
 ## BUILD files
 

--- a/doc/contributing/dv/methodology/README.md
+++ b/doc/contributing/dv/methodology/README.md
@@ -629,7 +629,7 @@ We use the [OpenTitan GitHub Issue tracker](https://github.com/lowRISC/opentitan
 ## Getting Started with DV
 
 The process for getting started with DV involves many steps, including getting clarity on its purpose, setting up the testbench, documentation, etc.
-These are discussed in the [Getting Started with DV](https://docs.opentitan.org/doc/guides/getting_started/src/setup_dv.md) document.
+These are discussed in the [Getting Started with DV](https://opentitan.org/guides/getting_started/setup_dv.html) document.
 
 ## Pending Work Items
 

--- a/doc/contributing/hw/methodology.md
+++ b/doc/contributing/hw/methodology.md
@@ -109,7 +109,7 @@ Linting errors and warnings can be closed by fixing the code in question (prefer
 These waivers have to be reviewed as part of the pull request review process.
 
 Note that our continuous integration infrastructure does not currently run AscentLint on each pull request as it does with Verilator lint.
-However, all designs with enabled AscentLint targets on the master branch will be run through the tool in eight-hour intervals and the results are published as part of the tool dashboards on the [hardware IP overview page](https://docs.opentitan.org/hw), enabling designers to close the lint errors and warnings even if they cannot run the sign-off tool locally.
+However, all designs with enabled AscentLint targets on the master branch will be run through the tool in eight-hour intervals and the results are published as part of the tool dashboards on the [hardware IP overview page](https://opentitan.org/book/hw), enabling designers to close the lint errors and warnings even if they cannot run the sign-off tool locally.
 
 Goals for sign-off linting closure per design development stage are given in the [OpenTitan Development Stages](../../project_governance/development_stages.md) document.
 
@@ -224,7 +224,7 @@ These are discussed in the [Getting Started Designing Hardware](./design.md) doc
 ## FPGA vs Silicon
 
 One output of the OpenTitan project will be silicon instantiations of hardware functionality described in this open source repository.
-The RTL repository defines design functionality at a level satisfactory to prove the hardware and software functionality in an FPGA (see [user guides](https://docs.opentitan.org/doc/guides/getting_started/)).
+The RTL repository defines design functionality at a level satisfactory to prove the hardware and software functionality in an FPGA (see [user guides](https://opentitan.org/guides/getting_started)).
 That level is so-called "tapeout ready".
 Once the project reaches that milestone, the team will work with a vendor or vendors to ensure a trustworthy, industry-quality, fully functional OpenTitan chip is manufactured.
 

--- a/doc/guides/getting_started/src/README.md
+++ b/doc/guides/getting_started/src/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/lowRISC/opentitan.git
 ```
 
 If you wish to *contribute* to OpenTitan you will need to make a fork on GitHub and may wish to clone the fork instead.
-We have some [notes for using GitHub](https://opentitan.org/book/doc/contributing/github_notes.md) which explain how to work with your own fork (and perform many other GitHub tasks) in the OpenTitan context.
+We have some [notes for using GitHub](https://opentitan.org/book/doc/contributing/github_notes.html) which explain how to work with your own fork (and perform many other GitHub tasks) in the OpenTitan context.
 
 ***Note: throughout the documentation `$REPO_TOP` refers to the path where the OpenTitan repository is checked out.***
 Unless you've specified some other name in the clone, `$REPO_TOP` will be a directory called `opentitan`.
@@ -186,7 +186,7 @@ It also may make sense to stick with the basic setup and come back to these step
 ### Step 6a: Install Verible (optional)
 
 Verible is an open source SystemVerilog style linter and formatting tool.
-The style linter is relatively mature and we use it as part of our [RTL design flow](https://opentitan.org/book/doc/contributing/hw/methodology.md).
+The style linter is relatively mature and we use it as part of our [RTL design flow](https://opentitan.org/book/doc/contributing/hw/methodology.html).
 The formatter is still under active development, and hence its usage is more experimental in OpenTitan.
 
 You can download and build Verible from scratch as explained on the [Verible GitHub page](https://github.com/google/verible/).
@@ -242,16 +242,16 @@ As you may have guessed, there are several other pieces of hardware and software
 If you are interested in these, check out the additional resources below.
 
 ### General
-* [Directory Structure](https://opentitan.org/book/doc/contributing/directory_structure.md)
-* [GitHub Notes](https://opentitan.org/book/doc/contributing/github_notes.md)
+* [Directory Structure](https://opentitan.org/book/doc/contributing/directory_structure.html)
+* [GitHub Notes](https://opentitan.org/book/doc/contributing/github_notes.html)
 * [Building Documentation](./build_docs.md)
-* [Design Methodology within OpenTitan](https://opentitan.org/book/doc/contributing/hw/methodology.md)
+* [Design Methodology within OpenTitan](https://opentitan.org/book/doc/contributing/hw/methodology.html)
 
 ### Hardware
-* [Designing Hardware](https://opentitan.org/book/doc/contributing/hw/design.md)
-* [OpenTitan Hardware](https://opentitan.org/book/hw/README.md)
+* [Designing Hardware](https://opentitan.org/book/doc/contributing/hw/design.html)
+* [OpenTitan Hardware](https://opentitan.org/book/hw)
 
 ### Software
-* [OpenTitan Software](https://opentitan.org/book/sw/README.md)
-* [Writing and Building Software for OTBN](https://opentitan.org/book/doc/contributing/sw/otbn_sw.md)
-* [Rust for Embedded C Programmers](https://opentitan.org/book/doc/rust_for_c_devs.md)
+* [OpenTitan Software](https://opentitan.org/book/sw)
+* [Writing and Building Software for OTBN](https://opentitan.org/book/doc/contributing/sw/otbn_sw.html)
+* [Rust for Embedded C Programmers](https://opentitan.org/book/doc/rust_for_c_devs.html)

--- a/doc/guides/getting_started/src/SUMMARY.md
+++ b/doc/guides/getting_started/src/SUMMARY.md
@@ -8,7 +8,7 @@
 - [Formal Verification](setup_formal.md)
 - [Building (and Testing) Software](build_sw.md)
 - [Building Documentation](build_docs.md)
-- [Running e2e Tests](https://opentitan.org/book/sw/device/silicon_creator/rom/doc/e2e_tests.md)
+- [Running e2e Tests](https://opentitan.org/book/sw/device/silicon_creator/rom/doc/e2e_tests.html)
 
 # Tools Setup
 

--- a/doc/guides/getting_started/src/build_docs.md
+++ b/doc/guides/getting_started/src/build_docs.md
@@ -2,7 +2,7 @@
 
 The documentation for OpenTitan is available [online](https://opentitan.org).
 The creation of documentation is mainly based around the conversion from Markdown to HTML files with [mdbook](https://rust-lang.github.io/mdBook/).
-Rules for how to write correct Markdown files can be found in the [reference manual](https://opentitan.org/book/doc/contributing/style_guides/markdown_usage_style.md).
+Rules for how to write correct Markdown files can be found in the [reference manual](https://opentitan.org/book/doc/contributing/style_guides/markdown_usage_style.html).
 
 ## Building locally
 

--- a/doc/guides/getting_started/src/build_sw.md
+++ b/doc/guides/getting_started/src/build_sw.md
@@ -3,7 +3,7 @@
 _Before following this guide, make sure you have read the_:
 * main [Getting Started](README.md) instructions,
 * install Verilator section of the [Verilator guide](./setup_verilator.md), and
-* [OpenTitan Software](https://opentitan.org/book/sw/README.md) documentation.
+* [OpenTitan Software](https://opentitan.org/book/sw/) documentation.
 
 All OpenTitan software is built with [Bazel](https://bazel.build/).
 Additionally, _most_ tests may be run with Bazel too.
@@ -94,12 +94,12 @@ There are two categories of OpenTitan tests Bazel can build and run:
 On-host tests are compiled and run on the host machine, while on-device tests are compiled and run on (simulated/emulated) OpenTitan hardware.
 
 Examples of on-host tests are:
-* unit tests for device software, such as [DIF](https://opentitan.org/book/sw/device/lib/dif/README.md) and [ROM](https://opentitan.org/book/sw/device/silicon_creator/rom/README.md) unit tests.
+* unit tests for device software, such as [DIF](https://opentitan.org/book/sw/device/lib/dif/) and [ROM](https://opentitan.org/book/sw/device/silicon_creator/rom/) unit tests.
 * any test for host software, such as `opentitan{lib,tool}`.
 
 Examples of on-device tests are:
-* [chip-level tests](https://opentitan.org/book/sw/device/tests/README.md).
-* [ROM functional tests](https://opentitan.org/book/sw/device/silicon_creator/rom/README.md)
+* [chip-level tests](https://opentitan.org/book/sw/device/tests/).
+* [ROM functional tests](https://opentitan.org/book/sw/device/silicon_creator/rom/)
 
 Test target names normally match file names (for instance, `//sw/device/tests:uart_smoketest` corresponds to `sw/device/test/uart_smoketest.c`).
 You can see all tests available under a given directory using `bazel query`, e.g.:
@@ -161,7 +161,7 @@ For more information, please refer to the [Verilator](./setup_verilator.md) and/
 
 ### Running on-host DIF Tests
 
-The Device Interface Function or [DIF](https://opentitan.org/book/sw/device/lib/dif/README.md) libraries contain unit tests that run on the host and are built and run with Bazel.
+The Device Interface Function or [DIF](https://opentitan.org/book/sw/device/lib/dif/) libraries contain unit tests that run on the host and are built and run with Bazel.
 As shown below, you may use Bazel to query which tests are available, build and run all tests, or build and run only one test.
 
 #### Querying which tests are available
@@ -182,7 +182,7 @@ bazel test //sw/device/lib/dif:uart_unittest
 
 ### Running on-host ROM Tests
 
-Similar to the DIF libraries, you can query, build, and run all the [ROM](https://opentitan.org/book/sw/device/silicon_creator/rom/README.md) unit tests (which also run on the host) with Bazel.
+Similar to the DIF libraries, you can query, build, and run all the [ROM](https://opentitan.org/book/sw/device/silicon_creator/rom/) unit tests (which also run on the host) with Bazel.
 
 #### Querying which (on-host) tests are available
 Note, the ROM has both on-host and on-device tests.
@@ -206,7 +206,7 @@ bazel test //sw/device/silicon_creator/lib/drivers:uart_unittest
 
 ### Bazel-built Software Artifacts
 
-As described in the [OpenTitan Software](https://opentitan.org/book/sw/README.md) documentation, there are three categories of OpenTitan software, all of which are built with Bazel. These include:
+As described in the [OpenTitan Software](https://opentitan.org/book/sw/) documentation, there are three categories of OpenTitan software, all of which are built with Bazel. These include:
 1. _device_ software,
 1. _OTBN_ software,
 1. _host_ software,

--- a/doc/guides/getting_started/src/setup_dv.md
+++ b/doc/guides/getting_started/src/setup_dv.md
@@ -1,14 +1,14 @@
 # Design Verification Setup
 
-_Before following this guide, make sure you've followed the [dependency installation and software build instructions](https://opentitan.org/book/doc/guides/getting_started/)._
+_Before following this guide, make sure you've followed the [dependency installation and software build instructions](README.md)._
 
 This document aims to enable a contributor to get started with a design verification (DV) effort within the OpenTitan project.
 While most of the focus is on development of a testbench from scratch, it should also be useful to understand how to contribute to an existing effort.
-Please refer to the [DV methodology](https://opentitan.org/book/doc/contributing/dv/methodology/README.md) document for information on how design verification is done in OpenTitan.
+Please refer to the [DV methodology](https://opentitan.org/book/doc/contributing/dv/methodology) document for information on how design verification is done in OpenTitan.
 
 ## Stages of DV
 
-The life stages of a design / DV effort within the OpenTitan are described in the [Hardware Development Stages](https://opentitan.org/book/doc/project_governance/development_stages.md) document.
+The life stages of a design / DV effort within the OpenTitan are described in the [Hardware Development Stages](https://opentitan.org/book/doc/project_governance/development_stages.html) document.
 It separates the life of DV into three broad stages: Initial Work, Under Test and Testing Complete.
 This document attempts to give guidance on how to get going with the first stage and have a smooth transition into the Under Test stage.
 They are not hard and fast rules but methods we have seen work well in the project.
@@ -17,9 +17,9 @@ The design specification, once available, is used as a starting point.
 
 ## Getting Started
 
-The very first thing to do in any DV effort is to [document the plan](https://opentitan.org/book/doc/contributing/dv/methodology/README.md#documentation) detailing the overall effort.
+The very first thing to do in any DV effort is to [document the plan](https://opentitan.org/book/doc/contributing/dv/methodology#documentation) detailing the overall effort.
 This is done in conjunction with developing the initial testbench.
-It is recommended to use the [uvmdvgen](https://opentitan.org/book/util/uvmdvgen/README.md) tool, which serves both needs.
+It is recommended to use the [uvmdvgen](https://opentitan.org/book/util/uvmdvgen) tool, which serves both needs.
 
 The `uvmdvgen` tool provides the ability to generate the outputs in a specific directory.
 This should be set to the root of the DUT directory where the `rtl` directory exists.
@@ -31,20 +31,20 @@ One of these for example, is to create appropriate interfaces for the DUT-specif
 
 ## Documentation and Initial Review
 
-The skeleton [DV document](https://opentitan.org/book/doc/contributing/dv/methodology/README.md#dv-document) and the [Hjson testplan](https://opentitan.org/book/doc/contributing/dv/methodology/README.md#testplan) should be addressed first.
+The skeleton [DV document](https://opentitan.org/book/doc/contributing/dv/methodology#dv-document) and the [Hjson testplan](https://opentitan.org/book/doc/contributing/dv/methodology#testplan) should be addressed first.
 The DV documentation is not expected to be completed in full detail at this point.
 However, it is expected to list all the verification components needed and depict the planned testbench as a block diagram.
 Under the 'design verification' directory in the OpenTitan team drive, some sample testbench block diagrams are available in the `.svg` format, which can be used as a template.
 The Hjson testplan, on the other hand, is required to be completed.
-Please refer to the [testplanner tool](https://opentitan.org/book/util/dvsim/doc/testplanner.md) documentation for additional details on how to write the Hjson testplan.
+Please refer to the [testplanner tool](https://opentitan.org/book/util/dvsim/doc/testplanner.html) documentation for additional details on how to write the Hjson testplan.
 Once done, these documents are to be reviewed with the designer(s) and other project members for completeness and clarity.
 
 ## UVM RAL Model
 
-Before running any test, the [UVM RAL model](https://opentitan.org/book/doc/contributing/dv/methodology/README.md#uvm-register-abstraction-layer-ral-model) needs to exist (if the design contains CSRs).
-The [DV simulation flow](https://opentitan.org/book/util/dvsim/README.md) has been updated to generate the RAL model automatically at the start of the simulation.
+Before running any test, the [UVM RAL model](https://opentitan.org/book/doc/contributing/dv/methodology#uvm-register-abstraction-layer-ral-model) needs to exist (if the design contains CSRs).
+The [DV simulation flow](https://opentitan.org/book/util/dvsim) has been updated to generate the RAL model automatically at the start of the simulation.
 As such, nothing extra needs to be done.
-It can be created manually by invoking [`regtool`](https://opentitan.org/book/util/reggen/doc/setup_and_use.md):
+It can be created manually by invoking [`regtool`](https://opentitan.org/book/util/reggen/doc/setup_and_use.html):
 ```console
 $ util/regtool.py -s -t /path-to-dv /path-to-module/data/<dut>.hjson
 ```
@@ -54,7 +54,7 @@ The generated file is placed in the simulation build scratch area instead of bei
 ## Supported Simulators
 
 The use of advanced verification constructs such as SystemVerilog classes (on which UVM is based on) requires commercial simulators.
-The [DV simulation flow](https://opentitan.org/book/util/dvsim/README.md) fully supports Synopsys VCS.
+The [DV simulation flow](https://opentitan.org/book/util/dvsim) fully supports Synopsys VCS.
 There is support for Cadence Xcelium as well, which is being slowly ramped up.
 
 ## Building and Running Tests
@@ -74,19 +74,19 @@ VCS is used as the default simulator. It can be switched to Xcelium by setting `
 To dump waves from the simulation, pass the `--waves <format>` argument to `dvsim.py`.
 If you are using Verdi for waveform viewing, then '--waves fsdb' is probably the best option. For use with other viewers, '--waves shm' is probably the best choice for Xcelium, and '--waves vpd' with vcs.
 
-Please refer to the [DV simulation flow](https://opentitan.org/book/util/dvsim/README.md) for additional details.
+Please refer to the [DV simulation flow](https://opentitan.org/book/util/dvsim) for additional details.
 
 The `uvmdvgen` script also enables the user to run the full suite of CSR tests, if the DUT does have CSRs in it.
 The most basic CSR power-on-reset check test can be run by invoking:
 ```console
 $ util/dvsim/dvsim.py path/to/<dut>_sim_cfg.hjson -i <dut>_csr_hw_reset [--waves <format>] [--tool xcelium]
 ```
-Please refer to [CSR utilities](https://opentitan.org/book/hw/dv/sv/csr_utils/README.md) for more information on how to add exclusions for the CSR tests.
+Please refer to [CSR utilities](https://opentitan.org/book/hw/dv/sv/csr_utils) for more information on how to add exclusions for the CSR tests.
 
 ## Full DV
 
-Running the sanity and CSR suite of tests while making progress toward reaching the [V1 stage](https://opentitan.org/book/doc/project_governance/development_stages.md#hardware-verification-stages) should provide a good reference in terms of how to develop tests as outlined in the testplan and running and debugging them.
-Please refer to the [checklist](https://opentitan.org/book/doc/project_governance/checklist/README.md) to understand the key requirements for progressing through the subsequent verification stages and final signoff.
+Running the sanity and CSR suite of tests while making progress toward reaching the [V1 stage](https://opentitan.org/book/doc/project_governance/development_stages.html#hardware-verification-stages-v) should provide a good reference in terms of how to develop tests as outlined in the testplan and running and debugging them.
+Please refer to the [checklist](https://opentitan.org/book/doc/project_governance/checklist) to understand the key requirements for progressing through the subsequent verification stages and final signoff.
 
 The [UART DV](https://github.com/lowRISC/opentitan/tree/master/hw/ip/uart/dv) area can be used as a canonical example for making progress.
 If it is not clear on how to proceed, feel free to file an issue requesting assistance.

--- a/doc/guides/getting_started/src/setup_formal.md
+++ b/doc/guides/getting_started/src/setup_formal.md
@@ -5,7 +5,7 @@ _Before following this guide, make sure you've followed the [dependency installa
 This document aims to enable a contributor to get started with a formal verification effort within the OpenTitan project.
 While most of the focus is on development of a testbench from scratch, it should also be useful to understand how to contribute to an existing effort.
 
-Please refer to the [OpenTitan Assertions](https://opentitan.org/book/hw/formal/README.md) for information on how formal verification is done in OpenTitan.
+Please refer to the [OpenTitan Assertions](https://opentitan.org/book/hw/formal/) for information on how formal verification is done in OpenTitan.
 
 ## Formal property verification (FPV)
 
@@ -13,15 +13,15 @@ The formal property verification is used to prove assertions in the target.
 There are three sets of FPV jobs in OpenTitan. They are all under the directory `hw/top_earlgrey/formal`.
 * `top_earlgrey_fpv_ip_cfgs.hjson`: List of IP targets.
 * `top_earlgrey_fpv_prim_cfgs.hjson`: List of prim targets (such as counters, fifos, etc) that are usually imported by an IP.
-* `top_earlgrey_fpv_sec_cm_cfgs.hjson`: List of IPs that contains standard security countermeasure assertions. This FPV environment only proves these security countermeasure assertions. Detailed description of this FPV use case is documented in [Running FPV on security blocks for common countermeasure primitives](https://opentitan.org/book/hw/formal/README.md#running-fpv-on-security-blocks-for-common-countermeasure-primitives).
+* `top_earlgrey_fpv_sec_cm_cfgs.hjson`: List of IPs that contains standard security countermeasure assertions. This FPV environment only proves these security countermeasure assertions. Detailed description of this FPV use case is documented in [Running FPV on security blocks for common countermeasure primitives](https://opentitan.org/book/hw/formal/#running-fpv-on-security-blocks-for-common-countermeasure-primitives).
 
-To automatically create a FPV testbench, it is recommended to use the [fpvgen](https://opentitan.org/book/util/fpvgen/README.md) tool to create a template.
+To automatically create a FPV testbench, it is recommended to use the [fpvgen](https://opentitan.org/book/util/fpvgen/) tool to create a template.
 To run the FPV tests in `dvsim`, please add the target to the corresponding `top_earlgrey_fpv_{category}_cfgs.hjson` file , then run with command:
 ```console
 util/dvsim/dvsim.py hw/top_earlgrey/formal/top_earlgrey_fpv_{category}_cfgs.hjson --select-cfgs {target_name}
 ```
 
-It is recommended to add the FPV target to [lint](https://opentitan.org/book/hw/lint/README.md) script `hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson` to quickly find typos.
+It is recommended to add the FPV target to [lint](https://opentitan.org/book/hw/lint/) script `hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson` to quickly find typos.
 
 ## Formal connectivity verification
 

--- a/doc/guides/getting_started/src/setup_fpga.md
+++ b/doc/guides/getting_started/src/setup_fpga.md
@@ -15,7 +15,7 @@ To use the OpenTitan on an FPGA you need two things:
 Depending on the design/target combination that you want to synthesize you will need different tools and boards.
 Refer to the design documentation for information on what exactly is needed.
 
-* [Obtain an FPGA board](https://opentitan.org/book/doc/contributing/fpga/get_a_board.md)
+* [Obtain an FPGA board](https://opentitan.org/book/doc/contributing/fpga/get_a_board.html)
 
 ## Obtain an FPGA bitstream
 
@@ -38,7 +38,7 @@ tar -xvf bitstream-latest.tar.gz
 By default, the bitstream is built with a version of the boot ROM used for testing (called the _test ROM_; pulled from `sw/device/lib/testing/test_rom`).
 There is also a version of the boot ROM used in production (called the _ROM_; pulled from `sw/device/silicon_creator/rom`).
 When the bitstream cache is used in bazel flows, the ROMs from the cache are not used.
-Instead, the bazel-built ROMs are spliced into the image to create new bitstreams, using the mechanism described in the [FPGA Reference Manual](https://opentitan.org/book/doc/contributing/fpga/ref_manual_fpga.md#boot-rom-development).
+Instead, the bazel-built ROMs are spliced into the image to create new bitstreams, using the mechanism described in the [FPGA Reference Manual](https://opentitan.org/book/doc/contributing/fpga/ref_manual_fpga.html#boot-rom-development).
 The metadata for the latest bitstream (the approximate creation time and the associated commit hash) is also available as a text file and can be [downloaded separately](https://storage.googleapis.com/opentitan-bitstreams/master/latest.txt).
 
 ### Using the `@bitstreams` repository

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -9,8 +9,8 @@ This repository exists to enable collaboration across partners participating in 
 
 ## Getting Started
 
-To get started with OpenTitan, see the [Getting Started](./guides/getting_started/src/README.md) page.
-For additional resources when working with OpenTitan, see the [list of user guides](https://opentitan.org/guides/getting_started/).
+To get started with OpenTitan, see the [Getting Started](https://opentitan.org/guides/getting_started) page.
+For additional resources when working with OpenTitan, see the [contributor's reference](./contributing/README.md).
 For details on coding styles or how to use our project-specific tooling, see the [reference manuals](../util/README.md).
 Lastly, the [Hardware Dashboard page](../hw/README.md) contains technical documentation on the SoC, the Ibex processor core, and the individual IP blocks.
 For questions about how the project is organized, see the [project](./project_governance/README.md) landing spot for more information.
@@ -32,9 +32,9 @@ For questions about how the project is organized, see the [project](./project_go
 
 ## Development
 
-* [Getting Started](./guides/getting_started/src/README.md)
-* [User Guides](https://opentitan.org/guides/getting_started)
-* [Reference Manuals](../util/README.md)
+* [Getting Started](https://opentitan.org/guides/getting_started)
+* [Contributor's Reference](./contributing/README.md)
+* [Tool References](../util/README.md)
 * [Style Guides](./contributing/style_guides/README.md)
 
 ## Repository Structure

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -10,7 +10,7 @@ This repository exists to enable collaboration across partners participating in 
 ## Getting Started
 
 To get started with OpenTitan, see the [Getting Started](./guides/getting_started/src/README.md) page.
-For additional resources when working with OpenTitan, see the [list of user guides](https://docs.opentitan.org/doc/guides/getting_started/).
+For additional resources when working with OpenTitan, see the [list of user guides](https://opentitan.org/guides/getting_started/).
 For details on coding styles or how to use our project-specific tooling, see the [reference manuals](../util/README.md).
 Lastly, the [Hardware Dashboard page](../hw/README.md) contains technical documentation on the SoC, the Ibex processor core, and the individual IP blocks.
 For questions about how the project is organized, see the [project](./project_governance/README.md) landing spot for more information.
@@ -33,7 +33,7 @@ For questions about how the project is organized, see the [project](./project_go
 ## Development
 
 * [Getting Started](./guides/getting_started/src/README.md)
-* [User Guides](https://docs.opentitan.org/doc/guides/getting_started/)
+* [User Guides](https://opentitan.org/guides/getting_started)
 * [Reference Manuals](../util/README.md)
 * [Style Guides](./contributing/style_guides/README.md)
 

--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -569,7 +569,7 @@ All additional design deltas have been captured adequately and appropriately in 
 
 ### X_PROP_ANALYSIS_COMPLETED
 
-[X-propagation](https://docs.opentitan.org/doc/ug/dv_methodology/#x-propagation-xprop) is enabled in DV simulations.
+[X-propagation](../../contributing/dv/methodology/README.md#x-propagation-xprop) is enabled in DV simulations.
 There are no pieces of logic that are reported unsuitable for X-propagation instrumentation by the simulator during the build step.
 
 ### FPV_ASSERTIONS_PROVEN_AT_V3

--- a/doc/security/specs/secure_boot/README.md
+++ b/doc/security/specs/secure_boot/README.md
@@ -93,7 +93,7 @@ If the key indicated in the manifest has a role that doesn't match the lifecycle
 All of these keys are 3072-bit RSA public keys with exponent e=65537 (the “F4 exponent”).
 
 The `ROM` has `N` key slots (the exact number depends on the `ROM`) numbered from `0` to `N-1`.
-The `CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN` item in the [OTP](otp-mmap) can be used to invalidate a key at
+The `CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN` item in the OTP can be used to invalidate a key at
 manufacturing time. This item consists of several little-endian 32-bit words. Each word contains four 8-bit hardened booleans
 (see `hardened_byte_bool_t` in `hardened.h`) that specifies whether the key is valid (`kHardenedByteBoolTrue`)
 or invalid (any value other that `kHardenedByteBoolTrue`). In order to verify that the key slot `i` contains

--- a/hw/ip/kmac/doc/programmers_guide.md
+++ b/hw/ip/kmac/doc/programmers_guide.md
@@ -12,14 +12,14 @@ These determine the byte order of incoming messages (msg_endianness) and the Kec
 This section describes the expected software process to run the KMAC/SHA3 HWIP.
 At first, the software configures [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) for KMAC operation.
 If KMAC is enabled, the software should configure [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to cSHAKE and [`CFG_SHADOWED.kstrength`](../data/kmac.hjson#cfg_shadowed) to 128 or 256 bit security strength.
-The software also updates [`PREFIX`](../data/kmac.hjson#prefix) registers if cSHAKE mode is used.
-Current design does not convert cSHAKE mode to SHAKE even if [`PREFIX`](../data/kmac.hjson#prefix) is empty string.
-It is the software's responsibility to change the [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to SHAKE in case of empty [`PREFIX`](../data/kmac.hjson#prefix).
-The KMAC/SHA3 HWIP uses [`PREFIX`](../data/kmac.hjson#prefix) registers as it is.
-It means that the software should update [`PREFIX`](../data/kmac.hjson#prefix) with encoded values.
+The software also updates [`PREFIX`](../data/kmac.hjson#prefix_0) registers if cSHAKE mode is used.
+Current design does not convert cSHAKE mode to SHAKE even if [`PREFIX`](../data/kmac.hjson#prefix_0) is empty string.
+It is the software's responsibility to change the [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to SHAKE in case of empty [`PREFIX`](../data/kmac.hjson#prefix_0).
+The KMAC/SHA3 HWIP uses [`PREFIX`](../data/kmac.hjson#prefix_0) registers as it is.
+It means that the software should update [`PREFIX`](../data/kmac.hjson#prefix_0) with encoded values.
 
 If [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) is set, the software should update the secret key.
-The software prepares two shares of the secret key and selects its length in [`KEY_LEN`](../data/kmac.hjson#key_len) then writes the shares of the secret key to [`KEY_SHARE0`](../data/kmac.hjson#key_share0) and [`KEY_SHARE1`](../data/kmac.hjson#key_share1) .
+The software prepares two shares of the secret key and selects its length in [`KEY_LEN`](../data/kmac.hjson#key_len) then writes the shares of the secret key to [`KEY_SHARE0`](../data/kmac.hjson#key_share0_0) and [`KEY_SHARE1`](../data/kmac.hjson#key_share1_0) .
 The two shares of the secret key are the values that represent the secret key value when they are XORed together.
 The software can XOR the unmasked secret key with entropy.
 The XORed value is a share and the entropy used is the other share.
@@ -59,7 +59,7 @@ For example, when the software writes `0xDEADBEEF` with endianness as 1, the log
 The software managed secret key, and the prefix are always little-endian values.
 For example, if the software configures the function name `N` in KMAC operation, it writes `encode_string("KMAC")`.
 The `encode_string("KMAC")` represents `0x01 0x20 0x4b 0x4d 0x41 0x43` in byte order.
-The software writes `0x4d4b2001` into [`PREFIX0`](../data/kmac.hjson#prefix0) and `0x????4341` into [`PREFIX1`](../data/kmac.hjson#prefix1) .
+The software writes `0x4d4b2001` into [`PREFIX0`](../data/kmac.hjson#prefix_0) and `0x????4341` into [`PREFIX1`](../data/kmac.hjson#prefix_1) .
 Upper 2 bytes can vary depending on the customization input string `S`.
 
 ## KMAC/SHA3 context switching
@@ -240,8 +240,8 @@ The padding logic clears internal variables and goes back to Idle state.
 KMAC core prepends and appends additional bitstream on top of Keccak padding logic in SHA3 core.
 The [NIST SP 800-185][] defines `KMAC[128,256](K, X, L, S)` as a cSHAKE function.
 See the section 4.3 in NIST SP 800-185 for details.
-If KMAC is enabled, the software should configure [`CMD.mode`](../data/kmac.hjson#cmd) to cSHAKE and the first six bytes of [`PREFIX`](../data/kmac.hjson#prefix) to `0x01204B4D4143` (bigendian).
-The first six bytes of [`PREFIX`](../data/kmac.hjson#prefix) represents the value of `encode_string("KMAC")`.
+If KMAC is enabled, the software should configure [`CMD.mode`](../data/kmac.hjson#cmd) to cSHAKE and the first six bytes of [`PREFIX`](../data/kmac.hjson#prefix_0) to `0x01204B4D4143` (bigendian).
+The first six bytes of [`PREFIX`](../data/kmac.hjson#prefix_0) represents the value of `encode_string("KMAC")`.
 
 The KMAC padding logic prepends a block containing the encoded secret key to the output message.
 The KMAC first sends the block of secret key then accepts the incoming message bitstream.
@@ -332,7 +332,7 @@ The secret key, however, is stored as masked form always.
 
 If the `EnMasking` parameter is not set, the masking is disabled.
 Then, the software has to provide the key in unmasked form by default.
-Any write operations to [`KEY_SHARE1_0`](../data/kmac.hjson#key_share1_0) - [`KEY_SHARE1_15`](../data/kmac.hjson#key_share1_5) are ignored.
+Any write operations to [`KEY_SHARE1_0`](../data/kmac.hjson#key_share1_0) - [`KEY_SHARE1_15`](../data/kmac.hjson#key_share1_15) are ignored.
 
 If the `EnMasking` parameter is not set and the `SwKeyMasked` parameter is set, software has to provide the key in masked form.
 Internally, the design then unmasks the key by XORing the two key shares together when loading the key into the engine.
@@ -504,7 +504,7 @@ The SW may get the incorrect digest value.
 
 #### IncorrectFunctionName (0x07)
 
-If [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) is set and the SW issues the `Start` command, the KMAC_ERRCHK checks if the [`PREFIX`](../data/kmac.hjson#prefix) has correct function name, `encode_string("KMAC")`.
+If [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) is set and the SW issues the `Start` command, the KMAC_ERRCHK checks if the [`PREFIX`](../data/kmac.hjson#prefix_0) has correct function name, `encode_string("KMAC")`.
 If the value does not match to the byte form of `encode_string("KMAC")` (`0x4341_4D4B_2001`), it reports the `IncorrectFunctionName` error.
 
 As same as `UnexpectedModeStrength` error, this error does not block the hashing operation.
@@ -533,14 +533,14 @@ These determine the byte order of incoming messages (msg_endianness) and the Kec
 This section describes the expected software process to run the KMAC/SHA3 HWIP.
 At first, the software configures [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) for KMAC operation.
 If KMAC is enabled, the software should configure [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to cSHAKE and [`CFG_SHADOWED.kstrength`](../data/kmac.hjson#cfg_shadowed) to 128 or 256 bit security strength.
-The software also updates [`PREFIX`](../data/kmac.hjson#prefix) registers if cSHAKE mode is used.
-Current design does not convert cSHAKE mode to SHAKE even if [`PREFIX`](../data/kmac.hjson#prefix) is empty string.
-It is the software's responsibility to change the [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to SHAKE in case of empty [`PREFIX`](../data/kmac.hjson#prefix).
-The KMAC/SHA3 HWIP uses [`PREFIX`](../data/kmac.hjson#prefix) registers as it is.
-It means that the software should update [`PREFIX`](../data/kmac.hjson#prefix) with encoded values.
+The software also updates [`PREFIX`](../data/kmac.hjson#prefix_0) registers if cSHAKE mode is used.
+Current design does not convert cSHAKE mode to SHAKE even if [`PREFIX`](../data/kmac.hjson#prefix_0) is empty string.
+It is the software's responsibility to change the [`CFG_SHADOWED.mode`](../data/kmac.hjson#cfg_shadowed) to SHAKE in case of empty [`PREFIX`](../data/kmac.hjson#prefix_0).
+The KMAC/SHA3 HWIP uses [`PREFIX`](../data/kmac.hjson#prefix_0) registers as it is.
+It means that the software should update [`PREFIX`](../data/kmac.hjson#prefix_0) with encoded values.
 
 If [`CFG_SHADOWED.kmac_en`](../data/kmac.hjson#cfg_shadowed) is set, the software should update the secret key.
-The software prepares two shares of the secret key and selects its length in [`KEY_LEN`](../data/kmac.hjson#key_len) then writes the shares of the secret key to [`KEY_SHARE0`](../data/kmac.hjson#key_share0) and [`KEY_SHARE1`](../data/kmac.hjson#key_share1) .
+The software prepares two shares of the secret key and selects its length in [`KEY_LEN`](../data/kmac.hjson#key_len) then writes the shares of the secret key to [`KEY_SHARE0`](../data/kmac.hjson#key_share0_0) and [`KEY_SHARE1`](../data/kmac.hjson#key_share1_0) .
 The two shares of the secret key are the values that represent the secret key value when they are XORed together.
 The software can XOR the unmasked secret key with entropy.
 The XORed value is a share and the entropy used is the other share.

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -1114,7 +1114,7 @@ Depending on the application additional steps might be necessary, such as deleti
 
 ## Driver {#driver}
 
-A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/otbn.h` ([API documentation](../../../sw/apis/lib_2runtime_2otbn_8h.html)).
+A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/otbn.h`.
 
 Another driver for OTBN is part of the silicon creator code at `sw/device/silicon_creator/lib/drivers/otbn.h`.
 

--- a/hw/ip/otbn/doc/developer-guide.md
+++ b/hw/ip/otbn/doc/developer-guide.md
@@ -4,7 +4,7 @@ This directory contains the implementation of the OpenTitan Big Number
 Accelerator (OTBN). OTBN is a coprocessor for asymmetric cryptographic
 operations like RSA or Elliptic Curve Cryptography (ECC).
 
-See https://docs.opentitan.org/hw/ip/otbn/doc/index.html for documentation on
+See [here](../README.md) for documentation on
 the current version of OTBN; documentation matching the code in this directory
 can be found in the `doc` directory.
 
@@ -18,9 +18,9 @@ through the [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
 An assembler, linker and disassembler for OTBN can be found in
 `hw/ip/otbn/util`. These are wrappers around a RISC-V GCC and binutils toolchain
 so one must be available (see the OpenTitan documentation on [obtaining a
-toolchain](https://docs.opentitan.org/doc/ug/install_instructions/#software-development).
+toolchain](https://opentitan.org/guides/getting_started#step-3-install-the-lowrisc-risc-v-toolchain).
 For more details about the toolchain, see the [user
-guide](https://docs.opentitan.org/doc/ug/otbn_sw)).
+guide](../../../../doc/contributing/sw/otbn_sw.md)).
 
 `otbn_as.py` and `otbn_ld.py` can be used to build .elf files for use with
 simulations. They work work similarly to binutils programs they wrap.

--- a/hw/ip/usbdev/dv/README.md
+++ b/hw/ip/usbdev/dv/README.md
@@ -20,9 +20,6 @@ For detailed information on USBDEV design features, please see the [USBDEV HWIP 
 ## Testbench architecture
 USBDEV testbench has been constructed based on the [CIP testbench architecture](../../../dv/sv/cip_lib/README.md).
 
-### Block diagram
-![Block diagram](tb.svg)
-
 ### Top level testbench
 Top level testbench is located at `hw/ip/usbdev/dv/tb/tb.sv`.
 It instantiates the USBDEV DUT module `hw/ip/usbdev/rtl/usbdev.sv`.

--- a/hw/ip_templates/alert_handler/doc/checklist.md
+++ b/hw/ip_templates/alert_handler/doc/checklist.md
@@ -1,7 +1,7 @@
 # Alert Handler Checklist
 
-This checklist is for [Hardware Stage](../../../../doc/project_governance/development_stages.md) transitions for the [Alert Handler peripheral.](../README.md)
-All checklist items refer to the content in the [Checklist.](../../../../doc/project_governance/checklist/README.md)
+This checklist is for [Hardware Stage](../../../../../doc/project_governance/development_stages.md) transitions for the [Alert Handler peripheral.](../README.md)
+All checklist items refer to the content in the [Checklist.](../../../../../doc/project_governance/checklist/README.md)
 
 ## Design Checklist
 
@@ -19,15 +19,15 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[SPEC_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#spec_complete
-[CSR_DEFINED]:                ../../../../doc/project_governance/checklist/README.md#csr_defined
-[CLKRST_CONNECTED]:           ../../../../doc/project_governance/checklist/README.md#clkrst_connected
-[IP_TOP]:                     ../../../../doc/project_governance/checklist/README.md#ip_top
-[IP_INSTANTIABLE]:            ../../../../doc/project_governance/checklist/README.md#ip_instantiable
-[PHYSICAL_MACROS_DEFINED_80]: ../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
-[FUNC_IMPLEMENTED]:           ../../../../doc/project_governance/checklist/README.md#func_implemented
-[ASSERT_KNOWN_ADDED]:         ../../../../doc/project_governance/checklist/README.md#assert_known_added
-[LINT_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#lint_setup
+[SPEC_COMPLETE]:              ../../../../../doc/project_governance/checklist/README.md#spec_complete
+[CSR_DEFINED]:                ../../../../../doc/project_governance/checklist/README.md#csr_defined
+[CLKRST_CONNECTED]:           ../../../../../doc/project_governance/checklist/README.md#clkrst_connected
+[IP_TOP]:                     ../../../../../doc/project_governance/checklist/README.md#ip_top
+[IP_INSTANTIABLE]:            ../../../../../doc/project_governance/checklist/README.md#ip_instantiable
+[PHYSICAL_MACROS_DEFINED_80]: ../../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
+[FUNC_IMPLEMENTED]:           ../../../../../doc/project_governance/checklist/README.md#func_implemented
+[ASSERT_KNOWN_ADDED]:         ../../../../../doc/project_governance/checklist/README.md#assert_known_added
+[LINT_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#lint_setup
 
 ### D2
 
@@ -52,24 +52,24 @@ Code Quality  | [AREA_CHECK][]            | Done        |
 Code Quality  | [TIMING_CHECK][]          | Done        |
 Security      | [SEC_CM_DOCUMENTED][]     | Done        |
 
-[NEW_FEATURES]:          ../../../../doc/project_governance/checklist/README.md#new_features
-[BLOCK_DIAGRAM]:         ../../../../doc/project_governance/checklist/README.md#block_diagram
-[DOC_INTERFACE]:         ../../../../doc/project_governance/checklist/README.md#doc_interface
-[DOC_INTEGRATION_GUIDE]: ../../../../doc/project_governance/checklist/README.md#doc_integration_guide
-[MISSING_FUNC]:          ../../../../doc/project_governance/checklist/README.md#missing_func
-[FEATURE_FROZEN]:        ../../../../doc/project_governance/checklist/README.md#feature_frozen
-[FEATURE_COMPLETE]:      ../../../../doc/project_governance/checklist/README.md#feature_complete
-[PORT_FROZEN]:           ../../../../doc/project_governance/checklist/README.md#port_frozen
-[ARCHITECTURE_FROZEN]:   ../../../../doc/project_governance/checklist/README.md#architecture_frozen
-[REVIEW_TODO]:           ../../../../doc/project_governance/checklist/README.md#review_todo
-[STYLE_X]:               ../../../../doc/project_governance/checklist/README.md#style_x
-[CDC_SYNCMACRO]:         ../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
-[LINT_PASS]:             ../../../../doc/project_governance/checklist/README.md#lint_pass
-[CDC_SETUP]:             ../../../../doc/project_governance/checklist/README.md#cdc_setup
-[RDC_SETUP]:             ../../../../doc/project_governance/checklist/README.md#rdc_setup
-[AREA_CHECK]:            ../../../../doc/project_governance/checklist/README.md#area_check
-[TIMING_CHECK]:          ../../../../doc/project_governance/checklist/README.md#timing_check
-[SEC_CM_DOCUMENTED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_documented
+[NEW_FEATURES]:          ../../../../../doc/project_governance/checklist/README.md#new_features
+[BLOCK_DIAGRAM]:         ../../../../../doc/project_governance/checklist/README.md#block_diagram
+[DOC_INTERFACE]:         ../../../../../doc/project_governance/checklist/README.md#doc_interface
+[DOC_INTEGRATION_GUIDE]: ../../../../../doc/project_governance/checklist/README.md#doc_integration_guide
+[MISSING_FUNC]:          ../../../../../doc/project_governance/checklist/README.md#missing_func
+[FEATURE_FROZEN]:        ../../../../../doc/project_governance/checklist/README.md#feature_frozen
+[FEATURE_COMPLETE]:      ../../../../../doc/project_governance/checklist/README.md#feature_complete
+[PORT_FROZEN]:           ../../../../../doc/project_governance/checklist/README.md#port_frozen
+[ARCHITECTURE_FROZEN]:   ../../../../../doc/project_governance/checklist/README.md#architecture_frozen
+[REVIEW_TODO]:           ../../../../../doc/project_governance/checklist/README.md#review_todo
+[STYLE_X]:               ../../../../../doc/project_governance/checklist/README.md#style_x
+[CDC_SYNCMACRO]:         ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
+[LINT_PASS]:             ../../../../../doc/project_governance/checklist/README.md#lint_pass
+[CDC_SETUP]:             ../../../../../doc/project_governance/checklist/README.md#cdc_setup
+[RDC_SETUP]:             ../../../../../doc/project_governance/checklist/README.md#rdc_setup
+[AREA_CHECK]:            ../../../../../doc/project_governance/checklist/README.md#area_check
+[TIMING_CHECK]:          ../../../../../doc/project_governance/checklist/README.md#timing_check
+[SEC_CM_DOCUMENTED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
 
 ### D2S
 
@@ -83,13 +83,13 @@ Security      | [SEC_CM_SHADOW_REGS][]       | Done        |
 Security      | [SEC_CM_RTL_REVIEWED][]      | Done        |
 Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Done        |
 
-[SEC_CM_ASSETS_LISTED]:    ../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
-[SEC_CM_IMPLEMENTED]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
-[SEC_CM_RND_CNST]:         ../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
-[SEC_CM_NON_RESET_FLOPS]:  ../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
-[SEC_CM_SHADOW_REGS]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
-[SEC_CM_RTL_REVIEWED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
-[SEC_CM_COUNCIL_REVIEWED]: ../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
+[SEC_CM_ASSETS_LISTED]:    ../../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
+[SEC_CM_IMPLEMENTED]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
+[SEC_CM_RND_CNST]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
+[SEC_CM_NON_RESET_FLOPS]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
+[SEC_CM_SHADOW_REGS]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
+[SEC_CM_RTL_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
+[SEC_CM_COUNCIL_REVIEWED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
 
 ### D3
 
@@ -107,15 +107,15 @@ Review        | [REVIEW_SW_ERRATA][]    | Done        |
 Review        | Reviewer(s)             | Done        | msf@ vogelpi@ chencindy@ ttrippel@ tjaychen@
 Review        | Signoff date            | Done        | 2022-07-11
 
-[NEW_FEATURES_D3]:      ../../../../doc/project_governance/checklist/README.md#new_features_d3
-[TODO_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#todo_complete
-[LINT_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#lint_complete
-[CDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#cdc_complete
-[RDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#rdc_complete
-[REVIEW_RTL]:           ../../../../doc/project_governance/checklist/README.md#review_rtl
-[REVIEW_DELETED_FF]:    ../../../../doc/project_governance/checklist/README.md#review_deleted_ff
-[REVIEW_SW_CHANGE]:     ../../../../doc/project_governance/checklist/README.md#review_sw_change
-[REVIEW_SW_ERRATA]:     ../../../../doc/project_governance/checklist/README.md#review_sw_errata
+[NEW_FEATURES_D3]:      ../../../../../doc/project_governance/checklist/README.md#new_features_d3
+[TODO_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#todo_complete
+[LINT_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#lint_complete
+[CDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#cdc_complete
+[RDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#rdc_complete
+[REVIEW_RTL]:           ../../../../../doc/project_governance/checklist/README.md#review_rtl
+[REVIEW_DELETED_FF]:    ../../../../../doc/project_governance/checklist/README.md#review_deleted_ff
+[REVIEW_SW_CHANGE]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_change
+[REVIEW_SW_ERRATA]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_errata
 
 ## Verification Checklist
 
@@ -146,28 +146,28 @@ Review        | [TESTPLAN_REVIEWED][]                 | Done        |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        |
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
-[DV_DOC_DRAFT_COMPLETED]:             ../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
-[TESTPLAN_COMPLETED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_completed
-[TB_TOP_CREATED]:                     ../../../../doc/project_governance/checklist/README.md#tb_top_created
-[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
-[SIM_TB_ENV_CREATED]:                 ../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
-[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
-[CSR_CHECK_GEN_AUTOMATED]:            ../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
-[TB_GEN_AUTOMATED]:                   ../../../../doc/project_governance/checklist/README.md#tb_gen_automated
-[SIM_SMOKE_TEST_PASSING]:             ../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
-[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
-[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
-[SIM_ALT_TOOL_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
-[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
-[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
-[FPV_REGRESSION_SETUP]:               ../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
-[SIM_COVERAGE_MODEL_ADDED]:           ../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
-[TB_LINT_SETUP]:                      ../../../../doc/project_governance/checklist/README.md#tb_lint_setup
-[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
-[DESIGN_SPEC_REVIEWED]:               ../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
-[TESTPLAN_REVIEWED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_reviewed
-[STD_TEST_CATEGORIES_PLANNED]:        ../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
-[V2_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
+[DV_DOC_DRAFT_COMPLETED]:             ../../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
+[TESTPLAN_COMPLETED]:                 ../../../../../doc/project_governance/checklist/README.md#testplan_completed
+[TB_TOP_CREATED]:                     ../../../../../doc/project_governance/checklist/README.md#tb_top_created
+[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
+[SIM_TB_ENV_CREATED]:                 ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
+[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
+[CSR_CHECK_GEN_AUTOMATED]:            ../../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
+[TB_GEN_AUTOMATED]:                   ../../../../../doc/project_governance/checklist/README.md#tb_gen_automated
+[SIM_SMOKE_TEST_PASSING]:             ../../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
+[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
+[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
+[SIM_ALT_TOOL_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
+[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
+[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
+[FPV_REGRESSION_SETUP]:               ../../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
+[SIM_COVERAGE_MODEL_ADDED]:           ../../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
+[TB_LINT_SETUP]:                      ../../../../../doc/project_governance/checklist/README.md#tb_lint_setup
+[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
+[DESIGN_SPEC_REVIEWED]:               ../../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
+[TESTPLAN_REVIEWED]:                  ../../../../../doc/project_governance/checklist/README.md#testplan_reviewed
+[STD_TEST_CATEGORIES_PLANNED]:        ../../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
+[V2_CHECKLIST_SCOPED]:                ../../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
 
 ### V2
 
@@ -194,42 +194,42 @@ Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
-[DESIGN_DELTAS_CAPTURED_V2]:          ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
-[DV_DOC_COMPLETED]:                   ../../../../doc/project_governance/checklist/README.md#dv_doc_completed
-[FUNCTIONAL_COVERAGE_IMPLEMENTED]:    ../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
-[ALL_INTERFACES_EXERCISED]:           ../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
-[ALL_ASSERTION_CHECKS_ADDED]:         ../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
-[SIM_TB_ENV_COMPLETED]:               ../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
-[SIM_ALL_TESTS_PASSING]:              ../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
-[FPV_ALL_ASSERTIONS_WRITTEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
-[FPV_ALL_ASSUMPTIONS_REVIEWED]:       ../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
-[SIM_FW_SIMULATED]:                   ../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
-[SIM_NIGHTLY_REGRESSION_V2]:          ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
-[SIM_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
-[SIM_FUNCTIONAL_COVERAGE_V2]:         ../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
-[FPV_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
-[FPV_COI_COVERAGE_V2]:                ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
-[PRE_VERIFIED_SUB_MODULES_V2]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
-[NO_HIGH_PRIORITY_ISSUES_PENDING]:    ../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
-[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
-[DV_DOC_TESTPLAN_REVIEWED]:           ../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
-[V3_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
+[DESIGN_DELTAS_CAPTURED_V2]:           ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
+[DV_DOC_COMPLETED]:                    ../../../../../doc/project_governance/checklist/README.md#dv_doc_completed
+[FUNCTIONAL_COVERAGE_IMPLEMENTED]:     ../../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
+[ALL_INTERFACES_EXERCISED]:            ../../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
+[ALL_ASSERTION_CHECKS_ADDED]:          ../../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
+[SIM_TB_ENV_COMPLETED]:                ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
+[SIM_ALL_TESTS_PASSING]:               ../../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
+[FPV_ALL_ASSERTIONS_WRITTEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
+[FPV_ALL_ASSUMPTIONS_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
+[SIM_FW_SIMULATED]:                    ../../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
+[SIM_NIGHTLY_REGRESSION_V2]:           ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
+[SIM_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
+[SIM_FUNCTIONAL_COVERAGE_V2]:          ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
+[FPV_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
+[FPV_COI_COVERAGE_V2]:                 ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
+[PRE_VERIFIED_SUB_MODULES_V2]:         ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
+[NO_HIGH_PRIORITY_ISSUES_PENDING]:     ../../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
+[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]: ../../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
+[DV_DOC_TESTPLAN_REVIEWED]:            ../../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
+[V3_CHECKLIST_SCOPED]:                 ../../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
 
 ### V2S
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Done        |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
 Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Done        |
 
-[SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
-[FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified
-[SIM_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
-[SIM_COVERAGE_REVIEWED]:              ../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
-[SEC_CM_DV_REVIEWED]:                 ../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
+[SEC_CM_TESTPLAN_COMPLETED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
+[FPV_SEC_CM_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven
+[SIM_SEC_CM_VERIFIED]:       ../../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
+[SIM_COVERAGE_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
+[SEC_CM_DV_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
 
 ### V3
 
@@ -251,16 +251,16 @@ Issues        | [NO_ISSUES_PENDING][]             | Not Started |
 Review        | Reviewer(s)                       | Not Started |
 Review        | Signoff date                      | Not Started |
 
-[DESIGN_DELTAS_CAPTURED_V3]:     ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
-[X_PROP_ANALYSIS_COMPLETED]:     ../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
-[FPV_ASSERTIONS_PROVEN_AT_V3]:   ../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
-[SIM_NIGHTLY_REGRESSION_AT_V3]:  ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
-[SIM_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
-[SIM_FUNCTIONAL_COVERAGE_AT_100]:../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
-[FPV_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
-[FPV_COI_COVERAGE_AT_100]:       ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
-[ALL_TODOS_RESOLVED]:            ../../../../doc/project_governance/checklist/README.md#all_todos_resolved
-[NO_TOOL_WARNINGS_THROWN]:       ../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
-[TB_LINT_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#tb_lint_complete
-[PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
-[NO_ISSUES_PENDING]:             ../../../../doc/project_governance/checklist/README.md#no_issues_pending
+[DESIGN_DELTAS_CAPTURED_V3]:      ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
+[X_PROP_ANALYSIS_COMPLETED]:      ../../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
+[FPV_ASSERTIONS_PROVEN_AT_V3]:    ../../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
+[SIM_NIGHTLY_REGRESSION_AT_V3]:   ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
+[SIM_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
+[SIM_FUNCTIONAL_COVERAGE_AT_100]: ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
+[FPV_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
+[FPV_COI_COVERAGE_AT_100]:        ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
+[ALL_TODOS_RESOLVED]:             ../../../../../doc/project_governance/checklist/README.md#all_todos_resolved
+[NO_TOOL_WARNINGS_THROWN]:        ../../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
+[TB_LINT_COMPLETE]:               ../../../../../doc/project_governance/checklist/README.md#tb_lint_complete
+[PRE_VERIFIED_SUB_MODULES_V3]:    ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
+[NO_ISSUES_PENDING]:              ../../../../../doc/project_governance/checklist/README.md#no_issues_pending

--- a/hw/ip_templates/alert_handler/dv/README.md
+++ b/hw/ip_templates/alert_handler/dv/README.md
@@ -12,14 +12,14 @@
 
 ## Current status
 * [Design & verification stage](../../../README.md)
-  * [HW development stages](../../../../doc/project_governance/development_stages.md)
+  * [HW development stages](../../../../../doc/project_governance/development_stages.md)
 * [Simulation results](https://reports.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/dv/latest/report.html)
 
 ## Design features
 For detailed information on ALERT_HANDLER design features, please see the [ALERT_HANDLER HWIP technical specification](../README.md).
 
 ## Testbench architecture
-ALERT_HANDLER testbench has been constructed based on the [CIP testbench architecture](../../../dv/sv/cip_lib/README.md).
+ALERT_HANDLER testbench has been constructed based on the [CIP testbench architecture](../../../../dv/sv/cip_lib/README.md).
 
 ### Block diagram
 ![Block diagram](./doc/tb.svg)
@@ -27,19 +27,19 @@ ALERT_HANDLER testbench has been constructed based on the [CIP testbench archite
 ### Top level testbench
 Top level testbench is located at `hw/ip/alert_handler/dv/tb/tb.sv`. It instantiates the ALERT_HANDLER DUT module `hw/ip/alert_handler/rtl/alert_handler.sv`.
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
-* [Clock and reset interface](../../../dv/sv/common_ifs/README.md)
-* [TileLink host interface](../../../dv/sv/tl_agent/README.md)
+* [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
+* [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
 * ALERT_HANDLER IOs
-* Alerts and escalations([`alert_esc_if`](../../../dv/sv/alert_esc_agent/README.md))
-* Interrupts ([`pins_if`](../../../dv/sv/common_ifs/README.md))
-* Devmode ([`pins_if`](../../../dv/sv/common_ifs/README.md))
+* Alerts and escalations([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
+* Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md#pins_if))
+* Devmode ([`pins_if`](../../../../dv/sv/common_ifs/README.md#pins_if))
 
 The alert_handler testbench environment can be reused in chip level testing.
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
-* [dv_utils_pkg](../../../dv/sv/dv_utils/README.md)
-* [csr_utils_pkg](../../../dv/sv/csr_utils/README.md)
+* [dv_utils_pkg](../../../../dv/sv/dv_utils/README.md)
+* [csr_utils_pkg](../../../../dv/sv/csr_utils/README.md)
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
@@ -49,18 +49,18 @@ All common types and methods defined at the package level can be found in
 ```
 
 ### TL_agent
-ALERT_HANDLER testbench instantiates (already handled in CIP base env) [tl_agent](../../../dv/sv/tl_agent/README.md)
+ALERT_HANDLER testbench instantiates (already handled in CIP base env) [tl_agent](../../../../dv/sv/tl_agent/README.md)
 which provides the ability to drive and independently monitor random traffic via
 TL host interface into ALERT_HANDLER device.
 
 ### ALERT_ESC Agent
-[ALERT_ESC agent](../../../dv/sv/alert_esc_agent/README.md) is used to drive and monitor transmitter and receiver pairs for the alerts and escalators.
+[ALERT_ESC agent](../../../../dv/sv/alert_esc_agent/README.md) is used to drive and monitor transmitter and receiver pairs for the alerts and escalators.
 Alert_handler DUT includes alert_receivers and esc_senders, so the alert_esc agent will drive output signals of the alert_senders and esc_receivers.
 
 ### UVM RAL Model
-The ALERT_HANDLER RAL model is created with the [`ralgen`](../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
+The ALERT_HANDLER RAL model is created with the [`ralgen`](../../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
 
-It can be created manually by invoking [`regtool`](../../../../util/reggen/doc/setup_and_use.md).
+It can be created manually by invoking [`regtool`](../../../../../util/reggen/doc/setup_and_use.md).
 
 ### Stimulus strategy
 #### Test sequences
@@ -104,11 +104,11 @@ To ensure certain alert, interrupt, or escalation signals are triggered at the e
 The alert_handler scoreboard is parameterized to support different number of classes, alert pairs, and escalation pairs.
 
 #### Assertions
-* TLUL assertions: The `tb/alert_handler_bind.sv` binds the `tlul_assert` [assertions](../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
+* TLUL assertions: The `tb/alert_handler_bind.sv` binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 
 ## Building and running tests
-We are using our in-house developed [regression tool](../../../../util/dvsim/README.md) for building and running our tests and regressions.
+We are using our in-house developed [regression tool](../../../../../util/dvsim/README.md) for building and running our tests and regressions.
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
 Here's how to run a smoke test:
 ```console

--- a/hw/ip_templates/rv_plic/doc/checklist.md
+++ b/hw/ip_templates/rv_plic/doc/checklist.md
@@ -51,7 +51,6 @@ Code Quality  | [CDC_SETUP][]           | N/A         |
 Code Quality  | [TIMING_CHECK][]        | Done        | Fmax @ 50MHz on NexysVideo
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
 Security      | [SEC_CM_DOCUMENTED][]   | N/A         |
-Security      | [SEC_RND_CNST][]        | N/A         |
 
 [NEW_FEATURES]:        ../../../../../doc/project_governance/checklist/README.md#new_features
 [BLOCK_DIAGRAM]:       ../../../../../doc/project_governance/checklist/README.md#block_diagram
@@ -69,7 +68,6 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 [TIMING_CHECK]:         ../../../../../doc/project_governance/checklist/README.md#timing_check
 [CDC_SYNCMACRO]:       ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
 [SEC_CM_DOCUMENTED]:   ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
-[SEC_RND_CNST]:        ../../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
 
 ### D2S
 

--- a/hw/ip_templates/rv_plic/doc/checklist.md
+++ b/hw/ip_templates/rv_plic/doc/checklist.md
@@ -1,7 +1,7 @@
 # RV_PLIC Checklist
 
-This checklist is for [Hardware Stage](../../../../doc/project_governance/development_stages.md) transitions for the [RV_PLIC peripheral](../README.md).
-All checklist items refer to the content in the [Checklist.](../../../../doc/project_governance/checklist/README.md)
+This checklist is for [Hardware Stage](../../../../../doc/project_governance/development_stages.md) transitions for the [RV_PLIC peripheral](../README.md).
+All checklist items refer to the content in the [Checklist.](../../../../../doc/project_governance/checklist/README.md)
 
 ## Design Checklist
 
@@ -21,15 +21,15 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 
 [RV_PLIC Spec]: ../README.md
 
-[SPEC_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#spec_complete
-[CSR_DEFINED]:                ../../../../doc/project_governance/checklist/README.md#csr_defined
-[CLKRST_CONNECTED]:           ../../../../doc/project_governance/checklist/README.md#clkrst_connected
-[IP_TOP]:                     ../../../../doc/project_governance/checklist/README.md#ip_top
-[IP_INSTANTIABLE]:            ../../../../doc/project_governance/checklist/README.md#ip_instantiable
-[PHYSICAL_MACROS_DEFINED_80]: ../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
-[FUNC_IMPLEMENTED]:           ../../../../doc/project_governance/checklist/README.md#func_implemented
-[ASSERT_KNOWN_ADDED]:         ../../../../doc/project_governance/checklist/README.md#assert_known_added
-[LINT_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#lint_setup
+[SPEC_COMPLETE]:              ../../../../../doc/project_governance/checklist/README.md#spec_complete
+[CSR_DEFINED]:                ../../../../../doc/project_governance/checklist/README.md#csr_defined
+[CLKRST_CONNECTED]:           ../../../../../doc/project_governance/checklist/README.md#clkrst_connected
+[IP_TOP]:                     ../../../../../doc/project_governance/checklist/README.md#ip_top
+[IP_INSTANTIABLE]:            ../../../../../doc/project_governance/checklist/README.md#ip_instantiable
+[PHYSICAL_MACROS_DEFINED_80]: ../../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
+[FUNC_IMPLEMENTED]:           ../../../../../doc/project_governance/checklist/README.md#func_implemented
+[ASSERT_KNOWN_ADDED]:         ../../../../../doc/project_governance/checklist/README.md#assert_known_added
+[LINT_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#lint_setup
 
 ### D2
 
@@ -48,28 +48,28 @@ RTL           | [REVIEW_TODO][]         | Done        | One TODO about Vivado Is
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |
 Code Quality  | [CDC_SETUP][]           | N/A         |
-Code Quality  | [FPGA_TIMING][]         | Done        | Fmax @ 50MHz on NexysVideo
+Code Quality  | [TIMING_CHECK][]        | Done        | Fmax @ 50MHz on NexysVideo
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
 Security      | [SEC_CM_DOCUMENTED][]   | N/A         |
 Security      | [SEC_RND_CNST][]        | N/A         |
 
-[NEW_FEATURES]:        ../../../../doc/project_governance/checklist/README.md#new_features
-[BLOCK_DIAGRAM]:       ../../../../doc/project_governance/checklist/README.md#block_diagram
-[DOC_INTERFACE]:       ../../../../doc/project_governance/checklist/README.md#doc_interface
-[MISSING_FUNC]:        ../../../../doc/project_governance/checklist/README.md#missing_func
-[FEATURE_FROZEN]:      ../../../../doc/project_governance/checklist/README.md#feature_frozen
-[FEATURE_COMPLETE]:    ../../../../doc/project_governance/checklist/README.md#feature_complete
-[AREA_CHECK]:          ../../../../doc/project_governance/checklist/README.md#area_check
-[PORT_FROZEN]:         ../../../../doc/project_governance/checklist/README.md#port_frozen
-[ARCHITECTURE_FROZEN]: ../../../../doc/project_governance/checklist/README.md#architecture_frozen
-[REVIEW_TODO]:         ../../../../doc/project_governance/checklist/README.md#review_todo
-[STYLE_X]:             ../../../../doc/project_governance/checklist/README.md#style_x
-[LINT_PASS]:           ../../../../doc/project_governance/checklist/README.md#lint_pass
-[CDC_SETUP]:           ../../../../doc/project_governance/checklist/README.md#cdc_setup
-[FPGA_TIMING]:         ../../../../doc/project_governance/checklist/README.md#fpga_timing
-[CDC_SYNCMACRO]:       ../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
-[SEC_CM_DOCUMENTED]:   ../../../../doc/project_governance/checklist/README.md#sec_cm_documented
-[SEC_RND_CNST]:        ../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
+[NEW_FEATURES]:        ../../../../../doc/project_governance/checklist/README.md#new_features
+[BLOCK_DIAGRAM]:       ../../../../../doc/project_governance/checklist/README.md#block_diagram
+[DOC_INTERFACE]:       ../../../../../doc/project_governance/checklist/README.md#doc_interface
+[MISSING_FUNC]:        ../../../../../doc/project_governance/checklist/README.md#missing_func
+[FEATURE_FROZEN]:      ../../../../../doc/project_governance/checklist/README.md#feature_frozen
+[FEATURE_COMPLETE]:    ../../../../../doc/project_governance/checklist/README.md#feature_complete
+[AREA_CHECK]:          ../../../../../doc/project_governance/checklist/README.md#area_check
+[PORT_FROZEN]:         ../../../../../doc/project_governance/checklist/README.md#port_frozen
+[ARCHITECTURE_FROZEN]: ../../../../../doc/project_governance/checklist/README.md#architecture_frozen
+[REVIEW_TODO]:         ../../../../../doc/project_governance/checklist/README.md#review_todo
+[STYLE_X]:             ../../../../../doc/project_governance/checklist/README.md#style_x
+[LINT_PASS]:           ../../../../../doc/project_governance/checklist/README.md#lint_pass
+[CDC_SETUP]:           ../../../../../doc/project_governance/checklist/README.md#cdc_setup
+[TIMING_CHECK]:         ../../../../../doc/project_governance/checklist/README.md#timing_check
+[CDC_SYNCMACRO]:       ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
+[SEC_CM_DOCUMENTED]:   ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
+[SEC_RND_CNST]:        ../../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
 
 ### D2S
 
@@ -83,13 +83,13 @@ Security      | [SEC_CM_SHADOW_REGS][]       | N/A         |
 Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
 Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
-[SEC_CM_ASSETS_LISTED]:    ../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
-[SEC_CM_IMPLEMENTED]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
-[SEC_CM_RND_CNST]:         ../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
-[SEC_CM_NON_RESET_FLOPS]:  ../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
-[SEC_CM_SHADOW_REGS]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
-[SEC_CM_RTL_REVIEWED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
-[SEC_CM_COUNCIL_REVIEWED]: ../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
+[SEC_CM_ASSETS_LISTED]:    ../../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
+[SEC_CM_IMPLEMENTED]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
+[SEC_CM_RND_CNST]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
+[SEC_CM_NON_RESET_FLOPS]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
+[SEC_CM_SHADOW_REGS]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
+[SEC_CM_RTL_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
+[SEC_CM_COUNCIL_REVIEWED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
 
 ### D3
 
@@ -107,15 +107,15 @@ Review        | [REVIEW_SW_ERRATA][]    | Done        |
 Review        | Reviewer(s)             | Done        | eunchan@ gac@ chencindy@ ttrippel@
 Review        | Signoff date            | Done        | 2022-07-25
 
-[NEW_FEATURES_D3]:      ../../../../doc/project_governance/checklist/README.md#new_features_d3
-[TODO_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#todo_complete
-[LINT_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#lint_complete
-[CDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#cdc_complete
-[RDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#rdc_complete
-[REVIEW_RTL]:           ../../../../doc/project_governance/checklist/README.md#review_rtl
-[REVIEW_DELETED_FF]:    ../../../../doc/project_governance/checklist/README.md#review_deleted_ff
-[REVIEW_SW_CHANGE]:     ../../../../doc/project_governance/checklist/README.md#review_sw_change
-[REVIEW_SW_ERRATA]:     ../../../../doc/project_governance/checklist/README.md#review_sw_errata
+[NEW_FEATURES_D3]:      ../../../../../doc/project_governance/checklist/README.md#new_features_d3
+[TODO_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#todo_complete
+[LINT_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#lint_complete
+[CDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#cdc_complete
+[RDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#rdc_complete
+[REVIEW_RTL]:           ../../../../../doc/project_governance/checklist/README.md#review_rtl
+[REVIEW_DELETED_FF]:    ../../../../../doc/project_governance/checklist/README.md#review_deleted_ff
+[REVIEW_SW_CHANGE]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_change
+[REVIEW_SW_ERRATA]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_errata
 
 ## Verification Checklist
 
@@ -146,28 +146,28 @@ Review        | [TESTPLAN_REVIEWED][]                 | Done        |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | N/A         |
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
-[DV_DOC_DRAFT_COMPLETED]:             ../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
-[TESTPLAN_COMPLETED]:                 ../../../../doc/project_governance/checklist/README.md#testplan_completed
-[TB_TOP_CREATED]:                     ../../../../doc/project_governance/checklist/README.md#tb_top_created
-[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
-[SIM_TB_ENV_CREATED]:                 ../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
-[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
-[CSR_CHECK_GEN_AUTOMATED]:            ../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
-[TB_GEN_AUTOMATED]:                   ../../../../doc/project_governance/checklist/README.md#tb_gen_automated
-[SIM_SMOKE_TEST_PASSING]:             ../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
-[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
-[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
-[SIM_ALT_TOOL_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
-[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
-[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
-[FPV_REGRESSION_SETUP]:               ../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
-[SIM_COVERAGE_MODEL_ADDED]:           ../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
-[TB_LINT_SETUP]:                      ../../../../doc/project_governance/checklist/README.md#tb_lint_setup
-[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
-[DESIGN_SPEC_REVIEWED]:               ../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
-[TESTPLAN_REVIEWED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_reviewed
-[STD_TEST_CATEGORIES_PLANNED]:        ../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
-[V2_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
+[DV_DOC_DRAFT_COMPLETED]:             ../../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
+[TESTPLAN_COMPLETED]:                 ../../../../../doc/project_governance/checklist/README.md#testplan_completed
+[TB_TOP_CREATED]:                     ../../../../../doc/project_governance/checklist/README.md#tb_top_created
+[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
+[SIM_TB_ENV_CREATED]:                 ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
+[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
+[CSR_CHECK_GEN_AUTOMATED]:            ../../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
+[TB_GEN_AUTOMATED]:                   ../../../../../doc/project_governance/checklist/README.md#tb_gen_automated
+[SIM_SMOKE_TEST_PASSING]:             ../../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
+[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
+[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
+[SIM_ALT_TOOL_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
+[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
+[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
+[FPV_REGRESSION_SETUP]:               ../../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
+[SIM_COVERAGE_MODEL_ADDED]:           ../../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
+[TB_LINT_SETUP]:                      ../../../../../doc/project_governance/checklist/README.md#tb_lint_setup
+[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
+[DESIGN_SPEC_REVIEWED]:               ../../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
+[TESTPLAN_REVIEWED]:                  ../../../../../doc/project_governance/checklist/README.md#testplan_reviewed
+[STD_TEST_CATEGORIES_PLANNED]:        ../../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
+[V2_CHECKLIST_SCOPED]:                ../../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
 
 ### V2
 
@@ -194,42 +194,42 @@ Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
-[DESIGN_DELTAS_CAPTURED_V2]:          ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
-[DV_DOC_COMPLETED]:                   ../../../../doc/project_governance/checklist/README.md#dv_doc_completed
-[FUNCTIONAL_COVERAGE_IMPLEMENTED]:    ../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
-[ALL_INTERFACES_EXERCISED]:           ../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
-[ALL_ASSERTION_CHECKS_ADDED]:         ../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
-[SIM_TB_ENV_COMPLETED]:               ../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
-[SIM_ALL_TESTS_PASSING]:              ../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
-[FPV_ALL_ASSERTIONS_WRITTEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
-[FPV_ALL_ASSUMPTIONS_REVIEWED]:       ../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
-[SIM_FW_SIMULATED]:                   ../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
-[SIM_NIGHTLY_REGRESSION_V2]:          ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
-[SIM_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
-[SIM_FUNCTIONAL_COVERAGE_V2]:         ../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
-[FPV_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
-[FPV_COI_COVERAGE_V2]:                ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
-[PRE_VERIFIED_SUB_MODULES_V2]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
-[NO_HIGH_PRIORITY_ISSUES_PENDING]:    ../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
-[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
-[DV_DOC_TESTPLAN_REVIEWED]:           ../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
-[V3_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
+[DESIGN_DELTAS_CAPTURED_V2]:           ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
+[DV_DOC_COMPLETED]:                    ../../../../../doc/project_governance/checklist/README.md#dv_doc_completed
+[FUNCTIONAL_COVERAGE_IMPLEMENTED]:     ../../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
+[ALL_INTERFACES_EXERCISED]:            ../../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
+[ALL_ASSERTION_CHECKS_ADDED]:          ../../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
+[SIM_TB_ENV_COMPLETED]:                ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
+[SIM_ALL_TESTS_PASSING]:               ../../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
+[FPV_ALL_ASSERTIONS_WRITTEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
+[FPV_ALL_ASSUMPTIONS_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
+[SIM_FW_SIMULATED]:                    ../../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
+[SIM_NIGHTLY_REGRESSION_V2]:           ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
+[SIM_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
+[SIM_FUNCTIONAL_COVERAGE_V2]:          ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
+[FPV_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
+[FPV_COI_COVERAGE_V2]:                 ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
+[PRE_VERIFIED_SUB_MODULES_V2]:         ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
+[NO_HIGH_PRIORITY_ISSUES_PENDING]:     ../../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
+[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]: ../../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
+[DV_DOC_TESTPLAN_REVIEWED]:            ../../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
+[V3_CHECKLIST_SCOPED]:                 ../../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
 
 ### V2S
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Not Started |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
 Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
 
-[SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
-[FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified
-[SIM_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
-[SIM_COVERAGE_REVIEWED]:              ../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
-[SEC_CM_DV_REVIEWED]:                 ../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
+[SEC_CM_TESTPLAN_COMPLETED]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
+[FPV_SEC_CM_PROVEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven
+[SIM_SEC_CM_VERIFIED]:        ../../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
+[SIM_COVERAGE_REVIEWED]:      ../../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
+[SEC_CM_DV_REVIEWED]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
 
 ### V3
 
@@ -251,16 +251,16 @@ Issues        | [NO_ISSUES_PENDING][]             | Not Started |
 Review        | Reviewer(s)                       | Not Started |
 Review        | Signoff date                      | Not Started |
 
-[DESIGN_DELTAS_CAPTURED_V3]:     ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
-[X_PROP_ANALYSIS_COMPLETED]:     ../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
-[FPV_ASSERTIONS_PROVEN_AT_V3]:   ../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
-[SIM_NIGHTLY_REGRESSION_AT_V3]:  ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
-[SIM_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
-[SIM_FUNCTIONAL_COVERAGE_AT_100]:../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
-[FPV_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
-[FPV_COI_COVERAGE_AT_100]:       ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
-[ALL_TODOS_RESOLVED]:            ../../../../doc/project_governance/checklist/README.md#all_todos_resolved
-[NO_TOOL_WARNINGS_THROWN]:       ../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
-[TB_LINT_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#tb_lint_complete
-[PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
-[NO_ISSUES_PENDING]:             ../../../../doc/project_governance/checklist/README.md#no_issues_pending
+[DESIGN_DELTAS_CAPTURED_V3]:      ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
+[X_PROP_ANALYSIS_COMPLETED]:      ../../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
+[FPV_ASSERTIONS_PROVEN_AT_V3]:    ../../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
+[SIM_NIGHTLY_REGRESSION_AT_V3]:   ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
+[SIM_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
+[SIM_FUNCTIONAL_COVERAGE_AT_100]: ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
+[FPV_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
+[FPV_COI_COVERAGE_AT_100]:        ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
+[ALL_TODOS_RESOLVED]:             ../../../../../doc/project_governance/checklist/README.md#all_todos_resolved
+[NO_TOOL_WARNINGS_THROWN]:        ../../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
+[TB_LINT_COMPLETE]:               ../../../../../doc/project_governance/checklist/README.md#tb_lint_complete
+[PRE_VERIFIED_SUB_MODULES_V3]:    ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
+[NO_ISSUES_PENDING]:              ../../../../../doc/project_governance/checklist/README.md#no_issues_pending

--- a/hw/ip_templates/rv_plic/doc/dv/README.md
+++ b/hw/ip_templates/rv_plic/doc/dv/README.md
@@ -11,7 +11,7 @@
 
 ## Current status
 * [Design & verification stage](../../../../README.md)
-  * [HW development stages](../../../../../doc/project_governance/development_stages.md)
+  * [HW development stages](../../../../../../doc/project_governance/development_stages.md)
 * FPV dashboard (link TBD)
 
 ## Design features
@@ -20,13 +20,13 @@ For detailed information on RV_PLIC design features, please see the
 
 ## Testbench architecture
 RV_PLIC FPV testbench has been constructed based on the [formal
-architecture](../../../../formal/README.md).
+architecture](../../../../../formal/README.md).
 
 ### Block diagram
 ![Block diagram](fpv.svg)
 
 #### TLUL assertions
-* The file `rv_plic_bind.sv` binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md)
+* The file `rv_plic_bind.sv` binds the `tlul_assert` [assertions](../../../../../ip/tlul/doc/TlulProtocolChecker.md)
   to rv_plic to ensure TileLink interface protocol compliance.
 * The `hw/rv_plic/fpv/tb/rv_plic_bind.sv` also binds the `rv_plic_csr_assert_fpv`
   under `fpv/vip/` to check if TileLink writes and reads correct
@@ -42,7 +42,7 @@ is used to reduce the number of repeated assertions code. In RV_PLIC, we
 declared two symbolic variables `src_sel` and `tgt_sel` to represent the index for
 interrupt source and interrupt target.
 Detailed explanation is listed in the
-[Symbolic Variables](../../../../formal/README.md#symbolic-variables) section.
+[Symbolic Variables](../../../../../formal/README.md#symbolic-variables) section.
 
 ## Testplan
-[Testplan](../data/rv_plic_fpv_testplan.hjson)
+[Testplan](../../data/rv_plic_fpv_testplan.hjson)

--- a/hw/lint/README.md
+++ b/hw/lint/README.md
@@ -13,9 +13,9 @@ The lint flow run scripts and waiver files are available in the GitHub repositor
 However, the _"lowRISC Lint Rules"_ are available as part of the default policies in AscentLint release 2019.A.p3 or newer (as `LRLR-v1.0.policy`).
 This enables designers that have access to this tool to run the lint flow provided locally on their premises.
 
-Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this open source package manager and [here](https://docs.opentitan.org/doc/ug/install_instructions/) for installation instructions.
+Our linting flow leverages FuseSoC to resolve dependencies, build file lists and call the linting tools. See [here](https://github.com/olofk/fusesoc) for an introduction to this open source package manager and [here](https://opentitan.org/guides/getting_started) for installation instructions.
 
-In order to run lint on a [comportable IP](https://docs.opentitan.org/doc/rm/comportability_specification/) block, the corresponding FuseSoC core file must have a lint target and include (optional) waiver files as shown in the following example taken from the FuseSoC core of the AES comportable IP:
+In order to run lint on a [comportable IP](../../doc/contributing/hw/comportability/README.md) block, the corresponding FuseSoC core file must have a lint target and include (optional) waiver files as shown in the following example taken from the FuseSoC core of the AES comportable IP:
 ```
 filesets:
 

--- a/hw/top_earlgrey/dv/README.md
+++ b/hw/top_earlgrey/dv/README.md
@@ -143,4 +143,4 @@ For a list of available tests  to run, please see the 'Tests' column in the [tes
 
 ## Testplan (Gate level simulations)
 Note that the descriptions of the test below may be replicated from the table above.
-[Testplan](../data/chip_testplan.hjson:gls)
+[Testplan](../data/chip_testplan.hjson)

--- a/hw/top_earlgrey/ip/ast/README.md
+++ b/hw/top_earlgrey/ip/ast/README.md
@@ -280,7 +280,7 @@ system clock.</td>
 <td>1</td>
 <td>async</td>
 <td>System clock valid. Used as "ack" signals for the <a
-href="https://docs.opentitan.org/hw/ip/pwrmgr/doc/"><u>power
+href="https://opentitan.org/book/hw/ip/pwrmgr"><u>power
 manager</u></a></td>
 </tr>
 <tr class="even">
@@ -322,7 +322,7 @@ usb_ref_pulse_i is available and +/-3% otherwise. It may take up to 50
 ms for this clock to reach the accuracy target from the time
 'usb_ref_pulse_i' is available. USB clock calibration interface is
 further detailed <a
-href="https://docs.opentitan.org/hw/ip/usbdev/doc/#clocking"><u>here</u></a>.</td>
+href="https://opentitan.org/book/hw/ip/usbdev#clocking"><u>here</u></a>.</td>
 </tr>
 <tr class="odd">
 <td>clk_src_usb_val_o</td>
@@ -373,7 +373,7 @@ that require a fixed frequency, for example SPI and UART</td>
 <td>1</td>
 <td>async</td>
 <td>I/O and timer clock valid. Used as "ack" signals for the <a
-href="https://docs.opentitan.org/hw/ip/pwrmgr/doc/"><u>Power
+href="https://opentitan.org/book/hw/ip/pwrmgr"><u>Power
 manager</u></a>.</td>
 </tr>
 <tr class="odd">
@@ -651,14 +651,14 @@ programming.</p>
 <p>Clock calibration: AST clock sources are inaccurate by default and
 must be calibrated prior to use. The results of the calibration are
 stored in <a
-href="https://docs.opentitan.org/hw/ip/otp_ctrl/doc/"><u>OTP</u></a> and
+href="https://opentitan.org/book/hw/ip/otp_ctrl"><u>OTP</u></a> and
 reloaded by software upon system boot.</p>
 <p>First Flash / OTP programming: AST clock sources are inaccurate by
 default and may be out of range for initial flash and OTP programming.
 In this situation, an external clock may be required for initial
 programming such that a software image can be loaded to calibrate clocks
 and advance <a
-href="https://docs.opentitan.org/doc/security/specs/device_life_cycle/"><u>life
+href="https://opentitan.org/book/doc/security/specs/device_life_cycle"><u>life
 cycle</u></a>.</p></td>
 </tr>
 <tr class="odd">
@@ -983,7 +983,7 @@ released to the system.
 The USB clock requires an accuracy that cannot be achieved by the AST
 clocks natively. As a result, information from USB frames are used to
 [<u>calibrate the
-clock</u>](https://github.com/lowRISC/opentitan/blob/master/hw/ip/usbdev/doc/_index.md#clocking).
+clock</u>](../../../ip/usbdev/README.md#clocking).
 
 # Clock and Reset Inputs
 
@@ -1059,7 +1059,7 @@ AST contains an analog to digital converter that can be used to sample
 various input signals. For OpenTitan this will primarily be used for
 [<u>debug cable detection</u>](https://www.sparkfun.com/products/14746).
 To activate the ADC, the corresponding [<u>comportable
-module</u>](https://docs.opentitan.org/hw/ip/adc_ctrl/doc/) must first
+module</u>](../../../ip/adc_ctrl/README.md) must first
 activate the ADC through 'adc_pd_i'. Once activated, it should select
 the channel to sample. Channel transition from zero to non-zero value
 starts the ADC conversion. The ADC output is synchronous to the ADC
@@ -1098,7 +1098,7 @@ edge: [ 'a<->b wakeup time', ] }
 
 AST contains a random number generator that outputs random number
 bitstreams whenever it is enabled. After enabled by the [<u>comportable
-controller</u>](https://docs.opentitan.org/hw/ip/entropy_src/doc/)
+controller</u>](../../../ip/entropy_src/README.md)
 through 'rng_en_i', the AST begins generating multiple
 independent four random bit streams. rng_b_o bit streams are valid and
 can be sampled whenever 'rng_val_o' is asserted according to the
@@ -1114,14 +1114,14 @@ following diagram.
 
 The expected rng_b_o valid output rate is about 50KHz. For more
 information on the RNG interface, please see the [<u>OpenTitan entropy
-source module</u>](https://docs.opentitan.org/hw/ip/entropy_src/doc/).
+source module</u>](../../../ip/entropy_src/README.md).
 
 # Entropy Consumption
 
 AST consumes entropy for defensive purposes. However, AST does not
 consume its raw entropy directly. Instead, AST receives entropy from the
 [<u>Entropy Distribution Network
-(EDN)</u>](https://docs.opentitan.org/hw/ip/edn/doc/index.html). Note
+(EDN)</u>](../../../ip/edn/README.md). Note
 that entropy_ack and entropy_i are packed into enropy_rsp_i in the
 interface. Also note that once entropy_req_o is set, it will remain set
 until ack or until reset.
@@ -1152,7 +1152,7 @@ ensure they cannot be hard-wired or faulted to either '1' or
 
 Inside the sensor controller, the events are then converted into alerts
 as part of the wider [<u>OpenTitan alert handling
-system</u>](https://docs.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/doc/).
+system</u>](../../ip_autogen/alert_handler/README.md).
 
 ## Alert Signaling
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/doc/programmers_guide.md
+++ b/hw/top_earlgrey/ip/sensor_ctrl/doc/programmers_guide.md
@@ -6,7 +6,7 @@ Fatal events are not acknowledged, and continuously send alert events in the sys
 
 ## Device Interface Functions (DIFs)
 
-- [Device Interface Functions](../../../sw/device/lib/dif/dif_sensor_ctrl.h)
+- [Device Interface Functions](../../../../../sw/device/lib/dif/dif_sensor_ctrl.h)
 
 ## Register Table
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/doc/checklist.md
@@ -1,7 +1,7 @@
 # Alert Handler Checklist
 
-This checklist is for [Hardware Stage](../../../../doc/project_governance/development_stages.md) transitions for the [Alert Handler peripheral.](../README.md)
-All checklist items refer to the content in the [Checklist.](../../../../doc/project_governance/checklist/README.md)
+This checklist is for [Hardware Stage](../../../../../doc/project_governance/development_stages.md) transitions for the [Alert Handler peripheral.](../README.md)
+All checklist items refer to the content in the [Checklist.](../../../../../doc/project_governance/checklist/README.md)
 
 ## Design Checklist
 
@@ -19,15 +19,15 @@ RTL           | [FUNC_IMPLEMENTED][]           | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
 Code Quality  | [LINT_SETUP][]                 | Done        |
 
-[SPEC_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#spec_complete
-[CSR_DEFINED]:                ../../../../doc/project_governance/checklist/README.md#csr_defined
-[CLKRST_CONNECTED]:           ../../../../doc/project_governance/checklist/README.md#clkrst_connected
-[IP_TOP]:                     ../../../../doc/project_governance/checklist/README.md#ip_top
-[IP_INSTANTIABLE]:            ../../../../doc/project_governance/checklist/README.md#ip_instantiable
-[PHYSICAL_MACROS_DEFINED_80]: ../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
-[FUNC_IMPLEMENTED]:           ../../../../doc/project_governance/checklist/README.md#func_implemented
-[ASSERT_KNOWN_ADDED]:         ../../../../doc/project_governance/checklist/README.md#assert_known_added
-[LINT_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#lint_setup
+[SPEC_COMPLETE]:              ../../../../../doc/project_governance/checklist/README.md#spec_complete
+[CSR_DEFINED]:                ../../../../../doc/project_governance/checklist/README.md#csr_defined
+[CLKRST_CONNECTED]:           ../../../../../doc/project_governance/checklist/README.md#clkrst_connected
+[IP_TOP]:                     ../../../../../doc/project_governance/checklist/README.md#ip_top
+[IP_INSTANTIABLE]:            ../../../../../doc/project_governance/checklist/README.md#ip_instantiable
+[PHYSICAL_MACROS_DEFINED_80]: ../../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
+[FUNC_IMPLEMENTED]:           ../../../../../doc/project_governance/checklist/README.md#func_implemented
+[ASSERT_KNOWN_ADDED]:         ../../../../../doc/project_governance/checklist/README.md#assert_known_added
+[LINT_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#lint_setup
 
 ### D2
 
@@ -52,24 +52,24 @@ Code Quality  | [AREA_CHECK][]            | Done        |
 Code Quality  | [TIMING_CHECK][]          | Done        |
 Security      | [SEC_CM_DOCUMENTED][]     | Done        |
 
-[NEW_FEATURES]:          ../../../../doc/project_governance/checklist/README.md#new_features
-[BLOCK_DIAGRAM]:         ../../../../doc/project_governance/checklist/README.md#block_diagram
-[DOC_INTERFACE]:         ../../../../doc/project_governance/checklist/README.md#doc_interface
-[DOC_INTEGRATION_GUIDE]: ../../../../doc/project_governance/checklist/README.md#doc_integration_guide
-[MISSING_FUNC]:          ../../../../doc/project_governance/checklist/README.md#missing_func
-[FEATURE_FROZEN]:        ../../../../doc/project_governance/checklist/README.md#feature_frozen
-[FEATURE_COMPLETE]:      ../../../../doc/project_governance/checklist/README.md#feature_complete
-[PORT_FROZEN]:           ../../../../doc/project_governance/checklist/README.md#port_frozen
-[ARCHITECTURE_FROZEN]:   ../../../../doc/project_governance/checklist/README.md#architecture_frozen
-[REVIEW_TODO]:           ../../../../doc/project_governance/checklist/README.md#review_todo
-[STYLE_X]:               ../../../../doc/project_governance/checklist/README.md#style_x
-[CDC_SYNCMACRO]:         ../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
-[LINT_PASS]:             ../../../../doc/project_governance/checklist/README.md#lint_pass
-[CDC_SETUP]:             ../../../../doc/project_governance/checklist/README.md#cdc_setup
-[RDC_SETUP]:             ../../../../doc/project_governance/checklist/README.md#rdc_setup
-[AREA_CHECK]:            ../../../../doc/project_governance/checklist/README.md#area_check
-[TIMING_CHECK]:          ../../../../doc/project_governance/checklist/README.md#timing_check
-[SEC_CM_DOCUMENTED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_documented
+[NEW_FEATURES]:          ../../../../../doc/project_governance/checklist/README.md#new_features
+[BLOCK_DIAGRAM]:         ../../../../../doc/project_governance/checklist/README.md#block_diagram
+[DOC_INTERFACE]:         ../../../../../doc/project_governance/checklist/README.md#doc_interface
+[DOC_INTEGRATION_GUIDE]: ../../../../../doc/project_governance/checklist/README.md#doc_integration_guide
+[MISSING_FUNC]:          ../../../../../doc/project_governance/checklist/README.md#missing_func
+[FEATURE_FROZEN]:        ../../../../../doc/project_governance/checklist/README.md#feature_frozen
+[FEATURE_COMPLETE]:      ../../../../../doc/project_governance/checklist/README.md#feature_complete
+[PORT_FROZEN]:           ../../../../../doc/project_governance/checklist/README.md#port_frozen
+[ARCHITECTURE_FROZEN]:   ../../../../../doc/project_governance/checklist/README.md#architecture_frozen
+[REVIEW_TODO]:           ../../../../../doc/project_governance/checklist/README.md#review_todo
+[STYLE_X]:               ../../../../../doc/project_governance/checklist/README.md#style_x
+[CDC_SYNCMACRO]:         ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
+[LINT_PASS]:             ../../../../../doc/project_governance/checklist/README.md#lint_pass
+[CDC_SETUP]:             ../../../../../doc/project_governance/checklist/README.md#cdc_setup
+[RDC_SETUP]:             ../../../../../doc/project_governance/checklist/README.md#rdc_setup
+[AREA_CHECK]:            ../../../../../doc/project_governance/checklist/README.md#area_check
+[TIMING_CHECK]:          ../../../../../doc/project_governance/checklist/README.md#timing_check
+[SEC_CM_DOCUMENTED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
 
 ### D2S
 
@@ -83,13 +83,13 @@ Security      | [SEC_CM_SHADOW_REGS][]       | Done        |
 Security      | [SEC_CM_RTL_REVIEWED][]      | Done        |
 Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Done        |
 
-[SEC_CM_ASSETS_LISTED]:    ../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
-[SEC_CM_IMPLEMENTED]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
-[SEC_CM_RND_CNST]:         ../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
-[SEC_CM_NON_RESET_FLOPS]:  ../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
-[SEC_CM_SHADOW_REGS]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
-[SEC_CM_RTL_REVIEWED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
-[SEC_CM_COUNCIL_REVIEWED]: ../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
+[SEC_CM_ASSETS_LISTED]:    ../../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
+[SEC_CM_IMPLEMENTED]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
+[SEC_CM_RND_CNST]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
+[SEC_CM_NON_RESET_FLOPS]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
+[SEC_CM_SHADOW_REGS]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
+[SEC_CM_RTL_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
+[SEC_CM_COUNCIL_REVIEWED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
 
 ### D3
 
@@ -107,15 +107,15 @@ Review        | [REVIEW_SW_ERRATA][]    | Done        |
 Review        | Reviewer(s)             | Done        | msf@ vogelpi@ chencindy@ ttrippel@ tjaychen@
 Review        | Signoff date            | Done        | 2022-07-11
 
-[NEW_FEATURES_D3]:      ../../../../doc/project_governance/checklist/README.md#new_features_d3
-[TODO_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#todo_complete
-[LINT_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#lint_complete
-[CDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#cdc_complete
-[RDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#rdc_complete
-[REVIEW_RTL]:           ../../../../doc/project_governance/checklist/README.md#review_rtl
-[REVIEW_DELETED_FF]:    ../../../../doc/project_governance/checklist/README.md#review_deleted_ff
-[REVIEW_SW_CHANGE]:     ../../../../doc/project_governance/checklist/README.md#review_sw_change
-[REVIEW_SW_ERRATA]:     ../../../../doc/project_governance/checklist/README.md#review_sw_errata
+[NEW_FEATURES_D3]:      ../../../../../doc/project_governance/checklist/README.md#new_features_d3
+[TODO_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#todo_complete
+[LINT_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#lint_complete
+[CDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#cdc_complete
+[RDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#rdc_complete
+[REVIEW_RTL]:           ../../../../../doc/project_governance/checklist/README.md#review_rtl
+[REVIEW_DELETED_FF]:    ../../../../../doc/project_governance/checklist/README.md#review_deleted_ff
+[REVIEW_SW_CHANGE]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_change
+[REVIEW_SW_ERRATA]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_errata
 
 ## Verification Checklist
 
@@ -146,28 +146,28 @@ Review        | [TESTPLAN_REVIEWED][]                 | Done        |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        |
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
-[DV_DOC_DRAFT_COMPLETED]:             ../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
-[TESTPLAN_COMPLETED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_completed
-[TB_TOP_CREATED]:                     ../../../../doc/project_governance/checklist/README.md#tb_top_created
-[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
-[SIM_TB_ENV_CREATED]:                 ../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
-[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
-[CSR_CHECK_GEN_AUTOMATED]:            ../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
-[TB_GEN_AUTOMATED]:                   ../../../../doc/project_governance/checklist/README.md#tb_gen_automated
-[SIM_SMOKE_TEST_PASSING]:             ../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
-[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
-[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
-[SIM_ALT_TOOL_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
-[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
-[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
-[FPV_REGRESSION_SETUP]:               ../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
-[SIM_COVERAGE_MODEL_ADDED]:           ../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
-[TB_LINT_SETUP]:                      ../../../../doc/project_governance/checklist/README.md#tb_lint_setup
-[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
-[DESIGN_SPEC_REVIEWED]:               ../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
-[TESTPLAN_REVIEWED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_reviewed
-[STD_TEST_CATEGORIES_PLANNED]:        ../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
-[V2_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
+[DV_DOC_DRAFT_COMPLETED]:             ../../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
+[TESTPLAN_COMPLETED]:                 ../../../../../doc/project_governance/checklist/README.md#testplan_completed
+[TB_TOP_CREATED]:                     ../../../../../doc/project_governance/checklist/README.md#tb_top_created
+[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
+[SIM_TB_ENV_CREATED]:                 ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
+[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
+[CSR_CHECK_GEN_AUTOMATED]:            ../../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
+[TB_GEN_AUTOMATED]:                   ../../../../../doc/project_governance/checklist/README.md#tb_gen_automated
+[SIM_SMOKE_TEST_PASSING]:             ../../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
+[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
+[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
+[SIM_ALT_TOOL_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
+[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
+[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
+[FPV_REGRESSION_SETUP]:               ../../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
+[SIM_COVERAGE_MODEL_ADDED]:           ../../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
+[TB_LINT_SETUP]:                      ../../../../../doc/project_governance/checklist/README.md#tb_lint_setup
+[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
+[DESIGN_SPEC_REVIEWED]:               ../../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
+[TESTPLAN_REVIEWED]:                  ../../../../../doc/project_governance/checklist/README.md#testplan_reviewed
+[STD_TEST_CATEGORIES_PLANNED]:        ../../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
+[V2_CHECKLIST_SCOPED]:                ../../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
 
 ### V2
 
@@ -194,42 +194,42 @@ Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
-[DESIGN_DELTAS_CAPTURED_V2]:          ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
-[DV_DOC_COMPLETED]:                   ../../../../doc/project_governance/checklist/README.md#dv_doc_completed
-[FUNCTIONAL_COVERAGE_IMPLEMENTED]:    ../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
-[ALL_INTERFACES_EXERCISED]:           ../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
-[ALL_ASSERTION_CHECKS_ADDED]:         ../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
-[SIM_TB_ENV_COMPLETED]:               ../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
-[SIM_ALL_TESTS_PASSING]:              ../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
-[FPV_ALL_ASSERTIONS_WRITTEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
-[FPV_ALL_ASSUMPTIONS_REVIEWED]:       ../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
-[SIM_FW_SIMULATED]:                   ../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
-[SIM_NIGHTLY_REGRESSION_V2]:          ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
-[SIM_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
-[SIM_FUNCTIONAL_COVERAGE_V2]:         ../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
-[FPV_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
-[FPV_COI_COVERAGE_V2]:                ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
-[PRE_VERIFIED_SUB_MODULES_V2]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
-[NO_HIGH_PRIORITY_ISSUES_PENDING]:    ../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
-[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
-[DV_DOC_TESTPLAN_REVIEWED]:           ../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
-[V3_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
+[DESIGN_DELTAS_CAPTURED_V2]:           ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
+[DV_DOC_COMPLETED]:                    ../../../../../doc/project_governance/checklist/README.md#dv_doc_completed
+[FUNCTIONAL_COVERAGE_IMPLEMENTED]:     ../../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
+[ALL_INTERFACES_EXERCISED]:            ../../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
+[ALL_ASSERTION_CHECKS_ADDED]:          ../../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
+[SIM_TB_ENV_COMPLETED]:                ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
+[SIM_ALL_TESTS_PASSING]:               ../../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
+[FPV_ALL_ASSERTIONS_WRITTEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
+[FPV_ALL_ASSUMPTIONS_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
+[SIM_FW_SIMULATED]:                    ../../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
+[SIM_NIGHTLY_REGRESSION_V2]:           ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
+[SIM_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
+[SIM_FUNCTIONAL_COVERAGE_V2]:          ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
+[FPV_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
+[FPV_COI_COVERAGE_V2]:                 ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
+[PRE_VERIFIED_SUB_MODULES_V2]:         ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
+[NO_HIGH_PRIORITY_ISSUES_PENDING]:     ../../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
+[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]: ../../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
+[DV_DOC_TESTPLAN_REVIEWED]:            ../../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
+[V3_CHECKLIST_SCOPED]:                 ../../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
 
 ### V2S
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Done        |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
 Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Done        |
 
-[SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
-[FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified
-[SIM_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
-[SIM_COVERAGE_REVIEWED]:              ../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
-[SEC_CM_DV_REVIEWED]:                 ../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
+[SEC_CM_TESTPLAN_COMPLETED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
+[FPV_SEC_CM_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven
+[SIM_SEC_CM_VERIFIED]:       ../../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
+[SIM_COVERAGE_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
+[SEC_CM_DV_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
 
 ### V3
 
@@ -251,16 +251,16 @@ Issues        | [NO_ISSUES_PENDING][]             | Not Started |
 Review        | Reviewer(s)                       | Not Started |
 Review        | Signoff date                      | Not Started |
 
-[DESIGN_DELTAS_CAPTURED_V3]:     ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
-[X_PROP_ANALYSIS_COMPLETED]:     ../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
-[FPV_ASSERTIONS_PROVEN_AT_V3]:   ../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
-[SIM_NIGHTLY_REGRESSION_AT_V3]:  ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
-[SIM_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
-[SIM_FUNCTIONAL_COVERAGE_AT_100]:../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
-[FPV_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
-[FPV_COI_COVERAGE_AT_100]:       ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
-[ALL_TODOS_RESOLVED]:            ../../../../doc/project_governance/checklist/README.md#all_todos_resolved
-[NO_TOOL_WARNINGS_THROWN]:       ../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
-[TB_LINT_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#tb_lint_complete
-[PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
-[NO_ISSUES_PENDING]:             ../../../../doc/project_governance/checklist/README.md#no_issues_pending
+[DESIGN_DELTAS_CAPTURED_V3]:      ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
+[X_PROP_ANALYSIS_COMPLETED]:      ../../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
+[FPV_ASSERTIONS_PROVEN_AT_V3]:    ../../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
+[SIM_NIGHTLY_REGRESSION_AT_V3]:   ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
+[SIM_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
+[SIM_FUNCTIONAL_COVERAGE_AT_100]: ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
+[FPV_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
+[FPV_COI_COVERAGE_AT_100]:        ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
+[ALL_TODOS_RESOLVED]:             ../../../../../doc/project_governance/checklist/README.md#all_todos_resolved
+[NO_TOOL_WARNINGS_THROWN]:        ../../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
+[TB_LINT_COMPLETE]:               ../../../../../doc/project_governance/checklist/README.md#tb_lint_complete
+[PRE_VERIFIED_SUB_MODULES_V3]:    ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
+[NO_ISSUES_PENDING]:              ../../../../../doc/project_governance/checklist/README.md#no_issues_pending

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/README.md
@@ -12,14 +12,14 @@
 
 ## Current status
 * [Design & verification stage](../../../README.md)
-  * [HW development stages](../../../../doc/project_governance/development_stages.md)
+  * [HW development stages](../../../../../doc/project_governance/development_stages.md)
 * [Simulation results](https://reports.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/dv/latest/report.html)
 
 ## Design features
 For detailed information on ALERT_HANDLER design features, please see the [ALERT_HANDLER HWIP technical specification](../README.md).
 
 ## Testbench architecture
-ALERT_HANDLER testbench has been constructed based on the [CIP testbench architecture](../../../dv/sv/cip_lib/README.md).
+ALERT_HANDLER testbench has been constructed based on the [CIP testbench architecture](../../../../dv/sv/cip_lib/README.md).
 
 ### Block diagram
 ![Block diagram](./doc/tb.svg)
@@ -27,19 +27,19 @@ ALERT_HANDLER testbench has been constructed based on the [CIP testbench archite
 ### Top level testbench
 Top level testbench is located at `hw/ip/alert_handler/dv/tb/tb.sv`. It instantiates the ALERT_HANDLER DUT module `hw/ip/alert_handler/rtl/alert_handler.sv`.
 In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
-* [Clock and reset interface](../../../dv/sv/common_ifs/README.md)
-* [TileLink host interface](../../../dv/sv/tl_agent/README.md)
+* [Clock and reset interface](../../../../dv/sv/common_ifs/README.md)
+* [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
 * ALERT_HANDLER IOs
-* Alerts and escalations([`alert_esc_if`](../../../dv/sv/alert_esc_agent/README.md))
-* Interrupts ([`pins_if`](../../../dv/sv/common_ifs/README.md))
-* Devmode ([`pins_if`](../../../dv/sv/common_ifs/README.md))
+* Alerts and escalations([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
+* Interrupts ([`pins_if`](../../../../dv/sv/common_ifs/README.md#pins_if))
+* Devmode ([`pins_if`](../../../../dv/sv/common_ifs/README.md#pins_if))
 
 The alert_handler testbench environment can be reused in chip level testing.
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
-* [dv_utils_pkg](../../../dv/sv/dv_utils/README.md)
-* [csr_utils_pkg](../../../dv/sv/csr_utils/README.md)
+* [dv_utils_pkg](../../../../dv/sv/dv_utils/README.md)
+* [csr_utils_pkg](../../../../dv/sv/csr_utils/README.md)
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
@@ -49,18 +49,18 @@ All common types and methods defined at the package level can be found in
 ```
 
 ### TL_agent
-ALERT_HANDLER testbench instantiates (already handled in CIP base env) [tl_agent](../../../dv/sv/tl_agent/README.md)
+ALERT_HANDLER testbench instantiates (already handled in CIP base env) [tl_agent](../../../../dv/sv/tl_agent/README.md)
 which provides the ability to drive and independently monitor random traffic via
 TL host interface into ALERT_HANDLER device.
 
 ### ALERT_ESC Agent
-[ALERT_ESC agent](../../../dv/sv/alert_esc_agent/README.md) is used to drive and monitor transmitter and receiver pairs for the alerts and escalators.
+[ALERT_ESC agent](../../../../dv/sv/alert_esc_agent/README.md) is used to drive and monitor transmitter and receiver pairs for the alerts and escalators.
 Alert_handler DUT includes alert_receivers and esc_senders, so the alert_esc agent will drive output signals of the alert_senders and esc_receivers.
 
 ### UVM RAL Model
-The ALERT_HANDLER RAL model is created with the [`ralgen`](../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
+The ALERT_HANDLER RAL model is created with the [`ralgen`](../../../../dv/tools/ralgen/README.md) FuseSoC generator script automatically when the simulation is at the build stage.
 
-It can be created manually by invoking [`regtool`](../../../../util/reggen/doc/setup_and_use.md).
+It can be created manually by invoking [`regtool`](../../../../../util/reggen/doc/setup_and_use.md).
 
 ### Stimulus strategy
 #### Test sequences
@@ -104,11 +104,11 @@ To ensure certain alert, interrupt, or escalation signals are triggered at the e
 The alert_handler scoreboard is parameterized to support different number of classes, alert pairs, and escalation pairs.
 
 #### Assertions
-* TLUL assertions: The `tb/alert_handler_bind.sv` binds the `tlul_assert` [assertions](../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
+* TLUL assertions: The `tb/alert_handler_bind.sv` binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
 
 ## Building and running tests
-We are using our in-house developed [regression tool](../../../../util/dvsim/README.md) for building and running our tests and regressions.
+We are using our in-house developed [regression tool](../../../../../util/dvsim/README.md) for building and running our tests and regressions.
 Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
 Here's how to run a smoke test:
 ```console

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
@@ -51,7 +51,6 @@ Code Quality  | [CDC_SETUP][]           | N/A         |
 Code Quality  | [TIMING_CHECK][]        | Done        | Fmax @ 50MHz on NexysVideo
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
 Security      | [SEC_CM_DOCUMENTED][]   | N/A         |
-Security      | [SEC_RND_CNST][]        | N/A         |
 
 [NEW_FEATURES]:        ../../../../../doc/project_governance/checklist/README.md#new_features
 [BLOCK_DIAGRAM]:       ../../../../../doc/project_governance/checklist/README.md#block_diagram
@@ -69,7 +68,6 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 [TIMING_CHECK]:         ../../../../../doc/project_governance/checklist/README.md#timing_check
 [CDC_SYNCMACRO]:       ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
 [SEC_CM_DOCUMENTED]:   ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
-[SEC_RND_CNST]:        ../../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
 
 ### D2S
 

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
@@ -1,7 +1,7 @@
 # RV_PLIC Checklist
 
-This checklist is for [Hardware Stage](../../../../doc/project_governance/development_stages.md) transitions for the [RV_PLIC peripheral](../README.md).
-All checklist items refer to the content in the [Checklist.](../../../../doc/project_governance/checklist/README.md)
+This checklist is for [Hardware Stage](../../../../../doc/project_governance/development_stages.md) transitions for the [RV_PLIC peripheral](../README.md).
+All checklist items refer to the content in the [Checklist.](../../../../../doc/project_governance/checklist/README.md)
 
 ## Design Checklist
 
@@ -21,15 +21,15 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 
 [RV_PLIC Spec]: ../README.md
 
-[SPEC_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#spec_complete
-[CSR_DEFINED]:                ../../../../doc/project_governance/checklist/README.md#csr_defined
-[CLKRST_CONNECTED]:           ../../../../doc/project_governance/checklist/README.md#clkrst_connected
-[IP_TOP]:                     ../../../../doc/project_governance/checklist/README.md#ip_top
-[IP_INSTANTIABLE]:            ../../../../doc/project_governance/checklist/README.md#ip_instantiable
-[PHYSICAL_MACROS_DEFINED_80]: ../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
-[FUNC_IMPLEMENTED]:           ../../../../doc/project_governance/checklist/README.md#func_implemented
-[ASSERT_KNOWN_ADDED]:         ../../../../doc/project_governance/checklist/README.md#assert_known_added
-[LINT_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#lint_setup
+[SPEC_COMPLETE]:              ../../../../../doc/project_governance/checklist/README.md#spec_complete
+[CSR_DEFINED]:                ../../../../../doc/project_governance/checklist/README.md#csr_defined
+[CLKRST_CONNECTED]:           ../../../../../doc/project_governance/checklist/README.md#clkrst_connected
+[IP_TOP]:                     ../../../../../doc/project_governance/checklist/README.md#ip_top
+[IP_INSTANTIABLE]:            ../../../../../doc/project_governance/checklist/README.md#ip_instantiable
+[PHYSICAL_MACROS_DEFINED_80]: ../../../../../doc/project_governance/checklist/README.md#physical_macros_defined_80
+[FUNC_IMPLEMENTED]:           ../../../../../doc/project_governance/checklist/README.md#func_implemented
+[ASSERT_KNOWN_ADDED]:         ../../../../../doc/project_governance/checklist/README.md#assert_known_added
+[LINT_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#lint_setup
 
 ### D2
 
@@ -48,28 +48,28 @@ RTL           | [REVIEW_TODO][]         | Done        | One TODO about Vivado Is
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |
 Code Quality  | [CDC_SETUP][]           | N/A         |
-Code Quality  | [FPGA_TIMING][]         | Done        | Fmax @ 50MHz on NexysVideo
+Code Quality  | [TIMING_CHECK][]        | Done        | Fmax @ 50MHz on NexysVideo
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
 Security      | [SEC_CM_DOCUMENTED][]   | N/A         |
 Security      | [SEC_RND_CNST][]        | N/A         |
 
-[NEW_FEATURES]:        ../../../../doc/project_governance/checklist/README.md#new_features
-[BLOCK_DIAGRAM]:       ../../../../doc/project_governance/checklist/README.md#block_diagram
-[DOC_INTERFACE]:       ../../../../doc/project_governance/checklist/README.md#doc_interface
-[MISSING_FUNC]:        ../../../../doc/project_governance/checklist/README.md#missing_func
-[FEATURE_FROZEN]:      ../../../../doc/project_governance/checklist/README.md#feature_frozen
-[FEATURE_COMPLETE]:    ../../../../doc/project_governance/checklist/README.md#feature_complete
-[AREA_CHECK]:          ../../../../doc/project_governance/checklist/README.md#area_check
-[PORT_FROZEN]:         ../../../../doc/project_governance/checklist/README.md#port_frozen
-[ARCHITECTURE_FROZEN]: ../../../../doc/project_governance/checklist/README.md#architecture_frozen
-[REVIEW_TODO]:         ../../../../doc/project_governance/checklist/README.md#review_todo
-[STYLE_X]:             ../../../../doc/project_governance/checklist/README.md#style_x
-[LINT_PASS]:           ../../../../doc/project_governance/checklist/README.md#lint_pass
-[CDC_SETUP]:           ../../../../doc/project_governance/checklist/README.md#cdc_setup
-[FPGA_TIMING]:         ../../../../doc/project_governance/checklist/README.md#fpga_timing
-[CDC_SYNCMACRO]:       ../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
-[SEC_CM_DOCUMENTED]:   ../../../../doc/project_governance/checklist/README.md#sec_cm_documented
-[SEC_RND_CNST]:        ../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
+[NEW_FEATURES]:        ../../../../../doc/project_governance/checklist/README.md#new_features
+[BLOCK_DIAGRAM]:       ../../../../../doc/project_governance/checklist/README.md#block_diagram
+[DOC_INTERFACE]:       ../../../../../doc/project_governance/checklist/README.md#doc_interface
+[MISSING_FUNC]:        ../../../../../doc/project_governance/checklist/README.md#missing_func
+[FEATURE_FROZEN]:      ../../../../../doc/project_governance/checklist/README.md#feature_frozen
+[FEATURE_COMPLETE]:    ../../../../../doc/project_governance/checklist/README.md#feature_complete
+[AREA_CHECK]:          ../../../../../doc/project_governance/checklist/README.md#area_check
+[PORT_FROZEN]:         ../../../../../doc/project_governance/checklist/README.md#port_frozen
+[ARCHITECTURE_FROZEN]: ../../../../../doc/project_governance/checklist/README.md#architecture_frozen
+[REVIEW_TODO]:         ../../../../../doc/project_governance/checklist/README.md#review_todo
+[STYLE_X]:             ../../../../../doc/project_governance/checklist/README.md#style_x
+[LINT_PASS]:           ../../../../../doc/project_governance/checklist/README.md#lint_pass
+[CDC_SETUP]:           ../../../../../doc/project_governance/checklist/README.md#cdc_setup
+[TIMING_CHECK]:         ../../../../../doc/project_governance/checklist/README.md#timing_check
+[CDC_SYNCMACRO]:       ../../../../../doc/project_governance/checklist/README.md#cdc_syncmacro
+[SEC_CM_DOCUMENTED]:   ../../../../../doc/project_governance/checklist/README.md#sec_cm_documented
+[SEC_RND_CNST]:        ../../../../../doc/project_governance/checklist/README.md#sec_rnd_cnst
 
 ### D2S
 
@@ -83,13 +83,13 @@ Security      | [SEC_CM_SHADOW_REGS][]       | N/A         |
 Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
 Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
-[SEC_CM_ASSETS_LISTED]:    ../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
-[SEC_CM_IMPLEMENTED]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
-[SEC_CM_RND_CNST]:         ../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
-[SEC_CM_NON_RESET_FLOPS]:  ../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
-[SEC_CM_SHADOW_REGS]:      ../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
-[SEC_CM_RTL_REVIEWED]:     ../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
-[SEC_CM_COUNCIL_REVIEWED]: ../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
+[SEC_CM_ASSETS_LISTED]:    ../../../../../doc/project_governance/checklist/README.md#sec_cm_assets_listed
+[SEC_CM_IMPLEMENTED]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_implemented
+[SEC_CM_RND_CNST]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_rnd_cnst
+[SEC_CM_NON_RESET_FLOPS]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_non_reset_flops
+[SEC_CM_SHADOW_REGS]:      ../../../../../doc/project_governance/checklist/README.md#sec_cm_shadow_regs
+[SEC_CM_RTL_REVIEWED]:     ../../../../../doc/project_governance/checklist/README.md#sec_cm_rtl_reviewed
+[SEC_CM_COUNCIL_REVIEWED]: ../../../../../doc/project_governance/checklist/README.md#sec_cm_council_reviewed
 
 ### D3
 
@@ -107,15 +107,15 @@ Review        | [REVIEW_SW_ERRATA][]    | Done        |
 Review        | Reviewer(s)             | Done        | eunchan@ gac@ chencindy@ ttrippel@
 Review        | Signoff date            | Done        | 2022-07-25
 
-[NEW_FEATURES_D3]:      ../../../../doc/project_governance/checklist/README.md#new_features_d3
-[TODO_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#todo_complete
-[LINT_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#lint_complete
-[CDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#cdc_complete
-[RDC_COMPLETE]:         ../../../../doc/project_governance/checklist/README.md#rdc_complete
-[REVIEW_RTL]:           ../../../../doc/project_governance/checklist/README.md#review_rtl
-[REVIEW_DELETED_FF]:    ../../../../doc/project_governance/checklist/README.md#review_deleted_ff
-[REVIEW_SW_CHANGE]:     ../../../../doc/project_governance/checklist/README.md#review_sw_change
-[REVIEW_SW_ERRATA]:     ../../../../doc/project_governance/checklist/README.md#review_sw_errata
+[NEW_FEATURES_D3]:      ../../../../../doc/project_governance/checklist/README.md#new_features_d3
+[TODO_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#todo_complete
+[LINT_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#lint_complete
+[CDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#cdc_complete
+[RDC_COMPLETE]:         ../../../../../doc/project_governance/checklist/README.md#rdc_complete
+[REVIEW_RTL]:           ../../../../../doc/project_governance/checklist/README.md#review_rtl
+[REVIEW_DELETED_FF]:    ../../../../../doc/project_governance/checklist/README.md#review_deleted_ff
+[REVIEW_SW_CHANGE]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_change
+[REVIEW_SW_ERRATA]:     ../../../../../doc/project_governance/checklist/README.md#review_sw_errata
 
 ## Verification Checklist
 
@@ -146,28 +146,28 @@ Review        | [TESTPLAN_REVIEWED][]                 | Done        |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | N/A         |
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
-[DV_DOC_DRAFT_COMPLETED]:             ../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
-[TESTPLAN_COMPLETED]:                 ../../../../doc/project_governance/checklist/README.md#testplan_completed
-[TB_TOP_CREATED]:                     ../../../../doc/project_governance/checklist/README.md#tb_top_created
-[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
-[SIM_TB_ENV_CREATED]:                 ../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
-[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
-[CSR_CHECK_GEN_AUTOMATED]:            ../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
-[TB_GEN_AUTOMATED]:                   ../../../../doc/project_governance/checklist/README.md#tb_gen_automated
-[SIM_SMOKE_TEST_PASSING]:             ../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
-[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
-[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
-[SIM_ALT_TOOL_SETUP]:                 ../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
-[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
-[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
-[FPV_REGRESSION_SETUP]:               ../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
-[SIM_COVERAGE_MODEL_ADDED]:           ../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
-[TB_LINT_SETUP]:                      ../../../../doc/project_governance/checklist/README.md#tb_lint_setup
-[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
-[DESIGN_SPEC_REVIEWED]:               ../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
-[TESTPLAN_REVIEWED]:                  ../../../../doc/project_governance/checklist/README.md#testplan_reviewed
-[STD_TEST_CATEGORIES_PLANNED]:        ../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
-[V2_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
+[DV_DOC_DRAFT_COMPLETED]:             ../../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
+[TESTPLAN_COMPLETED]:                 ../../../../../doc/project_governance/checklist/README.md#testplan_completed
+[TB_TOP_CREATED]:                     ../../../../../doc/project_governance/checklist/README.md#tb_top_created
+[PRELIMINARY_ASSERTION_CHECKS_ADDED]: ../../../../../doc/project_governance/checklist/README.md#preliminary_assertion_checks_added
+[SIM_TB_ENV_CREATED]:                 ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_created
+[SIM_RAL_MODEL_GEN_AUTOMATED]:        ../../../../../doc/project_governance/checklist/README.md#sim_ral_model_gen_automated
+[CSR_CHECK_GEN_AUTOMATED]:            ../../../../../doc/project_governance/checklist/README.md#csr_check_gen_automated
+[TB_GEN_AUTOMATED]:                   ../../../../../doc/project_governance/checklist/README.md#tb_gen_automated
+[SIM_SMOKE_TEST_PASSING]:             ../../../../../doc/project_governance/checklist/README.md#sim_smoke_test_passing
+[SIM_CSR_MEM_TEST_SUITE_PASSING]:     ../../../../../doc/project_governance/checklist/README.md#sim_csr_mem_test_suite_passing
+[FPV_MAIN_ASSERTIONS_PROVEN]:         ../../../../../doc/project_governance/checklist/README.md#fpv_main_assertions_proven
+[SIM_ALT_TOOL_SETUP]:                 ../../../../../doc/project_governance/checklist/README.md#sim_alt_tool_setup
+[SIM_SMOKE_REGRESSION_SETUP]:         ../../../../../doc/project_governance/checklist/README.md#sim_smoke_regression_setup
+[SIM_NIGHTLY_REGRESSION_SETUP]:       ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_setup
+[FPV_REGRESSION_SETUP]:               ../../../../../doc/project_governance/checklist/README.md#fpv_regression_setup
+[SIM_COVERAGE_MODEL_ADDED]:           ../../../../../doc/project_governance/checklist/README.md#sim_coverage_model_added
+[TB_LINT_SETUP]:                      ../../../../../doc/project_governance/checklist/README.md#tb_lint_setup
+[PRE_VERIFIED_SUB_MODULES_V1]:        ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v1
+[DESIGN_SPEC_REVIEWED]:               ../../../../../doc/project_governance/checklist/README.md#design_spec_reviewed
+[TESTPLAN_REVIEWED]:                  ../../../../../doc/project_governance/checklist/README.md#testplan_reviewed
+[STD_TEST_CATEGORIES_PLANNED]:        ../../../../../doc/project_governance/checklist/README.md#std_test_categories_planned
+[V2_CHECKLIST_SCOPED]:                ../../../../../doc/project_governance/checklist/README.md#v2_checklist_scoped
 
 ### V2
 
@@ -194,42 +194,42 @@ Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
 Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
-[DESIGN_DELTAS_CAPTURED_V2]:          ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
-[DV_DOC_COMPLETED]:                   ../../../../doc/project_governance/checklist/README.md#dv_doc_completed
-[FUNCTIONAL_COVERAGE_IMPLEMENTED]:    ../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
-[ALL_INTERFACES_EXERCISED]:           ../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
-[ALL_ASSERTION_CHECKS_ADDED]:         ../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
-[SIM_TB_ENV_COMPLETED]:               ../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
-[SIM_ALL_TESTS_PASSING]:              ../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
-[FPV_ALL_ASSERTIONS_WRITTEN]:         ../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
-[FPV_ALL_ASSUMPTIONS_REVIEWED]:       ../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
-[SIM_FW_SIMULATED]:                   ../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
-[SIM_NIGHTLY_REGRESSION_V2]:          ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
-[SIM_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
-[SIM_FUNCTIONAL_COVERAGE_V2]:         ../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
-[FPV_CODE_COVERAGE_V2]:               ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
-[FPV_COI_COVERAGE_V2]:                ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
-[PRE_VERIFIED_SUB_MODULES_V2]:        ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
-[NO_HIGH_PRIORITY_ISSUES_PENDING]:    ../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
-[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
-[DV_DOC_TESTPLAN_REVIEWED]:           ../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
-[V3_CHECKLIST_SCOPED]:                ../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
+[DESIGN_DELTAS_CAPTURED_V2]:           ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v2
+[DV_DOC_COMPLETED]:                    ../../../../../doc/project_governance/checklist/README.md#dv_doc_completed
+[FUNCTIONAL_COVERAGE_IMPLEMENTED]:     ../../../../../doc/project_governance/checklist/README.md#functional_coverage_implemented
+[ALL_INTERFACES_EXERCISED]:            ../../../../../doc/project_governance/checklist/README.md#all_interfaces_exercised
+[ALL_ASSERTION_CHECKS_ADDED]:          ../../../../../doc/project_governance/checklist/README.md#all_assertion_checks_added
+[SIM_TB_ENV_COMPLETED]:                ../../../../../doc/project_governance/checklist/README.md#sim_tb_env_completed
+[SIM_ALL_TESTS_PASSING]:               ../../../../../doc/project_governance/checklist/README.md#sim_all_tests_passing
+[FPV_ALL_ASSERTIONS_WRITTEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_all_assertions_written
+[FPV_ALL_ASSUMPTIONS_REVIEWED]:        ../../../../../doc/project_governance/checklist/README.md#fpv_all_assumptions_reviewed
+[SIM_FW_SIMULATED]:                    ../../../../../doc/project_governance/checklist/README.md#sim_fw_simulated
+[SIM_NIGHTLY_REGRESSION_V2]:           ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_v2
+[SIM_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_v2
+[SIM_FUNCTIONAL_COVERAGE_V2]:          ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_v2
+[FPV_CODE_COVERAGE_V2]:                ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_v2
+[FPV_COI_COVERAGE_V2]:                 ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_v2
+[PRE_VERIFIED_SUB_MODULES_V2]:         ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v2
+[NO_HIGH_PRIORITY_ISSUES_PENDING]:     ../../../../../doc/project_governance/checklist/README.md#no_high_priority_issues_pending
+[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]: ../../../../../doc/project_governance/checklist/README.md#all_low_priority_issues_root_caused
+[DV_DOC_TESTPLAN_REVIEWED]:            ../../../../../doc/project_governance/checklist/README.md#dv_doc_testplan_reviewed
+[V3_CHECKLIST_SCOPED]:                 ../../../../../doc/project_governance/checklist/README.md#v3_checklist_scoped
 
 ### V2S
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Not Started |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
 Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
 
-[SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
-[FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified
-[SIM_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
-[SIM_COVERAGE_REVIEWED]:              ../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
-[SEC_CM_DV_REVIEWED]:                 ../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
+[SEC_CM_TESTPLAN_COMPLETED]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
+[FPV_SEC_CM_PROVEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven
+[SIM_SEC_CM_VERIFIED]:        ../../../../../doc/project_governance/checklist/README.md#sim_sec_cm_verified
+[SIM_COVERAGE_REVIEWED]:      ../../../../../doc/project_governance/checklist/README.md#sim_coverage_reviewed
+[SEC_CM_DV_REVIEWED]:         ../../../../../doc/project_governance/checklist/README.md#sec_cm_dv_reviewed
 
 ### V3
 
@@ -251,16 +251,16 @@ Issues        | [NO_ISSUES_PENDING][]             | Not Started |
 Review        | Reviewer(s)                       | Not Started |
 Review        | Signoff date                      | Not Started |
 
-[DESIGN_DELTAS_CAPTURED_V3]:     ../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
-[X_PROP_ANALYSIS_COMPLETED]:     ../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
-[FPV_ASSERTIONS_PROVEN_AT_V3]:   ../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
-[SIM_NIGHTLY_REGRESSION_AT_V3]:  ../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
-[SIM_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
-[SIM_FUNCTIONAL_COVERAGE_AT_100]:../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
-[FPV_CODE_COVERAGE_AT_100]:      ../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
-[FPV_COI_COVERAGE_AT_100]:       ../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
-[ALL_TODOS_RESOLVED]:            ../../../../doc/project_governance/checklist/README.md#all_todos_resolved
-[NO_TOOL_WARNINGS_THROWN]:       ../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
-[TB_LINT_COMPLETE]:              ../../../../doc/project_governance/checklist/README.md#tb_lint_complete
-[PRE_VERIFIED_SUB_MODULES_V3]:   ../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
-[NO_ISSUES_PENDING]:             ../../../../doc/project_governance/checklist/README.md#no_issues_pending
+[DESIGN_DELTAS_CAPTURED_V3]:      ../../../../../doc/project_governance/checklist/README.md#design_deltas_captured_v3
+[X_PROP_ANALYSIS_COMPLETED]:      ../../../../../doc/project_governance/checklist/README.md#x_prop_analysis_completed
+[FPV_ASSERTIONS_PROVEN_AT_V3]:    ../../../../../doc/project_governance/checklist/README.md#fpv_assertions_proven_at_v3
+[SIM_NIGHTLY_REGRESSION_AT_V3]:   ../../../../../doc/project_governance/checklist/README.md#sim_nightly_regression_at_v3
+[SIM_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#sim_code_coverage_at_100
+[SIM_FUNCTIONAL_COVERAGE_AT_100]: ../../../../../doc/project_governance/checklist/README.md#sim_functional_coverage_at_100
+[FPV_CODE_COVERAGE_AT_100]:       ../../../../../doc/project_governance/checklist/README.md#fpv_code_coverage_at_100
+[FPV_COI_COVERAGE_AT_100]:        ../../../../../doc/project_governance/checklist/README.md#fpv_coi_coverage_at_100
+[ALL_TODOS_RESOLVED]:             ../../../../../doc/project_governance/checklist/README.md#all_todos_resolved
+[NO_TOOL_WARNINGS_THROWN]:        ../../../../../doc/project_governance/checklist/README.md#no_tool_warnings_thrown
+[TB_LINT_COMPLETE]:               ../../../../../doc/project_governance/checklist/README.md#tb_lint_complete
+[PRE_VERIFIED_SUB_MODULES_V3]:    ../../../../../doc/project_governance/checklist/README.md#pre_verified_sub_modules_v3
+[NO_ISSUES_PENDING]:              ../../../../../doc/project_governance/checklist/README.md#no_issues_pending

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/dv/README.md
@@ -11,7 +11,7 @@
 
 ## Current status
 * [Design & verification stage](../../../../README.md)
-  * [HW development stages](../../../../../doc/project_governance/development_stages.md)
+  * [HW development stages](../../../../../../doc/project_governance/development_stages.md)
 * FPV dashboard (link TBD)
 
 ## Design features
@@ -20,13 +20,13 @@ For detailed information on RV_PLIC design features, please see the
 
 ## Testbench architecture
 RV_PLIC FPV testbench has been constructed based on the [formal
-architecture](../../../../formal/README.md).
+architecture](../../../../../formal/README.md).
 
 ### Block diagram
 ![Block diagram](fpv.svg)
 
 #### TLUL assertions
-* The file `rv_plic_bind.sv` binds the `tlul_assert` [assertions](../../../../ip/tlul/doc/TlulProtocolChecker.md)
+* The file `rv_plic_bind.sv` binds the `tlul_assert` [assertions](../../../../../ip/tlul/doc/TlulProtocolChecker.md)
   to rv_plic to ensure TileLink interface protocol compliance.
 * The `hw/rv_plic/fpv/tb/rv_plic_bind.sv` also binds the `rv_plic_csr_assert_fpv`
   under `fpv/vip/` to check if TileLink writes and reads correct
@@ -42,7 +42,7 @@ is used to reduce the number of repeated assertions code. In RV_PLIC, we
 declared two symbolic variables `src_sel` and `tgt_sel` to represent the index for
 interrupt source and interrupt target.
 Detailed explanation is listed in the
-[Symbolic Variables](../../../../formal/README.md#symbolic-variables) section.
+[Symbolic Variables](../../../../../formal/README.md#symbolic-variables) section.
 
 ## Testplan
-[Testplan](../data/rv_plic_fpv_testplan.hjson)
+[Testplan](../../data/rv_plic_fpv_testplan.hjson)

--- a/sw/README.md
+++ b/sw/README.md
@@ -1,7 +1,7 @@
 # Software
 
 This is the landing spot for software documentation within the OpenTitan project.
-More description and information can be found within the [Reference Manual](../util/README.md) and [User Guide](https://docs.opentitan.org/doc/guides/getting_started/) areas.
+More description and information can be found within the [Reference Manual](../util/README.md) and [User Guide](https://opentitan.org/guides/getting_started) areas.
 
 There are three major parts to the OpenTitan software stack:
 

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -63,7 +63,7 @@ DIFs are very low-level software, so they have a more rigorous coding style than
 other parts of the codebase.
 
 DIFs should follow the [OpenTitan C/C++ style
-guide](https://docs.opentitan.org/doc/rm/c_cpp_coding_style/) where it does not
+guide](../../../../doc/contributing/style_guides/c_cpp_coding_style.md) where it does not
 contradict with the guidelines below.
 
 The guidelines below apply to writing DIFs, and code should be written in a

--- a/sw/device/lib/testing/test_rom/README.md
+++ b/sw/device/lib/testing/test_rom/README.md
@@ -1,7 +1,7 @@
 # Test Boot ROM
 
 The Boot ROM is a **testing-only** device image.
-The [ROM](https://docs.opentitan.org/sw/device/silicon_creator/rom/docs/) is the reference implementation of the OpenTitan Secure Boot specification.
+The [ROM](https://opentitan.org/book/sw/device/silicon_creator/rom) is the reference implementation of the OpenTitan Secure Boot specification.
 
 The boot ROM is always the first piece of code run in the system.
 At the moment, it serves 2 functions:

--- a/sw/device/silicon_creator/manuf/README.md
+++ b/sw/device/silicon_creator/manuf/README.md
@@ -2,4 +2,4 @@
 
 ## Testplan
 
-- [Test Plan](./sw/device/silicon_creator/manuf/data/manuf_testplan.hjson)
+- [Test Plan](data/manuf_testplan.hjson)

--- a/sw/device/silicon_creator/rom_ext/doc/manifest.md
+++ b/sw/device/silicon_creator/rom_ext/doc/manifest.md
@@ -81,7 +81,7 @@ the manifest is 896 bytes.
 
 *   `address_translation`: A hardened boolean representing whether address
     translation should be used for the `ROM_EXT` (see the [Ibex wrapper
-    documentation](https://docs.opentitan.org/hw/ip/rv_core_ibex/doc/)).
+    documentation](https://opentitan.org/book/hw/ip/rv_core_ibex)).
     This value should be either `0x739` (true) or `0x1d4` (false).
 
 *   `identifier`: Image identifier used to identify boot stage images. The
@@ -120,4 +120,4 @@ the manifest is 896 bytes.
     the start of the manifest in bytes. Must be 4-byte word aligned.
 
 [rsassa_pkcs1_v1_5]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
-[key_manager]: https://docs.opentitan.org/hw/ip/keymgr/doc/
+[key_manager]: https://opentitan.org/book/hw/ip/keymgr

--- a/util/dvsim/README.md
+++ b/util/dvsim/README.md
@@ -39,7 +39,7 @@ Note that you may have already done this if you followed the getting started ste
 
 # Other related documents
 
-* [Testplanner tool](./doc/testplanner)
+* [Testplanner tool](./doc/testplanner.md)
 * [Design document](./doc/design_doc.md)
 * [Glossary](./doc/glossary.md)
 

--- a/util/dvsim/README.md
+++ b/util/dvsim/README.md
@@ -18,7 +18,7 @@ The following flows are currently supported:
 
 # Installation
 
-Clone the OpenTitan repository by following the [Getting Started](https://docs.opentitan.org/doc/guides/getting_started/) steps.
+Clone the OpenTitan repository by following the [Getting Started](https://opentitan.org/guides/getting_started) steps.
 The rest of the documentation will assume `$REPO_TOP` as the root of the local OpenTitan repository.
 DVSim is located at `$REPO_TOP/util/dvsim/dvsim.py`.
 

--- a/util/dvsim/doc/testplanner.md
+++ b/util/dvsim/doc/testplanner.md
@@ -4,7 +4,7 @@
 * Expanding the testplan inline within the DV document as a table;
 * Annotating the simulation results with testplan entries for a document driven DV execution;
 
-Please see [DV methodology](../../doc/contributing/dv/methodology/README.md#documentation) for more details on the rationale and motivation for writing and maintaining testplans in a machine-parseable format (`Hjson`).
+Please see [DV methodology](../../../doc/contributing/dv/methodology/README.md#documentation) for more details on the rationale and motivation for writing and maintaining testplans in a machine-parseable format (`Hjson`).
 This document will focus on the anatomy of an Hjson testplan, the list of features supported and some of the ways of using the tool.
 
 ## Hjson testplan
@@ -15,7 +15,7 @@ A testplan consists of a list of planned tests (testpoints) and a list of planne
 
 A testpoint is an entry in the testplan representing a planned test.
 Each testpoint maps one-to-one to a unique feature of the design.
-Additionally, a testpoint for each of the [key areas of focus](../../doc/contributing/dv/methodology/README.md#key-test-focus-areas) (whichever ones are applicable) is also captured in the testplan.
+Additionally, a testpoint for each of the [key areas of focus](../../../doc/contributing/dv/methodology/README.md#key-test-focus-areas) (whichever ones are applicable) is also captured in the testplan.
 
 The following attributes are used to define each testpoint, at minimum:
 * **name: testpoint name**
@@ -36,11 +36,11 @@ The following attributes are used to define each testpoint, at minimum:
     A multi-line string that briefly describes the intent of the test.
     It is recommended, but not always necessary to add a high level goal, stimulus, and the checking procedure so that the reader gets a clear idea of what and how the said feature is going to be tested.
 
-    Full [Markdown](../../doc/contributing/style_guides/markdown_usage_style.md) syntax is supported when writing the description.
+    Full [Markdown](../../../doc/contributing/style_guides/markdown_usage_style.md) syntax is supported when writing the description.
 
 * **tests: list of written test(s) for this testpoint**
 
-    The testplan is written in the initial work stage of the verification [life-cycle](../../doc/project_governance/development_stages.md#hardware-verification-stages).
+    The testplan is written in the initial work stage of the verification [life-cycle](../../../doc/project_governance/development_stages.md#hardware-verification-stages-v).
     Later, when the DV engineer writes the tests, they may not map one-to-one to a testpoint - it may be possible that a written test satisfactorily addresses multiple testpoints; OR it may also be possible that a testpoint needs to be split into multiple smaller tests.
     To cater to these needs, we provide the ability to set a list of written tests for each testpoint.
     It is used to not only indicate the current progress so far into each verification stage, but also map the simulation results to the testpoints to generate the final report table.
@@ -210,7 +210,7 @@ The following examples provided within `util/dvsim/examples/testplanner` can be 
 * **`common_testplan.hjson`**: shared testplan imported within the DUT testplan
 * **`foo_dv_doc.md`**: DUT testplan imported within the DV document doc in Markdown
 
-In addition, see the [UART DV document](../../hw/ip/uart/dv/README.md) for a 'production' example of inline expansion of an imported testplan as a table within the DV document.
+In addition, see the [UART DV document](../../../hw/ip/uart/dv/README.md) for a 'production' example of inline expansion of an imported testplan as a table within the DV document.
 The [UART testplan](https://github.com/lowRISC/opentitan/blob/master/hw/ip/uart/data/uart_testplan.hjson) imports some of the shared testplans located at `hw/dv/tools/dvsim/testplans` area.
 
 ### Limitations


### PR DESCRIPTION
This fixes broken links in the documentation. Broken links were found using  [`lychee`](https://github.com/lycheeverse/lychee).

```sh
cargo install lychee
lychee . -o /tmp/output.md -f markdown --require-https --exclude-all-private --cache --exclude-path sw/vendor/ --exclude-path hw/vendor/ --exclude-path site/ --exclude-path hw/ip_templates
```

*Note: Currently links between books have to be URLs. Lychee can't check for this.*

These changes are split over two PRs to make reviews easier. This PR has the large number of fixes to internal links. The second PR, https://github.com/lowRISC/opentitan/pull/17655, fewer more miscellaneous changes.

Fixes: https://github.com/lowRISC/opentitan/issues/17588