### PR TITLE
[topgen,bazel] Add missing source files for topgen py_library

### DIFF
--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -11,7 +11,9 @@ py_library(
     name = "topgen",
     srcs = [
         "__init__.py",
+        "entropy_buffer_generator.py",
         "gen_top_docs.py",
+        "strong_random.py",
         "validate.py",
     ],
     deps = [


### PR DESCRIPTION
They are part of the dependent modules for util/topgen.py, so they need to be added to the `//util/topgen` `py_library`.