### PR TITLE
[reggen, doc] Doc fix for reggen documentation

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -562,11 +562,10 @@ The output is two Verilog files that can be instantiated by a peripheral that fo
 
 The register generation tool will generate the RTL if it is invoked with the `-r` flag.
 The `-t <directory>` flag is used to specify the output directory where the two files will be written.
-As an example the tool can be invoked to generate the uart registers with:
+As an example the tool can be invoked from the top project directory to generate the uart registers with:
 
 ```console
-$ cd hw/ip/uart/doc
-$ ../../../../util/regtool.py -r -t ../rtl uart.hjson
+$ ./util/regtool.py -r -t hw/ip/uart/rtl hw/ip/uart/data/uart.hjson
 ```
 
 The first created file (`name_reg_pkg.sv`, from `name.hjson`) contains a SystemVerilog package definition that includes type definitions for two packed structures that have details of the registers and fields (all names are converted to lowercase).
@@ -1030,11 +1029,10 @@ It is intended that there will be several generators to output different formats
 
 The register generation tool will generate simple headers if it is invoked with the `-D` flag.
 The `-o <file.h>` flag may be used to specify the output file.
-As an example the tool can be invoked to generate the uart headers with:
+As an example the tool can be invoked from the top project directory to generate the uart headers with:
 
 ```console
-$ cd hw/ip/uart/doc
-$ ../../../../util/regtool.py -D -o ~/src/uart.h uart.hjson
+$ ./util/regtool.py -D -o hw/ip/uart.h hw/ip/uart/data/uart.hjson
 ```
 
 This format assumes that there is a base address `NAME`n`_BASE_ADDR` defined where n is an identifying number to allow for multiple instantiations of peripherals.


### PR DESCRIPTION
Hjson files for each IP is inside their `data` folder, but not `doc`. Fixes this.