### PR TITLE
[entropy_src, dv] Tune entropy_src_rng_max_rate config for coverage

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -74,8 +74,8 @@
 
     {
       name: entropy_src_rng_max_rate
-      reseed: 50
-      uvm_test: entropy_src_rng_test
+      reseed: 400
+      uvm_test: entropy_src_rng_max_rate_test
       uvm_test_seq: entropy_src_rng_vseq
       // Set the delay constraint of the RNG agent to at most 1, so that the agent delivers entropy
       // at the highest possible rate.

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_max_rate_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_max_rate_test.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_rng_max_rate_test extends entropy_src_rng_test;
+
+  `uvm_component_utils(entropy_src_rng_max_rate_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    // RNG failures and CSR-driven alert events won't happen in this test.
+    cfg.hard_mtbf                = -1;
+    cfg.soft_mtbf                = -1;
+    cfg.mean_rand_csr_alert_time = -1;
+    // We are interested in reconfiguring the DUT frequently to try many configurations for
+    // coverage. To this end, this test configures the RNG agent to produce entropy at the
+    // highest possible rate. At this rate, the initial boot-time/non-FIPS seed is produced
+    // after roughly 7us (rng_bit_enable = 0) or 30us (rng_bit_enable = 1) on average. The
+    // first FIPS seed is then available after roughly 80us and further seeds after 40us
+    // (rng_bit_enable = 0).
+    cfg.mean_rand_reconfig_time = 500us;
+    // This test automatically switches the DUT from non-FIPS to FIPS mode once a seed
+    // is observed. However, as we reconfigure the DUT very frequently, this automatic
+    // switch might not happen.
+    cfg.dut_cfg.fips_enable_pct = 60;
+    // We want to hit all rng_bit_enable settings (off, bit 0 - 3) w/ and w/o bypass and
+    // fips_enable.
+    cfg.dut_cfg.rng_bit_enable_pct = 80;
+    cfg.dut_cfg.type_bypass_pct = 50;
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
+  endfunction
+endclass : entropy_src_rng_max_rate_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test.core
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test.core
@@ -14,6 +14,7 @@ filesets:
       - entropy_src_smoke_test.sv: {is_include_file: true}
       - entropy_src_fw_ov_test.sv: {is_include_file: true}
       - entropy_src_rng_test.sv: {is_include_file: true}
+      - entropy_src_rng_max_rate_test.sv: {is_include_file: true}
       - entropy_src_stress_all_test.sv: {is_include_file: true}
       - entropy_src_functional_errors_test.sv: {is_include_file: true}
       - entropy_src_alert_test.sv: {is_include_file: true}

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
@@ -16,6 +16,7 @@ package entropy_src_test_pkg;
   `include "entropy_src_base_test.sv"
   `include "entropy_src_smoke_test.sv"
   `include "entropy_src_rng_test.sv"
+  `include "entropy_src_rng_max_rate_test.sv"
   `include "entropy_src_fw_ov_test.sv"
   `include "entropy_src_stress_all_test.sv"
   `include "entropy_src_functional_errors_test.sv"


### PR DESCRIPTION
This commit tunes the configuration of the max rate test to improve functional coverage. This is achieved 1) by lowering the average time between random re-configurations, doing more configs with FIPS mode enabled, and fewer runs with ES_TYPE set to true (SHA3 conditioner off), and 2) by increasing the number of runs.

This helps to push the functional coverage for the cr_config cross of the csrng_hw_cg covergroup from roughly 70% to 96%. The remaining