### PR TITLE
[util] un-permute OTP image bits when processing in flash scramble script

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -18,6 +18,7 @@ load(
     _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
     _opentitan_transition = "opentitan_transition",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 """Rules to build OpenTitan for the RISC-V target"""
 
@@ -462,6 +463,11 @@ def _scramble_flash_vmem_impl(ctx):
     if ctx.file.otp:
         arguments.extend(["--in-otp-vmem", ctx.file.otp.path])
         inputs.append(ctx.file.otp)
+        if ctx.attr.otp_data_perm:
+            arguments.extend([
+                "--otp-data-perm",
+                ctx.attr.otp_data_perm[BuildSettingInfo].value,
+            ])
 
     # Run the action script.
     ctx.actions.run(
@@ -480,6 +486,10 @@ scramble_flash_vmem = rv_rule(
     attrs = {
         "otp": attr.label(allow_single_file = True),
         "vmem": attr.label(allow_single_file = True),
+        "otp_data_perm": attr.label(
+            default = "//hw/ip/otp_ctrl/data:data_perm",
+            doc = "Option to indicate OTP VMEM file bit layout.",
+        ),
         "_tool": attr.label(
             default = "@//util/design:gen-flash-img",
             executable = True,

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -24,6 +24,7 @@ py_binary(
     srcs = ["gen-flash-img.py"],
     deps = [
         ":secded_gen",
+        "//util/design/lib:common",
         "//util/design/lib:present",
         requirement("pyfinite"),
     ],

--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -9,12 +9,11 @@ import argparse
 import datetime
 import logging as log
 import random
-import re
 from pathlib import Path
 
 import hjson
 
-from lib.common import wrapped_docstring
+from lib.common import vmem_permutation_string, wrapped_docstring
 from lib.OtpMemImg import OtpMemImg
 
 # Get the memory map definition.
@@ -44,33 +43,6 @@ def _override_seed(args, name, config):
         if config.setdefault('seed', new_seed) == new_seed:
             log.warning('No {} specified, setting to {}.'.format(
                 name, new_seed))
-
-
-def _permutation_string(data_perm):
-    '''Check permutation format and expand the ranges'''
-
-    if not isinstance(data_perm, str):
-        TypeError()
-
-    if not data_perm:
-        return ''
-
-    # Check the format first
-    pattern = r'^((?:\[[0-9]+:[0-9]+\])+(?:,\[[0-9]+:[0-9]+\])*)'
-    match = re.fullmatch(pattern, data_perm)
-    if match is None:
-        raise ValueError()
-    # Expand the ranges
-    expanded_perm = []
-    groups = match.groups()
-    for group in groups[0].split(','):
-        k1, k0 = [int(x) for x in group[1:-1].split(':')]
-        if k1 > k0:
-            expanded_perm = list(range(k0, k1 + 1)) + expanded_perm
-        else:
-            expanded_perm = list(range(k0, k1 - 1, -1)) + expanded_perm
-
-    return expanded_perm
 
 
 # TODO: this can be removed when we have moved to Python 3.8
@@ -193,7 +165,7 @@ def main():
                         are ignored.
                         ''')
     parser.add_argument('--data-perm',
-                        type=_permutation_string,
+                        type=vmem_permutation_string,
                         metavar='<map>',
                         default='',
                         help='''
@@ -203,7 +175,7 @@ def main():
                         of bit slices, where the numbers refer to the bit positions in
                         the original data word before remapping, for example:
 
-                        "[7:0],[16:8]".
+                        "[7:0],[15:8]".
 
                         The mapping must be bijective - otherwise this will generate
                         an error.

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -225,13 +225,23 @@ def validate_data_perm_option(word_bit_length, data_perm):
             'since it contains duplicated indices.'.format(data_perm))
 
 
-def permute_bits(bits, permutation):
-    '''Permute the bits in a bitstring'''
-    bitlen = len(bits)
+def inverse_permute_bits(bit_str, permutation):
+    '''Un-permute the bits in a bitstring (inverse of `permute_bits`).'''
+    bit_str_len = len(bit_str)
+    assert bit_str_len == len(permutation)
+    bit_vector = ["0"] * bit_str_len
+    for i, perm_idx in enumerate(permutation):
+        bit_vector[bit_str_len - perm_idx - 1] = bit_str[bit_str_len - i - 1]
+    return ''.join(bit_vector)
+
+
+def permute_bits(bit_str, permutation):
+    '''Permute the bits in a bitstring.'''
+    bitlen = len(bit_str)
     assert bitlen == len(permutation)
     permword = ''
     for k in permutation:
-        permword = bits[bitlen - k - 1] + permword
+        permword = bit_str[bitlen - k - 1] + permword
     return permword
 
 

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -4,6 +4,7 @@
 r"""Shared subfunctions.
 """
 import random
+import re
 import textwrap
 from math import ceil, log2
 
@@ -206,6 +207,24 @@ def scatter_bits(mask, bits):
     return scatterword
 
 
+def validate_data_perm_option(word_bit_length, data_perm):
+    '''Validate OTP data permutation option by checking for bijectivity.'''
+    if len(data_perm) != word_bit_length:
+        raise RuntimeError(
+            'Data permutation "{}" is not bijective, since '
+            'it does not have the same length ({}) as the data.'.format(
+                data_perm, word_bit_length))
+    for k in data_perm:
+        if k >= word_bit_length:
+            raise RuntimeError('Data permutation "{}" is not bijective, '
+                               'since the index {} is out of bounds.'.format(
+                                   data_perm, k))
+    if len(set(data_perm)) != word_bit_length:
+        raise RuntimeError(
+            'Data permutation "{}" is not bijective, '
+            'since it contains duplicated indices.'.format(data_perm))
+
+
 def permute_bits(bits, permutation):
     '''Permute the bits in a bitstring'''
     bitlen = len(bits)
@@ -251,10 +270,36 @@ def random_or_hexvalue(dict_obj, key, num_bits):
         try:
             dict_obj[key] = _parse_hex(dict_obj[key])
             if dict_obj[key] >= 2**num_bits:
-                raise RuntimeError(
-                    'Value "{}" is out of range.'
-                    .format(dict_obj[key]))
+                raise RuntimeError('Value "{}" is out of range.'.format(
+                    dict_obj[key]))
         except ValueError:
             raise RuntimeError(
-                'Invalid value "{}". Must be hex or "<random>".'
-                .format(dict_obj[key]))
+                'Invalid value "{}". Must be hex or "<random>".'.format(
+                    dict_obj[key]))
+
+
+def vmem_permutation_string(data_perm):
+    """Check VMEM permutation format and expand the ranges."""
+
+    if not isinstance(data_perm, str):
+        raise TypeError()
+
+    if not data_perm:
+        return ""
+
+    # Check the format first.
+    pattern = r"^((?:\[[0-9]+:[0-9]+\])+(?:,\[[0-9]+:[0-9]+\])*)"
+    match = re.fullmatch(pattern, data_perm)
+    if match is None:
+        raise ValueError()
+    # Expand the ranges.
+    expanded_perm = []
+    groups = match.groups()
+    for group in groups[0].split(","):
+        k1, k0 = [int(x) for x in group[1:-1].split(":")]
+        if k1 > k0:
+            expanded_perm = list(range(k0, k1 + 1)) + expanded_perm
+        else:
+            expanded_perm = list(range(k0, k1 - 1, -1)) + expanded_perm
+
+    return expanded_perm


### PR DESCRIPTION
This un-permutes the OTP image bits when processing the OTP image in the flash ECC/scrambling script, as the scrambling enablement option is read directly out of the OTP image.

This was preventing the power virus test from running in the closed source environment where bits in the OTP images are permuted.

CC @sha-ron: you may want to pull this down and make sure this fixes the issue you were encountering with the power virus test in the closed source before we merge, since I don't have the ability to run anything in the closed source.