### PR TITLE
CI Offline Link Checker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,8 @@ jobs:
     displayName: Check trailing whitespace
   - bash: ci/scripts/build-docs.sh
     displayName: Render documentation
+  - bash: ci/scripts/check-links.sh
+    displayName: Check File Links
   - bash: ci/scripts/get-build-type.sh "$SYSTEM_PULLREQUEST_TARGETBRANCH" "$(Build.Reason)"
     displayName: Type of change
     # Check what kinds of changes the PR contains

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -142,5 +142,20 @@ sw/vendor/rustup/rustup-init.sh -y \
     --default-toolchain "${RUST_VERSION}"
 export PATH=$HOME/.cargo/bin:$PATH
 
+# Install lychee
+LYCHEE_VERSION="v0.11.1"
+LYCHEE_BASE_URL="https://github.com/lycheeverse/lychee/releases/download"
+LYCHEE_TARBALL="lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+LYCHEE_URL="${LYCHEE_BASE_URL}/${LYCHEE_VERSION}/${LYCHEE_TARBALL}"
+LYCHEE_DOWNLOAD="$TMPDIR/lychee.tar.gz"
+
+curl -f -Ls -o "$LYCHEE_DOWNLOAD" "${LYCHEE_URL}" || {
+    error "Failed to download lychee from ${LYCHEE_URL}"
+}
+sudo mkdir -p /tools/lychee
+sudo chmod 777 /tools/lychee
+tar -C /tools/lychee -xf "$LYCHEE_DOWNLOAD"
+export PATH=/tools/lychee:$PATH
+
 # Propagate PATH changes to all subsequent steps of the job
 echo "##vso[task.setvariable variable=PATH]$PATH"

--- a/ci/scripts/check-links.sh
+++ b/ci/scripts/check-links.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks links between files.
+
+set -e
+
+# Remove file containing invalid UTF-8
+rm -f sw/vendor/eembc_coremark/docs/html/index/General2.html
+
+# Run Offline Link Check
+lychee hw/ sw/ doc/ util/ \
+    --offline --no-progress \
+    --exclude-path sw/vendor \
+    --exclude-path util/i2csvg/smbus/SMBus.md \
+    --exclude-path hw/ip_templates/ \
+    --exclude-path hw/dv/doc/dv_doc_template.md \
+    --exclude-path doc/rust_for_c_devs.md \
+    --exclude-path hw/top_earlgrey/ip/pinmux/doc/autogen/targets.md \
+    || {
+      echo -n "##vso[task.logissue type=error]"
+      echo "Link Check failed."
+      exit 1
+    }


### PR DESCRIPTION
This CI script checks that links between documentation files don't break.

It is an offline only check, because URL breakages aren’t always caused by changes in the repository.

Online checks could be added to the nightlies in the future.