### PR TITLE
[doc] Fix broken link to OpenTitan Early Grey Chip Datasheet

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -23,7 +23,7 @@ For questions about how the project is organized, see the [project](./project_go
 
 ## Datasheets
 
-* [OpenTitan Earl Grey Chip Datasheet](../hw/top_earlgrey/doc/specification.md)
+* [OpenTitan Earl Grey Chip Datasheet](hw/top_earlgrey/doc/specification.md)
 
 ## Documentation
 


### PR DESCRIPTION
The relative URL appears at <https://opentitan.org/book/>, but it begins with `../` which effectively removed `book/` from the target (<https://opentitan.org/book/hw/top_earlgrey/doc/specification.html>), breaking the link.