### PR TITLE
[sw/silicon_creator] Add generic key lookup and validity check for SPX keys

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -116,6 +116,7 @@ cc_library(
         ":rom_epmp",
         ":sigverify_keys",
         ":sigverify_keys_rsa",
+        ":sigverify_keys_spx",
         "//hw/ip/aon_timer/data:aon_timer_regs",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:bitfield",
@@ -310,6 +311,24 @@ cc_library(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
+    ],
+)
+
+cc_library(
+    name = "sigverify_keys_spx",
+    srcs = [
+        "sigverify_keys_spx.c",
+    ],
+    hdrs = [
+        "sigverify_keys_spx.h",
+    ],
+    deps = [
+        ":sigverify_keys",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify:spx_key",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -115,6 +115,7 @@ cc_library(
         ":bootstrap",
         ":rom_epmp",
         ":sigverify_keys",
+        ":sigverify_keys_rsa",
         "//hw/ip/aon_timer/data:aon_timer_regs",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:bitfield",
@@ -274,14 +275,15 @@ cc_test(
 
 cc_library(
     name = "sigverify_keys",
-    srcs = ["sigverify_keys.c"],
-    hdrs = [
-        "sigverify_keys.h",
+    srcs = [
+        "sigverify_keys.c",
         "sigverify_keys_rsa.h",
         "sigverify_keys_spx.h",
     ],
+    hdrs = [
+        "sigverify_keys.h",
+    ],
     deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
@@ -289,9 +291,25 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
-        "//sw/device/silicon_creator/lib/sigverify:rsa_key",
         "//sw/device/silicon_creator/lib/sigverify:sigverify_without_mock_mod_exp_ibex",
-        "//sw/device/silicon_creator/lib/sigverify:spx_key",
+    ],
+)
+
+cc_library(
+    name = "sigverify_keys_rsa",
+    srcs = [
+        "sigverify_keys_rsa.c",
+    ],
+    hdrs = [
+        "sigverify_keys_rsa.h",
+    ],
+    deps = [
+        ":sigverify_keys",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify:rsa_key",
     ],
 )
 
@@ -300,6 +318,7 @@ cc_test(
     srcs = ["sigverify_keys_unittest.cc"],
     deps = [
         ":sigverify_keys",
+        ":sigverify_keys_rsa",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/rom/keys/fake/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/BUILD
@@ -30,6 +30,7 @@ cc_test(
         ":fake",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/silicon_creator/rom:sigverify_keys",
+        "//sw/device/silicon_creator/rom:sigverify_keys_rsa",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake.c
+++ b/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake.c
@@ -34,16 +34,25 @@ const size_t kSigverifyRsaKeysStep = 1;
  */
 const sigverify_rom_rsa_key_t kSigverifyRsaKeys[kSigverifyRsaKeysCnt_] = {
     {
-        .key = TEST_KEY_0_RSA_3072_EXP_F4,
-        .key_type = kSigverifyKeyTypeTest,
+        .entry =
+            {
+                .key = TEST_KEY_0_RSA_3072_EXP_F4,
+                .key_type = kSigverifyKeyTypeTest,
+            },
     },
     {
-        .key = DEV_KEY_0_RSA_3072_EXP_F4,
-        .key_type = kSigverifyKeyTypeDev,
+        .entry =
+            {
+                .key = DEV_KEY_0_RSA_3072_EXP_F4,
+                .key_type = kSigverifyKeyTypeDev,
+            },
     },
     {
-        .key = PROD_KEY_0_RSA_3072_EXP_F4,
-        .key_type = kSigverifyKeyTypeProd,
+        .entry =
+            {
+                .key = PROD_KEY_0_RSA_3072_EXP_F4,
+                .key_type = kSigverifyKeyTypeProd,
+            },
     },
 };
 

--- a/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake_unittest.cc
+++ b/sw/device/silicon_creator/rom/keys/fake/sigverify_rsa_keys_fake_unittest.cc
@@ -28,7 +28,7 @@ using ::testing::Return;
 TEST(Keys, UniqueIds) {
   std::unordered_set<uint32_t> ids;
   for (size_t i = 0; i < kSigverifyRsaKeysCnt; ++i) {
-    ids.insert(sigverify_rsa_key_id_get(&kSigverifyRsaKeys[i].key.n));
+    ids.insert(sigverify_rsa_key_id_get(&kSigverifyRsaKeys[i].entry.key.n));
   }
 
   EXPECT_EQ(ids.size(), kSigverifyRsaKeysCnt);
@@ -99,7 +99,7 @@ struct RsaVerifyTestCase {
 const RsaVerifyTestCase kRsaVerifyTestCases[3]{
     // message: "test"
     {
-        .key = &kSigverifyRsaKeys[0].key,
+        .key = &kSigverifyRsaKeys[0].entry.key,
         .sig =
             {
                 0xeb28a6d3, 0x936b42bb, 0x76d3973d, 0x6322d536, 0x253c7547,
@@ -125,7 +125,7 @@ const RsaVerifyTestCase kRsaVerifyTestCases[3]{
             },
     },
     {
-        .key = &kSigverifyRsaKeys[1].key,
+        .key = &kSigverifyRsaKeys[1].entry.key,
         .sig =
             {
                 0x3106a8c5, 0xb7b48a3a, 0xb06af030, 0x9dca44b1, 0x55eaa90a,
@@ -151,7 +151,7 @@ const RsaVerifyTestCase kRsaVerifyTestCases[3]{
             },
     },
     {
-        .key = &kSigverifyRsaKeys[2].key,
+        .key = &kSigverifyRsaKeys[2].entry.key,
         .sig =
             {
                 0x39b92a38, 0xf584ed48, 0x25f5f323, 0x04dde936, 0x608871c1,

--- a/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake.c
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake.c
@@ -34,16 +34,25 @@ const size_t kSigverifySpxKeysStep = 1;
  */
 const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
     {
-        .key = TEST_KEY_0_SPX,
-        .key_type = kSigverifyKeyTypeTest,
+        .entry =
+            {
+                .key = TEST_KEY_0_SPX,
+                .key_type = kSigverifyKeyTypeTest,
+            },
     },
     {
-        .key = DEV_KEY_0_SPX,
-        .key_type = kSigverifyKeyTypeDev,
+        .entry =
+            {
+                .key = DEV_KEY_0_SPX,
+                .key_type = kSigverifyKeyTypeDev,
+            },
     },
     {
-        .key = PROD_KEY_0_SPX,
-        .key_type = kSigverifyKeyTypeProd,
+        .entry =
+            {
+                .key = PROD_KEY_0_SPX,
+                .key_type = kSigverifyKeyTypeProd,
+            },
     },
 };
 

--- a/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake_unittest.cc
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake_unittest.cc
@@ -14,7 +14,7 @@ using ::testing::Return;
 TEST(Keys, UniqueIds) {
   std::unordered_set<uint32_t> ids;
   for (size_t i = 0; i < kSigverifySpxKeysCnt; ++i) {
-    ids.insert(sigverify_spx_key_id_get(&kSigverifySpxKeys[i].key));
+    ids.insert(sigverify_spx_key_id_get(&kSigverifySpxKeys[i].entry.key));
   }
 
   EXPECT_EQ(ids.size(), kSigverifySpxKeysCnt);

--- a/sw/device/silicon_creator/rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys.c
@@ -214,3 +214,6 @@ rom_error_t sigverify_rsa_key_get(uint32_t key_id, lifecycle_state_t lc_state,
 
   return kErrorSigverifyBadKey;
 }
+
+// Extern declarations for the inline functions in the header.
+extern uint32_t sigverify_rom_key_id_get(const sigverify_rom_key_header_t *key);

--- a/sw/device/silicon_creator/rom/sigverify_keys.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys.h
@@ -8,6 +8,8 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,6 +103,57 @@ inline uint32_t sigverify_rom_key_id_get(
     const sigverify_rom_key_header_t *key) {
   return key->key_id;
 }
+
+/**
+ * Input parameters for `sigverify_key_get()`.
+ */
+typedef struct sigverify_key_get_in_params {
+  /**
+   * A key ID.
+   */
+  uint32_t key_id;
+  /**
+   * Life cycle state of the device.
+   */
+  lifecycle_state_t lc_state;
+  /**
+   * Array in which the requested key is searched for.
+   */
+  const sigverify_rom_key_header_t *key_array;
+  /**
+   * Offset of the OTP item that determines the validity of the keys.
+   */
+  size_t otp_offset;
+  /**
+   * Number of keys in `key_array`.
+   */
+  size_t key_cnt;
+  /**
+   * Size of each entry in `key_array`.
+   */
+  size_t key_size;
+  /**
+   * Step size to use when looking for public keys.
+   *
+   * This must be coprime with and less than `key_cnt`.
+   * Note: Step size is not applicable when `key_cnt` is 1.
+   */
+  size_t step;
+} sigverify_key_get_in_params_t;
+
+/**
+ * Returns the key with the given ID.
+ *
+ * This function returns the key only if it can be used in the given life cycle
+ * state and is valid in OTP. OTP check is performed only if the device is in a
+ * non-test operational state (PROD, PROD_END, DEV, RMA).
+ *
+ * @param in_params Input parameters.
+ * @param key Key with the given ID, valid only if it exists.
+ * @return Result of the operation.
+ */
+rom_error_t sigverify_key_get(sigverify_key_get_in_params_t in_params,
+                              const sigverify_rom_key_header_t **key);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/rom/sigverify_keys.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -59,6 +61,29 @@ enum {
    */
   kSigverifyNumEntriesPerOtpWord = sizeof(uint32_t),
 };
+
+/**
+ * Common initial sequence of public keys stored in ROM.
+ *
+ * OpenTitan ROM contains RSA and SPX keys whose definitions share this common
+ * initial sequence. This common initial sequence allows us to perform key
+ * lookup and validity checks in a generic manner by casting
+ * `sigverify_rom_rsa_key_t` or `sigverify_rom_spx_key_t` to this type.
+ */
+typedef struct sigverify_rom_key_header {
+  /**
+   * Type of the key.
+   */
+  sigverify_key_type_t key_type;
+  /**
+   * ID of the key.
+   */
+  uint32_t key_id;
+} sigverify_rom_key_header_t;
+
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
+OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/rom/sigverify_keys.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys.h
@@ -85,6 +85,23 @@ OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
 OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
 
+/**
+ * Gets the ID of a public key.
+ *
+ * ID of an RSA key is the least significant word of its modulus. ID of an SPX
+ * key is its least significant word. This function leverages the common initial
+ * sequence of both types of keys to get their IDs in a generic manner.
+ *
+ * Callers must make sure that `key` is valid before calling this function.
+ *
+ * @param key A public key.
+ * @return ID of the key.
+ */
+inline uint32_t sigverify_rom_key_id_get(
+    const sigverify_rom_key_header_t *key) {
+  return key->key_id;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/rom/sigverify_keys_rsa.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys_rsa.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/sigverify_keys_rsa.h"
+
+#include "sw/device/silicon_creator/rom/sigverify_keys.h"
+
+#include "otp_ctrl_regs.h"
+
+rom_error_t sigverify_rsa_key_get(uint32_t key_id, lifecycle_state_t lc_state,
+                                  const sigverify_rsa_key_t **key) {
+  const sigverify_rom_key_header_t *rom_key = NULL;
+  rom_error_t error = sigverify_key_get(
+      (sigverify_key_get_in_params_t){
+          .key_id = key_id,
+          .lc_state = lc_state,
+          .key_array = (const sigverify_rom_key_header_t *)kSigverifyRsaKeys,
+          .otp_offset =
+              OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN_OFFSET,
+          .key_cnt = kSigverifyRsaKeysCnt,
+          .key_size = sizeof(sigverify_rom_rsa_key_t),
+          .step = kSigverifyRsaKeysStep,
+      },
+      &rom_key);
+  RETURN_IF_ERROR(error);
+  *key = &((const sigverify_rom_rsa_key_t *)rom_key)->entry.key;
+  return error;
+}

--- a/sw/device/silicon_creator/rom/sigverify_keys_rsa.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_rsa.h
@@ -18,17 +18,44 @@ extern "C" {
 
 /**
  * An RSA public key stored in ROM.
+ *
+ * This struct must start with the common initial sequence
+ * `sigverify_rom_key_header_t`.
  */
-typedef struct sigverify_rom_rsa_key {
-  /**
-   * An RSA public key.
-   */
-  sigverify_rsa_key_t key;
+typedef struct sigverify_rom_rsa_key_entry {
   /**
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+  /**
+   * An RSA public key.
+   */
+  sigverify_rsa_key_t key;
+} sigverify_rom_rsa_key_entry_t;
+
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key.n.data[0], 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
+
+/**
+ * Union type to inspect the common initial sequence of RSA public keys stored
+ * in ROM.
+ */
+typedef union sigverify_rom_rsa_key {
+  /**
+   * Common initial sequence.
+   */
+  sigverify_rom_key_header_t key_header;
+  /**
+   * Actual RSA public key entry.
+   */
+  sigverify_rom_rsa_key_entry_t entry;
 } sigverify_rom_rsa_key_t;
+
+static_assert(
+    sizeof(sigverify_rom_rsa_key_entry_t) == sizeof(sigverify_rom_rsa_key_t),
+    "Size of an RSA public key entry must be equal to the size of a key");
 
 /**
  * Number of RSA public keys.

--- a/sw/device/silicon_creator/rom/sigverify_keys_spx.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys_spx.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/sigverify_keys_spx.h"
+
+#include "sw/device/silicon_creator/rom/sigverify_keys.h"
+
+#include "otp_ctrl_regs.h"
+
+rom_error_t sigverify_spx_key_get(uint32_t key_id, lifecycle_state_t lc_state,
+                                  const sigverify_spx_key_t **key) {
+  const sigverify_rom_key_header_t *rom_key = NULL;
+  rom_error_t error = sigverify_key_get(
+      (sigverify_key_get_in_params_t){
+          .key_id = key_id,
+          .lc_state = lc_state,
+          .key_array = (const sigverify_rom_key_header_t *)kSigverifySpxKeys,
+          .otp_offset =
+              OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN_OFFSET,
+          .key_cnt = kSigverifySpxKeysCnt,
+          .key_size = sizeof(sigverify_rom_spx_key_t),
+          .step = kSigverifySpxKeysStep,
+      },
+      &rom_key);
+  RETURN_IF_ERROR(error);
+  *key = &((const sigverify_rom_spx_key_t *)rom_key)->entry.key;
+  return error;
+}

--- a/sw/device/silicon_creator/rom/sigverify_keys_spx.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_spx.h
@@ -18,17 +18,44 @@ extern "C" {
 
 /**
  * An SPX public key stored in ROM.
+ *
+ * This struct must start with the common initial sequence
+ * `sigverify_rom_key_header_t`.
  */
-typedef struct sigverify_rom_spx_key {
-  /**
-   * An SPX public key.
-   */
-  sigverify_spx_key_t key;
+typedef struct sigverify_rom_spx_key_entry {
   /**
    * Type of the key.
    */
   sigverify_key_type_t key_type;
+  /**
+   * An SPX public key.
+   */
+  sigverify_spx_key_t key;
+} sigverify_rom_spx_key_entry_t;
+
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key.data[0], 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
+
+/**
+ * Union type to inspect the common initial sequence of SPX public keys stored
+ * in ROM.
+ */
+typedef union sigverify_rom_spx_key {
+  /**
+   * Common initial sequence.
+   */
+  sigverify_rom_key_header_t key_header;
+  /**
+   * Actual SPX public key entry.
+   */
+  sigverify_rom_spx_key_entry_t entry;
 } sigverify_rom_spx_key_t;
+
+static_assert(
+    sizeof(sigverify_rom_spx_key_entry_t) == sizeof(sigverify_rom_spx_key_t),
+    "Size of an SPX public key entry must be equal to the size of a key");
 
 /**
  * Number of SPX public keys.

--- a/sw/device/silicon_creator/rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/rom/sigverify_keys_unittest.cc
@@ -34,33 +34,33 @@ extern "C" {
  */
 constexpr sigverify_rom_rsa_key_t kSigverifyRsaKeys[]{
     {
-        .key = {.n = {{0xa0}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeTest,
+        .entry = {.key_type = kSigverifyKeyTypeTest,
+                  .key = {.n = {{0xa0}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xb0}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeProd,
+        .entry = {.key_type = kSigverifyKeyTypeProd,
+                  .key = {.n = {{0xb0}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xc0}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeDev,
+        .entry = {.key_type = kSigverifyKeyTypeDev,
+                  .key = {.n = {{0xc0}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xa1}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeTest,
+        .entry = {.key_type = kSigverifyKeyTypeTest,
+                  .key = {.n = {{0xa1}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xb1}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeProd,
+        .entry = {.key_type = kSigverifyKeyTypeProd,
+                  .key = {.n = {{0xb1}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xc1}}, .n0_inv = {0}},
-        .key_type = kSigverifyKeyTypeDev,
+        .entry = {.key_type = kSigverifyKeyTypeDev,
+                  .key = {.n = {{0xc1}}, .n0_inv = {0}}},
     },
     {
-        .key = {.n = {{0xff}}, .n0_inv = {0}},
-        .key_type = static_cast<sigverify_key_type_t>(
-            std::numeric_limits<uint32_t>::max()),
+        .entry = {.key_type = static_cast<sigverify_key_type_t>(
+                      std::numeric_limits<uint32_t>::max()),
+                  .key = {.n = {{0xff}}, .n0_inv = {0}}},
     },
 };
 
@@ -87,7 +87,7 @@ using ::testing::Return;
 std::vector<size_t> MockKeyIndicesOfType(sigverify_key_type_t key_type) {
   std::vector<size_t> indices;
   for (size_t i = 0; i < kSigverifyRsaKeysCnt; ++i) {
-    if (kSigverifyRsaKeys[i].key_type == key_type) {
+    if (kSigverifyRsaKeys[i].entry.key_type == key_type) {
       indices.push_back(i);
     }
   }
@@ -206,7 +206,7 @@ TEST_P(NonOperationalStateDeathTest, BadKey) {
       {
         ExpectKeysGet();
         sigverify_rsa_key_get(
-            sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].key.n),
+            sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].entry.key.n),
             lc_state, &key);
       },
       "");
@@ -229,11 +229,12 @@ TEST_P(ValidBasedOnOtp, ValidInOtp) {
   ExpectOtpRead(key_index, kHardenedByteBoolTrue);
 
   const sigverify_rsa_key_t *key;
-  EXPECT_EQ(sigverify_rsa_key_get(
-                sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].key.n),
-                lc_state, &key),
-            kErrorOk);
-  EXPECT_EQ(key, &kSigverifyRsaKeys[key_index].key);
+  EXPECT_EQ(
+      sigverify_rsa_key_get(
+          sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].entry.key.n),
+          lc_state, &key),
+      kErrorOk);
+  EXPECT_EQ(key, &kSigverifyRsaKeys[key_index].entry.key);
 }
 
 TEST_P(ValidBasedOnOtp, InvalidInOtp) {
@@ -245,10 +246,11 @@ TEST_P(ValidBasedOnOtp, InvalidInOtp) {
   ExpectOtpRead(key_index, kHardenedByteBoolFalse);
 
   const sigverify_rsa_key_t *key;
-  EXPECT_EQ(sigverify_rsa_key_get(
-                sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].key.n),
-                lc_state, &key),
-            kErrorSigverifyBadKey);
+  EXPECT_EQ(
+      sigverify_rsa_key_get(
+          sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].entry.key.n),
+          lc_state, &key),
+      kErrorSigverifyBadKey);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -279,11 +281,12 @@ TEST_P(ValidInState, Get) {
   ExpectKeysGet();
 
   const sigverify_rsa_key_t *key;
-  EXPECT_EQ(sigverify_rsa_key_get(
-                sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].key.n),
-                lc_state, &key),
-            kErrorOk);
-  EXPECT_EQ(key, &kSigverifyRsaKeys[key_index].key);
+  EXPECT_EQ(
+      sigverify_rsa_key_get(
+          sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].entry.key.n),
+          lc_state, &key),
+      kErrorOk);
+  EXPECT_EQ(key, &kSigverifyRsaKeys[key_index].entry.key);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -308,10 +311,11 @@ TEST_P(InvalidInState, Get) {
   ExpectKeysGet();
 
   const sigverify_rsa_key_t *key;
-  EXPECT_EQ(sigverify_rsa_key_get(
-                sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].key.n),
-                lc_state, &key),
-            kErrorSigverifyBadKey);
+  EXPECT_EQ(
+      sigverify_rsa_key_get(
+          sigverify_rsa_key_id_get(&kSigverifyRsaKeys[key_index].entry.key.n),
+          lc_state, &key),
+      kErrorSigverifyBadKey);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
This PR 
* Reorders the fields of the struct types `sigverify_rom_rsa_key_t` and `sigverify_rom_spx_key_t` that are used to stored public keys in ROM so that they have a common initial sequence (CIS) that can be used to alias to a common type (`sigverify_rom_key_common_sequence_t`), and 
* Refactors the existing `sigverify_rsa_key_get()` function into a generic function (`sigverify_key_get()`) to reuse the same core implementation for both RSA and SPX public keys.

@luismarques I read the standard (I think the relevant part is 6.5.2.3.6 in https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf), several posts and discussions on this topic and my understanding is this _should_ be OK but I'd appreciate it if you could let me know what you think.