### PR TITLE
[dv/otp] Fix two OTP dv TODOs

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -314,7 +314,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       end
 
       if (`gmv(ral.hw_cfg_digest[0]) || `gmv(ral.hw_cfg_digest[1])) begin
-        // TODO: hw_cfg part cannot be read locked.
+        // ICEBOX (#17770): hw_cfg part cannot be read locked.
         // if (!$urandom_range(0, 4)) cfg.forced_mubi_part_access[HwCfgIdx].read_lock = 1;
         if (!$urandom_range(0, 4)) forced_mubi_part_access[HwCfgIdx].write_lock = 1;
       end
@@ -593,11 +593,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin
       repeat (10) begin
         bit [TL_DW-1:0] data;
-        bit test_access_en = cfg.otp_ctrl_vif.lc_dft_en_i == lc_ctrl_pkg::On;
+        bit test_access_en;
         bit [TL_AW-1:0] rand_addr = $urandom_range(0, NUM_PRIM_REG - 1) * 4;
         bit [TL_AW-1:0] tlul_addr =
             cfg.ral_models["otp_ctrl_prim_reg_block"].get_addr_from_offset(rand_addr);
+        rand_drive_dft_en();
         `DV_CHECK_STD_RANDOMIZE_FATAL(data)
+        test_access_en = cfg.otp_ctrl_vif.lc_dft_en_i == lc_ctrl_pkg::On;
         tl_access(.addr(tlul_addr), .write(1), .data(data), .exp_err_rsp(~test_access_en),
                   .tl_sequencer_h(p_sequencer.tl_sequencer_hs["otp_ctrl_prim_reg_block"]));
         tl_access(.addr(tlul_addr), .write(0), .data(data), .exp_err_rsp(~test_access_en),
@@ -606,4 +608,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
      end
   endtask
 
+  // Empty task, only drive it under `otp_ctrl_test_access_vseq`
+  virtual task rand_drive_dft_en();
+  endtask
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_test_access_vseq.sv
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: add support to randomly turn on and off lc_dft_en to fully verify the `prim_lc_gate`
-// module.
 class otp_ctrl_test_access_vseq extends otp_ctrl_dai_lock_vseq;
   `uvm_object_utils(otp_ctrl_test_access_vseq)
 
@@ -20,4 +18,15 @@ class otp_ctrl_test_access_vseq extends otp_ctrl_dai_lock_vseq;
     cfg.clk_rst_vif.wait_clks(3);
   endtask
 
+  virtual task rand_drive_dft_en();
+    super.rand_drive_dft_en();
+    // 25% chance drive lc_dft_en to a random value.
+    if ($urandom_range(0, 3) == 3) begin
+      cfg.otp_ctrl_vif.drive_lc_dft_en(get_rand_lc_tx_val(
+                                       .t_weight(1), .f_weight(1), .other_weight(1)));
+      // Once turn on lc_dft_en regiser, will need some time to update the state register
+      // two clock cycles for lc_async mode, one clock cycle for driving dft_en.
+      cfg.clk_rst_vif.wait_clks(3);
+    end
+  endtask
 endclass


### PR DESCRIPTION
1). Icebox an otp todo and documented in issue #17770
2). Implement the testbench to randomly drive OTP lc_dft_en signal in test_access vseq.