### PR TITLE
[opentitantool] Emulator RESET pin

### DIFF
--- a/sw/host/opentitanlib/src/transport/ti50emulator/emu.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/emu.rs
@@ -188,11 +188,7 @@ impl EmulatorProcess {
                         .map(|a| self.executable_directory.join(a).into()),
                 );
             }
-            None => {
-                bail!(EmuError::StartFailureCause(
-                    "Ti50 sub-process missing application list".to_string()
-                ))
-            }
+            None => (),
             _ => {
                 bail!(EmuError::StartFailureCause(
                     "Ti50 sub-process expect apps to be list of string".to_string()
@@ -391,7 +387,7 @@ impl EmulatorProcess {
     /// sub-process. If `args` contains paths to files they will be copied to the runtime directory.
     fn update_args(&mut self, factory_reset: bool, args: &HashMap<String, EmuValue>) -> Result<()> {
         let allowed = HashSet::from(["exec", "flash", "apps", "version_state", "pmu_state"]);
-        let mandatory = ["exec", "apps"];
+        let mandatory = ["exec"];
         for &name in mandatory.iter() {
             if !self.current_args.contains_key(name) && !args.contains_key(name) {
                 bail!(EmuError::StartFailureCause(format!(

--- a/sw/host/opentitanlib/src/transport/ti50emulator/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/mod.rs
@@ -26,7 +26,7 @@ mod i2c;
 mod spi;
 mod uart;
 
-use crate::transport::ti50emulator::emu::{EmulatorProcess, Ti50SubProcess};
+use crate::transport::ti50emulator::emu::{EmulatorProcess, ResetPin, Ti50SubProcess};
 use crate::transport::ti50emulator::gpio::Ti50GpioPin;
 use crate::transport::ti50emulator::i2c::Ti50I2cBus;
 use crate::transport::ti50emulator::uart::Ti50Uart;
@@ -77,6 +77,11 @@ impl Ti50Emulator {
     }
 
     fn configure_devices(&self) -> Result<()> {
+        let reset_pin = ResetPin::open(&self.inner)?;
+        self.inner
+            .borrow_mut()
+            .gpio_map
+            .insert("RESET".to_string(), Rc::new(reset_pin));
         let conf = self.inner.borrow().process.get_configurations()?;
         for (name, state) in conf.gpio.iter() {
             let path = format!("gpio{}", name);
@@ -117,7 +122,7 @@ impl Drop for Ti50Emulator {
 }
 
 /// Structure representing internal state of emulator
-struct Inner {
+pub struct Inner {
     /// Path of parent directory representing `Ti50Emulator` instance.
     instance_directory: PathBuf,
     /// SubProcess instance


### PR DESCRIPTION
In order to reduce the need for test scripts to be aware of the differences between physical development boards and host emulation, this CL introduces a special RESET pin into host emulation. Manipulation of this pin is translated into stopping and starting the emulator.

Also, refactorings of parts of host emulation code, in preparation for supporting the setting of "external" drive of GPIO pins while the emulator is off, and having the emulated code see the external drive upon startup, e.g. for software strappings.
