### PR TITLE
[crypto] Connect HMAC block hardware ops to the cryptolib.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -121,6 +121,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/impl:status",

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -6,68 +6,121 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/crypto/impl/status.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-void hmac_sha256_init(void) {
-  // Clear the config, stopping the SHA engine.
+/**
+ * Stop any current operation on the HMAC block.
+ *
+ * In addition to stopping any in-progress operation, this routine:
+ * - clears secret internal values and keys using the WIPE_SECRET register.
+ * - disables and clears interrupts.
+ */
+static void hmac_halt(void) {
+  // Clear the config, which stops operation if the HMAC block was running.
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, 0);
+
+  // Wipe secrets (e.g. key).
+  // TODO: this value is used directy by the HMAC hardware to overwrite the
+  // key; replace it with a random number read from Ibex's RND.
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_WIPE_SECRET_REG_OFFSET,
+                   0xffffffff);
 
   // Disable and clear interrupts. INTR_STATE register is rw1c.
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_ENABLE_REG_OFFSET,
                    0);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
                    UINT32_MAX);
-
-  uint32_t reg = 0;
-  // Digest is little-endian by default.
-  reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, false);
-  // Message is little-endian by default.
-  reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
-  reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
-  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
-
-  reg = 0;
-  reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_START_BIT, true);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 }
 
-status_t hmac_sha256_update(const void *data, size_t len) {
-  if (data == NULL) {
-    return OTCRYPTO_BAD_ARGS;
+/**
+ * Initialize the HMAC block.
+ *
+ * If `enable_hmac` is `kHardenedBoolTrue`, starts the block in HMAC mode. If
+ * it is `kHardenedBoolFalse`, starts in SHA256 mode.
+ *
+ * @param enable_hmac Whether to start HMAC mode.
+ */
+static void hmac_init(hardened_bool_t enable_hmac) {
+  uint32_t cfg = 0;
+  // Digest is little-endian by default.
+  cfg = bitfield_bit32_write(cfg, HMAC_CFG_DIGEST_SWAP_BIT, false);
+  // Message is little-endian by default.
+  cfg = bitfield_bit32_write(cfg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
+  cfg = bitfield_bit32_write(cfg, HMAC_CFG_SHA_EN_BIT, true);
+  if (launder32(enable_hmac) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(enable_hmac, kHardenedBoolTrue);
+    cfg = bitfield_bit32_write(cfg, HMAC_CFG_HMAC_EN_BIT, true);
+  } else {
+    HARDENED_CHECK_EQ(enable_hmac, kHardenedBoolFalse);
+    cfg = bitfield_bit32_write(cfg, HMAC_CFG_HMAC_EN_BIT, false);
   }
-  const uint8_t *data_sent = (const uint8_t *)data;
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, cfg);
 
+  uint32_t cmd = bitfield_bit32_write(0, HMAC_CMD_HASH_START_BIT, true);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
+}
+
+void hmac_sha256_init(void) {
+  // Stop any currently in-progress operation.
+  hmac_halt();
+
+  // Initialize in SHA256 mode.
+  hmac_init(kHardenedBoolFalse);
+}
+
+void hmac_hmac_init(const hmac_key_t *key) {
+  // Stop any currently in-progress operation.
+  hmac_halt();
+
+  // Write key registers.
+  static_assert(ARRAYSIZE(key->key) == 8, "Unexpected HMAC key size.");
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_0_REG_OFFSET,
+                   key->key[0]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_1_REG_OFFSET,
+                   key->key[1]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_2_REG_OFFSET,
+                   key->key[2]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_3_REG_OFFSET,
+                   key->key[3]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_4_REG_OFFSET,
+                   key->key[4]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_5_REG_OFFSET,
+                   key->key[5]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_6_REG_OFFSET,
+                   key->key[6]);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_7_REG_OFFSET,
+                   key->key[7]);
+
+  // Initialize in HMAC mode.
+  hmac_init(kHardenedBoolTrue);
+}
+
+void hmac_update(const uint8_t *data, size_t len) {
   // Individual byte writes are needed if the buffer isn't word aligned.
-  for (; len != 0 && (uintptr_t)data_sent & 3; --len) {
+  for (; len != 0 && (uintptr_t)data & 3; --len) {
     abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
-                    *data_sent++);
+                    *data++);
   }
 
   for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t)) {
-    uint32_t data_aligned = read_32(data_sent);
+    uint32_t data_aligned = read_32(data);
     abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
                      data_aligned);
