### PR TITLE
[sca, fpga] Increase start trigger delay for AES and KMAC peripherals

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -993,11 +993,11 @@ module chip_earlgrey_cw310 #(
   top_earlgrey #(
     .SecAesMasking(1'b1),
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
-    .SecAesStartTriggerDelay(40),
+    .SecAesStartTriggerDelay(320),
     .SecAesAllowForcingMasks(1'b1),
     .KmacEnMasking(0),
     .KmacSwKeyMasked(1),
-    .SecKmacCmdDelay(40),
+    .SecKmacCmdDelay(320),
     .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -44,11 +44,11 @@ enum {
    * Number of cycles (at `kClockFreqCpuHz`) that Ibex should sleep to minimize
    * noise during AES operations. Caution: This number should be chosen to
    * provide enough time. Otherwise, Ibex might wake up while AES is still busy
-   * and disturb the capture. Currently, we use a start trigger delay of 40
-   * clock cycles and the scope captures 90 clock cycles at kClockFreqCpuHz (900
-   * samples).
+   * and disturb the capture. Currently, we use a start trigger delay of 320
+   * clock cycles and the scope captures 60 clock cycles at kClockFreqCpuHz
+   * (1200 samples).
    */
-  kIbexAesSleepCycles = 400,
+  kIbexAesSleepCycles = 680,
   /**
    * Max number of encryption that can be captured with the scope
    * 81 is selected for AES with CW Husky

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -50,11 +50,13 @@ enum {
    * Number of cycles (at `kClockFreqCpuHz`) that Ibex should sleep to minimize
    * noise during SHA3 operations. Caution: This number should be chosen to
    * provide enough time. Otherwise, Ibex might wake up while SHA3 is still busy
-   * and disturb the capture. Currently, we use a start trigger delay of 40
-   * clock cycles and the scope captures 200 clock cycles at kClockFreqCpuHz
-   * (2000 samples).
+   * and disturb the capture. Currently, we use a start trigger delay of 320
+   * clock cycles and the scope captures 160 clock cycles at kClockFreqCpuHz
+   * (3200 samples). On the scope side, an offset of 395 clock cycles (7900
+   * samples) is used to ignore 1) the start trigger delay for the PROCESS
+   * command, and 2) the absorb phase for the fixed prefix.
    */
-  kIbexSha3SleepCycles = 800,
+  kIbexSha3SleepCycles = 1180,
   /**
    * Max number of traces per batch.
    */

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -50,11 +50,13 @@ enum {
    * Number of cycles (at `kClockFreqCpuHz`) that Ibex should sleep to minimize
    * noise during SHA3 operations. Caution: This number should be chosen to
    * provide enough time. Otherwise, Ibex might wake up while SHA3 is still busy
-   * and disturb the capture. Currently, we use a start trigger delay of 40
-   * clock cycles and the scope captures 200 clock cycles at kClockFreqCpuHz
-   * (2000 samples).
+   * and disturb the capture. Currently, we use a start trigger delay of 320
+   * clock cycles and the scope captures 120 clock cycles at kClockFreqCpuHz
+   * (2400 samples). On the scope side, an offset of 320 clock cycles (6400
+   * samples) can be used to ignore the start trigger delay for the PROCESS
+   * command.
    */
-  kIbexSha3SleepCycles = 800,
+  kIbexSha3SleepCycles = 1060,
   /**
    * Max number of traces per batch.
    */

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "kmac_regs.h"  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -174,6 +175,11 @@ void run_sha3_test(dif_kmac_t *kmac) {
         dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len, NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
+    // Wait for the hardware engine to actually finish. On FPGA, it may take
+    // a while until the DONE command gets actually executed (see SecCmdDelay
+    // SystemVerilog parameter).
+    CHECK_DIF_OK(dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_IDLE_BIT));
+
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],
             "test %d: mismatch at %d got=0x%x want=0x%x", i, j, out[j],
@@ -210,6 +216,11 @@ void run_sha3_alignment_test(dif_kmac_t *kmac) {
         dif_kmac_squeeze(kmac, &operation_state, &out, sizeof(uint32_t), NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
+    // Wait for the hardware engine to actually finish. On FPGA, it may take
+    // a while until the DONE command gets actually executed (see SecCmdDelay
+    // SystemVerilog parameter).
+    CHECK_DIF_OK(dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_IDLE_BIT));
+
     CHECK_DIF_OK((out == kExpect),
                  "mismatch at alignment %u got 0x%u want 0x%x", i, out,
                  kExpect);
@@ -230,6 +241,11 @@ void run_sha3_alignment_test(dif_kmac_t *kmac) {
     CHECK_DIF_OK(
         dif_kmac_squeeze(kmac, &operation_state, &out, sizeof(uint32_t), NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
+
+    // Wait for the hardware engine to actually finish. On FPGA, it may take
+    // a while until the DONE command gets actually executed (see SecCmdDelay
+    // SystemVerilog parameter).
+    CHECK_DIF_OK(dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_IDLE_BIT));
 
     CHECK_DIF_OK((out == kExpect), "mismatch got 0x%u want 0x%x", out, kExpect);
   }
@@ -254,6 +270,11 @@ void run_shake_test(dif_kmac_t *kmac) {
     CHECK_DIF_OK(
         dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len, NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
+
+    // Wait for the hardware engine to actually finish. On FPGA, it may take
+    // a while until the DONE command gets actually executed (see SecCmdDelay
+    // SystemVerilog parameter).
+    CHECK_DIF_OK(dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_IDLE_BIT));
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1065,11 +1065,11 @@ module chip_${top["name"]}_${target["name"]} #(
 % if target["name"] == "cw310":
     .SecAesMasking(1'b1),
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
-    .SecAesStartTriggerDelay(40),
+    .SecAesStartTriggerDelay(320),
     .SecAesAllowForcingMasks(1'b1),
     .KmacEnMasking(0),
     .KmacSwKeyMasked(1),
-    .SecKmacCmdDelay(40),
+    .SecKmacCmdDelay(320),
     .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
@@ -1081,7 +1081,7 @@ module chip_${top["name"]}_${target["name"]} #(
 % elif target["name"] == "cw305":
     .SecAesMasking(1'b1),
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
-    .SecAesStartTriggerDelay(40),
+    .SecAesStartTriggerDelay(320),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
     .UsbdevStub(1'b1),


### PR DESCRIPTION
During FPGA measurements we have been observing stability issues with the power rails for fixed vs. random TVLA. In some cases, loading the fixed plaintext/key discharges the power rails slightly more or less than loading random plaintexts/keys, which then leads to a vertical offset in the traces and thus "fake" leakage unrelated to the actual processing. Increasing the start trigger delay allows the power rails to recharge before the actual processing phase to be analyzed starts.