### PR TITLE
[dv/clkmgr] Fix AllClkBypReqFall_A

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_extclk_sva_if.sv
@@ -58,7 +58,7 @@ interface clkmgr_extclk_sva_if
           $fell(
               extclk_sel_enabled
           ) |=> ##[FallCyclesMin:FallCyclesMax]
-              extclk_sel_enabled || (all_clk_byp_req_o == MuBi4False),
+              extclk_sel_enabled || (all_clk_byp_req_o != MuBi4True),
           clk_i, !rst_ni || disable_sva)
 
   logic hi_speed_enabled;


### PR DESCRIPTION
The all_clk_byp_req_o output is determined by extclk CSR, which can have any 4-bit value, not just Mubi4 True or False.