### PR TITLE
Fix build of OTBN smoke test with recent Verilator

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -41,7 +41,7 @@ class OtbnTraceUtil : public SimCtrlExtension {
 
   bool SetupTraceLog(const std::string &log_filename) {
     try {
-      log_trace_listener_ = std::make_unique<LogTraceListener>(log_filename);
+      log_trace_listener_.reset(new LogTraceListener(log_filename));
       OtbnTraceSource::get().AddListener(log_trace_listener_.get());
       return true;
     } catch (const std::runtime_error &err) {


### PR DESCRIPTION
This should fix #16591.

The non-trivial bit is the second commit, which avoids mutating a global in what Verilator has inferred is sequential block (so treats it like an always_ff). The first commit is more minor, but is needed for building with recent GCCs like the one that happens to be on my laptop!