### PR TITLE
[rv_core_ibex] Remove old TODO

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -283,8 +283,6 @@ module rv_core_ibex
     .lc_en_o(pwrmgr_cpu_en)
   );
 
-  // TODO: This is a hoaky fix, we really should converge everthing
-  // through rv_plic.
   // timer interrupts do not come from
   // rv_plic and may not be synchronous to the ibex core
   logic irq_timer_sync;


### PR DESCRIPTION
Putting the timer interrupt through a synchroniser within rv_core_ibex is acceptable for now.

Issue here to track re-routing this interrupt at a later point: https://github.com/lowRISC/opentitan/issues/18093