### PR TITLE
[site] Minor tweaks for the block diagram

### DIFF
--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -95,8 +95,6 @@
 /**
  * Lay the root out vertically. Various grids are used for horizontal layout
  * within the block diagram.
- *
- * Block diagrams can be given a `.block-diagram-title`.
  */
 .block-diagram {
     display: flex;
@@ -106,12 +104,6 @@
 
     background-color: var(--diagram-bg);
     color: var(--diagram-fg);
-}
-
-.block-diagram .block-diagram-title {
-    font-size: var(--font-size);
-    font-weight: bold;
-    text-transform: uppercase;
 }
 
 /********

--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -229,6 +229,7 @@
     text-transform: uppercase;
     padding: 0;
     margin: 0;
+    margin-top: calc(-1 * var(--padding));
 }
 
 .domain.always-on .domain-title {

--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -106,6 +106,13 @@
     color: var(--diagram-fg);
 }
 
+/**
+ * Remove vertical margins for captions of the block diagram.
+ */
+.block-diagram > figcaption {
+    margin: calc(-1 * var(--gap)) 0;
+}
+
 /********
  * Tops *
  ********/

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -17,6 +17,7 @@ window.onload = (event) => {
 <div class="scroll-container" style="width: 100%; overflow-x: auto">
 <figure class="block-diagram" id="earlgrey-block-diagram">
     <figcaption><b>OpenTitan Earlgrey ASIC</b></figcaption>
+    <a href="https://opentitan.org/book/hw/top_earlgrey/doc/specification.html">📋 <b>Datasheet</b></a>
     <div class="top">
         <div class="domains" grid="2">
             <div class="domain">

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -14,7 +14,7 @@ window.onload = (event) => {
 }
 </script>
 
-<div class="scroll-container" style="width: 100%; overflow-x: scroll">
+<div class="scroll-container" style="width: 100%; overflow-x: auto">
 <figure class="block-diagram" id="earlgrey-block-diagram">
     <figcaption class="block-diagram-title">Chip_Earlgrey_ASIC</figcaption>
     <div class="top">

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -16,9 +16,8 @@ window.onload = (event) => {
 
 <div class="scroll-container" style="width: 100%; overflow-x: auto">
 <figure class="block-diagram" id="earlgrey-block-diagram">
-    <figcaption class="block-diagram-title">Chip_Earlgrey_ASIC</figcaption>
+    <figcaption><b>OpenTitan Earlgrey ASIC</b></figcaption>
     <div class="top">
-        <h2 class="top-title">Top_Earlgrey</h2>
         <div class="domains" grid="2">
             <div class="domain">
                 <h3 class="domain-title">High speed domain</h2>


### PR DESCRIPTION
## Summary

Small PR with some minor tweaks for the site's block diagram:

* Hide the horizontal scrollbar when not needed.
* Centre domain titles vertically.
* Make the block diagram's title larger and Title Case.
* Add a link to the datasheet.

## Screenshot

![image](https://user-images.githubusercontent.com/105280833/233049468-1292393d-9aec-4aa6-9ac3-7437c4d3cfc5.png)


