### PR TITLE
[manuf,opentitanlib] add option to clear bitstream when loading one

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -131,8 +131,8 @@ opentitan_functest(
     srcs = ["provisioning_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev_individualized",
-        clear_bitstream = True,
         test_cmds = [
+            "--clear-bitstream",
             "--rom-kind=rom",
             "--bitstream=\"$(location {bitstream})\"",
             "--bootstrap=\"$(location {flash})\"",

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -9,12 +9,15 @@ use std::time::Duration;
 use structopt::StructOpt;
 
 use crate::app::{StagedProgressBar, TransportWrapper};
-use crate::transport::common::fpga::FpgaProgram;
+use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
 use crate::util::rom_detect::RomKind;
 
 /// Load a bitstream into the FPGA.
 #[derive(Debug, StructOpt)]
 pub struct LoadBitstream {
+    #[structopt(long, help = "Whether to clear out any existing bitstream.")]
+    pub clear_bitstream: bool,
+
     #[structopt(long, help = "The bitstream to load for the test")]
     pub bitstream: Option<PathBuf>,
 
@@ -25,14 +28,22 @@ pub struct LoadBitstream {
         help = "OpenTitan ROM type"
     )]
     pub rom_kind: Option<RomKind>,
+
     #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value="50ms", help = "Duration of the reset pulse.")]
     pub rom_reset_pulse: Duration,
+
     #[structopt(long, parse(try_from_str=humantime::parse_duration), default_value="2s", help = "Duration of ROM detection timeout")]
     pub rom_timeout: Duration,
 }
 
 impl LoadBitstream {
     pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Annotate>>> {
+        // Clear out existing bitstream, if requested.
+        if self.clear_bitstream {
+            log::info!("Clearing bitstream.");
+            transport.dispatch(&ClearBitstream)?;
+        }
+        // Load the specified bitstream, if provided.
         if let Some(bitstream) = &self.bitstream {
             self.load(transport, bitstream)
         } else {


### PR DESCRIPTION
On the FPGA, OTP is modeled using memories and are initialized from portions of the bitstream. The current Bazel/opentitanlib test infrastructure checks if the ROM has changed by reading an FPGA-only CSR, and triggers a bitstream load if it has. However, this mechanism does not take into account OTP changes that could impact test behavior.

Since the provisioning_functest modifies OTP and is designed to be reentrant, test behavior will change between consecutive runs if we do not first clear the bitstream. This adds a option to the test_utils `init` function to clear the bitstream if reqested in the test commands.