### PR TITLE
Spi host flash profiling

### DIFF
--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -171,15 +171,14 @@
  * equal rather than aborting.
  */
 #define TRY_CHECK_ARRAYS_EQ(actual_, expected_, num_items_, ...) \
-  TRY(CHECK_ARRAYS_EQ_IMPL(true, actual_, expected_, num_items_, ##__VA_ARGS__))
+  TRY(CHECK_ARRAYS_IMPL(true, actual_, expected_, num_items_, ##__VA_ARGS__))
 
 /**
  * Same as `CHECK_ARRAYS_NE` above but returns `kInternal` if the arrays are not
  * equal rather than aborting.
  */
-#define TRY_CHECK_ARRAYS_NE(actual_, expected_, num_items_, ...)  \
-  TRY(CHECK_ARRAYS_EQ_IMPL(false, actual_, expected_, num_items_, \
-                           ##__VA_ARGS__))
+#define TRY_CHECK_ARRAYS_NE(actual_, expected_, num_items_, ...) \
+  TRY(CHECK_ARRAYS_IMPL(false, actual_, expected_, num_items_, ##__VA_ARGS__))
 
 /**
  * Compare `num_items_` of `actual_` against `not_expected_` buffer.

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -62,8 +62,8 @@ status_t test_read_sfdp(void) {
   TRY(spi_flash_testutils_read_sfdp(&spi_host, 0, sfdp.data,
                                     sizeof(sfdp.data)));
   LOG_INFO("SFDP signature is 0x%08x", sfdp.header.signature);
-  TRY_CHECK(sfdp.header.signature == kSfdpSignature,
-            "Expected to find the SFDP signature!");
+  CHECK(sfdp.header.signature == kSfdpSignature,
+        "Expected to find the SFDP signature!");
 
   uint32_t bfpt_offset = sfdp.param.table_pointer[0] |
                          sfdp.param.table_pointer[1] << 8 |
@@ -85,7 +85,7 @@ status_t test_chip_erase(void) {
                                   /*dummy=*/0));
   uint8_t expected[256];
   memset(expected, 0xFF, sizeof(expected));
-  CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
+  TRY_CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
   return OK_STATUS();
 }
 
@@ -101,9 +101,9 @@ status_t test_enable_quad_mode(void) {
 
 // Program a pattern into the flash part and read it back.
 status_t test_page_program(void) {
-  spi_flash_testutils_program_page(&spi_host, kGettysburgPrelude,
-                                   sizeof(kGettysburgPrelude),
-                                   /*address=*/0, /*addr_is_4b=*/0);
+  TRY(spi_flash_testutils_program_page(&spi_host, kGettysburgPrelude,
+                                       sizeof(kGettysburgPrelude),
+                                       /*address=*/0, /*addr_is_4b=*/0));
 
   uint8_t buf[256];
   TRY(spi_flash_testutils_read_op(&spi_host, kSpiDeviceFlashOpReadNormal, buf,
@@ -111,7 +111,7 @@ status_t test_page_program(void) {
                                   /*addr_is_4b=*/false,
                                   /*width=*/1,
                                   /*dummy=*/0));
-  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
   return OK_STATUS();
 }
 
@@ -123,7 +123,7 @@ status_t test_fast_read(void) {
                                   /*addr_is_4b=*/false,
                                   /*width=*/1,
                                   /*dummy=*/8));
-  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
   return OK_STATUS();
 }
 
@@ -135,7 +135,7 @@ status_t test_dual_read(void) {
                                   /*addr_is_4b=*/false,
                                   /*width=*/2,
                                   /*dummy=*/8));
-  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
   return OK_STATUS();
 }
 
@@ -147,7 +147,7 @@ status_t test_quad_read(void) {
                                   /*addr_is_4b=*/false,
                                   /*width=*/4,
                                   /*dummy=*/8));
-  CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
   return OK_STATUS();
 }
 


### PR DESCRIPTION
This PR:
 - Fixup the `TRY_CHECK_ARRAYS_*` macros
 - Replace `CHECK_ARRAYS_EQ` for `TRY_CHECK_ARRAYS_EQ`  in the `spi_host_flash_smoketest.c`
 - Add profiling to the EXECUTE_TEST macro to get this log:
 <details>
  <summary>Log</summary>

```
[2023-04-05T16:15:07Z INFO  opentitanlib::io::uart] set_flow_control to false
I00000 test_rom.c:155] Version: earlgrey_silver_release_v5-10276-gff2806c8a, Build Date: 2023-04-03 12:12:55
I00001 test_rom.c:179] TestROM:876f4548
I00002 test_rom.c:196] Boot strap requested
I00000 test_rom.c:155] Version: earlgrey_silver_release_v5-10276-gff2806c8a, Build Date: 2023-04-03 12:12:55
I00001 test_rom.c:179] TestROM:876f4548
I00002 test_rom.c:236] Test ROM complete, jumping to flash (addr: 20000480)!
I00000 ottf_main.c:110] Running sw/device/tests/spi_host_smoketest.c
I00001 spi_host_smoketest.c:168] Starting test test_software_reset...
I00002 spi_host_smoketest.c:168] Successfully finished test test_software_reset in 852 cycles or 85 us @ 10 MHz.
I00003 spi_host_smoketest.c:169] Starting test test_read_sfdp...
I00004 spi_host_smoketest.c:64] SFDP signature is 0x50444653
I00005 spi_host_smoketest.c:169] Successfully finished test test_read_sfdp in 68524 cycles or 6852 us @ 10 MHz.
I00006 spi_host_smoketest.c:170] Starting test test_chip_erase...
I00007 spi_host_smoketest.c:170] Successfully finished test test_chip_erase in 245408512 cycles or 24540851 us @ 10 MHz.
I00008 spi_host_smoketest.c:171] Starting test test_enable_quad_mode...
I00009 spi_host_smoketest.c:97] Setting the EEPROM's QE bit via mechanism 2
I00010 spi_host_smoketest.c:171] Successfully finished test test_enable_quad_mode in 78905 cycles or 7890 us @ 10 MHz.
I00011 spi_host_smoketest.c:172] Starting test test_page_program...
I00012 spi_host_smoketest.c:172] Successfully finished test test_page_program in 18869 cycles or 1886 us @ 10 MHz.
I00013 spi_host_smoketest.c:173] Starting test test_fast_read...
I00014 spi_host_smoketest.c:173] Successfully finished test test_fast_read in 8570 cycles or 857 us @ 10 MHz.
I00015 spi_host_smoketest.c:174] Starting test test_dual_read...
I00016 spi_host_smoketest.c:174] Successfully finished test test_dual_read in 8568 cycles or 856 us @ 10 MHz.
I00017 spi_host_smoketest.c:175] Starting test test_quad_read...
I00018 spi_host_smoketest.c:175] Successfully finished test test_quad_read in 8579 cycles or 857 us @ 10 MHz.
I00019 ottf_main.c:86] Finished sw/device/tests/spi_host_smoketest.c
I00020 status.c:28] PASS!
```
 </details>