### PR TITLE
[data/sensor_ctrl] Remove stale TODO

### DIFF
--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
@@ -1,9 +1,6 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// TODO: This module is only a draft implementation that covers most of the ast_wrapper
-// functionality but is incomplete
-
 
 # SENSOR_CTRL register template
 #


### PR DESCRIPTION
In `sensor_ctrl.hjson`, there is a stale TODO saying the hjson is a template and not functional. I believe this is not accaplicable and sensor_ctrl has been used in chip level testing.