### PR TITLE
[dv/hmac] Remove SWPUshMsgWhenShaDisabled

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -29,7 +29,8 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
   covergroup err_code_cg with function sample (bit [TL_DW-1:0] err_code);
     hmac_errors: coverpoint err_code {
       bins no_error                     = {NoError};
-      bins push_msg_when_sha_sisabled   = {SwPushMsgWhenShaDisabled};
+      // This error code is not used in this version. PR #13854.
+      // bins push_msg_when_sha_disabled   = {SwPushMsgWhenShaDisabled};
       bins hash_start_when_sha_disabled = {SwHashStartWhenShaDisabled};
       bins update_secret_key_in_process = {SwUpdateSecretKeyInProcess};
       bins hash_start_when_active       = {SwHashStartWhenActive};


### PR DESCRIPTION
This PR removes the err_code SWPUshMsgWhenShaDisabled. PR #13854 indicates that this err code is not supported in this version of HMAC.