### PR TITLE
[opentitantool] Allow not running image immediately after bootstrap

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -357,8 +357,10 @@ impl UpdateProtocol for Rescue {
 
         // Reset, in order to leave rescue mode.
         container.reset_pin.write(false)?; // Low active
-        std::thread::sleep(container.reset_delay);
-        container.reset_pin.write(true)?; // Release reset
+        if !container.leave_in_reset {
+            std::thread::sleep(container.reset_delay);
+            container.reset_pin.write(true)?; // Release reset
+        }
         progress.progress(frames.len() * Frame::DATA_LEN);
         eprintln!("Success!");
         Ok(())


### PR DESCRIPTION
Sometimes automated tests want to set up serial ports, GPIO edge detection, etc. before booting a firmware image under test.  The bootstrapping protocol may itself use some of the same pins, meaning that some time after completed bootstrap could pass, before the testing infrastructure is ready to observe the startup behavior of the firmware. Also, the firmware in question could read and modify persistent storage on the chip, meaning that it is undesirable to have it execute immediately after completed bootstrapping, only to have to reset it again, while the testing infrastructure gets ready for the "real" test run.

This PR adds an option to have `opentitantool bootstrap` perform its logic, but leave the RESET pin asserted in the end (as it is removing strappings, etc.).  This will allow the testing infrastructure to first load the firmware image to be tested, and then take its sweet time to set up whatever pins and ports, before eventually releasing the chip from reset.
