### PR TITLE
[dv/clkmgr] Handle some TODOs

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.hjson
@@ -1,10 +1,10 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-// TODO: This module is only a draft implementation that covers most of the clkmgr
-// functionality but is incomplete
 
-
+// ICEBOX: This module is only a draft implementation that covers most of the clkmgr
+// functionality but is incomplete. The chip actually uses
+// hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
 
 # CLKMGR register template
 #

--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "clkmgr"
-  // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
-                     // TODO: Top-level specific Hjson imported here. This will likely be resolved
+                     // ICEBOX: Top-level specific Hjson imported here. This will likely be resolved
                      // once we move to IPgen flow.
                      "hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson"]

--- a/hw/ip/clkmgr/dv/env/clkmgr_csrs_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_csrs_if.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This interface is used to sample some csr values directly from the rtl
+// to avoid any confusion.
+
+interface clkmgr_csrs_if (
+  input logic clk,
+  input logic [10:0] recov_err_csr,
+  input logic [2:0] fatal_err_csr,
+  input logic [3:0] clk_enables,
+  input logic [3:0] clk_hints
+);
+
+clocking csrs_cb @(posedge clk);
+  input recov_err_csr;
+  input fatal_err_csr;
+  input clk_enables;
+  input clk_hints;
+endclocking
+
+endinterface : clkmgr_csrs_if

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
     files:
