### PR TITLE
[sw/silicon_creator] Add structured kChipInfo to ROM

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -125,11 +125,11 @@ extern const uint32_t kUartNCOValue;
  * Helper macro to calculate the time it takes to transmit the entire UART TX
  * FIFO in CPU cycles.
  *
- * This macro assumes 10 bits per byte (no parity bits) and a 32 byte deep TX
+ * This macro assumes 10 bits per byte (no parity bits) and a 128 byte deep TX
  * FIFO.
  */
 #define CALCULATE_UART_TX_FIFO_CPU_CYCLES(baud_rate_, cpu_freq_) \
-  ((cpu_freq_)*10 * 32 / (baud_rate_))
+  ((cpu_freq_)*10 * 128 / (baud_rate_))
 
 /**
  * The time it takes to transmit the entire UART TX fifo in CPU cycles.

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -5,15 +5,10 @@
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_rom_binary")
 load("//rules:opentitan_test.bzl", "opentitan_functest")
 load("//rules:exclude_files.bzl", "exclude_files")
-load("//rules:autogen.bzl", "autogen_chip_info")
 load("//rules:linker.bzl", "ld_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
-
-autogen_chip_info(
-    name = "chip_info",
-)
 
 ld_library(
     name = "linker_script",
@@ -120,7 +115,6 @@ cc_library(
     ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        ":chip_info",
         ":target_test_rom_lib",
         ":test_rom_manifest",
         "//hw/ip/csrng/data:csrng_regs",
@@ -153,6 +147,7 @@ cc_library(
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib:chip_info",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
         "//sw/device/silicon_creator/lib/base:static_critical_epmp_state",

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -22,8 +22,8 @@
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
-#include "sw/device/lib/testing/test_rom/chip_info.h"  // Generated.
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/chip_info.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
@@ -152,7 +152,7 @@ bool rom_test_main(void) {
   }
 
   // Print the chip version information
-  LOG_INFO("%s", chip_info);
+  LOG_INFO("kChipInfo: scm_revision=%x", kChipInfo.scm_revision);
 
   // Skip sram_init for test_rom
   dif_rstmgr_reset_info_bitfield_t reset_reasons;

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules:autogen.bzl", "autogen_chip_info")
 load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 
@@ -272,6 +273,8 @@ filegroup(
     ],
 )
 
+autogen_chip_info(name = "chip_info")
+
 dual_cc_library(
     name = "shutdown",
     srcs = dual_inputs(
@@ -289,6 +292,7 @@ dual_cc_library(
             "@googletest//:gtest",
         ],
         shared = [
+            ":chip_info",
             ":error",
             ":epmp_defs",
             "//sw/device/lib/base:hardened",

--- a/sw/device/silicon_creator/lib/chip_info.h
+++ b/sw/device/silicon_creator/lib/chip_info.h
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CHIP_INFO_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CHIP_INFO_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+typedef struct chip_info {
+  // A truncated commit hash from the open-source OpenTitan repo that can be
+  // used to reproduce the ROM binary.
+  uint64_t scm_revision;
+} chip_info_t;
+
+// This struct contains information about the ROM's provenance, and critically,
+// it can be manually decoded from a hexdump. The linker script should place
+// this at the top of the ROM.
+extern const chip_info_t kChipInfo __attribute__((section(".chip_info")));
+
+// Track the size of `kChipInfo` so we can compute how much space is left in the
+// `.chip_info` section. If it becomes too large, linking will fail.
+OT_ASSERT_SIZE(chip_info_t, 8);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CHIP_INFO_H_

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -325,7 +325,7 @@ enum {
   /**
    * UART TX FIFO size.
    */
-  kUartFifoSize = 32,
+  kUartFifoSize = 128,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -87,6 +87,7 @@ typedef enum shutdown_error_redact {
 typedef enum shutdown_log_prefix {
   kShutdownLogPrefixBootFault = LOG_PREFIX_('B', 'F', 'V'),
   kShutdownLogPrefixLifecycle = LOG_PREFIX_('L', 'C', 'V'),
+  kShutdownLogPrefixVersion = LOG_PREFIX_('V', 'E', 'R'),
 } shutdown_log_prefix_t;
 
 /**

--- a/util/BUILD
+++ b/util/BUILD
@@ -23,6 +23,13 @@ genrule(
     stamp = 1,  # this provides volatile-status.txt
 )
 
+genrule(
+    name = "scm_revision_file",
+    outs = ["scm_revision.txt"],
+    cmd = """awk '/BUILD_SCM_REVISION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
+    stamp = 1,  # this provides volatile-status.txt
+)
+
 py_binary(
     name = "otbn_build",
     srcs = ["otbn_build.py"],


### PR DESCRIPTION

This commit adds a new `chip_info_t` struct that contains info about the ROM's provenance. The ROM now prints the Git commit hash on shutdown after the "VER:" prefix.

The ROM linker script was already configured to place the .chip_info section at the top of ROM, but I'm not confident that it worked as expected. The autogenerated header contained a static constant, so I think a copy would be inlined at some arbitrary location into any compilation unit that used it, rather than being placed by the linker script.

To verify that the ROM prints the Git commit hash on shutdown:

    ./bazelisk.sh test --test_output=streamed \
      //sw/device/silicon_creator/rom/e2e:shutdown_output_dev_fpga_cw310_rom

To verify that the .chip_info section contains data from chip_info.o:

    ./bazelisk.sh build-then 'less %s' --config riscv32 \
      //sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_map

To see the value of `kChipInfo` at the end of ROM:

    ./bazelisk.sh build-then 'xxd %s | less' --config riscv32 \
      //sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_bin

For example, here's the end of the ROM from the previous command. At 0x7f80, there are 64 bits of a Git commit hash (e20871e1cf102bf6).

    00007f70: 0000 0000 0000 0000 0000 0000 0000 0000  ................
    00007f80: f62b 10cf e171 08e2                      .+...q..

Fixes https://github.com/lowRISC/opentitan/issues/14892
Further discussion in https://github.com/lowRISC/opentitan/issues/18198