### PR TITLE
[dv/lc_ctrl] Add seq to check claim_transition_if reg

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -58,6 +58,20 @@
       tests: ["lc_ctrl_regwen_during_op"]
     }
     {
+      name: rand_wr_claim_transition_if
+      desc: '''
+            `claim_transition_if` only accept `Mubi8True` or 0 value.
+            This test will write random value to this register.
+            **Checks**:
+            - When write value `Mubi8True` to `claim_transition_if` register, the
+              `transition_regwen` is set to 1.
+            - When write any other value to `claim_transition_if` register, the `transition_regwen`
+              register remains value 0.
+            '''
+      stage: V2
+      tests: ["lc_ctrl_claim_transition_if"]
+    }
+    {
       name: lc_prog_failure
       desc: '''
             This test checks lc_program failure by setting the error bit after otp program request.

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/lc_ctrl_sec_mubi_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_sec_token_mux_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_sec_token_digest_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_claim_transition_if_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Write random value to claim_transition_if register, and check only
+class lc_ctrl_claim_transition_if_vseq extends lc_ctrl_smoke_vseq;
+  `uvm_object_utils(lc_ctrl_claim_transition_if_vseq)
+
+  `uvm_object_new
+
+  rand bit [TL_DW-1:0] rand_claim_trans_val;
+
+  constraint rand_claim_trans_val_c {
+    rand_claim_trans_val dist {
+        CLAIM_TRANS_VAL :/ 1,
+        [0 : CLAIM_TRANS_VAL-1] :/ 1,
+        [CLAIM_TRANS_VAL+1 : $] :/ 1
+    };
+  }
+
+  virtual task pre_start();
+    super.pre_start();
+    cfg.en_scb = 0;
+  endtask
+
+  task body();
+    fork
+      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_flash_rma_rsp(flash_rma_error_rsp);
+    join_none
+
+    csr_wr(ral.claim_transition_if, rand_claim_trans_val);
+    `uvm_info(`gfn, $sformatf("write value %0h to claim_transition_if reg", rand_claim_trans_val),
+              UVM_LOW)
+    if ((rand_claim_trans_val & 'hff) == CLAIM_TRANS_VAL) begin
+      csr_rd_check(.ptr(ral.claim_transition_if), .compare_value(CLAIM_TRANS_VAL));
+      if (lc_state != LcStScrap) begin
+        csr_rd_check(.ptr(ral.transition_regwen), .compare_value(1));
+      end else begin
+        csr_rd_check(.ptr(ral.transition_regwen), .compare_value(0));
+      end
+    end else begin
+      csr_rd_check(.ptr(ral.claim_transition_if), .compare_value((rand_claim_trans_val & 'hff)));
+      csr_rd_check(.ptr(ral.transition_regwen), .compare_value(0));
+    end
+
+  endtask : body
+
+endclass : lc_ctrl_claim_transition_if_vseq

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -17,4 +17,5 @@
 `include "lc_ctrl_sec_mubi_vseq.sv"
 `include "lc_ctrl_sec_token_mux_vseq.sv"
 `include "lc_ctrl_sec_token_digest_vseq.sv"
+`include "lc_ctrl_claim_transition_if_vseq.sv"
 `include "lc_ctrl_stress_all_vseq.sv"

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -106,6 +106,12 @@
     }
 
     {
+      name: lc_ctrl_claim_transition_if
+      uvm_test_seq: lc_ctrl_claim_transition_if_vseq
+      reseed: 10
+    }
+
+    {
       name: lc_ctrl_jtag_smoke
       uvm_test_seq: lc_ctrl_smoke_vseq
       run_opts: ["+jtag_csr=1", "+create_jtag_riscv_map=1"]


### PR DESCRIPTION
In current sequence, we only write value mubi8true or 0 to the `claim_transition_if` reg, we did not write any other values. This PR adds a sequence to write rand value to `claim_transition_if` reg and check the reg only lock when `mubi8true` is written.