### PR TITLE
[ast] some alignments after ast module ownership transfer

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
+      - lowrisc:prim:multibit_sync
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip_interfaces:alert_handler_reg

--- a/hw/top_earlgrey/ip/ast/doc/ast_regs.html
+++ b/hw/top_earlgrey/ip/ast/doc/ast_regs.html
@@ -68,97 +68,97 @@
  <tr>
   <th class="regdef">Name</th>  <th class="regdef">Offset</th>  <th class="regdef">Length</th>  <th class="regdef">Description</th> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega0">REGA0</a></td>  <td class="regfn">0x0</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Register 0 for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega0">REGA0</a></td>  <td class="regfn">0x0</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Register 0 for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega1">REGA1</a></td>  <td class="regfn">0x4</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 1 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega1">REGA1</a></td>  <td class="regfn">0x4</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 1 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega2">REGA2</a></td>  <td class="regfn">0x8</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 2 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega2">REGA2</a></td>  <td class="regfn">0x8</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 2 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega3">REGA3</a></td>  <td class="regfn">0xc</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 3 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega3">REGA3</a></td>  <td class="regfn">0xc</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 3 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega4">REGA4</a></td>  <td class="regfn">0x10</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 4 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega4">REGA4</a></td>  <td class="regfn">0x10</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 4 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega5">REGA5</a></td>  <td class="regfn">0x14</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 5 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega5">REGA5</a></td>  <td class="regfn">0x14</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 5 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega6">REGA6</a></td>  <td class="regfn">0x18</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 6 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega6">REGA6</a></td>  <td class="regfn">0x18</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 6 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega7">REGA7</a></td>  <td class="regfn">0x1c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 7 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega7">REGA7</a></td>  <td class="regfn">0x1c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 7 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega8">REGA8</a></td>  <td class="regfn">0x20</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 8 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega8">REGA8</a></td>  <td class="regfn">0x20</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 8 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega9">REGA9</a></td>  <td class="regfn">0x24</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 9 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega9">REGA9</a></td>  <td class="regfn">0x24</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 9 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega10">REGA10</a></td>  <td class="regfn">0x28</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 10 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega10">REGA10</a></td>  <td class="regfn">0x28</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 10 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega11">REGA11</a></td>  <td class="regfn">0x2c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 11 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega11">REGA11</a></td>  <td class="regfn">0x2c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 11 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega12">REGA12</a></td>  <td class="regfn">0x30</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 13 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega12">REGA12</a></td>  <td class="regfn">0x30</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 13 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega13">REGA13</a></td>  <td class="regfn">0x34</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 13 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega13">REGA13</a></td>  <td class="regfn">0x34</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 13 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega14">REGA14</a></td>  <td class="regfn">0x38</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 14 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega14">REGA14</a></td>  <td class="regfn">0x38</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 14 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega15">REGA15</a></td>  <td class="regfn">0x3c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 15 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega15">REGA15</a></td>  <td class="regfn">0x3c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 15 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega16">REGA16</a></td>  <td class="regfn">0x40</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 16 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega16">REGA16</a></td>  <td class="regfn">0x40</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 16 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega17">REGA17</a></td>  <td class="regfn">0x44</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 17 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega17">REGA17</a></td>  <td class="regfn">0x44</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 17 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega18">REGA18</a></td>  <td class="regfn">0x48</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 18 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega18">REGA18</a></td>  <td class="regfn">0x48</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 18 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega19">REGA19</a></td>  <td class="regfn">0x4c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 19 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega19">REGA19</a></td>  <td class="regfn">0x4c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 19 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega20">REGA20</a></td>  <td class="regfn">0x50</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 20 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega20">REGA20</a></td>  <td class="regfn">0x50</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 20 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega21">REGA21</a></td>  <td class="regfn">0x54</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 21 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega21">REGA21</a></td>  <td class="regfn">0x54</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 21 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega22">REGA22</a></td>  <td class="regfn">0x58</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 22 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega22">REGA22</a></td>  <td class="regfn">0x58</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 22 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega23">REGA23</a></td>  <td class="regfn">0x5c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 23 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega23">REGA23</a></td>  <td class="regfn">0x5c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 23 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega24">REGA24</a></td>  <td class="regfn">0x60</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 24 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega24">REGA24</a></td>  <td class="regfn">0x60</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 24 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega25">REGA25</a></td>  <td class="regfn">0x64</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 25 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega25">REGA25</a></td>  <td class="regfn">0x64</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 25 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega26">REGA26</a></td>  <td class="regfn">0x68</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 26 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega26">REGA26</a></td>  <td class="regfn">0x68</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 26 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega27">REGA27</a></td>  <td class="regfn">0x6c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 27 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega27">REGA27</a></td>  <td class="regfn">0x6c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 27 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega28">REGA28</a></td>  <td class="regfn">0x70</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 28 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega28">REGA28</a></td>  <td class="regfn">0x70</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 28 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega29">REGA29</a></td>  <td class="regfn">0x74</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 29 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega29">REGA29</a></td>  <td class="regfn">0x74</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 29 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega30">REGA30</a></td>  <td class="regfn">0x78</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 30 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega30">REGA30</a></td>  <td class="regfn">0x78</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 30 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega31">REGA31</a></td>  <td class="regfn">0x7c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 31 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega31">REGA31</a></td>  <td class="regfn">0x7c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 31 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega32">REGA32</a></td>  <td class="regfn">0x80</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 32 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega32">REGA32</a></td>  <td class="regfn">0x80</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 32 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega33">REGA33</a></td>  <td class="regfn">0x84</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 33 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega33">REGA33</a></td>  <td class="regfn">0x84</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 33 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega34">REGA34</a></td>  <td class="regfn">0x88</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 34 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega34">REGA34</a></td>  <td class="regfn">0x88</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 34 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega35">REGA35</a></td>  <td class="regfn">0x8c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 35 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega35">REGA35</a></td>  <td class="regfn">0x8c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 35 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega36">REGA36</a></td>  <td class="regfn">0x90</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 36 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega36">REGA36</a></td>  <td class="regfn">0x90</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 36 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_rega37">REGA37</a></td>  <td class="regfn">0x94</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 37 Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#rega37">REGA37</a></td>  <td class="regfn">0x94</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST 37 Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regal">REGAL</a></td>  <td class="regfn">0x98</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Last Register for OTP/ROM Write Testing</p></td> </tr>
