### PR TITLE
[dv/chip] Add testunlock to strap test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -479,7 +479,8 @@
             host (SV testbench) performs these stimulus / checks.
             '''
       stage: V2
-      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
+      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma",
+              "chip_tap_straps_testunlock0"]
     }
 
     // PATTGEN (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1622,6 +1622,12 @@
       run_timeout_mins: 120
     }
     {
+      name: chip_tap_straps_testunlock0
+      uvm_test_seq: chip_tap_straps_vseq
+      en_run_modes: ["strap_tests_mode"]
+      run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0"]
+    }
+    {
       name: chip_tap_straps_rma
       uvm_test_seq: chip_tap_straps_vseq
       en_run_modes: ["strap_tests_mode"]


### PR DESCRIPTION
As mentioned in issue #17687, we can add testunlock lc state to the strap test. And to avoid duplicate the test too many tests, we can use `testunlock0` as a sample state.