### PR TITLE
[dual port SRAMs] Fixing dp ram configuration

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -809,7 +809,7 @@
           width: 1
           inst_name: spi_device
           default: ""
-          top_signame: ast_ram_2p_cfg
+          top_signame: ast_spi_ram_2p_cfg
           index: -1
         }
         {
@@ -2555,7 +2555,7 @@
           width: 1
           inst_name: usbdev
           default: ""
-          top_signame: ast_ram_2p_cfg
+          top_signame: ast_usb_ram_2p_cfg
           index: -1
         }
         {
@@ -7876,14 +7876,30 @@
           struct: ram_2p_cfg
           package: prim_ram_2p_pkg
           type: uni
-          name: ram_2p_cfg
+          name: spi_ram_2p_cfg
           act: rcv
           inst_name: ast
           width: 1
           default: ""
           end_idx: -1
           top_type: broadcast
-          top_signame: ast_ram_2p_cfg
+          top_signame: ast_spi_ram_2p_cfg
+          index: -1
+          external: true
+          conn_type: true
+        }
+        {
+          struct: ram_2p_cfg
+          package: prim_ram_2p_pkg
+          type: uni
+          name: usb_ram_2p_cfg
+          act: rcv
+          inst_name: ast
+          width: 1
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: ast_usb_ram_2p_cfg
           index: -1
           external: true
           conn_type: true
@@ -7939,9 +7955,12 @@
         sram_ctrl_ret_aon.cfg
         rv_core_ibex.ram_cfg
       ]
-      ast.ram_2p_cfg:
+      ast.spi_ram_2p_cfg:
       [
         spi_device.ram_cfg
+      ]
+      ast.usb_ram_2p_cfg:
+      [
         usbdev.ram_cfg
       ]
       ast.rom_cfg:
@@ -8522,7 +8541,8 @@
       ast.lc_dft_en: ""
       ast.obs_ctrl: obs_ctrl
       ast.ram_1p_cfg: ram_1p_cfg
-      ast.ram_2p_cfg: ram_2p_cfg
+      ast.spi_ram_2p_cfg: spi_ram_2p_cfg
+      ast.usb_ram_2p_cfg: usb_ram_2p_cfg
       ast.rom_cfg: rom_cfg
       clkmgr_aon.jitter_en: clk_main_jitter_en
       clkmgr_aon.io_clk_byp_req: io_clk_byp_req
@@ -15185,7 +15205,7 @@
         width: 1
         inst_name: spi_device
         default: ""
