### PR TITLE
[Spi host] New DIFS

### DIFF
--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -476,3 +476,15 @@ dif_result_t dif_spi_host_get_status(const dif_spi_host_t *spi_host,
 
   return kDifOk;
 }
+
+dif_result_t dif_spi_host_write_command(const dif_spi_host_t *spi_host,
+                                        uint16_t length,
+                                        dif_spi_host_width_t speed,
+                                        dif_spi_host_direction_t direction,
+                                        bool last_segment) {
+  if (spi_host == NULL) {
+    return kDifBadArg;
+  }
+  write_command_reg(spi_host, length, speed, direction, last_segment);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -92,6 +92,14 @@ dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
   reg = bitfield_bit32_write(reg, SPI_HOST_CONFIGOPTS_CPHA_0_BIT, config.cpha);
   reg = bitfield_bit32_write(reg, SPI_HOST_CONFIGOPTS_CPOL_0_BIT, config.cpol);
   mmio_region_write32(spi_host->base_addr, SPI_HOST_CONFIGOPTS_REG_OFFSET, reg);
+
+  reg = mmio_region_read32(spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET);
+  reg = bitfield_field32_write(reg, SPI_HOST_CONTROL_TX_WATERMARK_FIELD,
+                               config.tx_watermark);
+  reg = bitfield_field32_write(reg, SPI_HOST_CONTROL_RX_WATERMARK_FIELD,
+                               config.rx_watermark);
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET, reg);
+
   spi_host_enable(spi_host, true);
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -227,9 +227,9 @@ typedef enum dif_spi_host_events {
    */
   kDifSpiHostEvtReady = 1 << 4,
   /**
-   * Enable IRQ to be fired when `STATUS.ACTIVE` goes high.
+   * Enable IRQ to be fired when `STATUS.ACTIVE` goes low.
    */
-  kDifSpiHostEvtActive = 1 << 5,
+  kDifSpiHostEvtIdle = 1 << 5,
   /**
    * All above together.
    */

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -249,6 +249,7 @@ typedef uint32_t dif_spi_host_events_t;
  * @param enable True to enable the `events` or false to disable.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_host_event_set_enabled(const dif_spi_host_t *spi_host,
                                             dif_spi_host_events_t events,
                                             bool enable);
@@ -261,6 +262,7 @@ dif_result_t dif_spi_host_event_set_enabled(const dif_spi_host_t *spi_host,
  * enabled.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_host_event_get_enabled(const dif_spi_host_t *spi_host,
                                             dif_spi_host_events_t *events);
 
@@ -337,8 +339,9 @@ typedef struct dif_spi_host_status {
  *
  * @param spi_host A SPI Host handle.
  * @param[out] status The status of the spi.
- * @return dif_result_t
+ * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_host_get_status(const dif_spi_host_t *spi_host,
                                      dif_spi_host_status_t *status);
 

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -42,6 +42,12 @@ typedef struct dif_spi_host_config {
   bool cpha;
   /** SPI clock polarity. */
   bool cpol;
+  /** If `EVENT_ENABLE.TXWM` is set, an interrupt will fire when the depth of
+   * the TX FIFO drops below `TX_WATERMARK` words (32b each). */
+  size_t tx_watermark;
+  /** If `EVENT_ENABLE.RXWM` is set, an interrupt will fire when the depth of
+   * the RX FIFO drops below `RX_WATERMARK` words (32b each). */
+  size_t rx_watermark;
 } dif_spi_host_config_t;
 
 /**

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -345,6 +345,25 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_host_get_status(const dif_spi_host_t *spi_host,
                                      dif_spi_host_status_t *status);
 
+/**
+ * Issues a command segment to a spi_host.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param length The number of 1-byte burst for read and write segments, or the
+ * number of cycles for dummy segments.
+ * @param speed Which speed the transmission should use.
+ * @param direction Which direction the operation should use.
+ * @param last_segment If true the chip select line is raised after the
+ * transmission, otherwise it is kept low.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_write_command(const dif_spi_host_t *spi_host,
+                                        uint16_t length,
+                                        dif_spi_host_width_t speed,
+                                        dif_spi_host_direction_t direction,
+                                        bool last_segment);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -642,5 +642,25 @@ TEST_F(StatusTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_spi_host_get_status(&spi_host_, nullptr));
 }
 
+class WriteCommandTest : public SpiHostTest {};
+
+TEST_F(WriteCommandTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_spi_host_write_command(
+      nullptr, 4, kDifSpiHostWidthStandard, kDifSpiHostDirectionRx, false));
+}
+
+// Checks that arguments are validated.
+TEST_F(WriteCommandTest, ValidArgs) {
+  EXPECT_WRITE32(SPI_HOST_COMMAND_REG_OFFSET,
+                 {{SPI_HOST_COMMAND_LEN_OFFSET, 899},
+                  {SPI_HOST_COMMAND_SPEED_OFFSET, 1},
+                  {SPI_HOST_COMMAND_DIRECTION_OFFSET, 3},
+                  {SPI_HOST_COMMAND_CSAAT_BIT, 1}});
+
+  EXPECT_DIF_OK(
+      dif_spi_host_write_command(&spi_host_, 900, kDifSpiHostWidthDual,
+                                 kDifSpiHostDirectionBidirectional, false));
+}
+
 }  // namespace
 }  // namespace dif_spi_host_unittest

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -490,7 +490,7 @@ class EventEnableRegTest : public SpiHostTest {
       {kDifSpiHostEvtRxWm, SPI_HOST_EVENT_ENABLE_RXWM_BIT},
       {kDifSpiHostEvtTxWm, SPI_HOST_EVENT_ENABLE_TXWM_BIT},
       {kDifSpiHostEvtReady, SPI_HOST_EVENT_ENABLE_READY_BIT},
-      {kDifSpiHostEvtActive, SPI_HOST_EVENT_ENABLE_IDLE_BIT},
+      {kDifSpiHostEvtIdle, SPI_HOST_EVENT_ENABLE_IDLE_BIT},
   }};
 };
 // C++ 14 requires this.

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -100,6 +100,8 @@ class SpiHostTest : public Test, public MmioTest {
       .full_cycle = false,
       .cpha = false,
       .cpol = false,
+      .tx_watermark = 0,
+      .rx_watermark = 0,
   };
 };
 
@@ -132,6 +134,9 @@ TEST_F(ConfigTest, Default) {
                      {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
                      {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
                  });
+
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET, 0);
   EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
                  {
                      {SPI_HOST_CONTROL_SPIEN_BIT, true},
@@ -170,6 +175,8 @@ TEST_F(ConfigTest, ClockRate) {
                      {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
                      {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
                  });
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET, 0);
   EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
                  {
                      {SPI_HOST_CONTROL_SPIEN_BIT, true},
@@ -196,6 +203,8 @@ TEST_F(ConfigTest, ChipSelectOptions) {
                      {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
                      {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
                  });
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET, 0);
   EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
                  {
                      {SPI_HOST_CONTROL_SPIEN_BIT, true},
@@ -222,6 +231,36 @@ TEST_F(ConfigTest, SpiOptions) {
                      {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, true},
                      {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, true},
                  });
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_SPIEN_BIT, true},
+                 });
+
+  EXPECT_DIF_OK(dif_spi_host_configure(&spi_host_, config_));
+}
+
+// Checks the SPI tx and rx watermark.
+TEST_F(ConfigTest, SpiTxRxWatermark) {
+  config_.tx_watermark = 0x7f;
+  config_.rx_watermark = 0x7e;
+
+  ExpectDeviceReset();
+  EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
+                 });
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {{SPI_HOST_CONTROL_TX_WATERMARK_OFFSET, 0x7f},
+                  {SPI_HOST_CONTROL_RX_WATERMARK_OFFSET, 0x7e}});
   EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
                  {
                      {SPI_HOST_CONTROL_SPIEN_BIT, true},


### PR DESCRIPTION
This PR:
 - Add OT_WARN_UNUSED_RESULT to recently added DIFs.
 - Add an external function to access the `spi_host.COMMAND` register.
 - Add rx and tx watermark options to the `dif_spi_host_configure` function.
