### PR TITLE
[entropy_src/rtl] Remove stale TODO

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -77,8 +77,6 @@ module entropy_src
   entropy_src_xht_req_t core_xht;
   logic core_intr_es_entropy_valid;
   logic core_intr_es_health_test_failed;
-  // TODO: add intrp
-//  logic core_intr_es_ebus_check_failed;
   logic core_intr_es_observe_fifo_ready;
   logic core_intr_es_fatal_err;
   logic [NumAlerts-1:0] core_alert_test;


### PR DESCRIPTION
An interrupt named `es_ebus_check_failed` for failed entropy bus checks seems to have been planned originally.  `entropy_src.hjson` contained a TODO that was added in #7531 and removed in #8632.  The code removed by this commit seems to be a leftover of that.