### PR TITLE
[data/lc_ctrl] remove redundant regwen

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -890,7 +890,6 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
-      regwen:   "TRANSITION_REGWEN",
       tags: [ // To update this register, SW needs to claim the associated hardware mutex via
               // CLAIM_TRANSITION_IF, so can not auto predict its value.
               "excl:CsrNonInitTests:CsrExclCheck"],


### PR DESCRIPTION
The vendor_test_status register is RO so regwen has no effect on it. This PR removes the regwen on that csr.