### PR TITLE
[hw,i2c,dv] Use num_trans in base host sequence

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_smoke_vseq.sv
@@ -10,4 +10,23 @@ class i2c_host_smoke_vseq extends i2c_rx_tx_vseq;
   // increase num_trans to cover all transaction types
   constraint num_trans_c { num_trans inside {[50 : 100]}; }
 
+  virtual task body();
+    bit do_interrupt = 1'b1;
+    initialization(.mode(Host));
+    `uvm_info(`gfn, "\n--> start of sequence", UVM_DEBUG)
+    fork
+      begin
+        while (!cfg.under_reset && do_interrupt) process_interrupts();
+      end
+      begin
+        host_send_trans(.max_trans(num_trans),
+                        .trans_type(ReadOnly),
+                        .read(1));
+        do_interrupt = 1'b0; // gracefully stop process_interrupts
+      end
+    join
+    `uvm_info(`gfn, "\n--> end of sequence", UVM_DEBUG)
+  endtask : body
+
+
 endclass : i2c_host_smoke_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -18,9 +18,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
         while (!cfg.under_reset && do_interrupt) process_interrupts();
       end
       begin
-        host_send_trans(.max_trans(1),
-                        .trans_type(ReadOnly),
-                        .read(1));
+        host_send_trans(.max_trans(num_trans));
         do_interrupt = 1'b0; // gracefully stop process_interrupts
       end
     join
@@ -60,7 +58,6 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rw_bit)
           rw_bit = (trans_type  == WriteOnly) ? 1'b0 :
                    ((trans_type == ReadOnly)  ? 1'b1 : rw_bit);
-
           // program address for folowing transaction types
           chained_read = fmt_item.read && fmt_item.rcont;
           if ((cur_tran == 1'b1) ||    // first read transaction


### PR DESCRIPTION
update `host_send_trans task` call in `i2c_rx_tx_vseq.sv` to use `num_trans` variable so that the number of transactions issued are overridden in derived sequences.
skip `trans_type` argument so that the type of transactions are randomized

Closes: https://github.com/lowRISC/opentitan/issues/18065