### PR TITLE
[chip-test] Test rv_core_ibex_rnd in entropy auto

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1066,7 +1066,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests:rv_core_ibex_rnd_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=10_000_000"]
+      run_opts: ["+sw_test_timeout_ns=10_000_000", "+rng_srate_value_max=32"]
     }
     {
       name: chip_sw_rv_core_ibex_nmi_irq

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1066,7 +1066,6 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests:rv_core_ibex_rnd_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      // Timeout based on a 10min dvsim runtime.
       run_opts: ["+sw_test_timeout_ns=10_000_000"]
     }
     {

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/rv_core_ibex_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -18,20 +19,23 @@
 // Initialize OTTF.
 OTTF_DEFINE_TEST_CONFIG();
 
-// Declare two assembly function defined in `rv_core_ibex_rnd_test.S`.
+// Declare two assembly functions defined in `rv_core_ibex_rnd_test.S`.
 extern volatile uint32_t rv_core_ibex_rnd_read_and_immediately_check_status();
 extern volatile uint32_t
 rv_core_ibex_check_rnd_read_possible_while_status_invalid();
 
-#define RANDOM_DATA_READS 32
-#define MAX_STATUS_CHECKS 1024
+enum {
+  kRandomDataReads = 32,
+  kMaxStatusChecks = 1024,
+};
 
 bool test_main(void) {
   // Verify the functionality of the random number generation CSRs.
 
   // Enable entropy complex, CSRNG and EDN so Ibex can get entropy.
-  // No code is necessary for this because EDN0 is automatically initialized
-  // by the ROM.
+  // Configure entropy in auto_mode to avoid starving the system from entropy,
+  // given that boot mode entropy has a limited number of generated bits.
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 
   // Initialize Ibex.
   dif_rv_core_ibex_t rv_core_ibex;
@@ -44,9 +48,9 @@ bool test_main(void) {
   // and that the random data is never zero or all ones.
   uint32_t rnd_data;
   uint32_t previous_rnd_data = 0;
-  for (int i = 0; i < RANDOM_DATA_READS; i++) {
+  for (int i = 0; i < kRandomDataReads; i++) {
     CHECK_STATUS_OK(rv_core_ibex_testutils_get_rnd_data(
-        &rv_core_ibex, MAX_STATUS_CHECKS, &rnd_data));
+        &rv_core_ibex, kMaxStatusChecks, &rnd_data));
     CHECK(rnd_data != previous_rnd_data);
     previous_rnd_data = rnd_data;
   }
@@ -57,14 +61,14 @@ bool test_main(void) {
 
   // Perform repeated reads from `RND_DATA` without `RND_STATUS` polling to
   // check read when invalid doesn't block.
-  for (int i = 0; i < RANDOM_DATA_READS; i++) {
+  for (int i = 0; i < kRandomDataReads; i++) {
     CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &rnd_data));
   }
 
   // Check to see that we can really do an RND while status is invalid before
   // and after.
   IBEX_SPIN_FOR(rv_core_ibex_testutils_is_rnd_data_valid(&rv_core_ibex),
-                MAX_STATUS_CHECKS);
+                kMaxStatusChecks);
   uint32_t status_value =
       rv_core_ibex_check_rnd_read_possible_while_status_invalid();
   CHECK(status_value == 0);


### PR DESCRIPTION
Update `rv_core_ibex_rnd_test()` to use auto_mode entropy complex configuration to reflect the production use-case.