### PR TITLE
[dv, keymgr] Add assertion to check validity of OTP root key

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -36,6 +36,9 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   task body();
     // invalid HW input may cause unstable data on kmac interface
     $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
+    // The following assertion is not relevant for block-level, it was added
+    // to double check OTP root key becomes valid when it is needed
+    $assertoff(0, "tb.dut.u_ctrl.RootKeyValidDuringLatching_A");
     super.body();
   endtask : body
 endclass : keymgr_hwsw_invalid_input_vseq

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -831,6 +831,9 @@ module keymgr_ctrl
   // Assertions
   /////////////////////////////////
 
+  // Verify that OTP root key is valid when FSM reaches to latching state
+  `ASSERT(RootKeyValidDuringLatching_A, (state_q == StCtrlRootKey) && en_i |-> root_key_valid_q)
+
   // This assertion will not work if fault_status ever takes on metafields such as
   // qe / re etc.
   `ASSERT_INIT(SameErrCnt_A, $bits(keymgr_reg2hw_fault_status_reg_t) ==


### PR DESCRIPTION
Addresses #17521.

Keymgr assumes that when it is time to latch OTP root key, this key is already valid. Our power-up flow/boot-up sequence already makes OTP root key available before keymgr reaches to flopping stage. However, this commit adds an assertion to make sure this assumption does not slip through the cracks.

This assertion is relevant for the top-level IP interaction and it needs a waiver for block-level testing. Requesting help from @cindychip. 
