### PR TITLE
[crypto] Connect AES-GCM to the top-level API.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:aes",
+        "//sw/device/lib/crypto/impl/aes_gcm",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -298,11 +298,13 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
  * input.
  *
  * @param key AES key for the GCTR operation.
+ * @param icb Initial counter block.
  * @param input Input buffer.
  * @param[out] output Output buffer (same length as input).
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
+                                      crypto_const_uint8_buf_t icb,
                                       crypto_const_uint8_buf_t input,
                                       crypto_uint8_buf_t output);
 

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -88,7 +88,9 @@ typedef enum aes_padding {
  * Representation is internal to the hmac implementation; initialize
  * with #otcrypto_gcm_ghash_init.
  */
-typedef struct gcm_ghash_context gcm_ghash_context_t;
+typedef struct gcm_ghash_context {
+  uint32_t ctx[68];
+} gcm_ghash_context_t;
 
 /**
  * Generates a new AES key.
@@ -183,10 +185,13 @@ crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
  * @return Result of the authenticated encryption.
  * operation
  */
-crypto_status_t otcrypto_aes_encrypt_gcm(
-    const crypto_blinded_key_t *key, crypto_const_uint8_buf_t plaintext,
-    crypto_uint8_buf_t iv, crypto_uint8_buf_t aad, aead_gcm_tag_len_t tag_len,
-    crypto_uint8_buf_t *ciphertext, crypto_uint8_buf_t *auth_tag);
+crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
+                                         crypto_const_uint8_buf_t plaintext,
+                                         crypto_const_uint8_buf_t iv,
+                                         crypto_const_uint8_buf_t aad,
+                                         aead_gcm_tag_len_t tag_len,
+                                         crypto_uint8_buf_t *ciphertext,
+                                         crypto_uint8_buf_t *auth_tag);
 
 /**
  * Performs the AES-GCM authenticated decryption operation.
@@ -200,21 +205,25 @@ crypto_status_t otcrypto_aes_encrypt_gcm(
  * in the `len` field of `plaintext`. If the user-set length and the
  * output length does not match, an error message will be returned.
  *
+ * The caller must check the `success` argument before operating on
+ * `plaintext`. If the authentication check fails, then `plaintext` should not
+ * be used and there are no guarantees about its contents.
+ *
  * @param key Pointer to the blinded gcm-key struct.
  * @param ciphertext Input data to be decrypted.
  * @param iv Initialization vector for the decryption function.
  * @param aad Additional authenticated data.
  * @param auth_tag Authentication tag to be verified.
  * @param[out] plaintext Decrypted plaintext data, same len as input data.
+ * @param[out] success True if the authentication check passed, otherwise false.
  * @return Result of the authenticated decryption.
  * operation
  */
-crypto_status_t otcrypto_aes_decrypt_gcm(const crypto_blinded_key_t *key,
-                                         crypto_const_uint8_buf_t ciphertext,
-                                         crypto_uint8_buf_t iv,
-                                         crypto_uint8_buf_t aad,
-                                         crypto_uint8_buf_t auth_tag,
-                                         crypto_uint8_buf_t *plaintext);
+crypto_status_t otcrypto_aes_decrypt_gcm(
+    const crypto_blinded_key_t *key, crypto_const_uint8_buf_t ciphertext,
+    crypto_const_uint8_buf_t iv, crypto_const_uint8_buf_t aad,
+    aead_gcm_tag_len_t tag_len, crypto_const_uint8_buf_t auth_tag,
+    crypto_uint8_buf_t *plaintext, hardened_bool_t *success);
 
 /**
  * Internal GHASH operation of Galois Counter Mode (GCM).

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -48,7 +48,9 @@ cc_library(
     srcs = ["aes_gcm_testutils.c"],
     hdrs = ["aes_gcm_testutils.h"],
     deps = [
-        "//sw/device/lib/crypto/impl/aes_gcm",
+        "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -5,8 +5,9 @@
 #include "sw/device/tests/crypto/aes_gcm_testutils.h"
 
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/lib/crypto/drivers/aes.h"
-#include "sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -28,34 +29,109 @@ static uint32_t profile_end(uint64_t t_start) {
   return (uint32_t)cycles;
 }
 
-uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
-  uint8_t actual_ciphertext[test.plaintext_len];
-  uint8_t actual_tag[test.tag_len];
+/**
+ * Static mask to use for testing.
+ */
+static const uint32_t kKeyMask[8] = {
+    0x01234567, 0x89abcdef, 0x00010203, 0x04050607,
+    0x08090a0b, 0x0c0d0e0f, 0x10111213, 0x14151617,
+};
 
