### PR TITLE
[doc] Enable MathJax for equations

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,6 +15,7 @@ fold = { enable = true}
 git-repository-url = "https://github.com/lowrisc/opentitan"
 edit-url-template = "https://github.com/lowrisc/opentitan/edit/master/{path}"
 curly-quotes = true
+mathjax-support = true
 
 additional-js = [
     "./util/mdbook/wavejson/default.js",


### PR DESCRIPTION
Enable MathJax so that equations are actually rendered. See before and after below:
**Before**
![image](https://user-images.githubusercontent.com/34654485/227992416-34c274e3-5273-4d94-8f4a-05ec62418a91.png)
**After**
![image](https://user-images.githubusercontent.com/34654485/227992498-41832ec7-088a-4b7a-830e-c0c79224bbb0.png)

One caveat is that these equations do take a little while to load, but I think this is better than not rendering at all.
