### PR TITLE
Update pulp_riscv_dbg to pulp-platform/riscv-dbg@138d74bcaa

### DIFF
--- a/hw/vendor/pulp_riscv_dbg.lock.hjson
+++ b/hw/vendor/pulp_riscv_dbg.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/riscv-dbg
-    rev: 09c8d7a4e67f6bde756c4de6319d87e929faf188
+    rev: 138d74bcaa90c70180c12215db3776813d2a95f2
   }
 }

--- a/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
+++ b/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [0.8.0] - 2023-04-05
+### Fixed
+- dm_csrs: Fix W1C behavior of `sberror` (#155) [@andreaskurth](https://github.com/andreaskurth)
+- gen_rom.py: Port to python3 (#152) [@andreaskurth](https://github.com/andreaskurth)
+
+### Added
+- `xprop_off` to Xprop-incompatible processes (#151) [@andreaskurth](https://github.com/andreaskurth)
+
 ## [0.7.0] - 2022-11-02
 ### Fixed
 - 64-bit unaligned accesses (#145) [@creinwar](https://github.com/creinwar)

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -457,7 +457,7 @@ module dm_csrs #(
             sbcs_d = sbcs;
             // R/W1C
             sbcs_d.sbbusyerror = sbcs_q.sbbusyerror & (~sbcs.sbbusyerror);
-            sbcs_d.sberror     = sbcs_q.sberror     & {3{~(sbcs.sberror == 3'd1)}};
+            sbcs_d.sberror     = (|sbcs.sberror) ? 3'b0 : sbcs_q.sberror;
           end
         end
         dm::SBAddress0: begin


### PR DESCRIPTION
Update code from upstream repository https://github.com/pulp-platform/riscv-dbg to revision
138d74bcaa90c70180c12215db3776813d2a95f2

* Update CHANGELOG.md (bluew)
* dm_csrs: Fix W1C behavior of `sberror` (Andreas Kurth)

This should fix a problem with `rom_e2e_debug_test_otp_test_unlocked0` described in https://github.com/lowRISC/opentitan/issues/17729.