-  // Construct AES key. Construct key shares by setting first share to full key
-  // and second share to 0. (Note: this is not a secure construction! But it
-  // makes debugging tests easier because there is only one thing to print.)
-  const uint32_t share1[8] = {0};
-  const aes_key_t test_key = {
-      .mode = kAesCipherModeCtr,
-      .sideload = kHardenedBoolFalse,
-      .key_len = test.key_len,
-      .key_shares = {test.key, share1},
+/**
+ * Get the enum value for a given tag length.
+ */
+static aead_gcm_tag_len_t get_tag_length(size_t tag_len_bytes) {
+  switch (tag_len_bytes) {
+    case (128 / 8):
+      return kAeadGcmTagLen128;
+    case (120 / 8):
+      return kAeadGcmTagLen120;
+    case (112 / 8):
+      return kAeadGcmTagLen112;
+    case (104 / 8):
+      return kAeadGcmTagLen104;
+    case (96 / 8):
+      return kAeadGcmTagLen96;
+    case (64 / 8):
+      return kAeadGcmTagLen64;
+    case (32 / 8):
+      return kAeadGcmTagLen32;
+    default:
+      // Should not get here.
+      CHECK(false);
+  }
+  // Should not get here.
+  CHECK(false);
+  return 0;
+}
+
+uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
+  // Construct the blinded key configuration.
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = kKeyModeAesGcm,
+      .key_length = test.key_len * sizeof(uint32_t),
+      .hw_backed = kHardenedBoolFalse,
+      .diversification_hw_backed = NULL,
+      .security_level = kSecurityLevelLow,
   };
+
+  // Construct blinded key from the key and testing mask.
+  uint32_t keyblob[keyblob_num_words(config)];
+  CHECK_STATUS_OK(
+      keyblob_from_key_and_mask(test.key, kKeyMask, config, keyblob));
+
+  // Construct the blinded key.
+  crypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+      .checksum = 0,
+  };
+
+  // Set the checksum.
+  key.checksum = integrity_blinded_checksum(&key);
+
+  crypto_const_uint8_buf_t iv = {
+      .data = test.iv,
+      .len = test.iv_len,
+  };
+  crypto_const_uint8_buf_t plaintext = {
+      .data = test.plaintext,
+      .len = test.plaintext_len,
+  };
+  crypto_const_uint8_buf_t aad = {
+      .data = test.aad,
+      .len = test.aad_len,
+  };
+
+  uint8_t actual_tag_data[test.tag_len];
+  crypto_uint8_buf_t actual_tag = {
+      .data = actual_tag_data,
+      .len = sizeof(actual_tag_data),
+  };
+
+  uint8_t actual_ciphertext_data[test.plaintext_len];
+  crypto_uint8_buf_t actual_ciphertext = {
+      .data = actual_ciphertext_data,
+      .len = sizeof(actual_ciphertext_data),
+  };
+
+  aead_gcm_tag_len_t tag_len = get_tag_length(test.tag_len);
 
   // Call encrypt() with a cycle count timing profile.
   uint64_t t_start = profile_start();
-  status_t err = aes_gcm_encrypt(
-      test_key, test.iv_len, test.iv, test.plaintext_len, test.plaintext,
-      test.aad_len, test.aad, test.tag_len, actual_tag, actual_ciphertext);
+  crypto_status_t err = otcrypto_aes_encrypt_gcm(
+      &key, plaintext, iv, aad, tag_len, &actual_ciphertext, &actual_tag);
   uint32_t cycles = profile_end(t_start);
   LOG_INFO("aes_gcm_encrypt took %d cycles", cycles);
 
   // Check for errors and that the tag and plaintext match expected values.
-  CHECK_STATUS_OK(err);
-  CHECK_ARRAYS_EQ(actual_tag, test.tag, test.tag_len);
+  CHECK(err == kCryptoStatusOK);
+  CHECK_ARRAYS_EQ(actual_tag_data, test.tag, test.tag_len);
   if (test.plaintext_len > 0) {
-    int cmp = memcmp(actual_ciphertext, test.ciphertext, test.plaintext_len);
+    int cmp =
+        memcmp(actual_ciphertext_data, test.ciphertext, test.plaintext_len);
     CHECK(cmp == 0, "AES-GCM encryption output does not match ciphertext");
   }
 
