### PR TITLE
[hw,i2c,dv] Add check for unstable and interference interrupts

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_error_intr_vseq.sv
@@ -68,6 +68,19 @@ class i2c_host_error_intr_vseq extends i2c_rx_tx_vseq;
   virtual task process_error_interrupts();
     forever begin
       @(posedge cfg.clk_rst_vif.clk) begin
+        // Check for interrupts
+        if(cfg.m_i2c_agent_cfg.timing_cfg.tSclInterference == 0 &&
+          cfg.intr_vif.pins[SclInference]) begin
+          `uvm_error(`gfn, "Unexpected assertion of intr_scl_interference_o")
+        end
+        if(cfg.m_i2c_agent_cfg.timing_cfg.tSdaInterference == 0 &&
+           cfg.intr_vif.pins[SdaInference]) begin
+          `uvm_error(`gfn, "Unexpected assertion of intr_sda_interference_o")
+        end
+        if((cfg.m_i2c_agent_cfg.timing_cfg.tSdaUnstable == 0) &&
+            cfg.intr_vif.pins[SdaUnstable]) begin
+          `uvm_error(`gfn, "Unexpected assertion of intr_sda_unstable_o")
+        end
         if (cfg.intr_vif.pins[SclInference] ||
             cfg.intr_vif.pins[SdaInference] ||
             cfg.intr_vif.pins[SdaUnstable]) begin


### PR DESCRIPTION
Using timing_cfg structure, add a check for sda_unstable, sda_interference and scl_interference interrupts.

- `intr_scl_interference_o` should only assert when `tSclInterference` is non-zero
- `intr_sda_interference_o` should only assert only when `tSdaInterference` is non-zero
- `intr_sda_unstable_o` should only assert when `tSdaUnstable` is non-zero