### PR TITLE
[dv/xbar] Add exclusion for dv modules

### DIFF
--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
@@ -18,6 +18,8 @@
 -node tb.dut tl_*.d_param
 -node tb.dut tl_*.d_opcode[2:1]
 
+-moduletree prim_cdc_rand_delay  // exclude DV construct.
+
 // [UNR] these device address bits are always 0
 -node tb.dut tl_rv_dm__regs_o.a_address[20:2]
 -node tb.dut tl_rv_dm__regs_o.a_address[23:22]

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
@@ -18,6 +18,8 @@
 -node tb.dut tl_*.d_param
 -node tb.dut tl_*.d_opcode[2:1]
 
+-moduletree prim_cdc_rand_delay  // exclude DV construct.
+
 // [UNR] these device address bits are always 0
 -node tb.dut tl_uart0_o.a_address[29:6]
 -node tb.dut tl_uart0_o.a_address[31:31]

--- a/util/tlgen/xbar_cover.cfg.tpl
+++ b/util/tlgen/xbar_cover.cfg.tpl
@@ -28,6 +28,8 @@
 -node tb.dut tl_*.d_param
 -node tb.dut tl_*.d_opcode[2:1]
 
+-moduletree prim_cdc_rand_delay  // exclude DV construct.
+
 // [UNR] these device address bits are always 0
 % for device in xbar.devices:
 <%


### PR DESCRIPTION
This PR adds an exclusion for DV cdc module. We should not collect non-RTL code coverage.