### PR TITLE
[opentitantool] Do not convert line endings in opentitantool

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -279,8 +279,7 @@ dual_cc_library(
 
 _FLOW_CONTROL_MESSAGE = (
     "Mary had a little lamb, its fleece was white as snow. " +
-    "Everywhere that Mary went the lamb was sure to go." +
-    "\n"
+    "Everywhere that Mary went the lamb was sure to go."
 )
 
 opentitan_functest(
@@ -293,7 +292,7 @@ opentitan_functest(
             "--exec=\"console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control\"",
             "console",
             "--flow-control",
-            "--send=\"{}\"".format(_FLOW_CONTROL_MESSAGE),
+            "--send=\"{}\n\"".format(_FLOW_CONTROL_MESSAGE),
             "--exit-success=\"RESULT:{}\"".format(_FLOW_CONTROL_MESSAGE),
             "--exit-failure=\"PASS|FAIL\"",
         ],
@@ -307,7 +306,7 @@ opentitan_functest(
             "--exec \"console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control\"",
             "console",
             "--flow-control",
-            "--send=\"{}\"".format(_FLOW_CONTROL_MESSAGE),
+            "--send=\"{}\n\"".format(_FLOW_CONTROL_MESSAGE),
             "--exit-success=\"{}\"".format(_FLOW_CONTROL_MESSAGE),
             "--exit-failure=\"PASS|FAIL\"",
         ],

--- a/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
+++ b/sw/device/lib/testing/test_framework/ottf_flow_control_functest.c
@@ -27,11 +27,11 @@ status_t ottf_flow_control_test(ujson_t *uj) {
     // Print a bunch of stuff so that ibex will be busy
     // driving the transmitter while the host sends data
     // to the UART.
-    base_printf("WAIT\n");
+    base_printf("WAIT\r\n");
     busy_spin_micros(delay);
   }
 
-  base_printf("Reading\n");
+  base_printf("Reading\r\n");
   // Receive a line of text into a buffer.
   uint8_t buf[256] = {0};
   for (size_t i = 0; i < sizeof(buf) - 1; ++i) {
@@ -47,7 +47,7 @@ status_t ottf_flow_control_test(ujson_t *uj) {
 
   // Print out the received data so the test can check that it matches what was
   // sent.
-  base_printf("RESULT:%s\n", buf);
+  base_printf("RESULT:%s\r\n", buf);
   return OK_STATUS();
 }
 

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -88,13 +88,9 @@ impl UartConsole {
                 self.newline = false;
             }
             self.newline = buf[i] == b'\n';
-            stdout.as_mut().map_or(Ok(()), |out| {
-                out.write_all(if self.newline {
-                    b"\r\n"
-                } else {
-                    &buf[i..i + 1]
-                })
-            })?;
+            stdout
+                .as_mut()
+                .map_or(Ok(()), |out| out.write_all(&buf[i..i + 1]))?;
         }
         stdout.as_mut().map_or(Ok(()), |out| out.flush())?;
 


### PR DESCRIPTION
Serial output from an embedded microcontroller is often used for debugging.  In production systems, connection would typically require something like a FTDI device, to pick up the TTL-level UART output, and present it in a way that `minicom` or similar can access through `/dev/ttyUSBn`.

If used as above, it is important that the microcontroller outputs `"\r\n"` line terminators, in order for minicom to do both carriage return and newline.

Given that the firmware should already output that two-character sequence, there is no point in having opentitantool convert `"\n"` into `"\r\n"`.  In fact, doing so i counter-productive, in that it causes `"\r\r\n"`, which is at best harmless, but at worst causes undesired empty lines, or mangles up binary communication piped through `opentitantool console`.  (Googlers, see b/255397131)