### PR TITLE
[kmac] Remove or icebox TODO items for D2.5

### DIFF
--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -460,12 +460,4 @@ module keccak_round
         inside {KeccakStPhase1, KeccakStPhase2Cycle1, KeccakStPhase2Cycle2, KeccakStPhase2Cycle3}),
         clk_i, !rst_ni)
   end
-
-  // If message is fed, it shall start from 0
-  // TODO: Handle the case `addr_i` changes prior to `valid_i`
-  //`ASSUME(MsgStartFrom0_A, valid_i |->
-  //                         (addr_i == 0) || (addr_i == $past(addr_i) + 1),
-  //        clk_i,!rst_ni)
-
-
 endmodule

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -345,7 +345,7 @@ module keccak_round
     if (xor_message) begin
       for (int j = 0 ; j < Share ; j++) begin
         for (int unsigned i = 0 ; i < DInEntry ; i++) begin
-          // TODO: handle If Width is not integer divisable by DInWidth
+          // ICEBOX(#18029): handle If Width is not integer divisable by DInWidth
           // Currently it is not allowed to have partial write
           // Please see the Assertion `WidthDivisableByDInWidth_A`
           if (addr_i == i[DInAddr-1:0]) begin

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -138,7 +138,7 @@ package sha3_pkg;
     // completed. The main indicator is `absorbed` signal.
     StAbsorb_sparse = 6'b100001,
 
-    // TODO: Implement StAbort later after context-switching discussion.
+    // Reserved state for context-switching. See #3479.
     // Abort stage can be moved from StAbsorb stage. It basically holds the
     // keccak round operation and opens up the internal state variable to the
     // software. This stage is for the software to pause current operation and


### PR DESCRIPTION
This PR resolves 3 TODO items from KMAC RTL. I am iceboxing one of them and removing the other two.

- I think we can remove the commented-out assertion `MsgStartFrom0_A` and drop it from our TODO list. I can see that assertion being useful at the earlier stages of KMAC development, but I do not see its use at this point. Could I be missing something @vogelpi, @cindychip, @m-temp?

- The comments about `StAbort` is useful to keep in the code, but I don't think it should be tagged as TODO. We do not even have a decision on whether to implement context switching yet. So, I added a reference to the discussion issue, but I removed the TODO tag.
- For `DInWidth` possibly not being multiple of `Width`, I created an issue https://github.com/lowRISC/opentitan/issues/18029. I think this TODO might be relevant but it looks low priority (P4).