### PR TITLE
[test] Remove incorrect wakeup check in chip_power_sleep_load

### DIFF
--- a/sw/device/tests/chip_power_sleep_load.c
+++ b/sw/device/tests/chip_power_sleep_load.c
@@ -114,9 +114,6 @@ void prepare_to_exit(void) {
   // Check that no external interrupts have occurred.
   CHECK(ext_irq_fired == false, "Unexpected external interrupt triggered.");
 
-  // Check that the system has not been reset due to escalation
-  CHECK(UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) == true);
-
   CHECK_STATUS_OK(aon_timer_testutils_shutdown(&aon_timer));
 
   // Set the test status flag back to "TestStatusInTest"


### PR DESCRIPTION
The prepare_to_exit() function contained a superfluous and invalid check for wakeup reasons. Under all conditions in which it is called, the aon_timer's wakeup is expected to be active. However, prepare_to_exit() asserted that no wakeups should have happened. This was incorrect.

Meanwhile, the correct check is already done in the test_main() function.