### PR TITLE
[ast] Adjust ADC power-up SVA to 6 cycles

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/adc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/adc.sv
@@ -116,6 +116,6 @@ end
 `ASSERT(NoChannelWhileDisabled, (adc_en == 0) |-> (adc_chnsel_i == 4'h0), clk_adc_i, !rst_adc_ni)
 
 // Add Assertion RE of adc_en on the first 30us (=6*5us cc) after adc_en rose chnsel is 0.
-`ASSERT(ChannelStableOnAdcEn, $rose(adc_en) |-> (adc_chnsel_i == 4'h0)[*7], clk_adc_i, !rst_adc_ni)
+`ASSERT(ChannelStableOnAdcEn, $rose(adc_en) |-> (adc_chnsel_i == 4'h0)[*6], clk_adc_i, !rst_adc_ni)
 
 endmodule : adc


### PR DESCRIPTION
Previously, it required adc_chnsel_i to be '0 for 7 cycles, but this goes beyond the spec and comment.

Alternate, instead of #18178. However, this assertion is technically not valid if clk_adc's period is less than nominal. A spec writer would need to be careful about communicating the required values to program into adc_ctrl.