### PR TITLE
[hw,rv_dm,dv] Improve TAP FSM coverage

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_pkg.sv
@@ -17,6 +17,8 @@ package jtag_agent_pkg;
   // parameters
   parameter uint JTAG_IRW = 32; // max IR width
   parameter uint JTAG_DRW = 64; // max DR width
+  // Number of consecutive cycles of tsm==1 to reset the JTAG state machine
+  parameter uint JTAG_TEST_LOGIC_RESET_CYCLES = 5;
 
   typedef enum bit [3:0] {
     JtagResetState,

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -16,6 +16,14 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   // If the same IR was already selected earlier, then don't resend IR based on seq item knob.
   logic [JTAG_IRW-1:0]  selected_ir;
   uint                  selected_ir_len;
+  // Variable to save the previous value of exit_to_rti_ir
+  bit                   exit_to_rti_ir_past = 1;
+  // Variable to save the previous value of exit_to_rti_dr
+  // Before fetching a new request, `drive_jtag_req` task waits for a clock cycle.
+  // Since, in the `drive_ir` task, there is a possibility to introduce TAP reset by consecutively
+  // driving `tsm` high for five cycles if previous state is UpdateDr (previous `drive_dr` exit
+  // without going to Run-Test-Idle), this extra cycle must be skipped
+  bit                   exit_to_rti_dr_past = 1;
 
   // do reset signals (function)
   virtual function void do_reset_signals();
@@ -25,6 +33,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
       cfg.vif.tdi <= 1'b0;
       selected_ir = '{default:0};
       selected_ir_len = 0;
+      exit_to_rti_ir_past = 1;
+      exit_to_rti_dr_past = 1;
     end
     else begin
       cfg.vif.tdo <= 1'b0;
@@ -57,6 +67,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
       if (!cfg.vif.trst_n) begin
         `DV_WAIT(cfg.vif.trst_n)
         cfg.vif.wait_tck(1);
+        drive_jtag_test_logic_reset();
       end
       seq_item_port.get_next_item(req);
       $cast(rsp, req.clone());
@@ -68,30 +79,71 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     end
   endtask
 
+  // Task to drive TMS such that TAP FSM resets to Test-Logic-Reset state
+  task drive_jtag_test_logic_reset();
+    `uvm_info(`gfn, "Driving JTAG to Test-Logic-Reset state", UVM_MEDIUM)
+    // Enable clock
+    cfg.vif.tck_en <= 1'b1;
+    `HOST_CB.tms <= 1'b0;
+    @(`HOST_CB);
+    // Go to Test Logic Reset
+    repeat (JTAG_TEST_LOGIC_RESET_CYCLES) begin
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end
+    // Go to Run-Test/Idle
+    `HOST_CB.tms <= 1'b0;
+    `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
+  endtask
+
   // drive jtag req and retrieve rsp
   virtual task drive_jtag_req(jtag_item req, jtag_item rsp);
     cfg.vif.tck_en <= 1'b1;
-    @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
+    if (req.reset_tap_fsm) begin
+      drive_jtag_test_logic_reset();
+    end
+    if (exit_to_rti_dr_past) begin
+      @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
+    end else begin
+      `uvm_info(`gfn, "Skip wait cycles because of past exit to RTI in drive_dr", UVM_MEDIUM)
+    end
     if (req.ir_len) begin
       if (req.skip_reselected_ir && req.ir == selected_ir && req.ir_len == selected_ir_len) begin
-        `uvm_info(`gfn, $sformatf("UpdateIR for 0x%0h skipped", selected_ir), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("UpdateIR for 0x%0h skipped", selected_ir), UVM_MEDIUM)
       end else begin
-        drive_jtag_ir(req.ir_len, req.ir, req.ir_pause_count, req.ir_pause_cycle);
+        if (req.dummy_ir) begin
+          drive_dummy_ir();
+        end
+        drive_jtag_ir(req.ir_len,
+                      req.ir,
+                      req.ir_pause_count,
+                      req.ir_pause_cycle,
+                      req.exit_to_rti_ir);
       end
     end
-    if (req.dr_len) drive_jtag_dr(req.dr_len,
-                                  req.dr,
-                                  rsp.dout,
-                                  req.dr_pause_count,
-                                  req.dr_pause_cycle);
+    if (req.dr_len) begin
+      if (req.dummy_dr) begin
+        drive_dummy_dr();
+      end
+      drive_jtag_dr(req.dr_len,
+                    req.dr,
+                    rsp.dout,
+                    req.dr_pause_count,
+                    req.dr_pause_cycle,
+                    req.exit_to_rti_dr);
+    end
     cfg.vif.tck_en <= 1'b0;
   endtask
 
   task drive_jtag_ir(int len,
                      bit [JTAG_DRW-1:0] ir,
                      uint pause_count = 0,
-                     uint pause_cycle = 0);
+                     uint pause_cycle = 0,
+                     bit exit_to_rti = 1'b1);
     logic [JTAG_DRW-1:0] dout;
+    exit_to_rti_ir_past = exit_to_rti;
     `uvm_info(`gfn, $sformatf("ir: 0x%0h, len: %0d", ir, len), UVM_MEDIUM)
     // Assume starting in RTI state
     // SelectDR
@@ -125,14 +177,37 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
       end
     end
     @(`HOST_CB);
-    // UpdateIR
-    `HOST_CB.tms <= 1'b1;
-    `HOST_CB.tdi <= 1'b0;
-    @(`HOST_CB);
-    // RTI
-    `HOST_CB.tms <= 1'b0;
-    `HOST_CB.tdi <= 1'b0;
-    @(`HOST_CB);
+    // go to RTI either via
+    // - PauseIR -> exit2IR -> UpdateIR -> RTI or
+    // - Exit1IR -> UpdateIR -> RTI
+    if (req.exit_via_pause_ir) begin
+      `uvm_info(`gfn, "Exiting via PauseIR", UVM_MEDIUM)
+      // Go to PauseIR
+      `HOST_CB.tms <= 1'b0;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+      // Go to Exit2IR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+      // Go to UpdateIR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end else begin
+      // UpdateIR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end
+    if (exit_to_rti) begin
+      // Go to RTI
+      `HOST_CB.tms <= 1'b0;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end else begin
+      `uvm_info(`gfn, "drive_ir: skip going to RTI", UVM_MEDIUM)
+    end
     selected_ir = ir;
     selected_ir_len = len;
   endtask
@@ -140,9 +215,11 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   task drive_jtag_dr(input  int                  len,
                      input  logic [JTAG_DRW-1:0] dr,
                      output logic [JTAG_DRW-1:0] dout,
-                     input uint                  pause_count,
-                     input uint                  pause_cycle);
+                     input  uint                 pause_count,
+                     input  uint                 pause_cycle,
+                     input  bit                  exit_to_rti = 1'b1);
     bit pause_injected = 0;
+    exit_to_rti_dr_past = exit_to_rti;
     `uvm_info(`gfn, $sformatf("dr: 0x%0h, len: %0d", dr, len), UVM_MEDIUM)
     // assume starting in RTI
     // go to SelectDR
@@ -182,16 +259,89 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     `HOST_CB.tdi <= dr[len - 1];
     dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
     @(`HOST_CB);
-    // go to UpdateIR
+    // go to RTI either via
+    // - PauseDR -> exit2DR -> UpdateDR -> RTI or
+    // - Exit1DR -> UpdateDR -> RTI
+    if (req.exit_via_pause_dr) begin
+      `uvm_info(`gfn, "Exiting via PauseDR", UVM_MEDIUM)
+      // Go to PauseDR
+      `HOST_CB.tms <= 1'b0;
+      `HOST_CB.tdi <= 1'b0;
+      dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
+      @(`HOST_CB);
+      // Go to Exit2DR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+      // Go to UpdateDR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end else begin
+      // go to UpdateDR
+      `HOST_CB.tms <= 1'b1;
+      `HOST_CB.tdi <= 1'b0;
+      dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
+      @(`HOST_CB);
+    end
+    if (exit_to_rti) begin
+      // go to RTI
+      `HOST_CB.tms <= 1'b0;
+      `HOST_CB.tdi <= 1'b0;
+      @(`HOST_CB);
+    end else begin
+      `uvm_info(`gfn, "drive_dr: skip going to RTI", UVM_MEDIUM)
+    end
+    dout >>= (JTAG_DRW - len);
+  endtask
+
+  // Task to drive tms such that TAP FSM transitions through
+  // CaptureIR/ CaptureDR -> Exit1IR/ Exit1DR -> UpdateIR/ UpdateDR -> RTI
+  task drive_dummy_ir_dr();
+      // go to CaptureDR/ CaptureIR
+    `HOST_CB.tms <= 1'b0;
+    `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
+    // go to Exit1DR/ Exit1IR
     `HOST_CB.tms <= 1'b1;
     `HOST_CB.tdi <= 1'b0;
-    dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
+    @(`HOST_CB);
+    // go to UpdateDR/ UpdateIR
+    `HOST_CB.tms <= 1'b1;
+    `HOST_CB.tdi <= 1'b0;
     @(`HOST_CB);
     // go to RTI
     `HOST_CB.tms <= 1'b0;
     `HOST_CB.tdi <= 1'b0;
     @(`HOST_CB);
-    dout >>= (JTAG_DRW - len);
+  endtask
+
+  // Task to drive tms such that TAP FSM transitions through
+  // IR sequence without going through ShiftIR state
+  task drive_dummy_ir();
+    `uvm_info(`gfn, "Introducing dummy IR", UVM_MEDIUM)
+    // assume starting in RTI
+    // go to SelectDR
+    `HOST_CB.tms <= 1'b1;
+    `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
+    // go to SelectIR
+    `HOST_CB.tms <= 1'b1;
+    `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
+    drive_dummy_ir_dr();
+  endtask
+
+  // Task to drive tms such that TAP FSM transitions through
+  // DR sequence without going through ShiftDR state
+  task drive_dummy_dr();
+    `uvm_info(`gfn, "Introducing dummy DR", UVM_MEDIUM)
+    // assume starting in RTI
+    // go to SelectDR
+    `HOST_CB.tms <= 1'b1;
+    `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
+    drive_dummy_ir_dr();
   endtask
 
   // Task to drive TMS such that JTAG state machine moves to