+  <td class="regfn">ast.<a href="#regal">REGAL</a></td>  <td class="regfn">0x98</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Last Register for OTP/ROM Write Testing</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regb_0">REGB_0</a></td>  <td class="regfn">0x200</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
+  <td class="regfn">ast.<a href="#regb_0">REGB_0</a></td>  <td class="regfn">0x200</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regb_1">REGB_1</a></td>  <td class="regfn">0x204</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
+  <td class="regfn">ast.<a href="#regb_1">REGB_1</a></td>  <td class="regfn">0x204</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regb_2">REGB_2</a></td>  <td class="regfn">0x208</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
+  <td class="regfn">ast.<a href="#regb_2">REGB_2</a></td>  <td class="regfn">0x208</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regb_3">REGB_3</a></td>  <td class="regfn">0x20c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
+  <td class="regfn">ast.<a href="#regb_3">REGB_3</a></td>  <td class="regfn">0x20c</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
  <tr>
-  <td class="regfn">ast.<a href="#Reg_regb_4">REGB_4</a></td>  <td class="regfn">0x210</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
-</table><table class="regdef" id="Reg_rega0">
+  <td class="regfn">ast.<a href="#regb_4">REGB_4</a></td>  <td class="regfn">0x210</td>  <td class="regfn">4</td>  <td class="regfn"><p>AST Registers Array-B to set address space size</p></td> </tr>
+</table><table class="regdef" id="rega0">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega0">REGA0</a> @ 0x0</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega0">REGA0</a> @ 0x0</div>
    <div><p>AST Register 0 for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
