### PR TITLE
[opentitanlib] Refactor out `collection!` macro

### DIFF
--- a/sw/host/opentitanlib/src/transport/dediprog/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/dediprog/gpio.rs
@@ -3,12 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Result};
-use lazy_static::lazy_static;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::collection;
 use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::dediprog::Inner;
 use crate::util::parse_int::ParseInt;
@@ -41,10 +38,7 @@ impl DediprogPin {
         }
         let pinname = pinname.to_uppercase();
         let pn = pinname.as_str();
-        PIN_NAMES
-            .get(pn)
-            .copied()
-            .ok_or_else(|| GpioError::InvalidPinName(pinname).into())
+        pin_from_name(pn).ok_or_else(|| GpioError::InvalidPinName(pinname).into())
     }
 }
 
@@ -78,8 +72,8 @@ impl GpioPin for DediprogPin {
     }
 }
 
-lazy_static! {
-    static ref PIN_NAMES: HashMap<&'static str, u8> = collection! {
+fn pin_from_name(name: &str) -> Option<u8> {
+    let pin = match name {
         "IO2" => 0,
         "IO1" => 1,
         "IO3" => 2,
@@ -87,5 +81,8 @@ lazy_static! {
         "PASS_LED" => 8,
         "BUSY_LED" => 9,
         "ERROR_LED" => 10,
+        _ => return None,
     };
+
+    Some(pin)
 }

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -3,13 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Context, Result};
-use lazy_static::lazy_static;
 use safe_ftdi as ftdi;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::collection;
 use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
@@ -58,10 +55,7 @@ impl UltradebugGpio {
         }
         let pinname = pinname.to_uppercase();
         let pn = pinname.as_str();
-        PIN_NAMES
-            .get(pn)
-            .copied()
-            .ok_or_else(|| GpioError::InvalidPinName(pinname).into())
+        pin_from_name(pn).ok_or_else(|| GpioError::InvalidPinName(pinname).into())
     }
 }
 
@@ -105,11 +99,14 @@ impl GpioPin for UltradebugGpioPin {
     }
 }
 
-lazy_static! {
-    static ref PIN_NAMES: HashMap<&'static str, u8> = collection! {
+fn pin_from_name(name: &str) -> Option<u8> {
+    let pin = match name {
         "SPI_ZB" => 4,
         "RESET_B" => 5,
         "BOOTSTRAP" => 6,
         "TGT_RESET" => 7,
+        _ => return None,
     };
+
+    Some(pin)
 }

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -17,22 +17,6 @@ pub mod usb;
 pub mod usr_access;
 pub mod voltage;
 
-/// The `collection` macro provides syntax for hash and set literals.
-#[macro_export]
-macro_rules! collection {
-    // map-like
-    ($($k:expr => $v:expr),* $(,)?) => {{
-        use std::iter::{Iterator, IntoIterator};
-        Iterator::collect(IntoIterator::into_iter([$(($k, $v),)*]))
-    }};
-
-    // set-like
-    ($($v:expr),* $(,)?) => {{
-        use std::iter::{Iterator, IntoIterator};
-        Iterator::collect(IntoIterator::into_iter([$($v),*]))
-    }};
-}
-
 /// The `testdata` macro can be used in tests to reference testdata directories.
 #[macro_export]
 #[cfg(test)]


### PR DESCRIPTION
This PR replaces the uses of `collection!` with plain match statements and removes the macro.

* Removes need for `HashMap` and `LazyStatic`.
* Reduces indirection and complexity from macros.

These string comparisons should be as fast or faster than hashes.