### PR TITLE
Revert "[doc] Fix broken link to OpenTitan Early Grey Chip Datasheet"

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -23,7 +23,7 @@ For questions about how the project is organized, see the [project](./project_go
 
 ## Datasheets
 
-* [OpenTitan Earl Grey Chip Datasheet](hw/top_earlgrey/doc/specification.md)
+* [OpenTitan Earl Grey Chip Datasheet](../hw/top_earlgrey/doc/specification.md)
 
 ## Documentation
 


### PR DESCRIPTION
This reverts commit 7d5bc5f3df74f8f56a1d6d1cb70dfa8a2cedad91.

See https://github.com/lowRISC/opentitan/pull/17847#pullrequestreview-1378968940 for the reason behind reverting this PR.

The cause of the problem is tracked in https://github.com/lowRISC/opentitan/issues/17931 and a working solution is https://github.com/lowRISC/opentitan/pull/17996 .