@@ -169,10 +169,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x0</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega1">
+<table class="regdef" id="rega1">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega1">REGA1</a> @ 0x4</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega1">REGA1</a> @ 0x4</div>
    <div><p>AST 1 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1, mask 0xffffffff</div>
   </th>
@@ -183,10 +183,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x1</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega2">
+<table class="regdef" id="rega2">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega2">REGA2</a> @ 0x8</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega2">REGA2</a> @ 0x8</div>
    <div><p>AST 2 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x2, mask 0xffffffff</div>
   </th>
@@ -197,10 +197,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x2</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega3">
+<table class="regdef" id="rega3">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega3">REGA3</a> @ 0xc</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega3">REGA3</a> @ 0xc</div>
    <div><p>AST 3 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x3, mask 0xffffffff</div>
   </th>
@@ -211,10 +211,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x3</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega4">
+<table class="regdef" id="rega4">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega4">REGA4</a> @ 0x10</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega4">REGA4</a> @ 0x10</div>
    <div><p>AST 4 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x4, mask 0xffffffff</div>
   </th>
@@ -225,10 +225,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x4</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega5">
+<table class="regdef" id="rega5">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega5">REGA5</a> @ 0x14</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega5">REGA5</a> @ 0x14</div>
    <div><p>AST 5 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x5, mask 0xffffffff</div>
   </th>
@@ -239,10 +239,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x5</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega6">
+<table class="regdef" id="rega6">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega6">REGA6</a> @ 0x18</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega6">REGA6</a> @ 0x18</div>
    <div><p>AST 6 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x6, mask 0xffffffff</div>
   </th>
@@ -253,10 +253,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x6</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega7">
+<table class="regdef" id="rega7">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega7">REGA7</a> @ 0x1c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega7">REGA7</a> @ 0x1c</div>
    <div><p>AST 7 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x7, mask 0xffffffff</div>
   </th>
@@ -267,10 +267,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x7</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega8">
+<table class="regdef" id="rega8">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega8">REGA8</a> @ 0x20</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega8">REGA8</a> @ 0x20</div>
    <div><p>AST 8 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x8, mask 0xffffffff</div>
   </th>
@@ -281,10 +281,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x8</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega9">
+<table class="regdef" id="rega9">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega9">REGA9</a> @ 0x24</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega9">REGA9</a> @ 0x24</div>
    <div><p>AST 9 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x9, mask 0xffffffff</div>
   </th>
@@ -295,10 +295,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x9</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega10">
+<table class="regdef" id="rega10">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega10">REGA10</a> @ 0x28</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega10">REGA10</a> @ 0x28</div>
    <div><p>AST 10 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xa, mask 0xffffffff</div>
   </th>
@@ -309,10 +309,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xa</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega11">
+<table class="regdef" id="rega11">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega11">REGA11</a> @ 0x2c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega11">REGA11</a> @ 0x2c</div>
    <div><p>AST 11 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xb, mask 0xffffffff</div>
   </th>
@@ -323,10 +323,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xb</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega12">
+<table class="regdef" id="rega12">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega12">REGA12</a> @ 0x30</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega12">REGA12</a> @ 0x30</div>
    <div><p>AST 13 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xc, mask 0xffffffff</div>
   </th>
@@ -337,10 +337,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xc</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega13">
+<table class="regdef" id="rega13">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega13">REGA13</a> @ 0x34</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega13">REGA13</a> @ 0x34</div>
    <div><p>AST 13 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xd, mask 0xffffffff</div>
   </th>
@@ -351,10 +351,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xd</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega14">
+<table class="regdef" id="rega14">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega14">REGA14</a> @ 0x38</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega14">REGA14</a> @ 0x38</div>
    <div><p>AST 14 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xe, mask 0xffffffff</div>
   </th>
