### PR TITLE
Sram load testutil

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -1132,7 +1132,8 @@ def opentitan_ram_binary(
     Emits rules:
       For each device in per_device_deps entry:
         rules emitted by `opentitan_binary` named: see `opentitan_binary` macro
-      bin_to_archive named: <name>
+      bin_to_archive            named: <name>
+      bin_to_vmem               named: <name>_<device>_vmem
     """
     deps = kwargs.pop("deps", [])
     hdrs = kwargs.pop("hdrs", [])

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -21,9 +21,6 @@ DEFAULT_TEST_FAILURE_MSG = "({})|({})".format(
 )
 
 OPENTITANTOOL_OPENOCD_TEST_CMDS = [
-    "--rom-kind=rom",
-    "--bitstream=\"$(rootpath {bitstream})\"",
-    "--bootstrap=\"$(rootpath {flash})\"",
     "--openocd=\"$(rootpath //third_party/openocd:openocd_bin)\"",
     "--openocd-adapter-config=\"$(rootpath //third_party/openocd:jtag_adapter_cfg)\"",
     "--openocd-riscv-target-config=\"$(rootpath //util/openocd/target:lowrisc-earlgrey.cfg)\"",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2381,6 +2381,42 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
     )
 ]
 
+[
+    # We are using a bitstream with disabled execution so the content of the flash
+    # does not matter but opentitan_functest() is unhappy if we don't provide one.
+    # Since execution in the ROM is disabled, bootstrap is not possible so we need
+    # to make sure that the test does not try to bootstrap
+    opentitan_functest(
+        name = "sram_program_testutil_fpga_cw310_test_otp_{}".format(lc_state),
+        srcs = ["empty_test.c"],
+        cw310 = cw310_params(
+            bitstream = ":rom_otp_{}_exec_disabled".format(lc_state),
+            logging = "debug",
+            tags = ["cw310_rom"],
+            test_cmds = [
+                "--rom-kind=rom",
+                "--bitstream=\"$(rootpath {bitstream})\"",
+                "--vmem=\"$(rootpath //sw/device/examples/sram_program:sram_program_fpga_cw310_vmem)\"",
+            ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        ),
+        data = [
+            "//sw/device/examples/sram_program:sram_program_fpga_cw310_vmem",
+        ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
+        targets = ["cw310_rom"],
+        test_harness = "//sw/host/tests/chip/jtag:sram_load",
+        deps = [
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+        ],
+    )
+    for lc_state, _ in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.DEV,
+        CONST.LCV.RMA,
+    )
+]
+
 test_suite(
     name = "rom_e2e_jtag_inject_tests",
     tags = ["manual"],

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -506,7 +506,11 @@ opentitan_functest(
         tags = [
             "jtag",
         ],
-        test_cmds = OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        test_cmds = [
+            "--rom-kind=rom",
+            "--bitstream=\"$(rootpath {bitstream})\"",
+            "--bootstrap=\"$(rootpath {flash})\"",
+        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
     key = LC_KEY_TYPES[CONST.LCV.PROD][0],

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2279,7 +2279,7 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "test_openocd",
+    name = "openocd_test",
     srcs = ["example_test_from_flash.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
@@ -2292,7 +2292,7 @@ opentitan_functest(
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
     targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/chip/jtag",
+    test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2284,7 +2284,11 @@ opentitan_functest(
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
         tags = ["jtag"],
-        test_cmds = OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        test_cmds = [
+            "--rom-kind=rom",
+            "--bitstream=\"$(rootpath {bitstream})\"",
+            "--bootstrap=\"$(rootpath {flash})\"",
+        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
     targets = ["cw310_rom"],

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -211,8 +211,8 @@ rust_library(
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
     },
     deps = [
-        "//sw/host/opentitanlib/bindgen",
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
+        "//sw/host/opentitanlib/bindgen",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
         "@crate_index//:bitflags",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -105,6 +105,7 @@ rust_library(
         "src/test_utils/init.rs",
         "src/test_utils/lc_transition.rs",
         "src/test_utils/load_bitstream.rs",
+        "src/test_utils/load_sram_program.rs",
         "src/test_utils/mod.rs",
         "src/test_utils/poll.rs",
         "src/test_utils/rpc.rs",
@@ -211,6 +212,7 @@ rust_library(
     },
     deps = [
         "//sw/host/opentitanlib/bindgen",
+        "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
         "@crate_index//:bitflags",

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -111,6 +111,10 @@ pub trait Jtag {
     /// If run is true, the target will start running code immediately
     /// after reset, otherwise it will be halted immediately.
     fn reset(&self, run: bool) -> Result<()>;
+
+    /// Read/write a RISC-V register
+    fn read_riscv_reg(&self, reg: &RiscvReg) -> Result<u32>;
+    fn write_riscv_reg(&self, reg: &RiscvReg, val: u32) -> Result<()>;
 }
 
 /// Available JTAG TAPs (software TAPS) in OpenTitan.
@@ -120,4 +124,32 @@ pub enum JtagTap {
     RiscvTap,
     /// Lifecycle Controller's TAP.
     LcTap,
+}
+
+/// List of useful RISC-V general purpose registers
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum RiscvGpr {
+    GP,
+    SP,
+}
+
+/// List of useful RISC-V control and status registers
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum RiscvCsr {
+    DPC,
+    PMPCFG0,
+    PMPCFG1,
+    PMPCFG2,
+    PMPCFG3,
+    PMPADDR0,
+    PMPADDR15,
+}
+
+/// Available registers for RISC-V TAP
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum RiscvReg {
+    /// General Purpose Register
+    GprByName(RiscvGpr),
+    /// Control and Status Register
+    CsrByName(RiscvCsr),
 }

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -94,11 +94,23 @@ pub trait Jtag {
     fn write_memory(&self, addr: u32, buf: &[u8]) -> Result<()>;
     fn write_memory32(&self, addr: u32, buf: &[u32]) -> Result<()>;
 
-    /// Send a HALT command over Jtag.
+    /// Halt execution.
     fn halt(&self) -> Result<()>;
 
-    /// Send a RESUME command over Jtag.
+    /// Resume execution at its current code position.
     fn resume(&self) -> Result<()>;
+    /// Resume execution at the specified address.
+    fn resume_at(&self, addr: u32) -> Result<()>;
+
+    /// Single-step the target at its current code position.
+    fn step(&self) -> Result<()>;
+    /// Single-step the target at the specified address.
+    fn step_at(&self, addr: u32) -> Result<()>;
+
+    /// Reset the target as hard as possible.
+    /// If run is true, the target will start running code immediately
+    /// after reset, otherwise it will be halted immediately.
+    fn reset(&self, run: bool) -> Result<()>;
 }
 
 /// Available JTAG TAPs (software TAPS) in OpenTitan.

--- a/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::str::FromStr;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::impl_serializable_error;
+use crate::io::jtag::{Jtag, RiscvCsr, RiscvGpr, RiscvReg};
+use crate::util::vmem::Vmem;
+
+use top_earlgrey::top_earlgrey_memory;
+
+/// Errors related to loading an SRAM program.
+#[derive(Error, Debug, Deserialize, Serialize)]
+pub enum LoadSramProgramError {
+    #[error("Generic error {0}")]
+    Generic(String),
+}
+impl_serializable_error!(LoadSramProgramError);
+
+/// Load a program into SRAM using JTAG.
+pub fn load_sram_program(jtag: &Rc<dyn Jtag>, vmem: &Vmem, addr: u32) -> Result<()> {
+    for section in vmem.sections() {
+        log::info!(
+            "Load {} words at address {:x}",
+            section.data.len(),
+            addr + section.addr
+        );
+        jtag.write_memory32(addr + section.addr, &section.data)?;
+    }
+    Ok(())
+}
+
+/// Set up the ePMP to enable read/write/execute from SRAM.
+/// This function will set the PMP entry 15 to NAPOT to cover the SRAM as RWX
+/// This follows the memory layout used by the ROM [0].
+///
+/// The Ibex core is initialized with a default ePMP configuration [3]
+/// when it starts. This configuration has no PMP entry for the RAM
+/// and mseccfg.mmwp is set to 1 so accesses that don't match a PMP entry will
+/// be denied.
+///
+/// Before transferring the SRAM program to the device, we must configure
+/// the PMP unit to enable reading, writing to and executing from SRAM. Due to
+/// implementation details of OpenTitan's hardware debug module, it is important
+/// that the RV_ROM remains accessible at all times [1]. It uses entry 13 of the
+/// PMP on boot so we want to preserve that. However, we can safely
+/// modify the other PMP configuration registers.
+///
+/// In more detail, the problem is that our debug module implements the
+/// "Access Register" abstract command by assembling instructions in the
+/// program buffer and then executing the buffer. If one of those
+/// instructions clobbers the PMP configuration register that allows
+/// execution from the program buffer (PMP entry 13),
+/// subsequent instruction fetches will generate exceptions.
+///
+/// Debug module concepts like abstract commands and the program buffer
+/// buffer are defined in "RISC-V External Debug Support Version 0.13.2"
+/// [2]. OpenTitan's (vendored-in) implementation lives in
+/// hw/vendor/pulp_riscv_dbg.
+///
+/// [0]: https://opentitan.org/book/sw/device/silicon_creator/rom/doc/memory_protection.html
+/// [1]: https://github.com/lowRISC/opentitan/issues/14978
+/// [2]: https://riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf
+/// [3]: https://github.com/lowRISC/opentitan/blob/master/hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh
+pub fn prepare_epmp_for_sram(jtag: &Rc<dyn Jtag>) -> Result<()> {
+    log::info!("Configure ePMP for SRAM execution");
+    let pmpcfg3 = jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::PMPCFG3))?;
+    log::info!("Old value of pmpcfg3: {:x}", pmpcfg3);
+    // write "L NAPOT X W R" to pmp3cfg in pmpcfg3
+    let pmpcfg3 = (pmpcfg3 & 0x00ffffffu32) | 0x9f000000;
+    log::info!("New value of pmpcfg3: {:x}", pmpcfg3);
+    jtag.write_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::PMPCFG3), pmpcfg3)?;
+    // write pmpaddr15 to map the SRAM range
+    // hex((0x10000000 >> 2) | ((0x20000 - 1) >> 3)) = 0x4003fff
+    let base = top_earlgrey_memory::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR as u32;
+    let size = top_earlgrey_memory::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES as u32;
+    // make sure that this is a power of two
+    assert!(size & (size - 1) == 0);
+    let pmpaddr15 = (base >> 2) | ((size - 1) >> 3);
+    log::info!("New value of pmpaddr15: {:x}", pmpaddr15);
+    jtag.write_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::PMPADDR15), pmpaddr15)?;
+    Ok(())
+}
+
+/// Fills the stack with a known value (0xdeadbeef). This can be useful if SRAM scrambling
+/// is enabled to make sure that the core can read from the stack without errors.
+pub fn setup_stack(jtag: &Rc<dyn Jtag>, top_stack_addr: u32, stack_size: u32) -> Result<()> {
+    // the stack size must be a multiple of 4
+    assert_eq!(0, stack_size % 4);
+    log::info!(
+        "Setting up stack at [{:x}:{:x}]",
+        top_stack_addr - stack_size,
+        top_stack_addr
+    );
+    // it's much more efficient to write all the data at once
+    let stack = vec![0xdeadbeefu32; (stack_size / 4) as usize];
+    jtag.write_memory32(top_stack_addr - stack_size, &stack)
+}
+
+/// This function loads and execute a SRAM program. It takes care of all the details regarding
+/// the ePMP, the stack and the global pointer. It starts the execution at the beginning of the
+/// SRAM program.
+pub fn load_and_execute_sram_program(
+    jtag: &Rc<dyn Jtag>,
+    vmem_filename: &PathBuf,
+    sram_load_addr: u32,
+    top_stack_addr: u32,
+    stack_size: u32,
+    global_pointer: u32,
+) -> Result<()> {
+    log::info!("Loading VMEM file {}", vmem_filename.display());
+    let vmem_content = fs::read_to_string(vmem_filename)?;
+    let mut vmem = Vmem::from_str(&vmem_content)?;
+    vmem.merge_sections();
+    log::info!("Uploading program to SRAM at {:x}", sram_load_addr);
+    load_sram_program(jtag, &vmem, sram_load_addr)?;
+    log::info!("Preparing ePMP for execution");
+    prepare_epmp_for_sram(jtag)?;
+    setup_stack(jtag, top_stack_addr, stack_size)?;
+    log::info!("set SP to {:x}", top_stack_addr);
+    jtag.write_riscv_reg(&RiscvReg::GprByName(RiscvGpr::SP), top_stack_addr)?;
+    log::info!("set GP to {:x}", global_pointer);
+    jtag.write_riscv_reg(&RiscvReg::GprByName(RiscvGpr::GP), global_pointer)?;
+    log::info!("resume execution at {:x}", sram_load_addr);
+    jtag.resume_at(sram_load_addr)?;
+    Ok(())
+}

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -9,6 +9,7 @@ pub mod gpio;
 pub mod init;
 pub mod lc_transition;
 pub mod load_bitstream;
+pub mod load_sram_program;
 // The "english breakfast" variant of the chip doesn't have the same
 // set of IO and pinmux constants as the "earlgrey" chip.
 #[cfg(not(feature = "english_breakfast"))]

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -398,4 +398,59 @@ impl Jtag for OpenOcdServer {
 
         Ok(())
     }
+
+    fn resume_at(&self, addr: u32) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
+            JtagError::Tap(self.jtag_tap.get().unwrap())
+        );
+        let cmd = format!("resume 0x{:x}", addr);
+        let response = self.send_tcl_cmd(&cmd)?;
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+
+        Ok(())
+    }
+
+    fn reset(&self, run: bool) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
+            JtagError::Tap(self.jtag_tap.get().unwrap())
+        );
+        let cmd = format!("reset {}", if run { "run" } else { "halt" });
+        let response = self.send_tcl_cmd(&cmd)?;
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+
+        Ok(())
+    }
+
+    fn step(&self) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
+            JtagError::Tap(self.jtag_tap.get().unwrap())
+        );
+        let response = self.send_tcl_cmd("step")?;
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+
+        Ok(())
+    }
+
+    fn step_at(&self, addr: u32) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
+            JtagError::Tap(self.jtag_tap.get().unwrap())
+        );
+        let cmd = format!("step 0x{:x}", addr);
+        let response = self.send_tcl_cmd(&cmd)?;
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+
+        Ok(())
+    }
 }

--- a/sw/host/opentitanlib/src/util/vmem/mod.rs
+++ b/sw/host/opentitanlib/src/util/vmem/mod.rs
@@ -80,8 +80,8 @@ mod test {
 
     #[test]
     fn vmem_data() {
-        let vmem = Vmem::from_str("@42 12 23 34 @84 @96 45").unwrap();
-        let expected = [(0x42, 0x12), (0x46, 0x23), (0x4a, 0x34), (0x96, 0x45)]
+        let vmem = Vmem::from_str("@10 12 23 34 @20 @26 45").unwrap();
+        let expected = [(0x40, 0x12), (0x44, 0x23), (0x48, 0x34), (0x98, 0x45)]
             .map(|(addr, value)| Data { addr, value });
 
         let data: Vec<_> = vmem.data_addrs().collect();

--- a/sw/host/opentitanlib/src/util/vmem/mod.rs
+++ b/sw/host/opentitanlib/src/util/vmem/mod.rs
@@ -60,6 +60,21 @@ impl Vmem {
     pub fn data_addrs(&self) -> impl Iterator<Item = Data> + '_ {
         self.sections().flat_map(|section| section.data_addrs())
     }
+
+    /// Merge all continguous sections together in one section
+    pub fn merge_sections(&mut self) {
+        let mut res: Vec<Section> = Vec::new();
+        // we modify in place as much as possible to avoid copying data uselessly
+        for mut sec in std::mem::take(&mut self.sections) {
+            match res.last_mut() {
+                Some(ref mut last) if { last.addr + last.data.len() as u32 * 4 == sec.addr } => {
+                    last.data.append(&mut sec.data)
+                }
+                _ => res.push(sec),
+            }
+        }
+        self.sections = res
+    }
 }
 
 impl Section {

--- a/sw/host/opentitanlib/src/util/vmem/parser.rs
+++ b/sw/host/opentitanlib/src/util/vmem/parser.rs
@@ -82,8 +82,9 @@ impl VmemParser {
                 Token::Eof => break,
                 Token::Addr(addr) => {
                     // Add a new section to the `Vmem` at this address.
+                    // Here we translate between a "word index" to a byte address.
                     vmem.sections.push(Section {
-                        addr,
+                        addr: addr * 4,
                         data: Vec::new(),
                     });
                 }
@@ -227,7 +228,7 @@ mod test {
                     data: vec![0xAB, 0xCD, 0xEF],
                 },
                 Section {
-                    addr: 0x42,
+                    addr: 0x108,
                     data: vec![0x12, 0x34],
                 },
             ],

--- a/sw/host/tests/chip/jtag/BUILD
+++ b/sw/host/tests/chip/jtag/BUILD
@@ -23,3 +23,21 @@ rust_binary(
         "@crate_index//:structopt",
     ],
 )
+
+rust_binary(
+    name = "sram_load",
+    srcs = [
+        "src/sram_load.rs",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:regex",
+        "@crate_index//:anyhow",
+        "@crate_index//:humantime",
+        "@crate_index//:lazy_static",
+        "@crate_index//:log",
+        "@crate_index//:serde_json",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/chip/jtag/BUILD
+++ b/sw/host/tests/chip/jtag/BUILD
@@ -7,9 +7,9 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 package(default_visibility = ["//visibility:public"])
 
 rust_binary(
-    name = "jtag",
+    name = "openocd_test",
     srcs = [
-        "src/main.rs",
+        "src/openocd_test.rs",
     ],
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",

--- a/sw/host/tests/chip/jtag/src/sram_load.rs
+++ b/sw/host/tests/chip/jtag/src/sram_load.rs
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use regex::Regex;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::load_sram_program;
+use opentitanlib::uart::console::UartConsole;
+
+// use top_earlgrey::top_earlgrey_memory;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+    #[structopt(flatten)]
+    jtag: JtagParams,
+    /// Path to the program to load
+    #[structopt(long)]
+    vmem: PathBuf,
+}
+
+fn test_sram_load(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    //
+    // Connect to the RISC-V TAP
+    //
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    let jtag = transport.jtag(&opts.jtag)?;
+    log::info!("Connecting to RISC-V TAP");
+    jtag.connect(JtagTap::RiscvTap)?;
+    log::info!("Halting core");
+    jtag.halt()?;
+    // TODO don't hardcore this value, it depends on the linker script, there has
+    // to be a better way
+    let sram_load_addr = 0x10001fc4u32; // TODO don't hardcore that
+    let sram_stack_top = 0x10020000u32;
+    let sram_stack_size = 128;
+    let global_pointer = sram_load_addr + 2048;
+
+    load_sram_program::load_and_execute_sram_program(
+        &jtag,
+        &opts.vmem,
+        sram_load_addr,
+        sram_stack_top,
+        sram_stack_size,
+        global_pointer,
+    )?;
+
+    const CONSOLE_TIMEOUT: Duration = Duration::from_secs(5);
+    let mut console = UartConsole {
+        timeout: Some(CONSOLE_TIMEOUT),
+        exit_success: Some(Regex::new(
+            r"sram_program\.c:\d+\] PC: 0x1000[0-2][0-9a-f]{3}, SRAM: \[0x10000000, 0x10020000\)",
+        )?),
+        ..Default::default()
+    };
+    let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
+    log::info!("result: {:?}", result);
+    // TODO at the moment the sram_main just returns from the call which is BAD since it returns to nowhere
+    // probably should setup the stack to return to someplace safe and stop the CPU
+    jtag.halt()?;
+    jtag.disconnect()?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(test_sram_load, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
Goal: be able to run
```bash
bazel test --test_output=all //sw/device/silicon_creator/rom/e2e:sram_program_testutil_fpga_cw310_test_otp_test_unlocked0
```
that load a program to SRAM using JTAG and the testutils.