### PR TITLE
[edn,dv] Create error and alert covergroups

### DIFF
--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -121,7 +121,7 @@ covergroups: [
             '''
     }
     {
-      name: cs_cmds_cg
+      name: edn_cs_cmds_cg
       desc: '''
             Covers the following:
             - csrng_commands vs clen, flags, glen
@@ -131,17 +131,21 @@ covergroups: [
             '''
     }
     {
-      name: err_test_cg
+      name: edn_error_cg
       desc: '''
-            Covers that all fatal errors, all fifo errors and all error codes of edn
-            have been tested.
+            Covers that all fatal errors, all fifo errors and all error codes of edn have been tested.
             Individual config settings that will be covered include:
-            - which_fatal_err (0 to 4), 5 possible fatal errors including rescmd, gencmd fifo
-              error, ack_sm_err, main_sm_err and cntr_err
-            - which_fifo (0 to 1), 2 differnt fifos, rescmd fifo and gencmd fifo
-            - which_err_code (0 to 15), 8 ERR_CODE errors, plus 8 ERR_CODE_TEST bits test
-            - which_fifo_err (0 to 2), fifo write/read/state errors
-            - which_invalid_mubi (0 to 3), 4 possible invalid mubi4 value fields
+            - 3 different FIFOs: rescmd, gencmd and output
+            - 3 other error codes: ack state machine, main state machine and counter
+            - 3 types of FIFO errors: write/read/state errors
+            '''
+    }
+    {
+      name: edn_alert_cg
+      desc: '''
+            Cover all the recoverable alerts:
+            - Invalid MUBI values: enable field, boot request mode, auto request mode and command FIFO reset
+            - EDN bus comparison
             '''
     }
   ]

--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -63,9 +63,9 @@ interface edn_cov_if (
     }
   endgroup : edn_endpoints_cg
 
-  covergroup edn_cs_cmds_cg with function sample(bit[3:0]    clen,
-                                                 bit[3:0]    flags,
-                                                 bit[18:0]   glen
+  covergroup edn_cs_cmds_cg with function sample(bit[3:0]  clen,
+                                                 bit[3:0]  flags,
+                                                 bit[18:0] glen
                                                 );
     option.name         = "edn_cs_cmds_cg";
     option.per_instance = 1;
@@ -89,9 +89,25 @@ interface edn_cov_if (
     cr_clen_flags_glen:   cross cp_clen, cp_flags, cp_glen;
   endgroup : edn_cs_cmds_cg
 
+  covergroup edn_error_cg with function sample(err_code_test_e err_test);
+    option.name         = "edn_error_cg";
+    option.per_instance = 1;
+
+    cp_error_test: coverpoint err_test;
+  endgroup : edn_error_cg
+
+  covergroup edn_alert_cg with function sample(recov_alert_bit_e recov_alert);
+    option.name         = "edn_alert_cg";
+    option.per_instance = 1;
+
+    cp_recov_alert_cg: coverpoint recov_alert;
+  endgroup : edn_alert_cg
+
   `DV_FCOV_INSTANTIATE_CG(edn_cfg_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_endpoints_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_cs_cmds_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(edn_error_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(edn_alert_cg, en_full_cov)
 
   // Sample functions needed for xcelium
   function automatic void cg_cfg_sample(edn_env_cfg cfg);
@@ -102,9 +118,35 @@ interface edn_cov_if (
   endfunction
 
   function automatic void cg_cs_cmds_sample(bit[3:0] clen, bit[3:0] flags, bit[18:0] glen);
-    edn_cs_cmds_cg_inst.sample(clen,
-                               flags,
-                               glen);
+    edn_cs_cmds_cg_inst.sample(clen, flags, glen);
   endfunction
+
+  function automatic void cg_error_sample(bit[31:0] err_code);
+    err_code_test_e enum_val;
+    enum_val = enum_val.first();
+    forever begin
+      if(err_code[enum_val]) begin
+        edn_error_cg_inst.sample(enum_val);
+      end
+      if (enum_val == enum_val.last) begin
+        break;
+      end
+      enum_val = enum_val.next();
+    end
+  endfunction : cg_error_sample
+
+  function automatic void cg_alert_sample(bit[31:0] recov_alert_sts);
+    recov_alert_bit_e enum_val;
+    enum_val = enum_val.first();
+    forever begin
+      if(recov_alert_sts[enum_val]) begin
+        edn_alert_cg_inst.sample(enum_val);
+      end
+      if (enum_val == enum_val.last) begin
+        break;
+      end
+      enum_val = enum_val.next();
+    end
+  endfunction : cg_alert_sample
 
 endinterface : edn_cov_if

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -86,6 +86,14 @@ package edn_env_pkg;
   } err_code_test_e;
 
   typedef enum int {
+    edn_enable_field_alert    = 0,
+    boot_req_mode_field_alert = 1,
+    auto_req_mode_field_alert = 2,
+    cmd_fifo_rst_field_alert  = 3,
+    edn_bus_cmp_alert         = 12
+  } recov_alert_bit_e;
+
+  typedef enum int {
     sfifo_rescmd = 0,
     sfifo_gencmd = 1
   } which_fifo_e;

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -76,7 +76,7 @@ package edn_env_pkg;
   typedef enum int {
     EdnSfifoRescmdErrTest = 0,
     EdnSfifoGencmdErrTest = 1,
-    EdnErrTest            = 2,
+    EdnSfifoOutputErrTest = 2,
     EdnAckSmErrTest       = 20,
     EdnMainSmErrTest      = 21,
     EdnCntrErrTest        = 22,

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -66,6 +66,9 @@ class edn_alert_vseq extends edn_base_vseq;
     exp_recov_alert_sts = 32'b0;
     exp_recov_alert_sts[ral.recov_alert_sts.edn_bus_cmp_alert.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+    if (cfg.en_cov) begin
+      cov_vif.cg_alert_sample(.recov_alert_sts(exp_recov_alert_sts));
+    end
   endtask // edn_bus_cmp_alert
 
   task body();
@@ -103,6 +106,9 @@ class edn_alert_vseq extends edn_base_vseq;
     exp_recov_alert_sts = 32'b0;
     exp_recov_alert_sts[fld.get_lsb_pos()] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+    if (cfg.en_cov) begin
+      cov_vif.cg_alert_sample(.recov_alert_sts(exp_recov_alert_sts));
+    end
 
     // Write valid values
     ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4True);

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -129,7 +129,7 @@ class edn_base_vseq extends cip_base_vseq #(
     if (write_reserved_err_code_test_reg) begin
       `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.err_code_test.err_code_test,
           !(value inside
-          {EdnSfifoRescmdErrTest, EdnSfifoGencmdErrTest, EdnErrTest, EdnAckSmErrTest,
+          {EdnSfifoRescmdErrTest, EdnSfifoGencmdErrTest, EdnSfifoOutputErrTest, EdnAckSmErrTest,
            EdnMainSmErrTest, EdnCntrErrTest, EdnFifoWriteErrTest, EdnFifoReadErrTest,
            EdnFifoStateErrTest});)
       csr_update(ral.err_code_test);

--- a/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_common_vseq.sv
@@ -28,12 +28,25 @@ class edn_common_vseq extends edn_base_vseq;
   endtask : sec_cm_inject_fault
 
   virtual task check_sec_cm_fi_resp(sec_cm_pkg::sec_cm_base_if_proxy if_proxy);
+    bit [31:0] backdoor_err_code_val;
     if (!uvm_re_match("*.cnt_q*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_cntr_err), .compare_value(1'b1));
+      if (cfg.en_cov) begin
+        csr_rd(.ptr(ral.err_code), .value(backdoor_err_code_val));
+        cov_vif.cg_error_sample(.err_code(backdoor_err_code_val));
+      end
     end else if (!uvm_re_match("*.u_edn_ack_sm_ep*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_ack_sm_err), .compare_value(1'b1));
+      if (cfg.en_cov) begin
+        csr_rd(.ptr(ral.err_code), .value(backdoor_err_code_val));
+        cov_vif.cg_error_sample(.err_code(backdoor_err_code_val));
+      end
     end else if (!uvm_re_match("*.u_edn_main_sm*", if_proxy.path)) begin
       csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
+      if (cfg.en_cov) begin
+        csr_rd(.ptr(ral.err_code), .value(backdoor_err_code_val));
+        cov_vif.cg_error_sample(.err_code(backdoor_err_code_val));
+      end
     end
 
     // Check main_sm_state goes to error st.


### PR DESCRIPTION
This PR adds descriptions of the error and alert covergroups for EDN, and it implements and samples them appropriately.

Closes: https://github.com/lowRISC/opentitan/issues/17415