### PR TITLE
[chip-test] Fix flash_ctrl alert on FPGA target

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1964,9 +1964,6 @@ opentitan_functest(
 opentitan_functest(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
-    cw310 = cw310_params(
-        tags = ["broken"],  # FIXME #16576 fails in non-CI environments
-    ),
     targets = [
         "cw310_test_rom",
         "verilator",
@@ -1999,6 +1996,7 @@ opentitan_functest(
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -300,6 +300,7 @@ opentitan_functest(
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -20,6 +20,7 @@
 #include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
@@ -753,6 +754,14 @@ bool test_main(void) {
 
   // TODO(#13098): Change to equality after #13277 is merged.
   if (rst_info & kDifRstmgrResetInfoPor) {
+    // We need to initialize the info FLASH partitions storing the Creator and
+    // Owner secrets to avoid getting the flash controller into a fatal error
+    // state.
+    if (kDeviceType == kDeviceFpgaCw310 && rst_info & kDifRstmgrResetInfoPor) {
+      CHECK_STATUS_OK(keymgr_testutils_flash_init(&flash_ctrl, &kCreatorSecret,
+                                                  &kOwnerSecret));
+    }
+
     global_test_round = kRound1;
     prgm_alert_handler_round1();
 


### PR DESCRIPTION
Update the alert_handler_lpg_sleep_mode_pings_test target to initialize the Creator and Owner info flash pages to avoid fatal alerts in the flash_ctrl. This change is only required on the FPGA target.

Fixes https://github.com/lowRISC/opentitan/issues/16356
Fixes https://github.com/lowRISC/opentitan/issues/16576