### PR TITLE
Remove a pending work item that's not being worked on

### DIFF
--- a/doc/contributing/dv/methodology/README.md
+++ b/doc/contributing/dv/methodology/README.md
@@ -630,9 +630,3 @@ We use the [OpenTitan GitHub Issue tracker](https://github.com/lowRISC/opentitan
 
 The process for getting started with DV involves many steps, including getting clarity on its purpose, setting up the testbench, documentation, etc.
 These are discussed in the [Getting Started with DV](https://opentitan.org/guides/getting_started/setup_dv.html) document.
-
-## Pending Work Items
-
-These capabilities are currently under active development and will be available sometime in the near future:
-
-*  Provide ability to run regressions.


### PR DESCRIPTION
This was marked as being under active development in 2020, and I can't seen any sign that someone has worked on it. If we want to track it properly, something like a GitHub issue is probably more appropriate.

Fixes https://github.com/lowRISC/opentitan/issues/3169.