-        top_signame: ast_ram_2p_cfg
+        top_signame: ast_spi_ram_2p_cfg
         index: -1
       }
       {
@@ -16369,7 +16389,7 @@
         width: 1
         inst_name: usbdev
         default: ""
-        top_signame: ast_ram_2p_cfg
+        top_signame: ast_usb_ram_2p_cfg
         index: -1
       }
       {
@@ -20029,14 +20049,30 @@
         struct: ram_2p_cfg
         package: prim_ram_2p_pkg
         type: uni
-        name: ram_2p_cfg
+        name: spi_ram_2p_cfg
         act: rcv
         inst_name: ast
         width: 1
         default: ""
         end_idx: -1
         top_type: broadcast
-        top_signame: ast_ram_2p_cfg
+        top_signame: ast_spi_ram_2p_cfg
+        index: -1
+        external: true
+        conn_type: true
+      }
+      {
+        struct: ram_2p_cfg
+        package: prim_ram_2p_pkg
+        type: uni
+        name: usb_ram_2p_cfg
+        act: rcv
+        inst_name: ast
+        width: 1
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: ast_usb_ram_2p_cfg
         index: -1
         external: true
         conn_type: true
@@ -20163,14 +20199,26 @@
       {
         package: prim_ram_2p_pkg
         struct: ram_2p_cfg
-        signame: ram_2p_cfg_i
+        signame: spi_ram_2p_cfg_i
         width: 1
         type: uni
         default: ""
         direction: in
         conn_type: true
         index: -1
-        netname: ast_ram_2p_cfg
+        netname: ast_spi_ram_2p_cfg
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
+        signame: usb_ram_2p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: true
+        index: -1
+        netname: ast_usb_ram_2p_cfg
       }
       {
         package: prim_rom_pkg
@@ -20740,7 +20788,18 @@
       {
         package: prim_ram_2p_pkg
         struct: ram_2p_cfg
-        signame: ast_ram_2p_cfg
+        signame: ast_spi_ram_2p_cfg
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
+        suffix: ""
+        default: prim_ram_2p_pkg::RAM_2P_CFG_DEFAULT
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
+        signame: ast_usb_ram_2p_cfg
         width: 1
         type: uni
         end_idx: -1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -836,7 +836,16 @@
         { struct:  "ram_2p_cfg",
           package: "prim_ram_2p_pkg",
           type:    "uni",
-          name:    "ram_2p_cfg",
+          name:    "spi_ram_2p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
+        { struct:  "ram_2p_cfg",
+          package: "prim_ram_2p_pkg",
+          type:    "uni",
+          name:    "usb_ram_2p_cfg",
           // The activity direction for a port inter-signal is "opposite" of
           // what the external module actually needs.
           act:     "rcv"
@@ -877,7 +886,8 @@
                                    'sram_ctrl_main.cfg',
                                    'sram_ctrl_ret_aon.cfg',
                                    'rv_core_ibex.ram_cfg'],
-      'ast.ram_2p_cfg'          : ['spi_device.ram_cfg', 'usbdev.ram_cfg'],
+      'ast.spi_ram_2p_cfg'      : ['spi_device.ram_cfg'],
+      'ast.usb_ram_2p_cfg'      : ['usbdev.ram_cfg'],
       'ast.rom_cfg'             : ['rom_ctrl.rom_cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'alert_handler.esc_rx'    : ['rv_core_ibex.esc_rx',
@@ -1077,7 +1087,8 @@
         'ast.lc_dft_en'                   : '',
         'ast.obs_ctrl'                    : 'obs_ctrl',
         'ast.ram_1p_cfg'                  : 'ram_1p_cfg',
-        'ast.ram_2p_cfg'                  : 'ram_2p_cfg',
+        'ast.spi_ram_2p_cfg'              : 'spi_ram_2p_cfg',
+        'ast.usb_ram_2p_cfg'              : 'usb_ram_2p_cfg',
         'ast.rom_cfg'                     : 'rom_cfg',
         'clkmgr_aon.jitter_en'            : 'clk_main_jitter_en',
         'clkmgr_aon.io_clk_byp_req'       : 'io_clk_byp_req',

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -788,7 +788,8 @@ module chip_earlgrey_asic #(
   ast_pkg::dpm_rm_t ast_ram_2p_lcfg;
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -803,23 +804,32 @@ module chip_earlgrey_asic #(
               }
   };
 
-  assign ram_2p_cfg = '{
-    a_ram_fcfg: '{
+  // this maps as follows:
+  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
+  assign usb_ram_2p_cfg = '{
+    a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_fcfg.marg_en_a,
                    cfg:    ast_ram_2p_fcfg.marg_a
                  },
+    b_ram_lcfg: '{
+                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
+                   cfg:    ast_ram_2p_fcfg.marg_b
+                 },
+    default: '0
+  };
+
+  // this maps as follows:
+  // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
+  assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
-    b_ram_fcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
     b_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
-                 }
+                 },
+    default: '0
   };
 
   assign rom_cfg = '{
@@ -1159,7 +1169,9 @@ module chip_earlgrey_asic #(
 
     // Memory attributes
     .ram_1p_cfg_i                 ( ram_1p_cfg                 ),
-    .ram_2p_cfg_i                 ( ram_2p_cfg                 ),
+    .spi_ram_2p_cfg_i             ( spi_ram_2p_cfg             ),
+    .usb_ram_2p_cfg_i             ( usb_ram_2p_cfg             ),
+
     .rom_cfg_i                    ( rom_cfg                    ),
 
     // DFT signals

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -741,7 +741,8 @@ module chip_earlgrey_cw310 #(
   ast_pkg::dpm_rm_t ast_ram_2p_lcfg;
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -756,23 +757,32 @@ module chip_earlgrey_cw310 #(
               }
   };
 