-    data_sent += sizeof(uint32_t);
+    data += sizeof(uint32_t);
   }
 
   // Handle non-32bit aligned bytes at the end of the buffer.
   for (; len != 0; --len) {
     abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
-                    *data_sent++);
+                    *data++);
   }
-  return OTCRYPTO_OK;
 }
 
-status_t hmac_sha256_final(hmac_digest_t *digest) {
-  if (digest == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
+void hmac_final(hmac_digest_t *digest) {
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
@@ -86,5 +139,7 @@ status_t hmac_sha256_final(hmac_digest_t *digest) {
         abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
                         (i * sizeof(uint32_t)));
   }
-  return OTCRYPTO_OK;
+
+  // Clean up and put the block back in an idle state.
+  hmac_halt();
 }

--- a/sw/device/lib/crypto/drivers/hmac.h
+++ b/sw/device/lib/crypto/drivers/hmac.h
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/lib/base/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,17 +20,33 @@ enum {
   kHmacDigestNumBytes = kHmacDigestNumBits / 8,
   /* Number of words in an HMAC or SHA-256 digest. */
   kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
+  /* Number of bits in an HMAC key. */
+  kHmacKeyNumBits = 256,
+  /* Number of bytes in an HMAC key. */
+  kHmacKeyNumBytes = kHmacKeyNumBits / 8,
+  /* Number of words in an HMAC key. */
+  kHmacKeyNumWords = kHmacKeyNumBytes / sizeof(uint32_t),
 };
 
 /**
- * A typed representation of the HMAC digest.
+ * A typed representation of the HMAC or SHA256 digest.
  */
 typedef struct hmac_digest {
   uint32_t digest[kHmacDigestNumWords];
 } hmac_digest_t;
 
 /**
- * Initializes the HMAC in SHA256 mode.
+ * A typed representation of an HMAC key.
+ */
+typedef struct hmac_key {
+  uint32_t key[kHmacKeyNumWords];
+} hmac_key_t;
+
+/**
+ * Initializes the HMAC block in SHA256 mode.
+ *
+ * If the HMAC block is non-idle, calling this function aborts the previous
+ * operation.
  *
  * This function resets the HMAC module to clear the digest register.
  * It then configures the HMAC block in SHA256 mode with little endian
@@ -40,7 +55,21 @@ typedef struct hmac_digest {
 void hmac_sha256_init(void);
 
 /**
- * Sends `len` bytes from `data` to the SHA2-256 function.
+ * Initializes the HMAC block in HMAC mode.
+ *
+ * If the HMAC block is non-idle, calling this function aborts the previous
+ * operation.
+ *
+ * This function resets the HMAC module to clear the digest register.
+ * It then configures the HMAC block in SHA256 mode with little endian
+ * data input and digest output.
+ *
+ * @param key HMAC key.
+ */
+void hmac_hmac_init(const hmac_key_t *key);
+
+/**
+ * Sends `len` bytes from `data` to the HMAC or SHA2-256 function.
  *
  * This function does not check for the size of the available HMAC
  * FIFO. Since the this function is meant to run in blocking mode,
@@ -48,21 +77,18 @@ void hmac_sha256_init(void);
  *
  * @param data Buffer to copy data from.
  * @param len size of the `data` buffer in bytes.
- * @return The result of the operation.
  */
-OT_WARN_UNUSED_RESULT
-status_t hmac_sha256_update(const void *data, size_t len);
+void hmac_update(const uint8_t *data, size_t len);
 
 /**
- * Finalizes SHA256 operation and writes `digest` buffer.
+ * Finalizes HMAC or SHA256 operation and writes `digest` buffer.
  *
- * Blocks while the device is processing.
+ * Blocks while the device is processing. Clears the hardware digest registers
+ * and configuration when done.
  *
  * @param[out] digest Buffer to copy digest to.
- * @return The result of the operation.
  */
-OT_WARN_UNUSED_RESULT
-status_t hmac_sha256_final(hmac_digest_t *digest);
+void hmac_final(hmac_digest_t *digest);
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -8,11 +8,12 @@ cc_library(
     name = "hash",
     srcs = ["hash.c"],
     hdrs = [
-        "//sw/device/lib/crypto/drivers:kmac.h",
         "//sw/device/lib/crypto/include:hash.h",
     ],
     deps = [
+        ":status",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/include:datatypes",
     ],
@@ -74,14 +75,13 @@ cc_library(
     name = "mac",
     srcs = ["mac.c"],
     hdrs = [
-        "//sw/device/lib/crypto/drivers:kmac.h",
-        "//sw/device/lib/crypto/include:datatypes.h",
         "//sw/device/lib/crypto/include:mac.h",
     ],
     deps = [
         ":integrity",
         ":keyblob",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:kmac",
     ],
 )

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -6,10 +6,57 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
+
+/**
+ * Call the hardware HMAC-SHA256 driver.
+ *
+ * Note: the hardware implementation is unhardened against side-channel and
+ * fault attacks.
+ *
+ * @param key HMAC key.
+ * @param message Input message.
+ * @param[out] tag Output tag.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t hmac_sha256(const crypto_blinded_key_t *key,
+                            crypto_const_uint8_buf_t message,
+                            crypto_uint8_buf_t *tag) {
+  // Should never be called if the following checks fail; this indicates a
+  // possible fault attack.
+  HARDENED_CHECK_EQ(key->config.key_mode, kKeyModeHmacSha256);
+  HARDENED_CHECK_EQ(tag->len, kHmacDigestNumBytes);
+
+  // Get the individual key shares.
+  uint32_t *share0;
+  uint32_t *share1;
+  HARDENED_TRY(keyblob_to_shares(key, &share0, &share1));
+
+  // Convert the key to the HMAC-specific struct.
+  // NOTE: this unmasks the key, because the HMAC hardware is unhardened.
+  // TODO: randomize the iteration order of this loop.
+  hmac_key_t hmac_key;
+  for (size_t i = 0; i < kHmacKeyNumWords; i++) {
+    hmac_key.key[i] = share0[i] ^ share1[i];
+  }
+
+  // Initialize the hardware.
+  hmac_hmac_init(&hmac_key);
+
+  // Pass the message.
+  hmac_update(message.data, message.len);
+
+  // Retrieve the digest and copy it to the destination buffer.
+  hmac_digest_t hmac_digest;
+  hmac_final(&hmac_digest);
+  memcpy(tag->data, hmac_digest.digest, kHmacDigestNumBytes);
+
+  return OTCRYPTO_OK;
+}
 
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
@@ -19,6 +66,21 @@ crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
                              size_t required_output_len,
                              crypto_uint8_buf_t *tag) {
   // TODO (#16410) Revisit/complete error checks
+
+  // Check for null pointers.
+  if (key == NULL || key->keyblob == NULL || tag == NULL || tag->data == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check for null input message with nonzero length.
+  if (input_message.data == NULL && input_message.len != 0) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check for null customization string with nonzero length.
+  if (customization_string.data == NULL && customization_string.len != 0) {
+    return kCryptoStatusBadArgs;
+  }
 
   kmac_error_t err;
   size_t key_len = keyblob_share_num_words(key->config) * sizeof(uint32_t);
@@ -49,7 +111,6 @@ crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
       if (key->config.key_mode != kKeyModeKmac128) {
         return kCryptoStatusBadArgs;
       }
-
       err = kmac_kmac_128(&kmac_key, input_message, customization_string, tag);
       break;
     case kMacModeKmac256:
@@ -61,8 +122,21 @@ crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
       err = kmac_kmac_256(&kmac_key, input_message, customization_string, tag);
       break;
     case kMacModeHmacSha256:
-      // HMAC SHA-256 not implemented yet.
-      OT_FALLTHROUGH_INTENDED;
+      // Check `key_mode` matches `mac_mode`
+      if (key->config.key_mode != kKeyModeHmacSha256) {
+        return kCryptoStatusBadArgs;
+      }
+      // Check tag length.
+      if (tag->len != kHmacDigestNumBytes) {
+        return kCryptoStatusBadArgs;
+      }
+      // Call hardware HMAC driver.
+      OTCRYPTO_TRY_INTERPRET(hmac_sha256(key, input_message, tag));
+
+      // TODO(#16410) Appease the KMAC error check. Remove once KMAC uses
+      // status_t.
+      err = kKmacOk;
+      break;
     default:
       return kCryptoStatusBadArgs;
   }

--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
@@ -48,6 +48,10 @@ status_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
                                 rsa_3072_int_t *result) {
   enum { kSha256DigestNumWords = 8 };
 
+  if (msg == NULL && msgLen != 0) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
   // Message encoding as described in RFC 8017, Section 9.2. The encoded
   // message is:
   //
@@ -73,11 +77,9 @@ status_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
 
   // Compute the SHA-256 message digest.
   hmac_sha256_init();
-  if (msg != NULL) {
-    HARDENED_TRY(hmac_sha256_update(msg, msgLen));
-  }
+  hmac_update(msg, msgLen);
   hmac_digest_t digest;
-  HARDENED_TRY(hmac_sha256_final(&digest));
+  hmac_final(&digest);
 
   // Copy the message digest into the least significant end of the result.
   memcpy(result->data, digest.digest, sizeof(digest.digest));

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -194,6 +194,20 @@ py_binary(
     ],
 )
 
+opentitan_functest(
+    name = "hmac_functest",
+    srcs = ["hmac_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 py_binary(
     name = "rsa_3072_verify_set_testvectors",
     srcs = ["rsa_3072_verify_set_testvectors.py"],
@@ -213,6 +227,20 @@ py_binary(
         "//util/design/lib:common",
         requirement("hjson"),
         requirement("mako"),
+    ],
+)
+
+opentitan_functest(
+    name = "sha256_functest",
+    srcs = ["sha256_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -38,9 +38,9 @@ static const ecdsa_p256_private_key_t kPrivateKey = {
 static void compute_digest(void) {
   // Compute the SHA-256 digest using the HMAC device.
   hmac_sha256_init();
-  CHECK_STATUS_OK(hmac_sha256_update(&kMessage, sizeof(kMessage) - 1));
+  hmac_update((unsigned char *)&kMessage, sizeof(kMessage) - 1);
   hmac_digest_t hmac_digest;
-  CHECK_STATUS_OK(hmac_sha256_final(&hmac_digest));
+  hmac_final(&hmac_digest);
 
   // Copy digest into the destination array.
   memcpy(digest.h, hmac_digest.digest, sizeof(hmac_digest.digest));

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -19,9 +19,9 @@ static void compute_digest(size_t msg_len, const uint8_t *msg,
                            ecdsa_p256_message_digest_t *digest) {
   // Compute the SHA-256 digest using the HMAC device.
   hmac_sha256_init();
-  CHECK_STATUS_OK(hmac_sha256_update(msg, msg_len));
+  hmac_update(msg, msg_len);
   hmac_digest_t hmac_digest;
-  CHECK_STATUS_OK(hmac_sha256_final(&hmac_digest));
+  hmac_final(&hmac_digest);
 
   // Copy digest into the destination array.
   memcpy(digest->h, hmac_digest.digest, sizeof(hmac_digest.digest));

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Test key (big endian) =
+// 0x1bff10eaa5b9b204d6f3232a573e8e51a27b68c319366deaf26b91b0712f7a34
+static const hmac_key_t kTestKey = {
+    .key =
+        {
+            0x1bff10ea,
+            0xa5b9b204,
+            0xd6f3232a,
+            0x573e8e51,
+            0xa27b68c3,
+            0x19366dea,
+            0xf26b91b0,
+            0x712f7a34,
+        },
+};
+
+// Random value for masking (should not affect result).
+static const uint32_t kTestMask[kHmacKeyNumWords] = {
+    0x8cb847c3, 0xc6d34f36, 0x72edbf7b, 0x9bc0317f,
+    0x8f003c7f, 0x1d7ba049, 0xfd463b63, 0xbb720c44,
+};
+
+/**
+ * Call the `otcrypto_mac` API and check the resulting tag.
+ *
+ * @param msg Input message.
+ * @param exp_tag Expected tag (256 bits).
+ */
+static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_tag) {
+  // Construct blinded key.
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = kKeyModeHmacSha256,
+      .key_length = kHmacKeyNumBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .diversification_hw_backed = {.data = NULL, .len = 0},
+      .exportable = kHardenedBoolFalse,
+      .security_level = kSecurityLevelLow,
+  };
+
+  uint32_t keyblob[keyblob_num_words(config)];
+  keyblob_from_key_and_mask(kTestKey.key, kTestMask, config, keyblob);
+  crypto_blinded_key_t blinded_key = {
+      .config = config,
+      .keyblob = keyblob,
+      .keyblob_length = sizeof(keyblob),
+      .checksum = 0,
+  };
+  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+
+  crypto_const_uint8_buf_t customization_string = {.data = NULL, .len = 0};
+
+  uint32_t act_tag[kHmacDigestNumWords];
+  crypto_uint8_buf_t tag_buf = {
+      .data = (unsigned char *)act_tag,
+      .len = sizeof(act_tag),
+  };
+
+  crypto_status_t status = otcrypto_mac(&blinded_key, msg, kMacModeHmacSha256,
+                                        customization_string, 0, &tag_buf);
+  CHECK(status == kCryptoStatusOK, "Error during hmac operation: 0x%08x.",
+        status);
+  CHECK_ARRAYS_EQ(act_tag, exp_tag, kHmacDigestNumWords);
+}
+
+/**
+ * Simple test with a short message.
+ *
+ * HMAC-SHA256(kTestKey, 'Test message.')
+ *   = 0xb4595b02be2a1638893166366656ece12b749b95a2815e52d687535309f3126f
+ */
+static void simple_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[kHmacDigestNumWords] = {
+      0x09f3126f, 0xd6875353, 0xa2815e52, 0x2b749b95,
+      0x6656ece1, 0x89316636, 0xbe2a1638, 0xb4595b02,
+  };
+  run_test(msg_buf, exp_tag);
+}
+
+/**
+ * Test with an empty message.
+ *
+ * HMAC-SHA256(kTestKey, '')
+ * = 0xa9425cbb40d13a0e07916761c06c4aa37969305361508afae62e8bbca5c099a4
+ */
+static void empty_test(void) {
+  const uint32_t exp_tag[kHmacDigestNumWords] = {
+      0xa5c099a4, 0xe62e8bbc, 0x61508afa, 0x79693053,
+      0xc06c4aa3, 0x07916761, 0x40d13a0e, 0xa9425cbb,
+  };
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = NULL,
+      .len = 0,
+  };
+  run_test(msg_buf, exp_tag);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  simple_test();
+  empty_test();
+
+  return true;
+}

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+/**
+ * Call the `otcrypto_hash` API and check the resulting digest.
+ *
+ * @param msg Input message.
+ * @param exp_digest Expected digest (256 bits).
+ */
+static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_digest) {
+  uint32_t act_digest[kHmacDigestNumWords];
+  crypto_uint8_buf_t digest_buf = {
+      .data = (unsigned char *)act_digest,
+      .len = sizeof(act_digest),
+  };
+  crypto_status_t status = otcrypto_hash(msg, kHashModeSha256, &digest_buf);
+  CHECK(status == kCryptoStatusOK, "Error during hash operation: 0x%08x",
+        status);
+  CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
+}
+
+/**
+ * Simple test with a short message.
+ *
+ * SHA256('Test message.')
+ *   = 0xb2da997a966ee07c43e1f083807ce5884bc0a4cad13b02cadc72a11820b50917
+ */
+static void simple_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_digest[kHmacDigestNumWords] = {
+      0x20b50917, 0xdc72a118, 0xd13b02ca, 0x4bc0a4ca,
+      0x807ce588, 0x43e1f083, 0x966ee07c, 0xb2da997a,
+  };
+  run_test(msg_buf, exp_digest);
+}
+
+/**
+ * Test with an empty message.
+ *
+ * SHA256('')
+ *   = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+ */
+static void empty_test(void) {
+  const uint32_t exp_digest[kHmacDigestNumWords] = {
+      0x7852b855, 0xa495991b, 0x649b934c, 0x27ae41e4,
+      0x996fb924, 0x9afbf4c8, 0x98fc1c14, 0xe3b0c442,
+  };
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = NULL,
+      .len = 0,
+  };
+  run_test(msg_buf, exp_digest);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  simple_test();
+  empty_test();
+
+  return true;
+}


### PR DESCRIPTION
This connects the HMAC block to the cryptolib API for SHA256 and HMAC-SHA256. The block is unhardened and originally we did not intend to use it in the cryptolib, but for the first versions it can serve as an initial implementation and a placeholder until we have a hardened SHA256.