### PR TITLE
[dv/chip] Consolidate agent cfg settings

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -154,6 +154,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     foreach (m_spi_device_agent_cfgs[i]) begin
       m_spi_device_agent_cfgs[i] =
         spi_agent_cfg::type_id::create($sformatf("m_spi_device_agent_cfg%0d", i));
+      // all the spi_agents talking to the host interface should be configured into
+      // device mode
+      m_spi_device_agent_cfgs[i].if_mode = dv_utils_pkg::Device;
     end
 
     // create i2c agent config obj

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -45,12 +45,6 @@ class chip_base_test extends cip_base_test #(
     cfg.m_uart_agent_cfgs[0].en_logger = cfg.en_uart_logger;
     cfg.m_uart_agent_cfgs[0].write_logs_to_file = cfg.write_sw_logs_to_file;
 
-    // all the spi_agents talking to the host interface should be configured into
-    // device mode
-    foreach (cfg.m_spi_device_agent_cfgs[i]) begin
-       cfg.m_spi_device_agent_cfgs[i].if_mode = dv_utils_pkg::Device;
-    end
-
     // Knob to set the sw_test_timeout_ns (set to 12ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
 


### PR DESCRIPTION
All functional related agent cfg settings, such as if_mode, is_active, etc, should be set in chip_env_cfg `initilation` function.