### PR TITLE
[dv/otp_ctrl] restored origin freq after low freq vseq is finished

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_low_freq_read_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_low_freq_read_vseq.sv
@@ -15,6 +15,13 @@ class otp_ctrl_low_freq_read_vseq extends otp_ctrl_base_vseq;
     cfg.clk_rst_vif.set_freq_mhz(6);
   endtask
 
+  virtual task post_start();
+    super.post_start();
+
+    // restore original clock frequency
+    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
+  endtask : post_start
+
   virtual task body();
     // Backdoor write all partitions.
     for (int addr = VendorTestOffset / 4; addr < LifeCycleOffset / 4; addr++) begin


### PR DESCRIPTION
otp_ctrl_low_freq_read sets a low frequency (6MHz) to verify correct read operations.

However, it does not restore the original frequency (`clk_freq_mhz`), which causes problems in CS when running a stress test, as lower frequency is not a suitable mode for all types of OTP operation.

This PR solves this problem by restoring the original clock frequency in `otp_ctrl_low_freq_read::post_start`, after the main body of the test finishes.