### PR TITLE
[dv/otp] Fix otp_parallel_lc_esc seq

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -74,9 +74,6 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
   endtask
 
   virtual task set_lc_esc_and_check();
-    otp_ctrl_dai_lock_vseq dai_lock_vseq;
-    uvm_sequence           seq;
-
     // Random issue key requests before lc_esc_en is issued.
     randcase
       1: req_otbn_key(0);
@@ -95,18 +92,13 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
 
     // After LC_escalate is On, we trigger the dai_lock_vseq to check interfaces will return
     // default values and the design won't hang.
-    seq = create_seq_by_name("otp_ctrl_dai_lock_vseq");
-    `downcast(dai_lock_vseq, seq)
-    dai_lock_vseq.set_sequencer(p_sequencer);
-    `DV_CHECK_RANDOMIZE_FATAL(dai_lock_vseq)
-
-    // This sequence will only run one iteration and once we hit a reset, we will need to clear the
+    // This sequence will skip all the dut_init, and if reset is needed, the seq we will clear the
     // otp memories. Otherwise, if lc_esc is issued during OTP program, there might be ECC
     // uncorrectable errors and the OTP init will return an error.
-    // This sequence case is not handled by scb but checked via direct sequence.
-    dai_lock_vseq.num_trans = 1;
-    dai_lock_vseq.do_otp_ctrl_init = 1;
-    dai_lock_vseq.start(p_sequencer);
+    // The case `otp_init` errors are not handled by scb but checked via direct sequence.
+    do_dut_init = 0;
+    do_otp_ctrl_init = 1;
+    super.body();
   endtask
 
   virtual task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -107,7 +107,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       // to avoid access locked OTP partions, issue reset and clear the OTP memory to all 0.
       if (access_locked_parts == 0) begin
         do_otp_ctrl_init = 1;
-        if (i > 1) dut_init();
+        if (i > 1 && do_dut_init) dut_init();
         // after otp-init done, check status
         cfg.clk_rst_vif.wait_clks(1);
         if (!cfg.otp_ctrl_vif.lc_esc_on) begin
@@ -200,7 +200,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       if (cfg.otp_ctrl_vif.lc_prog_req == 0) csr_rd(.ptr(ral.err_code[0]), .value(tlul_val));
 
       if ($urandom_range(0, 1)) rd_digests();
-      dut_init();
+      if (do_dut_init) dut_init();
 
       // read and check digest in scb
       rd_digests();


### PR DESCRIPTION
PR #17753 tries to fix a close source failure, but created a coverage hole.
The intention of the sequence is to issue lc_esc and check afterwards the OTP_CTRL is indeed locked up.
The fix from #17753 is that - when we call a new sequence, it always starts with pre_start() and will call dut_init.

I think a cleaner solution is instead to use the knob `do_dut_init` to avoid triggering reset.

So this PR:
1). Added a `do_dut_init` check before issuing dut_init in otp_ctrl_smoke_seq.
2). Simply the otp_ctrl_parallel_lc_esc logic to set `do_dut_init = 0`.