### PR TITLE
[site] Add one-line descriptions to block diagram tooltips

### DIFF
--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -510,6 +510,15 @@ a.block:visited {
     font-weight: bold;
 }
 
+.tooltip-text {
+    grid-column: span 2;
+    padding: 0.2em 0.4em;
+    margin-top: 0;
+    margin-bottom: 0;
+    max-width: 30ch;
+    text-align: start;
+}
+
 .tooltip hr {
     grid-column: span 2;
     width: 100%;

--- a/site/block-diagram/block_diagram.js
+++ b/site/block-diagram/block_diagram.js
@@ -52,6 +52,14 @@ function buildTooltip(stats) {
         buildElement("p", "tooltip-title", name),
     ];
 
+    // Append the one-line-description if the block has one
+    if (stats.one_line_desc) {
+        children = children.concat([
+            buildElement("p", "tooltip-text", stats.one_line_desc),
+            buildElement("hr"),
+        ]);
+    }
+
     // Append the design and verification stages if the block has them.
     if (stats.design_stage && stats.verification_stage) {
         // Get status classes for design and verification stages.

--- a/util/site/fetch_block_stats.py
+++ b/util/site/fetch_block_stats.py
@@ -42,11 +42,14 @@ def parse_data_file(rel_path: str) -> Tuple[str, str, str]:
     with (REPO_TOP / rel_path).open() as f:
         block_data = hjson.load(f)
 
+    desc = block_data.get('one_line_desc')
+
     try:
         return (
             block_data['version'],
             block_data['design_stage'],
             block_data['verification_stage'],
+            desc,
         )
     except KeyError:
         # Assumes the last value is the most recent
@@ -55,6 +58,7 @@ def parse_data_file(rel_path: str) -> Tuple[str, str, str]:
             revision['version'],
             revision['design_stage'],
             revision['verification_stage'],
+            desc,
         )
 
 
@@ -81,7 +85,8 @@ def main() -> None:
             block_output['version'],
             block_output['design_stage'],
             block_output['verification_stage'],
-        ) = parse_data_file(block['data_file']) if block['data_file'] else (None, None, None)
+            block_output['one_line_desc'],
+        ) = parse_data_file(block['data_file']) if block['data_file'] else (None, None, None, None)
         (
             block_output['total_runs'],
             block_output['total_passing'],


### PR DESCRIPTION
## Summary

Adds the `one_line_desc` entries from block `.hjson` files to the block diagram tooltips.

## Screenshot

![image](https://user-images.githubusercontent.com/105280833/233054132-92053bd4-08b0-4ae9-8dd8-4e99526a4165.png)
