### PR TITLE
[dv/hmac] Add support to check idle_o

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:dv:test_vectors
     files:
       - hmac_env_pkg.sv
+      - hmac_if.sv
       - hmac_env_cfg.sv: {is_include_file: true}
       - hmac_env_cov.sv: {is_include_file: true}
       - hmac_scoreboard.sv: {is_include_file: true}

--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -11,6 +11,11 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
+    // config hmac virtual interface
+    if (!uvm_config_db#(hmac_vif)::get(this, "", "hmac_vif", cfg.hmac_vif)) begin
+      `uvm_fatal(`gfn, "failed to get hmac_vif from uvm_config_db")
+    end
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -11,6 +11,8 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   // This would help trying to issue reset at specific timing during hmac hashing.
   bit hash_process_triggered;
 
+  hmac_vif hmac_vif;
+
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -102,6 +102,8 @@ package hmac_env_pkg;
     endcase
   endfunction
 
+  typedef virtual hmac_if hmac_vif;
+
   // package sources
   `include "hmac_env_cfg.sv"
   `include "hmac_env_cov.sv"

--- a/hw/ip/hmac/dv/env/hmac_if.sv
+++ b/hw/ip/hmac/dv/env/hmac_if.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A lightweight interface to sample idle signal.
+interface hmac_if(input clk_i, input rst_ni);
+  prim_mubi_pkg::mubi4_t idle;
+
+  function automatic bit is_idle();
+    return (idle == prim_mubi_pkg::MuBi4True);
+  endfunction
+
+endinterface

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -77,8 +77,10 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               if (item.a_data[HashProcess] && hmac_start) begin
                 {hmac_process, hmac_start} = item.a_data[1:0];
                 predict_digest(msg_q);
+                check_idle_o(1'b0);
               end else if (item.a_data[HashStart]) begin
                 {hmac_process, hmac_start} = item.a_data[1:0];
+                check_idle_o(1'b0);
                 msg_q.delete(); // make sure next transaction won't include this msg_q
                 update_wr_msg_length(0);
               end
@@ -179,6 +181,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
             if (sha_en && hmac_process) begin
               void'(ral.intr_state.hmac_done.predict(.value(1), .kind(UVM_PREDICT_READ)));
             end
+            check_idle_o(1'b1);
             flush();
           end
         end
@@ -414,4 +417,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     end
   endfunction
 
+  virtual function void check_idle_o(bit val);
+    if (cfg.under_reset == 0) `DV_CHECK_EQ(cfg.hmac_vif.is_idle(), val)
+  endfunction
 endclass

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -34,6 +34,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
     if (do_hmac_init) hmac_init();
+    `DV_CHECK_EQ(cfg.hmac_vif.is_idle(), 1'b1)
   endtask
 
   virtual task apply_reset(string kind = "HARD");

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -27,6 +27,7 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
+  hmac_if hmac_if(.clk_i(clk), .rst_ni(rst_n));
 
   `DV_ALERT_IF_CONNECT()
 
@@ -45,9 +46,7 @@ module tb;
     .intr_fifo_empty_o  ( intr_fifo_empty),
     .intr_hmac_err_o    ( intr_hmac_err  ),
 
-    // TODO: connect this signal and check correctness: it will cause the clock to
-    // be turned off at the wrong time if it is not accurate.
-    .idle_o             ()
+    .idle_o             (hmac_if.idle)
   );
 
   assign interrupts[HmacDone]         = intr_hmac_done;
@@ -61,6 +60,7 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual hmac_if)::set(null, "*.env", "hmac_vif", hmac_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
This PR adds the DV support to check idle_o when hmac is idle, start process, and done processing.