### PR TITLE
[test] Remove workaround from e2e_bootstrap_rma test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -457,7 +457,7 @@ otp_json(
             name = "CREATOR_SW_CFG",
             items = {
                 "CREATOR_SW_CFG_RMA_SPIN_EN": hex(CONST.TRUE),
-                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "10",
+                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0x2000000",
             },
         ),
         otp_partition(

--- a/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
@@ -133,15 +133,6 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result
         .reset_target(opts.init.bootstrap.options.reset_delay, true)
         .context("failed to reset target")?;
 
-    // Remove the RMA_BOOTSTRAP strapping to bring the device out of the RMA spin loop.
-    // TODO: Transition to RMA requires the EDN to be initialised to wipe OTBN.
-    // Once <https://github.com/lowRISC/opentitan/issues/17944> is resolved, the RMA
-    // strapping should be kept and the delay removed.
-    rma_bootstrap_strapping
-        .remove()
-        .context("failed to remove strapping RMA_BOOTSTRAP")?;
-    std::thread::sleep(Duration::from_secs(1));
-
     log::info!("Connecting to JTAG interface");
 
     let jtag = transport.jtag(&opts.jtag).context("failed to get JTAG")?;
@@ -242,6 +233,11 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result
     // No longer need the JTAG interface, shut down gracefully.
     jtag.disconnect()
         .context("failed to disconnect from JTAG")?;
+
+    // Remove the RMA strapping so that future resets bring up normally.
+    rma_bootstrap_strapping
+        .remove()
+        .context("failed to remove strapping RMA_BOOTSTRAP")?;
 
     // Remove the strapping in case this state survives to another test.
     tap_strapping


### PR DESCRIPTION
This workaround took the device out of `BOOTSTRAP_RMA` and delayed for a little while to enable transitions into RMA. This was necessary because OTBN was not ready for RMA while in the spin loop that the `BOOTSTRAP_RMA` strapping creates.

Resolves <https://github.com/lowRISC/opentitan/issues/17944> and <https://github.com/lowRISC/opentitan/issues/17742>.

With <https://github.com/lowRISC/opentitan/pull/18123>, the chip is now able to transition to RMA while in the `BOOTSTRAP_RMA` strapping. This commit removes the workaround.

The `CREATOR_SW_CFG_RMA_SPIN_CYCLES` value is increased because `10` cycles is not enough to connect and transition within.