### PR TITLE
[ast] Fix up constraints and waivers for recent ext clk work

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -107,4 +107,4 @@ set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_a
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from [get_clocks clk_usb_48mhz] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]

--- a/hw/top_earlgrey/ip/ast/lint/ast.waiver
+++ b/hw/top_earlgrey/ip/ast/lint/ast.waiver
@@ -40,6 +40,10 @@ waive -rules CLOCK_EDGE -location {ast_clks_byp.sv} \
       -msg {Falling edge of clock 'clk_ast_ext_scn' used here, should use rising edge} \
       -comment {This negedge trigger is done on purpose.}
 
+waive -rules CLOCK_EDGE -location {ast_clks_byp.sv} \
+      -msg {'prim_flop_2sync' instance 'u_no_scan_ext_freq_is_96m_sync' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifdef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
 waive -rules CLOCK_DRIVER -location {ast.sv} \
       -regexp {'clk_src_(aon|io|sys)' is driven by instance 'u_ast_clks_byp' of module 'ast_clks_byp', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
@@ -53,7 +57,15 @@ waive -rules CLOCK_DRIVER -location {ast.sv} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
 waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
+      -msg {'clk_o' driven in module 'gfr_clk_mux2' at} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
       -regexp {'clk_src_(aon|io)_o' is driven by instance 'u_clk_src_(aon|io)_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
+      -regexp {'clk_src_io' is driven by instance 'u_clk_src_io_sel' of module 'gfr_clk_mux2', and used as a clock 'clk_i' at} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
 
 waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
@@ -63,6 +75,34 @@ waive -rules CLOCK_DRIVER -location {ast_clks_byp.sv} \
 waive -rules CLOCK_MUX -location {ast_clks_byp.sv} \
       -regexp {Clock '(clk_ast_ext_scn|clk_ext_scn|clk_src_ext_usb|clk_ext_aon)' is driven by a multiplexer here, used as a clock} \
       -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules CLOCK_MUX -location {ast_clks_byp.sv} \
+      -regexp {Clock 'clk_ast_ext' reaches a multiplexer here, used as a clock} \
+      -comment {This is clock generation logic, hence it needs to drive this clock signal.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {Assignment to 'clk_ast_ext_scn' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {Assignment to 'clk_ext_scn' contained within `else block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {Assignment to 'clk_src_io_val_o' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {'prim_clock_div' instance 'u_no_scan_clk_(ext_d1ord2|usb_div240_div)' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {'prim_flop_2sync' instance 'u_no_scan_ext_freq_is_96m_sync' contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
+
+waive -rules IFDEF_CODE -location {ast_clks_byp.sv} \
+      -regexp {always_latch block contained within `ifndef 'AST_BYPASS_CLK' block at} \
+      -comment {This ifndef statement is fine as it is part of the FPGA/Verilator clock bypass mechanism.}
 
 waive -rules CLOCK_MUX -location {ast.sv} \
       -regexp {Clock 'clk_aon_n' is driven by a multiplexer here, used as a clock} \

--- a/hw/top_englishbreakfast/data/clocks.xdc
+++ b/hw/top_englishbreakfast/data/clocks.xdc
@@ -87,4 +87,4 @@ set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_a
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from [get_clocks clk_usb_48mhz] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]


### PR DESCRIPTION
With the recent AST changes to reuse the same clocks for ext clk on the FPGA, lint was failing and the clock names could sometimes change. Waive the warnings associated with the ifdefs and clock drivers. Also avoid using nets as references for clocks in the XDC.