### PR TITLE
[crypto] Update ECDSA-P256 to better match API.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -12,8 +12,20 @@ cc_library(
     hdrs = ["ecdsa_p256.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":p256_common",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/otbn/crypto:p256_ecdsa",
+    ],
+)
+
+cc_library(
+    name = "p256_common",
+    srcs = ["p256_common.c"],
+    hdrs = ["p256_common.h"],
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:status",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/impl/ecc/ecdsa_p256.h"
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -34,110 +35,81 @@ static const otbn_addr_t kOtbnVarEcdsaD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 
 /* Mode is represented by a single word, 1 for sign and 2 for verify */
-static const uint32_t kOtbnEcdsaModeNumWords = 1;
+static const uint32_t kOtbnEcdsaModeWords = 1;
 static const uint32_t kOtbnEcdsaModeSign = 1;
 static const uint32_t kOtbnEcdsaModeVerify = 2;
 
-// TODO: This implementation waits while OTBN is processing; it should be
-// modified to be non-blocking.
-status_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
-                         const ecdsa_p256_private_key_t *private_key,
-                         ecdsa_p256_signature_t *result) {
+status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
+                               const p256_masked_scalar_t *private_key) {
   // Load the ECDSA/P-256 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdsa));
 
   // Set mode so start() will jump into p256_ecdsa_sign.
-  HARDENED_TRY(otbn_dmem_write(kOtbnEcdsaModeNumWords, &kOtbnEcdsaModeSign,
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdsaModeWords, &kOtbnEcdsaModeSign,
                                kOtbnVarEcdsaMode));
 
   // Set the message digest.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256ScalarNumWords, digest->h, kOtbnVarEcdsaMsg));
+  HARDENED_TRY(otbn_dmem_write(kP256ScalarWords, digest, kOtbnVarEcdsaMsg));
 
   // Set the private key shares.
-  HARDENED_TRY(otbn_dmem_write(kP256SecretScalarNumWords, private_key->d0,
-                               kOtbnVarEcdsaD0));
-  HARDENED_TRY(otbn_dmem_write(kP256SecretScalarNumWords, private_key->d1,
-                               kOtbnVarEcdsaD1));
-
-  // Write trailing 0s to the upper parts of d0 and d1 so that OTBN's 256-bit
-  // read of the 64-bit second share does not cause an error.
-  size_t num_zeroes = kOtbnWideWordNumWords -
-                      (kP256SecretScalarNumWords % kOtbnWideWordNumWords);
-  HARDENED_TRY(otbn_dmem_set(num_zeroes, 0,
-                             kOtbnVarEcdsaD0 + kP256SecretScalarNumBytes));
-  HARDENED_TRY(otbn_dmem_set(num_zeroes, 0,
-                             kOtbnVarEcdsaD1 + kP256SecretScalarNumBytes));
+  HARDENED_TRY(
+      p256_masked_scalar_write(private_key, kOtbnVarEcdsaD0, kOtbnVarEcdsaD1));
 
   // Start the OTBN routine.
-  HARDENED_TRY(otbn_execute());
+  return otbn_execute();
+}
 
+status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read signature R out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarNumWords, kOtbnVarEcdsaR, result->r));
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarEcdsaR, result->r));
 
   // Read signature S out of OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarNumWords, kOtbnVarEcdsaS, result->s));
-
-  // TODO: try to verify the signature, and return an error if verification
-  // fails.
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarEcdsaS, result->s));
 
   return OTCRYPTO_OK;
 }
 
-// TODO: This implementation waits while OTBN is processing; it should be
-// modified to be non-blocking.
-status_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
-                           const ecdsa_p256_message_digest_t *digest,
-                           const ecdsa_p256_public_key_t *public_key,
-                           hardened_bool_t *result) {
+status_t ecdsa_p256_verify_start(const ecdsa_p256_signature_t *signature,
+                                 const uint32_t digest[kP256ScalarWords],
+                                 const p256_point_t *public_key) {
   // Load the ECDSA/P-256 app and set up data pointers
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdsa));
 
   // Set mode so start() will jump into p256_ecdsa_verify.
-  HARDENED_TRY(otbn_dmem_write(kOtbnEcdsaModeNumWords, &kOtbnEcdsaModeVerify,
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdsaModeWords, &kOtbnEcdsaModeVerify,
                                kOtbnVarEcdsaMode));
-
   // Set the message digest.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256ScalarNumWords, digest->h, kOtbnVarEcdsaMsg));
+  HARDENED_TRY(otbn_dmem_write(kP256ScalarWords, digest, kOtbnVarEcdsaMsg));
 
   // Set the signature R.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256ScalarNumWords, signature->r, kOtbnVarEcdsaR));
