### PR TITLE
[dv/chip] switching to external clock before LC state transition from TEST_LOCKED1

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -844,6 +844,37 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `uvm_info(`gfn, "LC transition request succeeded successfully!", UVM_LOW)
   endtask
 
+  // Acquire the LC_CTRL transition interface mutex by LC JTAG
+  protected task claim_transition_interface();
+    `uvm_info(`gfn, "Claiming LC controller transition interface by JTAG...", UVM_MEDIUM)
+    jtag_riscv_agent_pkg::jtag_write_csr(
+        ral.lc_ctrl.claim_transition_if.get_offset(),
+        p_sequencer.jtag_sequencer_h,
+        prim_mubi_pkg::MuBi8True);
+  endtask : claim_transition_interface
+
+  // Bypass IO clock with the external clock
+  // using LC_CTRL.CTRL_TRANSITION.EXT_CLOCK_EN
+  task switch_to_external_clock();
+    // activate the external source clock with 48MHz
+    `uvm_info(`gfn, "Setting external clock to 48MHz...", UVM_MEDIUM)
+    cfg.chip_vif.ext_clk_if.set_freq_mhz(48);
+    cfg.chip_vif.ext_clk_if.set_active(.drive_clk_val(1), .drive_rst_n_val(0));
+
+    // switch OTP to use external clock instead of internal clock
+    // wait for LC to be ready, acquire the transition interface mutex and
+    // enable external clock
+    wait_lc_ready();
+    claim_transition_interface();
+
+    // switch to external clock via LC controller
+    `uvm_info(`gfn, "Switching to external clock via JTAG...", UVM_MEDIUM)
+    jtag_riscv_agent_pkg::jtag_write_csr(
+      ral.lc_ctrl.transition_ctrl.get_offset(),
+      p_sequencer.jtag_sequencer_h,
+      1);
+  endtask : switch_to_external_clock
+
   // Use JTAG interface to program OTP fields.
   virtual task jtag_otp_program32(int addr,
                                   bit [31:0] data);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -59,6 +59,13 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       // error. This error is permitted and can be ignored.
       wait_lc_ready(.allow_err(1));
 
+      // TEST_LOCKED* LC states do not allow ROM code execution -> IO clock calibration values aren't
+      // copied from OTP to AST -> internal clock isn't calibrated -> use external clock
+      // to perform LC transition
+      // activate the external source clock with 48MHz
+      switch_to_external_clock();
+
+      // perform the first LC state transition using LC JTAG
       jtag_lc_state_transition(DecLcStTestLocked1, DecLcStTestUnlocked2, {<<8{lc_unlock_token}});
 
       // LC state transition requires a chip reset.


### PR DESCRIPTION
By [specification](https://opentitan.org/book/doc/security/specs/device_life_cycle/), in `TEST_LOCKED1` the SW execution is disabled (CPU_EN == 0), hence IO clock calibration values are not copied from the OTP to AST. Therefore, since `chip_sw_lc_ctrl_transition` starts the first LC state transition from `TEST_LOCKED1`, it must use external clock in order to provide proper and stable clock frequency to the OTP for programming the LC partition.

Therefore, this PR adds a method that performs a switch to external clock usage via JTAG by enabling [LC_CTRL.CTRL_TRANSITION.EXT_CLOCK_EN](https://opentitan.org/book/hw/ip/lc_ctrl/data/lc_ctrl.html#transition_ctrl), and only then performs the LC state transition from TEST_LOCKED1.