### PR TITLE
[ci] Fix "package & deploy" dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -620,6 +620,7 @@ jobs:
     - sw_build
     - execute_verilated_tests
     - chip_earlgrey_cw310
+    - chip_englishbreakfast_verilator
   condition: and(eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   steps:
   - template: ci/checkout-template.yml


### PR DESCRIPTION
The `Package & Deploy` job needs the artifacts from `Verilated English Breakfast (Build)`, but it doesn't list it as a dependency.

Often this is not a problem since other `Package & Deploy` dependencies delay the execution until after `Verilated English Breakfast (Build)` has finished. But in some cases the other dependencies run faster than `Verilated English Breakfast (Build)` (e.g., due to caching) and `Package & Deploy` ends up running before `Verilated English Breakfast (Build)` finishes, producing a failure.

For an example, see [this CI run](https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=112753&view=logs&j=3f56db3a-5089-5d13-576b-70ad030dbc87&t=62f405ba-00db-5cb1-998e-b8ce51386841)

This PR fixes that issue.