### PR TITLE
[manuf] add rust host program for provisioning functest

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -126,10 +126,17 @@ opentitan_functest(
     srcs = ["provisioning_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev_individualized",
+        clear_bitstream = True,
+        test_cmds = [
+            "--rom-kind=rom",
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
     ),
     targets = [
         "cw310_rom",
     ],
+    test_harness = "//sw/host/tests/manuf/provisioning",
     deps = [
         ":provisioning",
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",

--- a/sw/host/tests/manuf/provisioning/BUILD
+++ b/sw/host/tests/manuf/provisioning/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "provisioning",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:regex",
+        "//third_party/rust/crates:structopt",
+    ],
+)

--- a/sw/host/tests/manuf/provisioning/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/src/main.rs
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "600s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+}
+
+fn provisioning(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let result = console.interact(&*uart, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(provisioning, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a custom host-side opentitanlib-linked host program for driving the provisioning functest. Currently this host program does not do anything additional that the standard opentitantool harness doesn't already do, but it will be further enhanced in future PRs.

This partially addresses #17393.