### PR TITLE
[entropy_src, rtl] Change sync FIFO prims to not output 0 when empty

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -245,14 +245,17 @@ module entropy_src
 
   // Entropy Interface
   `ASSERT_KNOWN(EsHwIfEsAckKnownO_A, entropy_src_hw_if_o.es_ack)
-  `ASSERT_KNOWN(EsHwIfEsBitsKnownO_A, entropy_src_hw_if_o.es_bits)
-  `ASSERT_KNOWN(EsHwIfEsFipsKnownO_A, entropy_src_hw_if_o.es_fips)
+  `ASSERT_KNOWN_IF(EsHwIfEsBitsKnownO_A, entropy_src_hw_if_o.es_bits,
+      entropy_src_hw_if_o.es_ack)
+  `ASSERT_KNOWN_IF(EsHwIfEsFipsKnownO_A, entropy_src_hw_if_o.es_fips,
+      entropy_src_hw_if_o.es_ack)
 
   // RNG Interface
   `ASSERT_KNOWN(EsRngEnableKnownO_A, entropy_src_rng_o.rng_enable)
 
   // External Health Test Interface
-  `ASSERT_KNOWN(EsXhtEntropyBitKnownO_A, entropy_src_xht_o.entropy_bit)
+  `ASSERT_KNOWN_IF(EsXhtEntropyBitKnownO_A, entropy_src_xht_o.entropy_bit,
+      entropy_src_xht_o.entropy_bit_valid)
   `ASSERT_KNOWN(EsXhtEntropyBitValidKnownO_A, entropy_src_xht_o.entropy_bit_valid)
   `ASSERT_KNOWN(EsXhtClearKnownO_A, entropy_src_xht_o.clear)
   `ASSERT_KNOWN(EsXhtActiveKnownO_A, entropy_src_xht_o.active)

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -971,7 +971,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   prim_fifo_sync #(
     .Width(RngBusWidth),
     .Pass(0),
-    .Depth(2)
+    .Depth(2),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_esrng (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -2678,7 +2679,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   prim_fifo_sync #(
     .Width(1+SeedLen),
     .Pass(0),
-    .Depth(EsFifoDepth)
+    .Depth(EsFifoDepth),
+    .OutputZeroIfEmpty(1'b0)
   ) u_prim_fifo_sync_esfinal (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),


### PR DESCRIPTION
Leaving the data just read from these FIFOs doesn't hurt but instead outputting a deterministic value such as 0 after read may open FI attack windows. This is especially true as we have countermeasures in various places in the entropy complex (e.g. at the input of CSRNG) to check that the entropy source doesn't deliver the same word twice in a row. However, these countermeasures don't detect if an adversary managed to latch a single all zero seed into CSRNG which may result in fully deterministic CSRNG output.

This is inline with lowRISC/OpenTitan#9261 and lowRISC/OpenTitan#5341 which implemented the same changes for packer FIFOs inside entropy source, CSRNG and EDN and sync FIFOs carrying entropy inside CSRNG already.