+  HARDENED_TRY(otbn_dmem_write(kP256ScalarWords, signature->r, kOtbnVarEcdsaR));
 
   // Set the signature S.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256ScalarNumWords, signature->s, kOtbnVarEcdsaS));
+  HARDENED_TRY(otbn_dmem_write(kP256ScalarWords, signature->s, kOtbnVarEcdsaS));
 
   // Set the public key x coordinate.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256CoordNumWords, public_key->x, kOtbnVarEcdsaX));
+  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarEcdsaX));
 
   // Set the public key y coordinate.
-  HARDENED_TRY(
-      otbn_dmem_write(kP256CoordNumWords, public_key->y, kOtbnVarEcdsaY));
+  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->y, kOtbnVarEcdsaY));
 
   // Start the OTBN routine.
-  HARDENED_TRY(otbn_execute());
+  return otbn_execute();
+}
 
+status_t ecdsa_p256_verify_finalize(const ecdsa_p256_signature_t *signature,
+                                    hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read x_r (recovered R) out of OTBN dmem.
-  uint32_t x_r[kP256ScalarNumWords];
-  HARDENED_TRY(otbn_dmem_read(kP256ScalarNumWords, kOtbnVarEcdsaXr, x_r));
+  uint32_t x_r[kP256ScalarWords];
+  HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarEcdsaXr, x_r));
 
-  // TODO: Harden this memory comparison or do it in OTBN.
-  // Check that x_r == R.
-  *result = kHardenedBoolTrue;
-  for (int i = 0; i < kP256ScalarNumWords; i++) {
-    if (x_r[i] != signature->r[i]) {
-      *result = kHardenedBoolFalse;
-    }
-  }
+  *result = hardened_memeq(x_r, signature->r, kP256ScalarWords);
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
@@ -10,35 +10,11 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p256_common.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-enum {
-  /**
-   * Length of a P-256 curve point coordinate in bits (integer modulo the "p"
-   * parameter, see FIPS 186-4 section D.1.2.3)
-   */
-  kP256CoordNumBits = 256,
-  /* Length of a P-256 curve point coordinate in words */
-  kP256CoordNumWords = kP256CoordNumBits / (sizeof(uint32_t) * 8),
-  /**
-   * Length of a number modulo the P-256 "n" parameter (see FIPS 186-4 section
-   * D.1.2.3) in bits
-   */
-  kP256ScalarNumBits = 256,
-  /* Length of a number modulo the P-256 "n" parameter in words */
-  kP256ScalarNumWords = kP256ScalarNumBits / (sizeof(uint32_t) * 8),
-  /**
-   * Length of a secret scalar share (uses extra redundant bits).
-   */
-  kP256SecretScalarNumBits = kP256ScalarNumBits + 64,
-  /* Length of secret scalar share in bytes. */
-  kP256SecretScalarNumBytes = kP256SecretScalarNumBits / 8,
-  /* Length of secret scalar share in words. */
-  kP256SecretScalarNumWords = kP256SecretScalarNumBytes / sizeof(uint32_t),
-};
 
 /**
  * A type that holds an ECDSA/P-256 signature.
@@ -46,57 +22,56 @@ enum {
  * The signature consists of two integers r and s, computed modulo n.
  */
 typedef struct ecdsa_p256_signature_t {
-  uint32_t r[kP256ScalarNumWords];
-  uint32_t s[kP256ScalarNumWords];
+  uint32_t r[kP256ScalarWords];
+  uint32_t s[kP256ScalarWords];
 } ecdsa_p256_signature_t;
 
 /**
- * A type that holds an ECDSA/P-256 private key.
+ * Start an async ECDSA/P-256 signature generation operation on OTBN.
  *
- * The private key consists of a single integer d, computed modulo n. The key
- * is represented in two shares, d0 and d1, such that d = (d0 + d1) mod n. The
- * shares d0 and d1 are also both computed modulo n.
- */
-typedef struct ecdsa_p256_private_key_t {
-  uint32_t d0[kP256SecretScalarNumWords];
-  uint32_t d1[kP256SecretScalarNumWords];
-} ecdsa_p256_private_key_t;
-
-/**
- * A type that holds an ECDSA/P-256 public key.
- *
- * The public key is a point Q on the p256 curve, consisting of two coordinates
- * x and y computed modulo p.
- */
-typedef struct ecdsa_p256_public_key_t {
-  uint32_t x[kP256CoordNumWords];
-  uint32_t y[kP256CoordNumWords];
-} ecdsa_p256_public_key_t;
-
-/**
- * A type that holds an ECDSA/P-256 message digest.
- *
- * The message digest is expected to already be transformed into an integer
- * h = H(msg) mod n, where H is the hash function.
- */
-typedef struct ecdsa_p256_message_digest_t {
-  uint32_t h[kP256ScalarNumWords];
-} ecdsa_p256_message_digest_t;
-
-/**
- * Generates an ECDSA/P-256 signature.
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
  * @param message_digest Digest of the message to sign.
- * @param private_key Key to sign the message with.
+ * @param private_key Secret key to sign the message with.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
+                               const p256_masked_scalar_t *private_key);
+
+/**
+ * Finish an async ECDSA/P-256 signature generation operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p256_sign` for details.
+ *
+ * Blocks until OTBN is idle.
+ *
  * @param result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
-status_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
-                         const ecdsa_p256_private_key_t *private_key,
-                         ecdsa_p256_signature_t *result);
+status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result);
 
 /**
- * Verifies an ECDSA/P-256 signature.
+ * Start an async ECDSA/P-256 signature verification operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p256_verify` for details.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param signature Signature to be verified.
+ * @param message_digest Digest of the message to check the signature against.
+ * @param public_key Key to check the signature against.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_verify_start(const ecdsa_p256_signature_t *signature,
+                                 const uint32_t digest[kP256ScalarWords],
+                                 const p256_point_t *public_key);
+
+/**
+ * Finish an async ECDSA/P-256 signature verification operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p256_verify` for details.
+ *
+ * Blocks until OTBN is idle.
  *
  * If the signature is valid, writes `kHardenedBoolTrue` to `result`;
  * otherwise, writes `kHardenedBoolFalse`.
@@ -107,15 +82,11 @@ status_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
  * status will be OK but `result` will be `kHardenedBoolFalse`.
  *
  * @param signature Signature to be verified.
- * @param message_digest Digest of the message to check the signature against.
- * @param public_key Key to check the signature against.
  * @param result Output buffer (true if signature is valid, false otherwise)
  * @return Result of the operation (OK or error).
  */
