### PR TITLE
[dv, keymgr] Remove assertion `RootKeyValidDuringLatching_A`

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -36,9 +36,6 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   task body();
     // invalid HW input may cause unstable data on kmac interface
     $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
-    // The following assertion is not relevant for block-level, it was added
-    // to double check OTP root key becomes valid when it is needed
-    $assertoff(0, "tb.dut.u_ctrl.RootKeyValidDuringLatching_A");
     super.body();
   endtask : body
 endclass : keymgr_hwsw_invalid_input_vseq

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -831,9 +831,6 @@ module keymgr_ctrl
   // Assertions
   /////////////////////////////////
 
-  // Verify that OTP root key is valid when FSM reaches to latching state
-  `ASSERT(RootKeyValidDuringLatching_A, (state_q == StCtrlRootKey) && en_i |-> root_key_valid_q)
-
   // This assertion will not work if fault_status ever takes on metafields such as
   // qe / re etc.
   `ASSERT_INIT(SameErrCnt_A, $bits(keymgr_reg2hw_fault_status_reg_t) ==


### PR DESCRIPTION
Reverts lowRISC/opentitan#17764

The assertion `RootKeyValidDuringLatching_A` is causing some problems, because there are some LC transition tests (see https://github.com/lowRISC/opentitan/issues/17834) where OTP root key is not valid. I could not find an easy way to update the assertion, because neither of the signals are passing through keymgr.