@@ -365,10 +365,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xe</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega15">
+<table class="regdef" id="rega15">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega15">REGA15</a> @ 0x3c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega15">REGA15</a> @ 0x3c</div>
    <div><p>AST 15 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0xf, mask 0xffffffff</div>
   </th>
@@ -379,10 +379,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xf</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega16">
+<table class="regdef" id="rega16">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega16">REGA16</a> @ 0x40</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega16">REGA16</a> @ 0x40</div>
    <div><p>AST 16 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x10, mask 0xffffffff</div>
   </th>
@@ -393,10 +393,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x10</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega17">
+<table class="regdef" id="rega17">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega17">REGA17</a> @ 0x44</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega17">REGA17</a> @ 0x44</div>
    <div><p>AST 17 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x11, mask 0xffffffff</div>
   </th>
@@ -407,10 +407,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x11</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega18">
+<table class="regdef" id="rega18">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega18">REGA18</a> @ 0x48</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega18">REGA18</a> @ 0x48</div>
    <div><p>AST 18 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x12, mask 0xffffffff</div>
   </th>
@@ -421,10 +421,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x12</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega19">
+<table class="regdef" id="rega19">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega19">REGA19</a> @ 0x4c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega19">REGA19</a> @ 0x4c</div>
    <div><p>AST 19 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x13, mask 0xffffffff</div>
   </th>
@@ -435,10 +435,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x13</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega20">
+<table class="regdef" id="rega20">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega20">REGA20</a> @ 0x50</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega20">REGA20</a> @ 0x50</div>
    <div><p>AST 20 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x14, mask 0xffffffff</div>
   </th>
@@ -449,10 +449,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x14</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega21">
+<table class="regdef" id="rega21">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega21">REGA21</a> @ 0x54</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega21">REGA21</a> @ 0x54</div>
    <div><p>AST 21 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x15, mask 0xffffffff</div>
   </th>
@@ -463,10 +463,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x15</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega22">
+<table class="regdef" id="rega22">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega22">REGA22</a> @ 0x58</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega22">REGA22</a> @ 0x58</div>
    <div><p>AST 22 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x16, mask 0xffffffff</div>
   </th>
@@ -477,10 +477,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x16</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega23">
+<table class="regdef" id="rega23">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega23">REGA23</a> @ 0x5c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega23">REGA23</a> @ 0x5c</div>
    <div><p>AST 23 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x17, mask 0xffffffff</div>
   </th>
@@ -491,10 +491,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x17</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega24">
+<table class="regdef" id="rega24">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega24">REGA24</a> @ 0x60</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega24">REGA24</a> @ 0x60</div>
    <div><p>AST 24 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x18, mask 0xffffffff</div>
   </th>
@@ -505,10 +505,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x18</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega25">
+<table class="regdef" id="rega25">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega25">REGA25</a> @ 0x64</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega25">REGA25</a> @ 0x64</div>
    <div><p>AST 25 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x19, mask 0xffffffff</div>
   </th>
@@ -519,10 +519,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x19</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega26">
+<table class="regdef" id="rega26">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega26">REGA26</a> @ 0x68</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega26">REGA26</a> @ 0x68</div>
    <div><p>AST 26 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1a, mask 0xffffffff</div>
   </th>
@@ -533,10 +533,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1a</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega27">
+<table class="regdef" id="rega27">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega27">REGA27</a> @ 0x6c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega27">REGA27</a> @ 0x6c</div>
    <div><p>AST 27 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1b, mask 0xffffffff</div>
   </th>
@@ -547,10 +547,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1b</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega28">
+<table class="regdef" id="rega28">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega28">REGA28</a> @ 0x70</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega28">REGA28</a> @ 0x70</div>
    <div><p>AST 28 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1c, mask 0xffffffff</div>
   </th>
