### PR TITLE
[otp] Updates to gen header scripts

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img.h.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img.h.tpl
@@ -47,7 +47,7 @@ extern "C" {
     # Print 4 numbers per line. This is why the step is set to 4 in the
     # iterator.
     if len(values) > 4:
-      for i in range(0, len(values) - 4, 4):
+      for i in range(0, len(values), 4):
         end = min(len(values), i + 4)
         out.append(", ".join(values[i:end]) + ",")
     else:

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -179,12 +179,10 @@ def _int_to_hex_array(val: int, size: int, alignment: int) -> List[str]:
         raise ValueError(len(bytes_hex))
 
     word_list = []
-    start = 0
-    stop = len(bytes_hex)
-    step = alignment
-    for i in range(start, stop, step):
-        word_list.append("".join(bytes_hex[i:i + step]))
+    for i in range(0, len(bytes_hex), alignment):
+        word_list.append("".join(bytes_hex[i:i + alignment]))
 
+    word_list.reverse()
     return [f"0x{y}" for y in word_list]
 
 


### PR DESCRIPTION
1. Swap word order to match ordering used in vmem generation flows.
2. Fix iteration range in header template file. The last four words were skipped on arrays with size > 4 words.

Part of https://github.com/lowRISC/opentitan/issues/17392