### PR TITLE
[flash_ctrl,dv] add close source integration hook

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -73,6 +73,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.
 
+  // Vendor flash model hook
+  bit use_vendor_flash = 0;
+  string vendor_flash_path = "";  // Use to indicate a vendor flash hierarchical path.
+
   uint op_erase_type_bank_pc;
   uint op_prog_type_repair_pc;
   uint op_max_words;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1320,7 +1320,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
   // Populate cfg.mp_info with default_info_page_cfg except scr, ecc.
   // Then program each info region.
-  task flash_ctrl_default_info_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
+  virtual task flash_ctrl_default_info_cfg(otf_cfg_mode_e scr_mode = OTFCfgFalse,
                                    otf_cfg_mode_e ecc_mode = OTFCfgFalse);
     mubi4_t scr_en, ecc_en;
     // If scr/ecc mode is random,


### PR DESCRIPTION
These value can be used in close source env.
- vendor flash indication
- vendor flash hierarchical path

Also skip error data comparison for vendor flash because it is implementation dependent.