### PR TITLE
[util] update flash scrambling script to read OTP mmap

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -50,6 +50,8 @@ autogen_hjson_header(
     ],
 )
 
+exports_files(["otp_ctrl_mmap.hjson"])
+
 otp_json(
     name = "otp_json_creator_sw_cfg",
     partitions = [

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -461,8 +461,21 @@ def _scramble_flash_vmem_impl(ctx):
         ctx.executable._tool,
     ]
     if ctx.file.otp:
-        arguments.extend(["--in-otp-vmem", ctx.file.otp.path])
-        inputs.append(ctx.file.otp)
+        arguments.extend([
+            "--in-otp-vmem",
+            ctx.file.otp.path,
+            "--in-otp-mmap",
+            ctx.file.otp_mmap.path,
+        ])
+        inputs.extend([
+            ctx.file.otp,
+            ctx.file.otp_mmap,
+        ])
+        if ctx.attr.otp_seed != None:
+            arguments.extend([
+                "--otp-seed",
+                str(ctx.attr.otp_seed[BuildSettingInfo].value),
+            ])
         if ctx.attr.otp_data_perm:
             arguments.extend([
                 "--otp-data-perm",
@@ -485,6 +498,14 @@ scramble_flash_vmem = rv_rule(
     implementation = _scramble_flash_vmem_impl,
     attrs = {
         "otp": attr.label(allow_single_file = True),
+        "otp_mmap": attr.label(
+            allow_single_file = True,
+            default = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
+            doc = "OTP memory map configuration HJSON file.",
+        ),
+        "otp_seed": attr.label(
+            doc = "Configuration override seed used to randomize OTP netlist constants.",
+        ),
         "vmem": attr.label(allow_single_file = True),
         "otp_data_perm": attr.label(
             default = "//hw/ip/otp_ctrl/data:data_perm",

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -25,6 +25,7 @@ py_binary(
     deps = [
         ":secded_gen",
         "//util/design/lib:common",
+        "//util/design/lib:otp_mem_map",
         "//util/design/lib:present",
         requirement("pyfinite"),
     ],

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -23,6 +23,13 @@ py_library(
 py_library(
     name = "otp_mem_map",
     srcs = ["OtpMemMap.py"],
+    # Since this module is used by the `gen-otp-img.py` script, which is invoked
+    # manually (by dvsim.py), and imported by the `gen-flash-img.py` script,
+    # which is invoked automatically (via Bazel), we cannot use full package
+    # includes within this module yet. Adding `util/design` to the imports path,
+    # temporarily resovles this issue until the entire hw/ subtree can be
+    # Bazelfied.
+    imports = ["../"],
     deps = [
         ":common",
         "//util/design/mubi:prim_mubi",

--- a/util/design/lib/OtpMemMap.py
+++ b/util/design/lib/OtpMemMap.py
@@ -10,9 +10,10 @@ import logging as log
 import random
 from math import ceil, log2
 
-from lib.common import check_bool, check_int, random_or_hexvalue
 from mubi.prim_mubi import is_width_valid, mubi_value_as_int
 from tabulate import tabulate
+
+from lib.common import check_bool, check_int, random_or_hexvalue
 
 DIGEST_SUFFIX = "_DIGEST"
 DIGEST_SIZE = 8


### PR DESCRIPTION
The flash scrambling keys are generated from seeds (embedded in the secret 1 OTP partition) and otp_ctrl netlist constants. These netlist constants can change when the HW build seed is changed (the `gen-otp-mmap.py` dirties the tree since the hw/ subtree has not yet been bazelfied).

This updates the flash scrambling script to read in the netlist constants from the OTP memory map HJSON file/script. This fixes #17181. This is also related to #16719.