### PR TITLE
[otbn, sca] DO-NOT-MERGE Use 320 bits bits in ECC Keygen

### DIFF
--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -2201,11 +2201,11 @@ p256_generate_k:
 boolean_to_arithmetic:
   /* Mask out excess bits from seed shares.
        [w21, w20] <= s0 mod 2^320
-       [w23, w22] <= s1 mod 2^320 = x1 */
+       [w11, w10] <= s1 mod 2^320 = x1 */
   bn.rshi   w21, w21, w31 >> 64
   bn.rshi   w21, w31, w21 >> 192
-  bn.rshi   w23, w23, w31 >> 64
-  bn.rshi   w23, w31, w23 >> 192
+  bn.rshi   w11, w11, w31 >> 64
+  bn.rshi   w11, w31, w11 >> 192
 
   /* Fetch 321 bits of randomness from URND.
        [w2, w1] <= gamma */
@@ -2232,9 +2232,9 @@ boolean_to_arithmetic:
   bn.xor    w3, w3, w20
   bn.xor    w4, w4, w21
 
-  /* [w2, w1] <= [w2, w1] ^ [w23, w22] = gamma ^ s1 = G */
-  bn.xor    w1, w1, w22
-  bn.xor    w2, w2, w23
+  /* [w2, w1] <= [w2, w1] ^ [w11, w10] = gamma ^ s1 = G */
+  bn.xor    w1, w1, w10
+  bn.xor    w2, w2, w11
 
   /* [w21, w20] <= [w21, w20] ^ [w2, w1] = s0 ^ G */
   bn.xor    w20, w20, w1
@@ -2343,15 +2343,15 @@ p256_key_from_seed:
   bn.rshi   w29, w31, w29 >> 192
 
   /* [w25,w24] <= (x1 - (n << 64)) mod 2^512 */
-  bn.sub    w24, w22, w28
-  bn.subb   w25, w23, w29
+  bn.sub    w24, w10, w28
+  bn.subb   w25, w11, w29
 
   /* Compute d1. Because 2^320 < 2 * (n << 64), a conditional subtraction is
      sufficient to reduce. Similarly to the carry bit, the conditional bit here
      is not very sensitive because the shares are large relative to n.
-       [w23,w22] <= x1 mod (n << 64) = d1 */
-  bn.sel    w22, w22, w24, FG0.C
-  bn.sel    w23, w23, w25, FG0.C
+       [w11,w10] <= x1 mod (n << 64) = d1 */
+  bn.sel    w10, w10, w24, FG0.C
+  bn.sel    w11, w11, w25, FG0.C
 
   /* Isolate the carry bit and shift it back into position.
        w25 <= x0[320] << 64 */

--- a/sw/otbn/crypto/p256.s
+++ b/sw/otbn/crypto/p256.s
@@ -2207,26 +2207,26 @@ boolean_to_arithmetic:
   bn.rshi   w11, w11, w31 >> 64
   bn.rshi   w11, w31, w11 >> 192
 
-  /* Fetch 321 bits of randomness from URND.
+  /* Fetch 320 bits of randomness from URND.
        [w2, w1] <= gamma */
   bn.wsrr   w1, 2
   bn.wsrr   w2, 2
-  bn.rshi   w2, w31, w2 >> 191
+  bn.rshi   w2, w31, w2 >> 192
 
   /* [w4, w3] <= [w21, w20] ^ [w2, w1] = s0 ^ gamma */
   bn.xor    w3, w20, w1
   bn.xor    w4, w21, w2
 
-  /* Subtract gamma. This may result in bits above 2^321, but these will be
+  /* Subtract gamma. This may result in bits above 2^320, but these will be
      stripped off in the next step.
        [w4, w3] <= [w4, w3] - [w2, w1] = ((s0 ^ gamma) - gamma) mod 2^512 */
   bn.sub    w3, w3, w1
   bn.subb   w4, w4, w2
 
-  /* Truncate subtraction result to 321 bits.
+  /* Truncate subtraction result to 320 bits.
        [w4, w3] <= [w4, w3] mod 2^321 = T */
-  bn.rshi   w4, w4, w31 >> 65
-  bn.rshi   w4, w31, w4 >> 191
+  bn.rshi   w4, w4, w31 >> 64
+  bn.rshi   w4, w31, w4 >> 192
 
   /* [w4, w3] <= [w4, w3] ^ [w21, w20] = T2 */
   bn.xor    w3, w3, w20
@@ -2245,8 +2245,8 @@ boolean_to_arithmetic:
   bn.subb   w21, w21, w2
 
   /* [w21, w20] <= [w21, w20] mod 2^321 = A */
-  bn.rshi   w21, w21, w31 >> 65
-  bn.rshi   w21, w31, w21 >> 191
+  bn.rshi   w21, w21, w31 >> 64
+  bn.rshi   w21, w31, w21 >> 192
 
   /* [w21, w20] <= [w21, w20] ^ [w4, w3] = A ^ T2 = x0 */
   bn.xor    w20, w20, w3

--- a/sw/otbn/crypto/p256_key_from_seed_sca.s
+++ b/sw/otbn/crypto/p256_key_from_seed_sca.s
@@ -53,33 +53,35 @@ run_gen_secret_key:
 
   /* Load shares of seed from DMEM.
        [w21,w20] <= dmem[seed0]
-       [w23,w33] <= dmem[seed1] */
+       [w11,w10] <= dmem[seed1] */
   li        x2, 20
   la        x3, seed0
   bn.lid    x2, 0(x3++)
   li        x2, 21
-  bn.lid    x2++, 0(x3)
+  bn.lid    x2, 0(x3)
+  li        x2, 10
   la        x3, seed1
   bn.lid    x2, 0(x3++)
-  li        x2, 23
+  li        x2, 11
   bn.lid    x2, 0(x3)
 
   /* Generate the derived secret key.
        [w21,w20] <= d0
-       [w23,w33] <= d1 */
+       [w11,w10] <= d1 */
   jal       x1, p256_key_from_seed
 
   /* Write the results to DMEM.
        dmem[d0] <= [w21, w20]
-       dmem[d1] <= [w23, w22] */
+       dmem[d1] <= [w11, w10] */
   li        x2, 20
   la        x3, d0
   bn.sid    x2, 0(x3++)
   li        x2, 21
-  bn.sid    x2++, 0(x3)
+  bn.sid    x2, 0(x3)
+  li        x2, 10
   la        x3, d1
   bn.sid    x2, 0(x3++)
-  li        x2, 23
+  li        x2, 11
   bn.sid    x2, 0(x3)
 
   ret


### PR DESCRIPTION
This is to get rid of the expected leakage.
    
This is just for experiments. DO NOT MERGE this PR!

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>