### PR TITLE
[manuf] Enable programming of SECRET2 partition 

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -271,6 +271,43 @@ otp_json(
     seed = "94259314771464387",
 )
 
+# Represents a device in DEV state with the SECRET0 and SECRET1 partitions in
+# locked state. SECRET2 partition is unlocked.
+otp_json(
+    name = "otp_json_dev_individualized",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                "TEST_UNLOCK_TOKEN": "<random>",
+                "TEST_EXIT_TOKEN": "<random>",
+            },
+            lock = True,
+        ),
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_ADDR_KEY_SEED": "<random>",
+                "FLASH_DATA_KEY_SEED": "<random>",
+                "SRAM_DATA_KEY_SEED": "<random>",
+            },
+            lock = True,
+        ),
+        # SECRET2 partition is empty and in unlocked state to allow
+        # personalization to configure the device secrets.
+        otp_partition(
+            name = "SECRET2",
+            lock = False,
+        ),
+        otp_partition(
+            name = "LIFE_CYCLE",
+            count = "5",
+            state = "DEV",
+        ),
+    ],
+    seed = "94259314771464387",
+)
+
 otp_json(
     name = "otp_json_prod",
     partitions = [
@@ -394,6 +431,14 @@ otp_alert_digest(
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
+    overlays = STD_OTP_OVERLAYS,
+)
+
+# Represents a device in DEV state with the SECRET0 and SECRET1 partitions in
+# locked state. SECRET2 partition is unlocked.
+otp_image(
+    name = "img_dev_individualized",
+    src = ":otp_json_dev_individualized",
     overlays = STD_OTP_OVERLAYS,
 )
 

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -49,6 +49,7 @@ def get_otp_images():
 
     img_targets = [
         "//hw/ip/otp_ctrl/data:img_dev",
+        "//hw/ip/otp_ctrl/data:img_dev_individualized",
         "//hw/ip/otp_ctrl/data:img_rma",
         "//hw/ip/otp_ctrl/data:img_test_unlocked0",
         "//hw/ip/otp_ctrl/data:img_prod",

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -284,7 +284,7 @@ typedef struct dif_otp_ctrl_status {
    * A list of root causes for each error status code.
    *
    * If the error status code `error` is present in `codes`, and
-   * `error <= kDifOtpCtrlStatusHasCauseLast`, then `causes[error]`
+   * `error <= kDifOtpCtrlStatusCodeHasCauseLast`, then `causes[error]`
    * will contain its root cause.
    */
   dif_otp_ctrl_error_t causes[kDifOtpCtrlStatusCodeHasCauseLast + 1];

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -26,7 +26,7 @@ opentitan_functest(
     name = "provisioning_functest",
     srcs = ["provisioning_functest.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_otp_dev",
+        bitstream = "//hw/bitstream:rom_otp_dev_individualized",
     ),
     targets = [
         "cw310_rom",


### PR DESCRIPTION
Switch to use the `rom_otp_dev_individualized` bitstream to enable
configuration of the SECRET2 partition. The default `rom_otp_dev` image
was using preconfigured values.

Update the test to enforce the programing of the SECRET2 partition
values and error out if the OTP read returns unexpected values.
