### PR TITLE
[manuf] Adds individualize@test_unlock state

### DIFF
--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -185,6 +185,36 @@
     }
 
     {
+      name: manuf_ft_sku_individualization_preop
+      desc: '''Configure device fuses before switching the device to an operational lc_state.
+
+            This includes configuration of the CREATOR_SW and OWNER_SW partition.
+
+            The test steps are expected to be executed from flash. In silicon, the program is loaded
+            using the ROM bootstrap protocol. It is recommended to use the same approach on the FPGA,
+            and enable it as a configuration option in DV.
+
+            - Pre-load OTP with a TEST_UNLCOKED* lc_state in pre-silicon
+              environments. Advance to state in silicon.
+            - Load test program into flash and start execution.
+            - Configure CREATOR_SW_CFG OTP words according to device SKU configuration.
+            - Configure OWNER_SW_CFG OTP words according to device SKU configuration.
+            - Perform reset triggered by software.
+            - Load test program again into flash and start execution.
+            - Send response to host with test result serialized in JSON format.
+            - Check status response on the host side.
+
+            **Note**: Tests are easier to integrate with Automated Test Equipment (ATE) if all
+            device-host interfaces are unidirectional. This influences the type of physical
+            interface selection (e.g. SPI versus UART). Make sure the interface design takes
+            this constraint into consideration.
+            '''
+      tags: ["dv", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
       name: manuf_ft_sku_individualization
       desc: '''Configure device fuses.
 
@@ -208,8 +238,6 @@
               - DEVICE_ID
               - MANUF_STATE
             - Lock HW_CFG OPT partition.
-            - Configure CREATOR_SW_CFG OTP words according to device SKU configuration.
-            - Configure OWNER_SW_CFG OTP words according to device SKU configuration.
             - Perform reset trigered by software.
             - Initialize entropy_src in FIPS mode. Check health status after setting appropriate
               health test parameters. Configure SW csrng instance to generate enough data to

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -66,6 +66,18 @@ cc_library(
 )
 
 cc_library(
+    name = "otp_img",
+    srcs = ["otp_img.c"],
+    hdrs = ["otp_img.h"],
+    deps = [
+        ":otp_img_types",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+    ],
+)
+
+cc_library(
     name = "individualize",
     srcs = ["individualize.c"],
     hdrs = [
@@ -104,6 +116,41 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+cc_library(
+    name = "individualize_preop",
+    srcs = ["individualize_preop.c"],
+    hdrs = [
+        "individualize_preop.h",
+    ],
+    deps = [
+        ":otp_img",
+        "//hw/ip/otp_ctrl/data/sku_earlgrey_a0:otp_img_sku_earlgrey_a0_stage_individualize",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+    ],
+)
+
+opentitan_functest(
+    name = "individualize_preop_functest",
+    srcs = ["individualize_preop_functest.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
+    ),
+    targets = [
+        "cw310_rom",
+    ],
+    deps = [
+        ":individualize_preop",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/individualize_preop.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_preop.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/silicon_creator/manuf/lib/individualize_preop.h"
+
+#include "otp_img_sku_earlgrey_a0_stage_individualize.h"  // Generated.
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_img.h"
+
+status_t individualize_preop_otp_write(const dif_otp_ctrl_t *otp) {
+  TRY(otp_img_write(otp, kDifOtpCtrlPartitionCreatorSwCfg, kOtpKvCreatorSwCfg,
+                    ARRAYSIZE(kOtpKvCreatorSwCfg)));
+  TRY(otp_img_write(otp, kDifOtpCtrlPartitionOwnerSwCfg, kOtpKvOwnerSwCfg,
+                    ARRAYSIZE(kOtpKvOwnerSwCfg)));
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/individualize_preop.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_preop.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_PREOP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_PREOP_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+
+/**
+ * Configures the CREATOR_SW an OWNER_SW OTP partitions.
+ *
+ * The CREATOR_SW and OWNER_SW partitions contain various settings for the ROM,
+ * for example:
+ * - ROM key enable/disable flags
+ * - Alert handler configuration
+ * - AST and entropy complex configuration
+ * - Various ROM feature knobs
+ *
+ * Note: The test will fail if there are any pre-programmed words not equal to
+ * the expected test values.
+ *
+ * The caller should reset the device after calling this function to verify that
+ * the ROM is able to boot with the new configuration.
+ *
+ * @param otp OTP controller instance.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t individualize_preop_otp_write(const dif_otp_ctrl_t *otp);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_PREOP_H_

--- a/sw/device/silicon_creator/manuf/lib/individualize_preop_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_preop_functest.c
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/manuf/lib/individualize_preop.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"  // Generated
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  static dif_otp_ctrl_t otp_ctrl;
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_STATUS_OK(individualize_preop_otp_write(&otp_ctrl));
+  return true;
+}

--- a/sw/device/silicon_creator/manuf/lib/otp_img.c
+++ b/sw/device/silicon_creator/manuf/lib/otp_img.c
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/silicon_creator/manuf/lib/otp_img.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_img_types.h"
+
+status_t otp_img_write(const dif_otp_ctrl_t *otp,
+                       dif_otp_ctrl_partition_t partition, const otp_kv_t *kv,
+                       size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    uint32_t offset;
+    TRY(dif_otp_ctrl_relative_address(partition, kv[i].offset, &offset));
+    switch (kv[i].type) {
+      case kOptValTypeUint32Buff:
+        TRY(otp_ctrl_testutils_dai_write32(otp, partition, offset,
+                                           kv[i].value32, kv[i].num_values));
+        break;
+      case kOptValTypeUint64Buff:
+        TRY(otp_ctrl_testutils_dai_write64(otp, partition, offset,
+                                           kv[i].value64, kv[i].num_values));
+        break;
+      case kOptValTypeUint64Rnd:
+        return UNIMPLEMENTED();
+      default:
+        return INTERNAL();
+    }
+  }
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/otp_img.h
+++ b/sw/device/silicon_creator/manuf/lib/otp_img.h
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_OTP_IMG_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_OTP_IMG_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_img_types.h"
+
+/**
+ * Writes OTP values to target OTP `partition`.
+ *
+ * The `kv` array is preferrably generated using the build infrastructure. See
+ * individualize_preop.c and its build target for an example.
+ *
+ * @param otp OTP Controller instance.
+ * @param partition Target OTP partition.
+ * @param kv OTP Array of OTP key values. See `otp_kv_t` documentation for more
+ * details.
+ * @param len Length of the `kv` array.
+ * @return OT_WARN_UNUSED_RESULT
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_img_write(const dif_otp_ctrl_t *otp,
+                       dif_otp_ctrl_partition_t partition, const otp_kv_t *kv,
+                       size_t len);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_OTP_IMG_H_


### PR DESCRIPTION
This commit adds the implementation of the
`manuf_ft_individualization_prop` test point, which configures the `CREATOR_SW` and `OWNER_SW` OTP partitions.

The test uses a newly added `otp_img` module which consumes OTP header files generated by Bazel using the `otp_image_header` rule.

Fixes: https://github.com/lowRISC/opentitan/issues/17392