### PR TITLE
[bazel] fix default `otp_seed` attr default

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -24,9 +24,10 @@ int_flag(
     build_setting_default = 0,
 )
 
-int_flag(
+string_flag(
     name = "otp_seed",
-    build_setting_default = 0,
+    # Default must match value in hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson.
+    build_setting_default = "10556718629619452145",
 )
 
 string_flag(

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -471,11 +471,10 @@ def _scramble_flash_vmem_impl(ctx):
             ctx.file.otp,
             ctx.file.otp_mmap,
         ])
-        if ctx.attr.otp_seed != None:
-            arguments.extend([
-                "--otp-seed",
-                str(ctx.attr.otp_seed[BuildSettingInfo].value),
-            ])
+        arguments.extend([
+            "--otp-seed",
+            str(ctx.attr.otp_seed[BuildSettingInfo].value),
+        ])
         if ctx.attr.otp_data_perm:
             arguments.extend([
                 "--otp-data-perm",
@@ -504,6 +503,7 @@ scramble_flash_vmem = rv_rule(
             doc = "OTP memory map configuration HJSON file.",
         ),
         "otp_seed": attr.label(
+            default = "//hw/ip/otp_ctrl/data:otp_seed",
             doc = "Configuration override seed used to randomize OTP netlist constants.",
         ),
         "vmem": attr.label(allow_single_file = True),


### PR DESCRIPTION
The `otp_seed` attr of the `scramble_flash_vmem` build rule was not configured to use the custom build configuration setting (also named `otp_seed`). This was causing the `chip_sw_power_virus` and `chip_sw_flash_scrambling_smoketest` to fail in the nightly regressions as dvsim attempts to override the default value.

This should (finally) fix #17181, and the broken nightly regression tests above.

I confirmed the `chip_sw_flash_scrambling_smoketest` is passing locally with `./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_flash_scrambling_smoketest --build-seed=1234`

<img width="1438" alt="Screenshot 2023-04-18 at 4 59 43 PM" src="https://user-images.githubusercontent.com/5633066/232929873-d8f6147a-f871-4ae1-af44-4d6706884723.png">
