### PR TITLE
[crypto] add RSA 3072 pub-key encryption

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
@@ -231,3 +231,19 @@ status_t rsa_3072_verify(const rsa_3072_int_t *signature,
   // Wait for OTBN operations to complete and signature to be verified.
   return rsa_3072_verify_finalize(message, result);
 }
+
+status_t rsa_3072_encrypt_public(const rsa_3072_int_t *plaintext,
+                                 const rsa_3072_public_key_t *public_key,
+                                 const rsa_3072_constants_t *constants,
+                                 rsa_3072_int_t *ciphertext) {
+  // Initiate OTBN modular exponentiation.
+  HARDENED_TRY(rsa_3072_verify_start(plaintext, public_key, constants));
+
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read ciphertext out of OTBN dmem.
+  HARDENED_TRY(read_rsa_3072_int_from_otbn(kOtbnVarRsaOutBuf, ciphertext));
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.h
@@ -154,6 +154,22 @@ status_t rsa_3072_verify(const rsa_3072_int_t *signature,
                          const rsa_3072_constants_t *constants,
                          hardened_bool_t *result);
 
+/**
+ * Encrypts data with an RSA-3072 public key; blocks until complete.
+ *
+ * The key exponent must be 65537; no other exponents are supported.
+ *
+ * @param plaintext Message to be encrypted.
+ * @param public_key Key to check the signature against.
+ * @param constants Precomputed Montgomery constants for the public_key.
+ * @param[out] ciphertext Encrypted version of the message.
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_3072_encrypt_public(const rsa_3072_int_t *plaintext,
+                                 const rsa_3072_public_key_t *public_key,
+                                 const rsa_3072_constants_t *constants,
+                                 rsa_3072_int_t *ciphertext);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
During provisioning, we need to generate an RMA token on-device and encrypt it with an HSM generated pubkey before exporting it from the device (see #17393). The current crypto lib only supports doing a signature verification, not just a simple encryption operation. This adds a function that can simply encrypt a 3072 bit value with a pubkey.

@jadephilipoom lmk what you prefer here, if you had a different API in mind, etc. Thanks!