### PR TITLE
[manuf] Add lc_ctrl_testutil operation state check

### DIFF
--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -102,3 +102,14 @@ status_t lc_ctrl_testutils_check_lc_state(const dif_lc_ctrl_t *lc_ctrl,
             lc_state);
   return OK_STATUS();
 }
+
+status_t lc_ctrl_testutils_operational_state_check(
+    const dif_lc_ctrl_t *lc_ctrl) {
+  dif_lc_ctrl_state_t state;
+  TRY(dif_lc_ctrl_get_state(lc_ctrl, &state));
+  if (state == kDifLcCtrlStateProd || state == kDifLcCtrlStateProdEnd ||
+      state == kDifLcCtrlStateDev) {
+    return OK_STATUS();
+  }
+  return FAILED_PRECONDITION();
+}

--- a/sw/device/lib/testing/lc_ctrl_testutils.h
+++ b/sw/device/lib/testing/lc_ctrl_testutils.h
@@ -47,4 +47,16 @@ status_t lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
 status_t lc_ctrl_testutils_check_lc_state(const dif_lc_ctrl_t *lc_ctrl,
                                           dif_lc_ctrl_state_t exp_lc_state);
 
+/**
+ * Checks the device life cycle state to determine if it is in operational
+ * state.
+ *
+ * @param lc_ctrl Life cycle controller instance.
+ * @return OK_STATUS if the device is in PROD, PROD_END or DEV state; otherwise
+ * FAILED_PRECONDITION.
+ */
+OT_WARN_UNUSED_RESULT
+status_t lc_ctrl_testutils_operational_state_check(
+    const dif_lc_ctrl_t *lc_ctrl);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_LC_CTRL_TESTUTILS_H_

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
     ],
 )


### PR DESCRIPTION
Add `lc_ctrl_testutils_operational_state_check()` to check if a device is in operational state: DEV, PROD or PROD_END.