### PR TITLE
[entropy_src/dv] Fixes for VCS compatibility

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -799,8 +799,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       if (main_sm_exp_alert_cond) begin
         if (!fw_ov_insert && !threshold_alert_active && !main_sm_escalates) begin
           if (dut_phase == STARTUP) begin
-            fmt =  "New alert anticpated with >= 2 failing windows.";
-            fmt += "(supercedes count/threshold of %01d/%01d)";
+            fmt =  "New alert anticpated with >= 2 failing windows." +
+                   "(supercedes count/threshold of %01d/%01d)";
           end else begin
             fmt = "New alert anticpated! Fail count (%01d) >= threshold (%01d)";
           end
@@ -2238,7 +2238,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           // update counters for processing next seed:
           pass_count = 0;
           seed_idx++;
-        end : window_loop
+        end
       end : enabled_loop
     end : simulation_loop
   endtask

--- a/hw/ip/entropy_src/dv/tests/entropy_src_functional_errors_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_functional_errors_test.sv
@@ -25,4 +25,4 @@ class entropy_src_functional_errors_test extends entropy_src_base_test;
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
-endclass : entropy_src_intr_test
+endclass : entropy_src_functional_errors_test


### PR DESCRIPTION
Tests for `entropy_src` currently don't build in VCS. With these fixes they do build and should also run (although I only tested `entropy_src_rng`, which resulted in pass rates similar to Xcelium).