### PR TITLE
[sw/device] Further optimize CRC32

### DIFF
--- a/sw/device/silicon_creator/lib/crc32.c
+++ b/sw/device/silicon_creator/lib/crc32.c
@@ -7,42 +7,49 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 
+#ifndef OT_PLATFORM_RV32
+static_assert(false, "CRC32 functions do not have a pure C implementation.");
+#endif
+
+static uint32_t crc32_internal_add8(uint32_t ctx, uint8_t byte) {
+  ctx ^= byte;
+  asm("crc32.b %0, %1;" : "+r"(ctx));
+  return ctx;
+}
+
+static uint32_t crc32_internal_add32(uint32_t ctx, uint32_t word) {
+  ctx ^= word;
+  asm("crc32.w %0, %1;" : "+r"(ctx));
+  return ctx;
+}
+
 void crc32_init(uint32_t *ctx) { *ctx = UINT32_MAX; }
 
 void crc32_add8(uint32_t *ctx, uint8_t byte) {
-#ifdef OT_PLATFORM_RV32
-  *ctx ^= byte;
-  asm("crc32.b %0, %1;" : "+r"(*ctx));
-#else
-  static_assert(false, "crc32_add8 does not have a pure C implementation.");
-#endif
+  *ctx = crc32_internal_add8(*ctx, byte);
 }
 
 void crc32_add32(uint32_t *ctx, uint32_t word) {
-#ifdef OT_PLATFORM_RV32
-  *ctx ^= word;
-  asm("crc32.w %0, %1;" : "+r"(*ctx));
-#else
-  static_assert(false, "crc32_add32 does not have a pure C implementation.");
-#endif
+  *ctx = crc32_internal_add32(*ctx, word);
 }
 
 void crc32_add(uint32_t *ctx, const void *buf, size_t len) {
   const char *data = buf;
-
+  uint32_t state = *ctx;
   // Unaligned head.
   for (; len > 0 && (uintptr_t)data & 0x3; --len, ++data) {
-    crc32_add8(ctx, *data);
+    state = crc32_internal_add8(state, *data);
   }
   // Aligned body.
   for (; len >= sizeof(uint32_t);
        len -= sizeof(uint32_t), data += sizeof(uint32_t)) {
-    crc32_add32(ctx, read_32(data));
+    state = crc32_internal_add32(state, read_32(data));
   }
   // Unaligned tail.
   for (; len > 0; --len, ++data) {
-    crc32_add8(ctx, *data);
+    state = crc32_internal_add8(state, *data);
   }
+  *ctx = state;
 }
 
 uint32_t crc32_finish(const uint32_t *ctx) { return *ctx ^ UINT32_MAX; }


### PR DESCRIPTION
(Dependent on #18066, so only review the last commit.)

    
  I noticed the disassembly of `crc32_add()` showed a number of
  unnecessary reads and writes to the `uint32_t *ctx` parameter.
  
  This commit inlines `crc32_add8()` and `crc32_add32()` into
  `crc32_add()` and uses a local variable as the context. This seems to
  enable the compiler to keep the context in a register.
  
  This brings the perf test to 28x faster than the first baseline, and
  1.3x faster than the previous optimization in PR #17989.
  
      I00001 crc32_perftest.c:33] CRC32 computed in 11353 cycles.
      I00002 crc32_perftest.c:33] CRC32 computed in 11320 cycles.
      I00003 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00004 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00005 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00006 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00007 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00008 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00009 crc32_perftest.c:33] CRC32 computed in 11314 cycles.
      I00010 crc32_perftest.c:33] CRC32 computed in 11314 cycles.

Issue #14037
