### PR TITLE
[crypto] Make some small adjustments to the asymmetric cryptolib API.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -9,7 +9,7 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('e', 'c', 'c')
 
-crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
+crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
                                       crypto_blinded_key_t *private_key,
                                       ecc_public_key_t *public_key) {
   // TODO: Connect ECDSA operations to API.
@@ -18,21 +18,22 @@ crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
 
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     crypto_const_uint8_buf_t input_message,
-                                    ecc_curve_t *elliptic_curve,
+                                    const ecc_curve_t *elliptic_curve,
                                     ecc_signature_t *signature) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ecdsa_verify(
-    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, ecc_curve_t *elliptic_curve,
-    verification_status_t *verification_result) {
+crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
+                                      crypto_const_uint8_buf_t input_message,
+                                      ecc_signature_t *signature,
+                                      const ecc_curve_t *elliptic_curve,
+                                      hardened_bool_t *verification_result) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
+crypto_status_t otcrypto_ecdh_keygen(const ecc_curve_t *elliptic_curve,
                                      crypto_blinded_key_t *private_key,
                                      ecc_public_key_t *public_key) {
   // TODO: Connect ECDH operations to API.
@@ -41,7 +42,7 @@ crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
 
 crypto_status_t otcrypto_ecdh(const crypto_blinded_key_t *private_key,
                               const ecc_public_key_t *public_key,
-                              ecc_curve_t *elliptic_curve,
+                              const ecc_curve_t *elliptic_curve,
                               crypto_blinded_key_t *shared_secret) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
@@ -64,7 +65,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature, verification_status_t *verification_result) {
+    ecc_signature_t *signature, hardened_bool_t *verification_result) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -82,67 +83,74 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve) {
+crypto_status_t otcrypto_ecdsa_keygen_async_start(
+    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
-    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key) {
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *private_key,
+    ecc_public_key_t *public_key) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, ecc_curve_t *elliptic_curve) {
+    crypto_const_uint8_buf_t input_message, const ecc_curve_t *elliptic_curve) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature) {
+crypto_status_t otcrypto_ecdsa_sign_async_finalize(
+    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdsa_verify_async_start(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, ecc_curve_t *elliptic_curve) {
+    ecc_signature_t *signature, const ecc_curve_t *elliptic_curve) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdsa_verify_async_finalize(
-    verification_status_t *verification_result) {
+    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature,
+    hardened_bool_t *verification_result) {
   // TODO: Connect ECDSA operations to API.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve) {
+crypto_status_t otcrypto_ecdh_keygen_async_start(
+    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdh_keygen_async_finalize(
-    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key) {
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *private_key,
+    ecc_public_key_t *public_key) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdh_async_start(
     const crypto_blinded_key_t *private_key, const ecc_public_key_t *public_key,
-    ecc_curve_t *elliptic_curve) {
+    const ecc_curve_t *elliptic_curve) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ecdh_async_finalize(
-    crypto_blinded_key_t *shared_secret) {
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *shared_secret) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_ed25519_keygen_async_start() {
+crypto_status_t otcrypto_ed25519_keygen_async_start(
+    crypto_key_config_t *config) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -176,12 +184,13 @@ crypto_status_t otcrypto_ed25519_verify_async_start(
 }
 
 crypto_status_t otcrypto_ed25519_verify_async_finalize(
-    verification_status_t *verification_result) {
+    hardened_bool_t *verification_result) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_x25519_keygen_async_start() {
+crypto_status_t otcrypto_x25519_keygen_async_start(
+    crypto_key_config_t *config) {
   // TODO: X25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -25,11 +25,12 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
   return kCryptoStatusNotImplemented;
 }
 
-crypto_status_t otcrypto_rsa_verify(
-    const rsa_public_key_t *rsa_public_key,
-    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
-    rsa_hash_t hash_mode, crypto_const_uint8_buf_t signature,
-    verification_status_t *verification_result) {
+crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
+                                    crypto_const_uint8_buf_t input_message,
+                                    rsa_padding_t padding_mode,
+                                    rsa_hash_t hash_mode,
+                                    crypto_const_uint8_buf_t signature,
+                                    hardened_bool_t *verification_result) {
   // TODO: Connect RSA implementations to API.
   return kCryptoStatusNotImplemented;
 }
@@ -69,7 +70,7 @@ crypto_status_t otcrypto_rsa_verify_async_start(
 
 crypto_status_t otcrypto_rsa_verify_async_finalize(
     crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
-    rsa_hash_t hash_mode, verification_status_t *verification_result) {
+    rsa_hash_t hash_mode, hardened_bool_t *verification_result) {
   // TODO: Connect RSA implementations to API.
   return kCryptoStatusNotImplemented;
 }

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -42,18 +42,6 @@ typedef enum crypto_status {
 } crypto_status_t;
 
 /**
- * Enum to handle return values of the verification APIs.
- *
- * Values are hardened.
- */
-typedef enum verification_status {
-  // Return value for successful verification.
-  kVerificationStatusPass = 0x5e34,
-  // Return value for unsuccessful verification.
-  kVerificationStatusFail = 0x2f4c,
-} verification_status_t;
-
-/**
  * Struct to handle crypto data buffer with pointer and length.
  * Note: If the crypto_uint8_buf_t is used for output data, it is
  * expected that the user (1) sets the length of the expected output

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -129,7 +129,7 @@ typedef struct ecc_curve {
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of the ECDSA key generation.
  */
-crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
+crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
                                       crypto_blinded_key_t *private_key,
                                       ecc_public_key_t *public_key);
 
@@ -148,7 +148,7 @@ crypto_status_t otcrypto_ecdsa_keygen(ecc_curve_t *elliptic_curve,
  */
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     crypto_const_uint8_buf_t input_message,
-                                    ecc_curve_t *elliptic_curve,
+                                    const ecc_curve_t *elliptic_curve,
                                     ecc_signature_t *signature);
 
 /**
@@ -166,10 +166,11 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  * (Pass/Fail).
  * @return Result of the ECDSA verification operation.
  */
-crypto_status_t otcrypto_ecdsa_verify(
-    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, ecc_curve_t *elliptic_curve,
-    verification_status_t *verification_result);
+crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
+                                      crypto_const_uint8_buf_t input_message,
+                                      ecc_signature_t *signature,
+                                      const ecc_curve_t *elliptic_curve,
+                                      hardened_bool_t *verification_result);
 
 /**
  * Performs the key generation for ECDH key agreement.
@@ -194,7 +195,7 @@ crypto_status_t otcrypto_ecdsa_verify(
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of the ECDH key generation.
  */
-crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
+crypto_status_t otcrypto_ecdh_keygen(const ecc_curve_t *elliptic_curve,
                                      crypto_blinded_key_t *private_key,
                                      ecc_public_key_t *public_key);
 
@@ -213,7 +214,7 @@ crypto_status_t otcrypto_ecdh_keygen(ecc_curve_t *elliptic_curve,
  */
 crypto_status_t otcrypto_ecdh(const crypto_blinded_key_t *private_key,
                               const ecc_public_key_t *public_key,
-                              ecc_curve_t *elliptic_curve,
+                              const ecc_curve_t *elliptic_curve,
                               crypto_blinded_key_t *shared_secret);
 
 /**
@@ -268,7 +269,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature, verification_status_t *verification_result);
+    ecc_signature_t *signature, hardened_bool_t *verification_result);
 
 /**
  * Generates a new key pair for X25519 key exchange.
@@ -321,9 +322,11 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
  * started.
  *
  * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param config Private key configuration.
  * @return Result of asynchronous ECDSA keygen start operation.
  */
-crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve);
+crypto_status_t otcrypto_ecdsa_keygen_async_start(
+    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -333,12 +336,19 @@ crypto_status_t otcrypto_ecdsa_keygen_async_start(ecc_curve_t *elliptic_curve);
  * `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
+ * The caller must ensure that the `elliptic_curve` parameter matches the one
+ * that was previously passed to the corresponding `_start` function; a
+ * mismatch will cause inconsistencies. Similarly, the private key
+ * configuration must match the one originally passed to `_start`.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of asynchronous ECDSA keygen finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
-    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key);
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *private_key,
+    ecc_public_key_t *public_key);
 
 /**
  * Starts the asynchronous ECDSA digital signature generation.
@@ -355,7 +365,7 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
  */
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, ecc_curve_t *elliptic_curve);
+    crypto_const_uint8_buf_t input_message, const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous ECDSA digital signature generation.
@@ -364,10 +374,16 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
  * busy or `kCryptoStatusInternalError` if there is an error.
  *
+ * The caller must ensure that the `elliptic_curve` parameter matches the one
+ * that was previously passed to the corresponding `_start` function; a
+ * mismatch will cause inconsistencies.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] signature Pointer to the signature struct with (r,s) values.
  * @return Result of async ECDSA finalize operation.
  */
-crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature);
+crypto_status_t otcrypto_ecdsa_sign_async_finalize(
+    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature);
 
 /**
  * Starts the asynchronous ECDSA digital signature verification.
@@ -385,7 +401,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(ecc_signature_t *signature);
  */
 crypto_status_t otcrypto_ecdsa_verify_async_start(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, ecc_curve_t *elliptic_curve);
+    ecc_signature_t *signature, const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous ECDSA digital signature verification.
@@ -396,12 +412,18 @@ crypto_status_t otcrypto_ecdsa_verify_async_start(
  * The computed signature is compared against the input signature
  * and a PASS or FAIL is returned.
  *
+ * The caller must ensure that the `elliptic_curve` and `signature` parameters
+ * matches the ones that were previously passed to the corresponding `_start`
+ * function; a mismatch will cause inconsistencies.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] verification_result Result of signature verification
  * (Pass/Fail).
  * @return Result of async ECDSA verify finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_verify_async_finalize(
-    verification_status_t *verification_result);
+    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature,
+    hardened_bool_t *verification_result);
 
 /**
  * Starts the asynchronous key generation for ECDH operation.
@@ -418,9 +440,11 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
  * started.
  *
  * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @param config Private key configuration.
  * @return Result of asynchronous ECDH keygen start operation.
  */
-crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve);
+crypto_status_t otcrypto_ecdh_keygen_async_start(
+    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -430,12 +454,19 @@ crypto_status_t otcrypto_ecdh_keygen_async_start(ecc_curve_t *elliptic_curve);
  * `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
  * `kCryptoStatusInternalError` if there is an error.
  *
+ * The caller must ensure that the `elliptic_curve` parameter matches the one
+ * that was previously passed to the corresponding `_start` function; a
+ * mismatch will cause inconsistencies. Similarly, the private key
+ * configuration must match the one originally passed to `_start`.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of asynchronous ECDH keygen finalize operation.
  */
 crypto_status_t otcrypto_ecdh_keygen_async_finalize(
-    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key);
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *private_key,
+    ecc_public_key_t *public_key);
 
 /**
  * Starts the asynchronous Elliptic Curve Diffie Hellman shared
@@ -452,7 +483,7 @@ crypto_status_t otcrypto_ecdh_keygen_async_finalize(
  */
 crypto_status_t otcrypto_ecdh_async_start(
     const crypto_blinded_key_t *private_key, const ecc_public_key_t *public_key,
-    ecc_curve_t *elliptic_curve);
+    const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous Elliptic Curve Diffie Hellman shared
@@ -462,11 +493,16 @@ crypto_status_t otcrypto_ecdh_async_start(
  * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN
  * is busy or `kCryptoStatusInternalError` if there is an error.
  *
+ * The caller must ensure that the `elliptic_curve` parameter matches the one
+ * that was previously passed to the corresponding `_start` function; a
+ * mismatch will cause inconsistencies.
+ *
+ * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] shared_secret Pointer to generated blinded shared key struct.
  * @return Result of async ECDH finalize operation.
  */
 crypto_status_t otcrypto_ecdh_async_finalize(
-    crypto_blinded_key_t *shared_secret);
+    const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *shared_secret);
 
 /**
  * Starts the asynchronous key generation for Ed25519.
@@ -476,9 +512,11 @@ crypto_status_t otcrypto_ecdh_async_finalize(
  *
  * No `domain_parameter` is needed and is automatically set for X25519.
  *
+ * @param config Private key configuration.
  * @return Result of asynchronous ed25519 keygen start operation.
  */
-crypto_status_t otcrypto_ed25519_keygen_async_start();
+crypto_status_t otcrypto_ed25519_keygen_async_start(
+    crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for Ed25519.
@@ -487,6 +525,9 @@ crypto_status_t otcrypto_ed25519_keygen_async_start();
  * (Q), if the OTBN status is done, or `kCryptoStatusAsyncIncomplete`
  * if the OTBN is busy or `kCryptoStatusInternalError` if there is an
  * error.
+ *
+ * The caller must ensure that `config` matches the key configuration initially
+ * passed to the `_start` complement of this function.
  *
  * @param[out] private_key Pointer to the blinded private key struct.
  * @param[out] public_key Pointer to the unblinded public key struct.
@@ -556,7 +597,7 @@ crypto_status_t otcrypto_ed25519_verify_async_start(
  * @return Result of async Ed25519 verification finalize operation.
  */
 crypto_status_t otcrypto_ed25519_verify_async_finalize(
-    verification_status_t *verification_result);
+    hardened_bool_t *verification_result);
 
 /**
  * Starts the asynchronous key generation for X25519.
@@ -566,9 +607,10 @@ crypto_status_t otcrypto_ed25519_verify_async_finalize(
  *
  * No `domain_parameter` is needed and is automatically set for X25519.
  *
+ * @param config Private key configuration.
  * @return Result of asynchronous X25519 keygen start operation.
  */
-crypto_status_t otcrypto_x25519_keygen_async_start();
+crypto_status_t otcrypto_x25519_keygen_async_start(crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for X25519.
@@ -577,6 +619,9 @@ crypto_status_t otcrypto_x25519_keygen_async_start();
  * (Q), if the OTBN status is done, or `kCryptoStatusAsyncIncomplete`
  * if the OTBN is busy or `kCryptoStatusInternalError` if there is an
  * error.
+ *
+ * The caller must ensure that `config` matches the key configuration initially
+ * passed to the `_start` complement of this function.
  *
  * @param[out] private_key Pointer to the blinded private key struct.
  * @param[out] public_key Pointer to the unblinded public key struct.

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -148,7 +148,7 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
                                     crypto_const_uint8_buf_t signature,
-                                    verification_status_t *verification_result);
+                                    hardened_bool_t *verification_result);
 
 /**
  * Starts the asynchronous RSA key generation function.
@@ -251,7 +251,7 @@ crypto_status_t otcrypto_rsa_verify_async_start(
  */
 crypto_status_t otcrypto_rsa_verify_async_finalize(
     crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
-    rsa_hash_t hash_mode, verification_status_t *verification_result);
+    rsa_hash_t hash_mode, hardened_bool_t *verification_result);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Two relatively small changes to the top-level API for asymmetric routines in the cryptolib:
- Replace `verification_result_t` with `hardened_bool_t`, since the `hardened_bool_t` type already appears in e.g. key configurations.
- Pass some additional information to certain ECC async routines.

The information passed to ECC async routines is:
- key-generation `start()` routines now get the private key configuration; without this the implementations can't know e.g. whether the key should be a sideloaded key or not
- all ECDSA/ECDH `finalize()` routines now get information about what curve in particular is being used; without this the implementations can't know which OTBN program is loaded and therefore where they should look for the results in OTBN's memory.

This introduces some consistency requirements for the caller; they might get a silently wrong answer if, for instance, they pass a different curve to `finalize()` than they passed to the previous `start()`. We could theoretically change that by adding something to the OTBN programs that e.g. writes some magic value specific to that OTBN binary or even that specific mode of the binary at a fixed memory address that is the same across all programs, and having the Ibex-side code return an error if the curve/sideloading combination if the number isn't the expected value. However, I think this might be overkill; the library already expects the caller to ensure that `start()` and `finalize()` calls always match, so this doesn't seem to me like a large escalation.