### PR TITLE
[manuf] Add provisioning end check to provisioning_functest

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -41,6 +41,8 @@ opentitan_functest(
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
Add `provisioning_device_secrets_end()` after reseting the device to verify that the SECRET2 partition was successfully locked.