### PR TITLE
[dv/pwrmgr] Fix reset SVA PwrmgrSecCmEscToLCReset_A

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
@@ -30,11 +30,6 @@ class pwrmgr_env extends cip_base_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get lc_clk_rst_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(virtual clk_rst_if)::get(
-            this, "", "aon_clk_rst_vif", cfg.aon_clk_rst_vif
-        )) begin
-      `uvm_fatal(`gfn, "failed to get aon_clk_rst_vif from uvm_config_db")
-    end
     if (!uvm_config_db#(virtual pwrmgr_if)::get(this, "", "pwrmgr_vif", cfg.pwrmgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get pwrmgr_vif from uvm_config_db")
     end

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -23,8 +23,6 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // ext interfaces
   virtual clk_rst_if esc_clk_rst_vif;
   virtual clk_rst_if lc_clk_rst_vif;
-  // same as main_clk but don't have a clk_gate
-  virtual clk_rst_if aon_clk_rst_vif;
   virtual clk_rst_if slow_clk_rst_vif;
   virtual pwrmgr_if pwrmgr_vif;
   virtual pwrmgr_clock_enables_sva_if pwrmgr_clock_enables_sva_vif;

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -207,7 +207,6 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       // Escalation resets are cleared when reset goes active.
       clear_escalation_reset();
       clear_ndm_reset();
-      cfg.aon_clk_rst_vif.apply_reset();
     join
     // And wait until the responders settle with all okay from the AST.
     `DV_WAIT(
@@ -221,9 +220,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     cfg.slow_clk_rst_vif.drive_rst_pin(0);
     cfg.esc_clk_rst_vif.drive_rst_pin(0);
     cfg.lc_clk_rst_vif.drive_rst_pin(0);
-    cfg.aon_clk_rst_vif.drive_rst_pin(0);
     super.apply_resets_concurrently(cfg.slow_clk_rst_vif.clk_period_ps);
-    cfg.aon_clk_rst_vif.drive_rst_pin(1);
     cfg.esc_clk_rst_vif.drive_rst_pin(1);
     cfg.lc_clk_rst_vif.drive_rst_pin(1);
     cfg.slow_clk_rst_vif.drive_rst_pin(1);
@@ -242,7 +239,6 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
               ), UVM_MEDIUM)
     cfg.esc_clk_rst_vif.set_freq_mhz(cfg.clk_rst_vif.clk_freq_mhz);
     cfg.lc_clk_rst_vif.set_freq_mhz(cfg.clk_rst_vif.clk_freq_mhz);
-    cfg.aon_clk_rst_vif.set_freq_mhz(cfg.clk_rst_vif.clk_freq_mhz);
     set_ndmreset_req('0);
     control_assertions(0);
   endtask
@@ -790,21 +786,21 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
-      cfg.aon_clk_rst_vif.wait_clks(10);
+      cfg.slow_clk_rst_vif.wait_clks(10);
       cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
       cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
-      cfg.aon_clk_rst_vif.wait_clks(5);
+      cfg.slow_clk_rst_vif.wait_clks(5);
       cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
       cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
-      cfg.aon_clk_rst_vif.wait_clks(5);
+      cfg.slow_clk_rst_vif.wait_clks(5);
       cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
       cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
     end

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_common_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_common_vseq.sv
@@ -108,6 +108,6 @@ class pwrmgr_common_vseq extends pwrmgr_base_vseq;
       default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
     endcase  // case (if_proxy.sec_cm_type)
     // This makes sure errors are not injected too close together to avoid confusion.
-    cfg.aon_clk_rst_vif.wait_clks(10);
+    cfg.slow_clk_rst_vif.wait_clks(10);
   endtask : check_sec_cm_fi_resp
 endclass

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -93,7 +93,7 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
       // at low power state, do not use clk_rst_vif, cause it is off.
       fork
         begin
-          cfg.aon_clk_rst_vif.wait_clks(cycles_before_reset);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_reset);
           cfg.pwrmgr_vif.update_resets(resets);
 
           if (power_glitch_reset) begin
@@ -105,7 +105,7 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
         end
 
         begin
-          cfg.aon_clk_rst_vif.wait_clks(cycles_before_wakeup);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
           cfg.pwrmgr_vif.update_wakeups(wakeups);
           `uvm_info(`gfn, $sformatf("Sending wakeup=%b", wakeups), UVM_MEDIUM)
         end

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -17,7 +17,6 @@ module tb;
   wire clk_esc, rst_esc_n;
   wire clk_lc, rst_lc_n;
   wire clk_slow, rst_slow_n;
-  wire aon_clk, aon_rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
@@ -33,10 +32,6 @@ module tb;
   clk_rst_if esc_clk_rst_if (
     .clk  (clk_esc),
     .rst_n(rst_esc_n)
-  );
-  clk_rst_if aon_clk_rst_if (
-    .clk  (aon_clk),
-    .rst_n(aon_rst_n)
   );
   clk_rst_if slow_clk_rst_if (
     .clk  (clk_slow),
@@ -127,12 +122,10 @@ module tb;
     esc_clk_rst_if.set_active();
     lc_clk_rst_if.set_active();
     slow_clk_rst_if.set_active();
-    aon_clk_rst_if.set_active();
 
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "esc_clk_rst_vif", esc_clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "lc_clk_rst_vif", lc_clk_rst_if);
-    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "aon_clk_rst_vif", aon_clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "slow_clk_rst_vif", slow_clk_rst_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -159,8 +159,8 @@ module pwrmgr
 `endif
 
   `ASSERT(PwrmgrSecCmEscToLCReset_A, u_fsm.reset_reqs_i[ResetEscIdx] &&
-          u_fsm.state_q == FastPwrStateActive |-> ##[0:2] pwr_rst_o.rst_lc_req == 2'b11,
-          clk_slow_i, !rst_slow_ni)
+          u_fsm.state_q == FastPwrStateActive |-> ##4 pwr_rst_o.rst_lc_req == 2'b11,
+          clk_i, !rst_ni)
 
   always_ff @(posedge clk_lc or negedge rst_lc_n) begin
     if (!rst_lc_n) begin


### PR DESCRIPTION
Clock PwrmgrSecCmEscToLCReset_A with clk_i instead of clk_slow_i for reliability.
Remove unused aon_clk_rst_if, and changed its uses to slow_clk_rst_if.