### PR TITLE
[ottool] Enhance SPI read and erase operations 

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -61,6 +61,12 @@ impl StagedProgressBar {
         }
     }
 
+    pub fn enable_steady_tick(&self, duration: Duration) {
+        let bar = self.current_progress_bar.borrow();
+        let bar = bar.as_ref().unwrap();
+        bar.enable_steady_tick(duration.as_millis() as u64);
+    }
+
     /// Returns the overall bytes per second for the most recent stage (either completed or in
     /// progress).
     pub fn bytes_per_second(&self) -> f64 {

--- a/sw/host/opentitanlib/src/spiflash/mod.rs
+++ b/sw/host/opentitanlib/src/spiflash/mod.rs
@@ -5,5 +5,5 @@
 pub mod flash;
 pub mod sfdp;
 
-pub use flash::SpiFlash;
+pub use flash::{EraseMode, ReadMode, SpiFlash};
 pub use sfdp::{BlockEraseSize, Sfdp, SupportedAddressModes, WriteGranularity};

--- a/sw/host/opentitanlib/src/spiflash/sfdp.rs
+++ b/sw/host/opentitanlib/src/spiflash/sfdp.rs
@@ -179,18 +179,18 @@ impl InternalJedecParams {
     field!(density_pow2 -> bool, 2, 31, 1);
 
     field!(wait_states_144 -> u8, 3, 0, 5);
-    field!(mode_bits_144 -> u8, 3, 0, 3);
-    field!(read_opcode_144 -> u8, 3, 0, 8);
+    field!(mode_bits_144 -> u8, 3, 5, 3);
+    field!(read_opcode_144 -> u8, 3, 8, 8);
     field!(wait_states_114 -> u8, 3, 16, 5);
     field!(mode_bits_114 -> u8, 3, 21, 3);
     field!(read_opcode_114 -> u8, 3, 24, 8);
 
-    field!(wait_states_122 -> u8, 4, 0, 5);
-    field!(mode_bits_122 -> u8, 4, 0, 3);
-    field!(read_opcode_122 -> u8, 4, 0, 8);
-    field!(wait_states_112 -> u8, 4, 16, 5);
-    field!(mode_bits_112 -> u8, 4, 21, 3);
-    field!(read_opcode_112 -> u8, 4, 22, 8);
+    field!(wait_states_112 -> u8, 4, 0, 5);
+    field!(mode_bits_112 -> u8, 4, 5, 3);
+    field!(read_opcode_112 -> u8, 4, 8, 8);
+    field!(wait_states_122 -> u8, 4, 16, 5);
+    field!(mode_bits_122 -> u8, 4, 21, 3);
+    field!(read_opcode_122 -> u8, 4, 24, 8);
 
     field!(support_fast_read_222 -> bool, 5, 0, 1);
     field!(support_fast_read_444 -> bool, 5, 4, 1);
@@ -430,7 +430,7 @@ impl Default for MaxSpeed {
 }
 
 /// `FastReadParam` represents the parameters for the different styles of fast read.
-#[derive(Default, Debug, Serialize, Annotate)]
+#[derive(Clone, Default, Debug, Serialize, Annotate)]
 pub struct FastReadParam {
     pub wait_states: u8,
     pub mode_bits: u8,
@@ -439,7 +439,7 @@ pub struct FastReadParam {
 }
 
 /// `SectorErase` represents the supported erase sector sizes of the device.
-#[derive(Default, Debug, Serialize, Annotate)]
+#[derive(Clone, Default, Debug, Serialize, Annotate)]
 pub struct SectorErase {
     pub size: u32,
     #[annotate(format=hex)]
@@ -447,7 +447,7 @@ pub struct SectorErase {
     pub time: Option<TimeBound>,
 }
 
-#[derive(Default, Debug, Serialize)]
+#[derive(Clone, Default, Debug, Serialize)]
 pub struct TimeBound {
     #[serde(with = "humantime_serde")]
     pub typical: Duration,

--- a/sw/host/tests/chip/spi_passthru/src/main.rs
+++ b/sw/host/tests/chip/spi_passthru/src/main.rs
@@ -216,7 +216,7 @@ fn test_sector_erase(opts: &Opts, transport: &TransportWrapper, address: u32) ->
     };
     flash.set_address_mode(&*spi, mode)?;
     let info = UploadInfo::execute(&*uart, || {
-        flash.erase(&*spi, address, flash.erase_size)?;
+        flash.erase(&*spi, address, flash.erase.last().unwrap().size)?;
         Ok(())
     })?;
 


### PR DESCRIPTION
1. Perform erases according to erase options in the SFDP.  When in `Standard` mode, always perform 4K sector erase.  When in `Block` mode, perform the largest erase consistent with the address alignment and remaining length.
2. Perform reads according to the the SFDP.  When in `Standard` or `Fast` mode, use READ(0x03) or FAST_READ(0x0b).  When in `Dual` or `Quad` modes, use the FAST_DUAL_READ and FAST_QUAD_READ opcodes reported in the SFDP.
3. Make the erase and read modes available to the CLI.
4. Allow erase to optionally issue CHIP_ERASE via `spi erase --chip`.