### PR TITLE
[hw,i2c,dv] Add watermark test to run in test plan

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -144,8 +144,7 @@
               - Ensure receving correct number of fmt_fifo and rx_fifo watermark interrupts
             '''
       stage: V2
-      //TODO add watermark test.
-      tests: [""]
+      tests: ["i2c_host_fifo_watermark"]
     }
     {
       name: host_fifo_overflow

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -27,7 +27,7 @@ filesets:
       - seq_lib/i2c_host_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_override_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_rx_oversample_vseq.sv: {is_include_file: true}
-      - seq_lib/i2c_host_fifo_threshold_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_host_fifo_watermark_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_fifo_overflow_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_fifo_reset_fmt_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_fifo_fmt_empty_vseq.sv: {is_include_file: true}

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_threshold_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_threshold_vseq.sv
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // test the threshold interrupt of fmt_fifo and rx_fifo
-// TODO: Weicai's comments in PR #3128: consider constraining rx_fifo_access_dly
-// to test threshold irq
 class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_host_fifo_threshold_vseq)
   `uvm_object_new
@@ -107,9 +105,9 @@ class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
     csr_rd(.ptr(ral.intr_enable), .value(intr_enable), .backdoor(1'b1));
     if (intr_enable[FmtThreshold] && cfg.intr_vif.pins[FmtThreshold]) begin
       cnt_fmt_threshold++;
-      // read registers via backdoor
-      csr_rd(.ptr(ral.fifo_ctrl.fmtilvl), .value(fmt_ilvl), .backdoor(1'b1));
-      csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
+      // read registers
+      csr_rd(.ptr(ral.fifo_ctrl.fmtilvl), .value(fmt_ilvl));
+      csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl));
       `uvm_info(`gfn, $sformatf("\n fmtilvl %0d, fmtlvl %0d", fmt_ilvl, fmt_lvl), UVM_DEBUG)
       // bound checking for fmt_lvl w.r.t fmt_ilvl because rx_fifo can received an extra data
       // before fmt_threshold intr pin is asserted (corner case)
@@ -133,9 +131,9 @@ class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
     csr_rd(.ptr(ral.intr_enable), .value(intr_enable), .backdoor(1'b1));
     if (intr_enable[RxThreshold] && cfg.intr_vif.pins[RxThreshold]) begin
       cnt_rx_threshold++;
-      // read registers via backdoor
-      csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
-      csr_rd(.ptr(ral.fifo_ctrl.rxilvl), .value(rx_ilvl), .backdoor(1'b1));
+      // read registers
+      csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl));
+      csr_rd(.ptr(ral.fifo_ctrl.rxilvl), .value(rx_ilvl));
       // bound checking for rx_lvl w.r.t rx_ilvl because rx_fifo can received an extra data
       // before rx_threshold intr pin is asserted (corner case)
       if (!cfg.under_reset) begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // test the threshold interrupt of fmt_fifo and rx_fifo
-class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
-  `uvm_object_utils(i2c_host_fifo_threshold_vseq)
+class i2c_host_fifo_watermark_vseq extends i2c_rx_tx_vseq;
+  `uvm_object_utils(i2c_host_fifo_watermark_vseq)
   `uvm_object_new
 
   // fast write data to fmt_fifo to quickly trigger fmt_threshold interrupt
@@ -31,7 +31,7 @@ class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
     bit check_fmt_threshold, check_rx_threshold;
 
     initialization(.mode(Host));
-    `uvm_info(`gfn, "\n--> start of i2c_host_fifo_threshold_vseq", UVM_DEBUG)
+    `uvm_info(`gfn, "\n--> start of i2c_host_fifo_watermark_vseq", UVM_DEBUG)
     for (int i = 1; i <= num_trans; i++) begin
       check_fmt_threshold = 1'b1;
       check_rx_threshold  = 1'b1;
@@ -94,7 +94,7 @@ class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
         end
       join
     end
-    `uvm_info(`gfn, "\n--> end of i2c_host_fifo_threshold_vseq", UVM_DEBUG)
+    `uvm_info(`gfn, "\n--> end of i2c_host_fifo_watermark_vseq", UVM_DEBUG)
   endtask : body
 
   task process_fmt_threshold_intr();
@@ -150,4 +150,4 @@ class i2c_host_fifo_threshold_vseq extends i2c_rx_tx_vseq;
     end
   endtask : process_rx_threshold_intr
 
-endclass : i2c_host_fifo_threshold_vseq
+endclass : i2c_host_fifo_watermark_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -8,7 +8,7 @@
 `include "i2c_host_smoke_vseq.sv"
 
 `include "i2c_host_override_vseq.sv"
-`include "i2c_host_fifo_threshold_vseq.sv"
+`include "i2c_host_fifo_watermark_vseq.sv"
 `include "i2c_host_fifo_overflow_vseq.sv"
 `include "i2c_host_fifo_reset_fmt_vseq.sv"
 `include "i2c_host_fifo_fmt_empty_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -65,8 +65,8 @@
     }
 
     {
-      name: i2c_host_fifo_threshold
-      uvm_test_seq: i2c_host_fifo_threshold_vseq
+      name: i2c_host_fifo_watermark
+      uvm_test_seq: i2c_host_fifo_watermark_vseq
     }
 
     {
@@ -227,7 +227,7 @@
     {
       name : host_sanity
       tests: ["i2c_host_smoke", "i2c_host_override", "i2c_host_perf",
-              "i2c_host_fifo_threshold", "i2c_host_fifo_overflow", "i2c_host_fifo_reset_fmt",
+              "i2c_host_fifo_watermark", "i2c_host_fifo_overflow", "i2c_host_fifo_reset_fmt",
               "i2c_host_rx_oversample",  "i2c_host_stretch_timeout",
               "i2c_host_fifo_fmt_empty", "i2c_host_fifo_reset_rx", "i2c_host_stretch_timeout",
               "i2c_host_fifo_full",


### PR DESCRIPTION
- On assertion of `fmt_watermark` and `rx_watermark` interrupts, read the fifo levels through front door access to `FIFO_STATUS` instead of backdoor.
- Removed the TODO comment(OT #3128), since the test addresses the requirement of triggering `fmt_watermark` and `rx_watermark` without triggering fifo_full interrupts.
- rename `i2c_fifo_threshold` to `i2c_fifo_watermark` since the interrupts use the word `watermark`
- This sequence addresses the requirements mentioned in https://github.com/lowRISC/opentitan/issues/17566 and covers a task in #17458 