### PR TITLE
[dv/clkmgr] Improve DV documentation and do simple cleanup

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -52,17 +52,21 @@
       name: peri_enables
       desc: '''
             Peripheral clocks are disabled if its `clk_enables` bit is off,
-            or `pwr_i.ip_clk_en` is off, and `scanmode_i` is not
-            `lc_ctrl_pkg::On`.
+            or the corresponding `pwr_i.*_ip_clk_en` is off, and `scanmode_i`
+            is not `lc_ctrl_pkg::On`.
 
-            This test runs multiple rounds, and on each one it randomizes
-             `ip_clk_en` and `scanmode_i`, and the initial setting of
-             `clk_enables`, it sends a CSR write to `csr_enables` with this
-             initial value followed by a write that flips all bits.
+            This test runs multiple rounds which do the following:
+            - Randomize `pwr_i.usb_ip_clk_en` and `scanmode_i`, and the initial
+              setting of `clk_enables`.
+            - Send a CSR write to `clk_enables` with its initial value.
+            - Send a CSR write to `clk_enables` that flips all bits.
+
+            It makes no sense to have `pwr_i.io_ip_clk_en` set to zero since
+            that would prevent the CPU from running and sending CSR updates.
 
             **Checks**:
-            - The scoreboard checks the gated clock activities against its
-              model of the expected behavior.
+            - SVA assertions for peripheral clocks enable and disable
+              properties.
             '''
       stage: V2
       tests: ["clkmgr_peri"]
