### PR TITLE
[crypto] Add tests for Miller-Rabin.

### DIFF
--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -411,6 +411,58 @@ otbn_consttime_test(
 )
 
 otbn_sim_test(
+    name = "primality_test",
+    timeout = "long",
+    srcs = [
+        "primality_test.s",
+    ],
+    exp = "primality_test.exp",
+    deps = [
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:modexp",
+    ],
+)
+
+otbn_sim_test(
+    name = "primality_test_witness_test",
+    timeout = "long",
+    srcs = [
+        "primality_test_witness_test.s",
+    ],
+    exp = "primality_test_witness_test.exp",
+    deps = [
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:modexp",
+    ],
+)
+
+otbn_sim_test(
+    name = "primality_test_witness_negative_test",
+    timeout = "long",
+    srcs = [
+        "primality_test_witness_negative_test.s",
+    ],
+    exp = "primality_test_witness_negative_test.exp",
+    deps = [
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:modexp",
+    ],
+)
+
+otbn_sim_test(
+    name = "primality_negative_test",
+    timeout = "long",
+    srcs = [
+        "primality_negative_test.s",
+    ],
+    exp = "primality_negative_test.exp",
+    deps = [
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:modexp",
+    ],
+)
+
+otbn_sim_test(
     name = "rsa_1024_dec_test",
     timeout = "long",
     srcs = [

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -418,8 +418,8 @@ otbn_sim_test(
     ],
     exp = "primality_test.exp",
     deps = [
-        "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:modexp",
+        "//sw/otbn/crypto:primality",
     ],
 )
 
@@ -431,8 +431,8 @@ otbn_sim_test(
     ],
     exp = "primality_test_witness_test.exp",
     deps = [
-        "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:modexp",
+        "//sw/otbn/crypto:primality",
     ],
 )
 
@@ -444,8 +444,8 @@ otbn_sim_test(
     ],
     exp = "primality_test_witness_negative_test.exp",
     deps = [
-        "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:modexp",
+        "//sw/otbn/crypto:primality",
     ],
 )
 
@@ -457,8 +457,59 @@ otbn_sim_test(
     ],
     exp = "primality_negative_test.exp",
     deps = [
-        "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:modexp",
+        "//sw/otbn/crypto:primality",
+    ],
+)
+
+# Miller-Rabin with 1024-bit primes (as in RSA-2048).
+otbn_consttime_test(
+    name = "miller_rabin_consttime_1024",
+    # 4 limbs, x30 = n and x31 = n -1
+    initial_constants = [
+        "x30:4",
+        "x31:3",
+    ],
+    # All secrets are stored in DMEM; timing is permitted to depend on the
+    # number of limbs.
+    secrets = ["dmem"],
+    subroutine = "miller_rabin",
+    deps = [
+        ":primality_test",
+    ],
+)
+
+# Miller-Rabin with 1536-bit primes (as in RSA-3072).
+otbn_consttime_test(
+    name = "miller_rabin_consttime_1536",
+    # 6 limbs, x30 = n and x31 = n -1
+    initial_constants = [
+        "x30:6",
+        "x31:5",
+    ],
+    # All secrets are stored in DMEM; timing is permitted to depend on the
+    # number of limbs.
+    secrets = ["dmem"],
+    subroutine = "miller_rabin",
+    deps = [
+        ":primality_test",
+    ],
+)
+
+# Miller-Rabin with 2048-bit primes (as in RSA-4096).
+otbn_consttime_test(
+    name = "miller_rabin_consttime_2048",
+    # 8 limbs, x30 = n and x31 = n -1
+    initial_constants = [
+        "x30:8",
+        "x31:7",
+    ],
+    # All secrets are stored in DMEM; timing is permitted to depend on the
+    # number of limbs.
+    secrets = ["dmem"],
+    subroutine = "miller_rabin",
+    deps = [
+        ":primality_test",
     ],
 )
 

--- a/sw/otbn/crypto/tests/primality_negative_test.exp
+++ b/sw/otbn/crypto/tests/primality_negative_test.exp
@@ -1,0 +1,2 @@
+# Input is composite, so we should get 0.
+w21 = 0x0

