### PR TITLE
[manuf] encrypt RMA unlock token with AES during provisioning

### DIFF
--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -145,7 +145,8 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
  * since doing so could expose a padding oracle (especially in CBC mode).
  *
  * @param key Pointer to the blinded key struct with key shares.
- * @param iv Initialization vector, used for CBC, CFB, OFB, CTR modes.
+ * @param iv Initialization vector, used for CBC, CFB, OFB, CTR modes. May be
+ *           NULL if mode is ECB.
  * @param aes_mode Required AES mode of operation.
  * @param aes_operation Required AES operation (encrypt or decrypt).
  * @param cipher_input Input data to be ciphered.

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -117,6 +117,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:aes",
         "//sw/device/lib/crypto/impl:ecc",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:keyblob",

--- a/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
@@ -59,7 +59,7 @@ bool test_main(void) {
 
     // TODO(#17393): store data in non-volatile flash region to persist across a
     // reset and LOG output data with ujson framework.
-    for (size_t i = 0; i < 4; ++i) {
+    for (size_t i = 0; i < kRmaUnlockTokenSizeIn32BitWords; ++i) {
       LOG_INFO("RMA unlock token (%d): %x", i,
                (uint32_t *)(wrapped_token.data)[i]);
     }


### PR DESCRIPTION
This uses the ECDH generated shared secret key to encrypt the RMA unlock token with AES-ECB before exporting the token from the device. We use ECB mode without any padding because the RMA unlock token is exactly 128-bits, i.e., the length of a single AES block. A future PR will test the decryption of the token on the host side. This partially addresses #17393.

Note: this depends on #18192.