### PR TITLE
[opentitantool] Remove RESET from default pincfg

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -1,10 +1,6 @@
 {
   "pins": [
     {
-      "name": "RESET",
-      "level": true
-    },
-    {
       "name": "SW_STRAP0",
       "mode": "PushPull",
       "level": false,

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -24,14 +24,14 @@
       "name": "TAP_STRAP0",
       "mode": "PushPull",
       "level": false,
-      "pull_mode": "None"
+      "pull_mode": "None",
       "alias_of": "USB_A18"
     },
     {
       "name": "TAP_STRAP1",
       "mode": "PushPull",
       "level": false,
-      "pull_mode": "None"
+      "pull_mode": "None",
       "alias_of": "USB_A19"
     }
   ],

--- a/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
@@ -16,10 +16,10 @@
       { "name": "IOR10", "alias_of": "10" },
       { "name": "IOR11", "alias_of": "11" },
       { "name": "IOR12", "alias_of": "12" },
-      { "name": "IOR13", "alias_of": "13" }
+      { "name": "IOR13", "alias_of": "13" },
 
-      { "name": "IOC0", "alias_of": "22" }
-      { "name": "IOC1", "alias_of": "23" }
+      { "name": "IOC0", "alias_of": "22" },
+      { "name": "IOC1", "alias_of": "23" },
       { "name": "IOC2", "alias_of": "24" }
   ],
   "spi": [


### PR DESCRIPTION
The RESET pin default appears to be overridden for all platforms other than verilator but is incompatible with verilator's transport. Removing it rescues the
//sw/device/silicon_creator/rom/e2e/weak_straps:sw_strap_value_sim_verilator test which was broken in December by setting these tests to initialize their pins based on their configs. I'm not sure why this test was the only one affected.
Signed-off-by: Drew Macrae <drewmacrae@gmail.com>