### PR TITLE
[flash/dv] Move some OTF methods and enable flash init in otp_rst test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -13,10 +13,10 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
     super.pre_start();
 
     for (int j = 0; j < NumBanks; j++) begin
-      for (int i = 0; i < PagesPerBank; i++) load_otf_mem_page(FlashPartData, j, i);
-      for (int i = 0; i < InfoTypeSize[0]; i++) load_otf_mem_page(FlashPartInfo, j, i);
-      for (int i = 0; i < InfoTypeSize[1]; i++) load_otf_mem_page(FlashPartInfo1, j, i);
-      for (int i = 0; i < InfoTypeSize[2]; i++) load_otf_mem_page(FlashPartInfo2, j, i);
+      for (int i = 0; i < InfoTypeSize[0]; i++) cfg.load_otf_mem_page(FlashPartInfo, j, i);
+      for (int i = 0; i < InfoTypeSize[1]; i++) cfg.load_otf_mem_page(FlashPartInfo1, j, i);
+      for (int i = 0; i < InfoTypeSize[2]; i++) cfg.load_otf_mem_page(FlashPartInfo2, j, i);
+      for (int i = 0; i < PagesPerBank; i++) cfg.load_otf_mem_page(FlashPartData, j, i);
     end
 
     cfg.scb_h.do_alert_check = 0;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otp_reset_vseq.sv
@@ -128,7 +128,6 @@ class flash_ctrl_otp_reset_vseq extends flash_ctrl_base_vseq;
               cfg.clk_rst_vif.wait_clks(10);
             end
             `uvm_info(`gfn, "RESET", UVM_LOW)
-            cfg.seq_cfg.disable_flash_init = 1;
             // Enable secret seed at the beginning of the loop
             cfg.seq_cfg.en_init_keys_seeds = 0;
             cfg.flash_ctrl_vif.rma_req = lc_ctrl_pkg::Off;


### PR DESCRIPTION
Hi,
This PR is changing 2 small things:
1. Moving some OTF methods to the env_cfg since those methods should be overriden in some cases in the extending close-source environment.
2. Enable flash initiation between transactions in flash_ctrl_otp_reset. This required because in some seeds the test apply reset during the RMA entry process which can make the flash data to be unknown (RMA entry starts with erasing the flash data & special partitions ). In this case, the flash should be reinitialized because the special partitions are read before each iteration after the reset.
Thanks!