### PR TITLE
[openocd] Work around problem with debug module by retrying failed commands

### DIFF
--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -13,4 +13,7 @@ def openocd_repos(local = None):
         strip_prefix = "openocd-" + OPENOCD_VERSION,
         build_file = "//third_party/openocd:BUILD.openocd.bazel",
         sha256 = "bb367fd19ab96a65ee5b269b60326d9f36bca1c64d9865cc36985d3651aba563",
+        # See Issue(#18087)
+        patches = [Label("//third_party/openocd:reset_on_dmi_op_error.patch")],
+        patch_args = ["-p1"],
     )

--- a/third_party/openocd/reset_on_dmi_op_error.patch
+++ b/third_party/openocd/reset_on_dmi_op_error.patch
@@ -1,0 +1,57 @@
+diff --git a/src/target/riscv/riscv-013.c b/src/target/riscv/riscv-013.c
+index 4e6c8dc36..63c01715d 100644
+--- a/src/target/riscv/riscv-013.c
++++ b/src/target/riscv/riscv-013.c
+@@ -538,6 +538,28 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
+ 	return buf_get_u32(in, DTM_DMI_OP_OFFSET, DTM_DMI_OP_LENGTH);
+ }
+ 
++/**
++ * The OpenTitan rv_dm can get stuck in certain circumstances. This can easily
++ * be detected because tdo is stuck at one so reading DTMCS returns all ones,
++ * a clearly invalid value. Also the rv_dm never sends back an operation status
++ * other than 0 (success) or 3 (busy). When this happens, continue reading until it gets
++ * unstuck and performs a hard dmi reset.
++ */
++static int opentitan_recover(struct target *target)
++{
++	/* wait until the dm is unstuck */
++	const int kNumTries = 100;
++	for(int try = 0; try < kNumTries; try++) {
++		uint32_t dtmcontrol = dtmcontrol_scan(target, DTM_DTMCS_DMIRESET);
++		if (dtmcontrol != 0xffffffff) {
++			LOG_ERROR("OpenTitan rv_dm unstuck after %d resets", try + 1);
++			return ERROR_OK;
++		}
++	}
++	LOG_ERROR("OpenTitan rv_dm still stuck after %d resets", kNumTries);
++	return ERROR_FAIL;
++}
++
+ /**
+  * @param target
+  * @param data_in  The data we received from the target.
+@@ -598,7 +620,10 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
+ 			break;
+ 		} else {
+ 			LOG_ERROR("failed %s at 0x%x, status=%d", op_name, address, status);
+-			return ERROR_FAIL;
++			int err = opentitan_recover(target);
++			if (err != ERROR_OK) {
++				return err;
++			}
+ 		}
+ 		if (time(NULL) - start > timeout_sec)
+ 			return ERROR_TIMEOUT_REACHED;
+@@ -630,7 +655,10 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
+ 					LOG_ERROR("Failed %s (NOP) at 0x%x; status=%d", op_name, address,
+ 							status);
+ 				}
+-				return ERROR_FAIL;
++				int err = opentitan_recover(target);
++				if (err != ERROR_OK) {
++					return err;
++				}
+ 			}
+ 			if (time(NULL) - start > timeout_sec)
+ 				return ERROR_TIMEOUT_REACHED;


### PR DESCRIPTION
Workaround rv_dm bug in OpenOCD by retrying failed commands

See issue https://github.com/lowRISC/opentitan/issues/18087 for more details. In short, this commits works around the
problem by detecting when a DMI operations fails, wait for the DM/DMI to
get unstuck, reset the DMI and retry. It logs an ERROR so that problem does
not go unoticed.

The "DMI is stuck" condition is easily detectable because by requesting a
DMI reset, we get back the current value of DTMCS. This value is (per spec
and per implementation) always of the form 0x0000xyzt. When stuck, we will
get 0xffffffff which is clearly invalid. When that happens, we continue
issuing DMI resets until we see something different.

At the moment, and it is unclear why, we never get "partly invalid" values,
ie we either get a correct DTMCS value or 0xffffffff which is why the
detection above works. If it turns out that this assumption is wrong,
this patch might fail to detect the problem.

**Upstreaming??**: This fix might be upstreamed at least partially. It seems to me that OpenOCD does not correctly clears the error condition and should issue a DMI reset when the command fails (which it does not at the moment). This patch does more by retrying the command and this might not be accepted upstream.