### PR TITLE
[dif,ottf,test] add example spi_device OTTF console test on hyperdebug

### DIFF
--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -630,6 +630,38 @@ dif_result_t dif_spi_device_send(dif_spi_device_handle_t *spi, const void *buf,
   return kDifOk;
 }
 
+dif_result_t dif_spi_device_send_polled(dif_spi_device_handle_t *spi,
+                                        const void *buf, size_t buf_len) {
+  if (spi == NULL || buf == NULL ||
+      buf_len > spi->config.mode_cfg.generic.tx_fifo_len) {
+    return kDifBadArg;
+  }
+  if (buf_len == 0) {
+    return kDifOk;
+  }
+
+  fifo_ptrs_t tx_fifo;
+  uint16_t free_fifo_space_bytes = 0;
+
+  do {
+    tx_fifo = decompress_ptrs(spi, kTxFifoParams);
+    free_fifo_space_bytes =
+        spi->config.mode_cfg.generic.tx_fifo_len -
+        fifo_bytes_in_use(tx_fifo, spi->config.mode_cfg.generic.tx_fifo_len);
+  } while (free_fifo_space_bytes < buf_len);
+
+  size_t bytes_copied =
+      spi_memcpy(spi, &tx_fifo, spi->config.mode_cfg.generic.rx_fifo_len,
+                 spi->config.mode_cfg.generic.tx_fifo_len, (uint8_t *)buf,
+                 buf_len, /*is_recv=*/false);
+  compress_ptrs(spi, kTxFifoParams, tx_fifo);
+
+  if (bytes_copied != buf_len) {
+    return kDifError;
+  }
+  return kDifOk;
+}
+
 dif_result_t dif_spi_device_enable_mailbox(dif_spi_device_handle_t *spi,
                                            uint32_t address) {
   if (spi == NULL) {

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -378,6 +378,21 @@ dif_result_t dif_spi_device_send(dif_spi_device_handle_t *spi, const void *buf,
                                  size_t buf_len, size_t *bytes_sent);
 
 /**
+ * Writes `buf_len` bytes to the TX FIFO, blocking until all bytes can be
+ * written.
+ *
+ * Applies only to generic mode.
+ *
+ * @param spi A SPI device.
+ * @param buf A pointer to bytes to be written.
+ * @param buf_len The length of the buffer `buf` points to.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_send_polled(dif_spi_device_handle_t *spi,
+                                        const void *buf, size_t buf_len);
+
+/**
  * Enable the mailbox region for spi_device flash / passthrough modes.
  *
  * Allocate 1 KiB for the mailbox, starting from the provided base `address`.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2300,3 +2300,27 @@ opentitan_functest(
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
+
+opentitan_functest(
+    name = "spi_device_ottf_console_test",
+    srcs = ["spi_device_ottf_console_test.c"],
+    cw310 = cw310_params(
+        interface = "hyper310",
+        tags = ["manual"],
+        test_cmds = [
+            "--rom-kind=testrom",
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
+    targets = [
+        "cw310_test_rom",
+    ],
+    test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/spi_device_ottf_console_test.c
+++ b/sw/device/tests/spi_device_ottf_console_test.c
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
+
+static const char test_str[] = "This is a SPI device OTTF console test.";
+
+static dif_spi_device_handle_t ottf_console_spi_device;
+
+bool test_main(void) {
+  LOG_INFO("%s", test_str);
+
+  return true;
+}

--- a/sw/host/tests/chip/spi_device_ottf_console/BUILD
+++ b/sw/host/tests/chip/spi_device_ottf_console/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "spi_device_ottf_console",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:regex",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+    long, parse(try_from_str=humantime::parse_duration),
+    default_value = "600s",
+    help = "Console receive timeout",
+    )]
+    timeout: Duration,
+
+    #[structopt(
+        long,
+        default_value = "BOOTSTRAP",
+        help = "Name of the SPI interface to connect to the OTTF console."
+    )]
+    console_spi: String,
+}
+
+fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let spi = transport.spi(&opts.console_spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi);
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+    let result = console.interact(&spi_console_device, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    execute_test!(spi_device_console_test, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR contains 3 commits that add the infrastructure and a test to demonstrate the use of the spi_device (operating in generic mode) acting as the OTTF console device (instead of the default device: UART0). The commits:
1. Add a blocking spi_device DIF to TX an arbitrary length buffer for use with the OTTF spi_device console `printf()` functions,
2. Add a simple framing protocol to the spi_device console `printf()` to accomodate pitfalls in the hyperdebug SPI generic mode hw/firmware. Specifically, a SPI read transaction must be performed before a write transaction, where all communication is half-duplex, for the operations to succeed. This means that naturally, some bytes will be lost during transmission. To account for this, the framing protocol that I developed contains 0xff padding bytes.
3.  Add a hyperdebug-driven test for OTTF spi_device console.

This fixes #17494.

**_Note: this depends on #17816 and #17817. Only review the last 3 commits._**