### PR TITLE
[usbdev] Larger OUT FIFOs

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -434,7 +434,7 @@
                 '''
         }
         {
-          bits: "18:16",
+          bits: "19:16",
           name: "av_depth",
           desc: '''
                 Number of buffers in the Available Buffer FIFO.
@@ -450,7 +450,7 @@
                 '''
         }
         {
-          bits: "26:24",
+          bits: "27:24",
           name: "rx_depth",
           desc: '''
                 Number of buffers in the Received Buffer FIFO.

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -102,11 +102,11 @@ module usbdev
 
   // AV fifo just stores buffer numbers
   localparam int AVFifoWidth = NBufWidth;
-  localparam int AVFifoDepth = 4;
+  localparam int AVFifoDepth = 8;
 
   // RX fifo stores              buf# +  size(0-MaxPktSizeByte)  + EP# + Type
   localparam int RXFifoWidth = NBufWidth + (1+SizeWidth)         +  4  + 1;
-  localparam int RXFifoDepth = 4;
+  localparam int RXFifoDepth = 8;
 
   usbdev_reg2hw_t reg2hw, reg2hw_regtop;
   usbdev_hw2reg_t hw2reg, hw2reg_regtop;

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -452,13 +452,13 @@ package usbdev_reg_pkg;
       logic        d;
     } sense;
     struct packed {
-      logic [2:0]  d;
+      logic [3:0]  d;
     } av_depth;
     struct packed {
       logic        d;
     } av_full;
     struct packed {
-      logic [2:0]  d;
+      logic [3:0]  d;
     } rx_depth;
     struct packed {
       logic        d;
@@ -584,9 +584,9 @@ package usbdev_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [241:208]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [207:200]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [199:176]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [243:210]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [209:202]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [201:176]
     usbdev_hw2reg_rxfifo_reg_t rxfifo; // [175:159]
     usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [158:135]
     usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [134:111]

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -326,9 +326,9 @@ module usbdev_reg_top (
   logic usbstat_host_lost_qs;
   logic [2:0] usbstat_link_state_qs;
   logic usbstat_sense_qs;
-  logic [2:0] usbstat_av_depth_qs;
+  logic [3:0] usbstat_av_depth_qs;
   logic usbstat_av_full_qs;
-  logic [2:0] usbstat_rx_depth_qs;
+  logic [3:0] usbstat_rx_depth_qs;
   logic usbstat_rx_empty_qs;
   logic avbuffer_we;
   logic [4:0] avbuffer_wd;
@@ -2759,9 +2759,9 @@ module usbdev_reg_top (
     .qs     (usbstat_sense_qs)
   );
 
-  //   F[av_depth]: 18:16
+  //   F[av_depth]: 19:16
   prim_subreg_ext #(
-    .DW    (3)
+    .DW    (4)
   ) u_usbstat_av_depth (
     .re     (usbstat_re),
     .we     (1'b0),
@@ -2789,9 +2789,9 @@ module usbdev_reg_top (
     .qs     (usbstat_av_full_qs)
   );
 
-  //   F[rx_depth]: 26:24
+  //   F[rx_depth]: 27:24
   prim_subreg_ext #(
-    .DW    (3)
+    .DW    (4)
   ) u_usbstat_rx_depth (
     .re     (usbstat_re),
     .we     (1'b0),
@@ -8489,9 +8489,9 @@ module usbdev_reg_top (
         reg_rdata_next[11] = usbstat_host_lost_qs;
         reg_rdata_next[14:12] = usbstat_link_state_qs;
         reg_rdata_next[15] = usbstat_sense_qs;
-        reg_rdata_next[18:16] = usbstat_av_depth_qs;
+        reg_rdata_next[19:16] = usbstat_av_depth_qs;
         reg_rdata_next[23] = usbstat_av_full_qs;
-        reg_rdata_next[26:24] = usbstat_rx_depth_qs;
+        reg_rdata_next[27:24] = usbstat_rx_depth_qs;
         reg_rdata_next[31] = usbstat_rx_empty_qs;
       end
 

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -755,7 +755,7 @@ dif_result_t dif_usbdev_status_get_available_fifo_depth(
 
   uint32_t reg_val =
       mmio_region_read32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET);
-  // Note: Size of available FIFO depth is 3 bits.
+  // Note: Size of available FIFO depth is 4 bits.
   *depth = bitfield_field32_read(reg_val, USBDEV_USBSTAT_AV_DEPTH_FIELD);
 
   return kDifOk;
@@ -782,7 +782,7 @@ dif_result_t dif_usbdev_status_get_rx_fifo_depth(const dif_usbdev_t *usbdev,
 
   uint32_t reg_val =
       mmio_region_read32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET);
-  // Note: Size of RX FIFO depth is 3 bits.
+  // Note: Size of RX FIFO depth is 4 bits.
   *depth = bitfield_field32_read(reg_val, USBDEV_USBSTAT_RX_DEPTH_FIELD);
 
   return kDifOk;


### PR DESCRIPTION
Doubles the size of each of Rx and Av FIFOs to increase OUT throughout in the event of high software latency, as discussed in Issue #17239 Software may preserve previous behavior or limit the number of queued buffers for other reasons since both Av and Rx FIFOS report their depths.

Running usbdev_stream_test with 11 concurrent serial streams on a modified CW310 FPGA build reports the lowest av depth as 3 (previously this would have been a FIFO empty, NAKing OUT data), and the highest rx depth as 8. The software is not doing a lot of work, and does not have to transfer data elsewhere, and this is with the slow mmio_memcpy_ routines running on a 10MHz Ibex, but the area increase is negligible and the previous smaller size of the FIFOs may be preserved by firmware should that - for some unforeseen reason - be required.


Total buffer count: 32; typically 8-16 in the Av/Rx FIFOs together. Remaining 24-16 buffers permit support 'being processed' Rx data and double-buffering of IN endpoints for performance.