### PR TITLE
Remove out-of-date "mode" in dvsim

### DIFF
--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -83,7 +83,7 @@ def parse_hjson(hjson_file):
     hjson_cfg_dict = None
     try:
         log.debug("Parsing %s", hjson_file)
-        f = open(hjson_file, 'rU')
+        f = open(hjson_file, 'r')
         text = f.read()
         hjson_cfg_dict = hjson.loads(text, use_decimal=True)
         f.close()


### PR DESCRIPTION
For years, Python generated a documentation warning if you use the 'U' mode. It has not had any other effect.

The latest versions of Python now die on a 'U' mode. So we should probably not use it!