--- a/sw/otbn/crypto/tests/primality_negative_test.s
+++ b/sw/otbn/crypto/tests/primality_negative_test.s
@@ -1,0 +1,108 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test for Miller-Rabin primality test.
+ *
+ * The test input is composite, so we expect the primality test to fail. Uses
+ * n=4 limbs (i.e. a 1024-bit prime candidate, as would be used in RSA-2048).
+ */
+
+.section .text.start
+
+main:
+  /* Initialize all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Number of limbs (n) and related constant.
+       x30 <= n
+       x31 <= n - 1 */
+  li        x30, 4
+  li        x31, 3
+
+  /* Compute Montgomery constants for the candidate prime.
+       dmem[mont_m0inv] <= (- dmem[input]) mod 2^256
+       dmem[mont_rr] <= (2^1024) mod dmem[input] */
+  la         x16, input
+  la         x17, mont_m0inv
+  la         x18, mont_rr
+  jal        x1, modload
+
+  /* Load pointers to temporary work buffers. */
+  la         x14, tmp1
+  la         x15, tmp2
+
+  /* Set number of Miller-Rabin rounds (see FIPS 186-5, table B.1). */
+  li        x10, 4
+
+  /* Call primality test.
+       w21 <= all 1s if dmem[input] is probably prime, otherwise 0 */
+  jal        x1, miller_rabin
+
+  ecall
+
+.data
+
+/* Candidate prime (Wycheproof test #39) =
+0xf67307e54779cfe9120bf862afc5466c5d6d0783d12df5215c0c981c51e4bfc098e9afd574f51b18c820259b692ec0bf7c9d6e56e9bb99fbd3b7ecc4082146a9d7a5b7bc6519d476c4a9975d9c3e3b12bee45b7accb07a6a68ea583ac2523ef32ee6d01bc766b59c43031f9c6980c9b4317da6825be9f7c5db03283d04c13323
+
+Note: this prime is a worst-case test for Miller-Rabin, since it has a high
+probability of producing false positives if the number of rounds is too low.
+*/
+.balign 32
+input:
+.word 0x04c13323
+.word 0xdb03283d
+.word 0x5be9f7c5
+.word 0x317da682
+.word 0x6980c9b4
+.word 0x43031f9c
+.word 0xc766b59c
+.word 0x2ee6d01b
+.word 0xc2523ef3
+.word 0x68ea583a
+.word 0xccb07a6a
+.word 0xbee45b7a
+.word 0x9c3e3b12
+.word 0xc4a9975d
+.word 0x6519d476
+.word 0xd7a5b7bc
+.word 0x082146a9
+.word 0xd3b7ecc4
+.word 0xe9bb99fb
+.word 0x7c9d6e56
+.word 0x692ec0bf
+.word 0xc820259b
+.word 0x74f51b18
+.word 0x98e9afd5
+.word 0x51e4bfc0
+.word 0x5c0c981c
+.word 0xd12df521
+.word 0x5d6d0783
+.word 0xafc5466c
+.word 0x120bf862
+.word 0x4779cfe9
+.word 0xf67307e5
+
+.section .scratchpad
+
+/* Space for Montgomery constant m0' (256 bits). */
+.balign 32
+mont_m0inv:
+.zero 32
+
+/* Space for Montgomery constant RR (1024 bits). */
+.balign 32
+mont_rr:
+.zero 128
+
+/* Temporary working buffer 1 (1024 bits). */
+.balign 32
+tmp1:
+.zero 128
+
+/* Temporary working buffer 2 (1024 bits). */
+.balign 32
+tmp2:
+.zero 128

