### PR TITLE
[opentitantool] Avoid no-op HyperDebug firmware upgrades

### DIFF
--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -175,6 +175,9 @@ pub struct UpdateFirmware<'a> {
     pub firmware: Option<Vec<u8>>,
     /// A progress function to provide user feedback, see details of the `Progress` struct.
     pub progress: Option<Box<dyn Fn(Progress) + 'a>>,
+    /// Should updating be attempted, even if the current firmware version matches that of the
+    /// image to be updated to.
+    pub force: bool,
 }
 
 /// An `EmptyTransport` provides no communications backend.

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -47,6 +47,12 @@ pub struct TransportUpdateFirmware {
         help = "Local firmware file to use instead of official release"
     )]
     filename: Option<PathBuf>,
+
+    #[structopt(
+        long,
+        help = "Update even if transport already reports identical version number"
+    )]
+    force: bool,
 }
 
 impl CommandDispatch for TransportUpdateFirmware {
@@ -63,6 +69,7 @@ impl CommandDispatch for TransportUpdateFirmware {
         let operation = UpdateFirmware {
             firmware,
             progress: Some(progress.pfunc()),
+            force: self.force,
         };
         transport.dispatch(&operation)
     }


### PR DESCRIPTION
The HyperDebug driver already has code to determine the current firmware version, and the version of a given binary image.  This PR adds logic to skip the transport firmware upgrade (with a warning), in case the same firmware is already running on HyperDebug.  (A --force flag allows overriding, for use in case of e.g. manually compiled firmwares with non-unique version numbers.)