### PR TITLE
[dv/kmac] Fix nightly regression error

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -159,15 +159,17 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-    fork
-      process_checked_kmac_cmd();
-      detect_kmac_app_start();
-      process_kmac_app_fsm();
-      process_edn();
-      process_kmac_app_req_fifo();
-      process_kmac_app_rsp_fifo();
-      process_sideload_key();
-    join_none
+    if (cfg.en_scb) begin
+      fork
+        process_checked_kmac_cmd();
+        detect_kmac_app_start();
+        process_kmac_app_fsm();
+        process_edn();
+        process_kmac_app_req_fifo();
+        process_kmac_app_rsp_fifo();
+        process_sideload_key();
+      join_none
+    end
   endtask
 
   // This task spins forever and assigns `checked_kmac_cmd` to `unchecked_kmac_cmd`

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -183,6 +183,7 @@
     {
       name: "{name}_entropy_mode_error"
       uvm_test_seq: kmac_entropy_mode_error_vseq
+      run_opts: ["+en_scb=0"]
       reseed: 20
     }
     {


### PR DESCRIPTION
The kmac entropy error should turn off scb, but the current mechanism did not turn it off fully, so we still see mismatches from scb.
Fix https://github.com/lowRISC/opentitan/issues/17926