@@ -63,36 +139,73 @@ uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
 }
 
 uint32_t call_aes_gcm_decrypt(aes_gcm_test_t test, bool tag_valid) {
-  hardened_bool_t success;
-  uint8_t actual_plaintext[test.plaintext_len];
-
-  // Construct AES key. Construct key shares by setting first share to full key
-  // and second share to 0. (Note: this is not a secure construction! But it
-  // makes debugging tests easier because there is only one thing to print.)
-  const uint32_t share1[8] = {0};
-  const aes_key_t test_key = {
-      .mode = kAesCipherModeCtr,
-      .sideload = kHardenedBoolFalse,
-      .key_len = test.key_len,
-      .key_shares = {test.key, share1},
+  // Construct the blinded key configuration.
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = kKeyModeAesGcm,
+      .key_length = test.key_len * sizeof(uint32_t),
+      .hw_backed = kHardenedBoolFalse,
+      .diversification_hw_backed = NULL,
+      .security_level = kSecurityLevelLow,
   };
+
+  // Construct blinded key from the key and testing mask.
+  uint32_t keyblob[keyblob_num_words(config)];
+  CHECK_STATUS_OK(
+      keyblob_from_key_and_mask(test.key, kKeyMask, config, keyblob));
+
+  // Construct the blinded key.
+  crypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+      .checksum = 0,
+  };
+
+  // Set the checksum.
+  key.checksum = integrity_blinded_checksum(&key);
+
+  crypto_const_uint8_buf_t iv = {
+      .data = test.iv,
+      .len = test.iv_len,
+  };
+  crypto_const_uint8_buf_t ciphertext = {
+      .data = test.ciphertext,
+      .len = test.plaintext_len,
+  };
+  crypto_const_uint8_buf_t aad = {
+      .data = test.aad,
+      .len = test.aad_len,
+  };
+  crypto_const_uint8_buf_t tag = {
+      .data = test.tag,
+      .len = test.tag_len,
+  };
+
+  uint8_t actual_plaintext_data[test.plaintext_len];
+  crypto_uint8_buf_t actual_plaintext = {
+      .data = actual_plaintext_data,
+      .len = sizeof(actual_plaintext_data),
+  };
+
+  aead_gcm_tag_len_t tag_len = get_tag_length(test.tag_len);
+  hardened_bool_t success;
 
   // Call decrypt() with a cycle count timing profile.
   uint64_t t_start = profile_start();
-  status_t err =
-      aes_gcm_decrypt(test_key, test.iv_len, test.iv, test.plaintext_len,
-                      test.ciphertext, test.aad_len, test.aad, test.tag_len,
-                      test.tag, actual_plaintext, &success);
+  crypto_status_t err = otcrypto_aes_decrypt_gcm(
+      &key, ciphertext, iv, aad, tag_len, tag, &actual_plaintext, &success);
   uint32_t cycles = profile_end(t_start);
   LOG_INFO("aes_gcm_decrypt took %d cycles", cycles);
 
   // Check the results.
-  CHECK_STATUS_OK(err);
+  CHECK(err == kCryptoStatusOK);
   if (tag_valid) {
     CHECK(success == kHardenedBoolTrue,
           "AES-GCM decryption failed on valid input");
     if (test.plaintext_len > 0) {
-      int cmp = memcmp(actual_plaintext, test.plaintext, test.plaintext_len);
+      int cmp =
+          memcmp(actual_plaintext_data, test.plaintext, test.plaintext_len);
       CHECK(cmp == 0, "AES-GCM decryption output does not match plaintext");
     }
   } else {

--- a/sw/device/tests/crypto/aes_gcm_testvectors.h
+++ b/sw/device/tests/crypto/aes_gcm_testvectors.h
@@ -31,7 +31,6 @@ static const uint32_t kKey256[8] = {
 /**
  * Authenticated data for testing.
  */
-static const uint32_t kAadLen = 18;
 static uint8_t kAad[18] = {
     // aad = 'authenticated data'
     //     = 61757468656e746963617465642064617461
@@ -41,7 +40,6 @@ static uint8_t kAad[18] = {
 /**
  * Plaintext for testing.
  */
-static const uint32_t kPlaintextLen = 32;
 static uint8_t kPlaintext[32] = {
     // plaintext = 'authenticated and encrypted data'
     //           =
@@ -112,9 +110,9 @@ const aes_gcm_test_t kAesGcmTestvectors[] = {
             {// IV = c58aded2e1bbecba8b16a5757e5475bd
              0xc5, 0x8a, 0xde, 0xd2, 0xe1, 0xbb, 0xec, 0xba, 0x8b, 0x16, 0xa5,
              0x75, 0x7e, 0x54, 0x75, 0xbd},
-        .plaintext_len = kPlaintextLen,
+        .plaintext_len = sizeof(kPlaintext),
         .plaintext = kPlaintext,
-        .aad_len = kAadLen,
+        .aad_len = sizeof(kAad),
         .aad = kAad,
         .ciphertext = kCiphertext256,
         .tag_len = 16,
@@ -133,9 +131,9 @@ const aes_gcm_test_t kAesGcmTestvectors[] = {
             {// IV = c58aded2e1bbecba8b16a5757e5475bd
              0xc5, 0x8a, 0xde, 0xd2, 0xe1, 0xbb, 0xec, 0xba, 0x8b, 0x16, 0xa5,
              0x75, 0x7e, 0x54, 0x75, 0xbd},
-        .plaintext_len = kPlaintextLen,
+        .plaintext_len = sizeof(kPlaintext),
         .plaintext = kPlaintext,
-        .aad_len = kAadLen,
+        .aad_len = sizeof(kAad),
         .aad = kAad,
         .ciphertext = kCiphertext256,
         .tag_len = 12,


### PR DESCRIPTION
This connects the AES-GCM implementation to the top-level cryptolib API, and adjusts the tests to use this top-level entrypoint instead of the internal implementation.

@y-srini I made a couple small changes to the API here:
- added a `success` parameter for decryption (similar to signature verifications, I think we need to return whether the authentication passed or not as an argument instead of an operational status)
- added an initial counter block to GCTR (I simply forgot to include this when I added GCTR to the API earlier)