--- a/hw/dv/sv/jtag_agent/jtag_item.sv
+++ b/hw/dv/sv/jtag_agent/jtag_item.sv
@@ -39,6 +39,20 @@ class jtag_item extends uvm_sequence_item;
   // This field is used to indicate the CaptureIr cycle on which the
   // pause state is introduced
   rand uint ir_pause_cycle;
+  // This field is used to enable dummy IR transaction
+  rand bit dummy_ir;
+  // This field is used to enable dummy DR transaction
+  rand bit dummy_dr;
+  // This field is used to indicate if IR transaction exit happens via PauseIR state
+  rand bit exit_via_pause_ir;
+  // This field is used to indicate if DR transaction exit happens via PauseDR state
+  rand bit exit_via_pause_dr;
+  // This field is used to indicate if at the end of IR transaction FSM moves to RunTestIdle state
+  rand bit exit_to_rti_ir;
+  // This field is used to indicate if at the end of DR transaction FSM moves to RunTestIdle state
+  rand bit exit_to_rti_dr;
+  // This field is used to reset TAP FSM to TestLogicReset state
+  rand bit reset_tap_fsm;
 
   constraint ir_len_c {
     ir_len <= JTAG_IRW;
@@ -46,6 +60,18 @@ class jtag_item extends uvm_sequence_item;
 
   constraint dr_len_c {
     dr_len <= JTAG_DRW;
+  }
+
+  constraint exit_to_rti_ir_c {
+    soft exit_to_rti_ir == 1;
+  }
+
+  constraint exit_to_rti_dr_c {
+    soft exit_to_rti_dr == 1;
+  }
+
+  constraint reset_tap_fsm_c {
+    soft reset_tap_fsm == 0;
   }
 
   // At least one of them should be non-zero.
@@ -83,6 +109,22 @@ class jtag_item extends uvm_sequence_item;
     }
     solve ir_len before ir_pause_cycle;
     solve ir_pause_count before ir_pause_cycle;
