### PR TITLE
[crypto] Add ECDH-P256 interface.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -7,6 +7,20 @@ package(default_visibility = ["//visibility:public"])
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 
 cc_library(
+    name = "ecdh_p256",
+    srcs = ["ecdh_p256.c"],
+    hdrs = ["ecdh_p256.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p256_common",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p256_ecdh",
+    ],
+)
+
+cc_library(
     name = "ecdsa_p256",
     srcs = ["ecdsa_p256.c"],
     hdrs = ["ecdsa_p256.h"],

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ecdh_p256.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '2', 'x')
+
+OTBN_DECLARE_APP_SYMBOLS(p256_ecdh);        // The OTBN ECDSH/P-256 app.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, mode);  // ECDH application mode.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, x);     // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, y);     // The public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh,
+                         d0);  // The private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh,
+                         d1);  // The private key scalar d (share 1).
+
+static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p256_ecdh);
+static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p256_ecdh, mode);
+static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p256_ecdh, x);
+static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p256_ecdh, y);
+static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p256_ecdh, d0);
+static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p256_ecdh, d1);
+
+// Mode is represented by a single word. See `p256_ecdh.s` for values.
+static const uint32_t kOtbnEcdhModeWords = 1;
+static const uint32_t kOtbnEcdhModeKeypairRandom = 0x3f1;
+static const uint32_t kOtbnEcdhModeSharedKey = 0x5ec;
+static const uint32_t kOtbnEcdhModeKeypairFromSeed = 0x29f;
+static const uint32_t kOtbnEcdhModeSharedKeyFromSeed = 0x74b;
+
+status_t ecdh_p256_keypair_start(void) {
+  // Load the ECDSA/P-256 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
+
+  // Set mode so start() will jump into keygen.
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &kOtbnEcdhModeKeypairRandom,
+                               kOtbnVarEcdhMode));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdh_p256_keypair_finalize(p256_masked_scalar_t *private_key,
+                                    p256_point_t *public_key) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the masked private key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarEcdhD0,
+                              private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP256MaskedScalarShareWords, kOtbnVarEcdhD1,
+                              private_key->share1));
+
+  // Read the public key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarEcdhX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarEcdhY, public_key->y));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}
+
+status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
+                                    const p256_point_t *public_key) {
+  // Load the ECDSA/P-256 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
+
+  // Set mode so start() will jump into shared-key generation.
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &kOtbnEcdhModeSharedKey,
+                               kOtbnVarEcdhMode));
+
+  // Set the private key shares.
+  HARDENED_TRY(
+      p256_masked_scalar_write(private_key, kOtbnVarEcdhD0, kOtbnVarEcdhD1));
+
+  // Set the public key x coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarEcdhX));
+
+  // Set the public key y coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->y, kOtbnVarEcdhY));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdh_p256_shared_key_finalize(ecdh_p256_shared_key_t *shared_key) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the shares of the key from OTBN dmem (at vars x and y).
+  HARDENED_TRY(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarEcdhX, shared_key->share0));
+  HARDENED_TRY(
+      otbn_dmem_read(kP256CoordWords, kOtbnVarEcdhY, shared_key->share1));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.h
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P256_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P256_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p256_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A type that holds a blinded ECDH shared secret key.
+ *
+ * The key is boolean-masked (XOR of the two shares).
+ */
+typedef struct ecdh_p256_shared_key {
+  uint32_t share0[kP256CoordWords];
+  uint32_t share1[kP256CoordWords];
+} ecdh_p256_shared_key_t;
+
+/**
+ * Start an async ECDH/P-256 keypair generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdh_p256_keypair_start(void);
+
+/**
+ * Finish an async ECDH/P-256 keypair generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] private_key Generated private key.
+ * @param[out] public_key Generated public key.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdh_p256_keypair_finalize(p256_masked_scalar_t *private_key,
+                                    p256_point_t *public_key);
+
+/**
+ * Start an async ECDH/P-256 shared key generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param private_key Private key (d).
+ * @param public_key Public key (Q).
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
+                                    const p256_point_t *public_key);
+
+/**
+ * Finish an async ECDH/P-256 shared key generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] shared_key Shared secret key (x-coordinate of d*Q).
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdh_p256_shared_key_finalize(ecdh_p256_shared_key_t *shared_key);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P256_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -86,6 +86,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "ecdh_p256_functest",
+    srcs = ["ecdh_p256_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl/ecc:ecdh_p256",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "ecdsa_p256_functest",
     srcs = ["ecdsa_p256_functest.c"],
     verilator = verilator_params(

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/ecdh_p256.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+status_t key_exchange_test(void) {
+  // Generate a keypair.
+  LOG_INFO("Generating keypair A...");
+  TRY(ecdh_p256_keypair_start());
+  p256_masked_scalar_t private_keyA;
+  p256_point_t public_keyA;
+  TRY(ecdh_p256_keypair_finalize(&private_keyA, &public_keyA));
+
+  // Generate a second keypair.
+  LOG_INFO("Generating keypair B...");
+  TRY(ecdh_p256_keypair_start());
+  p256_masked_scalar_t private_keyB;
+  p256_point_t public_keyB;
+  TRY(ecdh_p256_keypair_finalize(&private_keyB, &public_keyB));
+
+  // Sanity check; public keys should be different from each other.
+  CHECK_ARRAYS_NE(public_keyA.x, public_keyB.x, ARRAYSIZE(public_keyA.x));
+  CHECK_ARRAYS_NE(public_keyA.y, public_keyB.y, ARRAYSIZE(public_keyA.y));
+
+  // Compute the shared secret from A's side of the computation (using A's
+  // private key and B's public key).
+  LOG_INFO("Generating shared secret (A)...");
+  TRY(ecdh_p256_shared_key_start(&private_keyA, &public_keyB));
+  ecdh_p256_shared_key_t shared_keyA;
+  TRY(ecdh_p256_shared_key_finalize(&shared_keyA));
+
+  // Compute the shared secret from B's side of the computation (using B's
+  // private key and A's public key).
+  LOG_INFO("Generating shared secret (B)...");
+  TRY(ecdh_p256_shared_key_start(&private_keyB, &public_keyA));
+  ecdh_p256_shared_key_t shared_keyB;
+  TRY(ecdh_p256_shared_key_finalize(&shared_keyB));
+
+  // Unmask the keys and check that they match.
+  uint32_t keyA[ARRAYSIZE(shared_keyA.share0)];
+  uint32_t keyB[ARRAYSIZE(keyA)];
+  for (size_t i = 0; i < ARRAYSIZE(keyA); i++) {
+    keyA[i] = shared_keyA.share0[i] ^ shared_keyA.share1[i];
+    keyB[i] = shared_keyB.share0[i] ^ shared_keyB.share1[i];
+  }
+  CHECK_ARRAYS_EQ(keyA, keyB, ARRAYSIZE(keyA));
+
+  return OTCRYPTO_OK;
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  status_t err = key_exchange_test();
+  if (!status_ok(err)) {
+    // If there was an error, print the OTBN error bits and instruction count.
+    LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+    LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
+    // Print the error.
+    CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  return true;
+}

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -56,6 +56,16 @@ otbn_library(
 )
 
 otbn_binary(
+    name = "p256_ecdh",
+    srcs = [
+        "p256_ecdh.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
     name = "p256_ecdsa",
     srcs = [
         "p256_ecdsa.s",

--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -1930,14 +1930,20 @@ p256_scalar_mult:
   /* init all-zero register */
   bn.xor    w31, w31, w31
 
