### PR TITLE
[util/container] Install packages required for EDA tools

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -74,7 +74,7 @@ RUN echo "verilator-${VERILATOR_VERSION}" >>/tmp/apt-requirements.txt \
     && sed -i -e '/^$/d' -e '/^#/d' -e 's/#.*//' /tmp/apt-requirements.txt \
     && apt-get update \
     && xargs apt-get install -y </tmp/apt-requirements.txt \
-    && apt-get install -y \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
         sudo \
         gosu \
         locales \
@@ -84,6 +84,10 @@ RUN echo "verilator-${VERILATOR_VERSION}" >>/tmp/apt-requirements.txt \
         dc \
         time \
         software-properties-common \
+        environment-modules \
+        tclsh \
+        csh \
+        ksh \
     && apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 


### PR DESCRIPTION
When one wants to run EDA tools inside the OpenTitan container, additional packages are required. The shells (`tclsh`, `csh`, and `ksh`) are prerequisites for at least one of the simulators, and `environment-modules` is a popular package to load environment variables to run EDA tools.