### PR TITLE
[entropy_src] Define intention and limitations of `cs_aes_halt` and verify them

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -48,6 +48,16 @@
       name:    "cs_aes_halt"
       act:     "req"
       package: "entropy_src_pkg"
+      desc:    '''
+               Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+               The idea is that Entropy Source requests CSRNG's AES to halt and waits for CSRNG to acknowledge before it starts its SHA3.
+               While SHA3 runs, Entropy Source keeps the request high.
+               CSRNG may not drop the acknowledge before Entropy Source drops the request.
+
+               Current limitations:
+               1. During startup and in Firmware Override - Extract & Insert mode, Entropy Source makes no AES Halt requests but still activates its SHA3 engine.
+               2. Outside Firmware Override - Extract & Insert mode, Entropy Source may activate its SHA3 engine without requesting AES Halt, but no more than for 24 Keccak rounds (24 clock cycles) every 512 clock cycles.
+               '''
     }
     { struct:  "entropy_src_rng",
       type:    "req_rsp",

--- a/hw/ip/entropy_src/doc/programmers_guide.md
+++ b/hw/ip/entropy_src/doc/programmers_guide.md
@@ -59,6 +59,10 @@ Any entropy bits arriving after the observe FIFO is full are being discarded.
 Firmware has to read out the entire observe FIFO to restart entropy collection.
 Only entropy bits inserted by firmware by writing the [`FW_OV_WR_DATA`](../data/entropy_src.hjson#fw_ov_wr_data) register may eventually reach the block hardware interface.
 
+The `cs_aes_halt` interface that should halt CSRNG's AES while Entropy Source's SHA3 is active (to prevent power peaks) does not work when firmware inserts entropy.
+In this case, SHA3 activity is controlled by software.
+Thus, if power peaks are a concern, software must ensure that SHA3 is not active too frequently or not together with CSRNG's AES.
+
 ### Hardware Conditioning Bypass
 
 Firmware can enable bypassing of the hardware conditioning inside the ENTROPY_SRC block.

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2817,5 +2817,70 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign unused_entropy_data = (|reg2hw.entropy_data.q);
   assign unused_fw_ov_rd_data = (|reg2hw.fw_ov_rd_data.q);
 
+  //--------------------------------------------
+  // Assertions
+  //--------------------------------------------
+
+`ifdef INC_ASSERT
+  // entropy_src is known to activate Keccak without AES Halt handshakes with CSRNG (#17941).
+  // This code ensures that this does not happen too often (i.e., at most `KAWAH_THRESHOLD` out of
+  // `KAWAH_WINDOW_SIZE` consecutive clock cycles) outside *Firmware Override - Extract & Insert*
+  // mode.  When firmware inserts entropy, it is essentially in control of the SHA3 core
+  // and the current HW implementation cannot make guarantees around AES Halt and Keccak activity.
+  //
+  // When issue #17941 gets resolved and there are assertions (or equivalent checks) in place to
+  // ensure that Keccak is not activated without AES Halt handshakes, this code should be removed.
+
+  // Track activity of Keccak.
+  logic keccak_active;
+  assign keccak_active = u_sha3.u_keccak.keccak_st != sha3_pkg::KeccakStIdle;
+  `ASSERT_KNOWN(KeccakActiveKnown_A, keccak_active)
+
+  // Track state of AES Halt req/ack with CSRNG.
+  logic cs_aes_halt_active;
+  assign cs_aes_halt_active = cs_aes_halt_o.cs_aes_halt_req && cs_aes_halt_i.cs_aes_halt_ack;
+  `ASSERT_KNOWN(CsAesHaltActiveKnown_A, cs_aes_halt_active)
+
+  // Track when Keccak is active without AES Halt ('KAWAH') outside FW entropy insertion mode.
+  localparam int unsigned KAWAH_WINDOW_SIZE = 512;
+  logic [KAWAH_WINDOW_SIZE-1:0] kawah_window_d, kawah_window_q;
+  assign kawah_window_d[0] = keccak_active & ~cs_aes_halt_active & ~fw_ov_mode_entropy_insert;
+  assign kawah_window_d[KAWAH_WINDOW_SIZE-1:1] = kawah_window_q[KAWAH_WINDOW_SIZE-2:0];
+
+  // Count how many cycles Keccak was active without AES Halt in the current window.
+  localparam int unsigned KAWAH_COUNTER_SIZE = $clog2(KAWAH_WINDOW_SIZE);
+  logic [KAWAH_COUNTER_SIZE-1:0] kawah_counter_d, kawah_counter_q;
+  always_comb begin
+    kawah_counter_d = kawah_counter_q;
+    // Increment counter if Keccak is active without AES Halt in the current cycle.
+    if (kawah_window_d[0]) kawah_counter_d += 1;
+    // Decrement counter if Keccak was active without AES Halt in the cycle that falls out of the
+    // sliding window in this cycle.
+    if (kawah_window_q[KAWAH_WINDOW_SIZE-1]) begin
+      // If the counter would underflow, a testbench error has happened (only relevant if reset is
+      // deasserted).
+      `ASSERT_I(KawahCounterNoUnderflow_A, rst_ni !== 1'b1 || kawah_counter_d > 0)
+      kawah_counter_d -= 1;
+    end
+  end
+  // Ensure counter does not overflow.
+  `ASSERT(KawahCounterNoOverflow_A, kawah_counter_d < KAWAH_WINDOW_SIZE - 1)
+
+  // Assert that in the last KAWAH_WINDOW_SIZE clock cycles, Keccak was active without AES Halt for
+  // at most KAWAH_THRESHOLD clock cycles.
+  localparam int unsigned KAWAH_THRESHOLD = 24;
+  `ASSERT(KeccakNotTooActiveWithoutAesHalt_A, kawah_counter_q <= KAWAH_THRESHOLD)
+  `ASSERT_INIT(KawahParametersLegal_A, KAWAH_THRESHOLD < KAWAH_WINDOW_SIZE)
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (!rst_ni) begin
+      kawah_counter_q <= '0;
+      kawah_window_q  <= '0;
+    end else begin
+      kawah_counter_q <= kawah_counter_d;
+      kawah_window_q  <= kawah_window_d;
+    end
+  end
+`endif
 
 endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6629,6 +6629,17 @@
         }
         {
           name: cs_aes_halt
+          desc:
+            '''
+            Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+            The idea is that Entropy Source requests CSRNG's AES to halt and waits for CSRNG to acknowledge before it starts its SHA3.
+            While SHA3 runs, Entropy Source keeps the request high.
+            CSRNG may not drop the acknowledge before Entropy Source drops the request.
+
+            Current limitations:
+            1. During startup and in Firmware Override - Extract & Insert mode, Entropy Source makes no AES Halt requests but still activates its SHA3 engine.
+            2. Outside Firmware Override - Extract & Insert mode, Entropy Source may activate its SHA3 engine without requesting AES Halt, but no more than for 24 Keccak rounds (24 clock cycles) every 512 clock cycles.
+            '''
           struct: cs_aes_halt
           package: entropy_src_pkg
           type: req_rsp
@@ -18692,6 +18703,17 @@
       }
       {
         name: cs_aes_halt
+        desc:
+          '''
+          Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+          The idea is that Entropy Source requests CSRNG's AES to halt and waits for CSRNG to acknowledge before it starts its SHA3.
+          While SHA3 runs, Entropy Source keeps the request high.
+          CSRNG may not drop the acknowledge before Entropy Source drops the request.
+
+          Current limitations:
+          1. During startup and in Firmware Override - Extract & Insert mode, Entropy Source makes no AES Halt requests but still activates its SHA3 engine.
+          2. Outside Firmware Override - Extract & Insert mode, Entropy Source may activate its SHA3 engine without requesting AES Halt, but no more than for 24 Keccak rounds (24 clock cycles) every 512 clock cycles.
+          '''
         struct: cs_aes_halt
         package: entropy_src_pkg
         type: req_rsp


### PR DESCRIPTION
This resolves the short-term (M2.5-relevant) part of #17941 by adding the current behavior to the specification and by adding assertions to ensure that the implementation works according to the specification.

Tested locally with a full regression run of `entropy_src`.