### PR TITLE
[hw,i2c,dv]  Add sequence to disable host mode

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -244,6 +244,22 @@
       stage: V2
       tests: [""]
     }
+    {
+      name: i2c_host_mode_toggle
+      desc: '''
+            Host mode: disable host mode during host mode sequence
+
+            Stimulus:
+              - Host sends an address and data but receives NAK response
+                since agent is reset before transaction is complete and
+                host mode is disabled
+            Checking:
+              - Check if DUT goes to Idle state after Host mode is disabled
+              - Check that transactions process normally after recovery by running a smoketest vseq.
+            '''
+      stage: V2
+      tests: ["i2c_host_mode_toggle"]
+    }
 
     //-----------------------------------------------
     // Tests for I2C DUT in TARGET mode

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -51,6 +51,7 @@ filesets:
       - seq_lib/i2c_target_fifo_reset_tx_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_hrst_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_host_mode_toggle_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -429,6 +429,10 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         wait(exp_rd_q.size() > 0);
         exp_trn = exp_rd_q.pop_front();
       end
+      if (!cfg.en_scb) begin // Skip comparison
+        `uvm_info(`gfn, "Scoreboard disabled", UVM_LOW)
+        continue;
+      end
       // when rx_fifo is overflow, drop the last byte from dut_trn
       if (cfg.seq_cfg.en_rx_overflow && dut_trn.bus_op == BusOpRead) begin
         void'(dut_trn.data_q.pop_back());

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_mode_toggle_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_mode_toggle_vseq.sv
@@ -1,0 +1,101 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// In DUT=host_mode, create a read/write transaction and randomly disable host_mode
+//   mid-transaction by writing ctrl.enablehost = 1'b0.
+// Check if DUT goes to Idle state
+// To check the DUT has recovered, start a host_smoke_vseq to check transactions
+//   are processed as expected
+class i2c_host_mode_toggle_vseq extends i2c_base_vseq;
+  `uvm_object_utils(i2c_host_mode_toggle_vseq)
+  `uvm_object_new
+
+  rand bit rwbit;
+  rand bit[6:0] addr;
+  uint num_bytes = 1;
+  rand uint wait_cycles;
+  // Wait for address byte or data byte with equal probability
+  constraint wait_cycles_c{
+    wait_cycles dist {
+        [1:7] := 1,
+        [9:17] := 1
+    };
+  }
+
+  virtual task pre_start();
+    super.pre_start();
+    expected_intr[AcqFull] = 1;
+    expected_intr[TxStretch] = 1;
+    expected_intr[CmdComplete] = 1;
+    // Since after driver reset, SDA will be high, NAK interrupt will be raised
+    expected_intr[Nak] = 1;
+    expected_intr[HostTimeout] = 1;
+    for (int i = 0; i < NumI2cIntr; i++) intr_q.push_back(i2c_intr_e'(i));
+    if (cfg.bad_addr_pct > 0) cfg.m_i2c_agent_cfg.allow_bad_addr = 1;
+  endtask
+
+  virtual task body();
+    i2c_item fmt_item = new("addr_item");
+    bit [TL_DW-1:0] reg_val;
+    initialization(.mode(Host));
+    get_timing_values();
+    program_registers();
+    `uvm_info(`gfn, "Start i2c_host_mode_toggle_vseq", UVM_HIGH)
+    // start transmission in Host mode with a random read or write transaction
+    fmt_item.start = 1;
+    fmt_item.read = rwbit;
+    fmt_item.fbyte = {addr, rwbit};
+    program_format_flag(fmt_item, "Programming address in host mode", 1);
+    fmt_item = new("data_item");
+    if (rw_bit) begin // if read enable one byte read
+      fmt_item.read = 1;
+      fmt_item.fbyte = num_bytes;
+    end
+    else begin // if write send one byte
+      fmt_item.fbyte = $urandom_range(0,255);
+    end
+    fmt_item.stop = 1;
+    program_format_flag(fmt_item, "Programming data in host mode", 1);
+    // Wait for random number of cycles
+    repeat (wait_cycles) @(posedge cfg.m_i2c_agent_cfg.vif.scl_io);
+    `uvm_info(`gfn, "Disabling host mode", UVM_LOW)
+    // Disable host mode
+    cfg.en_scb = 0;
+    ral.ctrl.enablehost.set(1'b0);
+    csr_update(ral.ctrl);
+    // Clear Host mode FIFO
+    ral.fifo_ctrl.rxrst.set(1'b1);
+    ral.fifo_ctrl.fmtrst.set(1'b1);
+    csr_update(ral.fifo_ctrl);
+    // Wait for DUT to be in idle mode
+    do begin
+      csr_rd(.ptr(ral.status), .value(reg_val));
+      cfg.clk_rst_vif.wait_clks(1);
+    end while(!bit'(get_field_val(ral.status.hostidle, reg_val)));
+    `uvm_info(`gfn, "DUT in idle mode", UVM_LOW)
+    // Clear all interrupts
+    process_interrupts();
+    // Clear scoreboard FIFO
+    cfg.scb_h.target_mode_wr_exp_fifo.flush();
+    cfg.scb_h.target_mode_wr_obs_fifo.flush();
+    // Enable scorebaord
+    cfg.en_scb = 1;
+    `uvm_info(`gfn, "Enable Host mode", UVM_LOW)
+    cfg.m_i2c_agent_cfg.if_mode = Device;
+    // Enable host mode
+    ral.ctrl.enablehost.set(1'b1);
+    csr_update(ral.ctrl);
+    cfg.clk_rst_vif.wait_clks(10);
+    // Start host_smoke
+    begin
+      uvm_sequence seq = create_seq_by_name("i2c_host_smoke_vseq");
+      seq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(seq)
+      seq.start(p_sequencer);
+    end
+    `uvm_info(`gfn, "End i2c_host_mode_toggle_vseq", UVM_HIGH)
+  endtask : body
+
+
+endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -33,3 +33,4 @@
 `include "i2c_target_fifo_reset_tx_vseq.sv"
 `include "i2c_target_stress_all_vseq.sv"
 `include "i2c_target_hrst_vseq.sv"
+`include "i2c_host_mode_toggle_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -216,6 +216,11 @@
                  "+stress_seq=i2c_target_stress_all_vseq"]
       run_timeout_mins: 20
     }
+    {
+      name: "i2c_host_mode_toggle"
+      uvm_test_seq: "i2c_host_mode_toggle_vseq"
+      run_timeout_mins: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
To address requirements in https://github.com/lowRISC/opentitan/issues/17710, 
- Added a new sequence to disable host mode

The following FSM state transitions are observed
`PopFmtFifo` --> `ClockStop`
`HoldStop`  --> `Idle`

Closes: #17710 