### PR TITLE
[csrng] Define, fix, and verify `cs_aes_halt`

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -91,6 +91,10 @@
       name:    "cs_aes_halt"
       act:     "rsp"
       package: "entropy_src_pkg"
+      desc:    '''
+               Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+               When CSRNG gets a request and its AES is not active, it acknowledges and until the request has dropped neither runs its AES nor drops the acknowledge.
+               '''
     }
     { struct:  "mubi8"
       type:    "uni"

--- a/hw/ip/csrng/dv/env/csrng_env.sv
+++ b/hw/ip/csrng/dv/env/csrng_env.sv
@@ -35,9 +35,10 @@ class csrng_env extends cip_base_env #(
                        ::type_id::create("m_aes_halt_agent", this);
     uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(1)))
         ::set(this, "m_aes_halt_agent*", "cfg", cfg.m_aes_halt_agent_cfg);
-    cfg.m_aes_halt_agent_cfg.agent_type = push_pull_agent_pkg::PullAgent;
-    cfg.m_aes_halt_agent_cfg.if_mode    = dv_utils_pkg::Host;
-    cfg.m_aes_halt_agent_cfg.en_cov     = cfg.en_cov;
+    cfg.m_aes_halt_agent_cfg.agent_type          = push_pull_agent_pkg::PullAgent;
+    cfg.m_aes_halt_agent_cfg.if_mode             = dv_utils_pkg::Host;
+    cfg.m_aes_halt_agent_cfg.pull_handshake_type = push_pull_agent_pkg::FourPhase;
+    cfg.m_aes_halt_agent_cfg.en_cov              = cfg.en_cov;
 
     for (int i = 0; i < NUM_HW_APPS; i++) begin
       string edn_agent_name = $sformatf("m_edn_agent[%0d]", i);

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1630,7 +1630,7 @@ module csrng_core import csrng_pkg::*; #(
   // es to cs halt request to reduce power spikes
   assign cs_aes_halt_d =
          (ctr_drbg_upd_es_ack && ctr_drbg_gen_es_ack && block_encrypt_quiet &&
-          cs_aes_halt_i.cs_aes_halt_req && !cs_aes_halt_q);
+          cs_aes_halt_i.cs_aes_halt_req);
 
   assign cs_aes_halt_o.cs_aes_halt_ack = cs_aes_halt_q;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6517,6 +6517,11 @@
         }
         {
           name: cs_aes_halt
+          desc:
+            '''
+            Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+            When CSRNG gets a request and its AES is not active, it acknowledges and until the request has dropped neither runs its AES nor drops the acknowledge.
+            '''
           struct: cs_aes_halt
           package: entropy_src_pkg
           type: req_rsp
@@ -18620,6 +18625,11 @@
       }
       {
         name: cs_aes_halt
+        desc:
+          '''
+          Coordinate activity between CSRNG's AES and Entropy Source's SHA3.
+          When CSRNG gets a request and its AES is not active, it acknowledges and until the request has dropped neither runs its AES nor drops the acknowledge.
+          '''
         struct: cs_aes_halt
         package: entropy_src_pkg
         type: req_rsp


### PR DESCRIPTION
This PR:
- Adds a minimal specification of CSRNG's behavior on the `cs_aes_halt` interface.
- Fixes the acknowledge output of `cs_aes_halt` driven by CSRNG to be level instead of pulse.
- Configures CSRNG's DV so that it does not deassert the request of `cs_aes_halt` after a single acknowledge cycle.
- Adds assertions to CSRNG RTL to ensure its AES is only active while `cs_aes_halt` is not.

Tested locally with a full regression run of CSRNG. The added assertion never failed and all test results are in line with current nightly results.