### PR TITLE
Fix check macro

### DIFF
--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -31,21 +31,26 @@
  * @param ... Arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
-#define CHECK_IMPL(condition, ...)                   \
-  ({                                                 \
-    if (!(condition)) {                              \
-      /* NOTE: because the condition in this if      \
-         statement can be statically determined,     \
-         only one of the below string constants      \
-         will be included in the final binary.*/     \
-      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("CHECK-fail: " #condition);        \
-      } else {                                       \
-        LOG_ERROR("CHECK-fail: " __VA_ARGS__);       \
-      }                                              \
-      INTERNAL();                                    \
-    }                                                \
-    OK_STATUS();                                     \
+#define CHECK_IMPL(condition, ...)                                         \
+  ({                                                                       \
+    status_t sts_ = OK_STATUS();                                           \
+    /* NOTE: The volatile intermediate variable is added to guarantee that \
+     * this macro won't be optimized out when used with compiling time     \
+     * constants.*/                                                        \
+    volatile bool res_ = (condition);                                      \
+    if (!res_) {                                                           \
+      /* NOTE: because the condition in this if                            \
+         statement can be statically determined,                           \
+         only one of the below string constants                            \
+         will be included in the final binary.*/                           \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) {                       \
+        LOG_ERROR("CHECK-fail: " #condition);                              \
+      } else {                                                             \
+        LOG_ERROR("CHECK-fail: " __VA_ARGS__);                             \
+      }                                                                    \
+      sts_ = INTERNAL();                                                   \
+    }                                                                      \
+    sts_;                                                                  \
   })
 
 /**

--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -105,89 +105,106 @@
 // clang-format on
 
 /**
+ * Compare `actual_` against `ref_` buffer.
+ *
+ * Prints matches between `actual_` and `ref_` before logging an error.
+ *
+ * @param expect_eq_ True if the arrays are expected to be equal, false
+ * otherwise.
+ * @param actual_ Buffer containing actual values.
+ * @param ref_ Buffer containing the reference values.
+ * @param size_ Number of items to compare.
+ * @param ... Arguments to a LOG_* macro, which are evaluated if the check.
+ * @return Either `kOk` or `kInternal`.
+ */
+
+#define CHECK_ARRAYS_IMPL(expect_eq_, actual_, ref_, size_, ...)           \
+  ({                                                                       \
+    static_assert(sizeof(*(actual_)) == sizeof(*(ref_)),                   \
+                  "CHECK_ARRAYS requires arguments of equal size.");       \
+    status_t sts_ = OK_STATUS();                                           \
+    volatile bool is_eq =                                                  \
+        memcmp((actual_), (ref_), size_ * sizeof(*(actual_))) == 0;        \
+    if (is_eq != expect_eq_) {                                             \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) {                       \
+        LOG_ERROR("CHECK-fail: " #actual_ "%smatches " #ref_,              \
+                  expect_eq_ ? " un" : " ");                               \
+      } else {                                                             \
+        LOG_ERROR("CHECK-fail: " __VA_ARGS__);                             \
+      }                                                                    \
+      for (size_t i = 0; i < size_; ++i) {                                 \
+        if (expect_eq_) {                                                  \
+          LOG_ERROR(SHOW_MISMATCH_FMT_STR_((actual_)[i]), i, (actual_)[i], \
+                    (ref_)[i]);                                            \
+        } else {                                                           \
+          LOG_ERROR(SHOW_MATCH_FMT_STR_((actual_)[i]), i, (actual_)[i]);   \
+        }                                                                  \
+      }                                                                    \
+      sts_ = INTERNAL();                                                   \
+    }                                                                      \
+    sts_;                                                                  \
+  })
+
+/**
  * Compare `num_items_` of `actual_` against `expected_` buffer.
  *
  * Prints differences between `actual_` and `expected_` before logging an error.
- * Note, the differences between the actual and expected buffer values are
- * logged via LOG_INFO _before_ the error is logged with LOG_ERROR, since by
- * default DV simulations are configured to terminate upon the first error.
- *
+ * Note in case the arrays are not equal the test will be terminated.
  * @param actual_ Buffer containing actual values.
  * @param expected_ Buffer containing expected values.
  * @param num_items_ Number of items to compare.
  * @param ... Arguments to a LOG_* macro, which are evaluated if the check.
  */
-#define CHECK_ARRAYS_EQ(actual_, expected_, num_items_, ...)                  \
-  do {                                                                        \
-    static_assert(sizeof(*(actual_)) == sizeof(*(expected_)),                 \
-                  "CHECK_ARRAYS requires arguments of equal size.");          \
-    bool fail = false;                                                        \
-    for (size_t i = 0; i < num_items_; ++i) {                                 \
-      if ((actual_)[i] != (expected_)[i]) {                                   \
-        if (!fail) {                                                          \
-          /* Print a failure message as soon as possible. */                  \
-          if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) {                      \
-            LOG_ERROR("CHECK-fail: " #actual_ " does not match " #expected_); \
-          } else {                                                            \
-            LOG_ERROR("CHECK-fail: " __VA_ARGS__);                            \
-          }                                                                   \
-        }                                                                     \
-                                                                              \
-        LOG_ERROR(SHOW_MISMATCH_FMT_STR_((actual_)[i]), i, (actual_)[i],      \
-                  (expected_)[i]);                                            \
-        fail = true;                                                          \
-      }                                                                       \
-    }                                                                         \
-    if (fail) {                                                               \
-      /* Currently, this macro will call into                                 \
-          the test failure code, which logs                                   \
-          "FAIL" and aborts. In the future,                                   \
-          we will try to condition on whether                                 \
-          or not this is a test.*/                                            \
-      test_status_set(kTestStatusFailed);                                     \
-    }                                                                         \
+#define CHECK_ARRAYS_EQ(actual_, expected_, num_items_, ...)               \
+  do {                                                                     \
+    if (status_err(CHECK_ARRAYS_IMPL(true, actual_, expected_, num_items_, \
+                                     ##__VA_ARGS__))) {                    \
+      /* Currently, this macro will call into the test failure code,       \
+      which logs "FAIL" and aborts. In the future, we will try to          \
+      condition on whether or not this is a test.*/                        \
+      test_status_set(kTestStatusFailed);                                  \
+    }                                                                      \
   } while (false)
+
+/**
+ * Same as `CHECK_ARRAYS_EQ` above but returns `kInternal` if the arrays are not
+ * equal rather than aborting.
+ */
+#define TRY_CHECK_ARRAYS_EQ(actual_, expected_, num_items_, ...) \
+  TRY(CHECK_ARRAYS_EQ_IMPL(true, actual_, expected_, num_items_, ##__VA_ARGS__))
+
+/**
+ * Same as `CHECK_ARRAYS_NE` above but returns `kInternal` if the arrays are not
+ * equal rather than aborting.
+ */
+#define TRY_CHECK_ARRAYS_NE(actual_, expected_, num_items_, ...)  \
+  TRY(CHECK_ARRAYS_EQ_IMPL(false, actual_, expected_, num_items_, \
+                           ##__VA_ARGS__))
 
 /**
  * Compare `num_items_` of `actual_` against `not_expected_` buffer.
  *
  * Prints matches between `actual_` and `not_expected_` before logging an error.
- * Note, the matches between the actual and not_expected buffer values are
- * logged via LOG_INFO _before_ the error is logged with LOG_ERROR, since by
- * default DV simulations are configured to terminate upon the first error.
  *
  * @param actual_ Buffer containing actual values.
  * @param not_expected_ Buffer containing not expected values.
  * @param num_items_ Number of items to compare.
  * @param ... Arguments to a LOG_* macro, which are evaluated if the check.
  */
-#define CHECK_ARRAYS_NE(actual_, not_expected_, num_items_, ...)               \
-  do {                                                                         \
-    static_assert(sizeof(*(actual_)) == sizeof(*(not_expected_)),              \
-                  "CHECK_ARRAYS requires arguments of equal size.");           \
-    if (memcmp((actual_), (not_expected_), num_items_ * sizeof(*(actual_))) == \
-        0) {                                                                   \
-      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) {                           \
-        LOG_ERROR("CHECK-fail: " #actual_ " matches " #not_expected_);         \
-      } else {                                                                 \
-        LOG_ERROR("CHECK-fail: " __VA_ARGS__);                                 \
-      }                                                                        \
-      for (size_t i = 0; i < num_items_; ++i) {                                \
-        LOG_ERROR(SHOW_MATCH_FMT_STR_((actual_)[i]), i, (actual_)[i]);         \
-      }                                                                        \
-      /* Currently, this macro will call into                                  \
-          the test failure code, which logs                                    \
-          "FAIL" and aborts. In the future,                                    \
-          we will try to condition on whether                                  \
-          or not this is a test.*/                                             \
-      test_status_set(kTestStatusFailed);                                      \
-    }                                                                          \
+#define CHECK_ARRAYS_NE(actual_, not_expected_, num_items_, ...)            \
+  do {                                                                      \
+    if (status_err(CHECK_ARRAYS_IMPL(false, actual_, not_expected_,         \
+                                     num_items_, ##__VA_ARGS__))) {         \
+      /* Currently, this macro will call into the test failure code, which  \
+         logs "FAIL" and aborts. In the future, we will try to condition on \
+         whether or not this is a test.*/                                   \
+      test_status_set(kTestStatusFailed);                                   \
+    }                                                                       \
   } while (false)
 
 /**
- * Checks the characters of two strings are the same,
- * up to and including the first null character.
- * The CHECK macro is called on each character pair.
+ * Checks the characters of two strings are the same, up to and including the
+ * first null character. The CHECK macro is called on each character pair.
  *
  * @param actual_ The first string in the comparison.
  * @param expected_ The second string in the comparison.


### PR DESCRIPTION
This PR :
 - Fixes the macro `CHECK` and `TRY_CHECK` that are always returning success, no matter the result of the expression.
 - Assign the result of the expressions to a volatile variable to avoid the compiler to optimize out the macro in some tests.
 - Refactor the test `spi_device_tx_rx` as it was relying on timing and started to fail after the `CHECK` macro refactor.
 - Add the `TRY_ARRAY_CHECK*` macros.

