### PR TITLE
[test] Gate SPI upload processing on IRQ, not FIFO

### DIFF
--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -447,11 +447,12 @@ bool test_main(void) {
   LOG_INFO("Test setup complete.");
 
   while (true) {
-    uint8_t spi_device_cmdfifo_occupancy;
+    bool cmdfifo_not_empty_irq_pending;
     irq_global_ctrl(/*en=*/false);
-    CHECK_DIF_OK(dif_spi_device_get_flash_command_fifo_occupancy(
-        &spi_device, &spi_device_cmdfifo_occupancy));
-    if (spi_device_cmdfifo_occupancy == 0) {
+    CHECK_DIF_OK(dif_spi_device_irq_is_pending(
+        &spi_device.dev, kDifSpiDeviceIrqUploadCmdfifoNotEmpty,
+        &cmdfifo_not_empty_irq_pending));
+    if (!cmdfifo_not_empty_irq_pending) {
       wait_for_interrupt();
     }
     irq_global_ctrl(/*en=*/true);


### PR DESCRIPTION
Change the spi_passthrough_test software to gate command upload processing on whether the cmdfifo_not_empty IRQ is pending.

Previously, the test used a nonempty command FIFO as the start signal, but spi_device commits command FIFO entries and reports increased depth before the transaction completes. Meanwhile, the status bits do not update until the transaction is done. This would cause the test to spuriously fail for uploaded commands with longer payloads, as the test software checks that the WIP bit is high when an uploaded command is received.

Fixes #17184