### PR TITLE
[opentitantool] add context to uart stale lock file error

### DIFF
--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -226,7 +226,8 @@ impl SerialPortExclusiveLock {
                 )),
                 Err(_) => {
                     log::info!("Lockfile is stale. Overriding it...");
-                    std::fs::remove_file(&lockfilename)?;
+                    std::fs::remove_file(&lockfilename)
+                        .context(format!("Cannot remove stale file {}", &lockfilename))?;
                 }
             }
         }


### PR DESCRIPTION
In a shared environment (like fred), if a user runs opentitantool and grabs the UART, but for some reason does not stop properly, it might leave behind a stale file that other users cannot remove. This is really not obvious so this commit adds a bit of context to the error so that at least the user knows what the problem is.