### PR TITLE
[ottf,base] add spi_device as console device option

### DIFF
--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/dif:uart",
     ],
 )

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
 /**
@@ -278,6 +279,16 @@ size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
  * @param out the sink to use for "default" printing.
  */
 void base_set_stdout(buffer_sink_t out);
+
+/**
+ * Configures SPI device stdout for `base_print.h` to use.
+ *
+ * Note that this function will save `spi_device` in a global variable, so the
+ * pointer must have static storage duration.
+ *
+ * @param spi_device The SPI device handle to use for stdout.
+ */
+void base_spi_device_stdout(const dif_spi_device_handle_t *spi_device);
 
 /**
  * Configures UART stdout for `base_print.h` to use.

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -272,6 +272,7 @@ dual_cc_library(
         shared = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/dif:uart",
+            "//sw/device/lib/dif:spi_device",
         ],
     ),
 )

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -10,6 +10,7 @@
  */
 typedef enum ottf_console_type {
   kOttfConsoleUart = 0,
+  kOttfConsoleSpiDevice,
 } ottf_console_type_t;
 
 typedef struct ottf_console {


### PR DESCRIPTION
This adds the spi_device as a console device option within the OTTF, and the printf stack. A follow up PR will add a hyper310 test to demonstrate this feature.