+      - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv
       - clkmgr_env_cfg.sv: {is_include_file: true}
       - clkmgr_env_cov.sv: {is_include_file: true}

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.sv
@@ -53,6 +53,11 @@ class clkmgr_env extends cip_base_env #(
     if (!uvm_config_db#(virtual clkmgr_if)::get(this, "", "clkmgr_vif", cfg.clkmgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get clkmgr_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual clkmgr_csrs_if)::get(
+            this, "", "clkmgr_csrs_vif", cfg.clkmgr_csrs_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get clkmgr_csrs_vif from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -12,11 +12,12 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
   // ext component cfgs
 
   // ext interfaces
-  virtual clkmgr_if  clkmgr_vif;
-  virtual clk_rst_if main_clk_rst_vif;
-  virtual clk_rst_if io_clk_rst_vif;
-  virtual clk_rst_if usb_clk_rst_vif;
-  virtual clk_rst_if aon_clk_rst_vif;
+  virtual clkmgr_if      clkmgr_vif;
+  virtual clkmgr_csrs_if clkmgr_csrs_vif;
+  virtual clk_rst_if     main_clk_rst_vif;
+  virtual clk_rst_if     io_clk_rst_vif;
+  virtual clk_rst_if     usb_clk_rst_vif;
+  virtual clk_rst_if     aon_clk_rst_vif;
 
   virtual clk_rst_if root_io_clk_rst_vif;
   virtual clk_rst_if root_main_clk_rst_vif;

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -117,6 +117,42 @@ class clkmgr_env_cov extends cip_base_env_cov #(
     extclk_cross: cross csr_sel_cp, csr_low_speed_cp, hw_debug_en_cp, byp_req_cp, scanmode_cp;
   endgroup
 
+  // This collects coverage for recoverable errors.
+  covergroup recov_err_cg with function sample (
+      bit usb_timeout,
+      bit main_timeout,
+      bit io_div4_timeout,
+      bit io_div2_timeout,
+      bit io_timeout,
+      bit usb_measure,
+      bit main_measure,
+      bit io_div4_measure,
+      bit io_div2_measure,
+      bit io_measure,
+      bit shadow_update
+  );
+    shadow_update_cp: coverpoint shadow_update;
+    io_measure_cp: coverpoint io_measure;
+    io_div2_measure_cp: coverpoint io_div2_measure;
+    io_div4_measure_cp: coverpoint io_div4_measure;
+    main_measure_cp: coverpoint main_measure;
+    usb_measure_cp: coverpoint usb_measure;
+    io_timeout_cp: coverpoint io_timeout;
+    io_div2_timeout_cp: coverpoint io_div2_timeout;
+    io_div4_timeout_cp: coverpoint io_div4_timeout;
+    main_timeout_cp: coverpoint main_timeout;
+    usb_timeout_cp: coverpoint usb_timeout;
+  endgroup
+
+  // This collects coverage for fatal errors.
+  covergroup fatal_err_cg with function sample (
+      bit shadow_storage, bit idle_cnt, bit reg_integ
+  );
+    reg_integ_cp: coverpoint reg_integ;
+    idle_cnt_cp: coverpoint idle_cnt;
+    shadow_storage_cp: coverpoint shadow_storage;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     // The peripheral covergoups.
@@ -134,6 +170,8 @@ class clkmgr_env_cov extends cip_base_env_cov #(
       freq_measure_cg_wrap[i] = new(clk_mesr.name);
     end
     extclk_cg = new();
+    recov_err_cg = new();
+    fatal_err_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -218,11 +218,6 @@ interface clkmgr_if (
     io_clk_byp_ack = value;
   endfunction
 
-  // TODO:: this fix is not right since there are now 3 status
-  function automatic logic get_clk_status();
-    return pwr_o.main_status;
-  endfunction
-
   function automatic void force_high_starting_count(clk_mesr_e clk);
     `uvm_info("clkmgr_if", $sformatf("Forcing count of %0s to all 1.", clk.name()), UVM_MEDIUM)
     case (clk)

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -39,6 +39,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       sample_peri_covs();
       sample_trans_covs();
       sample_freq_measurement_covs();
+      sample_fatal_err_cov();
+      sample_recov_err_cov();
     join_none
   endtask
 
@@ -216,6 +218,44 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         @(posedge cfg.clkmgr_vif.usb_freq_measurement.valid or posedge cfg.clkmgr_vif.usb_timeout_err) begin
           sample_freq_measurement_cov(ClkMesrUsb, cfg.clkmgr_vif.usb_freq_measurement,
                                       cfg.clkmgr_vif.usb_timeout_err);
+        end
+    join_none
+  endtask
+
+  task sample_recov_err_cov();
+    fork
+      forever
+        @cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr if (cfg.en_cov) begin
+          cov.recov_err_cg.sample(
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[10],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[9],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[8],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[7],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[6],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[5],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[4],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[3],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[2],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[1],
+              cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr[0]);
+          `uvm_info(`gfn, $sformatf(
+                    "Recoverable errors sampled: 0x%x", cfg.clkmgr_csrs_vif.csrs_cb.recov_err_csr),
+                    UVM_MEDIUM)
+        end
+    join_none
+  endtask
+
+  task sample_fatal_err_cov();
+    fork
+      forever
+        @cfg.clkmgr_csrs_vif.csrs_cb.fatal_err_csr if (cfg.en_cov) begin
+          cov.fatal_err_cg.sample(
+              cfg.clkmgr_csrs_vif.csrs_cb.fatal_err_csr[2],
+              cfg.clkmgr_csrs_vif.csrs_cb.fatal_err_csr[1],
+              cfg.clkmgr_csrs_vif.csrs_cb.fatal_err_csr[0]);
+          `uvm_info(`gfn, $sformatf(
+                    "Fatal errors sampled: 0x%x", cfg.clkmgr_csrs_vif.csrs_cb.fatal_err_csr),
+                    UVM_MEDIUM)
         end
     join_none
   endtask

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -95,7 +95,6 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
       idle[trans] = prim_mubi_pkg::MuBi4True;
       cfg.clkmgr_vif.update_idle(idle);
       // Some cycles for the logic to settle.
-      // TODO: Temporary update to account for idle counts
       cfg.clk_rst_vif.wait_clks(IDLE_SYNC_CYCLES);
       csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
       if (!cfg.under_reset) begin

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -72,6 +72,38 @@ module tb;
     .rst_usb_n(rst_usb_n)
   );
 
+  bind clkmgr clkmgr_csrs_if clkmgr_csrs_if (
+    .clk(clk_i),
+    .recov_err_csr({
+        u_reg.u_recov_err_code_usb_timeout_err.qs,
+        u_reg.u_recov_err_code_main_timeout_err.qs,
+        u_reg.u_recov_err_code_io_div4_timeout_err.qs,
+        u_reg.u_recov_err_code_io_div2_timeout_err.qs,
+        u_reg.u_recov_err_code_io_timeout_err.qs,
+        u_reg.u_recov_err_code_usb_measure_err.qs,
+        u_reg.u_recov_err_code_main_measure_err.qs,
+        u_reg.u_recov_err_code_io_div4_measure_err.qs,
+        u_reg.u_recov_err_code_io_div2_measure_err.qs,
+        u_reg.u_recov_err_code_io_measure_err.qs,
+        u_reg.u_recov_err_code_shadow_update_err.qs
+    }),
+    .fatal_err_csr({
+        u_reg.u_fatal_err_code_shadow_storage_err.qs,
+        u_reg.u_fatal_err_code_idle_cnt.qs,
+        u_reg.u_fatal_err_code_reg_intg.qs
+     }),
+    .clk_enables({
+        reg2hw.clk_enables.clk_usb_peri_en.q,
+        reg2hw.clk_enables.clk_io_peri_en.q,
+        reg2hw.clk_enables.clk_io_div2_peri_en.q,
+        reg2hw.clk_enables.clk_io_div4_peri_en.q}),
+    .clk_hints({
+        reg2hw.clk_hints.clk_main_otbn_hint.q,
+        reg2hw.clk_hints.clk_main_kmac_hint.q,
+        reg2hw.clk_hints.clk_main_hmac_hint.q,
+        reg2hw.clk_hints.clk_main_aes_hint.q})
+  );
+
   rst_shadowed_if rst_shadowed_if (
     .rst_n(rst_n),
     .rst_shadowed_n(rst_shadowed_n)
@@ -147,8 +179,6 @@ module tb;
     .clocks_o   (clkmgr_if.clocks_o),
 
     .calib_rdy_i(clkmgr_if.calib_rdy),
-
-    // TODO: connect and use this interface.
     .hi_speed_sel_o(clkmgr_if.hi_speed_sel)
   );
 
@@ -168,6 +198,9 @@ module tb;
                                             root_usb_clk_rst_if);
 
     uvm_config_db#(virtual clkmgr_if)::set(null, "*.env", "clkmgr_vif", clkmgr_if);
+
+    uvm_config_db#(virtual clkmgr_csrs_if)::set(null, "*.env", "clkmgr_csrs_vif",
+                                                dut.clkmgr_csrs_if);
 
     // FIXME Un-comment this once interrupts are created for this ip.
     // uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);


### PR DESCRIPTION
Add covergroups for the recoverable and fatal error CSRs. Remove obsolete TODOs.
Move some TODOs to ICEBOX if they are for post 2.5.