@@ -70,12 +74,11 @@
     {
       name: trans_enables
       desc: '''
-            Transactional unit clocks are disabled if they are not busy and
-            their CSR `clk_hints` bit is off, or `pwr_i.ip_clk_en` is off,
+            Transactional unit clocks are disabled if they are idle and
+            their CSR `clk_hints` bit is off, or `pwr_i.main_ip_clk_en` is off,
             and `scanmode_i` is not `lc_ctrl_pkg::On`.
-            This test randomizes `ip_clk_en`, the initial setting of `idle_i`
-            and the desired value of `clk_hints`. Each round performs this
-            sequence:
+            This test randomizes the initial setting of `idle_i` and the
+            desired value of `clk_hints`. Each round performs this sequence:
             - Writes the desired value to CSR `clk_hints` and checks that the
               CSR `clk_hints_status` reflects CSR `clk_hints` except for the
               units not-idle.
@@ -157,7 +160,7 @@
             - Randomize the `pwr_i.*_ip_clk_en` setting for each clock.
 
             **Check**:
-            - The checks are done in SVA at `clkmbf_pwrmgr_sva_if.sv`.
+            - The checks are done in SVA at `clkmgr_pwrmgr_sva_if.sv`.
             '''
       stage: V2
       tests: ["clkmgr_clk_status"]
@@ -176,7 +179,7 @@
 
             **Check**:
             - The `jitter_en_o` output pin reflects the `jitter_enable` CSR.
-              Test is implemented in the scoreboard, and runs always.
+              Test is implemented in the scoreboard, and is always running.
             '''
       stage: V2
       tests: ["clkmgr_smoke"]
@@ -185,15 +188,23 @@
       name: frequency
       desc: '''This tests the frequency counters measured count functionality.
 
-            These counters compute the number of cycles of some clock relative
-            to the aon timer. It should trigger a recoverable alert when the
-            count is not in the expected interval. This tests programs counts
-            for each counter, with intervals set to trigger correct, fast, and
-            slow counts.
+            These counters compute the number of cycles of each clock relative
+            to the aon timer, and compares it to the corresponding
+            thresholds written into the `*_meas_ctrl_shadowed` CSR. Measurements
+            beyond these thresholds trigger a recoverable alert and set a bit
+            in the `recov_err_code` CSR. Also, if the counters reach their
+            maximum value they don't wrap around.
+
+            If clock calibration is lost, indicated by the `calib_rdy_i` input
+            being `prim_mubi_pkg::MuBi4False`, the measurements stop and no
+            error is triggered.
 
             **Stimulus**:
             - Randomly set slow, correct, and fast interval for each counter
               and test.
+            - Randomly set the `calib_rdy_i` input.
+            - Randomly trigger a clock saturation by forcing its cycle count
+              to be near its maximum value while counting.
 
             **Check**:
             - Slow and fast intervals should cause a recoverable alert.

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// The scoreboard checks io_clk_byp_req is driven in response to an external clock request,
-// drives io_clk_byp_ack response, checks the jitter_an_o output, and processes CSR checks.
+// The scoreboard checks the jitter_an_o output, and processes CSR checks.
+// It also samples most functional coverage groups.
 class clkmgr_scoreboard extends cip_base_scoreboard #(
   .CFG_T(clkmgr_env_cfg),
   .RAL_T(clkmgr_reg_block),

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This tests the transitions of clk_status under various scenarios:
-// - Transitions with ip_clk_en going active, assuming the usb clock is either active or inactive.
-// - Transitions with ip_clk_en going inactive, and assumming any subset of the clocks
-//   remain enabled (per controls in pwrmgr `control` CSR).
+// This tests the transitions of the various clock status outputs for random settings of the
+// various ip_clk_en inputs.
 //
 // The checks are done via SVA in clkmgr_pwrmgr_sva_if.
 class clkmgr_clk_status_vseq extends clkmgr_base_vseq;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -16,6 +16,7 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
   // The clk_enables CSR cannot be manipulated in low power mode.
   constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
   constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
+  // ICEBOX(#17963) randomize the usb clk enable.
   constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   task body();

--- a/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
@@ -12,13 +12,15 @@ interface clkmgr_gated_clock_sva_if (
   input logic gated_clk
 );
   // This fires at negedges: if the gated clock is inactive its value is expected to be low,
-  // and viceversa. The assertions pass if gating is not stable to avoid cycle accuracy, and
+  // and viceversa. The assertions pass if clk_enabled is not stable to avoid cycle accuracy, and
   // these gated clocks are expected to be changed infrequently.
-  logic gating;
-  always_comb gating = sw_clk_en && ip_clk_en || scanmode;
+  logic clk_enabled;
+  always_comb clk_enabled = sw_clk_en && ip_clk_en || scanmode;
 
-  `ASSERT(GateOpen_A, $rose(gating) |-> ##[0:3] !gating || $changed(gating) || gated_clk, !clk,
+  `ASSERT(GateOpen_A,
+          $rose(clk_enabled) |-> ##[0:3] !clk_enabled || $changed(clk_enabled) || gated_clk, !clk,
           !rst_n)
-  `ASSERT(GateClose_A, $fell(gating) |-> ##[0:3] gating || $changed(gating) || !gated_clk, !clk,
+  `ASSERT(GateClose_A,
+          $fell(clk_enabled) |-> ##[0:3] clk_enabled || $changed(clk_enabled) || !gated_clk, !clk,
           !rst_n)
 endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This contains SVA assertions to check loosing calibration turns off clock measurements.
+// This contains SVA assertions to check losing calibration turns off clock measurements.
 
 interface clkmgr_lost_calib_ctrl_en_sva_if (
   input logic clk,

--- a/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_regwen_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_regwen_sva_if.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This contains SVA assertions to check loosing calibration enables crtl regwen.
+// This contains SVA assertions to check losing calibration enables crtl regwen.
 
 interface clkmgr_lost_calib_regwen_sva_if (
   input logic clk,

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -102,7 +102,7 @@ module tb;
     .clk_main_i (clk_main),
     .rst_main_ni(rst_main_n),
     .clk_io_i   (clk_io),
-    // TODO(#17934): differentiate the io resets to check they generate the
+    // ICEBOX(#17934): differentiate the io resets to check they generate the
     // expected side-effects. Probably doable with a very simple test.
     .rst_io_ni  (rst_io_n),
     .rst_io_div2_ni(rst_io_n),
@@ -112,7 +112,7 @@ module tb;
     .clk_aon_i  (clk_aon),
     .rst_aon_ni (rst_aon_n),
 
-    // TODO(#17934): differentiate the root resets as mentioned for rst_io_ni above.
+    // ICEBOX(#17934): differentiate the root resets as mentioned for rst_io_ni above.
     .rst_root_ni(rst_root_io_n),
     .rst_root_io_ni(rst_root_io_n),
     .rst_root_io_div2_ni(rst_root_io_n),


### PR DESCRIPTION
Correct various inaccuracies in the DV documentation and add some missing test sequences and assertions.
Fix various inaccuracies in SV comments.
Change the confusing name of a signal.