### PR TITLE
[test] Add spi_passthrough support to the power virus test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
@@ -73,6 +73,64 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
       join
   endtask
 
+  // Utility task to send a SpiFlashReadQuad command to read 2048 bytes from
+  // the spi_device_agent0. The expected read response is initialized to
+  // an alternating pattern of 0xAA an Ox55 to maximize the toggling.
+  virtual task execute_spi_flash_sequence();
+    const int test_payload_size = 2048;
+    bit [7:0] test_opcode = SpiFlashReadQuad;
+    bit [7:0] rsp_fill_data;
+    spi_device_flash_seq m_spi_device_seq;
+    spi_host_flash_seq m_spi_host_seq;
+    spi_item host_rsp, device_rsp;
+    spi_item device_rsp_q[$];
+    spi_agent_cfg agent_cfg = cfg.m_spi_host_agent_cfg;
+
+    fork begin : isolation_fork
+      // The device agent handles the incoming command.
+      fork
+        forever begin : send_spi_device_seq_forever
+          `uvm_create_on(m_spi_device_seq, p_sequencer.spi_device_sequencer_hs[0]);
+          // To maximize the toggling, fill the device agent's response queue
+          // with an alternating pattern of 0xaa and 0x55.
+          for (int ii = 0; ii < test_payload_size; ii = ii + 1) begin
+            rsp_fill_data = (ii % 2 == 1) ? 8'haa : 8'h55;
+            m_spi_device_seq.byte_data_q.push_back(rsp_fill_data);
+          end
+          `uvm_send(m_spi_device_seq);
+          device_rsp_q.push_back(m_spi_device_seq.rsp);
+        end
+
+        // The host agent sends the command, receives the response, and
+        // checks the result.
+        begin : spi_host_thread
+          `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h);
+          // set the host sequence's parameters.
+          m_spi_host_seq.opcode = test_opcode;
+          m_spi_host_seq.read_size = test_payload_size;
+          `uvm_info(`gfn, $sformatf("spi passthrough payload size = %0x",
+                                    m_spi_host_seq.read_size), UVM_LOW);
+          `uvm_send(m_spi_host_seq);
+          // Wait for a small delay to allow the device agent to push the response
+          // into the queue.
+          #1ps;
+          `uvm_info(`gfn, $sformatf("spi passthrough opcode = %0x",
+                                    test_opcode), UVM_LOW);
+
+          // Check that the command, address, and data sent matches on both sides.
+          `DV_CHECK_EQ(device_rsp_q.size(), 1);
+          host_rsp = m_spi_host_seq.rsp;
+          device_rsp = device_rsp_q.pop_front();
+          if (!host_rsp.compare(device_rsp)) begin
+            `uvm_error(`gfn, $sformatf("Compare mismatch\nhost_rsp:\n%sdevice_rsp:\n%s",
+                                        host_rsp.sprint(), device_rsp.sprint()))
+          end
+        end
+      join_any
+      disable fork;
+    end join
+  endtask
+
   task pre_start();
     // i2c_agent configs
     configure_i2c_agents();
@@ -83,11 +141,27 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
     cfg.m_spi_device_agent_cfgs[1].spi_mode = Quad;
     cfg.m_spi_device_agent_cfgs[1].if_mode = dv_utils_pkg::Device;
     cfg.m_spi_device_agent_cfgs[1].is_active = 0;
+
+    // Configs for SPI passthrough part of the test
+    cfg.m_spi_device_agent_cfgs[0].byte_order = '0;
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+    spi_agent_configure_flash_cmds(cfg.m_spi_device_agent_cfgs[0]);
+    // 'kClockFreqHiSpeedPeripheralHz / 2' in SW
+    cfg.m_spi_host_agent_cfg.sck_period_ps = 48_000;
     super.pre_start();
   endtask
 
   virtual task body();
+    // Turn off the FIFO data output assertion, as spi_device issues a read
+    // before it knows whether it needs the data.
+    $assertoff(0, "tb.dut.top_earlgrey.u_spi_device.u_readcmd.u_readsram.u_sram_fifo.DataKnown_A");
+    $assertoff(0, "tb.dut.top_earlgrey.u_spi_device.u_readcmd.u_readsram.u_fifo.DataKnown_A");
     super.body();
+
     // Wait for test_main() to start and configurations to be computed.
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "All IPs configured.");
 
@@ -104,6 +178,14 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
       // Read bytes transmitted from spi_host1.
       begin: spi_host_1_thread
         read_spi_host1_bytes();
+      end
+
+      begin : spi_passthrough_thread
+        // Enable the spi agents.
+        cfg.chip_vif.enable_spi_host = 1;
+        cfg.chip_vif.enable_spi_device(.inst_num(0), .enable(1));
+        // Send the command and check the response.
+        execute_spi_flash_sequence();
       end
     join
   endtask


### PR DESCRIPTION
Add spi_device_agent_0 and spi_host_agent code to generate command-response sequence for the SPI passthrough part of the test.

The sequence:
1- spi_host_agent sends a SpiFlashReadQuad command
2- The command goes through the spi_device and spi_host_0 IPs that are configured in the passthrough mode
3- spi_device_agent_0 will respond with 2048 bytes of data.

Tested in DVSim.