### PR TITLE
[site] Fix overflows on documentation page when on mobile

### DIFF
--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -14,6 +14,7 @@ window.onload = (event) => {
 }
 </script>
 
+<div class="scroll-container" style="width: 100%; overflow-x: scroll">
 <figure class="block-diagram" id="earlgrey-block-diagram">
     <figcaption class="block-diagram-title">Chip_Earlgrey_ASIC</figcaption>
     <div class="top">
@@ -113,6 +114,7 @@ window.onload = (event) => {
         <div class="clock clock6">Logic Only</div>
     </div>
 </figure>
+</div>
 
 <!-- Specific stylings for this diagram -->
 <style>

--- a/site/landing/assets/scss/_boxes.scss
+++ b/site/landing/assets/scss/_boxes.scss
@@ -4,8 +4,7 @@
 
 .tiles__container {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
-  grid-template-rows: 1fr;
+  grid-template-columns: repeat(3, 1fr);
 
   width: 90vw;
   padding: 0.8em;
@@ -29,6 +28,7 @@
   font-size: 1.2em;
   text-decoration: none;
   text-align: center;
+  white-space: nowrap;
 
   background: var(--background);
   color: var(--text-color);


### PR DESCRIPTION
These changes:

* Move the interactive block diagram into a scrollable `<div>` to stop it overflowing the edge of the page.
* Move the documentation navigation into two rows so it fits better at smaller screen sizes.

Screenshot:

![image](https://user-images.githubusercontent.com/105280833/231407420-3ad666f6-23ea-4460-8d22-f78a346c1814.png)
