### PR TITLE
[opentitantool] New HyperDebug firmware

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,9 +111,5 @@ load("//rules:nonhermetic.bzl", "nonhermetic_repo")
 nonhermetic_repo(name = "nonhermetic")
 
 # Binary firmware image for HyperDebug
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-http_file(
-    name = "hyperdebug_firmware",
-    urls = ["https://storage.googleapis.com/aoa-recovery-test-images/hyperdebug_v2.0.20634-ee78d5668.bin"],
-    sha256 = "c72c418bc56d673d4106af9a0973c6e4268d09fb18d363e7ad336a877a127be9",
-)
+load("//third_party/hyperdebug:repos.bzl", "hyperdebug_repos")
+hyperdebug_repos()

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -185,7 +185,7 @@ rust_library(
         ":e2e_command",
         ":pinmux_config",
         ":spi_passthru",
-        "@hyperdebug_firmware//file",
+        "@hyperdebug_firmware//:hyperdebug/ec.bin",
     ],
     crate_features = [
         "include_hyperdebug_firmware",
@@ -203,7 +203,7 @@ rust_library(
         "gpio": "$(location :gpio)",
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
-        "hyperdebug_firmware": "$(location @hyperdebug_firmware//file)",
+        "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
     },
     deps = [
         "//sw/host/opentitanlib/bindgen",
@@ -256,7 +256,6 @@ rust_test(
         ":e2e_command",
         ":gpio",
         ":pinmux_config",
-        "@hyperdebug_firmware//file",
         "src/bootstrap/simple.bin",
         "src/spiflash/SFDP_MX66L1G.bin",
     ],

--- a/third_party/hyperdebug/BUILD
+++ b/third_party/hyperdebug/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "ec_bin",
+    srcs = ["@hyperdebug_firmware//:hyperdebug/ec.bin"],
+)
+
+exports_files([
+    "hyperdebug/ec.bin",
+])

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def hyperdebug_repos():
+    http_archive(
+        name = "hyperdebug_firmware",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230419_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "c0057273ae05a9970245256c376a719d01a53981ae3081e8282541e319081370",
+        build_file = "@//third_party/hyperdebug:BUILD",
+    )


### PR DESCRIPTION
Switch to using a HyperDebug firmware compiled are released through GitHub, rather than locally on developer workstation.

https://github.com/lowRISC/hyperdebug-firmware/releases/tag/20230419_01

This version also includes multi-lane SPI support, which goes together with PR #17589.