### PR TITLE
[rdc] Add ast.lib

### DIFF
--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -61,11 +61,12 @@ set ri_print_module_nand2_counts true
 set ri_max_total_range_bits 20
 set ri_prefer_liberty true
 
-############################
+########################
 ## Apply Liberty File ##
+########################
 
 read_liberty $AST_LIB -db_dir ./RI_compiled_libs/verix_libs
-############################
+
 
 #########################
 ## Analyze & Elaborate ##

--- a/hw/rdc/tools/dvsim/meridianrdc.hjson
+++ b/hw/rdc/tools/dvsim/meridianrdc.hjson
@@ -4,11 +4,12 @@
 {
   // Environment variables that are needed in the RDC script
   exports: [
-    { CONSTRAINT:         "{sdc_file}" },
-    { FOUNDRY_CONSTRAINT: "{foundry_sdc_file}" },
-    { RDC_WAIVER_FILE:    "{rdc_waiver_file}" }
-    { ENV_FILE:           "{env_file}" }
-    { RESET_SCENARIO_FILE: "{reset_scenario_file}"}
+    { CONSTRAINT:          "{sdc_file}" },
+    { FOUNDRY_CONSTRAINT:  "{foundry_sdc_file}" },
+    { RDC_WAIVER_FILE:     "{rdc_waiver_file}" },
+    { ENV_FILE:            "{env_file}" },
+    { RESET_SCENARIO_FILE: "{reset_scenario_file}"},
+    { AST_LIB:             "{ast_lib}" },
   ]
 
   // Tool invocation

--- a/hw/rdc/tools/meridianrdc/run-rdc.tcl
+++ b/hw/rdc/tools/meridianrdc/run-rdc.tcl
@@ -28,6 +28,7 @@ set RDC_WAIVER_FILE     [get_env_var "RDC_WAIVER_FILE"]
 set RDC_WAIVER_DIR      [file dirname $RDC_WAIVER_FILE]
 set ENV_FILE            [get_env_var "ENV_FILE"]
 set RESET_SCENARIO_FILE [get_env_var "RESET_SCENARIO_FILE"]
+set AST_LIB            [get_env_var "AST_LIB"]
 
 # WAVES is optional
 set WAVES ""
@@ -69,6 +70,7 @@ set ri_print_module_nand2_counts true
 set ri_max_total_range_bits 100000
 set ri_rdc_stop_at_clock_path_in_obs_analysis true
 set ri_rdc_no_observability_on_clock_nodes true
+set ri_prefer_liberty true
 
 #Dump waveforms for all violations
 switch $WAVES {
@@ -85,6 +87,12 @@ switch $WAVES {
     quit
   }
 }
+
+########################
+## Apply Liberty File ##
+########################
+
+read_liberty $AST_LIB -db_dir ./RI_compiled_libs/meridian_libs
 
 #########################
 ## Analyze & Elaborate ##

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
@@ -34,6 +34,9 @@
   // Main RDC waiver file. It includes waivers per module
   rdc_waiver_file: "{proj_root}/hw/top_earlgrey/rdc/rdc_waivers.tcl"
 
+  // AST.lib
+  ast_lib: "{proj_root}/hw/top_earlgrey/ip/ast/lib/ast.lib"
+
   // Technology path for this module (empty for open-source runs)
   foundry_root: ""
 


### PR DESCRIPTION
This commit adds a liberty configuration to the RDC flow to use the ast.lib model available for top earlgrey.