+  }
+
+  constraint dummy_ir_c {
+    dummy_ir dist { 0 := 99, 1 := 1};
+  }
+
+  constraint dummy_dr_c {
+    soft dummy_dr == 0;
+  }
+
+  constraint exit_via_pause_ir_c {
+    exit_via_pause_ir dist { 0 := 90, 1 := 10};
+  }
+
+  constraint exit_via_pause_dr_c {
+    exit_via_pause_dr dist { 0 := 90, 1 := 10};
   }
 
   `uvm_object_utils_begin(jtag_item)

--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -118,7 +118,7 @@ class jtag_monitor extends dv_base_monitor #(
           jtag_state = `MON_CB.tms ? JtagUpdateIrState : JtagShiftIrState;
         end
         JtagUpdateIrState: begin
-          jtag_state = `MON_CB.tms ? JtagSelectIrState : JtagIdleState;
+          jtag_state = `MON_CB.tms ? JtagSelectDrState : JtagIdleState;
 
           // Send IR packet to analysis port
           if (cfg.vif.trst_n) begin

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -342,7 +342,7 @@
             This test should verify that the standardized JTAG TAP FSM is working correctly.
             '''
       stage: V2
-      tests: [] // TODO(#17032)
+      tests: ["rv_dm_tap_fsm", "rv_dm_tap_fsm_rand_reset"]
     }
     {
       name: stress_all

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dtm_csr_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_csr_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_sba_tl_access_vseq_lib.sv: {is_include_file: true}
+      - seq_lib/rv_dm_tap_fsm_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequence to test the FSM state transitions uncovered in other sequences.
+// The following transitions are covered
+// CaptureIr to ExitIr -> This is a transition that wont update the IR register
+// UpdateIr to SelectDrScan -> This is a transition that goes to the SelectDrScan state
+//                              immediately after UpdateIr instead of going to Run-Test-Idle
+// UpdateDr to SelectDrScan -> This is a transition that goes to the SelectDrScan state
+//                             immediately after UpdateDr instead of going to Run-Test-Idle
+//                             this transition covers a scenario where there are two consecutive
+//                             updates to same register and IR remains the same
+// CaptureDr to ExitDr -> This is a transition that wont update the DR register
+// After each transition test smoke sequence is run to check if JTAG is still functional
+class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_tap_fsm_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Read the JTAG IDCODE register and verify that it matches the expected value.
+    jtag_item req;
+    rv_dm_smoke_vseq seq;
+    uvm_reg_data_t data;
+    uint dr_width = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_n_bits();
+    uint ir = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_address();
+    run_smoke();
+    `uvm_info(`gfn, "Starting fsm_tap sequence", UVM_LOW)
+    `uvm_create_on(req, p_sequencer.jtag_sequencer_h)
+    `uvm_info(`gfn, "Test TAP FSM transition from CaptureIr->Exit1Ir", UVM_LOW)
+    start_item(req);
+    req.randomize() with { ir == 'h0;
+        ir_len == 'd5;
+        dr == 'h0;
+        dr_len == dr_width;
+        skip_reselected_ir == 0;
+        ir_pause_count == 0;
+        dr_pause_count == 0;
+        dummy_ir == 1;
+        exit_via_pause_dr == 0;
+        exit_via_pause_ir == 0;
+        exit_to_rti_dr == 0;
+        exit_to_rti_ir == 0;};
+    finish_item(req);
+    // Test transition from UpdateIr->SelectDrScan
+    `uvm_info(`gfn, "Test TAP FSM transition from UpdateIr->SelectDrScan", UVM_LOW)
+    start_item(req);
+    req.randomize() with { ir == 'h0;
+        ir_len == 'd5;
+        dr == 'h0;
+        dr_len == dr_width;
+        skip_reselected_ir == 0;
+        ir_pause_count == 0;
+        dr_pause_count == 0;
+        exit_via_pause_dr == 0;
+        exit_via_pause_ir == 0;
+        exit_to_rti_dr == 0;
+        exit_to_rti_ir == 0;};
+    finish_item(req);
+    // Test transition from UpdateDr->SelectDrScan
+    `uvm_info(`gfn, "Test TAP FSM transition from UpdateDr->SelectDrScan", UVM_LOW)
+    start_item(req);
+    req.randomize() with { ir == 'h0;
+        ir_len == 'd5;
+        dr == 'h0;
+        dr_len == dr_width;
+        ir_pause_count == 0;
+        dr_pause_count == 0;
+        exit_via_pause_dr == 0;
+        exit_via_pause_ir == 0 ;
+        skip_reselected_ir == 1;
+        exit_to_rti_dr == 0;};
+    finish_item(req);
+    run_smoke();
+    // Test transition from CaptureDr->Exit1Dr
+    `uvm_info(`gfn, "Test TAP FSM transition from CaptureDr->Exit1Dr", UVM_LOW)
+    start_item(req);
+    req.randomize() with { ir == 'h0;
+        ir_len == 'd5;
+        dr == 'h0;
+        dr_len == dr_width;
+        dummy_dr == 1;
+        ir_pause_count == 0;
+        dr_pause_count == 0;
+        exit_via_pause_dr == 0;
+        exit_via_pause_ir == 0 ;
+        skip_reselected_ir == 1;
+        exit_to_rti_dr == 0;};
+    finish_item(req);
+    run_smoke();
+    // Test TAP FSM reset
+    `uvm_info(`gfn, "Test TAP FSM reset", UVM_LOW)
+    start_item(req);
+    req.randomize() with { ir == 'h0;
+        ir_len == 'd5;
+        dr == 'h0;
+        dr_len == dr_width;
+        reset_tap_fsm == 1;};
+    finish_item(req);
+    run_smoke();
+  endtask : body
+
+  task run_smoke();
+    rv_dm_smoke_vseq seq;
+    `uvm_info(`gfn, "Starting rv_dm_tap_fsm_vseq smoke test", UVM_LOW)
+    `uvm_do(seq)
+  endtask
+
+endclass : rv_dm_tap_fsm_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "rv_dm_jtag_dtm_csr_vseq.sv"
 `include "rv_dm_jtag_dmi_csr_vseq.sv"
 `include "rv_dm_sba_tl_access_vseq_lib.sv"
+`include "rv_dm_tap_fsm_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -79,6 +79,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_tap_fsm
+      uvm_test_seq: rv_dm_tap_fsm_vseq
+      reseed: 1
+    }
+    {
       name: rv_dm_jtag_dtm_csr_hw_reset
       uvm_test_seq: rv_dm_jtag_dtm_csr_vseq
       build_mode: "cover_reg_top"
@@ -154,6 +159,15 @@
       name: rv_dm_autoincr_sba_tl_access
       uvm_test_seq: rv_dm_autoincr_sba_tl_access_vseq
       reseed: 20
+    }
+    {
+      name: "rv_dm_tap_fsm_rand_reset"
+      uvm_test_seq: "rv_dm_common_vseq"
+      build_mode: "cover_reg_top"
+      run_opts: ["+run_stress_all_with_rand_reset",
+                 "+stress_seq=rv_dm_tap_fsm_vseq",
+                 "+en_scb=0"]
+      reseed: 40
     }
   ]
 


### PR DESCRIPTION
- Update jtag_driver to
  - Introduce dummy IR/DR transactions to make sure FSM transitions through IR sequence without going through `ShiftIR`/`ShiftDr` state.
  - `Exit Ir`/`DR` transactions via `PauseIr`/`PauseDr` states based on `exit_via_pause_ir`/`exit_via_pause_dr` in `jtag_item`
  - Retain `UpdateIr`/`UpdateDr` state at the end of `drive_ir`/`drive_dr` based on a variable in `jtag_item`
    - Update driver to skip extra cycle between `drive_dr` and subsequent `drive_ir` based on past values of `exit_to_rti_dr` variable.
  - Drive tms for five consecutive cycles to reset JTAG FSM at the start of simulation after reset and based on `reset_tap_fsm` variable in `jtag_item`

- Add a stress test based on the newly added `rv_dm_tap_fsm_vseq` in sim_cfg and link the newly added tests to the testplan item `tap_fsm_transitions`

This PR resolves https://github.com/lowRISC/opentitan/issues/17032