### PR TITLE
Add missing extern declarations to status.c

### DIFF
--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -117,3 +117,6 @@ bool status_extract(status_t s, const char **code, int32_t *arg, char *mod_id) {
     return false;
   }
 }
+
+extern bool status_ok(status_t s);
+extern absl_status_t status_err(status_t s);


### PR DESCRIPTION
This commit adds two missing `extern` declarations to status.c. We cannot build for on-target coverage measurements without these `extern` declarations since we compile without any optimizations when instrumenting.

The `status_err()` call that broke coverage measurements was added in 57f1d8f16b7e1abe20c21c1d3305b08485735367.