### PR TITLE
[adc_ctrl,dv] Test cleanup

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -29,6 +29,8 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
   // Wakeup control bits
   bit [ADC_CTRL_NUM_FILTERS-1:0] adc_wakeup_ctl = 0;
 
+  // For longtest, adjust large time value to avoid test timeout
+  bit                           fast_mode = 0;
 
   // Power up / wake up time
   rand int pwrup_time;

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -65,6 +65,10 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     uvm_reg_field min_v_fld, max_v_fld, cond_fld, en_fld;
     string regname;
     `uvm_info(`gfn, "Configuring adc_ctrl", UVM_MEDIUM)
+    if (cfg.fast_mode) begin
+      if (cfg.wakeup_time > 1000) cfg.wakeup_time = 1000;
+    end
+
     for (int channel = 0; channel < ADC_CTRL_CHANNELS; channel++) begin
       for (int filter = 0; filter < ADC_CTRL_NUM_FILTERS; filter++) begin
         regname = $sformatf("adc_chn%0d_filter_ctl_%0d", channel, filter);

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -39,7 +39,7 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
   constraint counters_c {
     pwrup_time inside {[0 : 2 ** ADC_CTRL_PWRUP_TIME_WIDTH - 1]};
     wakeup_time inside {[0 : 2 ** ADC_CTRL_WAKEUP_TIME_WIDTH - 1]};
-    np_sample_cnt inside {[1 : 2 ** ADC_CTRL_SAMPLE_CTL_WIDTH - 1]};
+    np_sample_cnt dist {[1 : 35] := 1, [36 : 2 ** ADC_CTRL_SAMPLE_CTL_WIDTH - 1] := 3};
     lp_sample_cnt inside {[1 : 2 ** ADC_CTRL_LP_SAMPLE_CTL_WIDTH - 1]};
 
     // Set up backdoor load values
@@ -49,10 +49,13 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
       wakeup_time_load_val == 0;
     }
 
-    if (np_sample_cnt > 20) {
-      np_sample_cnt_load_val inside {[np_sample_cnt - 3 : np_sample_cnt - 1]};
+    if (np_sample_cnt > 35) {
+      np_sample_cnt_load_val dist{
+        (2 ** ADC_CTRL_SAMPLE_CTL_WIDTH - 1) := 1,
+        [np_sample_cnt - 3 : np_sample_cnt - 1] := 4
+      };
     } else {
-      np_sample_cnt_load_val == 0;
+      np_sample_cnt_load_val inside {[0:32]};
     }
 
     if (lp_sample_cnt > 3) {

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_stress_all_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_stress_all_vseq.sv
@@ -16,6 +16,7 @@ class adc_ctrl_stress_all_vseq extends adc_ctrl_base_vseq;
     // Disable read of intr_state at the end of the sequence
     do_clear_all_interrupts = 0;
     super.pre_start();
+    cfg.fast_mode = 1;
   endtask
 
   task body();
@@ -56,7 +57,9 @@ class adc_ctrl_stress_all_vseq extends adc_ctrl_base_vseq;
       `uvm_info(`gfn, $sformatf("body: executing sequence %s", adc_ctrl_vseq.get_type_name()),
                 UVM_LOW)
       adc_ctrl_vseq.start(p_sequencer);
-
+      `uvm_info(`gfn, $sformatf("body: end sequence %s", adc_ctrl_vseq.get_type_name()),
+                UVM_LOW)
     end
   endtask : body
+
 endclass


### PR DESCRIPTION
- adc_ctrl_stress_all : Reduce wakeup timer upper bound to fix test timeout
- adc_ctrl_fsm_reset : Adjust np_sample_cnt  to stretch coverage