### PR TITLE
[usbdev] Clarify/tidy alerts

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -699,8 +699,8 @@ module usbdev
     reg2hw.alert_test.qe
   };
 
-  // TODO: stub alerts
-  localparam logic [NumAlerts-1:0] AlertIsFatal = {1'b1};
+  // Alerts not stubbed off because registers and T-L access still present.
+  localparam logic [NumAlerts-1:0] AlertIsFatal = {NumAlerts{1'b1}};
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),


### PR DESCRIPTION
Keep alerts even when stubbed, since registers persist. All alerts considered fatal; only one at present.

Comment: tidying up TODO; I think this is the intended behavior?