### PR TITLE
[dv/kmac] Disable scb for edn_error

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -178,6 +178,7 @@
     {
       name: "{name}_edn_timeout_error"
       uvm_test_seq: kmac_edn_timeout_error_vseq
+      run_opts: ["+en_scb=0"]
       reseed: 20
     }
     {


### PR DESCRIPTION
This PR should fix the nightly regression `kmac_edn_timeout_error`.