### PR TITLE
[test] Remove otp_ctrl fatal alerts from chip_sw_alert_handler_lpg_sl…

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1516,8 +1516,8 @@
             - After wake up from normal sleep mode, clear all alert cause registers and check that
               all alerts are still firing after waking up.
             - Repeat the previous steps for random number of iterations.
-            - Fatal alerts from flash_ctrl, sram_ctrl and lc_ctrl are omitted because they disable
-              the CPU and require a reset for the system to continue to function.
+            - Fatal alerts from flash_ctrl, otp_ctrl, sram_ctrl, and lc_ctrl are omitted because
+              they disable the CPU and require a reset for the system to continue to function.
             '''
       stage: V2
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_alerts"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1151,7 +1151,7 @@
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1", "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl"]
+      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1", "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl,otp_ctrl"]
       run_timeout_mins: 240
       reseed: 90
     }


### PR DESCRIPTION
…eep_mode_alerts

otp_ctrl fatal alerts prevent SW from continuing and require the alert_handler to issue a reset. Add those to the list of exceptions for the vseq.

Do we have an exhaustive list of these?