### PR TITLE
Teach dvsim to understand BUILD_ROOT

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -37,8 +37,7 @@ import SgeLauncher
 from CfgFactory import make_cfg
 from Deploy import RunTest
 from Timer import Timer
-from utils import (TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path,
-                   run_cmd_with_timeout)
+from utils import TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path
 
 # TODO: add dvsim_cfg.hjson to retrieve this info
 version = 0.1
@@ -59,20 +58,7 @@ def resolve_scratch_root(arg_scratch_root, proj_root):
         if scratch_root is None:
             arg_scratch_root = default_scratch_root
         else:
-            # Scratch space could be mounted in a filesystem (such as NFS) on a network drive.
-            # If the network is down, it could cause the access access check to hang. So run a
-            # simple ls command with a timeout to prevent the hang.
-            (out, status) = run_cmd_with_timeout(cmd="ls -d " + scratch_root,
-                                                 timeout=1,
-                                                 exit_on_failure=0)
-            if status == 0 and out != "":
-                arg_scratch_root = scratch_root
-            else:
-                arg_scratch_root = default_scratch_root
-                log.warning(
-                    "Env variable $SCRATCH_ROOT=\"{}\" is not accessible.\n"
-                    "Using \"{}\" instead.".format(scratch_root,
-                                                   arg_scratch_root))
+            arg_scratch_root = scratch_root
 
     try:
         os.makedirs(arg_scratch_root, exist_ok=True)

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -50,19 +50,15 @@ _LIST_CATEGORIES = ["build_modes", "run_modes", "tests", "regressions"]
 # If set on the command line, then use that as a preference.
 # Else, check if $SCRATCH_ROOT env variable exists and is a directory.
 # Else use the default (<proj_root>/scratch)
-# Try to create the directory if it does not already exist.
-def resolve_scratch_root(arg_scratch_root, proj_root):
-    default_scratch_root = proj_root + "/scratch"
+def resolve_scratch_root(scratch_root, proj_root):
+    if scratch_root:
+        return scratch_root
+
     scratch_root = os.environ.get('SCRATCH_ROOT')
-    if not arg_scratch_root:
-        if scratch_root is None:
-            arg_scratch_root = default_scratch_root
-        else:
-            arg_scratch_root = scratch_root
+    if scratch_root:
+        return scratch_root
 
-    os.makedirs(arg_scratch_root, exist_ok=True)
-
-    return arg_scratch_root
+    return proj_root + "/scratch"
 
 
 def read_max_parallel(arg):
@@ -663,6 +659,10 @@ def main():
     args.branch = resolve_branch(args.branch)
     proj_root_src, proj_root = resolve_proj_root(args)
     args.scratch_root = resolve_scratch_root(args.scratch_root, proj_root)
+
+    # Make sure our scratch root actually exists
+    os.makedirs(args.scratch_root, exist_ok=True)
+
     log.info("[proj_root]: %s", proj_root)
 
     # Create an empty FUSESOC_IGNORE file in scratch_root. This ensures that

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -73,8 +73,6 @@ def resolve_scratch_root(arg_scratch_root, proj_root):
                     "Env variable $SCRATCH_ROOT=\"{}\" is not accessible.\n"
                     "Using \"{}\" instead.".format(scratch_root,
                                                    arg_scratch_root))
-    else:
-        arg_scratch_root = os.path.realpath(arg_scratch_root)
 
     try:
         os.makedirs(arg_scratch_root, exist_ok=True)

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -60,12 +60,7 @@ def resolve_scratch_root(arg_scratch_root, proj_root):
         else:
             arg_scratch_root = scratch_root
 
-    try:
-        os.makedirs(arg_scratch_root, exist_ok=True)
-    except PermissionError as e:
-        log.fatal("Failed to create scratch root {}:\n{}.".format(
-            arg_scratch_root, e))
-        sys.exit(1)
+    os.makedirs(arg_scratch_root, exist_ok=True)
 
     if not os.access(arg_scratch_root, os.W_OK):
         log.fatal("Scratch root {} is not writable!".format(arg_scratch_root))

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -62,10 +62,6 @@ def resolve_scratch_root(arg_scratch_root, proj_root):
 
     os.makedirs(arg_scratch_root, exist_ok=True)
 
-    if not os.access(arg_scratch_root, os.W_OK):
-        log.fatal("Scratch root {} is not writable!".format(arg_scratch_root))
-        sys.exit(1)
-
     return arg_scratch_root
 
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -46,19 +46,28 @@ version = 0.1
 _LIST_CATEGORIES = ["build_modes", "run_modes", "tests", "regressions"]
 
 
-# Function to resolve the scratch root directory among the available options:
-# If set on the command line, then use that as a preference.
-# Else, check if $SCRATCH_ROOT env variable exists and is a directory.
-# Else use the default (<proj_root>/scratch)
+# Pick a scratch root. This might be given as an argument (in which case, it's
+# an argument to the function). Otherwise, select from the following, in
+# decreasing order of preference:
+#
+#    $SCRATCH_ROOT
+#    $BUILD_ROOT/build-scratch
+#    <proj_root>/scratch
 def resolve_scratch_root(scratch_root, proj_root):
-    if scratch_root:
-        return scratch_root
-
-    scratch_root = os.environ.get('SCRATCH_ROOT')
-    if scratch_root:
-        return scratch_root
-
-    return proj_root + "/scratch"
+    env = os.environ
+    pairs = [
+        (scratch_root, None),
+        (env.get('SCRATCH_ROOT'), None),
+        (env.get('BUILD_ROOT'), 'build-scratch'),
+        (proj_root, 'scratch')
+    ]
+    for root, subdir in pairs:
+        if not root:
+            continue
+        if subdir:
+            return os.path.join(root, subdir)
+        else:
+            return root
 
 
 def read_max_parallel(arg):


### PR DESCRIPTION
This should close https://github.com/lowRISC/opentitan/issues/5031. It also does a bit of other tidying up to make the code in question a bit easier to follow.

We're not actually using $BUILD_ROOT anywhere in our tree at the moment, but this needs to land first to make that do anything. And I checked it locally, so I'm reasonably convinced this works!