@@ -561,10 +561,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x1c</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega29">
+<table class="regdef" id="rega29">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega29">REGA29</a> @ 0x74</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega29">REGA29</a> @ 0x74</div>
    <div><p>AST 29 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1d, mask 0xffffffff</div>
   </th>
@@ -575,10 +575,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1d</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega30">
+<table class="regdef" id="rega30">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega30">REGA30</a> @ 0x78</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega30">REGA30</a> @ 0x78</div>
    <div><p>AST 30 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1e, mask 0xffffffff</div>
   </th>
@@ -589,10 +589,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1e</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega31">
+<table class="regdef" id="rega31">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega31">REGA31</a> @ 0x7c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega31">REGA31</a> @ 0x7c</div>
    <div><p>AST 31 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1f, mask 0xffffffff</div>
   </th>
@@ -603,10 +603,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1f</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega32">
+<table class="regdef" id="rega32">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega32">REGA32</a> @ 0x80</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega32">REGA32</a> @ 0x80</div>
    <div><p>AST 32 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x20, mask 0xffffffff</div>
   </th>
@@ -617,10 +617,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x20</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega33">
+<table class="regdef" id="rega33">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega33">REGA33</a> @ 0x84</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega33">REGA33</a> @ 0x84</div>
    <div><p>AST 33 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x21, mask 0xffffffff</div>
   </th>
@@ -631,10 +631,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x21</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega34">
+<table class="regdef" id="rega34">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega34">REGA34</a> @ 0x88</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega34">REGA34</a> @ 0x88</div>
    <div><p>AST 34 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x22, mask 0xffffffff</div>
   </th>
@@ -645,10 +645,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x22</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega35">
+<table class="regdef" id="rega35">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega35">REGA35</a> @ 0x8c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega35">REGA35</a> @ 0x8c</div>
    <div><p>AST 35 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x23, mask 0xffffffff</div>
   </th>
@@ -659,10 +659,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x23</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega36">
+<table class="regdef" id="rega36">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega36">REGA36</a> @ 0x90</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega36">REGA36</a> @ 0x90</div>
    <div><p>AST 36 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x24, mask 0xffffffff</div>
   </th>
@@ -673,10 +673,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x24</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_rega37">
+<table class="regdef" id="rega37">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_rega37">REGA37</a> @ 0x94</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#rega37">REGA37</a> @ 0x94</div>
    <div><p>AST 37 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x25, mask 0xffffffff</div>
   </th>
@@ -687,10 +687,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x25</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regal">
+<table class="regdef" id="regal">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regal">REGAL</a> @ 0x98</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regal">REGAL</a> @ 0x98</div>
    <div><p>AST Last Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x26, mask 0xffffffff</div>
   </th>
@@ -701,10 +701,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">wo</td><td class="regrv">0x26</td><td class="regfn">reg32</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regb_0">
+<table class="regdef" id="regb_0">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regb_0">REGB_0</a> @ 0x200</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regb_0">REGB_0</a> @ 0x200</div>
    <div><p>AST Registers Array-B to set address space size</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
@@ -715,10 +715,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_0</td><td class="regde"><p><p>32-bit Register</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regb_1">
+<table class="regdef" id="regb_1">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regb_1">REGB_1</a> @ 0x204</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regb_1">REGB_1</a> @ 0x204</div>
    <div><p>AST Registers Array-B to set address space size</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
@@ -729,10 +729,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_1</td><td class="regde"><p><p>For REGB1</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regb_2">
+<table class="regdef" id="regb_2">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regb_2">REGB_2</a> @ 0x208</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regb_2">REGB_2</a> @ 0x208</div>
    <div><p>AST Registers Array-B to set address space size</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
@@ -743,10 +743,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_2</td><td class="regde"><p><p>For REGB2</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regb_3">
+<table class="regdef" id="regb_3">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regb_3">REGB_3</a> @ 0x20c</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regb_3">REGB_3</a> @ 0x20c</div>
    <div><p>AST Registers Array-B to set address space size</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
