### PR TITLE
[dif] Add `otp_ctrl` utility to calculate relative offset addresses.

### DIFF
--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -427,6 +427,32 @@ static const partition_info_t kPartitions[] = {
         },
 };
 
+dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+                                           uint32_t abs_address,
+                                           uint32_t *relative_address) {
+  *relative_address = 0;
+
+  if (partition >= ARRAYSIZE(kPartitions)) {
+    return kDifBadArg;
+  }
+
+  if ((abs_address & kPartitions[partition].align_mask) != 0) {
+    return kDifUnaligned;
+  }
+
+  if (abs_address < kPartitions[partition].start_addr) {
+    return kDifOutOfRange;
+  }
+
+  *relative_address = abs_address - kPartitions[partition].start_addr;
+  if (*relative_address >= kPartitions[partition].len) {
+    *relative_address = 0;
+    return kDifOutOfRange;
+  }
+
+  return kDifOk;
+}
+
 dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
                                          dif_otp_ctrl_partition_t partition,
                                          uint32_t address) {

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -423,6 +423,22 @@ dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
                                      dif_otp_ctrl_status_t *status);
 
 /**
+ * Calculates a `relative_address` with respect to a `partition` start
+ * address.
+ *
+ * @param partition The partition to use to calculate the reference start
+ * address.
+ * @param abs_address Input address relative to the OTP memory start address.
+ * @param[out] relative_address The result relative address with respect to the
+ * `partition` start address.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_relative_address(dif_otp_ctrl_partition_t partition,
+                                           uint32_t abs_address,
+                                           uint32_t *relative_address);
+
+/**
  * Schedules a read on the Direct Access Interface.
  *
  * Reads are performed relative to a partition; `address` should be given


### PR DESCRIPTION
Add `otp_ctrl` utility to calculate relative offset addresses with respect to the start of a provided target partition.