### PR TITLE
Usb software fixes

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -265,7 +265,7 @@
     { name: "link_out_err",
       desc: '''
             Raised if a packet to an OUT endpoint started to be received but was then dropped due to an error.
-            This error is raised if either the data toggle, token, packet or CRC is invalid or if there is no buffer available in the Received Buffer FIFO.
+            This error is raised if the data toggle, token, packet and/or CRC are invalid, if the Available Buffer FIFO is empty or if the Received Buffer FIFO is full.
             '''
     }
   ]

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -159,9 +159,9 @@ typedef enum dif_usbdev_irq {
   kDifUsbdevIrqPowered = 15,
   /**
    * Raised if a packet to an OUT endpoint started to be received but was then
-   * dropped due to an error. This error is raised if either the data toggle,
-   * token, packet or CRC is invalid or if there is no buffer available in the
-   * Received Buffer FIFO.
+   * dropped due to an error. This error is raised if the data toggle, token,
+   * packet and/or CRC are invalid, if the Available Buffer FIFO is empty or if
+   * the Received Buffer FIFO is full.
    */
   kDifUsbdevIrqLinkOutErr = 16,
 } dif_usbdev_irq_t;

--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -161,7 +161,7 @@ void usb_testutils_poll(usb_testutils_ctx_t *ctx) {
       } else {
         // Note: this could happen following endpoint removal
         TRC_S("USB: unexpected RX ");
-        TRC_I(endpoint, 8);
+        TRC_I(ep, 8);
         CHECK_DIF_OK(
             dif_usbdev_buffer_return(ctx->dev, ctx->buffer_pool, &buffer));
       }

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -106,7 +106,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
   // Endpoint for SetFeature/ClearFeature/GetStatus requests
   dif_usbdev_endpoint_id_t endpoint = {
       .number = (uint8_t)wIndex,
-      .direction = bmRequestType & 0x80,
+      .direction = ((bmRequestType & 0x80U) != 0U),
   };
   dif_usbdev_buffer_t buffer;
   CHECK_DIF_OK(dif_usbdev_buffer_request(ctx->dev, ctx->buffer_pool, &buffer));
@@ -321,7 +321,7 @@ static void ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
                                               kDifToggleEnabled));
 
   TRC_C('0' + ctctx->ctrlstate);
-  uint32_t bytes_written;
+  size_t bytes_written;
   // TODO: Should check for canceled IN transactions due to receiving a SETUP
   // packet.
   switch (ctctx->ctrlstate) {

--- a/sw/device/lib/testing/usb_testutils_simpleserial.c
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.c
@@ -24,32 +24,41 @@ static void ss_rx(void *ssctx_v, dif_usbdev_rx_packet_info_t packet_info,
   }
 }
 
+static void ss_tx_done(void *ssctx_v, usb_testutils_xfr_result_t result) {
+  usb_testutils_ss_ctx_t *ssctx = (usb_testutils_ss_ctx_t *)ssctx_v;
+
+  ssctx->sending = false;
+}
+
 // Called periodically by the main loop to ensure characters don't
 // stick around too long
 static void ss_flush(void *ssctx_v) {
   usb_testutils_ss_ctx_t *ssctx = (usb_testutils_ss_ctx_t *)ssctx_v;
   usb_testutils_ctx_t *ctx = ssctx->ctx;
-  if (ssctx->cur_cpos <= 0) {
+  if (ssctx->cur_cpos <= 0 || ssctx->sending) {
     return;
   }
   if ((ssctx->cur_cpos & 0x3) != 0) {
     size_t bytes_written;
-    CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &ssctx->cur_buf,
-                                         ssctx->chold.data_b, /*src_len=*/4,
-                                         &bytes_written));
+    CHECK_DIF_OK(
+        dif_usbdev_buffer_write(ctx->dev, &ssctx->cur_buf, ssctx->chold.data_b,
+                                ssctx->cur_cpos & 0x3, &bytes_written));
   }
   CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ssctx->ep, &ssctx->cur_buf));
+  ssctx->sending = true;
   ssctx->cur_cpos = -1;  // given it to the hardware
 }
 
 // Simple send byte will gather data for a while and send
-void usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
+bool usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
                                           uint8_t c) {
   usb_testutils_ctx_t *ctx = ssctx->ctx;
   if (ssctx->cur_cpos == -1) {
     CHECK_DIF_OK(
         dif_usbdev_buffer_request(ctx->dev, ctx->buffer_pool, &ssctx->cur_buf));
     ssctx->cur_cpos = 0;
+  } else if (ssctx->cur_cpos >= MAX_GATHER && ssctx->sending) {
+    return false;
   }
   ssctx->chold.data_b[ssctx->cur_cpos++ & 0x3] = c;
   if ((ssctx->cur_cpos & 0x3) == 0) {
@@ -57,20 +66,23 @@ void usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
     CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &ssctx->cur_buf,
                                          ssctx->chold.data_b, /*src_len=*/4,
                                          &bytes_written));
-    if (ssctx->cur_cpos >= MAX_GATHER) {
+    if (ssctx->cur_cpos >= MAX_GATHER && !ssctx->sending) {
       CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ssctx->ep, &ssctx->cur_buf));
+      ssctx->sending = true;
       ssctx->cur_cpos = -1;  // given it to the hardware
     }
   }
+  return true;
 }
 
 void usb_testutils_simpleserial_init(usb_testutils_ss_ctx_t *ssctx,
                                      usb_testutils_ctx_t *ctx, int ep,
                                      void (*got_byte)(uint8_t)) {
-  usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutStream, ssctx, NULL, ss_rx,
-                               ss_flush, NULL);
+  usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutStream, ssctx, ss_tx_done,
+                               ss_rx, ss_flush, NULL);
   ssctx->ctx = ctx;
   ssctx->ep = ep;
+  ssctx->sending = false;
   ssctx->got_byte = got_byte;
   ssctx->cur_cpos = -1;
 }

--- a/sw/device/lib/testing/usb_testutils_simpleserial.h
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.h
@@ -15,6 +15,7 @@
 typedef struct usb_testutils_ss_ctx {
   usb_testutils_ctx_t *ctx;
   int ep;
+  bool sending;
   dif_usbdev_buffer_t cur_buf;
   int cur_cpos;
   union usb_ss_b2w {
@@ -29,8 +30,9 @@ typedef struct usb_testutils_ss_ctx {
  *
  * @param ssctx instance context
  * @param c byte to send
+ * @return true iff the character was accepted for transmission
  */
-void usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
+bool usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
                                           uint8_t c);
 
 /**


### PR DESCRIPTION
Small corrections to the usb_testutils software for the most part.

The simpleserial implementation did not handle transmission of multiple buffers in quick succession, attempting to overwrite the previous buffer with dif_usbdev_send, corrupting/losing data.

Fixing this allows the basic smoke test to send our test message to the host, before the host then sends it back via character echo. This means the host need only execute a `cat /dev/ttyUSB0` test command, for example, and it means that we're testing traffic in both directions to the serial endpoint. (`usbdev_test` is soon to be used as a basic smoke test at chip level simulation)