### PR TITLE
[dv/otp] Improve OTP coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -100,6 +100,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
     // only support 1 outstanding TL items in tlul_adapter
     m_tl_agent_cfg.max_outstanding_req = 1;
+    m_tl_agent_cfgs["otp_ctrl_prim_reg_block"].max_outstanding_req = 1;
 
     // create the inputs cfg instance
     dut_cfg = otp_ctrl_ast_inputs_cfg::type_id::create("dut_cfg");

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -120,6 +120,7 @@
     {
       name: otp_ctrl_parallel_lc_esc
       uvm_test_seq: otp_ctrl_parallel_lc_esc_vseq
+      reseed: 200
     }
 
     {


### PR DESCRIPTION
1). Add a max_outstanding number for tl_prim_reg interface. This is used
  for prim_otp and was not configured properly for coverage before.
2). Increase the nightly reseed for otp_parallel_lc_esc to increase the
  chance of error cases during OTP operations.