### PR TITLE
[dv/prim] Enable CDC instrumentation for some prims

### DIFF
--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -26,6 +26,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 20
 
+  // TODO(lowrisc/opentitan#16689): Enable cdc instrumentation
+  run_opts: ["+cdc_instrumentation_enabled=0"]
+
   build_modes: [
     {
       name: sync_alert

--- a/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
@@ -26,6 +26,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 20
 
+  // Enable cdc instrumentation
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -23,6 +23,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Enable cdc instrumentation
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // Add PRIM_LSFR specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/prim/dv/prim_lfsr/data/prim_lfsr_cov_excl.el"]
 

--- a/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson
@@ -23,6 +23,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Enable cdc instrumentation
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   overrides: [
     {
       name: vcs_cov_cfg_file
@@ -45,4 +48,3 @@
     }
   ]
 }
-

--- a/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson
@@ -27,6 +27,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Enable cdc instrumentation
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   overrides: [
     {
       name: vcs_cov_cfg_file
@@ -56,4 +59,3 @@
     }
   ]
 }
-

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -301,15 +301,13 @@ module prim_alert_receiver
         !(state_q inside {InitReq, InitAckWait}) &&
         mubi4_test_false_loose(init_trig_i)
         |->
-        integ_fail_o)
-    // TODO: need to add skewed cases as well, the assertions below assume no skew at the moment
-    // ping response
+        ##[0:1] integ_fail_o)
     `ASSERT(PingResponse1_A,
         ##1 $rose(alert_tx_i.alert_p) &&
         (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
         state_q == Idle && ping_pending_q
         |->
-        ping_ok_o,
+        ##[0:1] ping_ok_o,
         clk_i, !rst_ni || integ_fail_o || mubi4_test_true_strict(init_trig_i))
     // alert
     `ASSERT(Alert_A,

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -309,9 +309,9 @@ module prim_alert_sender
     // check propagation of sigint issues to output within three cycles
     // shift sequence to the right to avoid reset effects.
     `ASSERT(SigIntPing_A, ##1 PingSigInt_S |->
-        ##3 alert_tx_o.alert_p == alert_tx_o.alert_n)
+        ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
     `ASSERT(SigIntAck_A, ##1 AckSigInt_S |->
-        ##3 alert_tx_o.alert_p == alert_tx_o.alert_n)
+        ##[3:4] alert_tx_o.alert_p == alert_tx_o.alert_n)
   `endif
 
     // Test in-band FSM reset request (via signal integrity error)
@@ -325,10 +325,10 @@ module prim_alert_sender
     // handshakes can take indefinite time if blocked due to sigint on outgoing
     // lines (which is not visible here). thus, we only check whether the
     // handshake is correctly initiated and defer the full handshake checking to the testbench.
-    // TODO: add the staggered cases as well
     `ASSERT(PingHs_A, ##1 $changed(alert_rx_i.ping_p) &&
         (alert_rx_i.ping_p ^ alert_rx_i.ping_n) ##2 state_q == Idle |=>
-        $rose(alert_tx_o.alert_p), clk_i, !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
+        ##[0:1] $rose(alert_tx_o.alert_p), clk_i,
+        !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
   end else begin : gen_sync_assert
     sequence PingSigInt_S;
       alert_rx_i.ping_p == alert_rx_i.ping_n;


### PR DESCRIPTION
Enable CDC instrumentation for prim_esc, prim_lfsr, prim_present, and prim_prince.
Fix some assertions for prim_alert sender and receiver, but some failures remain.

Partially addresses #16689