### PR TITLE
[flash_ctrl,dv] regression fix (mp_regions failure and sec_info_access

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -51,6 +51,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Check permission and page range of info partition
   // Set exp recov_err alert if check fails
+  // Make sure your flash_op has right otf_addr associated with addr
   function bit check_info_part(flash_op_t flash_op, string str);
     bit drop = 0;
     int bank, page, end_page, loop;
@@ -1425,18 +1426,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         data = cfg.mem_bkdr_util_h[FlashPartInfo][0].read(addr);
         item.dq.push_back(data[31:0]);
         item.dq.push_back(data[63:32]);
-        // only scr/ecc enable counts.
-        if (page != 3) begin
-          item.region.scramble_en = prim_mubi_pkg::mubi4_and_hi(
-                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
-                                    mubi4_t'(~cfg.ovrd_scr_dis));
-          item.region.ecc_en = prim_mubi_pkg::mubi4_and_hi(
-                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
-                               mubi4_t'(~cfg.ovrd_ecc_dis));
-        end else begin
-          item.region.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-          item.region.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
-        end
+        item.region.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
+        item.region.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
         item.scramble(otp_addr_key, otp_data_key, addr, dis);
         cfg.mem_bkdr_util_h[FlashPartInfo][0].write(addr, item.fq[0]);
         mem_addr = addr >> 3;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -114,8 +114,7 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
     if (part == FlashIsolPart) begin
       scr_en = 1;
     end else begin
-      scr_en = ((flash_ctrl_pkg::CfgAllowRead.scramble_en == MuBi4True) &&
-                (mubi4_t'(~cfg.ovrd_scr_dis) == MuBi4True));
+      scr_en = (flash_ctrl_pkg::CfgAllowRead.scramble_en == MuBi4True);
     end
     case (op)
       FlashOpErase: begin
@@ -158,17 +157,8 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
   task init_sec_info_part();
     flash_bank_mp_info_page_cfg_t info_regions = '{default: MuBi4True};
     for (int i = 1; i < 4; i++) begin
-      if (i < 3) begin
-         info_regions.scramble_en = prim_mubi_pkg::mubi4_and_hi(
-                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
-                                    mubi4_t'(~cfg.ovrd_scr_dis));
-         info_regions.ecc_en = prim_mubi_pkg::mubi4_and_hi(
-                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
-                               mubi4_t'(~cfg.ovrd_ecc_dis));
-      end else begin
-        info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-        info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
-      end
+      info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
+      info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
       flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
     end
   endtask // init_info_part

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -201,7 +201,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
       cfg.scb_h.expected_alert["recov_err"].expected = 0;
     end
-
     // Send info region access and bank erase
     exp_alert_cnt = 0;
     cfg.scb_h.alert_count["recov_err"] = 0;
@@ -263,6 +262,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       `uvm_info("do_mp_reg", $sformatf("size:%0d tail:%0d bank:%0d addr:%x",
                                   size, tail, bank, tmp_addr), UVM_MEDIUM)
       for (int i = 0; i < size; i++) begin
+        flash_op.otf_addr = flash_op.addr[OTFBankId-1:0];
         if  (flash_op.partition == FlashPartData) begin
           page = cfg.addr2page(flash_op.addr);
           my_region = get_region_from_page(page);


### PR DESCRIPTION
Fix two regression failures by
- apply hw_cfg constraint only init phase
- update otf_addr before calculate info page