### PR TITLE
[ottf] refactor OTTF console configs to an `ottf_console` library

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -228,7 +228,6 @@ cc_library(
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:rand_testutils",
         "//third_party/freertos",
         "@manufacturer_test_hooks//:test_hooks",
@@ -262,7 +261,9 @@ dual_cc_library(
         device = [
             ":check",
             ":ottf_start",
+            ":ottf_test_config",
             "//sw/device/lib/base:mmio",
+            "//sw/device/lib/runtime:print",
             "//sw/device/lib/dif:rv_plic",
             "//sw/device/lib/runtime:ibex",
             "//sw/device/lib/runtime:irq",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -222,6 +222,7 @@ cc_library(
         ":status",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:uart",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -216,7 +216,7 @@ cc_library(
         ":check",
         ":coverage",
         ":freertos_port",
-        ":ottf_flow_control",
+        ":ottf_console",
         ":ottf_start",
         ":ottf_test_config",
         ":status",
@@ -244,7 +244,7 @@ cc_library(
     srcs = ["ujson_ottf.c"],
     hdrs = ["ujson_ottf.h"],
     deps = [
-        ":ottf_flow_control",
+        ":ottf_console",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:print",
@@ -253,11 +253,11 @@ cc_library(
 )
 
 dual_cc_library(
-    name = "ottf_flow_control",
+    name = "ottf_console",
     srcs = dual_inputs(
-        device = ["ottf_flow_control.c"],
+        device = ["ottf_console.c"],
     ),
-    hdrs = ["ottf_flow_control.h"],
+    hdrs = ["ottf_console.h"],
     deps = dual_inputs(
         device = [
             ":check",
@@ -312,7 +312,7 @@ opentitan_functest(
     ),
     deps = [
         ":check",
-        ":ottf_flow_control",
+        ":ottf_console",
         ":ottf_main",
         ":ujson_ottf",
         "//sw/device/lib/base:status",

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -10,6 +10,10 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
+#define FLOW_CONTROL_LOW_WATERMARK 4
+#define FLOW_CONTROL_HIGH_WATERMARK 8
+#define FLOW_CONTROL_WATERMARK_CONFIG kDifUartWatermarkByte8
+
 /**
  * Flow control state.
  */
@@ -29,6 +33,16 @@ typedef enum flow_control {
    */
   kFlowControlPause = 19,
 } flow_control_t;
+
+/**
+ * Returns a pointer to the OTTF console device DIF handle.
+ */
+void *get_ottf_console(void);
+
+/**
+ * Initializes the OTTF console device and connects to the printf buffer.
+ */
+void ottf_init_console(void);
 
 /**
  * Manage flow control by inspecting the UART receive FIFO.

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -10,48 +10,45 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
-#define FLOW_CONTROL_LOW_WATERMARK 4
-#define FLOW_CONTROL_HIGH_WATERMARK 8
-#define FLOW_CONTROL_WATERMARK_CONFIG kDifUartWatermarkByte8
-
 /**
  * Flow control state.
  */
-typedef enum flow_control {
+typedef enum ottf_console_flow_control {
   /** No flow control enabled. */
-  kFlowControlNone = 0,
+  kOttfConsoleFlowControlNone = 0,
   /** Automatically determine the next flow control state. */
-  kFlowControlAuto = 1,
+  kOttfConsoleFlowControlAuto = 1,
   /**
    * Flow control is in the `Resume` state (safe to receive).
    * This is also the ASCII code for `XON`.
    */
-  kFlowControlResume = 17,
+  kOttfConsoleFlowControlResume = 17,
   /**
    * Flow control is in the `Pause` state (risk of overrun).
    * This is also the ASCII code for `XOFF`.
    */
-  kFlowControlPause = 19,
-} flow_control_t;
+  kOttfConsoleFlowControlPause = 19,
+} ottf_console_flow_control_t;
 
 /**
  * Returns a pointer to the OTTF console device DIF handle.
  */
-void *get_ottf_console(void);
+void *ottf_console_get(void);
 
 /**
  * Initializes the OTTF console device and connects to the printf buffer.
  */
-void ottf_init_console(void);
+void ottf_console_init(void);
 
 /**
- * Manage flow control by inspecting the UART receive FIFO.
+ * Manage flow control by inspecting the OTTF console device's receive FIFO.
  *
  * @param uart A UART handle.
  * @param ctrl Set the next desired flow-control state.
  * @return The new state.
  */
-status_t ottf_flow_control(const dif_uart_t *uart, flow_control_t ctrl);
+status_t ottf_console_flow_control(const dif_uart_t *uart,
+                                   ottf_console_flow_control_t ctrl);
 
 /**
  * Enable flow control for the OTTF console.
@@ -64,11 +61,12 @@ status_t ottf_flow_control(const dif_uart_t *uart, flow_control_t ctrl);
  * This function configures UART interrupts at the PLIC and enables interrupts
  * at the CPU.
  */
-void ottf_flow_control_enable(void);
+void ottf_console_flow_control_enable(void);
 
 /**
- * The number of flow control interrupts that have occurred.
+ * Returns the number of OTTF console flow control interrupts that have
+ * occurred.
  */
-extern volatile uint32_t ottf_flow_control_intr;
+uint32_t ottf_console_get_flow_control_irqs(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -1,9 +1,10 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_FLOW_CONTROL_H_
-#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_FLOW_CONTROL_H_
 #include <stdint.h>
 
 #include "sw/device/lib/base/status.h"
@@ -56,4 +57,4 @@ void ottf_flow_control_enable(void);
  */
 extern volatile uint32_t ottf_flow_control_intr;
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_FLOW_CONTROL_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_

--- a/sw/device/lib/testing/test_framework/ottf_flow_control.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control.c
@@ -20,7 +20,7 @@
 
 // We declare this `extern` here to avoid a circular dependency with
 // `ottf_main.h`.
-extern dif_uart_t *ottf_console(void);
+extern void *get_ottf_console(void);
 
 #define FLOW_CONTROL_LOW_WATERMARK 4
 #define FLOW_CONTROL_HIGH_WATERMARK 8
@@ -36,7 +36,7 @@ void ottf_flow_control_enable(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic));
 
-  dif_uart_t *uart = ottf_console();
+  dif_uart_t *uart = (dif_uart_t *)get_ottf_console();
   CHECK_DIF_OK(dif_uart_watermark_rx_set(uart, FLOW_CONRTOL_WATERMARK_CONFIG));
   CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
                                         kDifToggleEnabled));
@@ -57,7 +57,7 @@ void ottf_flow_control_enable(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
   // Make sure we're in the Resume state and we emit a Resume to the UART.
-  ottf_flow_control(ottf_console(), kFlowControlResume);
+  ottf_flow_control((dif_uart_t *)get_ottf_console(), kFlowControlResume);
 }
 
 // This version of the function is safe to call from within the ISR.
@@ -86,7 +86,7 @@ static status_t manage_flow_control(const dif_uart_t *uart,
 }
 
 bool ottf_flow_control_isr(void) {
-  dif_uart_t *uart = ottf_console();
+  dif_uart_t *uart = (dif_uart_t *)get_ottf_console();
   ottf_flow_control_intr += 1;
   bool rx;
   CHECK_DIF_OK(dif_uart_irq_is_pending(uart, kDifUartIrqRxWatermark, &rx));

--- a/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
@@ -43,7 +43,7 @@ status_t ottf_flow_control_test(ujson_t *uj) {
   }
 
   // We'd better have gotten a flow control interrupt.
-  CHECK(ottf_flow_control_intr > 0);
+  CHECK(ottf_console_get_flow_control_irqs() > 0);
 
   // Print out the received data so the test can check that it matches what was
   // sent.

--- a/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/check.h"
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -150,7 +150,7 @@ void ottf_timer_isr(void) {
 }
 
 OT_WEAK
-bool ottf_flow_control_isr(void) { return false; }
+bool ottf_console_flow_control_isr(void) { return false; }
 
 OT_WEAK
 void ottf_external_isr(void) {
@@ -162,7 +162,7 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralUart0 &&
-      ottf_flow_control_isr()) {
+      ottf_console_flow_control_isr()) {
     // Complete the IRQ at PLIC.
     CHECK_DIF_OK(
         dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id));

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -18,7 +18,6 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/rand_testutils.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -82,7 +81,7 @@ static void report_test_status(bool result) {
   // Reinitialize UART before print any debug output if the test clobbered it.
   if (kDeviceType != kDeviceSimDV) {
     if (kOttfTestConfig.console.test_may_clobber) {
-      ottf_init_console();
+      ottf_console_init();
     }
     LOG_INFO("Finished %s", kOttfTestConfig.file);
   }
@@ -107,10 +106,7 @@ void _ottf_main(void) {
 
   // Initialize the console to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {
-    ottf_init_console();
-    if (kOttfTestConfig.enable_uart_flow_control) {
-      ottf_flow_control_enable();
-    }
+    ottf_console_init();
     LOG_INFO("Running %s", kOttfTestConfig.file);
   }
 

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -23,7 +23,7 @@
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/coverage.h"
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"

--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -38,9 +38,9 @@ enum {
 };
 
 /**
- * Returns the UART that is the console device.
+ * Returns the DIF handle that is the console device.
  */
-dif_uart_t *ottf_console(void);
+void *get_ottf_console(void);
 
 /**
  * TODO: add description

--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -38,11 +38,6 @@ enum {
 };
 
 /**
- * Returns the DIF handle that is the console device.
- */
-void *get_ottf_console(void);
-
-/**
  * TODO: add description
  */
 extern bool manufacturer_pre_test_hook(void);

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -21,7 +21,7 @@ typedef struct ottf_console {
   /**
    * Base address of the communication IP interface to use for the OTTF console.
    */
-  uintptr_t ip_base_addr;
+  uintptr_t base_addr;
   /**
    * Indicates if the test may clobber (i.e., reconfigure it and use it during
    * the test for another purpose) the OTTF console, and if the OTTF should

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -32,6 +32,6 @@ ujson_t ujson_ottf_console(void) {
   // requirement in bazel.  This is so ujson libraries can
   // provide dif-based implementations and still be host-compatible
   // and therefore can be depdendencies of opentitanlib.
-  extern dif_uart_t *ottf_console(void);
-  return ujson_init(ottf_console(), ottf_getc, ottf_putbuf);
+  extern void *get_ottf_console(void);
+  return ujson_init(get_ottf_console(), ottf_getc, ottf_putbuf);
 }

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -22,16 +22,10 @@ static status_t ottf_getc(void *io) {
   const dif_uart_t *uart = (const dif_uart_t *)io;
   uint8_t byte;
   TRY(dif_uart_byte_receive_polled(uart, &byte));
-  TRY(ottf_flow_control(uart, kFlowControlAuto));
+  TRY(ottf_console_flow_control(uart, kOttfConsoleFlowControlAuto));
   return OK_STATUS(byte);
 }
 
 ujson_t ujson_ottf_console(void) {
-  // We are not including ottf_main.h and just declaring this
-  // extern to avoid inheriting a `target_compatible_with`
-  // requirement in bazel.  This is so ujson libraries can
-  // provide dif-based implementations and still be host-compatible
-  // and therefore can be depdendencies of opentitanlib.
-  extern void *get_ottf_console(void);
-  return ujson_init(get_ottf_console(), ottf_getc, ottf_putbuf);
+  return ujson_init(ottf_console_get(), ottf_getc, ottf_putbuf);
 }

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/print.h"
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/ujson/ujson.h"
 
 static status_t ottf_putbuf(void *io, const char *buf, size_t len) {

--- a/sw/device/lib/testing/test_framework/ujson_ottf.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /**
- * Initializes and returns a ujson context linked to the ottf console.
+ * Initializes and returns a ujson context linked to the OTTF console.
  *
  * @return An initialized ujson_t context.
  */

--- a/sw/device/silicon_creator/lib/drivers/uart_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/uart_functest.c
@@ -13,7 +13,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG(.can_clobber_uart = true, );
+OTTF_DEFINE_TEST_CONFIG(.console.test_may_clobber = true);
 
 rom_error_t uart_test(void) {
   // Configure UART0 as stdout.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1126,7 +1126,6 @@ opentitan_functest(
         "//sw/device/lib/testing/json:command",
         "//sw/device/lib/testing/json:gpio",
         "//sw/device/lib/testing/json:pinmux_config",
-        "//sw/device/lib/testing/test_framework:ottf_flow_control",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -2224,7 +2223,6 @@ opentitan_functest(
         "//sw/device/lib/testing:spi_flash_testutils",
         "//sw/device/lib/testing/json:command",
         "//sw/device/lib/testing/json:spi_passthru",
-        "//sw/device/lib/testing/test_framework:ottf_flow_control",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
     ],

--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -102,8 +102,7 @@ static volatile bool task_done[kTestTaskIdCount];
  */
 static volatile uint32_t task_iter_count_max[kTestTaskIdCount];
 
-OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
-                        .can_clobber_uart = false, );
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true);
 
 /**
  * Initializes the peripherals used in this test.

--- a/sw/device/tests/example_concurrency_test.c
+++ b/sw/device/tests/example_concurrency_test.c
@@ -32,8 +32,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
-                        .can_clobber_uart = false, );
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true);
 
 static void task_1(void *task_parameters) {
   // ***************************************************************************

--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -30,13 +30,13 @@
  * bare-metal program. Note, for the majority of top-level tests, this
  * should be set to false.
  *
- * Set `can_clobber_uart` to true if this test will reconfigure the UART in
- * any way, since the OTTF uses the UART to communicate test results on
+ * Set `console.test_may_clobber` to true if this test will reconfigure the UART
+ * in any way, since the OTTF uses the UART to communicate test results on
  * Verilator and FPGA platforms, it must be reconfigured by the OTTF before
  * test results are printed.
  */
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = false, );
+                        .console.test_may_clobber = false, );
 
 /**
  * Override any of the default OTTF exception handlers (by uncommenting and

--- a/sw/device/tests/gpio_pinmux_test.c
+++ b/sw/device/tests/gpio_pinmux_test.c
@@ -13,7 +13,6 @@
 #include "sw/device/lib/testing/json/gpio.h"
 #include "sw/device/lib/testing/json/pinmux_config.h"
 #include "sw/device/lib/testing/test_framework/check.h"
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"

--- a/sw/device/tests/kmac_entropy_test.c
+++ b/sw/device/tests/kmac_entropy_test.c
@@ -10,8 +10,8 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = false, );
+
+OTTF_DEFINE_TEST_CONFIG();
 
 /**
  * Struct to pack timeout values.

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -58,8 +58,7 @@
 #include "rsa_3072_verify_testvectors.h"
 
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
-                        .enable_uart_flow_control = true,
-                        .can_clobber_uart = false, );
+                        .enable_uart_flow_control = true);
 
 /**
  * Peripheral DIF Handles.

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -151,8 +151,7 @@ static void execute_test(dif_uart_t *uart) {
   CHECK(uart_tx_empty_handled, "TX empty IRQ has not been handled!");
 }
 
-OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = true, );
+OTTF_DEFINE_TEST_CONFIG(.console.test_may_clobber = true);
 
 bool test_main(void) {
   // Enable IRQs on Ibex

--- a/sw/device/tests/sim_dv/rv_dm_ndm_reset_req_when_cpu_halted.c
+++ b/sw/device/tests/sim_dv/rv_dm_ndm_reset_req_when_cpu_halted.c
@@ -13,8 +13,7 @@
 
 static dif_rstmgr_t rstmgr;
 
-OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = false, );
+OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false);
 
 bool test_main(void) {
   CHECK_DIF_OK(dif_rstmgr_init(

--- a/sw/device/tests/spi_passthru_test.c
+++ b/sw/device/tests/spi_passthru_test.c
@@ -17,7 +17,6 @@
 #include "sw/device/lib/testing/spi_flash_emulator.h"
 #include "sw/device/lib/testing/spi_flash_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
-#include "sw/device/lib/testing/test_framework/ottf_flow_control.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -14,7 +14,7 @@
 static const uint8_t kSendData[] = "Smoke test!";
 
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = true, );
+                        .console.test_may_clobber = true, );
 
 bool test_main(void) {
   dif_uart_t uart;

--- a/third_party/coremark/top_earlgrey/core_portme.c
+++ b/third_party/coremark/top_earlgrey/core_portme.c
@@ -132,7 +132,7 @@ time_in_secs(CORE_TICKS ticks)
 ee_u32 default_num_contexts = 1;
 
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
-                        .can_clobber_uart = true, );
+                        .console.test_may_clobber = true, );
 dif_uart_t uart;
 
 /* Function : portable_init


### PR DESCRIPTION
This PR contains several commits that:
- refactors the OTTF console functions and consolidating them (including flow control functions) into an OTTF console library
- enables specifying the OTTF console device in the OTTF test config struct, enabling future addition of other console devices (e.g., spi_device for manufacturing)
- makes several style guide / code cleanups

This partially addresses #17494.