### PR TITLE
Extend lc_ctrl DIFs to support added LC_CTRL_CLAIM_TRANSITION_IF_REGWEN

### DIFF
--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -433,6 +433,16 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_lc_ctrl_get_otp_vendor_test_reg(const dif_lc_ctrl_t *lc,
                                                  uint32_t *settings);
 
+/**
+ * Clears LC_CTRL_CLAIM_TRANSITION_IF_REGWEN to lock ability to claim mutex over
+ * TL-UL, effectively disabling SW-initiated lifecycle transitions.
+ *
+ * @param lc A lifecycle handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_lc_ctrl_sw_mutex_lock(const dif_lc_ctrl_t *lc);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -156,10 +156,12 @@ TEST_F(StateTest, NullArgs) {
 class MutexTest : public LcCtrlTest {};
 
 TEST_F(MutexTest, Acquire) {
+  EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REGWEN_REG_OFFSET, true);
   EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, kMultiBitBool8True);
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, kMultiBitBool8True);
   EXPECT_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc_));
 
+  EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REGWEN_REG_OFFSET, true);
   EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, kMultiBitBool8True);
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, kMultiBitBool8False);
   EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifUnavailable);
@@ -177,6 +179,13 @@ TEST_F(MutexTest, Release) {
 TEST_F(MutexTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_lc_ctrl_mutex_try_acquire(nullptr));
   EXPECT_DIF_BADARG(dif_lc_ctrl_mutex_release(nullptr));
+}
+
+TEST_F(MutexTest, LockMutexClaim) {
+  EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REGWEN_REG_OFFSET, false);
+  EXPECT_DIF_OK(dif_lc_ctrl_sw_mutex_lock(&lc_));
+  EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REGWEN_REG_OFFSET, false);
+  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifLocked);
 }
 
 class ConfigureTest : public LcCtrlTest {};


### PR DESCRIPTION
This extends lc_ctrl DIFs and unit test to lock SW mutex claim and to check if it is locked while trying to acquire mutex.