### PR TITLE
[opentitanlib] Handle startup and shutdown of OpenOCD server more gracefully

### DIFF
--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::time::Duration;
 
 use crate::app::TransportWrapper;
 use crate::dif::lc_ctrl::LcCtrlReg;
@@ -35,6 +36,10 @@ pub struct JtagParams {
     /// Port used to start and connect to OpenOCD over.
     #[structopt(long, default_value = "6666")]
     pub openocd_port: u16,
+
+    /// Timeout when waiting for OpenOCD to start.
+    #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value = "3s")]
+    pub openocd_timeout: Duration,
 
     #[structopt(long, default_value = "200")]
     pub adapter_speed_khz: u64,


### PR DESCRIPTION
## Summary

This PR improves the startup and shutdown of the OpenOCD server (used for speaking JTAG) in `opentitanlib`.

* Replaced the fixed-length delay for the socket to appear with a polling loop.
* Sending the shutdown signal and give the server a chance to stop before we kill it.

## Unresolved questions

- [ ] These are very busy poll loops. Should we delay between each poll? Replace with async?
- [ ] Do we even need to `SIGKILL` OpenOCD? Can't we just send `shutdown` and leave it to its own devices?
- [ ] Is it okay to potentially delay in a `Drop` implementation? This feels like unexpected behaviour.
- [ ] Do the timeouts need to be configurable?