### PR TITLE
[ast] updating adc assertion to match specification

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/adc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/adc.sv
@@ -116,6 +116,6 @@ end
 `ASSERT(NoChannelWhileDisabled, (adc_en == 0) |-> (adc_chnsel_i == 4'h0), clk_adc_i, !rst_adc_ni)
 
 // Add Assertion RE of adc_en on the first 30us (=6*5us cc) after adc_en rose chnsel is 0.
-`ASSERT(ChannelStableOnAdcEn, $rose(adc_en) |-> (adc_chnsel_i == 4'h0)[*7], clk_adc_i, !rst_adc_ni)
+`ASSERT(ChannelStableOnAdcEn, $rose(adc_en) |-> (adc_chnsel_i == 4'h0)[*6], clk_adc_i, !rst_adc_ni)
 
 endmodule : adc


### PR DESCRIPTION
Updating adc assertion to match specification of 30us between adc_en and adc_chnsel !=0.
Previous value of 35us took some margin to be on the safe side.
As I recently learnt we got a "minimum power-up time" test (#18178), I updated it to 30us.
@msfschaffner @a-will @arnonsha 