--- a/sw/otbn/crypto/tests/primality_test.exp
+++ b/sw/otbn/crypto/tests/primality_test.exp
@@ -1,0 +1,2 @@
+# Input is prime, so we should get all 1s.
+w21 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/sw/otbn/crypto/tests/primality_test.s
+++ b/sw/otbn/crypto/tests/primality_test.s
@@ -1,0 +1,102 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test for Miller-Rabin primality test.
+ *
+ * The prime candidate in this case is a true prime, so we expect the primality
+ * test to succeed. Uses n=2 limbs (i.e. a 512-bit prime candidate, as would be
+ * used in RSA-1024).
+ */
+
+.section .text.start
+
+main:
+  /* Initialize all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Number of limbs (n) and related constant.
+       x30 <= n
+       x31 <= n - 1 */
+  li        x30, 2
+  li        x31, 1
+
+  /* Compute Montgomery constants for the candidate prime.
+       dmem[mont_m0inv] <= (- dmem[input]) mod 2^256
+       dmem[mont_rr] <= (2^1024) mod dmem[input] */
+  la         x16, input
+  la         x17, mont_m0inv
+  la         x18, mont_rr
+  jal        x1, modload
+
+
+  /* Load pointers to temporary work buffers. */
+  la         x14, tmp1
+  la         x15, tmp2
+
+  /* Set number of Miller-Rabin rounds. The prime should survive any number of
+     rounds, but we set a roughly realistic number. */
+  li        x10, 4
+
+  /* Call primality test.
+       w21 <= all 1s if dmem[input] is probably prime, otherwise 0 */
+  jal        x1, miller_rabin
+
+  /* Load Mont constants.
+       w0 <= m0_inv
+       w1, w2 <= rr */
+  la         x17, mont_m0inv
+  la         x18, mont_rr
+  li         x2, 0
+  bn.lid     x2++, 0(x17)
+  bn.lid     x2++, 0(x18)
+  bn.lid     x2++, 32(x18)
+
+  ecall
+
+.data
+
+/* Candidate prime (randomly generated using pycryptodome) =
+0x9ac5b6d69aa1d91c418d9bf315ba72595488aabddbd435dafe630ba818e3d4ef03ab9bf93147a781cc45f6219f8bc92fc500c92dc8539832055036f6537320a1
+*/
+.balign 32
+input:
+.word 0x537320a1
+.word 0x055036f6
+.word 0xc8539832
+.word 0xc500c92d
+.word 0x9f8bc92f
+.word 0xcc45f621
+.word 0x3147a781
+.word 0x03ab9bf9
+.word 0x18e3d4ef
+.word 0xfe630ba8
+.word 0xdbd435da
+.word 0x5488aabd
+.word 0x15ba7259
+.word 0x418d9bf3
+.word 0x9aa1d91c
+.word 0x9ac5b6d6
+
+.section .scratchpad
+
+/* Space for Montgomery constant m0' (256 bits). */
+.balign 32
+mont_m0inv:
+.zero 32
+
+/* Space for Montgomery constant RR (512 bits). */
+.balign 32
+mont_rr:
+.zero 64
+
+/* Temporary working buffer 1 (512 bits). */
+.balign 32
+tmp1:
+.zero 64
+
+/* Temporary working buffer 2 (512 bits). */
+.balign 32
+tmp2:
+.zero 64

--- a/sw/otbn/crypto/tests/primality_test_witness_negative_test.exp
+++ b/sw/otbn/crypto/tests/primality_test_witness_negative_test.exp
@@ -5,5 +5,3 @@ w1 = 0x65a498fbb4f35d9919fea51aaf2e83256c5f624f37bfc26e63a42a3c74f15a65
 
 # Result from witness test: 0 (indicating "composite")
 w21 = 0
-
-

--- a/sw/otbn/crypto/tests/primality_test_witness_negative_test.exp
+++ b/sw/otbn/crypto/tests/primality_test_witness_negative_test.exp
@@ -1,0 +1,9 @@
+# For this particular composite/witness pair, we don't hit an early-exit case;
+# expect to finish the loop so w0, w1 == (b^(w-1) * R) % w
+w0 = 0xb470f524ca68f2455a1a85b8dc006872131ceedf6d07883f0f010e0bd222c0e3
+w1 = 0x65a498fbb4f35d9919fea51aaf2e83256c5f624f37bfc26e63a42a3c74f15a65
+
+# Result from witness test: 0 (indicating "composite")
+w21 = 0
+
+

