### PR TITLE
[site] Change default content width for Hugo pages

### DIFF
--- a/site/landing/assets/scss/_content-body.scss
+++ b/site/landing/assets/scss/_content-body.scss
@@ -6,7 +6,7 @@ main {
 
 .content {
     margin: 0 auto;
-    max-width: $max-width-m;
+    max-width: $max-width-s;
 }
 
 /* Get the default margins back for these elements */


### PR DESCRIPTION
For the Hugo-generated pages within the current site, we only have a single page (https://opentitan.org/documentation/index.html) that has a significant amount of information within the 'content' div.
Currently, this page looks badly formatted as the text is significantly wider than the diagrams. 

- Change the width limit to `$max-width-s` (currently 52rem), as this works better for the current content.

If make more use of the Hugo-generated pages, we may need to reconsider how we manage the width of content. Personally I do not know any of the nuance of managing such considerations.

---

**Before**

![Screenshot from 2023-04-27 13-28-00](https://user-images.githubusercontent.com/102029880/234862666-415cb84a-4c35-4785-b6af-5a13db4a1395.png)

---

**After**

![Screenshot from 2023-04-27 13-27-42](https://user-images.githubusercontent.com/102029880/234862706-cabeb7a4-cd95-4fe0-aaa4-b3b475268eee.png)
