### PR TITLE
[crypto] Clean up AES-GCM code and make it match the API more closely.

### DIFF
--- a/sw/device/lib/crypto/impl/aes_gcm/BUILD
+++ b/sw/device/lib/crypto/impl/aes_gcm/BUILD
@@ -9,9 +9,20 @@ cc_library(
     srcs = ["aes_gcm.c"],
     hdrs = ["aes_gcm.h"],
     deps = [
+        ":ghash",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:aes",
+    ],
+)
+
+cc_library(
+    name = "ghash",
+    srcs = ["ghash.c"],
+    hdrs = ["ghash.h"],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
     ],
 )

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.c
@@ -12,176 +12,21 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
+#include "sw/device/lib/crypto/impl/aes_gcm/ghash.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('g', 'c', 'm')
 
 enum {
-  /* Log2 of the number of bytes in an AES block. */
+  /**
+   * Log2 of the number of bytes in an AES block.
+   */
   kAesBlockLog2NumBytes = 4,
 };
-OT_ASSERT_ENUM_VALUE(kAesBlockNumBytes, 1 << kAesBlockLog2NumBytes);
+static_assert(kAesBlockNumBytes == (1 << kAesBlockLog2NumBytes),
+              "kAesBlockLog2NumBytes does not match kAesBlockNumBytes");
 
