### PR TITLE
[chip_tb] Integrate usbdpi into chip tb

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -81,6 +81,7 @@ typedef uint32_t svBitVecVal;
 #define P2D_DN 2
 #define P2D_DP 4
 #define P2D_D 8
+#define P2D_OE 0x10
 
 /* Remember these go LSB first */
 

--- a/hw/dv/sv/usb20_agent/usb20_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_if.sv
@@ -2,10 +2,53 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface usb20_if ();
+interface usb20_if (
+  input clk_i,
+  input rst_ni,
 
-  // interface pins
+  output wire usb_vbus,
+  inout wire usb_p,
+  inout wire usb_n
+);
 
-  // debug signals
+  // This interface presently serves just to connect/disconnect the USB DPI
+  // model to/from the ASIC pins. In time it may be extended to support a DV
+  // block-level USB 2.0 agent.
+
+  // Clock and reset not presently required
+  wire unused_clk = clk_i;
+  wire unused_rst_n = rst_ni;
+
+  // Nomenclature notes:
+  //   dp (or p) and dn (or n) are the two signals of the differential USB
+  //   d2p means device to DPI
+  //   p2d means DPI to device
+
+  // VBUS/SENSE output from DPI
+  wire usb_sense_p2d;
+  // DPI driver enables
+  wire usb_dp_en_p2d;
+  wire usb_dn_en_p2d;
+  // DPI driver outputs
+  wire usb_dp_p2d;
+  wire usb_dn_p2d;
+
+  // Are our drivers connected?
+  bit connected = 0;
+
+  // Enable/disable the output drivers
+  function automatic void enable_driver(bit enabled);
+    connected = enabled;
+  endfunction
+
+  assign usb_vbus = connected ? usb_sense_p2d : 1'bZ;
+
+  // Weak pull downs so that we can detect the presence of the device, and we
+  // also prevent Z triggering 'X assertions' in usbdev
+  assign (weak0, weak1) usb_p = connected ? 1'b0 : 1'bZ;
+  assign (weak0, weak1) usb_n = connected ? 1'b0 : 1'bZ;
+  // Tri-stated output drivers
+  assign (strong0, strong1) usb_p = (connected & usb_dp_en_p2d) ? usb_dp_p2d : 1'bZ;
+  assign (strong0, strong1) usb_n = (connected & usb_dn_en_p2d) ? usb_dn_p2d : 1'bZ;
 
 endinterface