-status_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
-                           const ecdsa_p256_message_digest_t *digest,
-                           const ecdsa_p256_public_key_t *public_key,
-                           hardened_bool_t *result);
+status_t ecdsa_p256_verify_finalize(const ecdsa_p256_signature_t *signature,
+                                    hardened_bool_t *result);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
@@ -27,11 +27,32 @@ typedef struct ecdsa_p256_signature_t {
 } ecdsa_p256_signature_t;
 
 /**
+ * Start an async ECDSA/P-256 keypair generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_keygen_start(void);
+
+/**
+ * Finish an async ECDSA/P-256 keypair generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] private_key Generated private key.
+ * @param[out] public_key Generated public key.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_keygen_finalize(p256_masked_scalar_t *private_key,
+                                    p256_point_t *public_key);
+
+/**
  * Start an async ECDSA/P-256 signature generation operation on OTBN.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
- * @param message_digest Digest of the message to sign.
+ * @param digest Digest of the message to sign.
  * @param private_key Secret key to sign the message with.
  * @return Result of the operation (OK or error).
  */
@@ -45,7 +66,7 @@ status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
  *
  * Blocks until OTBN is idle.
  *
- * @param result Buffer in which to store the generated signature.
+ * @param[out] result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
 status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result);
@@ -58,7 +79,7 @@ status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result);
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
  *
  * @param signature Signature to be verified.
- * @param message_digest Digest of the message to check the signature against.
+ * @param digest Digest of the message to check the signature against.
  * @param public_key Key to check the signature against.
  * @return Result of the operation (OK or error).
  */
