### PR TITLE
[dv/cdc] Enable cdc instrumentation in two IPs

### DIFF
--- a/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
+++ b/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
@@ -45,6 +45,9 @@
   uvm_test: aon_timer_base_test
   uvm_test_seq: aon_timer_base_vseq
 
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -51,6 +51,7 @@
   uvm_test: csrng_base_test
   uvm_test_seq: csrng_base_vseq
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -49,6 +49,7 @@
   uvm_test: edn_base_test
   uvm_test_seq: edn_base_vseq
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -67,6 +67,9 @@
   uvm_test: flash_ctrl_base_test
   uvm_test_seq: flash_ctrl_base_vseq
 
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -47,6 +47,7 @@
   // Add GPIO specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/gpio/dv/cov/gpio_cov_excl.el"]
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -48,6 +48,7 @@
   uvm_test: hmac_base_test
   uvm_test_seq: hmac_base_vseq
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -43,7 +43,8 @@
   uvm_test: i2c_base_test
   uvm_test_seq: i2c_base_vseq
 
-  // run_opts: []
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.
   tests: [

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -47,6 +47,7 @@
   // Pattgen coverage exclusion
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/pattgen/dv/cov/pattgen_cov.vRefine"]
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
@@ -55,6 +55,7 @@
   uvm_test: rom_ctrl_base_test
   uvm_test_seq: rom_ctrl_base_vseq
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -43,6 +43,7 @@
   uvm_test: rv_timer_base_test
   uvm_test_seq: rv_timer_base_vseq
 
+  // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
+++ b/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson
@@ -64,6 +64,7 @@
   ]
 
   run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}",
+             // Enable cdc instrumentation.
              "+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -244,7 +244,8 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           end
 
           // according to issue #841, interrupt will have one clock cycle delay
-          cfg.clk_rst_vif.wait_n_clks(1);
+          // add an extra cycle for synchronizers from clk_edn to clk
+          cfg.clk_rst_vif.wait_n_clks(2);
           if (!under_reset) begin
             `DV_CHECK_CASE_EQ(cfg.intr_vif.pins[class_i], intr_en[class_i],
                             $sformatf("Interrupt class_%s, is_local_err %0b, local_alert_type %s",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -224,6 +224,10 @@
                                    echo "--otp-seed $line --lc-seed $line"; \
                                  done < $file; \
                                fi ''']
+
+  // TODO(lowrisc/opentitan#16689): Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=0"]
+
   // Add run modes.
   run_modes: [
     // Generates OTP images with different LC states with canonical values,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -244,7 +244,8 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           end
 
           // according to issue #841, interrupt will have one clock cycle delay
-          cfg.clk_rst_vif.wait_n_clks(1);
+          // add an extra cycle for synchronizers from clk_edn to clk
+          cfg.clk_rst_vif.wait_n_clks(2);
           if (!under_reset) begin
             `DV_CHECK_CASE_EQ(cfg.intr_vif.pins[class_i], intr_en[class_i],
                             $sformatf("Interrupt class_%s, is_local_err %0b, local_alert_type %s",


### PR DESCRIPTION
Add cdc instrumentation to aon_timer and flash_ctrl.
Increase wait times by one cycle in some assertions due to CDC delay.
Increase wait times for interrupts in alert_handler due to CDC delay.

Partially addresses #16689