### PR TITLE
[aes, sw, sca] Add seperate SW LFSR for key masking

### DIFF
--- a/hw/ip/aes/BUILD
+++ b/hw/ip/aes/BUILD
@@ -14,6 +14,7 @@ filegroup(
 cc_library(
     name = "model",
     hdrs = [
+        "model/aes.h",
         "model/aes_modes.h",
     ],
 )

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -221,7 +221,8 @@ static dif_result_t kmac_msg_start(dif_kmac_mode_kmac_t mode, size_t l,
   // Uniform sharing is achieved by XORing a random number into both shares.
   mmio_region_write32(kmac.base_addr, KMAC_KEY_LEN_REG_OFFSET, key_len);
   for (int i = 0; i < ARRAYSIZE(k->share0); ++i) {
-    const uint32_t a = next_lfsr();
+    // Run LFSR for 32 steps to ensure that all state bits are updated.
+    const uint32_t a = next_lfsr(32);
     mmio_region_write32(kmac.base_addr,
                         KMAC_KEY_SHARE0_0_REG_OFFSET + i * sizeof(uint32_t),
                         k->share0[i] ^ a);

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -222,7 +222,7 @@ static dif_result_t kmac_msg_start(dif_kmac_mode_kmac_t mode, size_t l,
   mmio_region_write32(kmac.base_addr, KMAC_KEY_LEN_REG_OFFSET, key_len);
   for (int i = 0; i < ARRAYSIZE(k->share0); ++i) {
     // Run LFSR for 32 steps to ensure that all state bits are updated.
-    const uint32_t a = next_lfsr(32);
+    const uint32_t a = sca_next_lfsr(32);
     mmio_region_write32(kmac.base_addr,
                         KMAC_KEY_SHARE0_0_REG_OFFSET + i * sizeof(uint32_t),
                         k->share0[i] ^ a);
@@ -565,7 +565,7 @@ static void sha3_serial_batch(const uint8_t *data, size_t data_len) {
  */
 static void sha3_serial_seed_lfsr(const uint8_t *seed, size_t seed_len) {
   SS_CHECK(seed_len == sizeof(uint32_t));
-  seed_lfsr(read_32(seed));
+  sca_seed_lfsr(read_32(seed));
 }
 
 /**

--- a/sw/device/sca/lib/BUILD
+++ b/sw/device/sca/lib/BUILD
@@ -40,6 +40,7 @@ cc_library(
     srcs = ["sca.c"],
     hdrs = ["sca.h"],
     deps = [
+        "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:bitfield",

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -324,12 +324,14 @@ void seed_lfsr(uint32_t seed) { lfsr_state = seed; }
 /**
  * step PRNG for masking key.
  */
-uint32_t next_lfsr(void) {
+uint32_t next_lfsr(uint16_t n) {
   const uint32_t lfsr_out = lfsr_state;
-  bool lfsr_bit = lfsr_state & 0x00000001;
-  lfsr_state = lfsr_state >> 1;
-  if (lfsr_bit) {
-    lfsr_state ^= 0x80000057;
+  for (size_t i = 0; i < n; i++) {
+    bool lfsr_bit = lfsr_state & 0x00000001;
+    lfsr_state = lfsr_state >> 1;
+    if (lfsr_bit) {
+      lfsr_state ^= 0x80000057;
+    }
   }
   return lfsr_out;
 }

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/sca/lib/sca.h"
 
+#include "hw/ip/aes/model/aes.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
@@ -325,4 +326,44 @@ uint32_t sca_next_lfsr(uint16_t num_steps) {
     }
   }
   return lfsr_out;
+}
+
+uint32_t sca_linear_layer(uint32_t input) {
+  uint32_t output =
+      // output[7:0]
+      (((input >> 0) & 0x1) << 7) | (((input >> 6) & 0x1) << 6) |
+      (((input >> 11) & 0x1) << 5) | (((input >> 14) & 0x1) << 4) |
+      (((input >> 1) & 0x1) << 3) | (((input >> 7) & 0x1) << 2) |
+      (((input >> 10) & 0x1) << 1) | (((input >> 13) & 0x1) << 0) |
+      // output[15:8]
+      (((input >> 2) & 0x1) << 15) | (((input >> 4) & 0x1) << 14) |
+      (((input >> 9) & 0x1) << 13) | (((input >> 12) & 0x1) << 12) |
+      (((input >> 3) & 0x1) << 11) | (((input >> 5) & 0x1) << 10) |
+      (((input >> 8) & 0x1) << 9) | (((input >> 15) & 0x1) << 8) |
+      // output[23:16]
+      (((input >> 16) & 0x1) << 23) | (((input >> 22) & 0x1) << 22) |
+      (((input >> 27) & 0x1) << 21) | (((input >> 30) & 0x1) << 20) |
+      (((input >> 17) & 0x1) << 19) | (((input >> 23) & 0x1) << 18) |
+      (((input >> 26) & 0x1) << 17) | (((input >> 29) & 0x1) << 16) |
+      // output[31:24]
+      (((input >> 18) & 0x1) << 31) | (((input >> 20) & 0x1) << 30) |
+      (((input >> 25) & 0x1) << 29) | (((input >> 28) & 0x1) << 28) |
+      (((input >> 19) & 0x1) << 27) | (((input >> 21) & 0x1) << 26) |
+      (((input >> 24) & 0x1) << 25) | (((input >> 31) & 0x1) << 24);
+
+  return output;
+}
+
+uint32_t sca_non_linear_layer(uint32_t input) {
+  uint32_t output;
+  if (input != 0) {
+    // Perform the AES S-Box look ups bytewise.
+    output = (sbox[(input >> 24) & 0xFF] << 24) |
+             (sbox[(input >> 16) & 0xFF] << 16) |
+             (sbox[(input >> 8) & 0xFF] << 8) | sbox[input & 0xFF];
+  } else {
+    output = input;
+  }
+
+  return output;
 }

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -311,26 +311,17 @@ void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {
       &clkmgr, CLKMGR_CLK_ENABLES_CLK_IO_DIV4_PERI_EN_BIT, kDifToggleEnabled));
 }
 
-/**
- * PRNG for masking key.
- */
-static uint32_t lfsr_state = 0xdeadbeef;
+static uint32_t sca_lfsr_state = 0xdeadbeef;
 
-/**
- * seed PRNG for masking key.
- */
-void seed_lfsr(uint32_t seed) { lfsr_state = seed; }
+void sca_seed_lfsr(uint32_t seed) { sca_lfsr_state = seed; }
 
-/**
- * step PRNG for masking key.
- */
-uint32_t next_lfsr(uint16_t n) {
-  const uint32_t lfsr_out = lfsr_state;
-  for (size_t i = 0; i < n; i++) {
-    bool lfsr_bit = lfsr_state & 0x00000001;
-    lfsr_state = lfsr_state >> 1;
+uint32_t sca_next_lfsr(uint16_t num_steps) {
+  const uint32_t lfsr_out = sca_lfsr_state;
+  for (size_t i = 0; i < num_steps; ++i) {
+    bool lfsr_bit = sca_lfsr_state & 0x00000001;
+    sca_lfsr_state = sca_lfsr_state >> 1;
     if (lfsr_bit) {
-      lfsr_state ^= 0x80000057;
+      sca_lfsr_state ^= 0x80000057;
     }
   }
   return lfsr_out;

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -183,4 +183,40 @@ void sca_seed_lfsr(uint32_t seed);
  */
 uint32_t sca_next_lfsr(uint16_t num_steps);
 
+/**
+ * Applies a linear layer.
+ *
+ * This function feeds the input through a linear permutation layer. This is
+ * suitable to ensure 1) that adjacent output bits of the software LFSR do not
+ * go into the same S-Box (see `sca_non_linear_layer()`) and 2) that the output
+ * of S-Box(n) is not always going to be equal to the output of S-Box(n+1) in
+ * the subsequent cycle. For details on how this can be achieved, refer to the
+ * corresponding hardware implementation in hw/ip/prim/rtl/prim_lfsr.sv.
+ *
+ * @param input The input value.
+ *
+ * @return The output of the linear layer.
+ *
+ */
+uint32_t sca_linear_layer(uint32_t input);
+
+/**
+ * Applies a non-linear layer.
+ *
+ * This function feeds the input through a non-linear layer. It is suitable to
+ * improve the statistical properties of the software LFSR usable for key
+ * masking, see `sca_seed_lfsr()` and `sca_next_lfsr()`. Internally, a LUT-based
+ * AES S-Box is applied to the invididual bytes of the input word.
+ *
+ * In addition, the ouput bytes are XORed with the sbox[0]. This is useful to
+ * ensure an all-zero seed (used to switch off key masking) also results in an
+ * all-zero output of the non-linear layer.
+ *
+ * @param input The input value.
+ *
+ * @return The output of the non-linear layer.
+ *
+ */
+uint32_t sca_non_linear_layer(uint32_t input);
+
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -160,13 +160,27 @@ typedef void (*sca_callee)(void);
 void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles);
 
 /**
- * seed PRNG for masking key.
+ * Seeds the software LFSR usable e.g. for key masking.
+ *
+ * This functions seeds the Galois XOR type LFSR with the provided seed value.
+ * Note that the LFSR itself has very low diffusion.
+ *
+ * @param seed The new seed value.
  */
-void seed_lfsr(uint32_t seed);
+void sca_seed_lfsr(uint32_t seed);
 
 /**
- * step PRNG for masking key.
+ * Steps the software LFSR usable e.g. for key masking `num_steps` times.
+ *
+ * This function steps the Galois XOR type LFSR n times. Note that the LFSR
+ * itself has very low diffusion. To improve the statistical properties, the
+ * multiple steps can be run. For example, by running 32 steps it can be
+ * ensured that each state bit depends on at least two previous state bits.
+ *
+ * @param num_steps The number of steps to run.
+
+ * @return The current state of the LFSR.
  */
-uint32_t next_lfsr(uint16_t n);
+uint32_t sca_next_lfsr(uint16_t num_steps);
 
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -167,6 +167,6 @@ void seed_lfsr(uint32_t seed);
 /**
  * step PRNG for masking key.
  */
-uint32_t next_lfsr(void);
+uint32_t next_lfsr(uint16_t n);
 
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -500,7 +500,7 @@ static void sha3_serial_batch(const uint8_t *data, size_t data_len) {
  */
 static void sha3_serial_seed_lfsr(const uint8_t *seed, size_t seed_len) {
   SS_CHECK(seed_len == sizeof(uint32_t));
-  seed_lfsr(read_32(seed));
+  sca_seed_lfsr(read_32(seed));
 }
 
 /**


### PR DESCRIPTION
Previously, we were using the same sofware PRNG used for generating plaintexts and keys. This was non-ideal for the following reasons:
1. One must be careful to keep the software PRNG on the target and the host in sync. Not only can this be difficult but it also limits capture performance on the host side.
2. This PRNG is not available in non-batch mode. As a result, we non-batch mode was always using unmasked keys which led to 1st-order leakage.

Therefore, this PR introduces an additional software LFSR for key masking (similar to what is done for KMAC already) including a simple serial command to seed that LFSR. Key re-masking can still be disabled by seeding this LFSR with 0.