### PR TITLE
[chip-test] Increase UART test timeouts

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -529,7 +529,7 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1",
                  "+test_timeout_ns=80_000_000"]
-      run_timeout_mins: 180
+      run_timeout_mins: 240
     }
     {
       name: chip_sw_inject_scramble_seed
@@ -553,6 +553,7 @@
       sw_images: ["//sw/device/tests/sim_dv:uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1"]
+      run_timeout_mins: 120
       reseed: 20
     }
     {
@@ -562,6 +563,7 @@
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+chip_clock_source=ChipClockSourceExternal96Mhz", "+calibrate_usb_clk=1"]
+      run_timeout_mins: 120
       reseed: 5
     }
     {


### PR DESCRIPTION
Due to the increased RX FIFO size, the UART tests take substantially longer than before, causing increased probability of timeouts for some tests. Increase the timeout for those tests to accommodate.

Note that the impacted test area is from https://github.com/lowRISC/opentitan/blob/2c75f3a500fd88d3e143bd25a988f3ae37cfdcc1/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv#L67-L68

(Proportionally-speaking, the bootstrap test is less significantly impacted by the FIFO size, but the run time is generally close enough to the edge that it needed a boost as well. I've lumped that into this PR.)

Fixes #18143, #18055 