### PR TITLE
[manuf] parse exported ujson provisioning data on host

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
@@ -48,32 +48,36 @@ static status_t peripheral_handles_init(void) {
   return OK_STATUS();
 }
 
+status_t provisioning_test(ujson_t *uj) {
+  LOG_INFO("Provisioning device.");
+  manuf_provisioning_t export_data = {
+      .wrapped_rma_unlock_token =
+          {
+              .data = {0},
+              .ecc_pk_device_x = {0},
+              .ecc_pk_device_y = {0},
+          },
+  };
+  TRY(provisioning_device_secrets_start(&flash_state, &lc_ctrl, &otp_ctrl,
+                                        &export_data));
+  RESP_OK(ujson_serialize_manuf_provisioning_t, uj, &export_data);
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   ujson_t uj = ujson_ottf_console();
   CHECK_STATUS_OK(peripheral_handles_init());
 
   dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
   if (info & kDifRstmgrResetInfoPor) {
-    LOG_INFO("provisioning start");
-
-    manuf_provisioning_t export_data = {
-        .wrapped_rma_unlock_token =
-            {
-                .data = {0},
-                .ecc_pk_device_x = {0},
-                .ecc_pk_device_y = {0},
-            },
-    };
-    CHECK_STATUS_OK(provisioning_device_secrets_start(&flash_state, &lc_ctrl,
-                                                      &otp_ctrl, &export_data));
-    CHECK_STATUS_OK(ujson_serialize_manuf_provisioning_t(&uj, &export_data));
-
+    CHECK_STATUS_OK(provisioning_test(&uj));
     // Issue and wait for reset.
     rstmgr_testutils_reason_clear();
     CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
     wait_for_interrupt();
   } else if (info == kDifRstmgrResetInfoSw) {
-    LOG_INFO("provisioning check status");
+    LOG_INFO("Provisioning complete.");
+    LOG_INFO("Checking status ...");
     CHECK_STATUS_OK(provisioning_device_secrets_end(&otp_ctrl));
   } else {
     LOG_FATAL("Unexpected reset reason: %08x", info);

--- a/sw/host/tests/manuf/provisioning/BUILD
+++ b/sw/host/tests/manuf/provisioning/BUILD
@@ -3,20 +3,33 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules:ujson.bzl", "ujson_rust")
 
 package(default_visibility = ["//visibility:public"])
+
+ujson_rust(
+    name = "provisioning_data",
+    srcs = ["//sw/device/lib/testing/json:provisioning_data"],
+)
 
 rust_binary(
     name = "provisioning",
     srcs = [
         "src/main.rs",
+        "src/provisioning_data.rs",
     ],
+    compile_data = [":provisioning_data"],
+    rustc_env = {
+        "provisioning_data": "$(location :provisioning_data)",
+    },
     deps = [
         "//sw/host/opentitanlib",
-        "//third_party/rust/crates:anyhow",
-        "//third_party/rust/crates:humantime",
-        "//third_party/rust/crates:log",
-        "//third_party/rust/crates:regex",
-        "//third_party/rust/crates:structopt",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+        "@crate_index//:structopt",
     ],
 )

--- a/sw/host/tests/manuf/provisioning/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/src/main.rs
@@ -4,14 +4,17 @@
 
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
-use regex::Regex;
+use anyhow::Result;
 use structopt::StructOpt;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::uart::console::{ExitStatus, UartConsole};
+use opentitanlib::test_utils::rpc::UartRecv;
+use opentitanlib::uart::console::UartConsole;
+
+mod provisioning_data;
+use provisioning_data::ManufProvisioning;
 
 #[derive(Debug, StructOpt)]
 struct Opts {
@@ -27,51 +30,24 @@ struct Opts {
 }
 
 fn provisioning(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Get UART, set flow control, and wait for for test to start running.
     let uart = transport.uart("console")?;
-    let mut console = UartConsole {
-        timeout: Some(opts.timeout),
-        exit_success: Some(Regex::new(r"PASS.*\n")?),
-        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
-        newline: true,
-        ..Default::default()
-    };
-    let mut stdout = std::io::stdout();
-    let result = console.interact(&*uart, None, Some(&mut stdout))?;
-    match result {
-        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
-        ExitStatus::Timeout => {
-            if console.exit_success.is_some() {
-                Err(anyhow!("Console timeout exceeded"))
-            } else {
-                Ok(())
-            }
-        }
-        ExitStatus::ExitSuccess => {
-            log::info!(
-                "ExitSuccess({:?})",
-                console.captures(result).unwrap().get(0).unwrap().as_str()
-            );
-            Ok(())
-        }
-        ExitStatus::ExitFailure => {
-            log::info!(
-                "ExitFailure({:?})",
-                console.captures(result).unwrap().get(0).unwrap().as_str()
-            );
-            Err(anyhow!("Matched exit_failure expression"))
-        }
-    }
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    // Wait for exported data to be transimitted over the console.
+    let export_data = ManufProvisioning::recv(&*uart, opts.timeout, false)?;
+    log::info!("{:#x?}", export_data);
+
+    // TODO: parse RMA unlock token, decrypt it, and try to issue an LC transition.
+    Ok(())
 }
 
 fn main() -> Result<()> {
     let opts = Opts::from_args();
     opts.init.init_logging();
+
     let transport = opts.init.init_target()?;
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
-
     execute_test!(provisioning, &opts, &transport);
-
     Ok(())
 }

--- a/sw/host/tests/manuf/provisioning/src/provisioning_data.rs
+++ b/sw/host/tests/manuf/provisioning/src/provisioning_data.rs
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Bring in the auto-generated sources.
+include!(env!("provisioning_data"));


### PR DESCRIPTION
This updates the provisioning_functest rust test harness to parse the provisioning data exported from the device over the console.

The console output now looks like:
```sh
[2023-04-27T06:36:22Z INFO  provisioning] manuf_provisioning_t {
        wrapped_rma_unlock_token: wrapped_rma_unlock_token_t {
            data: [
                0xec263a01,
                0x2ff5ff98,
                0x18360c73,
                0x14966f88,
            ],
            ecc_pk_device_x: [
                0xc54bd4f9,
                0xf92c02e1,
                0xbd533cca,
                0x1651e7a9,
                0xedf0140c,
                0xb5b0ced,
                0xa59b0b2,
                0xded0104c,
            ],
            ecc_pk_device_y: [
                0x448d8f3,
                0xcffcc5cc,
                0xe8b3798c,
                0x1ff89f35,
                0xf8add657,
                0xd77c699d,
                0x7105f1e7,
                0x295b9792,
            ],
        },
    }
```

This partially addresses https://github.com/lowRISC/opentitan/issues/17393.

Note this depends on https://github.com/lowRISC/opentitan/pull/18199 please only review the last commit.