-  /* load first share of scalar from dmem: w0 = dmem[k0] */
+  /* Load first share of secret key k from dmem.
+       w0,w1 = dmem[k0] */
   la        x16, k0
   li        x2, 0
+  bn.lid    x2, 0(x16++)
+  li        x2, 1
   bn.lid    x2, 0(x16)
 
-  /* load second share of scalar from dmem: w1 = dmem[k1] */
+  /* Load second share of secret key d from dmem.
+       w2,w3 = dmem[k1] */
   la        x16, k1
-  li        x2, 1
+  li        x2, 2
+  bn.lid    x2, 0(x16++)
+  li        x2, 3
   bn.lid    x2, 0(x16)
 
   /* call internal scalar multiplication routine
@@ -2518,11 +2524,11 @@ y:
 /* private key d (in two 320b shares) */
 .balign 32
 .weak d0
-d_share0:
+d0:
   .zero 64
 .balign 32
 .weak d1
-d_share1:
+d1:
   .zero 64
 
 /* verification result x_r (aka x_1) */

--- a/sw/otbn/crypto/p256_ecdh.s
+++ b/sw/otbn/crypto/p256_ecdh.s
@@ -1,0 +1,276 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Elliptic-curve Diffie-Hellman (ECDH) on curve P-256.
+ *
+ * This binary has the following modes of operation:
+ * 1. MODE_KEYGEN_RANDOM: generate a random keypair
+ * 2. MODE_SHARED_KEYGEN: compute shared key
+ * 3. MODE_KEYGEN_FROM_SEED: generate keypair from a sideloaded seed
+ * 4. MODE_SHARED_KEYGEN_FROM_SEED: compute shared key using sideloaded seed
+ */
+
+/**
+ * Mode magic values generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 4 -n 11 \
+ *    --avoid-zero -s 3660400884
+ *
+ * Call the same utility with the same arguments and a higher -m to generate
+ * additional value(s) without changing the others or sacrificing mutual HD.
+ *
+ * TODO(#17727): in some places the OTBN assembler support for .equ directives
+ * is lacking, so they cannot be used in bignum instructions or pseudo-ops such
+ * as `li`. If support is added, we could use 32-bit values here instead of
+ * 11-bit.
+ */
+.equ MODE_KEYPAIR_RANDOM, 0x3f1
+.equ MODE_SHARED_KEY, 0x5ec
+.equ MODE_KEYPAIR_FROM_SEED, 0x29f
+.equ MODE_SHARED_KEY_FROM_SEED, 0x74b
+
+.section .text.start
+start:
+  /* Init all-zero register. */
+  bn.xor  w31, w31, w31
+
+  /* Read the mode and tail-call the requested operation. */
+  la      x2, mode
+  lw      x2, 0(x2)
+
+  addi    x3, x0, MODE_KEYPAIR_RANDOM
+  beq     x2, x3, keypair_random
+
+  addi    x3, x0, MODE_SHARED_KEY
+  beq     x2, x3, shared_key
+
+  addi    x3, x0, MODE_KEYPAIR_FROM_SEED
+  beq     x2, x3, keypair_from_seed
+
+  addi    x3, x0, MODE_SHARED_KEY_FROM_SEED
+  beq     x2, x3, shared_key_from_seed
+
+  /* Unsupported mode; fail. */
+  unimp
+  unimp
+  unimp
+
+/**
+ * Generate a fresh random keypair.
+ *
+ * Returns secret key d in 320b shares d0, d1.
+ *
+ * Returns public key Q = d*G in affine coordinates (x, y).
+ *
+ * This routine runs in constant time (except potentially waiting for entropy
+ * from RND).
+ *
+ * @param[in]       w31: all-zero
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d1]: Second share of secret key.
+ * @param[out]  dmem[x]: Public key x-coordinate.
+ * @param[out]  dmem[y]: Public key y-coordinate.
+ *
+ * clobbered registers: x2, x3, x16, x17, x21, x22, w0 to w26
+ * clobbered flag groups: FG0
+ */
+keypair_random:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal   x1, p256_generate_random_key
+
+  /* Generate public key d*G.
+       dmem[x] <= (d*G).x
+       dmem[y] <= (d*G).y */
+  jal      x1, p256_base_mult
+
+  ecall
+
+/**
+ * Generate a shared key from a secret and public key.
+ *
+ * Returns the shared key, which is the affine x-coordinate of (d*Q). The
+ * shared key is expressed in boolean shares x0, x1 such that the key is (x0 ^
+ * x1).
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]       w31: all-zero
+ * @param[in]  dmem[k0]: First share of secret key.
+ * @param[in]  dmem[k1]: Second share of secret key.
+ * @param[in]   dmem[x]: Public key (Q) x-coordinate.
+ * @param[in]   dmem[y]: Public key (Q) y-coordinate.
+ * @param[out]  dmem[x]: x0, first share of shared key.
+ * @param[out]  dmem[y]: x1, second share of shared key.
+ */
+shared_key:
+  /* Generate shared key d*Q.
+       dmem[x] <= (d*Q).x
+       dmem[y] <= (d*Q).y */
+  jal      x1, p256_scalar_mult
+
+  /* TODO: `p256_scalar_mult` and the code below briefly handle the shared key
+     in unmasked form. The best way to fixing this is likely:
+       - modify scalar_mult_int to return projective coordinates
+       - get additive arithmetic mask for x before converting it to affine
+       - multiply both shares by Z^-1 to convert to affine form
+       - run a safe arithmetic-to-boolean conversion algorithm
+ */
+
+  /* Fetch a fresh random number for blinding.
+       w2 <= URND() */
+  bn.wsrr   w2, 0x2 /* URND */
+
+  /* Store the random number as the second share.
+       dmem[y] <= w2 */
+  li        x2, 2
+  la        x4, y
+  bn.sid    x2, 0(x4)
+
+  /* Blind the x-coordinate.
+       dmem[x] <= dmem[x] ^ w2 */
+  li        x3, 3
+  la        x4, x
+  bn.lid    x3, 0(x4)
+  bn.xor    w3, w3, w2
+  bn.sid    x3, 0(x4)
+
+  ecall
+
+/**
+ * Generate a keypair from a keymgr-derived seed.
+ *
+ * Returns secret key d in 320b shares d0, d1.
+ *
+ * Returns public key Q = d*G in affine coordinates (x, y).
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]       w31: all-zero
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d1]: Second share of secret key.
+ * @param[out]  dmem[x]: Public key x-coordinate.
+ * @param[out]  dmem[y]: Public key y-coordinate.
+ */
+keypair_from_seed:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal   x1, secret_key_from_seed
+
+  /* Generate public key d*G.
+       dmem[x] <= (d*G).x
+       dmem[y] <= (d*G).y */
+  jal      x1, p256_base_mult
+
+  ecall
+
+/**
+ * Generate a shared key from a keymgr-derived seed.
+ *
+ * Returns the shared key, which is the affine x-coordinate of (d*Q). The
+ * shared key is expressed in boolean shares x0, x1 such that the key is (x0 ^
+ * x1).
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]       w31: all-zero
+ * @param[in]   dmem[x]: Public key (Q) x-coordinate.
+ * @param[in]   dmem[y]: Public key (Q) y-coordinate.
+ * @param[out]  dmem[x]: x0, first share of shared key.
+ * @param[out]  dmem[y]: x1, second share of shared key.
+ */
+shared_key_from_seed:
+  /* Generate secret key d in shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  jal   x1, secret_key_from_seed
+
+  /* Tail-call shared-key generation. */
+  jal      x0, shared_key
+
+/**
+ * Generate a secret key from a keymgr-derived seed.
+ *
+ * Returns secret key d in 320b shares d0, d1 such that:
+ *   (d0 + d1) mod n = (seed0 ^ seed1) mod n
+ * ...where seed0 and seed1 are the 320-bit keymgr-provided seed values stored
+ * in KEY_S0_{L,H} and KEY_S1_{L,H} WSRs. Note that the keymgr actually
+ * provides 384 bits, but these higher bits are ignored.
+ *
+ * This routine runs in constant time.
+ *
+ * @param[in]       w31: all-zero
+ * @param[out] dmem[d0]: First share of secret key.
+ * @param[out] dmem[d0]: Second share of secret key.
+ *
+ * clobbered registers: x2, x3, w1 to w4, w20 to w29
+ * clobbered flag groups: FG0
+ */
+secret_key_from_seed:
+  /* Load keymgr seeds from WSRs.
+       w20,w21 <= seed0
+       w22,w23 <= seed1 */
+  bn.wsrr  w20, 0x4 /* KEY_S0_L */
+  bn.wsrr  w21, 0x5 /* KEY_S0_H */
+  bn.wsrr  w22, 0x6 /* KEY_S1_L */
+  bn.wsrr  w23, 0x7 /* KEY_S1_H */
+
+  /* Generate secret key shares.
+       w20, w21 <= d0
+       w22, w23 <= d1 */
+  jal      x1, p256_key_from_seed
+
+  /* Store secret key shares.
+       dmem[d0] <= d0
+       dmem[d1] <= d1 */
+  li       x2, 20
+  la       x3, d0
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2++, 32(x3)
+  la       x3, d0
+  bn.sid   x2++, 0(x3)
+  bn.sid   x2, 32(x3)
+
+  ret
+
+.bss
+
+/* Operational mode. */
+.globl mode
+.balign 4
+mode:
+  .zero 4
+
+/* Public key (Q) x-coordinate. */
+.globl x
+.balign 32
+x:
+  .zero 32
+
+/* Public key y-coordinate. */
+.globl y
+.balign 32
+y:
+  .zero 32
+
+/* Secret key (d) in two shares: d = (d0 + d1) mod n.
+
+   Note: This is also labeled k0, k1 because the `p256_scalar_mult` algorithm
+   is also used for ECDSA signing and reads from those labels; in the case of
+   ECDH, the scalar in `p256_scalar_mult` is always the private key (d). */
+.globl d0
+.globl k0
+.balign 32
+d0:
+k0:
+  .zero 64
+
+.globl d1
+.globl k1
+.balign 32
+d1:
+k1:
+  .zero 64

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -59,8 +59,6 @@ start:
   unimp
   unimp
 
-.text
-
 /**
  * Generate a fresh, random keypair.
  *


### PR DESCRIPTION
This PR adds:
- An OTBN entrypoint that runs P-256 ECDH operations
- An Ibex-side C file that calls that entrypoint
- A basic functional test for the above