@@ -82,7 +103,8 @@ status_t ecdsa_p256_verify_start(const ecdsa_p256_signature_t *signature,
  * status will be OK but `result` will be `kHardenedBoolFalse`.
  *
  * @param signature Signature to be verified.
- * @param result Output buffer (true if signature is valid, false otherwise)
+ * @param[out] result Output buffer (true if signature is valid, false
+ * otherwise)
  * @return Result of the operation (OK or error).
  */
 status_t ecdsa_p256_verify_finalize(const ecdsa_p256_signature_t *signature,

--- a/sw/device/lib/crypto/impl/ecc/p256_common.c
+++ b/sw/device/lib/crypto/impl/ecc/p256_common.c
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/p256_common.h"
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+enum {
+  /**
+   * Number of extra padding words needed for masked scalar shares.
+   *
+   * Where W is the word size and S is the share size, the padding needed is:
+   *   (W - (S % W)) % W
+   *
+   * The extra outer "% W" ensures that the padding is 0 if (S % W) is 0.
+   */
+  kMaskedScalarPaddingWords =
+      (kOtbnWideWordNumWords -
+       (kP256MaskedScalarShareWords % kOtbnWideWordNumWords)) %
+      kOtbnWideWordNumWords,
+};
+
+status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
+                                       const otbn_addr_t share0_addr,
+                                       const otbn_addr_t share1_addr) {
+  HARDENED_TRY(
+      otbn_dmem_write(kP256MaskedScalarShareWords, src->share0, share0_addr));
+  HARDENED_TRY(
+      otbn_dmem_write(kP256MaskedScalarShareWords, src->share1, share1_addr));
+
+  // Write trailing 0s so that OTBN's 256-bit read of the second share does not
+  // cause an error.
+  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                             share0_addr + kP256MaskedScalarShareBytes));
+  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                             share1_addr + kP256MaskedScalarShareBytes));
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/p256_common.c
+++ b/sw/device/lib/crypto/impl/ecc/p256_common.c
@@ -23,8 +23,8 @@ enum {
 };
 
 status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
