### PR TITLE
Disable ccache under Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,6 +62,9 @@ build:ot_coverage_on_target --per_file_copt='//sw/device/silicon_creator[/:].*,/
 # Needed to be able to build host binaries while collecting coverage.
 coverage:ot_coverage_on_target --platforms=""
 
+# Disable ccache if it happens to be installed
+build --define=CCACHE_DISABLE=true
+
 # Configuration to override resource constrained test
 # scheduling. Enable with `--config=local_test_jobs_per_cpus`
 test:local_test_jobs_per_cpus --local_test_jobs=HOST_CPUS*0.22


### PR DESCRIPTION
The combination doesn't really work, mainly because ccache is trying to write to a cache file on a read-only file system. This isn't unreasonable though: the two programs are trying to do the same job!

Passing a "don't actually cache anything" flag like this to ccache seems to be the easiest way to tell things to work under Bazel without requiring the user to uninstall ccache from their computer.

Note that 141f6e3fd is also to do with ccache interaction. But that's specifically for OpenOCD. I *think* that this change probably means that the 141f6e3fd won't be necessary any more, but I haven't actually checked.