--- a/sw/otbn/crypto/tests/primality_test_witness_negative_test.s
+++ b/sw/otbn/crypto/tests/primality_test_witness_negative_test.s
@@ -1,0 +1,126 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test for a subcomponent of the Miller-Rabin primality test.
+ *
+ * Testing the test_witness subroutine in isolation can be helpful for
+ * debugging and quick feedback.
+ */
+
+.section .text.start
+
+main:
+  /* Initialize all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Set number of limbs (n=2).
+       x30 <= n
+       x31 <= n - 1 */
+  li        x30, 2
+  li        x31, 1
+
+  /* Test the witness.
+       w21 <= all 1s if dmem[input] is possibly prime, otherwise 0 */
+  la         x14, witness
+  la         x15, tmp
+  la         x16, input
+  la         x17, mont_m0inv
+  la         x18, mont_rr
+  jal        x1, test_witness
+
+  /* Load the value from the working buffer into registers. This buffer holds
+     the witness raised to some portion of the exponent; we can check it to
+     ensure that w was found to be composite at exactly the point we expected.
+       w0,w1 <= dmem[tmp:tmp+n*32] */
+  li         x8, 0
+  la         x15, tmp
+  loop       x30, 2
+    bn.lid     x8, 0(x15++)
+    addi       x8, x8, 1
+
+  ecall
+
+.data
+
+/* Candidate prime (composite, randomly generated) =
+0xf7b5cc32e3c7c3ff6f220312fe4be4af76c9e51e8c17648c863751d70359bab17c1d7b4844e01d1ec0cd695ff3bae05dc51d95a001ab7b69f66d0c056c2dec39
+*/
+.balign 32
+input:
+.word 0x6c2dec39
+.word 0xf66d0c05
+.word 0x01ab7b69
+.word 0xc51d95a0
+.word 0xf3bae05d
+.word 0xc0cd695f
+.word 0x44e01d1e
+.word 0x7c1d7b48
+.word 0x0359bab1
+.word 0x863751d7
+.word 0x8c17648c
+.word 0x76c9e51e
+.word 0xfe4be4af
+.word 0x6f220312
+.word 0xe3c7c3ff
+.word 0xf7b5cc32
+
+/* Random witness for testing. */
+.balign 32
+witness:
+.word 0x4080769c
+.word 0x1262ef4d
+.word 0x98b11168
+.word 0xd0f601d0
+.word 0x4387fc64
+.word 0x8ab79fd2
+.word 0xf7252c67
+.word 0xe8a0ed3c
+.word 0x72a5ce33
+.word 0x082fb7fd
+.word 0x9d7863bb
+.word 0x80ea393b
+.word 0x4e4e9575
+.word 0x09455e2a
+.word 0x81a24e55
+.word 0x256943a7
+
+/* Precomputed Montgomery constant m0' (256 bits). */
+.balign 32
+mont_m0inv:
+.word 0xd0a3bdf7
+.word 0x7dde1093
+.word 0xf7fe594f
+.word 0x8f66b353
+.word 0x03a1c874
+.word 0x3c4a0e42
+.word 0x0d02fb70
+.word 0x2cf2f731
+
+/* Precomputed Montgomery constant RR (512 bits). */
+.balign 32
+mont_rr:
+.word 0xd04011c2
+.word 0x8ef6bac2
+.word 0x2c87d164
+.word 0x5f60cb7a
+.word 0x5e64a3f6
+.word 0xe9f883b0
+.word 0xa802122b
+.word 0xf910bf58
+.word 0x94680653
+.word 0x3dadc1f1
+.word 0x4adf397f
+.word 0xa87c8a2a
+.word 0x0576494c
+.word 0x5ce4999d
+.word 0x8188e572
+.word 0x0911fc89
+
+.section .scratchpad
+
+/* Temporary working buffer (512 bits). */
+.balign 32
+tmp:
+.zero 64

--- a/sw/otbn/crypto/tests/primality_test_witness_test.exp
+++ b/sw/otbn/crypto/tests/primality_test_witness_test.exp
@@ -1,0 +1,8 @@
+# w0, w1 <= (b^(w-1) * R) % w =  (1 * R) % w
+w0 = 0xf156a85066fa88460f3223454c58b0b878c560be590bf156363935bed6c123f5
+w1 = 0x72e3f25e319a983962943197fd7f7e1a7df76977ec8eb6b6e3d91b8199fb9c6c
+
+# Result from witness test: all 1s (indicating "possibly prime")
+w21 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+

--- a/sw/otbn/crypto/tests/primality_test_witness_test.exp
+++ b/sw/otbn/crypto/tests/primality_test_witness_test.exp
@@ -4,5 +4,3 @@ w1 = 0x72e3f25e319a983962943197fd7f7e1a7df76977ec8eb6b6e3d91b8199fb9c6c
 
 # Result from witness test: all 1s (indicating "possibly prime")
 w21 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-
-

