### PR TITLE
[test] Use sw straps API in chip_sw_inject_scramble_seed

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
@@ -61,7 +61,7 @@ class chip_sw_inject_scramble_seed_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, "Received C side acknowledgement", UVM_LOW)
 
     // setup triggers to bootstrap during the second run
-    cfg.chip_vif.sw_straps_if.drive({3{1'b1}});
+    cfg.use_spi_load_bootstrap = 1'b1;
 
     `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log ==
                       "Boot strap requested");,


### PR DESCRIPTION
The recently-added thread that takes control of SW straps conflicts with the vseq driving the SW straps, so use the cfg field that the new thread uses instead.

Fixes #18058 