### PR TITLE
[dv] Make SW strap thread more flexible

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
@@ -81,21 +81,14 @@ class chip_sw_exit_test_unlocked_bootstrap_vseq extends chip_sw_base_vseq;
     apply_reset();
 
     // setup triggers to bootstrap during the second run
-    cfg.chip_vif.sw_straps_if.drive({3{1'b1}});
+    cfg.use_spi_load_bootstrap = 1'b1;
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom)
 
     // bootstrap the same image
     spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
 
+    // Disable bootstrap for subsequent boots.
+    cfg.use_spi_load_bootstrap = 1'b0;
   endtask : body
-
-  task post_start();
-    // Disconnect straps driving so that subsequent tests can make use of this interface
-    // without any assumptions.
-    cfg.chip_vif.sw_straps_if.disconnect();
-  endtask : post_start
-
-
-
 
 endclass : chip_sw_exit_test_unlocked_bootstrap_vseq


### PR DESCRIPTION
The SW strap setting thread previously assumed the progression of all tests would proceed to being "InTest" before any need for bootstrapping on a subsequent boot. However, this is not true for all tests.

Change the thread to evaluate any time the SW status changes, and instead of requiring a particular set of paths to the "InBootRom" state, set up the straps regardless of how we reach the boot ROM.

Continue disconnecting the straps only upon reaching "InTest".