@@ -757,10 +757,10 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_3</td><td class="regde"><p><p>For REGB3</p></p></td></table>
 <br>
-<table class="regdef" id="Reg_regb_4">
+<table class="regdef" id="regb_4">
  <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.<a href="#Reg_regb_4">REGB_4</a> @ 0x210</div>
+  <th class="regdef" colspan=5 >
+   <div>ast.<a href="#regb_4">REGB_4</a> @ 0x210</div>
    <div><p>AST Registers Array-B to set address space size</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -258,7 +258,7 @@ prim_flop #(
 );
 
 // Replace Latch for the OS code
-assign vcaon_pok_por_lat = rglssm_brout || vcaon_pok_por_src;
+assign vcaon_pok_por_lat = rglssm_brout || por_sync_n;
 assign ast_pwst_o.aon_pok = vcaon_pok_por_lat;
 assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
 
@@ -520,6 +520,12 @@ ast_clks_byp u_ast_clks_byp (
   .clk_osc_aon_i ( clk_osc_aon ),
   .clk_osc_aon_val_i ( clk_osc_aon_val ),
   .clk_ast_ext_i ( clk_ast_ext_i ),
+`ifdef AST_BYPASS_CLK
+  .clk_ext_sys_i( clk_sys_ext ),
+  .clk_ext_io_i( clk_io_ext ),
+  .clk_ext_usb_i( clk_usb_ext ),
+  .clk_ext_aon_i( clk_aon_ext ),
+`endif
   .io_clk_byp_req_i ( io_clk_byp_req_i ),
   .all_clk_byp_req_i ( all_clk_byp_req_i ),
   .ext_freq_is_96m_i ( ext_freq_is_96m_i ),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv
@@ -44,7 +44,7 @@ package ast_bhv_pkg;
   parameter time RNG_EN_RDLY     = 5us;
 `endif  // of SYNTHESIS
   // ADC
-  parameter int unsigned AdcCnvtClks = 22;
+  parameter int unsigned AdcCnvtClks = 19;
 
 endpackage  // of ast_bhv_pkg
 `endif // of __AST_BHV_PKG_SV

--- a/hw/top_earlgrey/ip/ast/rtl/dev_entropy.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/dev_entropy.sv
@@ -56,14 +56,14 @@ logic [(1<<EntropyRateWidth)-1:0] erate_cnt, dev_rate;
 // In most cases the rate will be set ahead of the dev_en_i
 logic [EntropyRateWidth-1:0] dev_rate_sync;
 
-prim_flop_2sync #(
+prim_multibit_sync #(
   .Width ( EntropyRateWidth ),
   .ResetValue ( {EntropyRateWidth{1'b0}} )
 ) u_erate_sync (
   .clk_i ( clk_dev_i ) ,
   .rst_ni ( rst_dev_ni ),
-  .d_i ( dev_rate_i[EntropyRateWidth-1:0] ),
-  .q_o ( dev_rate_sync[EntropyRateWidth-1:0] )
+  .data_i ( dev_rate_i[EntropyRateWidth-1:0] ),
+  .data_o ( dev_rate_sync[EntropyRateWidth-1:0] )
 );
 
 // Fastest rate to init the LFSR


### PR DESCRIPTION
fixing bus synchronization method
----------------------------------------------
hw/top_earlgrey/ip/ast/ast.core
hw/top_earlgrey/ip/ast/rtl/dev_entropy.sv
hw/top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv

solving TODOs on ADC, updating assertions and convertion time
----------------------------------------------
hw/top_earlgrey/ip/ast/rtl/adc.sv
hw/top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv

using synchronous aon_pok output according to #16721
----------------------------------------------
hw/top_earlgrey/ip/ast/rtl/ast.sv


adding AST_BYPASS_CLK define according to #17492
----------------------------------------------
hw/top_earlgrey/ip/ast/rtl/ast.sv
hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
