### PR TITLE
[dv/otp] Remove two OTP dv TODOs

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -295,7 +295,7 @@
       desc: '''Covers if sequence issued various OTP_CTRL's background checks after any fatal alert
             is triggered.'''
     }
-    { // TODO: this is from a wrapper class, confirm if this is the correct format
+    {
       name: csr_rd_after_alert_cg
       desc: '''Covers if the following CSRs are being read and the value is checked in scoreboard
             after any fatal alert is triggered:
@@ -316,17 +316,17 @@
       name: lci_err_code_cg
       desc: '''Covers all applicable error codes in LCI.'''
     }
-    { // TODO: this is an array of covergroups, confirm if this is the correct format
+    {
       name: unbuf_err_code_cg
       desc: '''This is an array of covergroups to cover all applicable error codes in three
             unbuffered partitions.'''
     }
-    { // TODO: this is an array of covergroups, confirm if this is the correct format
+    {
       name: buf_err_code_cg
       desc: '''This is an array of covergroups to cover all applicable error codes in five
             buffered partitions.'''
     }
-    { // TODO: this is an array of covergroups, confirm if this is the correct format
+    {
       name: unbuf_access_lock_cg_wrap_cg
       desc: '''This is an array of covergroups to cover lock conditions below in three
             unbuffered partitions:
@@ -339,7 +339,7 @@
       name: dai_access_secret2_cg
       desc: '''Covers whether `lc_creator_seed_sw_rw_en` is On during any DAI accesses.'''
     }
-    { // TODO: this is an array of covergroups, confirm if this is the correct format
+    {
       name: status_csr_cg
       desc: '''Covers the value of every bit in `status` CSR.'''
     }

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -865,15 +865,21 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         end
 
         if (addr_phase_write && `gmv(ral.check_trigger_regwen) && item.a_data inside {[1:3]}) begin
+          bit [TL_DW-1] check_timout = `gmv(ral.check_timeout) == 0 ? '1 : `gmv(ral.check_timeout);
           exp_status[OtpCheckPendingIdx] = 1;
           under_chk = 1;
-          if (`gmv(ral.check_timeout) > 0 && `gmv(ral.check_timeout) <= CHK_TIMEOUT_CYC) begin
+          if (check_timout <= CHK_TIMEOUT_CYC) begin
             set_exp_alert("fatal_check_error", 1, `gmv(ral.check_timeout));
             predict_err(OtpTimeoutErrIdx);
           end else begin
             if (get_field_val(ral.check_trigger.consistency, item.a_data)) begin
-              foreach(cfg.ecc_chk_err[i]) begin
-                if (cfg.ecc_chk_err[i] == OtpEccCorrErr) predict_err(i, OtpMacroEccCorrError);
+              foreach (cfg.ecc_chk_err[i]) begin
+                if (cfg.ecc_chk_err[i] == OtpEccCorrErr) begin
+                  predict_err(i, OtpMacroEccCorrError);
+                end else if (cfg.ecc_chk_err[i] == OtpEccUncorrErr) begin
+                  set_exp_alert("fatal_macro_error", 1, check_timout);
+                  predict_err(i, OtpMacroEccUncorrError);
+                end
               end
             end
           end
@@ -1192,7 +1198,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
   endfunction
 
-  // TODO: consider combine it with function predict_err()
   virtual function void predict_no_err(otp_status_e status_err_idx);
     if (cfg.otp_ctrl_vif.under_error_states()) return;
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -364,6 +364,16 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
                               bit           wait_done = 1,
                               otp_ecc_err_e ecc_err = OtpNoEccErr);
     bit [TL_DW-1:0] backdoor_rd_val, addr;
+
+    // If ECC and check error happens in the same consistency check, the scb cannot predict which
+    // error will happen first, so it cannot correctly predict the error status and alert
+    // triggered.
+    // So the sequence only allows one error at a time.
+    if (get_field_val(ral.check_trigger.consistency, val) &&
+        `gmv(ral.check_timeout) > 0 && `gmv(ral.check_timeout) <= CHK_TIMEOUT_CYC) begin
+      ecc_err = OtpNoEccErr;
+    end
+
     // Backdoor write ECC errors
     if (ecc_err != OtpNoEccErr) begin
       int part_idx = $urandom_range(HwCfgIdx, LifeCycleIdx);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
@@ -5,7 +5,7 @@
 // This sequence creates the following check failure scenarios:
 // 1. Check timeout
 // 2. Correctable ECC check error
-// 3. TODO: add when support
+// 3. Uncorrectable ECC error
 class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_check_fail_vseq)
 
@@ -16,13 +16,14 @@ class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_lock_vseq;
   }
 
   constraint ecc_chk_err_c {
-    // TODO: currently only max to 1 error bits, once implemetned ECC in mem_bkdr_util, we can
-    // fully randomize num of error bits
     ecc_chk_err dist {OtpNoEccErr   :/ 1,
-                      OtpEccCorrErr :/ 1};
+                      OtpEccCorrErr :/ 1,
+                      OtpEccUncorrErr :/1 };
   }
 
   // 50% chance of having a check timeout
+  // Because of the regwen, even though we constrain the timeout value, it might not apply to the
+  // DUT.
   constraint check_timeout_val_c {
     check_timeout_val dist {[1 : CHK_TIMEOUT_CYC] :/ 1,
                             [100_000 :'1]         :/ 1};


### PR DESCRIPTION
1). Remove testplan TODO that is resolved during review meeting.
    For now the tool does not have a requirement for the wrapper class
    cg format.
2). Support ECC fatal errors in check_fail sequence.