### PR TITLE
[otbn] Change secure wipe to not reseed URND on RMA req

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -216,7 +216,7 @@ class OTBNSim:
         '''Step the simulation when executing code'''
 
         # The initial secure wipe *must* be done when executing code.
-        assert(self.state.init_sec_wipe_is_done())
+        assert self.state.init_sec_wipe_is_done()
 
         self.state.wsrs.URND.step()
 

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -178,7 +178,14 @@ module otbn_start_stop_control
       OtbnStartStopStateInitial: begin
         secure_wipe_running_o = 1'b1;
         urnd_reseed_req_o     = 1'b1;
-        if (urnd_reseed_ack_i) begin
+        if (rma_request) begin
+          // If we get an RMA request before the URND got reseeded, proceed with the initial secure
+          // wipe, as the entropy complex may not be able to provide entropy at this point.
+          state_d = OtbnStartStopSecureWipeWdrUrnd;
+          // As we don't reseed URND, there's no point in doing two rounds of wiping, so we pretend
+          // that the first round is already the second round.
+          wipe_after_urnd_refresh_d = MuBi4True;
+        end else if (urnd_reseed_ack_i) begin
           urnd_advance_o = 1'b1;
           state_d        = OtbnStartStopSecureWipeWdrUrnd;
         end


### PR DESCRIPTION
Prior to this PR, OTBN would always reseed its URND PRNG before the first and before the second round of a secure wipe. When OTBN gets an RMA request, however, the entropy complex may not be able to provide a seed for the PRNG. In this case, OTBN would never acknowledge the RMA request (see #17944 for a scenario in which this happens).

This PR changes OTBN to not reseed its URND PRNG when entering a secure wipe due to an RMA request, neither from the halted state (first commit) nor from the initial secure wipe (second commit), which happens immediately after reset. When the secure wipe happens from an RMA request, this PR changes it to have only a single round, since the second round would start with another PRNG reseed. This PR therefore resolves #18111.

This PR also makes some of the necessary DV changes, and I have been able to check the waves for an RMA request before, during, and after the initial secure wipe ('after' meaning from the halted state). It may be that further DV changes are necessary to make the model fully compatible with this change, though. However, the test for this (`otbn_escalate`) already before this PR had a pass rate of only 70% (see #18124). In particular, scenarios asserting RMA request frequently fail. It's thus currently not possible to rely on this test to ascertain the correct behavior neither before nor after this commit. The pass rate of `otbn_escalate` remains around 70%.