### PR TITLE
[dif,silicon_creator,rom] add 5us+ delays after pin pull enables

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -673,6 +673,7 @@ cc_library(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:multibits",
+        "//sw/device/lib/runtime:hart",
     ],
 )
 

--- a/sw/device/lib/dif/dif_pinmux_unittest.cc
+++ b/sw/device/lib/dif/dif_pinmux_unittest.cc
@@ -133,6 +133,7 @@ TEST_F(PinmuxTest, PadAttributes) {
             kDifLocked);
 
   EXPECT_READ32(PINMUX_MIO_PAD_ATTR_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_READ32(PINMUX_MIO_PAD_ATTR_1_REG_OFFSET, 0);
   EXPECT_WRITE32(PINMUX_MIO_PAD_ATTR_1_REG_OFFSET,
                  {
                      {PINMUX_MIO_PAD_ATTR_1_INVERT_1_BIT, 1},
@@ -157,6 +158,7 @@ TEST_F(PinmuxTest, PadAttributes) {
   EXPECT_EQ(attrs_check.flags, attrs.flags);
 
   EXPECT_READ32(PINMUX_DIO_PAD_ATTR_REGWEN_3_REG_OFFSET, 1);
+  EXPECT_READ32(PINMUX_DIO_PAD_ATTR_3_REG_OFFSET, 0);
   EXPECT_WRITE32(PINMUX_DIO_PAD_ATTR_3_REG_OFFSET,
                  {
                      {PINMUX_DIO_PAD_ATTR_3_INVERT_3_BIT, 1},

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
+load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 
 package(default_visibility = ["//visibility:public"])
@@ -441,8 +441,9 @@ cc_library(
         "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/runtime:hart",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/drivers:otp",
     ],
@@ -455,6 +456,7 @@ cc_test(
         ":pinmux",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_csr.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
@@ -23,6 +24,7 @@ class PinmuxTest : public rom_test::RomTest {
   uint32_t base_ = TOP_EARLGREY_PINMUX_AON_BASE_ADDR;
   rom_test::MockAbsMmio mmio_;
   rom_test::MockOtp otp_;
+  mock_csr::MockCsr csr_;
 };
 
 class InitTest : public PinmuxTest {
@@ -79,6 +81,10 @@ TEST_F(InitTest, WithBootstrap) {
                      {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
   EXPECT_ABS_WRITE32(RegPadAttr(kTopEarlgreyMuxedPadsIoc2),
                      {{PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, 1}});
+  EXPECT_CSR_WRITE(CSR_REG_MCYCLE, 0);
+  for (size_t i = 0; i < 6; ++i) {
+    EXPECT_CSR_READ(CSR_REG_MCYCLE, i * 100);
+  }
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio22),
                      kTopEarlgreyPinmuxInselIoc0)
   EXPECT_ABS_WRITE32(RegInSel(kTopEarlgreyPinmuxPeripheralInGpioGpio23),

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -260,6 +260,15 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   li   t0, SW_STRAP_2_INSEL
   sw   t0, (SW_STRAP_2_PERIPH * 4)(a0)
 
+  // Spin for a minimum of 5us worth of cycles (assuming 100MHz clock), while we
+  // wait for the RMA strap pull enables to propagate to the physical pads.
+  // Since this is a wait loop, disable the watchdog.
+  csrw mcycle, zero
+  li   t0, 500  // 500 clock cycles with 100MHz clock is 5us.
+.L_rma_strap_pu_spin_cycles_loop:
+  csrr t1, mcycle
+  bltu t1, t0, .L_rma_strap_pu_spin_cycles_loop
+
   // Read the strap GPIOs and check their value.
   li   a0, TOP_EARLGREY_GPIO_BASE_ADDR
   lw   t0, GPIO_DATA_IN_REG_OFFSET(a0)


### PR DESCRIPTION
As pointed out in #17862, when enabling pull ups/downs on real IOs, there is a delay of between when SW writes to the pinmux CSRs and when the physical pins are actually pulled up/down.

This fixes #17862 by:
1. adding 5us delay after pull up/down enablement is toggled in rom_start.S
2. adding 5us delay after pull up/down enablement is toggled in the silicon_creator pinmux driver
3. adding 5us delay after pull up/down enablement is toggled in dif_pinmux_pad_write_attrs()

One thing to note: the wait cycle counts to achieve a wait period of 5us (which is what @sha-ron [noted](https://github.com/lowRISC/opentitan/issues/17862#issuecomment-1503971607) we should wait for) are computed based on a 100MHz  clock. If the clocks are not yet calibrated yet, and running at a slower rate, the wait will end of being longer, so things should still be ok.

@sha-ron: when you [say](https://github.com/lowRISC/opentitan/issues/17862#issuecomment-1503971607) "I think 5usec should be enough for most IOs." How certain are you this is long enough? Or should we make this wait time OTP-configurable?