### PR TITLE
Introduce struct representing a strapping

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -176,10 +176,11 @@ impl<'a> Bootstrap<'a> {
     ) -> Result<()> {
         updater.verify_capabilities(self, transport)?;
         let perform_bootstrap_reset = updater.uses_common_bootstrap_reset();
+        let rom_boot_strapping = transport.pin_strapping("ROM_BOOTSTRAP")?;
 
         if perform_bootstrap_reset {
             log::info!("Asserting bootstrap pins...");
-            transport.apply_pin_strapping("ROM_BOOTSTRAP")?;
+            rom_boot_strapping.apply()?;
             transport.reset_target(self.reset_delay, self.clear_uart_rx)?;
             log::info!("Performing bootstrap...");
         }
@@ -187,7 +188,7 @@ impl<'a> Bootstrap<'a> {
 
         if perform_bootstrap_reset {
             log::info!("Releasing bootstrap pins...");
-            transport.remove_pin_strapping("ROM_BOOTSTRAP")?;
+            rom_boot_strapping.remove()?;
         }
 
         // Don't clear the UART RX buffer after bootstrap to preserve the bootstrap output.

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -321,11 +321,11 @@ impl<'a> TransportCommandHandler<'a> {
                     Ok(Response::Proxy(ProxyResponse::Bootstrap))
                 }
                 ProxyRequest::ApplyPinStrapping { strapping_name } => {
-                    self.transport.apply_pin_strapping(strapping_name)?;
+                    self.transport.pin_strapping(strapping_name)?.apply()?;
                     Ok(Response::Proxy(ProxyResponse::ApplyPinStrapping))
                 }
                 ProxyRequest::RemovePinStrapping { strapping_name } => {
-                    self.transport.remove_pin_strapping(strapping_name)?;
+                    self.transport.pin_strapping(strapping_name)?.remove()?;
                     Ok(Response::Proxy(ProxyResponse::RemovePinStrapping))
                 }
             },

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -244,7 +244,7 @@ impl CommandDispatch for GpioApplyStrapping {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
-        transport.apply_pin_strapping(&self.name)?;
+        transport.pin_strapping(&self.name)?.apply()?;
         Ok(None)
     }
 }
@@ -553,7 +553,7 @@ impl CommandDispatch for GpioRemoveStrapping {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
-        transport.remove_pin_strapping(&self.name)?;
+        transport.pin_strapping(&self.name)?.remove()?;
         Ok(None)
     }
 }

--- a/sw/host/tests/chip/jtag/src/main.rs
+++ b/sw/host/tests/chip/jtag/src/main.rs
@@ -29,7 +29,7 @@ struct Opts {
 fn reset(transport: &TransportWrapper, strappings: &[&str], reset_delay: Duration) -> Result<()> {
     log::info!("Resetting target...");
     for strapping in strappings.iter() {
-        transport.apply_pin_strapping(strapping)?;
+        transport.pin_strapping(strapping)?.apply()?;
     }
     transport.reset_target(reset_delay, true)?;
     // we want to hold the strapping configuration here because in some life cycle states,

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
@@ -40,7 +40,7 @@ fn test_bootstrap_disabled_requested(opts: &Opts, transport: &TransportWrapper) 
     };
 
     log::info!("Applying pin strapping");
-    transport.apply_pin_strapping("ROM_BOOTSTRAP")?;
+    transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
     log::info!("Resetting target");
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 
@@ -69,7 +69,7 @@ fn test_bootstrap_disabled_not_requested(opts: &Opts, transport: &TransportWrapp
     };
 
     log::info!("Not applying pin strapping");
-    transport.remove_pin_strapping("ROM_BOOTSTRAP")?;
+    transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     log::info!("Resetting target");
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 

--- a/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
@@ -130,11 +130,11 @@ if {{ $i == {MAX_ATTEMPTS} }} {{
 fn reset(transport: &TransportWrapper, strappings: &[&str], reset_delay: Duration) -> Result<()> {
     log::info!("Resetting target...");
     for strapping in strappings.iter() {
-        transport.apply_pin_strapping(strapping)?;
+        transport.pin_strapping(strapping)?.apply()?;
     }
     transport.reset_target(reset_delay, true)?;
     for strapping in strappings.iter() {
-        transport.remove_pin_strapping(strapping)?;
+        transport.pin_strapping(strapping)?.remove()?;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR introduces an `PinStrapping` object, such that `apply_pin_strapping()` is replaced with `pin_strapping().apply()`.  This allows callers to hang on to the `PinStrapping` objects beyond the lifetime of the `TransportWrapper`.

This is critical for the "IO expander" PR, as it introduces `Gpio` trait implementation that need to perform strapping operations, and these `Rc<dyn Gpio>` can outlive the `TransportWrapper`, and as such would not be able to call the existing `TransportWrapper.apply_pin_strapping()`.