### PR TITLE
[top-level,clk_rst] Create separate clk_rst_if for xbar mode

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -36,7 +36,6 @@ class chip_base_vseq #(
   endtask
 
   virtual task apply_reset(string kind = "HARD");
-    lc_ctrl_state_pkg::lc_state_e lc_state;
     callback_vseq.pre_apply_reset();
     // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
     // These IOs have pad attributes that are driven from registers, and as long as


### PR DESCRIPTION
Make the non-xbar clk_rst_if fully passive, and hook clk and rst_n inputs to the rv_core_ibex clk and rst_n.
Change clk_rst_if so apply_reset does nothing if not driving rst_n. Change clk_rst_if clk driver so it does nothing if not driving clk.

Fixes #17993