### PR TITLE
[top_earlgrey/dv] Fix name of `xbar_smoke` test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1836,7 +1836,7 @@
     }
     {
       name: smoke
-      tests: ["xbar_chip_smoke",
+      tests: ["xbar_smoke",
               "chip_sw_uart_tx_rx",
               "chip_sw_spi_host_tx_rx",
               "chip_sw_spi_device_pass_through",


### PR DESCRIPTION
This resolves the dvsim message `ERROR: [Modes] Test "chip_xbar_smoke" added to regression "smoke" not found!`. A full run (`util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i smoke -t xcelium`) passes.

Thanks @matutem for flagging this.

