### PR TITLE
[crypto] Connect ECDSA-P256 to top-level API.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -4,6 +4,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
 cc_library(
     name = "aes",
     srcs = ["aes.c"],
@@ -31,7 +33,11 @@ cc_library(
     name = "ecc",
     srcs = ["ecc.c"],
     hdrs = ["//sw/device/lib/crypto/include:ecc.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":keyblob",
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl/ecc:ecdsa_p256",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -4,6 +4,10 @@
 
 #include "sw/device/lib/crypto/include/ecc.h"
 
+#include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p256.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
 // Module ID for status codes.
@@ -12,25 +16,49 @@
 crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
                                       crypto_blinded_key_t *private_key,
                                       ecc_public_key_t *public_key) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+  const crypto_key_config_t config = private_key->config;
+  crypto_status_t err =
+      otcrypto_ecdsa_keygen_async_start(elliptic_curve, &config);
+  // TODO(#17803): replace this error check with HARDENED_TRY if cryptolib and
+  // status_t errors become more compatible.
+  if (launder32(err) != kCryptoStatusOK) {
+    return err;
+  }
+  HARDENED_CHECK_EQ(err, kCryptoStatusOK);
+  return otcrypto_ecdsa_keygen_async_finalize(elliptic_curve, private_key,
+                                              public_key);
 }
 
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     crypto_const_uint8_buf_t input_message,
                                     const ecc_curve_t *elliptic_curve,
-                                    ecc_signature_t *signature) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+                                    const ecc_signature_t *signature) {
+  crypto_status_t err = otcrypto_ecdsa_sign_async_start(
+      private_key, input_message, elliptic_curve);
+  // TODO(#17803): replace this error check with HARDENED_TRY if cryptolib and
+  // status_t errors become more compatible.
+  if (launder32(err) != kCryptoStatusOK) {
+    return err;
+  }
+  HARDENED_CHECK_EQ(err, kCryptoStatusOK);
+  return otcrypto_ecdsa_sign_async_finalize(elliptic_curve, signature);
 }
 
 crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
                                       crypto_const_uint8_buf_t input_message,
-                                      ecc_signature_t *signature,
+                                      const ecc_signature_t *signature,
                                       const ecc_curve_t *elliptic_curve,
                                       hardened_bool_t *verification_result) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+  crypto_status_t err = otcrypto_ecdsa_verify_async_start(
+      public_key, input_message, signature, elliptic_curve);
+  // TODO(#17803): replace this error check with HARDENED_TRY if cryptolib and
+  // status_t errors become more compatible.
+  if (launder32(err) != kCryptoStatusOK) {
+    return err;
+  }
+  HARDENED_CHECK_EQ(err, kCryptoStatusOK);
+  return otcrypto_ecdsa_verify_async_finalize(elliptic_curve, signature,
+                                              verification_result);
 }
 
 crypto_status_t otcrypto_ecdh_keygen(const ecc_curve_t *elliptic_curve,
@@ -57,7 +85,7 @@ crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
                                       crypto_const_uint8_buf_t input_message,
                                       eddsa_sign_mode_t sign_mode,
-                                      ecc_signature_t *signature) {
+                                      const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -65,7 +93,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature, hardened_bool_t *verification_result) {
+    const ecc_signature_t *signature, hardened_bool_t *verification_result) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -83,48 +111,539 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
   return kCryptoStatusNotImplemented;
 }
 
