### PR TITLE
Use hyperdebug firmware from the hyperdebug-firmware project

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,6 +91,10 @@ coremark_repos()
 load("//third_party/xkcp:repos.bzl", "xkcp_repos")
 xkcp_repos()
 
+# Binary firmware images for hyperdebug
+load("//third_party/hyperdebug:repos.bzl", "hyperdebug_repos")
+hyperdebug_repos()
+
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
@@ -109,11 +113,3 @@ hooks_repo(name = "manufacturer_test_hooks")
 # The nonhermetic_repo imports environment variables needed to run vivado.
 load("//rules:nonhermetic.bzl", "nonhermetic_repo")
 nonhermetic_repo(name = "nonhermetic")
-
-# Binary firmware image for HyperDebug
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-http_file(
-    name = "hyperdebug_firmware",
-    urls = ["https://storage.googleapis.com/aoa-recovery-test-images/hyperdebug_v2.0.20634-ee78d5668.bin"],
-    sha256 = "c72c418bc56d673d4106af9a0973c6e4268d09fb18d363e7ad336a877a127be9",
-)

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -176,7 +176,7 @@ rust_library(
         ":e2e_command",
         ":pinmux_config",
         ":spi_passthru",
-        "@hyperdebug_firmware//file",
+        "@lowrisc_hyperdebug//:ec.bin",
     ],
     crate_features = [
         "include_hyperdebug_firmware",
@@ -194,7 +194,7 @@ rust_library(
         "gpio": "$(location :gpio)",
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
-        "hyperdebug_firmware": "$(location @hyperdebug_firmware//file)",
+        "hyperdebug_firmware": "$(location @lowrisc_hyperdebug//:ec.bin)",
     },
     deps = [
         "//sw/host/opentitanlib/bindgen",
@@ -247,7 +247,7 @@ rust_test(
         ":e2e_command",
         ":gpio",
         ":pinmux_config",
-        "@hyperdebug_firmware//file",
+        "@lowrisc_hyperdebug//:ec.bin",
         "src/bootstrap/simple.bin",
         "src/spiflash/SFDP_MX66L1G.bin",
     ],

--- a/third_party/hyperdebug/BUILD.bazel
+++ b/third_party/hyperdebug/BUILD.bazel
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def hyperdebug_repos():
+    maybe(
+        http_archive,
+        name = "lowrisc_hyperdebug",
+        url = "https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230404_01/hyperdebug-firmware.tar.gz",
+        sha256 = "6030cf28196d63256a30c980825b635df139e70c098309bfa04f5e85c1b722e3",
+        strip_prefix = "hyperdebug",
+        build_file_content = "exports_files(glob([\"**\"]))",
+    )


### PR DESCRIPTION
Use the firmware archive published by the [hyperdebug-firmware](https://github.com/lowRISC/hyperdebug-firmware) project.  The hyperdebug-firmware project provides build-and-release for the versions of the EC firmware that serve as the hyperdebug firmweare.