--- a/hw/dv/sv/usb20_agent/usb20_usbdpi.core
+++ b/hw/dv/sv/usb20_agent/usb20_usbdpi.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:usb20_usbdpi:0.1"
+description: "USB20-USBDPI"
+
+filesets:
+  files_rtl:
+    files:
+      - usb20_if.sv: { file_type: systemVerilogSource }
+      - usb20_usbdpi.sv: { file_type: systemVerilogSource }
+
+  files_dv:
+    depend:
+      - lowrisc:dv_dpi:usbdpi
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/dv/sv/usb20_agent/usb20_usbdpi.sv
+++ b/hw/dv/sv/usb20_agent/usb20_usbdpi.sv
@@ -1,0 +1,160 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module usb20_usbdpi (
+  input   clk_i,
+  input   rst_ni,
+
+  // Enable DPI module functionality
+  input   enable,
+
+  // Outputs from the DPI module
+  output  usb_sense_p2d_o,
+  output  usb_dp_en_p2d_o,
+  output  usb_dn_en_p2d_o,
+  output  usb_dp_p2d_o,
+  output  usb_dn_p2d_o,
+
+  // Bidirectional, differential bus.
+  inout   usb_p,
+  inout   usb_n
+);
+
+  // Functioning sketch of integration of USBDPI model into dv top-level tb
+  // as a connectivity and function test for ASIC
+
+  // This module integrates the existing `usbdpi` module into the DV chip test
+  // bench, reconstructing the two unidirectional buses and driver enables that
+  // the DPI model requires for its operation, using just the bare bidirectional
+  // USB signals.
+  //
+  // Nomenclature notes:
+  //   dp (or p) and dn (or n) are the two signals of the differential USB
+  //   d2p means device to DPI
+  //   p2d means DPI to device
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Simple detection of pull up assertion indicating device presence;
+  // we simply respond to the first line to be pulled high by the device after
+  // VSENSE assertion, without regard for proper USB 2.0 timing
+  ///////////////////////////////////////////////////////////////////////////
+  logic usb_pullupdp_d2p;
+  logic usb_pullupdn_d2p;
+
+  // Has either pull up been asserted by the device?
+  wire usb_pullup_detect = usb_pullupdp_d2p | usb_pullupdn_d2p;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      usb_pullupdp_d2p <= 1'b0;
+      usb_pullupdn_d2p <= 1'b0;
+    end else if (enable & usb_sense_p2d_o && !usb_pullup_detect) begin
+      // Is the FS device pulling DP high?
+      if (usb_p === 1'b1) begin
+        usb_pullupdp_d2p <= 1'b1;
+      end
+      // Is the FS device pulling DN high, implying that it has been configured
+      // to perform pin-flipping?
+      if (usb_n === 1'b1) begin
+        usb_pullupdn_d2p <= 1'b1;
+      end
+    end
+  end
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Basic activity detection; DPI model indicates whether it is driving,
+  // but for the device we must detect a departure from the bus Idle state
+  ///////////////////////////////////////////////////////////////////////////
+  logic usb_dp_en_d2p_last;
+  logic usb_dn_en_d2p_last;
+  logic usb_dp_en_d2p;
+  logic usb_dn_en_d2p;
+
+  // Idle state of _P and _N bus signals depends upon which pull up has been
+  // asserted; the wire that is carrying the true D+ signal will be high
+  wire idle_p = usb_pullupdp_d2p;
+  wire idle_n = usb_pullupdn_d2p;
+
+  always_comb begin
+    usb_dp_en_d2p = usb_dp_en_d2p_last;
+    usb_dn_en_d2p = usb_dn_en_d2p_last;
+    // Detect transmission start of DPI (it tells us) or device (not already
+    // transmitting and there is a departure from the idle state)
+    if (usb_dp_en_p2d_o || (!usb_dp_en_d2p && usb_p != idle_p)) begin
+      usb_dp_en_d2p = !usb_dp_en_p2d_o;
+    end
+    if (usb_dn_en_p2d_o || (!usb_dn_en_d2p && usb_n != idle_n)) begin
+      usb_dn_en_d2p = !usb_dn_en_p2d_o;
+    end
+  end
+
+  // Count of SE0 cycles (1/4 bit intervals). This is just an approximate
+  // detection of EOP for the purpose of ascertaining when the device is
+  // relinquishing the bus; it will also count during bus resets.
+  logic [2:0] se0_cnt;
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      se0_cnt <= 'b0;
+    end else if (enable) begin
+      if (usb_p === 1'b0 && usb_n === 1'b0) begin
+        se0_cnt <= se0_cnt + 1'b1;
+      end else begin
+        se0_cnt <= 'b0;
+      end
+    end
+  end
+
+  // Assume that the device is driving if the DPI model is not
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      usb_dp_en_d2p_last <= 1'b0;
+      usb_dn_en_d2p_last <= 1'b0;
+    end else if (enable & usb_sense_p2d_o & usb_pullup_detect) begin
+      // Detect the end of EOP when the device has been transmitting
+      if (&{usb_dp_en_d2p_last, se0_cnt}) begin
+        usb_dp_en_d2p_last <= 1'b0;
+      end else begin
+        usb_dp_en_d2p_last <= usb_dp_en_d2p;
+      end
+      // Detect the end of EOP when the device has been transmitting
+      if ({usb_dn_en_d2p_last, se0_cnt}) begin
+        usb_dn_en_d2p_last <= 1'b0;
+      end else begin
+        usb_dn_en_d2p_last <= usb_dn_en_d2p;
+      end
+    end
+  end
+
+  // USB DPI
+  usbdpi u_usbdpi (
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .clk_48MHz_i     (clk_i),
+
+    .enable          (enable),
+
+    .sense_p2d       (usb_sense_p2d_o),
+    .pullupdp_d2p    (usb_pullupdp_d2p),
+    .pullupdn_d2p    (usb_pullupdn_d2p),
+
+    .dp_en_p2d       (usb_dp_en_p2d_o),
+    .dp_p2d          (usb_dp_p2d_o),
+    .dp_d2p          (usb_p),
+    .dp_en_d2p       (usb_dp_en_d2p),
+
+    .dn_en_p2d       (usb_dn_en_p2d_o),
+    .dn_p2d          (usb_dn_p2d_o),
+    .dn_d2p          (usb_n),
+    .dn_en_d2p       (usb_dn_en_d2p),
+
+    // ASIC communicates via true differential signaling
+    .d_p2d           (),
+    .d_d2p           (1'b0),  // not used
+    .d_en_d2p        (1'b0),
+    .se0_d2p         (1'b0),  // not used
+    .rx_enable_d2p   (1'b0),
+    .tx_use_d_se0_d2p(1'b0)
+  );
+
+endmodule

--- a/hw/ip/prim_generic/lint/prim_generic_usb_diff_rx.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_usb_diff_rx.waiver
@@ -5,9 +5,9 @@
 # waiver file for prim_generic_usb_diff_rx
 # note that this code is NOT synthesizable and meant for sim only
 
-waive -rules TRI_DRIVER -regexp {'(input_p|input_n)' is driven by a tristate driver} -location {prim_generic_usb_diff_rx.sv} \
+waive -rules TRI_DRIVER -regexp {'(input_pi|input_ni)' is driven by a tristate driver} -location {prim_generic_usb_diff_rx.sv} \
       -comment "This models the pullup behavior, hence the TRI driver."
-waive -rules MULTI_DRIVEN -regexp {'(input_p|input_n)' has 2 drivers, also driven at} -location {prim_generic_usb_diff_rx.sv} \
+waive -rules MULTI_DRIVEN -regexp {'(input_pi|input_ni)' has 2 drivers, also driven at} -location {prim_generic_usb_diff_rx.sv} \
       -comment "The simulation model has multiple drivers to emulate different IO terminations."
-waive -rules DRIVE_STRENGTH -regexp {Drive strength '\(weak0,weak1\)' encountered on assignment to '(input_p|input_n)'} -location {prim_generic_usb_diff_rx.sv} \
+waive -rules DRIVE_STRENGTH -regexp {Drive strength '\(weak0,pull1\)' encountered on assignment to '(input_pi|input_ni)'} -location {prim_generic_usb_diff_rx.sv} \
       -comment "The simulation model uses driving strength attributes to emulate different IO terminations."

--- a/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
@@ -10,8 +10,8 @@
 module prim_generic_usb_diff_rx #(
   parameter int CalibW = 32
 ) (
-  input wire         input_pi,      // differential input
-  input wire         input_ni,      // differential input
+  inout              input_pi,      // differential input
+  inout              input_ni,      // differential input
   input              input_en_i,    // input buffer enable
   input              core_pok_h_i,  // core power indication at VCC level
   input              pullup_p_en_i, // pullup enable for P
@@ -35,9 +35,9 @@ module prim_generic_usb_diff_rx #(
   assign unused_pullup_p_en = pullup_p_en_i;
   assign unused_pullup_n_en = pullup_n_en_i;
 `else
-  // pullup / pulldown termination
-  assign (weak0, weak1) input_p = pullup_p_en_i ? 1'b1 : 1'bz;
-  assign (weak0, weak1) input_n = pullup_n_en_i ? 1'b1 : 1'bz;
+  // pullup termination
+  assign (weak0, pull1) input_pi = pullup_p_en_i ? 1'b1 : 1'bz;
+  assign (weak0, pull1) input_ni = pullup_n_en_i ? 1'b1 : 1'bz;
 `endif
 
   assign input_o = (input_en_i) ? input_p & ~input_n : 1'b0;

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -299,6 +299,13 @@
 
     // USB (pre-verified IP) integration tests:
     {
+      name: chip_sw_usbdev_dpi
+      desc: '''Sketch of USBDPI integration.
+            '''
+      stage: V2
+      tests: ["chip_sw_usbdev_dpi"]
+    }
+    {
       name: chip_sw_usb_fs_tx_rx
       desc: '''Verify the transmission of single-ended data over the USB at full speed. As a part of
             this test, the enablement of USB pullup is also expected to be verified.

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -28,6 +28,8 @@ filesets:
       - lowrisc:dv:sw_test_status
       - lowrisc:dv:sw_logger_if
       - lowrisc:dv:mem_bkdr_util
+      - lowrisc:dv_dpi:usbdpi
+      - lowrisc:dv:usb20_usbdpi
     files:
       - tb/chip_hier_macros.svh: {is_include_file: true}
       - autogen/tb__xbar_connect.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -532,6 +532,15 @@
       run_timeout_mins: 180
     }
     {
+      name: chip_sw_usbdev_dpi
+      uvm_test_seq: chip_sw_usbdev_dpi_vseq
+      sw_images: ["//sw/device/tests:usbdev_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
+      run_timeout_mins: 120
+      reseed: 1
+    }
+    {
       name: chip_sw_inject_scramble_seed
       uvm_test_seq: chip_sw_inject_scramble_seed_vseq
       sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -121,6 +121,7 @@ filesets:
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_usbdev_dpi_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_device_tpm_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -77,6 +77,13 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get ast_ext_clk_vif from uvm_config_db")
     end
 
+    // get the handle to the usb20 interface.
+    if (!uvm_config_db#(usb20_vif)::get(
+            this, "", "usb20_vif", cfg.usb20_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get usb20_vif from uvm_config_db")
+    end
+
     // create components
     foreach (m_uart_agents[i]) begin
       m_uart_agents[i] = uart_agent::type_id::create($sformatf("m_uart_agent%0d", i), this);

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -78,6 +78,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   sw_test_status_vif sw_test_status_vif;
   ast_supply_vif     ast_supply_vif;
   ast_ext_clk_vif    ast_ext_clk_vif;
+  usb20_vif          usb20_vif;
 
   // Number of RAM tiles for each RAM instance.
   uint num_ram_main_tiles;

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -69,6 +69,7 @@ package chip_env_pkg;
   typedef virtual sw_test_status_if    sw_test_status_vif;
   typedef virtual ast_supply_if        ast_supply_vif;
   typedef virtual ast_ext_clk_if       ast_ext_clk_vif;
+  typedef virtual usb20_if             usb20_vif;
 
   // Types of memories in the chip.
   //
@@ -83,6 +84,7 @@ package chip_env_pkg;
     ICacheWay1Tag,
     ICacheWay0Data,
     ICacheWay1Data,
+    UsbdevBuf,
     OtbnDmem[16],
     OtbnImem,
     Otp,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_usbdev_dpi_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_usbdev_dpi_vseq)
+
+  `uvm_object_new
+
+  // Zero initialize the usbdev packet memory
+  function init_packet_mem();
+    cfg.mem_bkdr_util_h[UsbdevBuf].clear_mem();
+  endfunction
+
+  virtual task body();
+    super.body();
+
+    // We need to release the tb weak pull up on DP, otherwise usbdev appears
+    // to be connected much too soon
+    cfg.chip_vif.cfg_default_weak_pulls_on_dios(0);
+
+    // Connect the drivers of the DPI model
+    cfg.usb20_vif.enable_driver(1);
+
+    // Zero initialize the packet memory because otherwise partial word reads
+    // from a buffer will trigger 'X' assertions on the TileLink bus
+    init_packet_mem();
+  endtask
+
+endclass : chip_sw_usbdev_dpi_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -76,6 +76,7 @@
 `include "chip_sw_entropy_src_fuse_vseq.sv"
 `include "chip_sw_csrng_lc_hw_debug_en_vseq.sv"
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
+`include "chip_sw_usbdev_dpi_vseq.sv"
 `include "chip_sw_i2c_tx_rx_vseq.sv"
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_i2c_device_tx_rx_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -60,3 +60,4 @@
 `define OTP_MEM_HIER          `OTP_GENERIC_HIER.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
 `define OTBN_IMEM_HIER        `OTBN_HIER.u_imem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
 `define OTBN_DMEM_HIER        `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
+`define USBDEV_BUF_HIER       `USBDEV_HIER.gen_no_stubbed_memory.u_memory_2p.i_prim_ram_2p_async_adv.u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -142,6 +142,7 @@ module chip_sim_tb (
     .clk_i           (clk_i),
     .rst_ni          (rst_ni),
     .clk_48MHz_i     (clk_i),
+    .enable          (1'b1),
     .sense_p2d       (cio_usbdev_sense_p2d),
     .pullupdp_d2p    (cio_usbdev_dp_pullup_d2p),
     .pullupdn_d2p    (cio_usbdev_dn_pullup_d2p),

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -296,6 +296,7 @@ module chip_englishbreakfast_verilator (
     .clk_i           (clk_i),
     .rst_ni          (rst_ni),
     .clk_48MHz_i     (clk_i),
+    .enable          (1'b1),
     .sense_p2d       (cio_usbdev_sense_p2d),
     .pullupdp_d2p    (cio_usbdev_dp_pullup_d2p),
     .pullupdn_d2p    (cio_usbdev_dn_pullup_d2p),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1943,6 +1943,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "dv",
     ],
     verilator = verilator_params(
         timeout = "long",

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -98,11 +98,6 @@ static void usb_receipt_callback(uint8_t c) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK(kDeviceType == kDeviceSimVerilator || kDeviceType == kDeviceFpgaCw310,
-        "This test is not expected to run on platforms other than the "
-        "Verilator simulation or CW310 FPGA. It needs the USB DPI model "
-        "or host application.");
-
   LOG_INFO("Running USBDEV test");
 
   CHECK_DIF_OK(dif_pinmux_init(


### PR DESCRIPTION
IIntegration of USBDPI module into DV chip sim test bench as a smoke test of usbdev. Test `chip_sw_usbdev_dpi` runs to successful completion in ten minutes:

 - chip sw sets up usbdev and connects to the bus
 - usbdpi model detect device presence
 - usbdpi sets device address, reads descriptors and sets configuration
 - chip sw presents "Hi!Hi" test message for usbdpi to fetch as IN traffic
 - usbdpi sends "Hi!Hi" test message in response
 - chip sw checks the received message and concludes the test
 
The existing usbdpi model is instantiated inside usb20_usbdpi which constructs the additional signals that usbdpi requires, by monitoring just the three physical USB wires (VBUS/SENSE, USB_P/D+, USB_N/D-). Historically the DPI model has been connected directly to the usbdev and has both responded to and - alas - been steered in its own behavior by the additional signals present. The 'pull up enables' permit the usbdpi to detect device presence and to ascertain the bus configuration, and the 'output enables' from usbdev are used to determine when the device is transmitting.

usb20_usbdpi monitors the bus signals directly and detects the device presence and activity from changes in the USB_P/USB_N signals. This logic is sufficient to permit the usbdpi model to be used and to run `usbdev_test` to completion but it is not itself compliant with the USB 2.0 specification.

It should be adequate for other top-level tests such as `usbdev_stream_test` which performs much more extensive traffic, to/form multiple endpoints concurrently, but may require some refinement for suspend/resume/reset testing, for example.


**Points requiring attention**


_Pull ups at differential receiver_

See Issue #17986

This draft PR instantiates pull up resistors at the inputs of the differential receiver (making those ports 'inout') and the drive strengths are chosen to permit usb20_usbdpi to apply a weak pull down to zero on both USB_P and USB_N, such. It can then detect device presence as per the USB 2.0 specification by testing for either line being pulled high.

As far as I can see we also have pull up functionality available on the USB_P/N pads via the pinmux/padring functionality, but this is under software control and may not readily support the required sleep behavior in which control of the pull ups is passed to the usbdev_aon_wake module in pinmux.

Caveat: It is not entirely clear to me what the intent here is with regard to pull up functionality, since the current differential receiver is a placeholder.


_pinmux_testutils_

Also note that I have had to introduce a - draft - change to pinmux_testutils to increase the drive strength such that the drivers will overcome the applied pullup.

_dif_usbdev_

In order to avoid reading 'X' bytes across the TL-UL connection to usbdev (these trigger assertions in DV sim) I have introduced temporary code to zero initialize the packet buffer memory.

That sidesteps this issue when receiving packets that are not a multiple of 32 bits in length. The problem also occurs with mmio_memcpy_to_mmio32 writing to the packet buffer because it will try to perform a final 32-bit read when asked to perform a partial write of the final 32 bits of the packet data.


HTH, all feedback welcomed, please.

EDIT: @msfschaffner  I somehow missed your commit, so it hasn't (yet) been considered in the above/this draft