### PR TITLE
[crypto] Add a temporary status code to the cryptolib for unimplemented functionality.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -19,6 +19,24 @@ cc_library(
 )
 
 cc_library(
+    name = "drbg",
+    srcs = ["drbg.c"],
+    hdrs = ["//sw/device/lib/crypto/include:drbg.h"],
+    deps = [
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
+    name = "ecc",
+    srcs = ["ecc.c"],
+    hdrs = ["//sw/device/lib/crypto/include:ecc.h"],
+    deps = [
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
     name = "hash",
     srcs = ["hash.c"],
     hdrs = [
@@ -44,6 +62,15 @@ cc_library(
 )
 
 cc_library(
+    name = "kdf",
+    srcs = ["kdf.c"],
+    hdrs = ["//sw/device/lib/crypto/include:kdf.h"],
+    deps = [
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
     name = "keyblob",
     srcs = ["keyblob.c"],
     hdrs = ["keyblob.h"],
@@ -61,6 +88,24 @@ cc_test(
     deps = [
         ":keyblob",
         "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "key_transport",
+    srcs = ["key_transport.c"],
+    hdrs = ["//sw/device/lib/crypto/include:key_transport.h"],
+    deps = [
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
+    name = "rsa",
+    srcs = ["rsa.c"],
+    hdrs = ["//sw/device/lib/crypto/include:rsa.h"],
+    deps = [
+        "//sw/device/lib/crypto/include:datatypes",
     ],
 )
 

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -24,6 +24,13 @@ OT_ASSERT_ENUM_VALUE(kAesCipherModeCtr, (uint32_t)kBlockCipherModeCtr);
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('a', 'e', 's')
 
+crypto_status_t otcrypto_aes_keygen(crypto_blinded_key_t *key) {
+  // TODO: Implement AES sideloaded key generation once we have a keymgr
+  // driver. In the meantime, non-sideloaded AES keys can simply be generated
+  // using the DRBG and key-import functions.
+  return kCryptoStatusNotImplemented;
+}
+
 /**
  * Extract an AES key from the blinded key struct.
  *
@@ -318,4 +325,61 @@ crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
   OTCRYPTO_TRY_INTERPRET(aes_end());
 
   return kCryptoStatusOK;
+}
+
+crypto_status_t otcrypto_aes_encrypt_gcm(
+    const crypto_blinded_key_t *key, crypto_const_uint8_buf_t plaintext,
+    crypto_uint8_buf_t iv, crypto_uint8_buf_t aad, aead_gcm_tag_len_t tag_len,
+    crypto_uint8_buf_t *ciphertext, crypto_uint8_buf_t *auth_tag) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_aes_decrypt_gcm(const crypto_blinded_key_t *key,
+                                         crypto_const_uint8_buf_t ciphertext,
+                                         crypto_uint8_buf_t iv,
+                                         crypto_uint8_buf_t aad,
+                                         crypto_uint8_buf_t auth_tag,
+                                         crypto_uint8_buf_t *plaintext) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_gcm_ghash_init(const crypto_blinded_key_t *hash_subkey,
+                                        gcm_ghash_context_t *ctx) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
+                                          crypto_const_uint8_buf_t input) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
+                                         crypto_uint8_buf_t digest) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
+                                      crypto_const_uint8_buf_t input,
+                                      crypto_uint8_buf_t output) {
+  // TODO: Connect AES-GCM operations to the API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_aes_kwp_encrypt(
+    const crypto_blinded_key_t *key_to_wrap,
+    const crypto_blinded_key_t *key_kek, crypto_uint8_buf_t *wrapped_key) {
+  // TODO: AES-KWP is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_uint8_buf_t wrapped_key,
+                                         const crypto_blinded_key_t *key_kek,
+                                         crypto_blinded_key_t *unwrapped_key) {
+  // TODO: AES-KWP is not yet implemented.
+  return kCryptoStatusNotImplemented;
 }

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -38,7 +38,7 @@ static status_t construct_aes_key(const crypto_blinded_key_t *blinded_key,
   // TODO(#15590): add support for sideloaded keys by actuating keymgr here if
   // needed (this requires a keymgr driver).
   if (blinded_key->config.hw_backed != kHardenedBoolFalse) {
-    return OTCRYPTO_BAD_ARGS;
+    return OTCRYPTO_NOT_IMPLEMENTED;
   }
   aes_key->sideload = kHardenedBoolFalse;
 
@@ -123,10 +123,9 @@ static status_t aes_padding_apply(aes_padding_t padding_mode,
       break;
     case kAesPaddingNull:
       // This routine should not be called if padding is not needed.
-      return OTCRYPTO_BAD_ARGS;
+      return OTCRYPTO_RECOV_ERR;
     default:
-      // TODO(#15591): Add any other padding modes that will be included in the
-      // final API.
+      // Unrecognized padding mode.
       return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(padding_written, kHardenedBoolTrue);

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/drbg.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('r', 'b', 'g')
+
+crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t nonce,
+                                          crypto_uint8_buf_t perso_string) {
+  // TODO: Connect entropy driver to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input) {
+  // TODO: Connect entropy driver to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_drbg_manual_instantiate(
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t nonce,
+    crypto_uint8_buf_t perso_string) {
+  // TODO: Connect entropy driver to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_drbg_manual_reseed(
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t additional_input) {
+  // TODO: Connect entropy driver to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
+                                       size_t output_len,
+                                       crypto_uint8_buf_t *drbg_output) {
+  // TODO: Connect entropy driver to API.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -1,0 +1,206 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/ecc.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('e', 'c', 'c')
+
+crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
+                                      crypto_blinded_key_t *private_key,
+                                      ecc_public_key_t *public_key) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
+                                    crypto_const_uint8_buf_t input_message,
+                                    ecc_curve_t *elliptic_curve,
+                                    ecc_signature_t *signature) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_verify(
+    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    ecc_signature_t *signature, ecc_curve_t *elliptic_curve,
+    verification_status_t *verification_result) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
+                                     crypto_blinded_key_t *private_key,
+                                     ecc_public_key_t *public_key) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh(const crypto_blinded_key_t *private_key,
+                              const ecc_public_key_t *public_key,
+                              ecc_curve_t *elliptic_curve,
+                              crypto_blinded_key_t *shared_secret) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
+                                        crypto_unblinded_key_t *public_key) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
+                                      crypto_const_uint8_buf_t input_message,
+                                      eddsa_sign_mode_t sign_mode,
+                                      ecc_signature_t *signature) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_verify(
+    const crypto_unblinded_key_t *public_key,
+    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    ecc_signature_t *signature, verification_status_t *verification_result) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519_keygen(crypto_blinded_key_t *private_key,
+                                       crypto_unblinded_key_t *public_key) {
+  // TODO: Connect X25519 operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
+                                const crypto_unblinded_key_t *public_key,
+                                crypto_blinded_key_t *shared_secret) {
+  // TODO: Connect X25519 operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
+    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_sign_async_start(
+    const crypto_blinded_key_t *private_key,
+    crypto_const_uint8_buf_t input_message, ecc_curve_t *elliptic_curve) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_verify_async_start(
+    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    ecc_signature_t *signature, ecc_curve_t *elliptic_curve) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdsa_verify_async_finalize(
+    verification_status_t *verification_result) {
+  // TODO: Connect ECDSA operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh_keygen_async_finalize(
+    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh_async_start(
+    const crypto_blinded_key_t *private_key, const ecc_public_key_t *public_key,
+    ecc_curve_t *elliptic_curve) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ecdh_async_finalize(
+    crypto_blinded_key_t *shared_secret) {
+  // TODO: Connect ECDH operations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_keygen_async_start() {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_keygen_async_finalize(
+    crypto_blinded_key_t *private_key, crypto_unblinded_key_t *public_key) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_sign_async_start(
+    const crypto_blinded_key_t *private_key,
+    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    ecc_signature_t *signature) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_sign_async_finalize(
+    ecc_signature_t *signature) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_verify_async_start(
+    const crypto_unblinded_key_t *public_key,
+    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    ecc_signature_t *signature) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_ed25519_verify_async_finalize(
+    verification_status_t *verification_result) {
+  // TODO: Ed25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519_keygen_async_start() {
+  // TODO: X25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519_keygen_async_finalize(
+    crypto_blinded_key_t *private_key, crypto_unblinded_key_t *public_key) {
+  // TODO: X25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519_async_start(
+    const crypto_blinded_key_t *private_key,
+    const crypto_unblinded_key_t *public_key) {
+  // TODO: X25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_x25519_async_finalize(
+    crypto_blinded_key_t *shared_secret) {
+  // TODO: X25519 is not yet implemented.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -172,3 +172,21 @@ crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
 
   return kCryptoStatusOK;
 }
+
+crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
+                                   hash_mode_t hash_mode) {
+  // TODO: Implement streaming hash functions.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
+                                     crypto_const_uint8_buf_t input_message) {
+  // TODO: Implement streaming hash functions.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
+                                    crypto_uint8_buf_t *digest) {
+  // TODO: Implement streaming hash functions.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -116,8 +116,14 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
       // Call the HMAC block driver in SHA-256 mode.
       OTCRYPTO_TRY_INTERPRET(sha256(input_message, digest));
       break;
+    case kHashModeSha384:
+      // TODO: (#16410) Connect SHA2-384 implementation
+      return kCryptoStatusNotImplemented;
+    case kHashModeSha512:
+      // TODO: (#16410) Connect SHA2-512 implementation
+      return kCryptoStatusNotImplemented;
     default:
-      // TODO: (#16410) Connect SHA2-{384,512} implementations
+      // Unrecognized hash mode.
       return kCryptoStatusBadArgs;
   }
 

--- a/sw/device/lib/crypto/impl/kdf.c
+++ b/sw/device/lib/crypto/impl/kdf.c
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/kdf.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('k', 'd', 'f')
+
+crypto_status_t otcrypto_kdf_ctr(const crypto_blinded_key_t key_derivation_key,
+                                 kdf_type_t kdf_mode, key_mode_t key_mode,
+                                 size_t required_bit_len,
+                                 crypto_blinded_key_t keying_material) {
+  // TODO: Implement HMAC-KDF and KMAC-KDF.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/key_transport.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('k', 't', 'r')
+
+crypto_status_t otcrypto_build_unblinded_key(
+    crypto_const_uint8_buf_t plain_key, key_mode_t key_mode,
+    crypto_unblinded_key_t unblinded_key) {
+  // TODO: implement key transport functions.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_build_blinded_key(crypto_const_uint8_buf_t plain_key,
+                                           crypto_blinded_key_t blinded_key) {
+  // TODO: implement key transport functions.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_blinded_to_unblinded_key(
+    const crypto_blinded_key_t blinded_key,
+    crypto_unblinded_key_t unblinded_key) {
+  // TODO: implement key transport functions.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_unblinded_to_blinded_key(
+    const crypto_unblinded_key_t unblinded_key,
+    crypto_blinded_key_t blinded_key) {
+  // TODO: implement key transport functions.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -97,7 +97,7 @@ crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
 
   // TODO (#16410, #15590): Add sideload support.
   if (key->config.hw_backed == kHardenedBoolTrue) {
-    return kCryptoStatusBadArgs;
+    return kCryptoStatusNotImplemented;
   }
 
   kmac_blinded_key_t kmac_key;

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -15,6 +15,13 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('m', 'a', 'c')
 
+crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
+  // TODO: Implement KMAC sideloaded key generation once we have a keymgr
+  // driver. In the meantime, non-sideloaded KMAC or HMAC keys can simply be
+  // generated using the DRBG and key-import functions.
+  return kCryptoStatusNotImplemented;
+}
+
 /**
  * Call the hardware HMAC-SHA256 driver.
  *
@@ -140,4 +147,23 @@ crypto_status_t otcrypto_mac(const crypto_blinded_key_t *key,
   }
 
   return kCryptoStatusOK;
+}
+
+crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
+                                   const crypto_blinded_key_t *key,
+                                   mac_mode_t hmac_mode) {
+  // TODO: Implement streaming HMAC API once we have streaming SHA256.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
+                                     crypto_const_uint8_buf_t input_message) {
+  // TODO: Implement streaming HMAC API once we have streaming SHA256.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
+                                    crypto_uint8_buf_t *tag) {
+  // TODO: Implement streaming HMAC API once we have streaming SHA256.
+  return kCryptoStatusNotImplemented;
 }

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/rsa.h"
+
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('r', 's', 'a')
+
+crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
+                                    rsa_public_key_t *rsa_public_key,
+                                    rsa_private_key_t *rsa_private_key) {
+  // TODO: Implement RSA key generation.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
+                                  crypto_const_uint8_buf_t input_message,
+                                  rsa_padding_t padding_mode,
+                                  rsa_hash_t hash_mode,
+                                  crypto_uint8_buf_t *signature) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_verify(
+    const rsa_public_key_t *rsa_public_key,
+    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    rsa_hash_t hash_mode, crypto_const_uint8_buf_t signature,
+    verification_status_t *verification_result) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_keygen_async_start(
+    rsa_key_size_t required_key_len) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_keygen_async_finalize(
+    rsa_public_key_t *rsa_public_key, rsa_private_key_t *rsa_private_key) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_sign_async_start(
+    const rsa_private_key_t *rsa_private_key,
+    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    rsa_hash_t hash_mode) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_sign_async_finalize(
+    crypto_uint8_buf_t *signature) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_verify_async_start(
+    const rsa_public_key_t *rsa_public_key,
+    crypto_const_uint8_buf_t signature) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}
+
+crypto_status_t otcrypto_rsa_verify_async_finalize(
+    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    rsa_hash_t hash_mode, verification_status_t *verification_result) {
+  // TODO: Connect RSA implementations to API.
+  return kCryptoStatusNotImplemented;
+}

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -10,11 +10,10 @@
 
 crypto_status_t crypto_status_interpret(status_t status) {
   // First, check for a hardened-ok status.
-  uint32_t res = launder32(kCryptoStatusOK ^ kHardenedBoolTrue);
   hardened_bool_t is_ok = hardened_status_ok(status);
   if (launder32(is_ok) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(is_ok, kHardenedBoolTrue);
-    return res ^ is_ok;
+    return launder32(status.value);
   }
   HARDENED_CHECK_NE(is_ok, kHardenedBoolTrue);
 

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -44,7 +44,7 @@ crypto_status_t crypto_status_interpret(status_t status) {
     case kOutOfRange:
       return kCryptoStatusInternalError;
     case kUnimplemented:
-      return kCryptoStatusInternalError;
+      return kCryptoStatusNotImplemented;
     case kUnauthenticated:
       return kCryptoStatusInternalError;
     case kUnknown:

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -36,6 +36,9 @@ extern "C" {
 #define OTCRYPTO_ASYNC_INCOMPLETE                         \
   ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
+#define OTCRYPTO_NOT_IMPLEMENTED                          \
+  ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
+                                 ((__LINE__ & 0x7ff) << 5) | kUnImplemented)})
 
 /**
  * Convert a `status_t` into a `crypto_status_t`.
@@ -60,7 +63,7 @@ extern "C" {
  *   | kResourceExhausted  | kCryptoStatusInternalError   |
  *   | kAborted            | kCryptoStatusInternalError   |
  *   | kOutOfRange         | kCryptoStatusInternalError   |
- *   | kUnimplemented      | kCryptoStatusInternalError   |
+ *   | kUnimplemented      | kCryptoStatusNotImplemented  |
  *   | kUnauthenticated    | kCryptoStatusInternalError   |
  *   | kUnknown            | kCryptoStatusFatalError      |
  *   | kFailedPrecondition | kCryptoStatusFatalError      |

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -38,7 +38,7 @@ extern "C" {
                                  ((__LINE__ & 0x7ff) << 5) | kUnavailable)})
 #define OTCRYPTO_NOT_IMPLEMENTED                          \
   ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
-                                 ((__LINE__ & 0x7ff) << 5) | kUnImplemented)})
+                                 ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
 
 /**
  * Convert a `status_t` into a `crypto_status_t`.

--- a/sw/device/lib/crypto/impl/status_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_unittest.cc
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/crypto/impl/status.h"
 
+#include <array>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -12,6 +14,47 @@
 
 namespace status_unittest {
 namespace {
+
+TEST(Status, OkIsHardenedTrue) {
+  EXPECT_EQ(kCryptoStatusOK, kHardenedBoolTrue);
+}
+
+int HammingDistance(uint32_t a, uint32_t b) {
+  // The hamming distance is the number of bits different between the two words.
+  return bitfield_popcount32(a ^ b);
+}
+
+// Check the Hamming distances of the top-level error codes.
+constexpr int kMinimumHammingDistance = 5;
+TEST(Status, TopLevelStatusHammingDistance) {
+  std::array<crypto_status_t, 5> error_codes = {
+      kCryptoStatusBadArgs, kCryptoStatusInternalError, kCryptoStatusFatalError,
+      kCryptoStatusAsyncIncomplete, kCryptoStatusNotImplemented};
+
+  // Expect the "OK" code to have a significant Hamming distance from 0.
+  EXPECT_GE(HammingDistance(kCryptoStatusOK, 0), kMinimumHammingDistance)
+      << "The 'OK' status code " << kCryptoStatusOK << " is too close to zero.";
+
+  for (const crypto_status_t status1 : error_codes) {
+    // Expect a significant Hamming distance from 0.
+    EXPECT_GE(HammingDistance(status1, 0), kMinimumHammingDistance)
+        << "Error code " << status1 << " is too close to zero.";
+    // Expect an extra significant Hamming distance from the "OK" code.
+    EXPECT_GE(HammingDistance(status1, kCryptoStatusOK),
+              kMinimumHammingDistance)
+        << "Error code " << status1 << " is too close to the 'OK' value ("
+        << kCryptoStatusOK << ").";
+
+    // Expect a significant Hamming distance from all other error codes.
+    for (const crypto_status_t status2 : error_codes) {
+      if (status1 != status2) {
+        EXPECT_GE(HammingDistance(status1, status2), kMinimumHammingDistance)
+            << "Error codes " << status1 << " and " << status2
+            << " are too close to each other.";
+      }
+    }
+  }
+}
 
 TEST(Status, OkIsHardenedOk) {
   EXPECT_EQ(hardened_status_ok(OTCRYPTO_OK), kHardenedBoolTrue);

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -5,7 +5,6 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
 
-#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
 /**
@@ -79,12 +78,6 @@ typedef enum aes_padding {
   kAesPaddingPkcs7 = 0xce99,
   // Pads with 0x80 (10000000), followed by zero bytes.
   kAesPaddingIso9797M2 = 0xb377,
-  // Pads with 0x00 bytes.
-  kAesPaddingIso9797M1 = 0x49eb,
-  // Pads with random bytes, last byte is no. of padded bytes.
-  kAesPaddingRandom = 0x746c,
-  // Pads with 0x00 bytes, last byte is no. of padded bytes.
-  kAesPaddingX923 = 0xed32,
   // Add no padding.
   kAesPaddingNull = 0x259f,
 } aes_padding_t;

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -27,15 +27,18 @@ extern "C" {
  */
 typedef enum crypto_status {
   // Status is OK; no errors.
-  kCryptoStatusOK = 0xc6c5,
+  kCryptoStatusOK = 0xcb6,
   // Invalid input arguments; wrong length or invalid type.
-  kCryptoStatusBadArgs = 0xe9cb,
+  kCryptoStatusBadArgs = 0xb07,
   // Error after which it is OK to retry (e.g. timeout).
-  kCryptoStatusInternalError = 0x5eb2,
+  kCryptoStatusInternalError = 0x5c3,
   // Error after which it is not OK to retry (e.g. integrity check).
-  kCryptoStatusFatalError = 0xd176,
+  kCryptoStatusFatalError = 0xf5c,
   // An asynchronous operation is still in progress.
-  kCryptoStatusAsyncIncomplete = 0x37e1,
+  kCryptoStatusAsyncIncomplete = 0xae1,
+  // TODO: remove all instances of this error before release; it is to track
+  // implementations that are not yet complete.
+  kCryptoStatusNotImplemented = 0x7ff,
 } crypto_status_t;
 
 /**

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -27,7 +27,7 @@ extern "C" {
  */
 typedef enum crypto_status {
   // Status is OK; no errors.
-  kCryptoStatusOK = 0xcb6,
+  kCryptoStatusOK = 0x739,
   // Invalid input arguments; wrong length or invalid type.
   kCryptoStatusBadArgs = 0xb07,
   // Error after which it is OK to retry (e.g. timeout).
@@ -38,7 +38,7 @@ typedef enum crypto_status {
   kCryptoStatusAsyncIncomplete = 0xae1,
   // TODO: remove all instances of this error before release; it is to track
   // implementations that are not yet complete.
-  kCryptoStatusNotImplemented = 0x7ff,
+  kCryptoStatusNotImplemented = 0xff,
 } crypto_status_t;
 
 /**

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief DRBG for the OpenTitan cryptography library.

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief Elliptic curve operations for OpenTitan cryptography library.
@@ -366,40 +368,6 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
  * @return Result of async ECDSA finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature);
-
-/**
- * Starts the asynchronous deterministic ECDSA digital signature generation.
- *
- * Initializes OTBN and starts the OTBN routine to compute the digital
- * signature on the input message. The `domain_parameter` field of the
- * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to `NULL`.
- *
- * @param private_key Pointer to the blinded private key (d) struct.
- * @param input_message Input message to be signed.
- * @param elliptic_curve Pointer to the elliptic curve to be used.
- * @return Result of async ECDSA start operation.
- */
-crypto_status_t otcrypto_deterministic_ecdsa_sign_async_start(
-    const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, ecc_curve_t *elliptic_curve);
-
-/**
- * Finalizes the asynchronous deterministic ECDSA digital signature generation.
- *
- * In the case of deterministic ECDSA, the random value ‘k’ for the
- * signature generation is deterministically generated from the
- * private key and the input message. Refer to RFC6979 for details.
- *
- * Returns `kCryptoStatusOK` and copies the signature if the OTBN
- * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
- * busy or `kCryptoStatusInternalError` if there is an error.
- *
- * @param[out] signature Pointer to the signature struct with (r,s) values.
- * @return Result of async deterministic ECDSA finalize operation.
- */
-crypto_status_t otcrypto_ecdsa_deterministic_sign_async_finalize(
-    ecc_signature_t *signature);
 
 /**
  * Starts the asynchronous ECDSA digital signature verification.

--- a/sw/device/lib/crypto/include/kdf.h
+++ b/sw/device/lib/crypto/include/kdf.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief Key derivation functions for the OpenTitan cryptography library.

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief Key import/export for the OpenTitan cryptography library.
@@ -83,7 +85,8 @@ crypto_status_t otcrypto_blinded_to_unblinded_key(
  * @return Result of blinding operation.
  */
 crypto_status_t otcrypto_unblinded_to_blinded_key(
-    const crypto_unblinded_key unblinded_key, crypto_blinded_key_t blinded_key);
+    const crypto_unblinded_key_t unblinded_key,
+    crypto_blinded_key_t blinded_key);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
 
+#include "sw/device/lib/crypto/include/datatypes.h"
+
 /**
  * @file
  * @brief RSA signature operations for the OpenTitan cryptography library.


### PR DESCRIPTION
The idea here is to make it easy to search for missing functionality in the cryptolib, and to make it easier once we get to the integration stage to differentiate misformatted arguments from missing functionality. **The temporary status code should be removed before the first full release of the API.**

This PR:
- Adds a temporary "not implemented" status code to indicate that a particular code branch is planned, but not yet implemented.
- Uses this new status where applicable in existing code
- Adds stubs for all unimplemented functions from the API

Now, all work remaining on the cryptolib comes up when you search `kCryptoStatusNotImplemented` and `OTCRYPTO_NOT_IMPLEMENTED`, which will make my life easier in tracking things and reduce the risk that something in the API gets forgotten about.

While I was going through the code, I also fixed a couple minor things I found:
- AES padding modes we had already decided not to include were still in the API (removes a TODO and closes #15591)
- Deterministic ECDSA async modes were still there, even though the non-async one was removed
- Error codes had not yet been updated to the 12-bit values from the doc (we moved to 12-bit so they can fit in a single `addi` instruction)