### PR TITLE
[flash_ctrl] Address open TODOs on design side

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -783,9 +783,13 @@ module flash_ctrl
   // Flash memory Properties
   // Memory property is page based and thus should use phy addressing
   // This should move to flash_phy long term
+  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   flash_mp u_flash_mp (
     .clk_i,
     .rst_ni,
+
+    // This is only used in SVAs, hence we do not have to feed in a copy.
+    .lc_escalate_en_i(lc_escalate_en),
 
     // disable flash through memory protection
     .flash_disable_i(flash_disable[MpDisableIdx]),
@@ -973,7 +977,6 @@ module flash_ctrl
   // Flash Disable and execute enable
   //////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   prim_lc_sync #(
     .NumCopies(1)
   ) u_lc_escalation_en_sync (

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -784,9 +784,13 @@ module flash_ctrl
   // Flash memory Properties
   // Memory property is page based and thus should use phy addressing
   // This should move to flash_phy long term
+  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   flash_mp u_flash_mp (
     .clk_i,
     .rst_ni,
+
+    // This is only used in SVAs, hence we do not have to feed in a copy.
+    .lc_escalate_en_i(lc_escalate_en),
 
     // disable flash through memory protection
     .flash_disable_i(flash_disable[MpDisableIdx]),
@@ -974,7 +978,6 @@ module flash_ctrl
   // Flash Disable and execute enable
   //////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   prim_lc_sync #(
     .NumCopies(1)
   ) u_lc_escalation_en_sync (

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -877,10 +877,9 @@ module flash_ctrl_lcmgr
 
   end // always_comb
 
-  // TODO: Replace with a wrapper from tlul, that way the module does not need to know what this is
-  prim_secded_inv_39_32_enc u_bus_intg (
+  tlul_data_integ_enc u_bus_intg (
     .data_i(rand_i),
-    .data_o(wdata_o)
+    .data_intg_o(wdata_o)
   );
 
   assign wvalid_o = prog_cnt_en;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -170,8 +170,14 @@ module flash_ctrl_rd import flash_ctrl_pkg::*; (
   // natively handled by the phy.
   // All other errors do not result in an actual transaction to the flash, and therefore must use
   // the locally available error value.
-  assign data_o = ~err_sel | (err_sel & op_err_o.rd_err) ? flash_data_i :
-                  prim_secded_pkg::prim_secded_inv_39_32_enc({BusWidth{1'b1}});
+  logic [BusFullWidth-1:0] inv_data_integ;
+  tlul_data_integ_enc u_bus_intg (
+    .data_i({BusWidth{1'b1}}),
+    .data_intg_o(inv_data_integ)
+  );
+
+  assign data_o = ~err_sel | (err_sel & op_err_o.rd_err) ? flash_data_i : inv_data_integ;
+
   assign op_err_o = op_err_q | op_err_d;
 
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -790,9 +790,13 @@ module flash_ctrl
   // Flash memory Properties
   // Memory property is page based and thus should use phy addressing
   // This should move to flash_phy long term
+  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   flash_mp u_flash_mp (
     .clk_i,
     .rst_ni,
+
+    // This is only used in SVAs, hence we do not have to feed in a copy.
+    .lc_escalate_en_i(lc_escalate_en),
 
     // disable flash through memory protection
     .flash_disable_i(flash_disable[MpDisableIdx]),
@@ -980,7 +984,6 @@ module flash_ctrl
   // Flash Disable and execute enable
   //////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t lc_escalate_en;
   prim_lc_sync #(
     .NumCopies(1)
   ) u_lc_escalation_en_sync (


### PR DESCRIPTION
This addresses two open TODOs:
- replace explicit use of ECC code generation function with the abstract TLUL data integrity generator
- correct a temporary SVA fix

Done as part of #17880