### PR TITLE
[testutils] Add DAI read/write32 to otp_ctrl

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -38,6 +38,21 @@ status_t otp_ctrl_testutils_lock_partition(const dif_otp_ctrl_t *otp,
                                            uint64_t digest);
 
 /**
+ * Reads a 32bit value from OTP using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param address Address relative to the start of the `partition`. Must be a
+ * 32bit aligned address.
+ * @param[out] result The 32bit value result.
+ * @return OK_STATUS on successful read.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t otp_ctrl_testutils_dai_read32(
+    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
+    uint32_t address, uint32_t *result);
+
+/**
  * Reads a 64bit value from OTP using the DAI interface.
  *
  * @param otp otp_ctrl instance.
@@ -53,6 +68,25 @@ static status_t otp_ctrl_testutils_dai_read64(
     uint32_t address, uint64_t *result);
 
 /**
+ * Writes `len` number of 32bit words from buffer into otp `partition` starting
+ * at `start_address` using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param start_address Address relative to the start of the `partition`. Must
+ * be a 32bit aligned address.
+ * @param buffer The buffer containing the data to be written into OTP.
+ * @param len The number of 32bit words to write into otp. `buffer` must have at
+ * least `len` 32bit words.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t start_address,
+                                        const uint32_t *buffer, size_t len);
+
+/**
  * Writes `len` number of 64bit words from buffer into otp `partition` starting
  * at `start_address` using the DAI interface.
  *
@@ -61,8 +95,6 @@ static status_t otp_ctrl_testutils_dai_read64(
  * @param start_address Address relative to the start of the `partition`. Must
  * be a 64bit aligned address.
  * @param buffer The buffer containing the data to be written into OTP.
- * The function may override values for entries previously written. The caller
- * can use the result buffer to detect which OTP words were already programmed.
  * @param len The number of 64bit words to write into otp. `buffer` must have at
  * least `len` 64bit words.
  * @return OK_STATUS on success.


### PR DESCRIPTION
Adds 32bit read and write functions to `otp_ctrl_testutils`.