### PR TITLE
[opentitanlib] refactor uart console to enable adding future console interfaces (e.g., SPI)

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -69,6 +69,7 @@ rust_library(
         "src/image/manifest.rs",
         "src/image/manifest_def.rs",
         "src/image/mod.rs",
+        "src/io/console.rs",
         "src/io/eeprom.rs",
         "src/io/emu.rs",
         "src/io/gpio.rs",

--- a/sw/host/opentitanlib/src/io/console.rs
+++ b/sw/host/opentitanlib/src/io/console.rs
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use thiserror::Error;
+
+use crate::impl_serializable_error;
+
+/// Errors related to the console interface.
+#[derive(Error, Debug, Serialize, Deserialize)]
+pub enum ConsoleError {
+    #[error("Unsupported: {0}")]
+    UnsupportedError(String),
+    #[error("{0}")]
+    GenericError(String),
+}
+impl_serializable_error!(ConsoleError);
+
+pub trait ConsoleDevice {
+    /// Reads data from the UART to print to the console (used when this UART is the console device).
+    fn console_read(&self, _buf: &mut [u8], _timeout: Duration) -> Result<usize> {
+        Err(ConsoleError::UnsupportedError("console_read() not implemented.".into()).into())
+    }
+
+    /// Writes console input data to the UART (used when this UART is the console device).
+    fn console_write(&self, _buf: &[u8]) -> Result<()> {
+        Err(ConsoleError::UnsupportedError("console_write() not implemented.".into()).into())
+    }
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod console;
 pub mod eeprom;
 pub mod emu;
 pub mod gpio;

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use crate::app::TransportWrapper;
 use crate::impl_serializable_error;
+use crate::io::console::ConsoleDevice;
 
 #[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
 pub struct UartParams {
@@ -83,6 +84,16 @@ pub trait Uart {
         let mut buf = [0u8; 256];
         while self.read_timeout(&mut buf, TIMEOUT)? > 0 {}
         Ok(())
+    }
+}
+
+impl<'a> ConsoleDevice for dyn Uart + 'a {
+    fn console_read(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        self.read_timeout(buf, timeout)
+    }
+
+    fn console_write(&self, buf: &[u8]) -> Result<()> {
+        self.write(buf)
     }
 }
 

--- a/sw/host/opentitanlib/src/proxy/errors.rs
+++ b/sw/host/opentitanlib/src/proxy/errors.rs
@@ -112,6 +112,7 @@ impl From<anyhow::Error> for SerializedError {
             crate::bootstrap::BootstrapError,
             crate::bootstrap::LegacyBootstrapError,
             crate::bootstrap::RescueError,
+            crate::io::console::ConsoleError,
             crate::io::emu::EmuError,
             crate::io::gpio::GpioError,
             crate::io::i2c::I2cError,

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant, SystemTime};
 
-use crate::io::uart::{Uart, UartError};
+use crate::io::console::{ConsoleDevice, ConsoleError};
 use crate::util::file;
 
 #[derive(Default)]
@@ -42,17 +42,20 @@ impl UartConsole {
     const BUFFER_LEN: usize = 4096;
 
     // Runs an interactive console until CTRL_C is received.
-    pub fn interact(
+    pub fn interact<T>(
         &mut self,
-        uart: &dyn Uart,
+        device: &T,
         mut stdin: Option<&mut dyn ReadAsRawFd>,
         mut stdout: Option<&mut dyn Write>,
-    ) -> Result<ExitStatus> {
+    ) -> Result<ExitStatus>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
         if let Some(timeout) = &self.timeout {
             self.deadline = Some(Instant::now() + *timeout);
         }
         loop {
-            match self.interact_once(uart, &mut stdin, &mut stdout)? {
+            match self.interact_once(device, &mut stdin, &mut stdout)? {
                 ExitStatus::None => {}
                 status => return Ok(status),
             }
@@ -67,15 +70,18 @@ impl UartConsole {
         }
     }
 
-    // Read from the uart and process the data read.
-    fn uart_read(
+    // Read from the console device and process the data read.
+    fn uart_read<T>(
         &mut self,
-        uart: &dyn Uart,
+        device: &T,
         timeout: Duration,
         stdout: &mut Option<&mut dyn Write>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
         let mut buf = [0u8; 256];
-        let len = uart.read_timeout(&mut buf, timeout)?;
+        let len = device.console_read(&mut buf, timeout)?;
         if len == 0 {
             return Ok(());
         }
@@ -106,11 +112,14 @@ impl UartConsole {
         Ok(())
     }
 
-    fn process_input(
+    fn process_input<T>(
         &self,
-        uart: &dyn Uart,
+        device: &T,
         stdin: &mut Option<&mut (dyn ReadAsRawFd)>,
-    ) -> Result<ExitStatus> {
+    ) -> Result<ExitStatus>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
         if let Some(ref mut input) = stdin.as_mut() {
             if file::wait_fd_read_timeout(input.as_raw_fd(), Duration::from_millis(0)).is_ok() {
                 let mut buf = [0u8; 256];
@@ -119,19 +128,22 @@ impl UartConsole {
                     return Ok(ExitStatus::CtrlC);
                 }
                 if len > 0 {
-                    uart.write(&buf[..len])?;
+                    device.console_write(&buf[..len])?;
                 }
             }
         }
         Ok(ExitStatus::None)
     }
 
-    pub fn interact_once(
+    pub fn interact_once<T>(
         &mut self,
-        uart: &dyn Uart,
+        device: &T,
         stdin: &mut Option<&mut (dyn ReadAsRawFd)>,
         stdout: &mut Option<&mut dyn Write>,
-    ) -> Result<ExitStatus> {
+    ) -> Result<ExitStatus>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
         if let Some(deadline) = &self.deadline {
             if Instant::now() > *deadline {
                 return Ok(ExitStatus::Timeout);
@@ -149,7 +161,7 @@ impl UartConsole {
         // better way to approach waiting on the UART and keyboard.
 
         // Check for input on the uart.
-        self.uart_read(uart, Duration::from_millis(10), stdout)?;
+        self.uart_read(device, Duration::from_millis(10), stdout)?;
         if self
             .exit_success
             .as_ref()
@@ -166,7 +178,7 @@ impl UartConsole {
         {
             return Ok(ExitStatus::ExitFailure);
         }
-        self.process_input(uart, stdin)
+        self.process_input(device, stdin)
     }
 
     pub fn captures(&self, status: ExitStatus) -> Option<Captures> {
@@ -183,21 +195,24 @@ impl UartConsole {
         }
     }
 
-    pub fn wait_for(uart: &dyn Uart, rx: &str, timeout: Duration) -> Result<String> {
+    pub fn wait_for<T>(device: &T, rx: &str, timeout: Duration) -> Result<String>
+    where
+        T: ConsoleDevice + ?Sized,
+    {
         let mut console = UartConsole {
             timeout: Some(timeout),
             exit_success: Some(Regex::new(rx)?),
             ..Default::default()
         };
         let mut stdout = std::io::stdout();
-        let result = console.interact(uart, None, Some(&mut stdout))?;
+        let result = console.interact(device, None, Some(&mut stdout))?;
         match result {
             ExitStatus::ExitSuccess => {
                 let cap = console.captures(ExitStatus::ExitSuccess).expect("capture");
                 let s = cap.get(0).expect("capture group").as_str().to_owned();
                 Ok(s)
             }
-            ExitStatus::Timeout => Err(UartError::GenericError("Timed Out".into()).into()),
+            ExitStatus::Timeout => Err(ConsoleError::GenericError("Timed Out".into()).into()),
             _ => Err(anyhow!("Impossible result: {:?}", result)),
         }
     }


### PR DESCRIPTION
This PR has two commits that:
1. Refactors the UART console module to facilitate better code reuse when adding additional console devices in the future, e.g., the SPI.
2. Updates the power virus test to use the generic opentitanlib console module, instead of the UART specific one, to demonstrate the generic console module is working.

If / when the generic opentitanlib console module is in an acceptable state, and this PR is merged, the remaining tests can be migrated over to use it, and the UART specific console module can be removed.

This PR aims to support a future OTTF  SPI console (see #17494).