### PR TITLE
[rtl,rv_timer] Remove TODO about counter overflow

### DIFF
--- a/hw/ip/rv_timer/rtl/timer_core.sv
+++ b/hw/ip/rv_timer/rtl/timer_core.sv
@@ -41,7 +41,6 @@ module timer_core #(
   assign mtime_d = mtime + 64'(step);
 
   // interrupt is generated if mtime is greater than or equal to mtimecmp
-  // TODO: Check if it must consider overflow case
   for (genvar t = 0 ; t < N ; t++) begin : gen_intr
     assign intr[t] = active & (mtime >= mtimecmp[t]);
   end


### PR DESCRIPTION
mtime and mtimecmp as defined by the RISC-V specification do not need to make any special considerations about mtime overflowing. It is only specified that mtime wraps around if the count overflows.

See RISC-V ISA Vol 2 v1.12 section 3.2.1 (Machine Timer Registers)