### PR TITLE
[sw/device] Clean up CRC32 implementation

### DIFF
--- a/sw/device/silicon_creator/lib/crc32.c
+++ b/sw/device/silicon_creator/lib/crc32.c
@@ -4,28 +4,11 @@
 
 #include "sw/device/silicon_creator/lib/crc32.h"
 
-#include <stdbool.h>
-
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 
-enum {
-  /**
-   * CRC32 polynomial.
-   */
-  kCrc32Poly = 0xedb88320,
-};
-
 void crc32_init(uint32_t *ctx) { *ctx = UINT32_MAX; }
 
-/**
- * Computes the CRC32 of a buffer as expected by Python's `zlib.crc32()`. The
- * implementation below is basically a simplified, i.e. byte-by-byte and without
- * a lookup table, version of zlib's crc32, which also matches IEEE 802.3
- * CRC-32. See
- * https://github.com/madler/zlib/blob/2fa463bacfff79181df1a5270fb67cc679a53e71/crc32.c,
- * lines 111-112 and 276-279.
- */
 void crc32_add8(uint32_t *ctx, uint8_t byte) {
 #ifdef OT_PLATFORM_RV32
   *ctx ^= byte;

--- a/sw/device/silicon_creator/lib/crc32.h
+++ b/sw/device/silicon_creator/lib/crc32.h
@@ -55,7 +55,8 @@ void crc32_add(uint32_t *ctx, const void *buf, size_t len);
 uint32_t crc32_finish(const uint32_t *ctx);
 
 /**
- * Computes the CRC32 of a buffer.
+ * Computes the CRC32 of a buffer as defined by IEEE 802.3 CRC-32. It also
+ * matches Python's `zlib.crc32()`.
  *
  * @param buf A buffer, little-endian.
  * @param len Size of the buffer.


### PR DESCRIPTION
This PR cleans up a few things I missed in PR #17989:

* Implementation comments are now out of date.
* We no longer need the `kCrc32Poly` constant.