### PR TITLE
[entropy_src] Don't predict counter clearing in FW_OV mode, align doc

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1019,9 +1019,8 @@
           desc: '''This field will hold a running count of
                    the total alert count, which is a sum of all of the other
                    counters in the !!ALERT_FAIL_COUNTS register.
-                   It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
       ]
@@ -1035,57 +1034,57 @@
         { bits: "7:4",
           name: "REPCNT_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "11:8",
           name: "ADAPTP_HI_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "15:12",
           name: "ADAPTP_LO_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "19:16",
           name: "BUCKET_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "23:20",
           name: "MARKOV_HI_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "27:24",
           name: "MARKOV_LO_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "31:28",
           name: "REPCNTS_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
       ]
@@ -1099,17 +1098,17 @@
         { bits: "3:0",
           name: "EXTHT_HI_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
         { bits: "7:4",
           name: "EXTHT_LO_FAIL_COUNT",
           desc: '''This field will hold a running count of test failures that
-                   contribute to the total alert count. It will be reset after every
-                   passing test sequence. If an alert is signaled, this value
-                   will persist until it is cleared.
+                   contribute to the total alert count.
+                   It will be reset after every passing test sequence unless in firmware override mode (extract and insert only).
+                   If an alert is signaled, this value will persist until it is cleared.
                 '''
         }
       ]

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -824,9 +824,10 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
         `uvm_info(`gfn, $sformatf(fmt, any_fail_count_regval, alert_threshold), UVM_HIGH)
       end
     end else begin : no_test_failure
-      if (!threshold_alert_active && !main_sm_escalates) begin
-        any_fail_count_regval = 0;
-        // Now we know that all tests have passed we can clear the failure counts
+      if (!fw_ov_insert && !threshold_alert_active && !main_sm_escalates) begin
+        // Now we know that all tests have passed we can clear the failure counts. In FW_OV mode
+        // alerts are suppressed but we keep counting failures. In addition, even in case of a
+        // full passing test sequence, counters are not cleared.
         `DV_CHECK_FATAL(alert_fail_reg.predict(.value({TL_DW{1'b0}}), .kind(UVM_PREDICT_DIRECT)))
         `DV_CHECK_FATAL(extht_fail_reg.predict(.value({TL_DW{1'b0}}), .kind(UVM_PREDICT_DIRECT)))
         `DV_CHECK_FATAL(any_fail_count_fld.predict(.value('0), .kind(UVM_PREDICT_DIRECT)))


### PR DESCRIPTION
Previously, the scoreboard was assuming that even in FW_OV mode (extract and insert) the health test failure counters would be cleared upon full passing test sequences. But this is not right. In FW_OV mode those counters are not cleared as firmware may want to observe those values when working on the extracted entropy bits (during that time further entropy might be collected which is discarded and should not lead to a clearing of the failure counters).

This hasn't been explicitly documented yet but the main FSM (`entropy_src_main_sm.sv`) contains a comment on that:

> Even when stalled we keep monitoring for alerts and maintaining alert statistics. However, we don't signal alerts or clear HT stats in FW_OV mode.

Therefore, this commit aligns DV and doc with the RTL implementation.