### PR TITLE
[chip,external_clock] Improve clkmgr_external_clk_src_for_sw tests

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -58,7 +58,7 @@ interface clkmgr_extclk_sva_if
           $fell(
               extclk_sel_enabled
           ) |=> ##[FallCyclesMin:FallCyclesMax]
-              extclk_sel_enabled || (all_clk_byp_req_o != MuBi4False),
+              extclk_sel_enabled || (all_clk_byp_req_o == MuBi4False),
           clk_i, !rst_ni || disable_sva)
 
   logic hi_speed_enabled;


### PR DESCRIPTION
Add code to disable external clocks after they have been enabled and, using cycle counts, verify the system is back to running with nominal frequencies.
Fix a bug in the clkmgr's external clock SVA.

Fixes #16836