### PR TITLE
[manuf] Cleanup otp_ctrl testutils in provisioning

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -62,3 +62,54 @@ status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
   TRY(dif_otp_ctrl_dai_digest(otp, partition, digest));
   return otp_ctrl_testutils_wait_for_dai(otp);
 }
+
+status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
+                                       dif_otp_ctrl_partition_t partition,
+                                       uint32_t address, uint64_t *result) {
+  TRY(otp_ctrl_testutils_wait_for_dai(otp));
+  TRY(dif_otp_ctrl_dai_read_start(otp, partition, address));
+  TRY(otp_ctrl_testutils_wait_for_dai(otp));
+  TRY(dif_otp_ctrl_dai_read64_end(otp, result));
+  return OK_STATUS();
+}
+
+/**
+ * Checks if there were any errors found after executing a DAI write transaction
+ * to the SECRET2 partition.
+ *
+ * @param otp otp_ctrl instance
+ * @return OK_STATUS if there were no errors detected.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t otp_ctrl_dai_write_error_check(const dif_otp_ctrl_t *otp) {
+  dif_otp_ctrl_status_t status;
+  TRY(dif_otp_ctrl_get_status(otp, &status));
+
+  // TODO: Check for other OTP errors.
+  if (bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiIdle) &&
+      !bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
+    return OK_STATUS();
+  }
+  return INTERNAL();
+}
+
+status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t start_address,
+                                        const uint64_t *buffer, size_t len) {
+  uint32_t stop_address = start_address + (len * sizeof(uint64_t));
+  for (uint32_t addr = start_address, i = 0; addr < stop_address;
+       addr += sizeof(uint64_t), ++i) {
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(dif_otp_ctrl_dai_program64(otp, partition, addr, buffer[i]));
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_dai_write_error_check(otp));
+
+    uint64_t read_data;
+    TRY(otp_ctrl_testutils_dai_read64(otp, partition, addr, &read_data));
+    if (read_data != buffer[i]) {
+      return INTERNAL();
+    }
+  }
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -37,4 +37,40 @@ status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
                                            dif_otp_ctrl_partition_t partition,
                                            uint64_t digest);
 
+/**
+ * Reads a 64bit value from OTP using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param address Address relative to the start of the `partition`. Must be a
+ * 64bit aligned address.
+ * @param[out] result The 64bit value result.
+ * @return OK_STATUS on successful read.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t otp_ctrl_testutils_dai_read64(
+    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
+    uint32_t address, uint64_t *result);
+
+/**
+ * Writes `len` number of 64bit words from buffer into otp `partition` starting
+ * at `start_address` using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param start_address Address relative to the start of the `partition`. Must
+ * be a 64bit aligned address.
+ * @param buffer The buffer containing the data to be written into OTP.
+ * The function may override values for entries previously written. The caller
+ * can use the result buffer to detect which OTP words were already programmed.
+ * @param len The number of 64bit words to write into otp. `buffer` must have at
+ * least `len` 64bit words.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t start_address,
+                                        const uint64_t *buffer, size_t len);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_OTP_CTRL_TESTUTILS_H_


### PR DESCRIPTION
Move otp_ctrl functions to the otp_ctrl_testutil library so that they can be reused in other manufacturing test cases.