-                                       const otbn_addr_t share0_addr,
-                                       const otbn_addr_t share1_addr) {
+                                  const otbn_addr_t share0_addr,
+                                  const otbn_addr_t share1_addr) {
   HARDENED_TRY(
       otbn_dmem_write(kP256MaskedScalarShareWords, src->share0, share0_addr));
   HARDENED_TRY(

--- a/sw/device/lib/crypto/impl/ecc/p256_common.h
+++ b/sw/device/lib/crypto/impl/ecc/p256_common.h
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P256_COMMON_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P256_COMMON_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * Length of a P-256 curve point coordinate in bits (modulo p).
+   */
+  kP256CoordBits = 256,
+  /**
+   * Length of a P-256 curve point coordinate in bytes.
+   */
+  kP256CoordBytes = kP256CoordBits / 8,
+  /**
+   * Length of a P-256 curve point coordinate in words.
+   */
+  kP256CoordWords = kP256CoordBytes / sizeof(uint32_t),
+  /**
+   * Length of an element in the P-256 scalar field (modulo the curve order n).
+   */
+  kP256ScalarBits = 256,
+  /**
+   * Length of a secret scalar share in bytes.
+   */
+  kP256ScalarBytes = kP256ScalarBits / 8,
+  /**
+   * Length of secret scalar share in words.
+   */
+  kP256ScalarWords = kP256ScalarBytes / sizeof(uint32_t),
+  /**
+   * Length of a masked secret scalar share.
+   *
+   * This implementation uses extra redundant bits for side-channel protection.
+   */
+  kP256MaskedScalarShareBits = kP256ScalarBits + 64,
+  /**
+   * Length of a masked secret scalar share in bytes.
+   */
+  kP256MaskedScalarShareBytes = kP256MaskedScalarShareBits / 8,
+  /**
+   * Length of masked secret scalar share in words.
+   */
+  kP256MaskedScalarShareWords = kP256MaskedScalarShareBytes / sizeof(uint32_t),
+};
+
+/**
+ * A type that holds a masked value from the P-256 scalar field.
+ *
+ * This struct is used to represent secret keys, which are integers modulo n.
+ * The key d is represented in two 320-bit shares, d0 and d1, such that d = (d0
+ * + d1) mod n. Mathematically, d0 and d1 could also be reduced modulo n, but
+ * the extra bits provide side-channel protection.
+ */
+typedef struct p256_masked_scalar {
+  /**
+   * First share of the secret scalar.
+   */
+  uint32_t share0[kP256MaskedScalarShareWords];
+  /**
+   * Second share of the secret scalar.
+   */
+  uint32_t share1[kP256MaskedScalarShareWords];
+} p256_masked_scalar_t;
+
+/**
+ * A type that holds a P-256 curve point.
+ */
+typedef struct p256_point {
+  /**
+   * Affine x-coordinate.
+   */
+  uint32_t x[kP256CoordWords];
+  /**
+   * Affine y-coordinate.
+   */
+  uint32_t y[kP256CoordWords];
+} p256_point_t;
+
+/**
+ * Write a masked P-256 scalar to OTBN's data memory.
+ *
+ * OTBN actually requires that 512 bits be written, even though only 320 are
+ * used; the others are ignored but must be set to avoid an error when OTBN
+ * attempts to read uninitialized memory.
+ *
+ * @param src Masked scalar to write.
+ * @param share0_addr DMEM address of the first share.
+ * @param share1_addr DMEM address of the second share.
+ * @return Result of the operation.
+ */
+status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
+                                  const otbn_addr_t share0_addr,
+                                  const otbn_addr_t share1_addr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P256_COMMON_H_

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -150,29 +150,6 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     ecc_signature_t *signature);
 
 /**
- * Performs the deterministic ECDSA digital signature generation.
- *
- * In the case of deterministic ECDSA, the random value ‘k’ for the
- * signature generation is deterministically generated from the
- * private key and the input message. Refer to RFC6979 for details.
- *
- * The `domain_parameter` field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to `NULL`.
- *
- * @param private_key Pointer to the blinded private key (d) struct.
- * @param input_message Input message to be signed.
- * @param elliptic_curve Pointer to the elliptic curve to be used.
- * @param[out] signature Pointer to the signature struct with (r,s) values.
- * @return Result of the deterministic ECDSA signature.
- * generation
- */
-crypto_status_t otcrypto_deterministic_ecdsa_sign(
-    const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, ecc_curve_t *elliptic_curve,
-    ecc_signature_t *signature);
-
-/**
  * Performs the ECDSA digital signature verification.
  *
  * The `domain_parameter` field of the `elliptic_curve` is required

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -17,24 +17,6 @@ static const char kMessage[] = "test message";
 // Digest of the test message above.
 hmac_digest_t hmac_digest;
 
-static const p256_point_t kPublicKey = {
-    // Public key x-coordinate (Q.x)
-    .x = {0x558bb24e, 0x246288eb, 0x9e1bbff2, 0xa7094ad8, 0xcd926786,
-          0x075d07ca, 0xac2de782, 0x1f791431},
-    // Public key y-coordinate (Q.y)
-    .y = {0x23e49c27, 0xfaa21024, 0xf17353bd, 0x40f008a5, 0x2155c09e,
-          0x5954f0a4, 0x155f3e00, 0x874bc63c},
-};
-
-// Private key (d) in two shares
-static const p256_masked_scalar_t kPrivateKey = {
-    .share0 = {0xaf57b4cd, 0x744c9f1c, 0x8b7e0c02, 0x283e93e9, 0x0d18f00c,
-               0xda0b6cf4, 0x8fe6bb7a, 0x5545a0b7, 0x00000000, 0x00000000},
-    // TODO(#15409): add real data here to ensure the second share is
-    // incorporated.
-    .share1 = {0},
-};
-
 static void compute_digest(void) {
   // Compute the SHA-256 digest using the HMAC device.
   hmac_sha256_init();
@@ -42,24 +24,27 @@ static void compute_digest(void) {
   hmac_final(&hmac_digest);
 }
 
-status_t sign_then_verify_test(void) {
+status_t sign_then_verify_test(hardened_bool_t *verificationResult) {
   // Spin until OTBN is idle.
   TRY(otbn_busy_wait_for_done());
 
-  // Generate a signature for the message
+  // Generate a keypair.
+  LOG_INFO("Generating keypair...");
+  TRY(ecdsa_p256_keygen_start());
+  p256_masked_scalar_t private_key;
+  p256_point_t public_key;
+  TRY(ecdsa_p256_keygen_finalize(&private_key, &public_key));
+
+  // Generate a signature for the message.
   LOG_INFO("Signing...");
-  TRY(ecdsa_p256_sign_start(hmac_digest.digest, &kPrivateKey));
+  TRY(ecdsa_p256_sign_start(hmac_digest.digest, &private_key));
   ecdsa_p256_signature_t signature;
   TRY(ecdsa_p256_sign_finalize(&signature));
 
-  // Verify the signature
+  // Verify the signature.
   LOG_INFO("Verifying...");
-  TRY(ecdsa_p256_verify_start(&signature, hmac_digest.digest, &kPublicKey));
-  hardened_bool_t verificationResult;
-  TRY(ecdsa_p256_verify_finalize(&signature, &verificationResult));
-
-  // Signature verification is expected to succeed
-  CHECK(verificationResult == kHardenedBoolTrue);
+  TRY(ecdsa_p256_verify_start(&signature, hmac_digest.digest, &public_key));
+  TRY(ecdsa_p256_verify_finalize(&signature, verificationResult));
 
   return OTCRYPTO_OK;
 }
@@ -71,13 +56,20 @@ bool test_main(void) {
 
   compute_digest();
 
-  status_t err = sign_then_verify_test();
+  hardened_bool_t verificationResult;
+  status_t err = sign_then_verify_test(&verificationResult);
   if (!status_ok(err)) {
     // If there was an error, print the OTBN error bits and instruction count.
     LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
     LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
     // Print the error.
     CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  // Signature verification is expected to succeed.
+  if (verificationResult != kHardenedBoolTrue) {
+    LOG_ERROR("Signature failed to pass verification!");
     return false;
   }
 

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -30,7 +30,8 @@ status_t ecdsa_p256_verify_test(
   compute_digest(testvec->msg_len, testvec->msg, &digest);
 
   // Attempt to verify signature.
-  TRY(ecdsa_p256_verify_start(&testvec->signature, digest.digest, &testvec->public_key));
+  TRY(ecdsa_p256_verify_start(&testvec->signature, digest.digest,
+                              &testvec->public_key));
   hardened_bool_t result;
   TRY(ecdsa_p256_verify_finalize(&testvec->signature, &result));
 

--- a/sw/device/tests/crypto/ecdsa_p256_verify_testvectors.h.tpl
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_testvectors.h.tpl
@@ -23,7 +23,7 @@ extern "C" {
  */
 typedef const struct ecdsa_p256_verify_test_vector {
   // The public key.
-  ecdsa_p256_public_key_t public_key;
+  p256_point_t public_key;
   // The signature to verify.
   ecdsa_p256_signature_t signature;
   // Expected result (true iff signature is valid).

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -58,6 +58,14 @@ static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(p256_ecdsa, d0);
 static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 
+/**
+ * Hardened values for different modes (see p256_ecdsa.s).
+ */
+enum {
+  kModeSign = 0x15b,
+  kModeVerify = 0x727,
+};
+
 OTTF_DEFINE_TEST_CONFIG();
 
 /**
@@ -247,8 +255,8 @@ static void p256_ecdsa_sign(dif_otbn_t *otbn, const uint8_t *msg,
   CHECK(otbn != NULL);
 
   // Write input arguments.
-  uint32_t mode = 1;  // mode 1 => sign
-  otbn_testutils_write_data(otbn, sizeof(mode), &mode, kOtbnVarMode);
+  uint32_t mode = kModeSign;
+  otbn_testutils_write_data(otbn, sizeof(uint32_t), &mode, kOtbnVarMode);
   otbn_testutils_write_data(otbn, /*len_bytes=*/32, msg, kOtbnVarMsg);
   otbn_testutils_write_data(otbn, /*len_bytes=*/32, private_key_d, kOtbnVarD0);
 