+/**
+ * Consistency checks for caller-provided private key configurations.
+ *
+ * This check ensures:
+ *   - The key length in the configuration matches the given curve
+ *   - The key mode matches expectations.
+ *
+ * @param elliptic_curve Curve for which key is intended.
+ * @param config Private key configuration.
+ * @param expected_mode Expected key mode.
+ * @returns OK if the check passes, BAD_ARGS otherwise.
+ */
+static status_t key_config_check(const ecc_curve_t *elliptic_curve,
+                                 const crypto_key_config_t *config,
+                                 key_mode_t expected_mode) {
+  // Check the key mode.
+  if (config->key_mode != expected_mode) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(config->key_mode, expected_mode);
+
+  // Check the key length.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      if (launder32(config->key_length) != kP256ScalarBytes) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(config->key_length, kP256ScalarBytes);
+      return OTCRYPTO_OK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return OTCRYPTO_NOT_IMPLEMENTED;
+    default:
+      // Unrecognized curve type.
+      return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return OTCRYPTO_FATAL_ERR;
+}
+
 crypto_status_t otcrypto_ecdsa_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config) {
+  if (elliptic_curve == NULL || config == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  if (config->hw_backed != kHardenedBoolFalse) {
+    // TODO: Implement support for sideloaded keys.
+    return kCryptoStatusNotImplemented;
+  }
+
+  // Check the key configuration.
+  OTCRYPTO_TRY_INTERPRET(
+      key_config_check(elliptic_curve, config, kKeyModeEcdsa));
+
+  // Select the correct keygen operation and start it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(ecdsa_p256_keygen_start());
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}
+
+/**
+ * Check the lengths of private keys for curve P-256.
+ *
+ * Checks the length of caller-allocated buffers for a P-256 private key. This
+ * function may be used for both ECDSA and ECDH keys, since the key structure
+ * is the same.
+ *
+ * @param private_key Private key struct to check.
+ * @return OK if the lengths are correct or BAD_ARGS otherwise.
+ */
+static status_t p256_private_key_length_check(
+    const crypto_blinded_key_t *private_key) {
+  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+    // TODO: Implement support for sideloaded keys.
+    return OTCRYPTO_NOT_IMPLEMENTED;
+  }
+
+  // Since sideloaded keys are not supported, the keyblob may not be NULL.
+  if (private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Check the single-share length.
+  if (keyblob_share_num_words(private_key->config) !=
+      kP256MaskedScalarShareWords) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Check the keyblob length.
+  if (launder32(private_key->keyblob_length) !=
+      keyblob_num_words(private_key->config) * sizeof(uint32_t)) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Check the lengths of public keys for curve P-256.
+ *
+ * Checks the length of caller-allocated buffers for a P-256 public key. This
+ * function may be used for both ECDSA and ECDH keys, since the key structure
+ * is the same.
+ *
+ * @param public_key Public key struct to check.
+ * @return OK if the lengths are correct or BAD_ARGS otherwise.
+ */
+static status_t p256_public_key_length_check(
+    const ecc_public_key_t *public_key) {
+  if (launder32(public_key->x.key_length) != kP256CoordBytes ||
+      launder32(public_key->y.key_length != kP256CoordBytes)) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(public_key->x.key_length, kP256CoordBytes);
+  HARDENED_CHECK_EQ(public_key->y.key_length, kP256CoordBytes);
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Finalize an ECDSA key generation operation for curve P-256.
+ *
+ * This function assumes that space is already allocated for all key material
+ * and that the length parameters on the structs are set accordingly, in the
+ * same way as for `otcrypto_ecdsa_keygen_async_finalize`.
+ *
+ * @param[out] private_key Private key to populate.
+ * @param[out] public_key Public key to populate.
+ * @return OK or error.
+ */
+static status_t internal_ecdsa_p256_keygen_finalize(
+    crypto_blinded_key_t *private_key, ecc_public_key_t *public_key) {
+  // Check the lengths of caller-allocated buffers.
+  HARDENED_TRY(p256_private_key_length_check(private_key));
+  HARDENED_TRY(p256_public_key_length_check(public_key));
+
+  // Note: This operation wipes DMEM after retrieving the keys, so if an error
+  // occurs after this point then the keys would be unrecoverable. This should
+  // be the last potentially error-causing line before returning to the caller.
+  p256_masked_scalar_t sk;
+  p256_point_t pk;
+  HARDENED_TRY(ecdsa_p256_keygen_finalize(&sk, &pk));
+
+  // Prepare the private key.
+  keyblob_from_shares(sk.share0, sk.share1, private_key->config,
+                      private_key->keyblob);
+  private_key->checksum = integrity_blinded_checksum(private_key);
+
+  // Prepare the public key.
+  memcpy(public_key->x.key, pk.x, kP256CoordBytes);
+  memcpy(public_key->y.key, pk.y, kP256CoordBytes);
+  public_key->x.checksum = integrity_unblinded_checksum(&public_key->x);
+  public_key->y.checksum = integrity_unblinded_checksum(&public_key->y);
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Consistency checks for caller-provided public keys.
+ *
+ * Checks for NULL pointers within the struct and ensures that the key mode is
+ * as expected. Does not check integrity or length.
+ *
+ * @param public_key Caller-provided public key struct.
+ * @param expected_mode Expected key mode.
+ */
+static status_t ecc_public_key_check(ecc_public_key_t *public_key,
+                                     key_mode_t expected_mode) {
+  // Check for null pointers.
+  if (public_key->x.key == NULL || public_key->y.key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Check the mode.
+  if (public_key->x.key_mode != expected_mode ||
+      public_key->y.key_mode != expected_mode) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(public_key->x.key_mode, expected_mode);
+  HARDENED_CHECK_EQ(public_key->y.key_mode, expected_mode);
+
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
     const ecc_curve_t *elliptic_curve, crypto_blinded_key_t *private_key,
     ecc_public_key_t *public_key) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+  // Check for any NULL pointers.
+  if (elliptic_curve == NULL || private_key == NULL || public_key == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Consistency check for the public key.
+  OTCRYPTO_TRY_INTERPRET(ecc_public_key_check(public_key, kKeyModeEcdsa));
+
+  // Consistency check for the private key configuration.
+  OTCRYPTO_TRY_INTERPRET(
+      key_config_check(elliptic_curve, &private_key->config, kKeyModeEcdsa));
+
+  // Select the correct keygen operation and finalize it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(
+          internal_ecdsa_p256_keygen_finalize(private_key, public_key));
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}
+
+/**
+ * Start an ECDSA signature generation operation for curve P-256.
+ *
+ * @param private_key Private key to sign with.
+ * @param input_message Message to sign.
+ * @return OK or error.
+ */
+static status_t internal_ecdsa_p256_sign_start(
+    const crypto_blinded_key_t *private_key,
+    crypto_const_uint8_buf_t input_message) {
+  if (private_key->config.hw_backed != kHardenedBoolFalse) {
+    // TODO: Implement support for sideloaded keys.
+    return OTCRYPTO_NOT_IMPLEMENTED;
+  }
+
+  // Check the private key size.
+  HARDENED_TRY(p256_private_key_length_check(private_key));
+
+  // Get pointers to the individual shares within the blinded key.
+  uint32_t *share0;
+  uint32_t *share1;
+  HARDENED_TRY(keyblob_to_shares(private_key, &share0, &share1));
+
+  // Copy the shares into a P256-specific struct.
+  p256_masked_scalar_t sk;
+  memcpy(sk.share0, share0, sizeof(sk.share0));
+  memcpy(sk.share1, share1, sizeof(sk.share1));
+
+  // Get the SHA256 digest of the message.
+  hmac_sha256_init();
+  hmac_update(input_message.data, input_message.len);
+  hmac_digest_t digest;
+  hmac_final(&digest);
+
+  // Start the asynchronous signature-generation routine.
+  return ecdsa_p256_sign_start(digest.digest, &sk);
 }
 
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
     crypto_const_uint8_buf_t input_message, const ecc_curve_t *elliptic_curve) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+  if (private_key == NULL || elliptic_curve == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  if (input_message.data == NULL && input_message.len != 0) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check the integrity of the private key.
+  if (integrity_blinded_key_check(private_key) != kHardenedBoolTrue) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check the private key configuration.
+  OTCRYPTO_TRY_INTERPRET(
+      key_config_check(elliptic_curve, &private_key->config, kKeyModeEcdsa));
+
+  // Select the correct signing operation and start it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(
+          internal_ecdsa_p256_sign_start(private_key, input_message));
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}
+
+/**
+ * Finalize an ECDSA signature generation operation for curve P-256.
+ *
+ * This function assumes that space is already allocated for the signature and
+ * that the length parameters on the struct are set accordingly, in the same
+ * way as for `otcrypto_ecdsa_sign_async_finalize`.
+ *
+ * @param[out] signature Caller-allocated buffer for the signature.
+ * @return OK or error.
+ */
+static status_t internal_ecdsa_p256_sign_finalize(
+    const ecc_signature_t *signature) {
+  // Check the lengths of caller-allocated buffers.
+  if (signature->len_r != kP256ScalarBytes ||
+      signature->len_s != kP256ScalarBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(signature->len_r, kP256ScalarBytes);
+  HARDENED_CHECK_EQ(signature->len_s, kP256ScalarBytes);
+
+  // Note: This operation wipes DMEM, so if an error occurs after this point
+  // then the singature would be unrecoverable. This should be the last
+  // potentially error-causing line before returning to the caller.
+  ecdsa_p256_signature_t sig;
+  HARDENED_TRY(ecdsa_p256_sign_finalize(&sig));
+
+  // Copy the signature to the caller.
+  memcpy(signature->r, sig.r, kP256ScalarBytes);
+  memcpy(signature->s, sig.s, kP256ScalarBytes);
+
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_ecdsa_sign_async_finalize(
-    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+    const ecc_curve_t *elliptic_curve, const ecc_signature_t *signature) {
+  if (elliptic_curve == NULL || signature == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Select the correct signing operation and start it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(internal_ecdsa_p256_sign_finalize(signature));
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}
+
+/**
+ * Start an ECDSA signature verification operation for curve P-256.
+ *
+ * @param public_key Public key to check against.
+ * @param input_message Message to check against.
+ * @param signature Signature to verify.
+ * @return OK or error.
+ */
+static status_t internal_ecdsa_p256_verify_start(
+    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    const ecc_signature_t *signature) {
+  // Check the public key size.
+  HARDENED_TRY(p256_public_key_length_check(public_key));
+
+  // Copy the public key into a P256-specific struct.
+  p256_point_t pk;
+  memcpy(pk.x, public_key->x.key, sizeof(pk.x));
+  memcpy(pk.y, public_key->y.key, sizeof(pk.y));
+
+  // Check the signature lengths.
+  if (signature->len_r != kP256ScalarBytes ||
+      signature->len_s != kP256ScalarBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(signature->len_r, kP256ScalarBytes);
+  HARDENED_CHECK_EQ(signature->len_s, kP256ScalarBytes);
+
+  // Copy the signature into a P256-specific struct.
+  ecdsa_p256_signature_t sig;
+  memcpy(sig.r, signature->r, sizeof(sig.r));
+  memcpy(sig.s, signature->s, sizeof(sig.s));
+
+  // Get the SHA256 digest of the message.
+  hmac_sha256_init();
+  hmac_update(input_message.data, input_message.len);
+  hmac_digest_t digest;
+  hmac_final(&digest);
+
+  // Start the asynchronous signature-verification routine.
+  return ecdsa_p256_verify_start(&sig, digest.digest, &pk);
 }
 
 crypto_status_t otcrypto_ecdsa_verify_async_start(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, const ecc_curve_t *elliptic_curve) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+    const ecc_signature_t *signature, const ecc_curve_t *elliptic_curve) {
+  if (public_key == NULL || elliptic_curve == NULL || signature == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  if (input_message.data == NULL && input_message.len != 0) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check the integrity of the public key.
+  if (launder32(integrity_unblinded_key_check(&public_key->x)) !=
+          kHardenedBoolTrue ||
+      launder32(integrity_unblinded_key_check(&public_key->y)) !=
+          kHardenedBoolTrue) {
+    return kCryptoStatusBadArgs;
+  }
+  HARDENED_CHECK_EQ(integrity_unblinded_key_check(&public_key->x),
+                    kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(integrity_unblinded_key_check(&public_key->y),
+                    kHardenedBoolTrue);
+
+  // Select the correct verification operation and start it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(internal_ecdsa_p256_verify_start(
+          public_key, input_message, signature));
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
+}
+
+/**
+ * Finalize an ECDSA signature verification operation for curve P-256.
+ *
+ * @param verification_result Whether the signature passed verification.
+ * @return OK or error.
+ */
+static status_t internal_ecdsa_p256_verify_finalize(
+    const ecc_signature_t *signature, hardened_bool_t *verification_result) {
+  // Check the signature lengths.
+  if (signature->len_r != kP256ScalarBytes ||
+      signature->len_s != kP256ScalarBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(signature->len_r, kP256ScalarBytes);
+  HARDENED_CHECK_EQ(signature->len_s, kP256ScalarBytes);
+
+  // Copy the signature into a P256-specific struct.
+  ecdsa_p256_signature_t sig;
+  memcpy(sig.r, signature->r, sizeof(sig.r));
+  memcpy(sig.s, signature->s, sizeof(sig.s));
+
+  // Retrieve the result of the verification operation.
+  return ecdsa_p256_verify_finalize(&sig, verification_result);
 }
 
 crypto_status_t otcrypto_ecdsa_verify_async_finalize(
-    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature,
+    const ecc_curve_t *elliptic_curve, const ecc_signature_t *signature,
     hardened_bool_t *verification_result) {
-  // TODO: Connect ECDSA operations to API.
-  return kCryptoStatusNotImplemented;
+  if (elliptic_curve == NULL || verification_result == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Select the correct verification operation and finalize it.
+  switch (launder32(elliptic_curve->curve_type)) {
+    case kEccCurveTypeNistP256:
+      HARDENED_CHECK_EQ(elliptic_curve->curve_type, kEccCurveTypeNistP256);
+      OTCRYPTO_TRY_INTERPRET(
+          internal_ecdsa_p256_verify_finalize(signature, verification_result));
+      return kCryptoStatusOK;
+    case kEccCurveTypeNistP384:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeBrainpoolP256R1:
+      OT_FALLTHROUGH_INTENDED;
+    case kEccCurveTypeCustom:
+      // TODO: Implement support for other curves.
+      return kCryptoStatusNotImplemented;
+    default:
+      return kCryptoStatusBadArgs;
+  }
+
+  // Should never get here.
+  HARDENED_UNREACHABLE();
+  return kCryptoStatusFatalError;
 }
 
 crypto_status_t otcrypto_ecdh_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config) {
+    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config) {
   // TODO: Connect ECDH operations to API.
   return kCryptoStatusNotImplemented;
 }
@@ -150,7 +669,7 @@ crypto_status_t otcrypto_ecdh_async_finalize(
 }
 
 crypto_status_t otcrypto_ed25519_keygen_async_start(
-    crypto_key_config_t *config) {
+    const crypto_key_config_t *config) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -164,13 +683,13 @@ crypto_status_t otcrypto_ed25519_keygen_async_finalize(
 crypto_status_t otcrypto_ed25519_sign_async_start(
     const crypto_blinded_key_t *private_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature) {
+    const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
 
 crypto_status_t otcrypto_ed25519_sign_async_finalize(
-    ecc_signature_t *signature) {
+    const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -178,7 +697,7 @@ crypto_status_t otcrypto_ed25519_sign_async_finalize(
 crypto_status_t otcrypto_ed25519_verify_async_start(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature) {
+    const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }
@@ -190,7 +709,7 @@ crypto_status_t otcrypto_ed25519_verify_async_finalize(
 }
 
 crypto_status_t otcrypto_x25519_keygen_async_start(
-    crypto_key_config_t *config) {
+    const crypto_key_config_t *config) {
   // TODO: X25519 is not yet implemented.
   return kCryptoStatusNotImplemented;
 }

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -149,7 +149,7 @@ crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
                                     crypto_const_uint8_buf_t input_message,
                                     const ecc_curve_t *elliptic_curve,
-                                    ecc_signature_t *signature);
+                                    const ecc_signature_t *signature);
 
 /**
  * Performs the ECDSA digital signature verification.
@@ -168,7 +168,7 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  */
 crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
                                       crypto_const_uint8_buf_t input_message,
-                                      ecc_signature_t *signature,
+                                      const ecc_signature_t *signature,
                                       const ecc_curve_t *elliptic_curve,
                                       hardened_bool_t *verification_result);
 
@@ -253,7 +253,7 @@ crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
                                       crypto_const_uint8_buf_t input_message,
                                       eddsa_sign_mode_t sign_mode,
-                                      ecc_signature_t *signature);
+                                      const ecc_signature_t *signature);
 
 /**
  * Verifies an Ed25519 signature.
@@ -269,7 +269,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature, hardened_bool_t *verification_result);
+    const ecc_signature_t *signature, hardened_bool_t *verification_result);
 
 /**
  * Generates a new key pair for X25519 key exchange.
@@ -326,7 +326,7 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
  * @return Result of asynchronous ECDSA keygen start operation.
  */
 crypto_status_t otcrypto_ecdsa_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config);
+    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -383,7 +383,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
  * @return Result of async ECDSA finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_sign_async_finalize(
-    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature);
+    const ecc_curve_t *elliptic_curve, const ecc_signature_t *signature);
 
 /**
  * Starts the asynchronous ECDSA digital signature verification.
@@ -401,7 +401,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(
  */
 crypto_status_t otcrypto_ecdsa_verify_async_start(
     const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
-    ecc_signature_t *signature, const ecc_curve_t *elliptic_curve);
+    const ecc_signature_t *signature, const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous ECDSA digital signature verification.
@@ -422,7 +422,7 @@ crypto_status_t otcrypto_ecdsa_verify_async_start(
  * @return Result of async ECDSA verify finalize operation.
  */
 crypto_status_t otcrypto_ecdsa_verify_async_finalize(
-    const ecc_curve_t *elliptic_curve, ecc_signature_t *signature,
+    const ecc_curve_t *elliptic_curve, const ecc_signature_t *signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -444,7 +444,7 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
  * @return Result of asynchronous ECDH keygen start operation.
  */
 crypto_status_t otcrypto_ecdh_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, crypto_key_config_t *config);
+    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -516,7 +516,7 @@ crypto_status_t otcrypto_ecdh_async_finalize(
  * @return Result of asynchronous ed25519 keygen start operation.
  */
 crypto_status_t otcrypto_ed25519_keygen_async_start(
-    crypto_key_config_t *config);
+    const crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for Ed25519.
@@ -552,7 +552,7 @@ crypto_status_t otcrypto_ed25519_keygen_async_finalize(
 crypto_status_t otcrypto_ed25519_sign_async_start(
     const crypto_blinded_key_t *private_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature);
+    const ecc_signature_t *signature);
 
 /**
  * Finalizes the asynchronous Ed25519 digital signature generation.
@@ -565,7 +565,7 @@ crypto_status_t otcrypto_ed25519_sign_async_start(
  * @return Result of async Ed25519 finalize operation.
  */
 crypto_status_t otcrypto_ed25519_sign_async_finalize(
-    ecc_signature_t *signature);
+    const ecc_signature_t *signature);
 
 /**
  * Starts the asynchronous Ed25519 digital signature verification.
@@ -582,7 +582,7 @@ crypto_status_t otcrypto_ed25519_sign_async_finalize(
 crypto_status_t otcrypto_ed25519_verify_async_start(
     const crypto_unblinded_key_t *public_key,
     crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
-    ecc_signature_t *signature);
+    const ecc_signature_t *signature);
 
 /**
  * Finalizes the asynchronous Ed25519 digital signature verification.
@@ -610,7 +610,8 @@ crypto_status_t otcrypto_ed25519_verify_async_finalize(
  * @param config Private key configuration.
  * @return Result of asynchronous X25519 keygen start operation.
  */
-crypto_status_t otcrypto_x25519_keygen_async_start(crypto_key_config_t *config);
+crypto_status_t otcrypto_x25519_keygen_async_start(
+    const crypto_key_config_t *config);
 
 /**
  * Finalizes the asynchronous key generation for X25519.


### PR DESCRIPTION
Sideloaded key support is still missing, but this otherwise fills in the cryptolib API for ECDSA-P256, including input validation, message hashing, and calls to the core internal interface.