### PR TITLE
[opentitantool] fix openocd logging

### DIFF
--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -109,8 +109,8 @@ impl OpenOcdServer {
         let mut cmd = Command::new(&self.opts.openocd);
         cmd.args(args)
             .stdin(Stdio::null())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         let mut child = cmd.spawn().with_context(|| {
             let program = cmd.get_program();
             let args = cmd.get_args().collect::<Vec<_>>().join(OsStr::new(" "));


### PR DESCRIPTION
The current code fails because the stdout/stderr is not piped. This was missed in the commit that enabled logging.