### PR TITLE
[flash_ctrl,dv] regression cleanup - update timeout values

### DIFF
--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
@@ -42,7 +42,7 @@ class flash_phy_prim_monitor extends dv_base_monitor #(
   task run_phase(uvm_phase phase);
     if (cfg.scb_otf_en) begin
       `DV_SPINWAIT(wait(cfg.mon_start);,
-                   "timeout waiting for mon_start", 100_000)
+                   "timeout waiting for mon_start", 200_000)
       fork
         super.run_phase(phase);
         monitor_core();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -402,7 +402,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   virtual task flash_ctrl_intr_read(flash_op_t flash_op, ref data_q_t rdata);
     uvm_reg_data_t data;
     bit[31:0] intr_st;
-    int       rd_timeout_ns = 200000; // 200 us
+    int       rd_timeout_ns = 400000; // 400 us
     int       curr_rd, rd_idx = 0;
 
     `uvm_info("flash_ctrl_intr_read", $sformatf("num_rd:%0d",
@@ -1379,7 +1379,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   task init_controller(bit non_blocking = 0);
-    int wait_timeout_ns = 50000; // 50 us
+    int wait_timeout_ns = 200_000; // 200 us
 
     csr_wr(.ptr(ral.init), .value(1));
     `uvm_info(`gfn,"init_controller: OTP",UVM_LOW)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -71,7 +71,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
             csr_spinwait(.ptr(ral.debug_state),
                          .exp_data(flash_ctrl_env_pkg::FlashLcInvalid),
                          .spinwait_delay_ns(500_000),
-                         .timeout_ns(200_000_000));
+                         .timeout_ns(2_000_000_000));
             cfg.clk_rst_vif.wait_clks(3);
             `uvm_info(`gfn, "RMA FAIL DUE TO Wipe out write data failure (expected)", UVM_LOW)
             collect_err_cov_status(ral.std_fault_status);

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -283,7 +283,7 @@
       uvm_test_seq: flash_ctrl_oversize_error_vseq
       run_opts: ["+scb_otf_en=1", "+ecc_mode=2", "+serr_pct=0",
                  "+otf_num_hr=1000", "+otf_num_rw=100",
-		 "+otf_wr_pct=4", "+otf_rd_pct=4"]
+                 "+otf_wr_pct=4", "+otf_rd_pct=4"]
       reseed: 5
     }
     {
@@ -308,7 +308,7 @@
     {
       name: flash_ctrl_intr_rd_slow_flash
       uvm_test_seq: flash_ctrl_intr_rd_vseq
-      run_opts: ["+scb_otf_en=1", "+flash_read_latency=50", "+flash_program_latency=500"]
+      run_opts: ["+scb_otf_en=1", "+flash_read_latency=50", "+flash_program_latency=500", "+test_timeout_ns=500_000_000"]
       reseed: 40
     }
     {
@@ -423,7 +423,7 @@
     {
       name: flash_ctrl_rma_err
       uvm_test_seq: flash_ctrl_hw_rma_err_vseq
-      run_opts: ["+flash_program_latency=5", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+flash_program_latency=5", "+flash_erase_latency=50", "+test_timeout_ns=300_000_000_000"]
       reseed: 3
     }
     {


### PR DESCRIPTION
Adjust timeout value to fix following test failures
- flash_ctrl_intr_rd_slow_flash
- flash_ctrl_rma_err
- flash_ctrl_hw_read_seed_err