### PR TITLE
Fix references to not existing struct items

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -169,7 +169,7 @@ module rstmgr
     ) u_rst_sw_ctrl_reg (
       .clk_i,
       .rst_ni(local_rst_n),
-      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
+      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regwen[i]),
       .wd(reg2hw.sw_rst_ctrl_n[i].q),
       .de('0),
       .d('0),

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -552,7 +552,7 @@ module rstmgr
   ) u_cpu_reset_synced (
     .clk_i,
     .rst_ni(local_rst_n),
-    .d_i(cpu_i.rst_cpu_n),
+    .d_i(),
     .q_o(rst_cpu_nq)
   );
 


### PR DESCRIPTION
It looks like ``rst_cpu_n`` was removed in: https://github.com/lowRISC/opentitan/pull/11239 and ``sw_rst_regen`` was renamed to ``sw_rst_regwen`` in: https://github.com/lowRISC/opentitan/pull/8358