### PR TITLE
[ast] module ownership transfer

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
+      - lowrisc:prim:multibit_sync
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip_interfaces:alert_handler_reg

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -258,7 +258,7 @@ prim_flop #(
 );
 
 // Replace Latch for the OS code
-assign vcaon_pok_por_lat = rglssm_brout || vcaon_pok_por_src;
+assign vcaon_pok_por_lat = rglssm_brout || por_sync_n;
 assign ast_pwst_o.aon_pok = vcaon_pok_por_lat;
 assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
 
@@ -520,6 +520,12 @@ ast_clks_byp u_ast_clks_byp (
   .clk_osc_aon_i ( clk_osc_aon ),
   .clk_osc_aon_val_i ( clk_osc_aon_val ),
   .clk_ast_ext_i ( clk_ast_ext_i ),
+`ifdef AST_BYPASS_CLK
+  .clk_ext_sys_i( clk_sys_ext ),
+  .clk_ext_io_i( clk_io_ext ),
+  .clk_ext_usb_i( clk_usb_ext ),
+  .clk_ext_aon_i( clk_aon_ext ),
+`endif
   .io_clk_byp_req_i ( io_clk_byp_req_i ),
   .all_clk_byp_req_i ( all_clk_byp_req_i ),
   .ext_freq_is_96m_i ( ext_freq_is_96m_i ),

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -507,6 +507,7 @@ logic clk_src_sys, clk_src_io, clk_src_usb, clk_src_aon;
 
 ast_clks_byp u_ast_clks_byp (
   .vcaon_pok_i ( vcaon_pok ),
+  .vcaon_pok_por_i ( vcaon_pok_por ),
   .deep_sleep_i ( deep_sleep ),
   .clk_src_sys_en_i ( clk_src_sys_en_i ),
   .clk_osc_sys_i ( clk_osc_sys ),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv
@@ -44,7 +44,7 @@ package ast_bhv_pkg;
   parameter time RNG_EN_RDLY     = 5us;
 `endif  // of SYNTHESIS
   // ADC
-  parameter int unsigned AdcCnvtClks = 22;
+  parameter int unsigned AdcCnvtClks = 19;
 
 endpackage  // of ast_bhv_pkg
 `endif // of __AST_BHV_PKG_SV

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
@@ -14,6 +14,7 @@
 
 module ast_clks_byp (
   input vcaon_pok_i,                        // VCAON POK
+  input vcaon_pok_por_i,                    // VCAON POK POR
   input deep_sleep_i,                       // Deep Sleep (main regulator & switch are off)
   input clk_src_sys_en_i,                   // SYS Source Clock Enable
   input clk_osc_sys_i,                      // SYS Oscillator Clock
@@ -480,7 +481,7 @@ logic sys_clk_byp_en, io_clk_byp_en, usb_clk_byp_en, aon_clk_byp_en;
 logic rst_clk_osc_n, rst_clk_ext_n;
 
 assign rst_clk_osc_n = vcaon_pok;
-assign rst_clk_ext_n = vcaon_pok;
+assign rst_clk_ext_n = vcaon_pok_por_i;
 
 // DV Hooks for IO clocks
 logic io_clk_byp_select, io_clk_byp_sel_buf, io_clk_osc_en_buf, io_clk_byp_en_buf;

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
@@ -478,10 +478,11 @@ assign ext_freq_is_96m = extfreq_is_96m;
 ////////////////////////////////////////
 logic sys_clk_osc_en, io_clk_osc_en, usb_clk_osc_en, aon_clk_osc_en;
 logic sys_clk_byp_en, io_clk_byp_en, usb_clk_byp_en, aon_clk_byp_en;
-logic rst_clk_osc_n, rst_clk_ext_n;
+logic rst_clk_osc_n, rst_clk_ext_n, aon_rst_clk_ext_n;
 
 assign rst_clk_osc_n = vcaon_pok;
 assign rst_clk_ext_n = vcaon_pok_por_i;
+assign aon_rst_clk_ext_n = vcaon_pok;
 
 // DV Hooks for IO clocks
 logic io_clk_byp_select, io_clk_byp_sel_buf, io_clk_osc_en_buf, io_clk_byp_en_buf;
@@ -542,7 +543,7 @@ prim_buf u_rst_clk_osc_aon (
 );
 
 prim_buf u_rst_clk_ext_aon (
-  .in_i ( rst_clk_ext_n ),
+  .in_i ( aon_rst_clk_ext_n ),
   .out_o ( rst_clk_ext_aon_n )
 );
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
@@ -27,6 +27,12 @@ module ast_clks_byp (
   input clk_osc_aon_i,                      // AON Oscillator Clock
   input clk_osc_aon_val_i,                  // AON Oscillator Clock Valid
   input clk_ast_ext_i,                      // External Clock
+`ifdef AST_BYPASS_CLK
+  input clk_ext_sys_i,
+  input clk_ext_io_i,
+  input clk_ext_usb_i,
+  input clk_ext_aon_i,
+`endif // of AST_BYPASS_CLK
   input prim_mubi_pkg::mubi4_t io_clk_byp_req_i,    // External IO clock mux for OTP bootstrap
   input prim_mubi_pkg::mubi4_t all_clk_byp_req_i,   // External all clock mux override
   input prim_mubi_pkg::mubi4_t ext_freq_is_96m_i,   // External Clock Frequecy is 96MHz (else 48MHz)
@@ -83,7 +89,11 @@ end
 logic rst_sw_ckbpe_n, clk_ast_ext_scn, sw_clk_byp_en;
 
 assign rst_sw_ckbpe_n = scan_mode_i ? scan_reset_ni : rst_sw_clk_byp_en;
+`ifndef AST_BYPASS_CLK
 assign clk_ast_ext_scn = scan_mode_i ? clk_osc_sys_i : clk_ast_ext_i;
+`else // of AST_BYPASS_CLK
+assign clk_ast_ext_scn = scan_mode_i ? clk_osc_sys_i : clk_ext_sys_i;
+`endif // of AST_BYPASS_CLK
 
 // De-assert with external clock input
 always_ff @( negedge clk_ast_ext_scn, negedge rst_sw_ckbpe_n ) begin
@@ -97,7 +107,25 @@ end
 logic clk_ext_en, clk_ext_scn;
 
 assign clk_ext_en = sw_clk_byp_en;
-assign clk_ext_scn = scan_mode_i ? clk_osc_sys_i : clk_ast_ext_i && clk_ext_en;
+`ifdef AST_BYPASS_CLK
+logic clk_ast_ext;
+
+prim_clock_gating #(
+  .NoFpgaGate(1'b1)
+) u_clk_ast_ext_gating (
+  .clk_i( clk_ext_sys_i ),
+  .en_i( clk_ext_en ),
+  .test_en_i( 1'b0 ),
+  .clk_o( clk_ast_ext )
+);
+
+assign clk_ext_scn = scan_mode_i ? clk_osc_sys_i : clk_ast_ext;
+`else
+//we can't use prim_clock_gating here for the following reason:
+//prim_clock_gating default behavior at wakeup: clk_i=1'bx, en_i=don't care --> clk_o=1'bx
+//we want to mask that 1'bx as some tests doesn't use clk_ast_ext_i
+assign clk_ext_scn = scan_mode_i ? clk_osc_sys_i : (clk_ast_ext_i && clk_ext_en);
+`endif
 
 // Local EXT clock buffer
 ////////////////////////////////////////
@@ -126,6 +154,7 @@ assign rst_aon_exda_n = scan_mode_i ? scan_reset_ni : rst_aon_n_exda;
 
 // External USB & AON clocks genaration
 ////////////////////////////////////////
+`ifndef AST_BYPASS_CLK
 logic clk_src_ext_usb, ext_freq_is_96m, ext_freq_is_96m_sync;
 
 prim_flop_2sync #(
@@ -149,11 +178,16 @@ prim_clock_div #(
   .test_en_i ( scan_mode_i ),
   .clk_o ( clk_src_ext_usb )
 );
+`else // of AST_BYPASS_CLK
+logic clk_src_ext_usb, ext_freq_is_96m;
+assign clk_src_ext_usb = clk_ext_usb_i;
+`endif // of AST_BYPASS_CLK
 
 logic clk_ext_aon, clk_ext_aon_val;
 
 assign clk_ext_aon_val = 1'b1;  // Always ON clock
 
+`ifndef AST_BYPASS_CLK
 prim_clock_div #(
   .Divisor( 240 )
 ) u_no_scan_clk_usb_div240_div (
@@ -164,6 +198,9 @@ prim_clock_div #(
   .test_en_i ( scan_mode_i ),
   .clk_o ( clk_ext_aon )
 );
+`else // of AST_BYPASS_CLK
+assign clk_ext_aon = clk_ext_aon_i;
+`endif // of AST_BYPASS_CLK
 
 
 ////////////////////////////////////////
@@ -234,7 +271,11 @@ assign clk_ext_io_val = clk_ext_io_en;
 prim_clock_gating #(
   .NoFpgaGate ( 1'b1)
 ) u_clk_ext_io_ckgt (
+`ifndef AST_BYPASS_CLK
   .clk_i ( clk_ext ),
+`else // of AST_BYPASS_CLK
+  .clk_i ( clk_ext_io_i ),
+`endif // of AST_BYPASS_CLK
   .en_i ( clk_ext_io_en ),
   .test_en_i ( scan_mode_i ),
   .clk_o ( clk_ext_io )
@@ -412,6 +453,7 @@ assign extfreq_is_96m = sw_exfr_is_96m;
 ////////////////////////////////////////
 logic sys_clk_byp_sel, io_clk_byp_sel, usb_clk_byp_sel, aon_clk_byp_sel;
 
+`ifndef AST_BYPASS_CLK
 always_latch begin
   if ( !scan_mode_i ) begin
     sys_clk_byp_sel = sys_clk_byp;
@@ -421,6 +463,13 @@ always_latch begin
     ext_freq_is_96m = extfreq_is_96m;
   end
 end
+`else // of AST_BYPASS_CLK
+assign sys_clk_byp_sel = sys_clk_byp;
+assign io_clk_byp_sel  = io_clk_byp;
+assign usb_clk_byp_sel = usb_clk_byp;
+assign aon_clk_byp_sel = aon_clk_byp;
+assign ext_freq_is_96m = extfreq_is_96m;
+`endif // of AST_BYPASS_CLK
 
 
 ////////////////////////////////////////
@@ -496,6 +545,22 @@ prim_buf u_rst_clk_ext_aon (
   .out_o ( rst_clk_ext_aon_n )
 );
 
+// rst_aon_n deasset to io clock
+////////////////////////////////////////
+logic rst_aon_n_ioda, rst_aon_ioda_n;
+
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_rst_aon_n_ioda_sync (
+  .clk_i ( clk_src_io_o ),
+  .rst_ni ( rst_aon_n ),
+  .d_i ( 1'b1 ),
+  .q_o ( rst_aon_n_ioda )
+);
+
+assign rst_aon_ioda_n = scan_mode_i ? scan_reset_ni : rst_aon_n_ioda;
+
 // SYS Clock Bypass Mux
 ////////////////////////////////////////
 gfr_clk_mux2 u_clk_src_sys_sel (
@@ -514,6 +579,8 @@ gfr_clk_mux2 u_clk_src_sys_sel (
 
 // IO Clock Bypass Mux
 ////////////////////////////////////////
+logic clk_src_io, clk_src_io_val;
+
 gfr_clk_mux2 u_clk_src_io_sel (
   .clk_osc_i ( clk_osc_io_i ),
   .clk_osc_val_i ( clk_osc_io_val_i ),
@@ -524,9 +591,63 @@ gfr_clk_mux2 u_clk_src_io_sel (
   .ext_sel_i ( io_clk_byp_sel ),
   .clk_osc_en_o ( io_clk_osc_en ),
   .clk_ext_en_o ( io_clk_byp_en ),
-  .clk_val_o ( clk_src_io_val_o ),
+  .clk_val_o ( clk_src_io_val ),
+  .clk_o ( clk_src_io )
+);
+
+`ifndef AST_BYPASS_CLK
+assign clk_src_io_val_o = clk_src_io_val;
+assign clk_src_io_o = clk_src_io;
+`else // of AST_BYPASS_CLK
+// For FPGA, clk_ext is always the one frequency, so divide by 2 if downstream
+// thinks it should be "48 MHz" instead of "96 MHz".
+logic ext_freq_is_96m_io_sync;
+logic rst_src_io_n;
+
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_rst_src_io_n_sync (
+  .clk_i ( clk_src_io ),
+  .rst_ni ( rst_aon_n ),
+  .d_i ( 1'b1 ),
+  .q_o ( rst_src_io_n )
+);
+
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_ext_freq_is_96m_io_sync (
+  .clk_i ( clk_src_io ),
+  .rst_ni ( rst_src_io_n ),
+  .d_i ( ext_freq_is_96m ),
+  .q_o ( ext_freq_is_96m_io_sync )
+);
+
+logic clk_src_io_div2_sel;
+assign clk_src_io_div2_sel = !ext_freq_is_96m_io_sync & io_clk_byp_sel;
+
+prim_clock_div #(
+  .Divisor( 2 )
+) u_no_scan_clk_src_io_d1ord2 (
+  .clk_i ( clk_src_io ),
+  .rst_ni ( rst_src_io_n ),
+  .step_down_req_i( !clk_src_io_div2_sel ),
+  .step_down_ack_o ( ),
+  .test_en_i ( scan_mode_i ),
   .clk_o ( clk_src_io_o )
 );
+
+prim_flop_2sync #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_clk_src_io_val_sync (
+  .clk_i ( clk_src_io_o ),
+  .rst_ni ( rst_aon_ioda_n ),
+  .d_i ( clk_src_io_val ),
+  .q_o ( clk_src_io_val_o )
+);
+`endif // of AST_BYPASS_CLK
 
 // USB Clock Bypass Mux
 ////////////////////////////////////////
@@ -559,22 +680,6 @@ gfr_clk_mux2 u_clk_src_aon_sel (
   .clk_val_o ( clk_src_aon_val_o ),
   .clk_o ( clk_src_aon_o )
 );
-
-// rst_aon_n deasset to io clock
-////////////////////////////////////////
-logic rst_aon_n_ioda, rst_aon_ioda_n;
-
-prim_flop_2sync #(
-  .Width ( 1 ),
-  .ResetValue ( 1'b0 )
-) u_rst_aon_n_ioda_sync (
-  .clk_i ( clk_src_io_o ),
-  .rst_ni ( rst_aon_n ),
-  .d_i ( 1'b1 ),
-  .q_o ( rst_aon_n_ioda )
-);
-
-assign rst_aon_ioda_n = scan_mode_i ? scan_reset_ni : rst_aon_n_ioda;
 
 // All Clocks Bypass Acknowledge
 ////////////////////////////////////////

--- a/hw/top_earlgrey/ip/ast/rtl/dev_entropy.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/dev_entropy.sv
@@ -56,14 +56,14 @@ logic [(1<<EntropyRateWidth)-1:0] erate_cnt, dev_rate;
 // In most cases the rate will be set ahead of the dev_en_i
 logic [EntropyRateWidth-1:0] dev_rate_sync;
 
-prim_flop_2sync #(
+prim_multibit_sync #(
   .Width ( EntropyRateWidth ),
   .ResetValue ( {EntropyRateWidth{1'b0}} )
 ) u_erate_sync (
   .clk_i ( clk_dev_i ) ,
   .rst_ni ( rst_dev_ni ),
-  .d_i ( dev_rate_i[EntropyRateWidth-1:0] ),
-  .q_o ( dev_rate_sync[EntropyRateWidth-1:0] )
+  .data_i ( dev_rate_i[EntropyRateWidth-1:0] ),
+  .data_o ( dev_rate_sync[EntropyRateWidth-1:0] )
 );
 
 // Fastest rate to init the LFSR


### PR DESCRIPTION
ci 79287ee
1. Bus synchronization inside dev_entropy.sv synchronized each bit separately, this cause unwanted transition values to be used on the synchronizer output. I switched to this alternative synchronizer which transfer the value to its output only after the output data is stable. 

ci b3c34f9
2. Added assertions for ADC behavioral and updated conversion time to match analog module

ci 272423a
3. Here we have two unrelated commits which modify the same file, as one of the only change one word in the file, they are part of the same check in.
On #16721 we had the following discussion:
ast expect main_pd_ni to be driven synchronously, but it is driven asynchronously from aon_pok, therefore we decide to drive aon_pok synchronously also (using por_sync_n instead of vcaon_pok_por_src).
On #17492 we had the following discussion:
On fpga slow clock sources should be used. We were asked to add AST_BYPASS_CLK define.
The suggested solution added prim_clock_gating on clk_ast_ext. This solution isn't valid while clk_ast_ext_i = 1'bx.
Therefore I changed it a little bit, leaving the code as is while AST_BYPSSS_CLK isn't defined.

ci 5076dde
4. Using vcaon_pok_por which deasserts on por_n assertion to reset external clock to internal clock in case of por_n.
Previous implementation didn't reset on por_n assertion.

ci 0dfdbba
5. 5076dde caused aon_clk to be disabled while using external clock and asserting por_n. This ci fixes it.