### PR TITLE
[silicon_creator] move pinmux attr spin wait time to a macro

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -8,6 +8,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * @file
  * @brief This header contains declarations of device-specific information.
@@ -187,5 +191,9 @@ uint64_t to_cpu_cycles(uint64_t usec);
  * This function is a NOP unless we are building for an FPGA.
  */
 void device_fpga_version_print(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/arch/device.h"
 
 /**
- * Device-specific symbol definitions for the Verilator device.
+ * Device-specific symbol definitions for the DV simulation device.
  */
 
 const device_type_t kDeviceType = kDeviceSimDV;

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -44,6 +44,15 @@
 #define TEST_ROM_IDENTIFIER 0x54534554
 
 /**
+ * Pinmux pull up/down wait delay.
+ *
+ * After enabling the pull-up/down on a pin, we need to wait for ~5us for the
+ * configuration to propagate to the physical pads. 5us is 500 clock cycles
+ * assuming a 100MHz clock.
+ */
+#define PINMUX_PAD_ATTR_PROP_CYCLES 500
+
+/**
  * Pinmux peripheral input values for software strap pins.
  */
 #define SW_STRAP_0_PERIPH 22

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -455,9 +455,11 @@ cc_test(
     deps = [
         ":pinmux",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:sim_dv",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -20,7 +20,6 @@ enum {
    * Base address of the pinmux registers.
    */
   kBase = TOP_EARLGREY_PINMUX_AON_BASE_ADDR,
-  kPadAttrSpinWaitCycles = 500,  // 500 cycles is 5us with a 100MHz clock
 };
 
 /**
@@ -141,7 +140,7 @@ void pinmux_init(void) {
     uint32_t mcycle;
     do {
       CSR_READ(CSR_REG_MCYCLE, &mcycle);
-    } while (mcycle < kPadAttrSpinWaitCycles);
+    } while (mcycle < PINMUX_PAD_ATTR_PROP_CYCLES);
     configure_input(kInputSwStrap0);
     configure_input(kInputSwStrap1);
     configure_input(kInputSwStrap2);

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -5,8 +5,10 @@
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/base/mock_csr.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
@@ -70,6 +72,12 @@ class InitTest : public PinmuxTest {
            static_cast<uint32_t>(index) * sizeof(uint32_t);
   };
 };
+
+TEST_F(InitTest, PadAttrPropagationDelay) {
+  const uint64_t kCpuClockPeriodNs = 1'000'000'000 / kClockFreqCpuHz;
+  const uint64_t kCpuCyclesIn5Micros = 5000 / kCpuClockPeriodNs;
+  EXPECT_EQ(PINMUX_PAD_ATTR_PROP_CYCLES, kCpuCyclesIn5Micros);
+}
 
 TEST_F(InitTest, WithBootstrap) {
   // The inputs that will be configured.

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -264,7 +264,7 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   // wait for the RMA strap pull enables to propagate to the physical pads.
   // Since this is a wait loop, disable the watchdog.
   csrw mcycle, zero
-  li   t0, 500  // 500 clock cycles with 100MHz clock is 5us.
+  li   t0, PINMUX_PAD_ATTR_PROP_CYCLES
 .L_rma_strap_pu_spin_cycles_loop:
   csrr t1, mcycle
   bltu t1, t0, .L_rma_strap_pu_spin_cycles_loop


### PR DESCRIPTION
This addresses a review comment in #17959.