### PR TITLE
[site] Fixup build-docs.sh to use explicit python3 (for ubuntu)

### DIFF
--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -195,7 +195,7 @@ buildSite () {
 
     # Block diagram stats
     mkdir -p "${build_dir}/reports"
-    python "${proj_root}/util/site/fetch_block_stats.py" "${build_dir}/reports/earlgrey-stats.json"
+    python3 "${proj_root}/util/site/fetch_block_stats.py" "${build_dir}/reports/earlgrey-stats.json"
 }
 buildSite
 


### PR DESCRIPTION
The site-builder container uses Ubuntu22.04, which does not alias python=python3. Hence we need to be explicit here.

See following link for more details.
https://launchpad.net/ubuntu/focal/+package/python-is-python3

This fixes the failed build here : https://github.com/lowRISC/opentitan/runs/12472681466