### PR TITLE
[entropy_src/dv] Measure and improve coverage of disabling & re-enabling

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -265,6 +265,14 @@
             '''
     }
     {
+      name: enable_delay_cg
+      desc: '''
+            Covers the enable and disable delay mechanism in different states of the module.  This
+            covergroup only gets sampled when the enable input of `entropy_src_enable_delay`
+            changes.
+            '''
+    }
+    {
       name: win_ht_cg
       desc: '''
             Covers a range of window sizes for each windowed health test.  For each test we need:

--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -53,6 +53,14 @@
       tests: ["entropy_src_rng"]
     }
     {
+      name: rng_max_rate
+      desc: '''
+            Verify RNG entropy at maximum production rate
+            '''
+      stage: V2
+      tests: ["entropy_src_rng_max_rate"]
+    }
+    {
       name: health_checks
       desc: '''
             Verify AdaptProp, RepCnt, RepCntSym, Bucket, Markov health check results

--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -259,6 +259,12 @@
             '''
     }
     {
+      name: sw_disable_cg
+      desc: '''
+            Covers SW attempting to disable entropy_src in different states of the module.
+            '''
+    }
+    {
       name: win_ht_cg
       desc: '''
             Covers a range of window sizes for each windowed health test.  For each test we need:

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -8,6 +8,7 @@ interface entropy_src_cov_if
   import prim_mubi_pkg::*;
 (
   input logic clk_i,
+  input logic rst_ni,
   mubi8_t     otp_en_entropy_src_fw_read_i,
   mubi8_t     otp_en_entropy_src_fw_over_i
 );
@@ -956,18 +957,20 @@ interface entropy_src_cov_if
   assign csrng_if_ack = tb.dut.entropy_src_hw_if_o.es_ack;
 
   always @(posedge clk_i) begin
-    if(csrng_if_req && csrng_if_ack) begin
-      cg_csrng_hw_sample(tb.dut.reg2hw.conf.fips_enable.q,
-                         tb.dut.reg2hw.conf.threshold_scope.q,
-                         tb.dut.reg2hw.conf.rng_bit_enable.q,
-                         tb.dut.reg2hw.conf.rng_bit_sel.q,
-                         tb.dut.reg2hw.entropy_control.es_route.q,
-                         tb.dut.reg2hw.entropy_control.es_type.q,
-                         tb.dut.reg2hw.conf.entropy_data_reg_enable.q,
-                         otp_en_entropy_src_fw_read_i,
-                         tb.dut.reg2hw.fw_ov_control.fw_ov_mode.q,
-                         otp_en_entropy_src_fw_over_i,
-                         tb.dut.reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
+    if (rst_ni) begin
+      if(csrng_if_req && csrng_if_ack) begin
+        cg_csrng_hw_sample(tb.dut.reg2hw.conf.fips_enable.q,
+                           tb.dut.reg2hw.conf.threshold_scope.q,
+                           tb.dut.reg2hw.conf.rng_bit_enable.q,
+                           tb.dut.reg2hw.conf.rng_bit_sel.q,
+                           tb.dut.reg2hw.entropy_control.es_route.q,
+                           tb.dut.reg2hw.entropy_control.es_type.q,
+                           tb.dut.reg2hw.conf.entropy_data_reg_enable.q,
+                           otp_en_entropy_src_fw_read_i,
+                           tb.dut.reg2hw.fw_ov_control.fw_ov_mode.q,
+                           otp_en_entropy_src_fw_over_i,
+                           tb.dut.reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
+      end
     end
   end
 

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -73,6 +73,16 @@
     }
 
     {
+      name: entropy_src_rng_max_rate
+      reseed: 50
+      uvm_test: entropy_src_rng_test
+      uvm_test_seq: entropy_src_rng_vseq
+      // Set the delay constraint of the RNG agent to at most 1, so that the agent delivers entropy
+      // at the highest possible rate.
+      run_opts: ["+rng_max_delay=1"]
+    }
+
+    {
       name: entropy_src_rng_with_xht_rsps
       uvm_test: entropy_src_rng_test
       uvm_test_seq: entropy_src_rng_vseq

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1393,6 +1393,17 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     if (channel == AddrChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
+        if (csr.get_name() == "module_enable") begin
+          uvm_reg_data_t reg_data;
+          logic [3:0] tl_data_lsbs;
+          csr_rd(.ptr(ral.main_sm_state.main_sm_state), .value(reg_data), .backdoor(1));
+          tl_data_lsbs = item.get_written_data();
+          cov_vif.cg_sw_disable_sample(
+              ral.me_regwen.me_regwen.get_mirrored_value(),
+              tl_data_lsbs == MuBi4True,
+              entropy_src_main_sm_pkg::state_e'(reg_data)
+          );
+        end
         if (locked_reg_access) begin
           string msg = $sformatf("Attempt to write while locked: %s", csr.get_name());
           `uvm_info(`gfn, msg, UVM_FULL)

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -44,7 +44,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   bit interrupt_handler_active = 0;
 
   // List of states to specfically hit for main_sm transition coverage
-  localparam int NumRareMainFsmStates = 8;
+  localparam int NumRareMainFsmStates = 12;
 
   entropy_src_main_sm_pkg::state_e [NumRareMainFsmStates - 1:0] rare_fsm_states = {
      entropy_src_main_sm_pkg::StartupPass1,
@@ -54,7 +54,11 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
      entropy_src_main_sm_pkg::BootPostHTChk,
      entropy_src_main_sm_pkg::ContHTStart,
      entropy_src_main_sm_pkg::FWInsertStart,
-     entropy_src_main_sm_pkg::Sha3MsgDone
+     entropy_src_main_sm_pkg::Sha3MsgDone,
+     entropy_src_main_sm_pkg::Sha3Prep,
+     entropy_src_main_sm_pkg::Sha3Process,
+     entropy_src_main_sm_pkg::Sha3Valid,
+     entropy_src_main_sm_pkg::AlertState
   };
 
   // A checklist vector with each bit corresponding to each of the rare_fsm_states above.

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -66,8 +66,11 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   // to AlertState) by creating another checklist variable and updating the task
   // targeted_transition_thread()
 
-  bit [NumRareMainFsmStates - 1:0] rare_state_to_idle_checklist = 8'b00000000;
-  bit [NumRareMainFsmStates - 1:0] rare_state_to_idle_backdoor = 8'b00100000;
+  bit [NumRareMainFsmStates - 1:0] rare_state_to_idle_checklist = '{default: 1'b0};
+  bit [NumRareMainFsmStates - 1:0] rare_state_to_idle_backdoor = '{
+    NumRareMainFsmStates - 3: 1'b1, // StartupHTStart
+    default: 1'b0
+  };
 
   constraint dly_to_access_intr_c {
     dly_to_access_intr dist {

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -28,7 +28,12 @@ class entropy_src_base_test extends cip_base_test #(
 
   virtual function void configure_env();
     // Take plusargs into account.
+    int rng_max_delay;
     bit xht_only_default_rsp;
+    if ($value$plusargs("rng_max_delay=%0d", rng_max_delay)) begin
+      `uvm_info(`gfn, $sformatf("+rng_max_delay specified"), UVM_MEDIUM)
+      cfg.m_rng_agent_cfg.host_delay_max = rng_max_delay;
+    end
     if ($value$plusargs("xht_only_default_rsp=%0b", xht_only_default_rsp)) begin
       `uvm_info(`gfn, $sformatf("+xht_only_default_rsp specified"), UVM_MEDIUM)
       cfg.xht_only_default_rsp = xht_only_default_rsp;


### PR DESCRIPTION
This PR adds two new covergroups for `entropy_src`, namely `sw_disable_cg` to cover software disabling the module in different states of the main FSM and `enable_delay_cg` to cover the disable and re-enable delay mechanism in different states of the module (FIFOs and SHA3 core).

Based on the data obtained from these new covergroups, this PR then
- extends `entropy_src_rng_vseq` so that four more states of the main FSM, `Sha3Prep`, `Sha3Process`, `Sha3Valid`, and `AlertState`, are treated as "rare" and the sequence ensures that a disable occurs at least once from each of these states; and
- adds a new testpoint and test in which random bits are provided to `entropy_src` at maximum rate.

Coverage results from a full regression run in Xcelium are as follows:
- `sw_disable_cg`: 21/21 (100%)
- `enable_delay_cg`: 28/33 (84.85%) -- covered except:
  - `cp_sha3_state.sha3_done` (on its own and in `cr_enable_i_sha3_state`): _SHA3 Done_ is signaled for a single clock cycle, so it's very unlikely the disable comes in this exact cycle. It can happen, but we would have to write a test specifically waiting for this to happen to cover this reliably. I don't think that gives us a good ROI at this time.
  - `cr_enable_i_fifo_state`: disabling while (`esbit` FIFO not empty AND `postht` FIFO not empty) OR (`esrng` FIFO not empty AND `postht` FIFO empty): These bins can happen but they don't do so often, so their score is either low or zero. For this run, the score was 2 for one and 0 for the other three bins. As all those FIFOs are treated uniformly by `entropy_src_enable_delay, I don't think hunting these down gives us a good ROI at this time.
 
(`enable_delay_cg.cp_enable_io.enable_delayed`: Re-enable while `entropy_src` is still busy. There's a very short time window for which `entropy_src` would have to be disabled between two enabled phases to hit this. In this run there was exactly one hit, so it happens but is very seldom.)

Based on these numbers, I'd let this PR resolve #16431 because although not every single state in which the module may be in when it gets disabled or re-enabled is covered, but most cases are and work fine.

I've also tested this PR in VCS (with #17718 applied), and coverage numbers are similar.

All tests using `entropy_src_rng_vseq` maintain a pass rate >90 %.