### PR TITLE
[dv/chip] remove stale TODO

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -12,8 +12,6 @@
 // Verify pimux.dft_strap_test_o is always 0 in the states other than TEST_UNLOCKED* and
 // RMA, regardless of the value on DFT SW straps.
 
-// TODO: This test is broken. Drive functional JTAG traffic as opposed to pin connectivity.
-
 class chip_tap_straps_vseq extends chip_sw_base_vseq;
   string path_dft_strap_test_o = "tb.dut.top_earlgrey.dft_strap_test_o";
   string path_dft_tap_req = "tb.dut.top_earlgrey.u_dft_tap_breakout.req_i";


### PR DESCRIPTION
Remove stale TODO from chip_straps_test because it is addressed in PR num #15588 and the tests are passing in nightly regression.
Thanks @sha-ron for finding it in issue #17687