### PR TITLE
[alert_handler] remove alert_handler todos

### DIFF
--- a/hw/ip_templates/alert_handler/alert_handler_reg.core.tpl
+++ b/hw/ip_templates/alert_handler/alert_handler_reg.core.tpl
@@ -5,7 +5,6 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:alert_handler_reg:0.1")}
 description: "Auto-generated alert handler register sources"
 virtual:
-  # TODO: Check if the generated files actually maintain a stable public API.
   - "lowrisc:ip_interfaces:alert_handler_reg"
 
 filesets:

--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -566,7 +566,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       tags: [// Top level CSR automation test, CPU clock is disabled, so escalation response will
              // not send back to alert handler. This will set loc_alert_cause and could not predict
              // automatically.
-             // TODO: remove the exclusion after set up top-level esc_receiver_driver
              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0", name: "LA", desc: "Cause bit ", resval: 0}

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -729,9 +729,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       automatic int class_i = i;
       begin
         cfg.clk_rst_vif.wait_clks(1);
-        // TODO(#13026): Update `crashdump_triggered`.
-        // crashdump_triggered[class_i] = 0;
-        crashdump_triggered = 0;
+        crashdump_triggered[class_i] = 0;
         if (under_intr_classes[class_i]) begin
           if (cfg.en_cov) cov.clear_intr_cnt_cg.sample(class_i);
           clr_esc_under_intr[class_i] = 1;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_reg.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_reg.core
@@ -5,7 +5,6 @@ CAPI=2:
 name: lowrisc:opentitan:top_earlgrey_alert_handler_reg:0.1
 description: "Auto-generated alert handler register sources"
 virtual:
-  # TODO: Check if the generated files actually maintain a stable public API.
   - "lowrisc:ip_interfaces:alert_handler_reg"
 
 filesets:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -689,7 +689,6 @@
       tags: [// Top level CSR automation test, CPU clock is disabled, so escalation response will
              // not send back to alert handler. This will set loc_alert_cause and could not predict
              // automatically.
-             // TODO: remove the exclusion after set up top-level esc_receiver_driver
              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0", name: "LA", desc: "Cause bit ", resval: 0}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -729,9 +729,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       automatic int class_i = i;
       begin
         cfg.clk_rst_vif.wait_clks(1);
-        // TODO(#13026): Update `crashdump_triggered`.
-        // crashdump_triggered[class_i] = 0;
-        crashdump_triggered = 0;
+        crashdump_triggered[class_i] = 0;
         if (under_intr_classes[class_i]) begin
           if (cfg.en_cov) cov.clear_intr_cnt_cg.sample(class_i);
           clr_esc_under_intr[class_i] = 1;


### PR DESCRIPTION
Remove three todos from alert_handler:
1). Testbench todo: uncomment and remove the temp code. 
2). CSR exclusion - I removed the todo and filed an issue #17754. 
3). I think this is stale TODO, but filed an issue #17755 to check with msf.