### PR TITLE
[flash/dv] Enable access to isolated partition for erase_suspend test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -194,6 +194,8 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   virtual task do_erase();
     cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
     // Default region settings
     default_region_read_en    = MuBi4True;
     default_region_program_en = MuBi4True;


### PR DESCRIPTION
Hi,
This PR is enabling access to the isolated partition in the erase_suspend test. There is no apparent reason to not enable it here and since the erases are randomly selected the address and partition can be of the isolated partition.
Thanks!