### PR TITLE
[opentitanlib] fix hyper310 tests

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -1,6 +1,6 @@
 {
   "includes": ["/__builtin__/opentitan.json"],
-  "interface": "hyperdebug",
+  "interface": "hyper310",
   "pins": [
     {
       "name": "RESET",


### PR DESCRIPTION
Since #17480 merged, the hyper310 tests have been failing with: _"Error: Inconsistent configuration of transport interface hyper310 vs. hyperdebug."_ This was due to the fact that the `--interface=hyper310` parameter did not match the `interface` parameter in the config file. This attempts to fix this error, and renable hyper310 test.

Note, they are not currently run in CI, hence the regression.