-/**
- * Precomputed modular reduction constants for Galois field multiplication.
- *
- * This implementation uses 4-bit windows. The bytes here represent 12-bit
- * little-endian values.
- *
- * The entry with index i in this table is equal to i * 0xe1, where the bytes i
- * and 0xe1 are interpreted as polynomials in the GCM Galois field. For
- * example, 0xe1 = 0b1110_0001 is the degree-8 polynomial x^8 + x^2 + x + 1.
- *
- * The field modulus for GCM is 2^128 + x^8 + x^2 + x + 1. Therefore, if a
- * field element is shifted, it can be reduced by multiplying the high bits
- * (128 and above) by 0xe1 and adding them to the low bits.
- *
- * There is a size/speed tradeoff in window size. For 8-bit windows, GHASH
- * becomes significantly faster, but the overhead for computing the product
- * table of a given hash subkey becomes higher, so larger windows are slower
- * for smaller inputs but faster for large inputs.
- */
-static const uint16_t kGFReduceTable[16] = {
-    0x0000, 0x201c, 0x4038, 0x6024, 0x8070, 0xa06c, 0xc048, 0xe054,
-    0x00e1, 0x20fd, 0x40d9, 0x60c5, 0x8091, 0xa08d, 0xc0a9, 0xe0b5};
-
-/**
- * Product table for a given hash subkey.
- *
- * See `make_product_table`.
- */
-typedef struct aes_gcm_product_table {
-  aes_block_t products[16];
-} aes_gcm_product_table_t;
-
-/**
- * Performs a bitwise XOR of two blocks.
- *
- * This operation corresponds to addition in the Galois field.
- *
- * @param x First operand block
- * @param y Second operand block
- * @param[out] out Buffer in which to store output; can be the same as one or
- * both operands.
- */
-static inline void block_xor(const aes_block_t *x, const aes_block_t *y,
-                             aes_block_t *out) {
-  for (size_t i = 0; i < kAesBlockNumWords; ++i) {
-    out->data[i] = x->data[i] ^ y->data[i];
-  }
-}
-
-/**
- * Reverse the bits of a 4-bit number.
- *
- * @param byte Input byte.
- * @return byte with lower 4 bits reversed and upper 4 unmodified.
- */
-static uint8_t reverse_bits(uint8_t byte) {
-  /* TODO: replace with rev.n (from 0.93 draft of bitmanip) once bitmanip
-   * extension is enabled. */
-  uint8_t out = 0;
-  for (size_t i = 0; i < 4; ++i) {
-    out <<= 1;
-    out |= (byte >> i) & 1;
-  }
-  return out;
-}
-
-/**
- * Reverse the bytes of a 32-bit word.
- *
- * This function is convenient for converting between the processor's native
- * integers, which are little-endian, and NIST's integer representation, which
- * is big-endian.
- *
- * @param word Input word.
- * @return Word with bytes reversed.
- */
-static uint32_t reverse_bytes(uint32_t word) {
-  /* TODO: replace with rev8 once bitmanip extension is enabled. */
-  uint32_t out = 0;
-  for (size_t i = 0; i < sizeof(uint32_t); ++i) {
-    out <<= 8;
-    out |= (word >> (i << 3)) & 255;
-  }
-  return out;
-}
-
-/**
- * Logical right shift of an AES block.
- *
- * NIST represents AES blocks as big-endian, and a "right shift" in that
- * representation means shifting out the LSB. However, the processor is
- * little-endian, so we need to reverse the bytes before shifting.
- *
- * @param block Input AES block, modified in-place
- * @param nbits Number of bits to shift
- */
-static inline void block_shiftr(aes_block_t *block, size_t nbits) {
-  // To perform a "right shift" with respect to the big-endian block
-  // representation, we traverse the words of the block and, for each word,
-  // reverse the bytes, save the new LSB as `carry`, shift right, set the MSB
-  // to the last block's carry, and then reverse the bytes back.
-  uint32_t carry = 0;
-  for (size_t i = 0; i < kAesBlockNumWords; ++i) {
-    uint32_t rev = reverse_bytes(block->data[i]);
-    uint32_t next_carry = rev & ((1 << nbits) - 1);
-    rev >>= nbits;
-    rev |= carry << (32 - nbits);
-    carry = next_carry;
-    block->data[i] = reverse_bytes(rev);
-  }
-}
-
-/**
- * Retrieve the byte at a given index from the AES block.
- *
- * @param block Input AES block
- * @param index Index of byte to retrieve (must be < `kAesBlockNumBytes`)
- * @return Value of block[index]
- */
-static inline uint8_t block_byte_get(const aes_block_t *block, size_t index) {
-  return (uint8_t)((char *)block->data)[index];
-}
-
-/**
- * Get the size of the last block for a given input size.
- *
- * Equivalent to `sz % kAesBlockNumBytes`, except that if `sz` is a multiple of
- * `kAesBlockNumBytes` then this will return `kAesBlockNumBytes` (since the
- * last block would then be a full block).
- *
- * Assumes that `sz` is nonzero.
- *
- * @param sz Number of bytes in the buffer, must be nonzero
- * @return Number of bytes in the last block
- */
-static inline size_t get_last_block_num_bytes(size_t sz) {
-  size_t remainder = sz % kAesBlockNumBytes;
-  if (remainder == 0) {
-    return kAesBlockNumBytes;
-  }
-  return remainder;
-}
-
-/**
- * Get the minimum number of AES blocks needed to represent `sz` bytes.
- *
- * This routine does not run in constant time and should not be used for
- * sensitive input values.
- *
- * @param sz Number of bytes to represent
- * @return Minimum number of blocks needed
- */
-static inline size_t get_nblocks(size_t sz) {
-  size_t out = sz >> kAesBlockLog2NumBytes;
-  if (get_last_block_num_bytes(sz) != kAesBlockNumBytes) {
-    out += 1;
-  }
-  return out;
-}
 
 /**
  * Increment a 32-bit big-endian word.
@@ -196,7 +41,7 @@ static inline size_t get_nblocks(size_t sz) {
  */
 static inline uint32_t word_inc32(const uint32_t word) {
   // Reverse the bytes, increment, and reverse back.
-  return reverse_bytes(reverse_bytes(word) + 1);
+  return __builtin_bswap32(__builtin_bswap32(word) + 1);
 }
 
 /**
@@ -214,203 +59,15 @@ static inline void block_inc32(aes_block_t *block) {
 }
 
 /**
- * Multiply an element of the GCM Galois field by the polynomial `x`.
- *
- * This corresponds to a shift right in the bit representation, and then
- * reduction with the field modulus.
- *
- * Runs in constant time.
- *
- * @param p Polynomial to be multiplied
- * @param[out] out Buffer for output
- */
-static inline void galois_mulx(const aes_block_t *p, aes_block_t *out) {
-  // Get the very rightmost bit of the input block (coefficient of x^127).
-  uint8_t p127 = block_byte_get(p, kAesBlockNumBytes - 1) & 1;
-  // Set the output to p >> 1.
-  memcpy(out->data, p->data, kAesBlockNumBytes);
-  block_shiftr(out, 1);
-  // If the highest coefficient was 1, then subtract the polynomial that
-  // corresponds to (modulus - 2^128).
-  uint32_t mask = 0 - p127;
-  out->data[0] ^= (0xe1 & mask);
-}
-
-/**
- * Construct a product table for the hash subkey H.
- *
- * The product table entry at index i is equal to i * H, where both i and H are
- * interpreted as Galois field polynomials.
- *
- * @param H Hash subkey
- * @param[out] product_table Buffer for output
- */
-static void make_product_table(const aes_block_t *H,
-                               aes_gcm_product_table_t *tbl) {
-  // Initialize 0 * H = 0.
-  memset(tbl->products[0].data, 0, kAesBlockNumBytes);
-  // Initialize 1 * H = H.
-  memcpy(tbl->products[0x8].data, H->data, kAesBlockNumBytes);
-
-  // To get remaining entries, we use a variant of "shift and add"; in
-  // polynomial terms, a shift is a multiplication by x. Note that, because the
-  // processor represents bytes with the MSB on the left and NIST uses a fully
-  // little-endian polynomial representation with the MSB on the right, we have
-  // to reverse the bits of the indices.
-  for (size_t i = 2; i < 16; i += 2) {
-    // Find the product corresponding to (i >> 1) * H and multiply by x to
-    // shift 1; this will be i * H.
-    galois_mulx(&tbl->products[reverse_bits(i >> 1)],
-                &tbl->products[reverse_bits(i)]);
-
-    // Add H to i * H to get (i + 1) * H.
-    block_xor(&tbl->products[reverse_bits(i)], H,
-              &tbl->products[reverse_bits(i + 1)]);
-  }
-}
-
-/**
- * Computes the "product block" as defined in NIST SP800-38D, section 6.3.
- *
- * The NIST documentation shows a very slow double-and-add algorithm, which
- * iterates through the first operand bit-by-bit. However, since the second
- * operand is always the hash subkey H, we can speed things up significantly
- * with a little precomputation.
- *
- * The `tbl` input should be a precomputed table with the products of H and
- * 256 all possible byte values (see `make_product_table`).
- *
- * This operation corresponds to multiplication in the Galois field with order
- * 2^128, modulo the polynomial x^128 +  x^8 + x^2 + x + 1
- *
- * @param p Polynomial to multiply
- * @param tbl Precomputed product table for the hash subkey
- * @param[out] result Block in which to store output
- */
-static void galois_mul(const aes_block_t *p, const aes_gcm_product_table_t *tbl,
-                       aes_block_t *result) {
-  // Initialize the result to 0.
-  memset(result->data, 0, kAesBlockNumBytes);
-
-  // 4-bit windows, so number of windows is 2x number of bytes.
-  const size_t kNumWindows = kAesBlockNumBytes << 1;
-
-  // To compute the product, we iterate through the bytes of the input block,
-  // considering the most significant (in polynomial terms) first. For each
-  // byte b, we:
-  //   * multiply `result` by x^8 (shift all coefficients to the right)
-  //   * reduce the shifted `result` modulo the field modulus
-  //   * look up the product `b * H` and add it to `result`
-  //
-  // We can skip the shift and reduce steps on the first iteration, since
-  // `result` is 0.
-  for (size_t i = 0; i < kNumWindows; ++i) {
-    if (i != 0) {
-      // Save the most significant half-byte of `result` before shifting.
-      uint8_t overflow = block_byte_get(result, kAesBlockNumBytes - 1) & 0x0f;
-      // Shift `result` to the right, discarding high bits.
-      block_shiftr(result, 4);
-      // Look up the product of `overflow` and the low terms of the modulus in
-      // the precomputed table.
-      uint16_t reduce_term = kGFReduceTable[overflow];
-      // Add (xor) this product to the low bits to complete modular reduction.
-      // This works because (low + x^128 * high) is equivalent to (low + (x^128
-      // - modulus) * high).
-      result->data[0] ^= reduce_term;
-    }
-
-    // Add the product of the next window and H to `result`. We process the
-    // windows starting with the most significant polynomial terms, which means
-    // starting from the last byte and proceeding to the first.
-    uint8_t pi = block_byte_get(p, (kNumWindows - 1 - i) >> 1);
-
-    // Select the less significant 4 bits if i is even, or the more significant
-    // 4 bits if i is odd. This does not need to be constant time, since the
-    // values of i in this loop are constant.
-    if ((i & 1) == 1) {
-      pi >>= 4;
-    } else {
-      pi &= 0x0f;
-    }
-    block_xor(result, &tbl->products[pi], result);
-  }
-}
-
-/**
- * Advances the GHASH state for the given input.
- *
- * This function is convenient for computing the GHASH of large, concatenated
- * buffers. Given a state representing GHASH(A) and a new input B, this
- * function will return a state representing GHASH(A || B || <padding for B>).
- *
- * Pads the input with 0s on the right-hand side if needed so that the input
- * size is a multiple of the block size.
- *
- * The product table should match the format from `make_product_table`.
- *
- * @param tbl Precomputed product table
- * @param input_len Length of input in bytes
- * @param input Input buffer
- * @param state GHASH state, updated in place
- */
-static void aes_gcm_ghash_update(const aes_gcm_product_table_t *tbl,
-                                 const size_t input_len, const uint8_t *input,
-                                 aes_block_t *state) {
-  // Calculate the number of AES blocks needed for the input.
-  size_t nblocks = get_nblocks(input_len);
-
-  // Main loop.
-  for (size_t i = 0; i < nblocks; ++i) {
-    // Construct block i of the input.
-    aes_block_t input_block;
-    if (i == nblocks - 1) {
-      // Last block may be partial; pad with zeroes.
-      size_t nbytes = get_last_block_num_bytes(input_len);
-      memset(input_block.data, 0, kAesBlockNumBytes);
-      memcpy(input_block.data, input, nbytes);
-    } else {
-      // Full block; copy data and advance input pointer.
-      memcpy(input_block.data, input, kAesBlockNumBytes);
-      input += kAesBlockNumBytes;
-    }
-    // XOR `state` with the next input block.
-    block_xor(state, &input_block, state);
-    // Multiply state by H and update.
-    aes_block_t yH;
-    galois_mul(state, tbl, &yH);
-    memcpy(state->data, yH.data, kAesBlockNumBytes);
-  }
-}
-
-status_t aes_gcm_ghash(const aes_block_t *hash_subkey, const size_t input_len,
-                       const uint8_t *input, aes_block_t *output) {
-  // Compute the product table for H.
-  aes_gcm_product_table_t tbl;
-  make_product_table(hash_subkey, &tbl);
-
-  // If the input length is not a multiple of the block size, fail.
-  if (get_last_block_num_bytes(input_len) != kAesBlockNumBytes) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-
-  // Initialize the GHASH state to 0.
-  memset(output->data, 0, kAesBlockNumBytes);
-
-  // Update the GHASH state with the input.
-  aes_gcm_ghash_update(&tbl, input_len, input, output);
-
-  return OTCRYPTO_OK;
-}
-
-/**
  * One-shot version of the AES encryption API for a single block.
  */
