### PR TITLE
[opentitantool] Allow I2C bus aliases

### DIFF
--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -82,6 +82,17 @@ pub struct SpiConfiguration {
     pub alias_of: Option<String>,
 }
 
+/// Configuration of a particular I2C bus.
+#[derive(Deserialize, Clone, Debug)]
+pub struct I2cConfiguration {
+    /// The user-visible name of the I2C bus.
+    pub name: String,
+    /// Data communication rate in bits/second.
+    pub bits_per_sec: Option<u32>,
+    /// Name of the I2C bus as defined by the transport.
+    pub alias_of: Option<String>,
+}
+
 /// Representation of the complete and unresolved content of a single
 /// confguration file.
 #[derive(Deserialize, Clone, Debug)]
@@ -101,6 +112,8 @@ pub struct ConfigurationFile {
     /// List of UART configurations.
     #[serde(default)]
     pub spi: Vec<SpiConfiguration>,
+    #[serde(default)]
+    pub i2c: Vec<I2cConfiguration>,
     #[serde(default)]
     pub uarts: Vec<UartConfiguration>,
 }

--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -46,6 +46,12 @@ pub enum Transfer<'rd, 'wr> {
 
 /// A trait which represents a I2C Bus.
 pub trait Bus {
+    /// Gets the maximum allowed speed of the I2C bus.
+    fn get_max_speed(&self) -> Result<u32>;
+    /// Sets the maximum allowed speed of the I2C bus, typical values are 100_000, 400_000 or
+    /// 1_000_000.
+    fn set_max_speed(&self, max_speed: u32) -> Result<()>;
+
     /// Runs a I2C transaction composed from the slice of [`Transfer`] objects.
     fn run_transaction(&self, addr: u8, transaction: &mut [Transfer]) -> Result<()>;
 }

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -215,6 +215,14 @@ impl<'a> TransportCommandHandler<'a> {
             Request::I2c { id, command } => {
                 let instance = self.transport.i2c(id)?;
                 match command {
+                    I2cRequest::GetMaxSpeed => {
+                        let speed = instance.get_max_speed()?;
+                        Ok(Response::I2c(I2cResponse::GetMaxSpeed { speed }))
+                    }
+                    I2cRequest::SetMaxSpeed { value } => {
+                        instance.set_max_speed(*value)?;
+                        Ok(Response::I2c(I2cResponse::SetMaxSpeed))
+                    }
                     I2cRequest::RunTransaction {
                         address,
                         transaction: reqs,

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -168,6 +168,10 @@ pub enum I2cTransferResponse {
 
 #[derive(Serialize, Deserialize)]
 pub enum I2cRequest {
+    GetMaxSpeed,
+    SetMaxSpeed {
+        value: u32,
+    },
     RunTransaction {
         address: u8,
         transaction: Vec<I2cTransferRequest>,
@@ -176,6 +180,10 @@ pub enum I2cRequest {
 
 #[derive(Serialize, Deserialize)]
 pub enum I2cResponse {
+    GetMaxSpeed {
+        speed: u32,
+    },
+    SetMaxSpeed,
     RunTransaction {
         transaction: Vec<I2cTransferResponse>,
     },

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -182,6 +182,17 @@ impl HyperdebugI2cBus {
 }
 
 impl Bus for HyperdebugI2cBus {
+    /// Gets the maximum allowed speed of the I2C bus.
+    fn get_max_speed(&self) -> Result<u32> {
+        bail!(TransportError::UnsupportedOperation)
+    }
+
+    /// Sets the maximum allowed speed of the I2C bus, typical values are 100_000, 400_000 or
+    /// 1_000_000.
+    fn set_max_speed(&self, _max_speed: u32) -> Result<()> {
+        bail!(TransportError::UnsupportedOperation)
+    }
+
     fn run_transaction(&self, addr: u8, mut transaction: &mut [Transfer]) -> Result<()> {
         while !transaction.is_empty() {
             match transaction {

--- a/sw/host/opentitanlib/src/transport/proxy/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/i2c.rs
@@ -39,6 +39,19 @@ impl ProxyI2c {
 }
 
 impl Bus for ProxyI2c {
+    fn get_max_speed(&self) -> Result<u32> {
+        match self.execute_command(I2cRequest::GetMaxSpeed)? {
+            I2cResponse::GetMaxSpeed { speed } => Ok(speed),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+    fn set_max_speed(&self, value: u32) -> Result<()> {
+        match self.execute_command(I2cRequest::SetMaxSpeed { value })? {
+            I2cResponse::SetMaxSpeed => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn run_transaction(&self, address: u8, transaction: &mut [Transfer]) -> Result<()> {
         let mut req: Vec<I2cTransferRequest> = Vec::new();
         for transfer in &*transaction {
@@ -72,6 +85,7 @@ impl Bus for ProxyI2c {
                 }
                 Ok(())
             }
+            _ => bail!(ProxyError::UnexpectedReply()),
         }
     }
 }

--- a/sw/host/opentitanlib/src/transport/ti50emulator/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/i2c.rs
@@ -17,6 +17,7 @@ use crate::io::i2c::{Bus, I2cError, Transfer};
 use crate::transport::ti50emulator::emu::EMULATOR_INVALID_ID;
 use crate::transport::ti50emulator::Inner;
 use crate::transport::ti50emulator::Ti50Emulator;
+use crate::transport::TransportError;
 
 const MAX_READ_TIMEOUT: Duration = Duration::from_millis(35);
 const MAX_WRITE_TIMEOUT: Duration = Duration::from_millis(35);
@@ -230,6 +231,17 @@ impl Ti50I2cBus {
 }
 
 impl Bus for Ti50I2cBus {
+    /// Gets the maximum allowed speed of the I2C bus.
+    fn get_max_speed(&self) -> Result<u32> {
+        bail!(TransportError::UnsupportedOperation)
+    }
+
+    /// Sets the maximum allowed speed of the I2C bus, typical values are 100_000, 400_000 or
+    /// 1_000_000.
+    fn set_max_speed(&self, _max_speed: u32) -> Result<()> {
+        bail!(TransportError::UnsupportedOperation)
+    }
+
     fn run_transaction(&self, addr: u8, transaction: &mut [Transfer]) -> Result<()> {
         self.check_state()?;
         self.reconnect()?;


### PR DESCRIPTION
The .json configuration files allow attaching aliases such as "TPM" or "BOOTSTRAP" to the SPI busses provided by the transport. This plays well with having the various opentitantool commands use default SPI bus name depending on their nature.

This PR introduces the same functionality for I2C busses.