### PR TITLE
[crypto] Fix offset error in OTBN drivers.

### DIFF
--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -68,11 +68,20 @@ typedef enum otbn_status {
  */
 static status_t check_offset_len(uint32_t offset_bytes, size_t num_words,
                                  size_t mem_size) {
-  if (offset_bytes + num_words * sizeof(uint32_t) <
-          num_words * sizeof(uint32_t) ||
-      offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
+  if (num_words > UINT32_MAX / sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
+  uint32_t num_bytes = num_words * sizeof(uint32_t);
+
+  if (offset_bytes > UINT32_MAX - num_bytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  uint32_t adjusted_offset_bytes = offset_bytes + num_bytes;
+
+  if (adjusted_offset_bytes > mem_size) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
   return OTCRYPTO_OK;
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -33,11 +33,20 @@ enum {
  */
 static rom_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
                                     size_t mem_size) {
-  if (offset_bytes + num_words * sizeof(uint32_t) <
-          num_words * sizeof(uint32_t) ||
-      offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
+  if (num_words > UINT32_MAX / sizeof(uint32_t)) {
     return kErrorOtbnBadOffsetLen;
   }
+  uint32_t num_bytes = num_words * sizeof(uint32_t);
+
+  if (offset_bytes > UINT32_MAX - num_bytes) {
+    return kErrorOtbnBadOffsetLen;
+  }
+  uint32_t adjusted_offset_bytes = offset_bytes + num_bytes;
+
+  if (adjusted_offset_bytes > mem_size) {
+    return kErrorOtbnBadOffsetLen;
+  }
+
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -207,6 +207,24 @@ TEST_F(DmemWriteTest, FailureOutOfRange) {
             kErrorOtbnBadOffsetLen);
 }
 
+TEST_F(DmemWriteTest, FailureOverflowNumWords) {
+  // Try to trigger an integer overflow with `num_words`.
+  size_t num_words = (SIZE_MAX / sizeof(uint32_t)) + 1;
+  otbn_addr_t dest_addr = 0;
+
+  EXPECT_EQ(otbn_dmem_write(num_words, NULL, dest_addr),
+            kErrorOtbnBadOffsetLen);
+}
+
+TEST_F(DmemWriteTest, FailureOverflowOffset) {
+  // Try to trigger an integer overflow with `dest_addr`.
+  std::array<uint32_t, 2> test_data = {0x12345678, 0xabcdef01};
+  otbn_addr_t dest_addr = SIZE_MAX;
+
+  EXPECT_EQ(otbn_dmem_write(test_data.size(), test_data.data(), dest_addr),
+            kErrorOtbnBadOffsetLen);
+}
+
 class DmemReadTest : public OtbnTest {};
 
 TEST_F(DmemReadTest, SuccessWithoutOffset) {


### PR DESCRIPTION
Fixes a bug in the offset calculation in OTBN drivers for both the cryptolib and ROM, and adds a regression test.

See original discussion here: https://github.com/lowRISC/opentitan/pull/17077#discussion_r1073228530

Thanks @dmcardle for finding this one!