### PR TITLE
[manuf] Individualize SECRET1

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -100,6 +100,7 @@ static status_t otp_ctrl_dai_write_error_check(const dif_otp_ctrl_t *otp) {
       !bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiError)) {
     return OK_STATUS();
   }
+  LOG_ERROR("dai_write_error_check code: 0x%x", status.codes);
   return INTERNAL();
 }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -38,11 +38,42 @@ status_t individualize_dev_hw_cfg_start(dif_flash_ctrl_state_t *flash_state,
                                         const dif_otp_ctrl_t *otp);
 
 /**
- * Checks HW_CFG OTP partition end state.
+ * Checks the HW_CFG OTP partition end state.
  *
  * @param otp OTP controller interface.
  * @return OK_STATUS if the HW_CFG partition is locked.
  */
 status_t individualize_dev_hw_cfg_end(const dif_otp_ctrl_t *otp);
+
+/**
+ * Configures the SECRET1 OTP partition.
+ *
+ * The SECRET1 partition contains the Flash and SRAM scrambling seeds for the
+ * device.
+ *
+ * Preconditions:
+ * - Device is in DEV, PROD, or PROD_END lifecycle stage.
+ *
+ * Note: The test will skip all programming steps and succeed if the SECRET1
+ * parition is already locked. This is to facilitate test re-runs.
+ *
+ * The caller should reset the device after calling this function and call
+ * `individualize_dev_secret1_end()` afterwards to confirm that the OTP
+ * partition was successfully locked.
+ *
+ * @param lc_ctrl Lifecycle controller instance.
+ * @param otp OTP controller instance.
+ * @return The result of the operation.
+ */
+status_t individualize_dev_secret1_start(const dif_lc_ctrl_t *lc_ctrl,
+                                         const dif_otp_ctrl_t *otp);
+
+/**
+ * Checks the SECRET1 OTP partition end state.
+ *
+ * @param otp OTP controller interface.
+ * @return OK_STATUS if the SECRET1 partition is locked.
+ */
+status_t individualize_dev_secret1_end(const dif_otp_ctrl_t *otp);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_H_


### PR DESCRIPTION
Program the SECRET1 partition using entropy extracted from CSRNG.

Refactor the `individualize_functest` to include testing of the new functions added in this commit.

This is part of: https://github.com/lowRISC/opentitan/issues/17392