### PR TITLE
[rom] Skip `entropy_src` health config

### DIFF
--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -314,6 +314,14 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   unimp
 
 .L_rma_spin_skip:
+  // Skip the `entropy_src` health checks configuration if the
+  // `RNG_HEALTH_CONFIG_DIGEST` is not programmed. The default digest value is
+  // 0 given that it is stored in a software OTP partition.
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST_OFFSET(a0)
+  beqz t0, .L_entropy_enable
+
   // Copy the entropy source health checks configuration thresholds from OTP.
   li   a0, (TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR + \
             ENTROPY_SRC_REPCNT_THRESHOLDS_REG_OFFSET)
@@ -331,8 +339,10 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   lw t1, OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ALERT_THRESHOLD_OFFSET(a1)
   sw t1, ENTROPY_SRC_ALERT_THRESHOLD_REG_OFFSET(a0)
 
+.L_entropy_enable:
   // The following sequence enables the minimum level of entropy required to
   // initialize memory scrambling, as well as the entropy distribution network.
+  li a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
 
   // Note for BOOT_ROM initialization the FIPS_ENABLE bit is set to kMultiBitBool4False
   // to prevent the release of FIPS entropy until all the thresholds are set


### PR DESCRIPTION
Skip `entropy_src` health config if the
`CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST` OTP word is not set. This is to avoid configuring the health check values when the SW_CFG OTP partition has not been configured.

This resolves an issue with being able to initialize the `ROM` in `test_unlocked[0-7]` lc stages, when the OTP partions have not been fully initialized.