### PR TITLE
Offline signing demo

### DIFF
--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -1,0 +1,156 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+PreSigningBinary = provider(fields = ["files"])
+
+def _offline_presigning_artifacts(ctx):
+    digests = []
+    bins = []
+    for src in ctx.files.srcs:
+        pre = ctx.actions.declare_file(paths.replace_extension(src.basename, ".pre-signing"))
+        bins.append(pre)
+        ctx.actions.run(
+            outputs = [pre],
+            inputs = [src, ctx.file.manifest, ctx.file.key_file, ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "manifest",
+                "update",
+                "--manifest={}".format(ctx.file.manifest.path),
+                "--key-file={}".format(ctx.file.key_file.path),
+                "--output={}".format(pre.path),
+                src.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+
+        out = ctx.actions.declare_file(paths.replace_extension(src.basename, ".digest"))
+        digests.append(out)
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [pre, ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "digest",
+                "--bin={}".format(out.path),
+                pre.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+    return [
+        DefaultInfo(files = depset(digests), data_runfiles = ctx.runfiles(files = digests)),
+        PreSigningBinary(files = depset(bins)),
+        OutputGroupInfo(digest = depset(digests), binary = depset(bins)),
+    ]
+
+offline_presigning_artifacts = rule(
+    implementation = _offline_presigning_artifacts,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, doc = "Binary files to generate digests for"),
+        "manifest": attr.label(allow_single_file = True, doc = "Manifest for this image"),
+        "key_file": attr.label(allow_single_file = True, doc = "Public key to validate this image"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _strip_all_extensions(path):
+    path = path.split(".")[0]
+    return path
+
+def _offline_fake_sign(ctx):
+    outputs = []
+    for file in ctx.files.srcs:
+        out = ctx.actions.declare_file(paths.replace_extension(file.basename, ".sig"))
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [file, ctx.file.key_file],
+            arguments = [
+                "--rcfile=",
+                "rsa",
+                "sign",
+                "--input={}".format(file.path),
+                "--output={}".format(out.path),
+                ctx.file.key_file.path,
+            ],
+            executable = ctx.executable._tool,
+        )
+        outputs.append(out)
+    return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+offline_fake_sign = rule(
+    implementation = _offline_fake_sign,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, doc = "Digest files to sign"),
+        "key_file": attr.label(allow_single_file = True, doc = "Public key to validate this image"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = "Create detached signatures using on-disk private keys via opentitantool.",
+)
+
+def _offline_signature_attach(ctx):
+    inputs = {}
+    for src in ctx.attr.srcs:
+        if PreSigningBinary in src:
+            for file in src[PreSigningBinary].files.to_list():
+                f = _strip_all_extensions(file.basename)
+                inputs[f] = {"bin": file}
+        elif DefaultInfo in src:
+            for file in src[DefaultInfo].files.to_list():
+                f = _strip_all_extensions(file.basename)
+                inputs[f] = {"bin": file}
+    for sig in ctx.files.signatures:
+        f = _strip_all_extensions(sig.basename)
+        if f not in inputs:
+            fail("Signature {} does not have a corresponding entry in srcs".format(sig))
+        inputs[f]["sig"] = sig
+
+    outputs = []
+    for f in inputs:
+        if inputs[f].get("bin") == None:
+            print("WARNING: No pre-signed binary for", f)
+            continue
+        if inputs[f].get("sig") == None:
+            print("WARNING: No signature file for", f)
+            continue
+        out = ctx.actions.declare_file(paths.replace_extension(f, ".signed.bin"))
+        ctx.actions.run(
+            outputs = [out],
+            inputs = [inputs[f]["bin"], inputs[f]["sig"], ctx.executable._tool],
+            arguments = [
+                "--rcfile=",
+                "image",
+                "manifest",
+                "update",
+                "--signature-file={}".format(inputs[f]["sig"].path),
+                "--output={}".format(out.path),
+                inputs[f]["bin"].path,
+            ],
+            executable = ctx.executable._tool,
+        )
+        outputs.append(out)
+    return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+offline_signature_attach = rule(
+    implementation = _offline_signature_attach,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True, providers = [PreSigningBinary], doc = "Binary files to sign"),
+        "signatures": attr.label_list(allow_files = True, doc = "Signed digest files"),
+        "_tool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/signing/README.md
+++ b/signing/README.md
@@ -1,0 +1,94 @@
+# Demo of offline signing
+
+This demonstration of the offline signing flow does not use an HSM.
+It uses opentitantool to generate the image digests and to create the
+detached signatures.  Finally, it attaches the signatures to the binaries
+and emits signed artifacts.
+
+## Generate pre-signing artifacts
+
+Generating the pre-signing artifacts builds the requested targets and
+updates the manifest and public key.  Then, SHA256 digests are computed
+for each binary.
+```
+bazel build //siging/examples:digests
+```
+
+The bazel `offline_presigning_artifacts` rule updates the binary with
+a supplied manifest and public key:
+```
+opentitantool \
+   image manifest update \
+   --manifest=<manifest file> \
+   --key-file=<public key file> \
+   --output=<pre-signed binary> \
+   <original binary>
+```
+
+Having updated the manifest and public key, the rule then generates
+the SHA256 digest to be signed:
+```
+opentitantool \
+   image digest \
+   --bin=<sha256 digest> \
+   <pre-signed binary>
+```
+
+## Generate the detached signatures
+
+Normally, in this step, the pre-signing artifacts would be taken to the
+secure facility and a signing ceremony would be performed to create the
+detached signatures.
+
+```
+bazel build //siging/examples:fake
+```
+
+The bazel `offline_fake_sign` rule performs the same RSA signing
+operation as the HSM would perform, but public test keys are used
+instead of the real keys:
+```
+opentitantool \
+   rsa sign \
+   --input=<sha256 digest> \
+   --output=<signed digest> \
+   <private key file>
+```
+
+## Copy the signatures into into `signing/examples/signatures`
+
+Normally, in this step, the signatures created in the signing ceremony
+would be copied into the target directory.
+
+```
+cp -f bazel-bin/signing/examples/*.sig signing/examples/signatures/
+```
+
+## Attach signatures producing final signed binaries
+
+The detached signatures are attached to the pre-signing binaries and
+final signed binaries are produced.
+
+```
+bazel build //signing/examples:signed
+```
+
+The bazel `offline_signature_attach` rule takes the signed digests and
+attaches them to the pre-signed binaries, thus producing signed binaries
+that can be verified by the ROM.
+```
+opentitantool \
+   image manifest update \
+   --signature-file=<signed digest> \
+   --output=<final signed binary> \
+   <pre-signed binary>
+```
+
+## Inspect the signed artifacts (optional)
+
+```
+cd $REPO_TOP
+bazel run //sw/host/opentitantool -- \
+   image manifest show \
+   $PWD/bazel-bin/signing/examples/hello_world_fpga_cw310.signed.bin
+```

--- a/signing/examples/BUILD
+++ b/signing/examples/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:signing.bzl", "offline_fake_sign", "offline_presigning_artifacts", "offline_signature_attach")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+offline_presigning_artifacts(
+    name = "presigning",
+    srcs = [
+        "//sw/device/examples/hello_world:hello_world_bin",
+    ],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "digests",
+    srcs = [":presigning"],
+    mode = "0644",
+    tags = ["manual"],
+)
+
+# The `fake_sign` rule uses opentitantool to generate the detached signatures
+# that would normally be created by the offline signing operation.
+# These signatures can be copied into the `signatures` directory and attached
+# to the binaries to test the offline signing flow without an HSM operation.
+offline_fake_sign(
+    name = "fake",
+    srcs = [":presigning"],
+    key_file = "//sw/device/silicon_creator/rom/keys/fake:test_private_key_0",
+    tags = ["manual"],
+)
+
+offline_signature_attach(
+    name = "signed",
+    srcs = [
+        ":presigning",
+    ],
+    signatures = [
+        "//signing/examples/signatures:signatures",
+    ],
+    tags = ["manual"],
+)

--- a/signing/examples/signatures/BUILD
+++ b/signing/examples/signatures/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "signatures",
+    srcs = glob(["*.sig"]),
+)


### PR DESCRIPTION
This PR demonstrates the offline signing flow.

The current implementation does not require the use of an HSM; it demonstrates the signing flow only and uses `opentitantool` to perform the individual steps of the offline signing flow.  See `//signing/README.md` for a description of the offline flow.