### PR TITLE
[hsmtool] Create the basic application structure 

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -2,15 +2,18 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "hsmlib",
     srcs = [
+        "src/commands/mod.rs",
+        "src/commands/token.rs",
         "src/error.rs",
         "src/lib.rs",
+        "src/module.rs",
         "src/util/attribute/attr.rs",
         "src/util/attribute/attribute_type.rs",
         "src/util/attribute/certificate_type.rs",
@@ -31,9 +34,11 @@ rust_library(
     crate_name = "hsmtool",
     proc_macro_deps = [
         "@crate_index//:serde_derive",
+        "@lowrisc_serde_annotate//annotate_derive:annotate_derive",
     ],
     deps = [
         "@crate_index//:anyhow",
+        "@crate_index//:atty",
         "@crate_index//:clap",
         "@crate_index//:cryptoki",
         "@crate_index//:cryptoki-sys",
@@ -49,6 +54,22 @@ rust_library(
         "@crate_index//:sha2",
         "@crate_index//:strum",
         "@crate_index//:thiserror",
+        "@crate_index//:typetag",
+        "@lowrisc_serde_annotate//:serde_annotate",
+    ],
+)
+
+rust_binary(
+    name = "hsmtool",
+    srcs = ["src/hsmtool.rs"],
+    deps = [
+        ":hsmlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:cryptoki",
+        "@crate_index//:env_logger",
+        "@crate_index//:log",
+        "@crate_index//:secrecy",
     ],
 )
 

--- a/sw/host/hsmtool/src/commands/mod.rs
+++ b/sw/host/hsmtool/src/commands/mod.rs
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use atty::Stream;
+use cryptoki::context::Pkcs11;
+use cryptoki::session::Session;
+use serde::{Deserialize, Serialize};
+use serde_annotate::{Annotate, ColorProfile};
+use std::any::Any;
+
+mod token;
+
+#[typetag::serde(tag = "command")]
+pub trait Dispatch {
+    fn run(
+        &self,
+        context: &dyn Any,
+        pkcs11: &Pkcs11,
+        session: Option<&Session>,
+    ) -> Result<Box<dyn Annotate>>;
+}
+
+#[derive(clap::Subcommand, Debug, Serialize, Deserialize)]
+pub enum Commands {
+    #[command(subcommand)]
+    Token(token::Token),
+}
+
+#[typetag::serde(name = "__commands__")]
+impl Dispatch for Commands {
+    fn run(
+        &self,
+        context: &dyn Any,
+        pkcs11: &Pkcs11,
+        session: Option<&Session>,
+    ) -> Result<Box<dyn Annotate>> {
+        match self {
+            Commands::Token(x) => x.run(context, pkcs11, session),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BasicResult {
+    success: bool,
+    error: Option<String>,
+}
+
+impl BasicResult {
+    pub fn from_error(e: &anyhow::Error) -> Box<dyn Annotate> {
+        Box::new(BasicResult {
+            success: false,
+            error: Some(format!("{:?}", e)),
+        })
+    }
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Format {
+    Json,
+    Json5,
+    HJson,
+    Yaml,
+}
+
+pub fn print_result(
+    format: Format,
+    color: Option<bool>,
+    result: Result<Box<dyn Annotate>>,
+) -> Result<()> {
+    let (value, result) = match result {
+        Ok(value) => (value, Ok(())),
+        Err(e) => (BasicResult::from_error(&e), Err(e)),
+    };
+
+    let doc = serde_annotate::serialize(value.as_ref())?;
+    let profile = if atty::is(Stream::Stdout) && color.unwrap_or(true) {
+        ColorProfile::basic()
+    } else {
+        ColorProfile::default()
+    };
+    let string = match format {
+        Format::Json => doc.to_json().color(profile).to_string(),
+        Format::Json5 => doc.to_json5().color(profile).to_string(),
+        Format::HJson => doc.to_hjson().color(profile).to_string(),
+        Format::Yaml => doc.to_yaml().color(profile).to_string(),
+    };
+    println!("{}", string);
+    result
+}

--- a/sw/host/hsmtool/src/commands/token.rs
+++ b/sw/host/hsmtool/src/commands/token.rs
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use cryptoki::context::Pkcs11;
+use cryptoki::session::Session;
+use serde::{Deserialize, Serialize};
+use serde_annotate::Annotate;
+use std::any::Any;
+
+use crate::commands::Dispatch;
+
+#[derive(clap::Args, Debug, Serialize, Deserialize)]
+pub struct List;
+
+#[derive(Debug, Serialize)]
+pub struct TokenInfo {
+    label: String,
+    manufacturer_id: String,
+    model: String,
+    serial_number: String,
+}
+
+impl From<cryptoki::slot::TokenInfo> for TokenInfo {
+    fn from(token: cryptoki::slot::TokenInfo) -> Self {
+        TokenInfo {
+            label: token.label().into(),
+            manufacturer_id: token.manufacturer_id().into(),
+            model: token.model().into(),
+            serial_number: token.serial_number().into(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct ListResponse {
+    tokens: Vec<TokenInfo>,
+}
+
+#[typetag::serde(name = "token-list")]
+impl Dispatch for List {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        pkcs11: &Pkcs11,
+        _session: Option<&Session>,
+    ) -> Result<Box<dyn Annotate>> {
+        let mut response = Box::<ListResponse>::default();
+        for slot in pkcs11.get_slots_with_token()? {
+            let info = pkcs11.get_token_info(slot)?;
+            response.tokens.push(TokenInfo::from(info));
+        }
+        Ok(response)
+    }
+}
+
+#[derive(clap::Subcommand, Debug, Serialize, Deserialize)]
+pub enum Token {
+    List(List),
+}
+
+#[typetag::serde(name = "__token__")]
+impl Dispatch for Token {
+    fn run(
+        &self,
+        context: &dyn Any,
+        pkcs11: &Pkcs11,
+        session: Option<&Session>,
+    ) -> Result<Box<dyn Annotate>> {
+        match self {
+            Token::List(x) => x.run(context, pkcs11, session),
+        }
+    }
+}

--- a/sw/host/hsmtool/src/hsmtool.rs
+++ b/sw/host/hsmtool/src/hsmtool.rs
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use cryptoki::session::UserType;
+use log::LevelFilter;
+
+use hsmtool::commands::{print_result, Commands, Dispatch, Format};
+use hsmtool::module;
+use hsmtool::util::attribute::AttributeMap;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(long, default_value = "warn", help = "Logging level")]
+    logging: LevelFilter,
+
+    #[arg(
+        short,
+        long,
+        value_enum,
+        default_value = "json",
+        help = "Output format"
+    )]
+    format: Format,
+
+    #[arg(short, long, help = "Use color in the output")]
+    color: Option<bool>,
+
+    #[arg(long, env = "HSMTOOL_MODULE", help = "Path to a PKCS11 shared library")]
+    module: String,
+
+    #[arg(short, long, env = "HSMTOOL_TOKEN", help = "HSM Token to use")]
+    token: Option<String>,
+
+    #[arg(
+        short,
+        long,
+        env = "HSMTOOL_USER",
+        value_parser = module::parse_user_type,
+        help="User type ('so' or 'user')"
+    )]
+    user: Option<UserType>,
+
+    #[arg(short, long, env = "HSMTOOL_PIN", help = "Pin")]
+    pin: Option<String>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    env_logger::Builder::from_default_env()
+        .filter(None, args.logging)
+        .init();
+    let pkcs11 = module::initialize(&args.module).context(
+        "Loading the PKCS11 module usually depends on several environent variables.  Check HSMTOOL_MODULE, SOFTHSM2_CONF or your HSM's documentation.")?;
+
+    // Initialize the list of all valid attribute types early.  Disable logging
+    // so we don't have to see all the harmless conversion errors for the types
+    // that cryptoki doesn't support.
+    log::set_max_level(LevelFilter::Off);
+    let _ = AttributeMap::all();
+    log::set_max_level(args.logging);
+
+    let session = if let Some(token) = &args.token {
+        Some(module::connect(
+            &pkcs11,
+            token,
+            args.user,
+            args.pin.as_deref(),
+        )?)
+    } else {
+        None
+    };
+
+    let result = args.command.run(&(), &pkcs11, session.as_ref());
+    print_result(args.format, args.color, result)
+}

--- a/sw/host/hsmtool/src/lib.rs
+++ b/sw/host/hsmtool/src/lib.rs
@@ -2,5 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod commands;
 pub mod error;
+pub mod module;
 pub mod util;

--- a/sw/host/hsmtool/src/module.rs
+++ b/sw/host/hsmtool/src/module.rs
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use cryptoki::context::CInitializeArgs;
+use cryptoki::context::Pkcs11;
+use cryptoki::session::Session;
+use cryptoki::session::UserType;
+use cryptoki::slot::Slot;
+
+use crate::error::HsmError;
+
+pub fn initialize(module: &str) -> Result<Pkcs11> {
+    let mut pkcs11 = Pkcs11::new(module)?;
+    pkcs11.initialize(CInitializeArgs::OsThreads)?;
+    Ok(pkcs11)
+}
+
+pub fn get_token(pkcs11: &Pkcs11, label: &str) -> Result<Slot> {
+    let slots = pkcs11.get_slots_with_token()?;
+    for slot in slots {
+        let info = pkcs11.get_token_info(slot)?;
+        if label == info.label() {
+            return Ok(slot);
+        }
+    }
+    Err(HsmError::TokenNotFound(label.into()).into())
+}
+
+pub fn connect(
+    pkcs11: &Pkcs11,
+    token: &str,
+    user: Option<UserType>,
+    pin: Option<&str>,
+) -> Result<Session> {
+    let slot = get_token(pkcs11, token)?;
+    let session = pkcs11.open_rw_session(slot)?;
+    if let Some(user) = user {
+        session.login(user, pin).context("Failed HSM Login")?;
+    }
+    Ok(session)
+}
+
+pub fn parse_user_type(val: &str) -> Result<UserType> {
+    match val {
+        "So" | "SO" | "so" | "security_officer" => Ok(UserType::So),
+        "User" | "USER" | "user" => Ok(UserType::User),
+        _ => Err(HsmError::UnknownUser(val.into()).into()),
+    }
+}

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -66,14 +66,13 @@ typetag = "0.2"
 zerocopy = "0.5.0"
 
 # hsmtool dependencies
-clap = { version = "4.1", features = ["derive"] }
+clap = { version = "4.1", features = ["derive", "env"] }
 cryptoki = "0.4.1"
 # Possible tagging/release error in the cryptoki crates. Pin to a version of
 # cryptoki-sys known to work.
 # https://github.com/parallaxsecond/rust-cryptoki/issues/134#issuecomment-1516540075
 cryptoki-sys = "=0.1.4"
 indexmap = { version = "1.9", features = ["serde"] }
-pem-rfc7468 = { version = "0.7", features = ["std"] }
 secrecy = "0.8"
 strum = { version = "0.24", features = ["derive"] }
 

--- a/third_party/rust/crates/BUILD.clap-4.2.2.bazel
+++ b/third_party/rust/crates/BUILD.clap-4.2.2.bazel
@@ -32,6 +32,7 @@ rust_library(
         "color",
         "default",
         "derive",
+        "env",
         "error-context",
         "help",
         "std",

--- a/third_party/rust/crates/BUILD.clap_builder-4.2.2.bazel
+++ b/third_party/rust/crates/BUILD.clap_builder-4.2.2.bazel
@@ -30,6 +30,7 @@ rust_library(
     crate_features = [
         "cargo",
         "color",
+        "env",
         "error-context",
         "help",
         "std",


### PR DESCRIPTION
1. Implement a CLAP based command processor.
2. Regularize all command execution and results via a `Dispatch` trait.
3. Format the output as json with serde_annotate.
4. Implement a single command: `token list` which lists available HSM tokens.

Signed-off-by: Chris Frantz <cfrantz@google.com>