### PR TITLE
[dv,rom_e2e] fix failing `rom_e2e_asm_init` test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_asm_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_asm_init_vseq.sv
@@ -13,7 +13,7 @@ class chip_sw_rom_e2e_asm_init_vseq extends chip_sw_base_vseq;
   localparam bit [2:0] EPMP_ACCESS_RWX  = 3'b111; // Read-write-execute access.
 
   localparam bit [31:0] RAM_STACK_GUARD_ADDRESS  = 32'h1001C000;
-  localparam bit [31:0] FLASH_TEXT_START_ADDRESS = 32'h20000400;
+  localparam bit [31:0] FLASH_TEXT_START_ADDRESS = 32'h20002300;
   localparam bit [31:0] MMIO_START_ADDRESS       = 32'h40000000;
   localparam bit [31:0] MMIO_END_ADDRESS         = 32'h50000000;
 

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -293,7 +293,8 @@ fn check_sram(_opts: &Opts, cs: &ChipStartup) -> Result<()> {
     log::info!("lc_state = {:#x}", lc_state);
     assert!(cs.sram.scr_key_valid);
     match lc_state {
-        DifLcCtrlState::Dev
+        DifLcCtrlState::TestUnlocked0
+        | DifLcCtrlState::Dev
         | DifLcCtrlState::Prod
         | DifLcCtrlState::ProdEnd
         | DifLcCtrlState::Rma => {


### PR DESCRIPTION
 The `rom_e2e_asm_init` test was failing in DV because the manifest size was updated in #17795, but the DV vseq was not. This should address #18059.

Additionally the `chip_specific_startup_test_unlocked0` test (the FPGA equivalent of the above) was failing because the OTP image overlays were updated to provision an SRAM scrambling seed in all LC states. This fixes the FPGA test.