-  assign ram_2p_cfg = '{
-    a_ram_fcfg: '{
+  // this maps as follows:
+  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
+  assign usb_ram_2p_cfg = '{
+    a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_fcfg.marg_en_a,
                    cfg:    ast_ram_2p_fcfg.marg_a
                  },
+    b_ram_lcfg: '{
+                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
+                   cfg:    ast_ram_2p_fcfg.marg_b
+                 },
+    default: '0
+  };
+
+  // this maps as follows:
+  // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
+  assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
-    b_ram_fcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
     b_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
-                 }
+                 },
+    default: '0
   };
 
   assign rom_cfg = '{
@@ -1081,7 +1091,8 @@ module chip_earlgrey_cw310 #(
 
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),
-    .ram_2p_cfg_i    ( '0 ),
+    .spi_ram_2p_cfg_i( '0 ),
+    .usb_ram_2p_cfg_i( '0 ),
     .rom_cfg_i       ( '0 ),
 
     // DFT signals

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -135,7 +135,8 @@ module top_earlgrey #(
   output lc_ctrl_pkg::lc_tx_t       ast_lc_dft_en_o,
   input  ast_pkg::ast_obs_ctrl_t       obs_ctrl_i,
   input  prim_ram_1p_pkg::ram_1p_cfg_t       ram_1p_cfg_i,
-  input  prim_ram_2p_pkg::ram_2p_cfg_t       ram_2p_cfg_i,
+  input  prim_ram_2p_pkg::ram_2p_cfg_t       spi_ram_2p_cfg_i,
+  input  prim_ram_2p_pkg::ram_2p_cfg_t       usb_ram_2p_cfg_i,
   input  prim_rom_pkg::rom_cfg_t       rom_cfg_i,
   output prim_mubi_pkg::mubi4_t       clk_main_jitter_en_o,
   output prim_mubi_pkg::mubi4_t       io_clk_byp_req_o,
@@ -523,7 +524,8 @@ module top_earlgrey #(
   // define inter-module signals
   ast_pkg::ast_obs_ctrl_t       ast_obs_ctrl;
   prim_ram_1p_pkg::ram_1p_cfg_t       ast_ram_1p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t       ast_ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t       ast_spi_ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t       ast_usb_ram_2p_cfg;
   prim_rom_pkg::rom_cfg_t       ast_rom_cfg;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   prim_esc_pkg::esc_rx_t [3:0] alert_handler_esc_rx;
@@ -745,7 +747,8 @@ module top_earlgrey #(
   assign ast_lc_dft_en_o = lc_ctrl_lc_dft_en;
   assign ast_obs_ctrl = obs_ctrl_i;
   assign ast_ram_1p_cfg = ram_1p_cfg_i;
-  assign ast_ram_2p_cfg = ram_2p_cfg_i;
+  assign ast_spi_ram_2p_cfg = spi_ram_2p_cfg_i;
+  assign ast_usb_ram_2p_cfg = usb_ram_2p_cfg_i;
   assign ast_rom_cfg = rom_cfg_i;
 
   // define partial inter-module tie-off
@@ -1185,7 +1188,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[5:5] ),
 
       // Inter-module signals
-      .ram_cfg_i(ast_ram_2p_cfg),
+      .ram_cfg_i(ast_spi_ram_2p_cfg),
       .passthrough_o(spi_device_passthrough_req),
       .passthrough_i(spi_device_passthrough_rsp),
       .mbist_en_i('0),
@@ -1654,7 +1657,7 @@ module top_earlgrey #(
       .usb_aon_bus_reset_i(usbdev_usb_aon_bus_reset),
       .usb_aon_sense_lost_i(usbdev_usb_aon_sense_lost),
       .usb_aon_wake_detect_active_i(pinmux_aon_usbdev_wake_detect_active),
-      .ram_cfg_i(ast_ram_2p_cfg),
+      .ram_cfg_i(ast_usb_ram_2p_cfg),
       .tl_i(usbdev_tl_req),
       .tl_o(usbdev_tl_rsp),
 

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -580,7 +580,8 @@ module chip_earlgrey_verilator (
     // Memory attributes
     // This is different between verilator and the rest of the platforms right now
     .ram_1p_cfg_i                 ('0),
-    .ram_2p_cfg_i                 ('0),
+    .spi_ram_2p_cfg_i             ('0),
+    .usb_ram_2p_cfg_i             ('0),
     .rom_cfg_i                    ('0),
 
     // DFT signals

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -542,11 +542,21 @@
         { struct:  "ram_2p_cfg",
           package: "prim_ram_2p_pkg",
           type:    "uni",
-          name:    "ram_2p_cfg",
+          name:    "spi_ram_2p_cfg",
           // The activity direction for a port inter-signal is "opposite" of
           // what the external module actually needs.
           act:     "rcv"
         },
+
+        { struct:  "ram_2p_cfg",
+          package: "prim_ram_2p_pkg",
+          type:    "uni",
+          name:    "usb_ram_2p_cfg",
+          // The activity direction for a port inter-signal is "opposite" of
+          // what the external module actually needs.
+          act:     "rcv"
+        },
+
 
         { struct:  "rom_cfg",
           package: "prim_rom_pkg",
@@ -657,7 +667,8 @@
         'ast.edn'                      : '',
         'ast.lc_dft_en'                : '',
         'ast.ram_1p_cfg'               : 'ram_1p_cfg',
-        'ast.ram_2p_cfg'               : 'ram_2p_cfg',
+        'ast.spi_ram_2p_cfg'           : 'spi_ram_2p_cfg',
+        'ast.usb_ram_2p_cfg'           : 'usb_ram_2p_cfg',
         'ast.rom_cfg'                  : 'rom_cfg',
         'clkmgr_aon.jitter_en'         : 'clk_main_jitter_en',
         'clkmgr_aon.hi_speed_sel'      : 'hi_speed_sel',

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -213,7 +213,8 @@ module chip_englishbreakfast_verilator (
 
     // Memory attributes
     .ram_1p_cfg_i                 ('0),
-    .ram_2p_cfg_i                 ('0),
+    .spi_ram_2p_cfg_i             ('0),
+    .usb_ram_2p_cfg_i             ('0),
     .rom_cfg_i                    ('0),
 
     // DFT signals

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -569,7 +569,8 @@ module chip_${top["name"]}_${target["name"]} #(
   ast_pkg::dpm_rm_t ast_ram_2p_lcfg;
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
+  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -584,23 +585,32 @@ module chip_${top["name"]}_${target["name"]} #(
               }
   };
 
-  assign ram_2p_cfg = '{
-    a_ram_fcfg: '{
+  // this maps as follows:
+  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
+  assign usb_ram_2p_cfg = '{
+    a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_fcfg.marg_en_a,
                    cfg:    ast_ram_2p_fcfg.marg_a
                  },
+    b_ram_lcfg: '{
+                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
+                   cfg:    ast_ram_2p_fcfg.marg_b
+                 },
+    default: '0
+  };
+
+  // this maps as follows:
+  // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
+  assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
-    b_ram_fcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
     b_ram_lcfg: '{
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
-                 }
+                 },
+    default: '0
   };
 
   assign rom_cfg = '{
@@ -1000,7 +1010,9 @@ module chip_${top["name"]}_${target["name"]} #(
 
     // Memory attributes
     .ram_1p_cfg_i                 ( ram_1p_cfg                 ),
-    .ram_2p_cfg_i                 ( ram_2p_cfg                 ),
+    .spi_ram_2p_cfg_i             ( spi_ram_2p_cfg             ),
+    .usb_ram_2p_cfg_i             ( usb_ram_2p_cfg             ),
+
     .rom_cfg_i                    ( rom_cfg                    ),
 
     // DFT signals
@@ -1176,7 +1188,8 @@ module chip_${top["name"]}_${target["name"]} #(
 
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),
-    .ram_2p_cfg_i    ( '0 ),
+    .spi_ram_2p_cfg_i( '0 ),
+    .usb_ram_2p_cfg_i( '0 ),
     .rom_cfg_i       ( '0 ),
 
     // DFT signals


### PR DESCRIPTION
This adapts #18086 so that it works with topgen.
The new struct mapping is done at the chip-level instead of the top-level, since we have some more flexibilty there.

@arnonsha do these connections look good to you?