@@ -290,8 +298,8 @@ static void p256_ecdsa_verify(dif_otbn_t *otbn, const uint8_t *msg,
   CHECK(otbn != NULL);
 
   // Write input arguments.
-  uint32_t mode = 2;  // mode 2 => verify
-  otbn_testutils_write_data(otbn, sizeof(mode), &mode, kOtbnVarMode);
+  uint32_t mode = kModeVerify;
+  otbn_testutils_write_data(otbn, sizeof(uint32_t), &mode, kOtbnVarMode);
   otbn_testutils_write_data(otbn, /*len_bytes=*/32, msg, kOtbnVarMsg);
   otbn_testutils_write_data(otbn, /*len_bytes=*/32, signature_r, kOtbnVarR);
   otbn_testutils_write_data(otbn, /*len_bytes=*/32, signature_s, kOtbnVarS);

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -3,41 +3,310 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Elliptic curve P-256 ECDSA
+ * Entrypoint for P-256 ECDSA operations.
  *
- * Uses OTBN ECC P-256 lib to perform an ECDSA operations.
+ * This binary has the following modes of operation:
+ * 1. MODE_KEYGEN: generate a new keypair
+ * 2. MODE_SIGN: generate signature using caller-provided secret key
+ * 3. MODE_VERIFY: verify a signature
+ * 4. MODE_SIDELOAD_KEYGEN: generate a keypair from a sideloaded seed
+ * 5. MODE_SIDELOAD_SIGN: compute shared key using sideloaded seed
  */
+
+/**
+ * Mode magic values, generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 5 -n 11 \
+ *     --avoid-zero -s 2205231843
+ *
+ * Call the same utility with the same arguments and a higher -m to generate
+ * additional value(s) without changing the others or sacrificing mutual HD.
+ *
+ * TODO(#17727): in some places the OTBN assembler support for .equ directives
+ * is lacking, so they cannot be used in bignum instructions or pseudo-ops such
+ * as `li`. If support is added, we could use 32-bit values here instead of
+ * 11-bit.
+ */
+.equ MODE_KEYGEN, 0x3d4
+.equ MODE_SIGN, 0x15b
+.equ MODE_VERIFY, 0x727
+.equ MODE_SIDELOAD_KEYGEN, 0x5e8
+.equ MODE_SIDELOAD_SIGN, 0x49e
 
 .section .text.start
 .globl start
 start:
-  /* Read mode, then tail-call either p256_ecdsa_sign or p256_ecdsa_verify */
+  /* Read the mode and tail-call the requested operation. */
   la    x2, mode
   lw    x2, 0(x2)
 
-  li    x3, 1
-  beq   x2, x3, p256_ecdsa_sign
+  addi  x3, x0, MODE_KEYGEN
+  beq   x2, x3, random_keygen
 
-  li    x3, 2
-  beq   x2, x3, p256_ecdsa_verify
+  addi  x3, x0, MODE_SIGN
+  beq   x2, x3, ecdsa_sign
 
-  /* Mode is neither 1 (= sign) nor 2 (= verify). Fail. */
+  addi  x3, x0, MODE_VERIFY
+  beq   x2, x3, ecdsa_verify
+
+  addi  x3, x0, MODE_SIDELOAD_KEYGEN
+  beq   x2, x3, sideload_keygen
+
+  addi  x3, x0, MODE_SIDELOAD_SIGN
+  beq   x2, x3, sideload_ecdsa_sign
+
+  /* Invalid mode; fail. */
+  unimp
+  unimp
   unimp
 
 .text
-p256_ecdsa_sign:
+
+/**
+ * Generate a fresh, random keypair.
+ *
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d1]: Second share of secret key.
+ * @param[out]  dmem[x]: Public key x-coordinate.
+ * @param[out]  dmem[y]: Public key y-coordinate.
+ */
+random_keygen:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal      x1, p256_generate_random_key
+
+  /* Generate public key d*G.
+       dmem[x] <= (d*G).x
+       dmem[y] <= (d*G).y */
+  jal      x1, p256_base_mult
+
+  ecall
+
+/**
+ * Generate a signature.
+ *
+ * @param[in]  dmem[msg]: message to be signed (256 bits)
+ * @param[in]  dmem[r]:   dmem buffer for r component of signature (256 bits)
+ * @param[in]  dmem[s]:   dmem buffer for s component of signature (256 bits)
+ * @param[in]  dmem[d0]:  first share of private key d (320 bits)
+ * @param[in]  dmem[d1]:  second share of private key d (320 bits)
+ */
+ecdsa_sign:
+  /* Generate a fresh random scalar for signing.
+       dmem[k0] <= first share of k
+       dmem[k1] <= second share of k */
   jal      x1, p256_generate_k
+
+  /* Generate the signature. */
   jal      x1, p256_sign
+
   ecall
 
-p256_ecdsa_verify:
+/**
+ * Verify a signature.
+ *
+ * @param[in]  dmem[msg]: message to be verified (256 bits)
+ * @param[in]  dmem[r]:   r component of signature (256 bits)
+ * @param[in]  dmem[s]:   s component of signature (256 bits)
+ * @param[in]  dmem[x]:   affine x-coordinate of public key (256 bits)
+ * @param[in]  dmem[y]:   affine y-coordinate of public key (256 bits)
+ * @param[out] dmem[x_r]: dmem buffer for reduced affine x_r-coordinate (x_1)
+ */
+ecdsa_verify:
+  /* Validate the public key. */
+  jal      x1, check_public_key_valid
+
+  /* Verify the signature (compute x_r). */
   jal      x1, p256_verify
+
   ecall
 
+/**
+ * Generate a keypair from a sideloaded seed.
+ *
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d1]: Second share of secret key.
+ * @param[out]  dmem[x]: Public key x-coordinate.
+ * @param[out]  dmem[y]: Public key y-coordinate.
+ */
+sideload_keygen:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal   x1, secret_key_from_seed
+
+  /* Generate public key d*G.
+       dmem[x] <= (d*G).x
+       dmem[y] <= (d*G).y */
+  jal      x1, p256_base_mult
+
+  ecall
+
+/**
+ * Generate a signature using a private key from a sideloaded seed.
+ *
+ * @param[in]  dmem[msg]: message to be signed (256 bits)
+ * @param[in]  dmem[r]:   dmem buffer for r component of signature (256 bits)
+ * @param[in]  dmem[s]:   dmem buffer for s component of signature (256 bits)
+ */
+sideload_ecdsa_sign:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal   x1, secret_key_from_seed
+
+  /* Tail-call signature-generation routine. */
+  jal      x0, ecdsa_sign
+
+/**
+ * Generate a secret key from a keymgr-derived seed.
+ *
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d0]: Second share of secret key.
+ */
+secret_key_from_seed:
+  /* Load keymgr seeds from WSRs.
+       w20,w21 <= seed0
+       w22,w23 <= seed1 */
+  bn.wsrr  w20, 4 /*KEY_S0_L*/
+  bn.wsrr  w21, 5 /*KEY_S0_H*/
+  bn.wsrr  w22, 6 /*KEY_S1_L*/
+  bn.wsrr  w23, 7 /*KEY_S1_H*/
+
+  /* Init all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Generate secret key shares.
+       w20, w21 <= d0
+       w22, w23 <= d1 */
+  jal      x1, p256_key_from_seed
+
+  /* Store secret key shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  li       x2, 20
+  la       x3, d0
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2++, 32(x3)
+  la       x3, d0
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2, 32(x3)
+
+  ret
+
+/**
+ * Check if a provided public key is valid.
+ *
+ * For a given public key (x, y), check that:
+ * - x and y are both fully reduced mod p
+ * - (x, y) is on the P-256 curve.
+ *
+ * Note that, because the point is in affine form, it is not possible that (x,
+ * y) is the point at infinity. In some other forms such as projective
+ * coordinates, we would need to check for this also.
+ *
+ * This routine raises a software error and halts operation if the public key
+ * is invalid.
+ *
+ * @param[in] dmem[x]: Public key x-coordinate.
+ * @param[in] dmem[y]: Public key y-coordinate.
+ */
+check_public_key_valid:
+  /* Init all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Load domain parameter p.
+       w29 <= dmem[p256_p] = p */
+  li        x2, 29
+  la        x3, p256_p
+  bn.lid    x2, 0(x3)
+
+  /* Load public key x-coordinate.
+       w2 <= dmem[x] = x */
+  li        x2, 2
+  la        x3, x
+  bn.lid    x2, 0(x3)
+
+  /* Compare x to p.
+       FG0.C <= (x < p) */
+  bn.cmp    w2, w29
+
+  /* Trigger a fault if FG0.C is false. */
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 1
+  bne       x2, x0, _x_valid
+  unimp
+
+  _x_valid:
+
+  /* Load public key y-coordinate.
+       w2 <= dmem[y] = y */
+  li        x2, 2
+  la        x3, y
+  bn.lid    x2, 0(x3)
+
+  /* Compare y to p.
+       FG0.C <= (y < p) */
+  bn.cmp    w2, w29
+
+  /* Trigger a fault if FG0.C is false. */
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 1
+  bne       x2, x0, _y_valid
+  unimp
+
+  _y_valid:
+
+  /* Save the signature values to registers.
+       w4 <= dmem[r]
+       w5 <= dmem[s] */
+  li        x2, 4
+  la        x3, r
+  bn.lid    x2++, 0(x3)
+  la        x3, s
+  bn.lid    x2, 0(x3)
+
+  /* Compute both sides of the Weierstrauss equation.
+       dmem[r] <= (x^3 + ax + b) mod p
+       dmem[s] <= (y^2) mod p */
+  jal      x1, p256_isoncurve
+
+  /* Load both sides of the equation.
+       w2 <= dmem[r]
+       w3 <= dmem[s] */
+  li        x2, 2
+  la        x3, r
+  bn.lid    x2++, 0(x3)
+  la        x3, s
+  bn.lid    x2, 0(x3)
+
+  /* Compare the two sides of the equation.
+       FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
+  bn.cmp    w2, w3
+
+  /* Trigger a fault if FG0.Z is false. */
+  csrrs     x2, 0x7c0, x0
+  srli      x2, x2, 3
+  andi      x2, x2, 1
+  bne       x2, x0, _pk_valid
+  unimp
+
+  _pk_valid:
+
+  /* Write back the saved signature values.
+       dmem[r] <= w4
+       dmem[s] <= w5 */
+  li        x2, 4
+  la        x3, r
+  bn.sid    x2++, 0(x3)
+  la        x3, s
+  bn.sid    x2, 0(x3)
+
+  ret
 
 .bss
 
-/* Operation mode (1 = sign; 2 = verify) */
+/* Operation mode. */
 .globl mode
 .balign 4
 mode:


### PR DESCRIPTION
This PR packages up several smaller cleanups and updates to the ECDSA code in the cryptolib, in preparation for connecting both P-256 ECDH and ECDSA to the cryptolib API.
- Factors out P-256 data structures and constants to a shared library that will be used by ECDH as well
- Simplifies the ECDSA interface and makes it asynchronous
- On the assembly side, hardens the mode selector values and adds key-generation and sideloading options
- Removes deterministic ECDSA from the API (this was already removed from the working doc, but had missed being updated here)
- Adds random key generation to the interface and functional test.
- Adds public-key validation to the verification routine.