### PR TITLE
[dv/keymgr] Update testbench to not change OTP key on the fly

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -89,7 +89,11 @@ interface keymgr_if(input clk, input rst_n);
 
   string msg_id = "keymgr_if";
 
-  task automatic init();
+  task automatic init(bit rand_otp_key, bit invalid_otp_key);
+    // Keymgr only latches OTP key once, so this scb does not support change OTP key on the
+    // fly. Will write a direct sequence to cover otp key change on the fly.
+    otp_ctrl_pkg::otp_keymgr_key_t local_otp_key;
+
     // async delay as these signals are from different clock domain
     #($urandom_range(1000, 0) * 1ns);
     keymgr_en = lc_ctrl_pkg::On;
@@ -99,6 +103,16 @@ interface keymgr_if(input clk, input rst_n);
     flash   = flash_ctrl_pkg::KEYMGR_FLASH_DEFAULT;
     rom_digest.data = 256'hA20A046CF42E6EAC560A3F82BFA76285B5C1D4AEA7C915E49A32D1C89BE0F507;
     rom_digest.valid = '1;
+    if (rand_otp_key) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
+                                         local_otp_key.valid == 1;
+                                         !(local_otp_key.key_share0 inside {0, '1});
+                                         !(local_otp_key.key_share1 inside {0, '1});, , msg_id)
+    end else begin
+      local_otp_key = otp_ctrl_pkg::OTP_KEYMGR_KEY_DEFAULT;
+    end
+    if (invalid_otp_key) local_otp_key.valid = 0;
+    otp_key = local_otp_key;
   endtask
 
   // reset local exp variables when reset is issued
@@ -118,11 +132,10 @@ interface keymgr_if(input clk, input rst_n);
     start_edn_req = 0;
   endfunction
 
-  // randomize otp, lc, flash input data
+  // randomize lc, flash input data
   task automatic drive_random_hw_input_data(int num_invalid_input = 0);
     lc_ctrl_pkg::lc_keymgr_div_t     local_keymgr_div;
     bit [keymgr_pkg::DevIdWidth-1:0] local_otp_device_id;
-    otp_ctrl_pkg::otp_keymgr_key_t   local_otp_key;
     flash_ctrl_pkg::keymgr_flash_t   local_flash;
     rom_ctrl_pkg::keymgr_data_t      local_rom_digest;
 
@@ -135,11 +148,6 @@ interface keymgr_if(input clk, input rst_n);
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_device_id,
                                        !(local_otp_device_id inside {0, '1});, , msg_id)
-
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
-                                       local_otp_key.valid == 1;
-                                       !(local_otp_key.key_share0 inside {0, '1});
-                                       !(local_otp_key.key_share1 inside {0, '1});, , msg_id)
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_flash,
                                        foreach (local_flash.seeds[i]) {
@@ -162,16 +170,6 @@ interface keymgr_if(input clk, input rst_n);
                                              local_otp_device_id inside {0, '1};, , msg_id)
         end
         1: begin
-           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
-                                              !local_otp_key.valid;, , msg_id)
-         end
-        1: begin
-          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
-                                             local_otp_key.valid;
-                                             local_otp_key.key_share0 inside {0, '1} ||
-                                             local_otp_key.key_share1 inside {0, '1};, , msg_id)
-        end
-        1: begin
           int idx = $urandom_range(0, flash_ctrl_pkg::NumSeeds - 1);
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_flash,
                                              local_flash.seeds[idx] inside {0, '1};, , msg_id)
@@ -190,7 +188,6 @@ interface keymgr_if(input clk, input rst_n);
 
     keymgr_div = local_keymgr_div;
     otp_device_id = local_otp_device_id;
-    otp_key = local_otp_key;
     flash   = local_flash;
     rom_digest = local_rom_digest;
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -23,6 +23,9 @@ class keymgr_base_vseq extends cip_base_vseq #(
   rand keymgr_pkg::keymgr_ops_e gen_operation;
   rand keymgr_pkg::keymgr_key_dest_e key_dest;
 
+  rand bit do_rand_otp_key;
+  rand bit do_invalid_otp_key;
+
   // save DUT returned current state here, rather than using it from RAL, it's needed info to
   // predict operation result in seq
   keymgr_pkg::keymgr_working_state_e current_state = keymgr_pkg::StReset;
@@ -31,6 +34,11 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
   constraint is_key_version_err_c {
     is_key_version_err == 0;
+  }
+
+  constraint otp_key_c {
+    do_rand_otp_key == 0;
+    do_invalid_otp_key == 0;
   }
 
   constraint gen_operation_c {
@@ -50,7 +58,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
     op_before_enable_keymgr();
 
-    cfg.keymgr_vif.init();
+    cfg.keymgr_vif.init(do_rand_otp_key, do_invalid_otp_key);
 
     delay_after_reset_before_access_csr();
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -38,7 +38,7 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
   virtual task read_and_check_all_csrs_after_reset();
     // need to set keymgr_en to be On, before it can be read back with correct init values
-    cfg.keymgr_vif.init();
+    cfg.keymgr_vif.init(do_rand_otp_key, do_invalid_otp_key);
     delay_after_reset_before_access_csr();
 
     super.read_and_check_all_csrs_after_reset();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -27,6 +27,12 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
     return 0;
   endfunction
 
+  function void pre_randomize();
+    // Randomly send otp valid or invalid keys.
+    this.otp_key_c.constraint_mode(0);
+    super.pre_randomize();
+  endfunction
+
   task body();
     // invalid HW input may cause unstable data on kmac interface
     $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -23,6 +23,10 @@ class keymgr_random_vseq extends keymgr_sideload_vseq;
     num_invalid_hw_input == 0;
   }
 
+  constraint otp_key_c {
+    do_invalid_otp_key == 0;
+  }
+
   task write_random_sw_content();
     uvm_reg         csr_update_q[$];
 


### PR DESCRIPTION
Fix issue #17640. As Fatih analynized, when compute kmac keys, keymgr only samples the OTP key output once. But the timing is hard to predict on the scb side.
The current scb samples the otp keys when the request happened, but if the otp keys are changing on the fly, it might be sampled at a wrong timestamp.
To avoid this failure, we now only randomize OTP keys once and keep it stable. To test keymgr won't latch the wrong key when OTP keys are changing on the fly, we plan to have a V3 direct sequence test for it.