### PR TITLE
[dv/hmac] Remove two unnecessary todos

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -41,11 +41,6 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     cfg.hash_process_triggered = 0;
   endtask
 
-  virtual task dut_shutdown();
-    super.dut_shutdown();
-    // TODO: nothing extra to do yet
-  endtask
-
   virtual task hmac_init(bit sha_en = 1'b1,
                          bit hmac_en = 1'b1,
                          bit endian_swap = 1'b1,

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_datapath_stress_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_datapath_stress_vseq.sv
@@ -4,7 +4,6 @@
 
 // datapath_stress sequence will generate all message with size 1 and hmac_en
 // thus will have 2 hashes (one for key, one for msg) with the shortest message required
-// TODO: potentially use DV to check throughput here
 
 class hmac_datapath_stress_vseq extends hmac_smoke_vseq;
   `uvm_object_utils(hmac_datapath_stress_vseq)


### PR DESCRIPTION
1. The hmac dut_shutdown task do not need any extra statement. We can remove that task.

2. The TODO for throughput task is documented in PR #777 for V3 task. We can remove this TODO.