+OT_WARN_UNUSED_RESULT
 static status_t aes_encrypt_block(const aes_key_t key, const aes_block_t *iv,
                                   const aes_block_t *input,
                                   aes_block_t *output) {
   HARDENED_TRY(aes_encrypt_begin(key, iv));
-  HARDENED_TRY(aes_update(/*dest*/ NULL, input));
-  HARDENED_TRY(aes_update(output, /*src*/ NULL));
+  HARDENED_TRY(aes_update(/*dest=*/ NULL, input));
+  HARDENED_TRY(aes_update(output, /*src=*/ NULL));
   return aes_end();
 }
 
@@ -431,7 +88,7 @@ static status_t aes_encrypt_block(const aes_key_t key, const aes_block_t *iv,
  * same buffer)
  */
 status_t aes_gcm_gctr(const aes_key_t key, const aes_block_t *icb,
-                      const size_t len, const uint8_t *input, uint8_t *output) {
+                      size_t len, const uint8_t *input, uint8_t *output) {
   // If the input is empty, the output must be as well. Since the output length
   // is 0, simply return.
   if (len == 0) {
@@ -457,25 +114,19 @@ status_t aes_gcm_gctr(const aes_key_t key, const aes_block_t *icb,
   aes_block_t iv;
   memcpy(iv.data, icb->data, kAesBlockNumBytes);
 
-  // Calculate the number of blocks needed to represent the input. Since we
-  // checked for empty input above, nblocks must be at least 1.
-  size_t nblocks = get_nblocks(len);
-  for (size_t i = 0; i < nblocks; ++i) {
-    // Retrieve the next block of input. All blocks are full-size except for
-    // the last block, which may be partial. If the block is partial, the input
-    // data will be padded with zeroes.
+  // Process the input one block at a time.
+  while (len > 0) {
     aes_block_t block_in;
     size_t nbytes = kAesBlockNumBytes;
-    if (i == nblocks - 1) {
+    if (len < kAesBlockNumBytes) {
       // Last block is partial; copy the bytes that exist and set the rest of
       // the block to 0.
-      nbytes = get_last_block_num_bytes(len);
       memset(block_in.data, 0, kAesBlockNumBytes);
-      memcpy(block_in.data, &input[i * kAesBlockNumBytes], nbytes);
-    } else {
-      // This block is a full block.
-      memcpy(block_in.data, &input[i * kAesBlockNumBytes], kAesBlockNumBytes);
+      nbytes = len;
     }
+    memcpy(block_in.data, input, nbytes);
+    len -= nbytes;
+    input += nbytes;
 
     // Run the AES-CTR encryption operation on the next block of input.
     aes_block_t block_out;
@@ -483,7 +134,8 @@ status_t aes_gcm_gctr(const aes_key_t key, const aes_block_t *icb,
 
     // Copy the result block into the output buffer, truncating some bytes if
     // the input block was partial.
-    memcpy(&output[i * kAesBlockNumBytes], block_out.data, nbytes);
+    memcpy(output, block_out.data, nbytes);
+    output += nbytes;
 
     // Update the counter block with inc32().
     block_inc32(&iv);
@@ -505,6 +157,7 @@ status_t aes_gcm_gctr(const aes_key_t key, const aes_block_t *icb,
  * @return `OTCRYPTO_OK` if the lengths are OK, and `OTCRYPTO_BAD_ARGS`
  * otherwise.
  */
+OT_WARN_UNUSED_RESULT
 static status_t check_buffer_lengths(const size_t iv_len,
                                      const size_t plaintext_len,
                                      const size_t aad_len) {
@@ -524,20 +177,17 @@ static status_t check_buffer_lengths(const size_t iv_len,
 }
 
 /**
- * Compute the hash subkey for AES-GCM.
- *
- * This routine computes the hash subkey H and the product table for H; see
- * `make_product_table` for representation details.
+ * Compute and set the hash subkey for AES-GCM.
  *
  * If any step in this process fails, the function returns an error and the
  * output should not be used.
  *
  * @param key AES key
- * @param[out] tbl Destination for the output hash subkey product table
+ * @param[out] ctx Destination GHASH context object
  * @return OK or error
  */
-static status_t aes_gcm_hash_subkey(const aes_key_t key,
-                                    aes_gcm_product_table_t *tbl) {
+OT_WARN_UNUSED_RESULT
+static status_t aes_gcm_hash_subkey(const aes_key_t key, ghash_context_t *ctx) {
   // Compute the initial hash subkey H = AES_K(0). Note that to get this
   // result from AES_CTR, we set both the IV and plaintext to zero; this way,
   // AES-CTR's final XOR with the plaintext does nothing.
@@ -546,8 +196,8 @@ static status_t aes_gcm_hash_subkey(const aes_key_t key,
   aes_block_t hash_subkey;
   HARDENED_TRY(aes_encrypt_block(key, &zero, &zero, &hash_subkey));
 
-  // Compute the product table for H.
-  make_product_table(&hash_subkey, tbl);
+  // Set the key for the GHASH context.
+  ghash_init_subkey(hash_subkey.data, ctx);
 
   return OTCRYPTO_OK;
 }
@@ -560,26 +210,28 @@ static status_t aes_gcm_hash_subkey(const aes_key_t key,
  *
  * @param iv_len IV length in bytes
  * @param iv IV value
- * @param tbl Product table for the hash subkey H
+ * @param ctx GHASH context with product table for hash subkey H
  * @param[out] j0 Destination for the output counter block
  * @return OK or error
  */
+OT_WARN_UNUSED_RESULT
 static status_t aes_gcm_counter(const size_t iv_len, const uint8_t *iv,
-                                aes_gcm_product_table_t *tbl, aes_block_t *j0) {
+                                ghash_context_t *ctx, aes_block_t *j0) {
   if (iv_len == 12) {
     // If the IV is 96 bits, then J0 = (IV || {0}^31 || 1).
     memcpy(j0->data, iv, iv_len);
     // Set the last word to 1 (as a big-endian integer).
-    j0->data[kAesBlockNumWords - 1] = reverse_bytes(1);
+    j0->data[kAesBlockNumWords - 1] = __builtin_bswap32(1);
   } else if (iv_len == 16) {
     // If the IV is 128 bits, then J0 = GHASH(H, IV || {0}^120 || 0x80), where
     // {0}^120 means 120 zero bits (15 0x00 bytes).
-    memset(j0->data, 0, kAesBlockNumBytes);
-    aes_gcm_ghash_update(tbl, iv_len, iv, j0);
+    ghash_init(ctx);
+    ghash_update(ctx, iv_len, iv);
     uint8_t buffer[kAesBlockNumBytes];
     memset(buffer, 0, kAesBlockNumBytes);
     buffer[kAesBlockNumBytes - 1] = 0x80;
-    aes_gcm_ghash_update(tbl, kAesBlockNumBytes, buffer, j0);
+    ghash_update(ctx, kAesBlockNumBytes, buffer);
+    ghash_final(ctx, j0->data);
   } else {
     // Should not happen; invalid IV length.
     return OTCRYPTO_BAD_ARGS;
@@ -592,7 +244,7 @@ static status_t aes_gcm_counter(const size_t iv_len, const uint8_t *iv,
  * Compute the AES-GCM authentication tag.
  *
  * @param key AES key
- * @param tbl Product table for the hash subkey H
+ * @param ctx GHASH context with precomputed table for hash subkey H
  * @param ciphertext_len Length of the ciphertext in bytes
  * @param ciphertext Ciphertext value
  * @param aad_len Length of the associated data in bytes
@@ -600,8 +252,8 @@ static status_t aes_gcm_counter(const size_t iv_len, const uint8_t *iv,
  * @param j0 Counter block (J0 in the NIST specification)
  * @param[out] tag Buffer for output tag (128 bits)
  */
-static status_t aes_gcm_compute_tag(const aes_key_t key,
-                                    const aes_gcm_product_table_t *tbl,
+OT_WARN_UNUSED_RESULT
+static status_t aes_gcm_compute_tag(const aes_key_t key, ghash_context_t *ctx,
                                     const size_t ciphertext_len,
                                     const uint8_t *ciphertext,
                                     const size_t aad_len, const uint8_t *aad,
@@ -615,10 +267,9 @@ static status_t aes_gcm_compute_tag(const aes_key_t key,
   //     big-endian 64-bit integer.
 
   // Compute GHASH(H, expand(A) || expand(C)).
-  aes_block_t s;
-  memset(s.data, 0, kAesBlockNumBytes);
-  aes_gcm_ghash_update(tbl, aad_len, aad, &s);
-  aes_gcm_ghash_update(tbl, ciphertext_len, ciphertext, &s);
+  ghash_init(ctx);
+  ghash_update(ctx, aad_len, aad);
+  ghash_update(ctx, ciphertext_len, ciphertext);
 
   // Compute len64(A) and len64(C) by computing the length in *bits* (shift by
   // 3) and then converting to big-endian.
@@ -628,7 +279,9 @@ static status_t aes_gcm_compute_tag(const aes_key_t key,
   };
 
   // Finish computing S by appending (len64(A) || len64(C)).
-  aes_gcm_ghash_update(tbl, kAesBlockNumBytes, (unsigned char *)last_block, &s);
+  ghash_update(ctx, kAesBlockNumBytes, (unsigned char *)last_block);
+  aes_block_t s;
+  ghash_final(ctx, s.data);
 
   // Compute the tag T = GCTR(K, J0, S).
   return aes_gcm_gctr(key, j0, kAesBlockNumBytes, (unsigned char *)s.data, tag);
@@ -642,13 +295,13 @@ status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
   // Check that the input parameter sizes are valid.
   HARDENED_TRY(check_buffer_lengths(iv_len, plaintext_len, aad_len));
 
-  // Compute the hash subkey H as a product table.
-  aes_gcm_product_table_t Htbl;
-  HARDENED_TRY(aes_gcm_hash_subkey(key, &Htbl));
+  // Initialize the hash subkey H.
+  ghash_context_t ctx;
+  HARDENED_TRY(aes_gcm_hash_subkey(key, &ctx));
 
   // Compute the counter block (called J0 in the NIST specification).
   aes_block_t j0;
-  HARDENED_TRY(aes_gcm_counter(iv_len, iv, &Htbl, &j0));
+  HARDENED_TRY(aes_gcm_counter(iv_len, iv, &ctx, &j0));
 
   // Compute inc32(J0).
   aes_block_t j0_inc;
@@ -660,8 +313,8 @@ status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
       aes_gcm_gctr(key, &j0_inc, plaintext_len, plaintext, ciphertext));
 
   // Compute the authentication tag T.
-  return aes_gcm_compute_tag(key, &Htbl, plaintext_len, ciphertext, aad_len,
-                             aad, &j0, tag);
+  return aes_gcm_compute_tag(key, &ctx, plaintext_len, ciphertext, aad_len, aad,
+                             &j0, tag);
 }
 
 status_t aes_gcm_decrypt(const aes_key_t key, const size_t iv_len,
@@ -672,17 +325,17 @@ status_t aes_gcm_decrypt(const aes_key_t key, const size_t iv_len,
   // Check that the input parameter sizes are valid.
   HARDENED_TRY(check_buffer_lengths(iv_len, ciphertext_len, aad_len));
 
-  // Compute the hash subkey H as a product table.
-  aes_gcm_product_table_t Htbl;
-  HARDENED_TRY(aes_gcm_hash_subkey(key, &Htbl));
+  // Initialize the hash subkey H.
+  ghash_context_t ctx;
+  HARDENED_TRY(aes_gcm_hash_subkey(key, &ctx));
 
   // Compute the counter block (called J0 in the NIST specification).
   aes_block_t j0;
-  HARDENED_TRY(aes_gcm_counter(iv_len, iv, &Htbl, &j0));
+  HARDENED_TRY(aes_gcm_counter(iv_len, iv, &ctx, &j0));
 
   // Compute the expected authentication tag T.
   uint32_t expected_tag[kAesGcmTagNumBytes];
-  HARDENED_TRY(aes_gcm_compute_tag(key, &Htbl, ciphertext_len, ciphertext,
+  HARDENED_TRY(aes_gcm_compute_tag(key, &ctx, ciphertext_len, ciphertext,
                                    aad_len, aad, &j0,
                                    (unsigned char *)expected_tag));
 

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
@@ -52,25 +52,6 @@ status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
                          const uint8_t *iv, const size_t plaintext_len,
                          const uint8_t *plaintext, const size_t aad_len,
                          const uint8_t *aad, uint8_t *ciphertext, uint8_t *tag);
-/**
- * GHASH operation as defined in NIST SP800-38D, algorithm 2.
- *
- * The input size must be a multiple of the block size.
- *
- * This operation is an internal subcomponent of GCM and should not be used
- * directly except for implementing alternative, customized GCM interfaces
- * (such as using a block cipher other than AES). For other ciphers, the block
- * size must still be 128 bits.
- *
- * @param hash_subkey The hash subkey (a 128-bit cipher block).
- * @param input_len Number of bytes in the input.
- * @param input Pointer to input buffer.
- * @param[out] output Block in which to store the output.
- * @return Error status; OK if no errors
- */
-OT_WARN_UNUSED_RESULT
-status_t aes_gcm_ghash(const aes_block_t *hash_subkey, const size_t input_len,
-                       const uint8_t *input, aes_block_t *output);
 
 /**
  * AES-GCM authenticated decryption as defined in NIST SP800-38D, algorithm 5.

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.c
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.c
@@ -1,0 +1,260 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/aes_gcm/ghash.h"
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('g', 'h', 'a')
+
+enum {
+  /**
+   * Log2 of the number of bytes in an AES block.
+   */
+  kGhashBlockLog2NumBytes = 4,
+  /**
+   * Number of windows for Galois field pre-computed tables.
+   *
+   * We suse 4-bit windows, so the number of windows is 2x the number of bytes
+   * in a block.
+   */
+  kNumWindows = kGhashBlockNumBytes << 1,
+};
+static_assert(kGhashBlockNumBytes == (1 << kGhashBlockLog2NumBytes),
+              "kGhashBlockLog2NumBytes does not match kGhashBlockNumBytes");
+
+/**
+ * Precomputed modular reduction constants for Galois field multiplication.
+ *
+ * This implementation uses 4-bit windows. The bytes here represent 12-bit
+ * little-endian values.
+ *
+ * The entry with index i in this table is equal to i * 0xe1, where the bytes i
+ * and 0xe1 are interpreted as polynomials in the GCM Galois field. For
+ * example, 0xe1 = 0b1110_0001 is the degree-8 polynomial x^8 + x^2 + x + 1.
+ *
+ * The field modulus for GCM is 2^128 + x^8 + x^2 + x + 1. Therefore, if a
+ * field element is shifted, it can be reduced by multiplying the high bits
+ * (128 and above) by 0xe1 and adding them to the low bits.
+ *
+ * There is a size/speed tradeoff in window size. For 8-bit windows, GHASH
+ * becomes significantly faster, but the overhead for computing the product
+ * table of a given hash subkey becomes higher, so larger windows are slower
+ * for smaller inputs but faster for large inputs.
+ */
+static const uint16_t kGFReduceTable[16] = {
+    0x0000, 0x201c, 0x4038, 0x6024, 0x8070, 0xa06c, 0xc048, 0xe054,
+    0x00e1, 0x20fd, 0x40d9, 0x60c5, 0x8091, 0xa08d, 0xc0a9, 0xe0b5};
+
+/**
+ * Performs a bitwise XOR of two blocks.
+ *
+ * This operation corresponds to addition in the Galois field.
+ *
+ * @param x First operand block
+ * @param y Second operand block
+ * @param[out] out Buffer in which to store output; can be the same as one or
+ * both operands.
+ */
+static inline void block_xor(const ghash_block_t *x, const ghash_block_t *y,
+                             ghash_block_t *out) {
+  for (size_t i = 0; i < kGhashBlockNumWords; ++i) {
+    out->data[i] = x->data[i] ^ y->data[i];
+  }
+}
+
+/**
+ * Logical right shift of an AES block.
+ *
+ * NIST represents AES blocks as big-endian, and a "right shift" in that
+ * representation means shifting out the LSB. However, the processor is
+ * little-endian, so we need to reverse the bytes before shifting.
+ *
+ * @param block Input AES block, modified in-place
+ * @param nbits Number of bits to shift
+ */
+static inline void block_shiftr(ghash_block_t *block, size_t nbits) {
+  // To perform a "right shift" with respect to the big-endian block
+  // representation, we traverse the words of the block and, for each word,
+  // reverse the bytes, save the new LSB as `carry`, shift right, set the MSB
+  // to the last block's carry, and then reverse the bytes back.
+  uint32_t carry = 0;
+  for (size_t i = 0; i < kGhashBlockNumWords; ++i) {
+    uint32_t rev = __builtin_bswap32(block->data[i]);
+    uint32_t next_carry = rev & ((1 << nbits) - 1);
+    rev >>= nbits;
+    rev |= carry << (32 - nbits);
+    carry = next_carry;
+    block->data[i] = __builtin_bswap32(rev);
+  }
+}
+
+/**
+ * Retrieve the byte at a given index from the block.
+ *
+ * @param block Input cipher block
+ * @param index Index of byte to retrieve (must be < `kGhashBlockNumBytes`)
+ * @return Value of block[index]
+ */
+static inline uint8_t block_byte_get(const ghash_block_t *block, size_t index) {
+  return ((char *)block->data)[index];
+}
+
+/**
+ * Multiply an element of the GCM Galois field by the polynomial `x`.
+ *
+ * This corresponds to a shift right in the bit representation, and then
+ * reduction with the field modulus.
+ *
+ * Runs in constant time.
+ *
+ * @param p Polynomial to be multiplied
+ * @param[out] out Buffer for output
+ */
+static inline void galois_mulx(const ghash_block_t *p, ghash_block_t *out) {
+  // Get the very rightmost bit of the input block (coefficient of x^127).
+  uint8_t p127 = block_byte_get(p, kGhashBlockNumBytes - 1) & 1;
+  // Set the output to p >> 1.
+  memcpy(out->data, p->data, kGhashBlockNumBytes);
+  block_shiftr(out, 1);
+  // If the highest coefficient was 1, then subtract the polynomial that
+  // corresponds to (modulus - 2^128).
+  uint32_t mask = 0 - p127;
+  out->data[0] ^= (0xe1 & mask);
+}
+
+/**
+ * Reverse the bits of a 4-bit number.
+ *
+ * @param byte Input byte.
+ * @return byte with lower 4 bits reversed and upper 4 unmodified.
+ */
+static uint8_t reverse_bits(uint8_t byte) {
+  /* TODO: replace with rev.n (from 0.93 draft of bitmanip) once bitmanip
+   * extension is enabled. */
+  uint8_t out = 0;
+  for (size_t i = 0; i < 4; ++i) {
+    out <<= 1;
+    out |= (byte >> i) & 1;
+  }
+  return out;
+}
+
+void ghash_init_subkey(const uint32_t *hash_subkey, ghash_context_t *ctx) {
+  // Initialize 0 * H = 0.
+  memset(ctx->tbl[0].data, 0, kGhashBlockNumBytes);
+  // Initialize 1 * H = H.
+  memcpy(ctx->tbl[0x8].data, hash_subkey, kGhashBlockNumBytes);
+
+  // To get remaining entries, we use a variant of "shift and add"; in
+  // polynomial terms, a shift is a multiplication by x. Note that, because the
+  // processor represents bytes with the MSB on the left and NIST uses a fully
+  // little-endian polynomial representation with the MSB on the right, we have
+  // to reverse the bits of the indices.
+  for (size_t i = 2; i < 16; i += 2) {
+    // Find the product corresponding to (i >> 1) * H and multiply by x to
+    // shift 1; this will be i * H.
+    galois_mulx(&ctx->tbl[reverse_bits(i >> 1)], &ctx->tbl[reverse_bits(i)]);
+
+    // Add H to i * H to get (i + 1) * H.
+    block_xor(&ctx->tbl[reverse_bits(i)], &ctx->tbl[0x8],
+              &ctx->tbl[reverse_bits(i + 1)]);
+  }
+}
+
+void ghash_init(ghash_context_t *ctx) {
+  memset(ctx->state.data, 0, kGhashBlockNumBytes);
+}
+
+/**
+ * Multiply the GHASH state by the hash subkey.
+ *
+ * See NIST SP800-38D, section 6.3.
+ *
+ * The NIST documentation shows a very slow double-and-add algorithm, which
+ * iterates through the first operand bit-by-bit. However, since the second
+ * operand is always the hash subkey H, we can speed things up significantly
+ * with precomputed tables.
+ *
+ * This operation corresponds to multiplication in the Galois field with order
+ * 2^128, modulo the polynomial x^128 +  x^8 + x^2 + x + 1
+ *
+ * @param ctx GHASH context, updated in place.
+ */
+static void galois_mul_state_key(ghash_context_t *ctx) {
+  // Initialize the multiplication result to 0.
+  ghash_block_t result;
+  memset(result.data, 0, kGhashBlockNumBytes);
+
+  // To compute the product, we iterate through the bytes of the input block,
+  // considering the most significant (in polynomial terms) first. For each
+  // byte b, we:
+  //   * multiply `result` by x^8 (shift all coefficients to the right)
+  //   * reduce the shifted `result` modulo the field modulus
+  //   * look up the product `b * H` and add it to `result`
+  //
+  // We can skip the shift and reduce steps on the first iteration, since
+  // `result` is 0.
+  for (size_t i = 0; i < kNumWindows; ++i) {
+    if (i != 0) {
+      // Save the most significant half-byte of `result` before shifting.
+      uint8_t overflow =
+          block_byte_get(&result, kGhashBlockNumBytes - 1) & 0x0f;
+      // Shift `result` to the right, discarding high bits.
+      block_shiftr(&result, 4);
+      // Look up the product of `overflow` and the low terms of the modulus in
+      // the precomputed table.
+      uint16_t reduce_term = kGFReduceTable[overflow];
+      // Add (xor) this product to the low bits to complete modular reduction.
+      // This works because (low + x^128 * high) is equivalent to (low + (x^128
+      // - modulus) * high).
+      result.data[0] ^= reduce_term;
+    }
+
+    // Add the product of the next window and H to `result`. We process the
+    // windows starting with the most significant polynomial terms, which means
+    // starting from the last byte and proceeding to the first.
+    uint8_t tbl_index = block_byte_get(&ctx->state, (kNumWindows - 1 - i) >> 1);
+
+    // Select the less significant 4 bits if i is even, or the more significant
+    // 4 bits if i is odd. This does not need to be constant time, since the
+    // values of i in this loop are constant.
+    if ((i & 1) == 1) {
+      tbl_index >>= 4;
+    } else {
+      tbl_index &= 0x0f;
+    }
+    block_xor(&result, &ctx->tbl[tbl_index], &result);
+  }
+
+  memcpy(ctx->state.data, result.data, kGhashBlockNumBytes);
+}
+
+void ghash_update(ghash_context_t *ctx, size_t input_len,
+                  const uint8_t *input) {
+  while (input_len > 0) {
+    // Construct block i of the input.
+    ghash_block_t input_block;
+    size_t nbytes = kGhashBlockNumBytes;
+    if (input_len < kGhashBlockNumBytes) {
+      // Last block may be partial; pad with zeroes.
+      memset(input_block.data, 0, kGhashBlockNumBytes);
+      nbytes = input_len;
+    }
+    memcpy(input_block.data, input, nbytes);
+    input_len -= nbytes;
+    input += nbytes;
+
+    // XOR `state` with the next input block.
+    block_xor(&ctx->state, &input_block, &ctx->state);
+    // Multiply state by H in-place.
+    galois_mul_state_key(ctx);
+  }
+}
+
+void ghash_final(ghash_context_t *ctx, uint32_t *result) {
+  memcpy(result, ctx->state.data, kGhashBlockNumBytes);
+}

--- a/sw/device/lib/crypto/impl/aes_gcm/ghash.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/ghash.h
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_GCM_GHASH_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_GCM_GHASH_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * Size of a GHASH cipher block (128 bits) in bytes.
+   */
+  kGhashBlockNumBytes = 128 / 8,
+  /**
+   * Size of a GHASH cipher block (128 bits) in words.
+   */
+  kGhashBlockNumWords = kGhashBlockNumBytes / sizeof(uint32_t),
+};
+
+/**
+ * A type that holds a single cipher block.
+ */
+typedef struct ghash_block {
+  uint32_t data[kGhashBlockNumWords];
+} ghash_block_t;
+
+typedef struct ghash_context {
+  /**
+   * Precomputed product table for the hash subkey.
+   */
+  ghash_block_t tbl[16];
+  /**
+   * Cipher block representing the current GHASH state.
+   */
+  ghash_block_t state;
+} ghash_context_t;
+
+/**
+ * Precompute hash subkey information for GHASH.
+ *
+ * This routine will precompute a product table for the hash subkey for the
+ * GHASH context. It will not set the state to 0; call `ghash_init` afterwards.
+ *
+ * This operation should only be called once per key, and afterwards the
+ * context object can be used for multiple separate GHASH operations with that
+ * key. The reason for separating this and `ghash_init` into two functions is
+ * that computing the product table is computationally expensive, and some GCM
+ * computations need to compute more than one separate GHASH operation.
+ *
+ * @param hash_subkey Subkey for the GHASH operation (`kGhashBlockNumWords`
+ * words).
+ * @param[out] ctx Context object with product table populated.
+ */
+void ghash_init_subkey(const uint32_t *hash_subkey, ghash_context_t *ctx);
+
+/**
+ * Start a GHASH operation.
+ *
+ * This routine will initialize the GHASH state within the context object to
+ * zero. It will not precompute the key product table; call `ghash_init_subkey`
+ * first.
+ *
+ * @param[out] ctx Context object with GHASH state reset to zero.
+ */
+void ghash_init(ghash_context_t *ctx);
+
+/**
+ * Update the state of a GHASH operation.
+ *
+ * Pads the input with 0s on the right-hand side if needed so that the input
+ * size is a multiple of the block size. Given a state representing GHASH(A)
+ * and a new input B, this function will return a state representing:
+ *   GHASH(A || B || <padding for B>)
+ *
+ * Initialize the context object with `ghash_init_subkey` and `ghash_init`
+ * before calling this function.
+ *
+ * @param ctx Context object.
+ * @param input_len Number of bytes in the input.
+ * @param input Pointer to input buffer.
+ */
+void ghash_update(ghash_context_t *ctx, size_t input_len, const uint8_t *input);
+
+/**
+ * Update the state of a GHASH operation.
+ *
+ * Pads the input with 0s on the right-hand side if needed so that the input
+ * size is a multiple of the block size. Given a state representing GHASH(A)
+ * and a new input B, this function will return a state representing:
+ *   GHASH(A || B || <padding for B>)
+ *
+ * Initialize the context object with `ghash_init_subkey` and `ghash_init`
+ * before calling this function.
+ *
+ * The caller must ensure that at least `kGhashBlockNumWords` words are
+ * allocated in the `result` buffer.
+ *
+ * @param ctx Context object.
+ * @param[out] result Buffer in which to write the GHASH result block
+ */
+void ghash_final(ghash_context_t *ctx, uint32_t *result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_GCM_GHASH_H_

--- a/sw/device/tests/crypto/aes_gcm_testutils.h
+++ b/sw/device/tests/crypto/aes_gcm_testutils.h
@@ -41,13 +41,15 @@ typedef struct aes_gcm_test {
   size_t aad_len;
   uint8_t *aad;
   /**
-   * Authentication tag.
-   */
-  uint8_t tag[16];
-  /**
    * Ciphertext (same length as plaintext).
    */
   uint8_t *ciphertext;
+  /**
+   * Authentication tag. If the tag is short, the last elements should be
+   * ignored.
+   */
+  size_t tag_len;
+  uint8_t tag[16];
 } aes_gcm_test_t;
 
 /**

--- a/sw/device/tests/crypto/aes_gcm_testvectors.h
+++ b/sw/device/tests/crypto/aes_gcm_testvectors.h
@@ -60,7 +60,7 @@ static uint8_t kCiphertext256[32] = {
     0xaa, 0x83, 0x6f, 0x29, 0xb0, 0xfa, 0x06, 0xcd, 0xd5, 0x75, 0xaa,
     0xb8, 0x23, 0x3f, 0x1d, 0xf9, 0x3e, 0x80, 0x16, 0x33, 0x71};
 
-const aes_gcm_test_t kAesGcmTestvectors[3] = {
+const aes_gcm_test_t kAesGcmTestvectors[] = {
     // Empty input, empty aad, 96-bit IV, 128-bit key
     {
         .key_len = ARRAYSIZE(kKey128),
@@ -74,11 +74,12 @@ const aes_gcm_test_t kAesGcmTestvectors[3] = {
         .plaintext = NULL,
         .aad_len = 0,
         .aad = NULL,
+        .ciphertext = NULL,
+        .tag_len = 16,
         .tag =
             {// Tag = b7aa223a6c75a0976633ce79d9fddf06
              0xb7, 0xaa, 0x22, 0x3a, 0x6c, 0x75, 0xa0, 0x97, 0x66, 0x33, 0xce,
              0x79, 0xd9, 0xfd, 0xdf, 0x06},
-        .ciphertext = NULL,
     },
 
     // Empty input, empty aad, 128-bit IV, 128-bit key
@@ -94,11 +95,12 @@ const aes_gcm_test_t kAesGcmTestvectors[3] = {
         .plaintext = NULL,
         .aad_len = 0,
         .aad = NULL,
+        .ciphertext = NULL,
+        .tag_len = 16,
         .tag =
             {// Tag = 4c59f0d420d9eb8669c40ad23b5419ba
              0x4c, 0x59, 0xf0, 0xd4, 0x20, 0xd9, 0xeb, 0x86, 0x69, 0xc4, 0x0a,
              0xd2, 0x3b, 0x54, 0x19, 0xba},
-        .ciphertext = NULL,
     },
 
     // 128-bit IV, 256-bit key, real message and aad
@@ -114,11 +116,33 @@ const aes_gcm_test_t kAesGcmTestvectors[3] = {
         .plaintext = kPlaintext,
         .aad_len = kAadLen,
         .aad = kAad,
+        .ciphertext = kCiphertext256,
+        .tag_len = 16,
         .tag =
             {// Tag = 324895b3d2f656e4fa2f8ce056137061
              0x32, 0x48, 0x95, 0xb3, 0xd2, 0xf6, 0x56, 0xe4, 0xfa, 0x2f, 0x8c,
              0xe0, 0x56, 0x13, 0x70, 0x61},
+    },
+
+    // 128-bit IV, 256-bit key, real message and aad, short tag
+    {
+        .key_len = ARRAYSIZE(kKey256),
+        .key = kKey256,
+        .iv_len = 16,
+        .iv =
+            {// IV = c58aded2e1bbecba8b16a5757e5475bd
+             0xc5, 0x8a, 0xde, 0xd2, 0xe1, 0xbb, 0xec, 0xba, 0x8b, 0x16, 0xa5,
+             0x75, 0x7e, 0x54, 0x75, 0xbd},
+        .plaintext_len = kPlaintextLen,
+        .plaintext = kPlaintext,
+        .aad_len = kAadLen,
+        .aad = kAad,
         .ciphertext = kCiphertext256,
+        .tag_len = 12,
+        .tag =
+            {// Tag = 324895b3d2f656e4fa2f8ce0
+             0x32, 0x48, 0x95, 0xb3, 0xd2, 0xf6, 0x56, 0xe4, 0xfa, 0x2f, 0x8c,
+             0xe0, 0, 0, 0, 0},
     },
 };
 

--- a/sw/device/tests/crypto/aes_gcm_timing_test.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_test.c
@@ -24,20 +24,25 @@
  * @param test Test vector to use
  */
 static void test_decrypt_timing(aes_gcm_test_t test) {
+  size_t tag_num_words = test.tag_len / sizeof(uint32_t);
+  CHECK(tag_num_words * sizeof(uint32_t) == test.tag_len,
+        "Tag length %d is not a multiple of the word size (%d).", test.tag_len,
+        sizeof(uint32_t));
+
   // Call AES-GCM decrypt with an incorrect tag (first word wrong).
   test.tag[0]++;
   uint32_t cycles_invalid1 = call_aes_gcm_decrypt(test, /*tag_valid=*/false);
   test.tag[0]--;
 
   // Call AES-GCM decrypt with an incorrect tag (middle word wrong).
-  test.tag[kAesGcmTagNumWords / 2]++;
+  test.tag[tag_num_words / 2]++;
   uint32_t cycles_invalid2 = call_aes_gcm_decrypt(test, /*tag_valid=*/false);
-  test.tag[kAesGcmTagNumWords / 2]--;
+  test.tag[tag_num_words / 2]--;
 
   // Call AES-GCM decrypt with an incorrect tag (last word wrong).
-  test.tag[kAesGcmTagNumWords - 1]++;
+  test.tag[tag_num_words - 1]++;
   uint32_t cycles_invalid3 = call_aes_gcm_decrypt(test, /*tag_valid=*/false);
-  test.tag[kAesGcmTagNumWords - 1]--;
+  test.tag[tag_num_words - 1]--;
 
   // Check that the cycle counts for the invalid tags match.
   CHECK(cycles_invalid1 == cycles_invalid2,


### PR DESCRIPTION
- Move GHASH operations into their own file that does not depend on AES
  - in addition to nicer code organization, this will make it possible to unit-test GHASH specifically
- Add support for short tags and a test case

All this will help connect AES-GCM to the top-level API.

**Notes for reviewers:**
- Most of this PR just moves code from one file to another. The first commit mainly does the moving of code without much modification, and the second has an actual modification (adding short tags).
- The AES-GCM implementation is currently constant-time but otherwise completely unhardened; hardening will come at a later stage of the cryptolib's development schedule.