--- a/sw/otbn/crypto/tests/primality_test_witness_test.s
+++ b/sw/otbn/crypto/tests/primality_test_witness_test.s
@@ -1,0 +1,127 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test for a subcomponent of the Miller-Rabin primality test.
+ *
+ * Testing the test_witness subroutine in isolation can be helpful for
+ * debugging and quick feedback.
+ */
+
+.section .text.start
+
+main:
+  /* Initialize all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Set number of limbs (n=2).
+       x30 <= n
+       x31 <= n - 1 */
+  li        x30, 2
+  li        x31, 1
+
+  /* Test the witness.
+       w21 <= all 1s if dmem[input] is possibly prime, otherwise 0 */
+  la         x14, witness
+  la         x15, tmp
+  la         x16, input
+  la         x17, mont_m0inv
+  la         x18, mont_rr
+  jal        x1, test_witness
+
+  /* Load the value from the working buffer into registers. Since the candidate
+     is prime and the test should have processed all bits of (w-1) without any
+     early exit, we expect that the final value will be equal to
+     (witness^(input-1) * R) mod input.
+       w0,w1 <= dmem[tmp:tmp+n*32] */
+  li         x8, 0
+  la         x15, tmp
+  loop       x30, 2
+    bn.lid     x8, 0(x15++)
+    addi       x8, x8, 1
+
+  ecall
+
+.data
+
+/* Candidate prime (true prime, randomly generated using pycryptodome) =
+0x8d1c0da1ce6567c69d6bce68028081e582089688137149491c26e47e660463930ea957af990577b9f0cddcbab3a74f47873a9f41a6f40ea9c9c6ca41293edc0b
+*/
+.balign 32
+input:
+.word 0x293edc0b
+.word 0xc9c6ca41
+.word 0xa6f40ea9
+.word 0x873a9f41
+.word 0xb3a74f47
+.word 0xf0cddcba
+.word 0x990577b9
+.word 0x0ea957af
+.word 0x66046393
+.word 0x1c26e47e
+.word 0x13714949
+.word 0x82089688
+.word 0x028081e5
+.word 0x9d6bce68
+.word 0xce6567c6
+.word 0x8d1c0da1
+
+/* Random witness for testing. */
+.balign 32
+witness:
+.word 0x4080769c
+.word 0x1262ef4d
+.word 0x98b11168
+.word 0xd0f601d0
+.word 0x4387fc64
+.word 0x8ab79fd2
+.word 0xf7252c67
+.word 0xe8a0ed3c
+.word 0x72a5ce33
+.word 0x082fb7fd
+.word 0x9d7863bb
+.word 0x80ea393b
+.word 0x4e4e9575
+.word 0x09455e2a
+.word 0x81a24e55
+.word 0x256943a7
+
+/* Precomputed Montgomery constant m0' (256 bits). */
+.balign 32
+mont_m0inv:
+.word 0x19b8305d
+.word 0x62b7e8e7
+.word 0x641931c6
+.word 0xd0d2fa8c
+.word 0x09f82d11
+.word 0xc6fea5cb
+.word 0x85db6e31
+.word 0x3da16a04
+
+/* Precomputed Montgomery constant RR (512 bits). */
+.balign 32
+mont_rr:
+.word 0x7cace161
+.word 0x05dbf569
+.word 0x4abf6945
+.word 0x67ee4a0e
+.word 0x6f17717a
+.word 0x403da1b4
+.word 0x28cc1d74
+.word 0x6424c41f
+.word 0xc1edcb01
+.word 0x5f4d0e22
+.word 0x1e3966f1
+.word 0x6be6c4a8
+.word 0xc33f14ed
+.word 0xc8277904
+.word 0x084be9c3
+.word 0x2bd6414c
+
+.section .scratchpad
+
+/* Temporary working buffer (512 bits). */
+.balign 32
+tmp:
+.zero 64


### PR DESCRIPTION
Follow-up to #17558

This PR adds 5 tests for the Miller-Rabin primality test:
1. Full primality test with a prime number
2. Full primality test with a large worst-case composite number
3. One MR round with a fixed test seed and a prime number
4. One MR round with a fixed test seed and a non-prime number
5. Constant-time test.

The single-round tests are useful for debugging, since the "witness" used to test the prime candidate is always the same and intermediate values are easier to analyze. They also have a faster runtime.