### PR TITLE
[crypto] Add some extra checks to keyblob routines for asymmetric keys.

### DIFF
--- a/sw/device/lib/crypto/impl/keyblob.h
+++ b/sw/device/lib/crypto/impl/keyblob.h
@@ -73,17 +73,27 @@ void keyblob_from_shares(const uint32_t *share0, const uint32_t *share1,
  * 20 bytes would technically fit in 5. This is to preserve word-alignment of
  * the shares.
  *
+ * Returns an error if called for an asymmetric key configuration; asymmetric
+ * keys are likely to be masked with arithmetic rather than boolean (XOR)
+ * schemes, and this function cannot be used for them.
+ *
  * @param key Plaintext key.
  * @param mask Blinding value.
  * @param config Key configuration.
  * @param[out] keyblob Destination buffer.
+ * @return Result of the operation.
  */
-void keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
-                               const crypto_key_config_t config,
-                               uint32_t *keyblob);
+OT_WARN_UNUSED_RESULT
+status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
+                                   const crypto_key_config_t config,
+                                   uint32_t *keyblob);
 
 /**
  * Incorporate a fresh mask into the blinded key.
+ *
+ * Returns an error if called for an asymmetric key configuration; asymmetric
+ * keys are likely to be masked with arithmetic rather than boolean (XOR)
+ * schemes, and this function cannot be used for them.
  *
  * @param key Blinded key to re-mask. Modified in-place.
  * @param mask Blinding parameter (fresh random mask).

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -64,7 +64,8 @@ static void encrypt_decrypt_test(const aes_test_t *test) {
 
   // Construct blinded key from the key and testing mask.
   uint32_t keyblob[keyblob_num_words(config)];
-  keyblob_from_key_and_mask(test->key, kKeyMask, config, keyblob);
+  CHECK_STATUS_OK(
+      keyblob_from_key_and_mask(test->key, kKeyMask, config, keyblob));
   crypto_blinded_key_t key = {
       .config = config,
       .keyblob_length = sizeof(keyblob),

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -52,7 +52,8 @@ static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_tag) {
   };
 
   uint32_t keyblob[keyblob_num_words(config)];
-  keyblob_from_key_and_mask(kTestKey.key, kTestMask, config, keyblob);
+  CHECK_STATUS_OK(
+      keyblob_from_key_and_mask(kTestKey.key, kTestMask, config, keyblob));
   crypto_blinded_key_t blinded_key = {
       .config = config,
       .keyblob = keyblob,


### PR DESCRIPTION
The routines in keyblob.c only handle boolean (XOR) masking; add some extra checks that return errors if they are called for asymmetric keys, which will use arithmetic masking schemes (e.g. additive modulo a number) instead, and correct the share size for elliptic-curve keys.