### PR TITLE
[opentitanlib] fix TAP strap configs

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -24,15 +24,21 @@
       "level": false,
       "pull_mode": "None",
       "alias_of": "IOC2"
-    }
+    },
     {
       "name": "TAP_STRAP0",
-      "level": false
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "IOC8"
     },
     {
       "name": "TAP_STRAP1",
-      "level": true
-    },
+      "mode": "PushPull",
+      "level": true,
+      "pull_mode": "None",
+      "alias_of": "IOC5"
+    }
   ],
   "strappings": [
     {


### PR DESCRIPTION
This fixes the TAP strap configs for opentitanlib that was causing hyper310 tests to fail again. This bug was exposed by #17737.