### PR TITLE
[lc_ctrl] Raw unlock bypass for test chips 

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -51,6 +51,23 @@
   ////////////////
 
   param_list: [
+    // Secure parameters
+    { name:    "SecVolatileRawUnlockEn",
+      type:    "bit",
+      default: "1'b0",
+      desc:    '''
+        Disable (0) or enable (1) volatile RAW UNLOCK capability.
+        If enabled, it is possible to perform a volatile RAW -> TEST_UNLOCKED0 transition
+        without programming the OTP. This is a useful fallback mode in case the OTP is
+        not working correctly.
+
+        IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+        to 0 in production tapeouts since this weakens the security posture of the RAW 
+        UNLOCK mechanism.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
     // Random netlist constants
     { name:      "RndCnstLcKeymgrDivInvalid",
       desc:      "Compile-time random bits for lc state group diversification value",
@@ -718,6 +735,26 @@
           desc: '''
           When set to 1, the OTP clock will be switched to an externally supplied clock right away when the
           device is in a non-PROD life cycle state. The clock mux will remain switched until the next system reset.
+          '''
+        }
+        { bits: "31:24",
+          name: "VOLATILE_RAW_UNLOCK",
+          swaccess: "rw",
+          mubi: true,
+          resval: false,
+          desc: '''
+          When set to kMultiBitBool8True, LC_CTRL performs a volatile lifecycle transition from RAW -> TEST_UNLOCKED0.
+          No state update will be written to OTP, and no reset will be needed after the transition has succeeded.
+          The same RAW_UNLOCK token has to be provided as for the permanent transition and the token will be passed through KMAC first before performing the token comparison.
+
+          After a successful VOLATILE_RAW_UNLOCK transition from RAW -> TEST_UNLOCKED0, the LC_CTRL FSM will go back to the IdleSt and set the STATUS.TRANSITION_SUCCESSFUL bit.
+          The LC_CTRL accepts further transition commands in this state.
+
+          IMPORTANT NOTE: this feature is intended for test chips only in order to mitigate the risks of a malfunctioning 
+          OTP macro. Production devices will permanently disable this feature at compile time via the SecVolatileRawUnlockEn parameter.
+
+          Software can check whether VOLATILE_RAW_UNLOCK is available by writing kMultiBitBool8True and reading back 
+          the register value. If the register reads back as kMultiBitBool8True the mechanism is available, and if it reads back kMultiBitBool8False it is not.
           '''
         }
       ]

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -26,6 +26,7 @@ module tb;
     LcKeymgrDivWidth'({(LcKeymgrDivWidth/8){8'h5a}});
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction =
     LcKeymgrDivWidth'({(LcKeymgrDivWidth/8){8'ha5}});
+  parameter bit SecVolatileRawUnlockEn = 1;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -100,7 +101,8 @@ module tb;
     .RndCnstLcKeymgrDivTestDevRma(RndCnstLcKeymgrDivTestDevRma),
     .RndCnstLcKeymgrDivProduction(RndCnstLcKeymgrDivProduction),
     .ChipGen(LcCtrlChipGen[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0]),
-    .ChipRev(LcCtrlChipRev[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0])
+    .ChipRev(LcCtrlChipRev[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0]),
+    .SecLcCtrlVolatileRawUnlockEn(SecLcCtrlVolatileRawUnlockEn)
   ) dut (
     .clk_i (clk),
     .rst_ni(rst_n),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -51,8 +51,14 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_reg2hw_transition_cmd_reg_t;
 
   typedef struct packed {
-    logic        q;
-    logic        qe;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ext_clock_en;
+    struct packed {
+      logic [7:0]  q;
+      logic        qe;
+    } volatile_raw_unlock;
   } lc_ctrl_reg2hw_transition_ctrl_reg_t;
 
   typedef struct packed {
@@ -115,7 +121,12 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_transition_regwen_reg_t;
 
   typedef struct packed {
-    logic        d;
+    struct packed {
+      logic        d;
+    } ext_clock_en;
+    struct packed {
+      logic [7:0]  d;
+    } volatile_raw_unlock;
   } lc_ctrl_hw2reg_transition_ctrl_reg_t;
 
   typedef struct packed {
@@ -165,10 +176,10 @@ package lc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [214:209]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [208:200]
-    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [199:198]
-    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [197:196]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [223:218]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [217:209]
+    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [208:207]
+    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [206:196]
     lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [195:64]
     lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [63:33]
     lc_ctrl_reg2hw_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [32:0]
@@ -176,10 +187,10 @@ package lc_ctrl_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [853:843]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [842:835]
-    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [834:834]
-    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [833:833]
+    lc_ctrl_hw2reg_status_reg_t status; // [861:851]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [850:843]
+    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [842:842]
+    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [841:833]
     lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [832:705]
     lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [704:675]
     lc_ctrl_hw2reg_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [674:643]
@@ -239,7 +250,8 @@ package lc_ctrl_reg_pkg;
   parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_TRANSITION_REGWEN_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_TRANSITION_CMD_RESVAL = 1'h 0;
-  parameter logic [0:0] LC_CTRL_TRANSITION_CTRL_RESVAL = 1'h 0;
+  parameter logic [31:0] LC_CTRL_TRANSITION_CTRL_RESVAL = 32'h 69000000;
+  parameter logic [7:0] LC_CTRL_TRANSITION_CTRL_VOLATILE_RAW_UNLOCK_RESVAL = 8'h 69;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_0_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_1_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;
@@ -314,7 +326,7 @@ package lc_ctrl_reg_pkg;
     4'b 0001, // index[ 3] LC_CTRL_CLAIM_TRANSITION_IF
     4'b 0001, // index[ 4] LC_CTRL_TRANSITION_REGWEN
     4'b 0001, // index[ 5] LC_CTRL_TRANSITION_CMD
-    4'b 0001, // index[ 6] LC_CTRL_TRANSITION_CTRL
+    4'b 1111, // index[ 6] LC_CTRL_TRANSITION_CTRL
     4'b 1111, // index[ 7] LC_CTRL_TRANSITION_TOKEN_0
     4'b 1111, // index[ 8] LC_CTRL_TRANSITION_TOKEN_1
     4'b 1111, // index[ 9] LC_CTRL_TRANSITION_TOKEN_2

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -153,8 +153,10 @@ module lc_ctrl_reg_top (
   logic transition_cmd_wd;
   logic transition_ctrl_re;
   logic transition_ctrl_we;
-  logic transition_ctrl_qs;
-  logic transition_ctrl_wd;
+  logic transition_ctrl_ext_clock_en_qs;
+  logic transition_ctrl_ext_clock_en_wd;
+  logic [7:0] transition_ctrl_volatile_raw_unlock_qs;
+  logic [7:0] transition_ctrl_volatile_raw_unlock_wd;
   logic transition_token_0_re;
   logic transition_token_0_we;
   logic [31:0] transition_token_0_qs;
@@ -535,25 +537,42 @@ module lc_ctrl_reg_top (
 
   // R[transition_ctrl]: V(True)
   logic transition_ctrl_qe;
-  logic [0:0] transition_ctrl_flds_we;
+  logic [1:0] transition_ctrl_flds_we;
   assign transition_ctrl_qe = &transition_ctrl_flds_we;
   // Create REGWEN-gated WE signal
   logic transition_ctrl_gated_we;
   assign transition_ctrl_gated_we = transition_ctrl_we & transition_regwen_qs;
+  //   F[ext_clock_en]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_transition_ctrl (
+  ) u_transition_ctrl_ext_clock_en (
     .re     (transition_ctrl_re),
     .we     (transition_ctrl_gated_we),
-    .wd     (transition_ctrl_wd),
-    .d      (hw2reg.transition_ctrl.d),
+    .wd     (transition_ctrl_ext_clock_en_wd),
+    .d      (hw2reg.transition_ctrl.ext_clock_en.d),
     .qre    (),
     .qe     (transition_ctrl_flds_we[0]),
-    .q      (reg2hw.transition_ctrl.q),
+    .q      (reg2hw.transition_ctrl.ext_clock_en.q),
     .ds     (),
-    .qs     (transition_ctrl_qs)
+    .qs     (transition_ctrl_ext_clock_en_qs)
   );
-  assign reg2hw.transition_ctrl.qe = transition_ctrl_qe;
+  assign reg2hw.transition_ctrl.ext_clock_en.qe = transition_ctrl_qe;
+
+  //   F[volatile_raw_unlock]: 31:24
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_transition_ctrl_volatile_raw_unlock (
+    .re     (transition_ctrl_re),
+    .we     (transition_ctrl_gated_we),
+    .wd     (transition_ctrl_volatile_raw_unlock_wd),
+    .d      (hw2reg.transition_ctrl.volatile_raw_unlock.d),
+    .qre    (),
+    .qe     (transition_ctrl_flds_we[1]),
+    .q      (reg2hw.transition_ctrl.volatile_raw_unlock.q),
+    .ds     (),
+    .qs     (transition_ctrl_volatile_raw_unlock_qs)
+  );
+  assign reg2hw.transition_ctrl.volatile_raw_unlock.qe = transition_ctrl_qe;
 
 
   // Subregister 0 of Multireg transition_token
@@ -1170,7 +1189,9 @@ module lc_ctrl_reg_top (
   assign transition_ctrl_re = addr_hit[6] & reg_re & !reg_error;
   assign transition_ctrl_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign transition_ctrl_wd = reg_wdata[0];
+  assign transition_ctrl_ext_clock_en_wd = reg_wdata[0];
+
+  assign transition_ctrl_volatile_raw_unlock_wd = reg_wdata[31:24];
   assign transition_token_0_re = addr_hit[7] & reg_re & !reg_error;
   assign transition_token_0_we = addr_hit[7] & reg_we & !reg_error;
 
@@ -1297,7 +1318,8 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[0] = transition_ctrl_qs;
+        reg_rdata_next[0] = transition_ctrl_ext_clock_en_qs;
+        reg_rdata_next[31:24] = transition_ctrl_volatile_raw_unlock_qs;
       end
 
       addr_hit[7]: begin

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
@@ -8,7 +8,9 @@
 module lc_ctrl_state_transition
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;
-(
+#(
+  parameter bit             SecVolatileRawUnlockEn = 0
+) (
   // Life cycle state vector.
   input  lc_state_e         lc_state_i,
   input  lc_cnt_e           lc_cnt_i,
@@ -18,6 +20,12 @@ module lc_ctrl_state_transition
   input  ext_dec_lc_state_t dec_lc_state_i,
   // Transition target.
   input  ext_dec_lc_state_t trans_target_i,
+  // ------ VOLATILE_TEST_UNLOCKED CODE SECTION START ------
+  // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+  // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED VIA
+  // SecVolatileRawUnlockEn AT COMPILETIME FOR PRODUCTION DEVICES.
+  input prim_mubi_pkg::mubi8_t  volatile_raw_unlock_i,
+  // ------ VOLATILE_TEST_UNLOCKED CODE SECTION END ------
   // Updated state vector.
   output lc_state_e         next_lc_state_o,
   output lc_cnt_e           next_lc_cnt_o,
@@ -48,40 +56,56 @@ module lc_ctrl_state_transition
                             TokenCheck0St,
                             TokenCheck1St,
                             TransProgSt}) begin
-      // In this state, the life cycle counter is incremented.
-      // Throw an error if the counter is already maxed out.
-      unique case (lc_cnt_i)
-        LcCnt0:   next_lc_cnt_o = LcCnt1;
-        LcCnt1:   next_lc_cnt_o = LcCnt2;
-        LcCnt2:   next_lc_cnt_o = LcCnt3;
-        LcCnt3:   next_lc_cnt_o = LcCnt4;
-        LcCnt4:   next_lc_cnt_o = LcCnt5;
-        LcCnt5:   next_lc_cnt_o = LcCnt6;
-        LcCnt6:   next_lc_cnt_o = LcCnt7;
-        LcCnt7:   next_lc_cnt_o = LcCnt8;
-        LcCnt8:   next_lc_cnt_o = LcCnt9;
-        LcCnt9:   next_lc_cnt_o = LcCnt10;
-        LcCnt10:  next_lc_cnt_o = LcCnt11;
-        LcCnt11:  next_lc_cnt_o = LcCnt12;
-        LcCnt12:  next_lc_cnt_o = LcCnt13;
-        LcCnt13:  next_lc_cnt_o = LcCnt14;
-        LcCnt14:  next_lc_cnt_o = LcCnt15;
-        LcCnt15:  next_lc_cnt_o = LcCnt16;
-        LcCnt16:  next_lc_cnt_o = LcCnt17;
-        LcCnt17:  next_lc_cnt_o = LcCnt18;
-        LcCnt18:  next_lc_cnt_o = LcCnt19;
-        LcCnt19:  next_lc_cnt_o = LcCnt20;
-        LcCnt20:  next_lc_cnt_o = LcCnt21;
-        LcCnt21:  next_lc_cnt_o = LcCnt22;
-        LcCnt22:  next_lc_cnt_o = LcCnt23;
-        LcCnt23:  next_lc_cnt_o = LcCnt24;
-        LcCnt24:  trans_cnt_oflw_error_o = 1'b1;
-        default:  trans_cnt_oflw_error_o = 1'b1;
-      endcase // lc_cnt_i
+      // ------ VOLATILE_TEST_UNLOCKED CODE SECTION START ------
+      // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+      // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED VIA
+      // SecVolatileRawUnlockEn AT COMPILETIME FOR PRODUCTION DEVICES.
+      // If the volatile RAW unlock is enabled, the TransProgSt can be skipped iff we are in RAW state.
+      if (SecVolatileRawUnlockEn &&
+          prim_mubi_pkg::mubi8_test_true_strict(volatile_raw_unlock_i)) begin
+        if (dec_lc_state_i[0] != DecLcStRaw ||
+            dec_lc_state_i[1] != DecLcStRaw ||
+            trans_target_i[0] != DecLcStTestUnlocked0 ||
+            trans_target_i[1] != DecLcStTestUnlocked0) begin
+          trans_invalid_error_o = 1'b1;
+        end
+      // ------ VOLATILE_TEST_UNLOCKED CODE SECTION END ------
+      end else begin
+        // In this state, the life cycle counter is incremented.
+        // Throw an error if the counter is already maxed out.
+        unique case (lc_cnt_i)
+          LcCnt0:   next_lc_cnt_o = LcCnt1;
+          LcCnt1:   next_lc_cnt_o = LcCnt2;
+          LcCnt2:   next_lc_cnt_o = LcCnt3;
+          LcCnt3:   next_lc_cnt_o = LcCnt4;
+          LcCnt4:   next_lc_cnt_o = LcCnt5;
+          LcCnt5:   next_lc_cnt_o = LcCnt6;
+          LcCnt6:   next_lc_cnt_o = LcCnt7;
+          LcCnt7:   next_lc_cnt_o = LcCnt8;
+          LcCnt8:   next_lc_cnt_o = LcCnt9;
+          LcCnt9:   next_lc_cnt_o = LcCnt10;
+          LcCnt10:  next_lc_cnt_o = LcCnt11;
+          LcCnt11:  next_lc_cnt_o = LcCnt12;
+          LcCnt12:  next_lc_cnt_o = LcCnt13;
+          LcCnt13:  next_lc_cnt_o = LcCnt14;
+          LcCnt14:  next_lc_cnt_o = LcCnt15;
+          LcCnt15:  next_lc_cnt_o = LcCnt16;
+          LcCnt16:  next_lc_cnt_o = LcCnt17;
+          LcCnt17:  next_lc_cnt_o = LcCnt18;
+          LcCnt18:  next_lc_cnt_o = LcCnt19;
+          LcCnt19:  next_lc_cnt_o = LcCnt20;
+          LcCnt20:  next_lc_cnt_o = LcCnt21;
+          LcCnt21:  next_lc_cnt_o = LcCnt22;
+          LcCnt22:  next_lc_cnt_o = LcCnt23;
+          LcCnt23:  next_lc_cnt_o = LcCnt24;
+          LcCnt24:  trans_cnt_oflw_error_o = 1'b1;
+          default:  trans_cnt_oflw_error_o = 1'b1;
+        endcase // lc_cnt_i
 
-      // In case the transition target is SCRAP, max out the counter.
-      if (trans_target_i == {DecLcStateNumRep{DecLcStScrap}}) begin
-        next_lc_cnt_o = LcCnt24;
+        // In case the transition target is SCRAP, max out the counter.
+        if (trans_target_i == {DecLcStateNumRep{DecLcStScrap}}) begin
+          next_lc_cnt_o = LcCnt24;
+        end
       end
     end
 
@@ -102,35 +126,51 @@ module lc_ctrl_state_transition
         // check twice with different indices into the replicated state enumeration.
         if (TransTokenIdxMatrix[dec_lc_state_i[0]][trans_target_i[0]] != InvalidTokenIdx ||
             TransTokenIdxMatrix[dec_lc_state_i[1]][trans_target_i[1]] != InvalidTokenIdx) begin
-          // Encode the target state.
-          // Note that the life cycle encoding itself also ensures that only certain transitions are
-          // possible. So even if this logic here is tampered with, the encoding values won't allow
-          // an invalid transition (instead, the programming operation will fail and leave the life
-          // cycle state corrupted/invalid).
-          unique case (trans_target_i)
-            {DecLcStateNumRep{DecLcStRaw}}:           next_lc_state_o = LcStRaw;
-            {DecLcStateNumRep{DecLcStTestUnlocked0}}: next_lc_state_o = LcStTestUnlocked0;
-            {DecLcStateNumRep{DecLcStTestLocked0}}:   next_lc_state_o = LcStTestLocked0;
-            {DecLcStateNumRep{DecLcStTestUnlocked1}}: next_lc_state_o = LcStTestUnlocked1;
-            {DecLcStateNumRep{DecLcStTestLocked1}}:   next_lc_state_o = LcStTestLocked1;
-            {DecLcStateNumRep{DecLcStTestUnlocked2}}: next_lc_state_o = LcStTestUnlocked2;
-            {DecLcStateNumRep{DecLcStTestLocked2}}:   next_lc_state_o = LcStTestLocked2;
-            {DecLcStateNumRep{DecLcStTestUnlocked3}}: next_lc_state_o = LcStTestUnlocked3;
-            {DecLcStateNumRep{DecLcStTestLocked3}}:   next_lc_state_o = LcStTestLocked3;
-            {DecLcStateNumRep{DecLcStTestUnlocked4}}: next_lc_state_o = LcStTestUnlocked4;
-            {DecLcStateNumRep{DecLcStTestLocked4}}:   next_lc_state_o = LcStTestLocked4;
-            {DecLcStateNumRep{DecLcStTestUnlocked5}}: next_lc_state_o = LcStTestUnlocked5;
-            {DecLcStateNumRep{DecLcStTestLocked5}}:   next_lc_state_o = LcStTestLocked5;
-            {DecLcStateNumRep{DecLcStTestUnlocked6}}: next_lc_state_o = LcStTestUnlocked6;
-            {DecLcStateNumRep{DecLcStTestLocked6}}:   next_lc_state_o = LcStTestLocked6;
-            {DecLcStateNumRep{DecLcStTestUnlocked7}}: next_lc_state_o = LcStTestUnlocked7;
-            {DecLcStateNumRep{DecLcStDev}}:           next_lc_state_o = LcStDev;
-            {DecLcStateNumRep{DecLcStProd}}:          next_lc_state_o = LcStProd;
-            {DecLcStateNumRep{DecLcStProdEnd}}:       next_lc_state_o = LcStProdEnd;
-            {DecLcStateNumRep{DecLcStRma}}:           next_lc_state_o = LcStRma;
-            {DecLcStateNumRep{DecLcStScrap}}:         next_lc_state_o = LcStScrap;
-            default:                                  trans_invalid_error_o = 1'b1;
-          endcase // trans_target_i
+          // ------ VOLATILE_TEST_UNLOCKED CODE SECTION START ------
+          // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+          // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED VIA
+          // SecVolatileRawUnlockEn AT COMPILETIME FOR PRODUCTION DEVICES.
+          // If the volatile RAW unlock is enabled, the TransProgSt can be skipped iff we are in RAW state.
+          if (SecVolatileRawUnlockEn &&
+              prim_mubi_pkg::mubi8_test_true_strict(volatile_raw_unlock_i)) begin
+              if (dec_lc_state_i[0] == DecLcStRaw ||
+                  dec_lc_state_i[1] == DecLcStRaw ||
+                  trans_target_i[0] == DecLcStTestUnlocked0 ||
+                  trans_target_i[1] == DecLcStTestUnlocked0) begin
+                trans_invalid_error_o = 1'b1;
+              end
+          // ------ VOLATILE_TEST_UNLOCKED CODE SECTION END ------
+          end else begin
+            // Encode the target state.
+            // Note that the life cycle encoding itself also ensures that only certain transitions are
+            // possible. So even if this logic here is tampered with, the encoding values won't allow
+            // an invalid transition (instead, the programming operation will fail and leave the life
+            // cycle state corrupted/invalid).
+            unique case (trans_target_i)
+              {DecLcStateNumRep{DecLcStRaw}}:           next_lc_state_o = LcStRaw;
+              {DecLcStateNumRep{DecLcStTestUnlocked0}}: next_lc_state_o = LcStTestUnlocked0;
+              {DecLcStateNumRep{DecLcStTestLocked0}}:   next_lc_state_o = LcStTestLocked0;
+              {DecLcStateNumRep{DecLcStTestUnlocked1}}: next_lc_state_o = LcStTestUnlocked1;
+              {DecLcStateNumRep{DecLcStTestLocked1}}:   next_lc_state_o = LcStTestLocked1;
+              {DecLcStateNumRep{DecLcStTestUnlocked2}}: next_lc_state_o = LcStTestUnlocked2;
+              {DecLcStateNumRep{DecLcStTestLocked2}}:   next_lc_state_o = LcStTestLocked2;
+              {DecLcStateNumRep{DecLcStTestUnlocked3}}: next_lc_state_o = LcStTestUnlocked3;
+              {DecLcStateNumRep{DecLcStTestLocked3}}:   next_lc_state_o = LcStTestLocked3;
+              {DecLcStateNumRep{DecLcStTestUnlocked4}}: next_lc_state_o = LcStTestUnlocked4;
+              {DecLcStateNumRep{DecLcStTestLocked4}}:   next_lc_state_o = LcStTestLocked4;
+              {DecLcStateNumRep{DecLcStTestUnlocked5}}: next_lc_state_o = LcStTestUnlocked5;
+              {DecLcStateNumRep{DecLcStTestLocked5}}:   next_lc_state_o = LcStTestLocked5;
+              {DecLcStateNumRep{DecLcStTestUnlocked6}}: next_lc_state_o = LcStTestUnlocked6;
+              {DecLcStateNumRep{DecLcStTestLocked6}}:   next_lc_state_o = LcStTestLocked6;
+              {DecLcStateNumRep{DecLcStTestUnlocked7}}: next_lc_state_o = LcStTestUnlocked7;
+              {DecLcStateNumRep{DecLcStDev}}:           next_lc_state_o = LcStDev;
+              {DecLcStateNumRep{DecLcStProd}}:          next_lc_state_o = LcStProd;
+              {DecLcStateNumRep{DecLcStProdEnd}}:       next_lc_state_o = LcStProdEnd;
+              {DecLcStateNumRep{DecLcStRma}}:           next_lc_state_o = LcStRma;
+              {DecLcStateNumRep{DecLcStScrap}}:         next_lc_state_o = LcStScrap;
+              default:                                  trans_invalid_error_o = 1'b1;
+            endcase // trans_target_i
+          end
         end else begin
           trans_invalid_error_o = 1'b1;
         end

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1533,6 +1533,7 @@
       }
       param_decl:
       {
+        SecVolatileRawUnlockEn: "1"
         ChipGen: 16'h 0000
         ChipRev: 16'h 0000
         IdcodeValue: jtag_id_pkg::JTAG_IDCODE
@@ -1549,6 +1550,24 @@
       memory: {}
       param_list:
       [
+        {
+          name: SecVolatileRawUnlockEn
+          desc:
+            '''
+            Disable (0) or enable (1) volatile RAW UNLOCK capability.
+            If enabled, it is possible to perform a volatile RAW -> TEST_UNLOCKED0 transition
+            without programming the OTP. This is a useful fallback mode in case the OTP is
+            not working correctly.
+
+            IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+            to 0 in production tapeouts since this weakens the security posture of the RAW 
+            UNLOCK mechanism.
+            '''
+          type: bit
+          default: "1"
+          expose: "true"
+          name_top: SecLcCtrlVolatileRawUnlockEn
+        }
         {
           name: RndCnstLcKeymgrDivInvalid
           desc: Compile-time random bits for lc state group diversification value

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -304,6 +304,10 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "lc"},
       base_addr: "0x40140000",
       param_decl: {
+        // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+        // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR 
+        // PRODUCTION DEVICES.
+        SecVolatileRawUnlockEn: "1",
         ChipGen: "16'h 0000",
         ChipRev: "16'h 0000",
         IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -28,6 +28,7 @@ module top_earlgrey #(
   // parameters for otp_ctrl
   parameter OtpCtrlMemInitFile = "",
   // parameters for lc_ctrl
+  parameter bit SecLcCtrlVolatileRawUnlockEn = 1,
   parameter logic [15:0] LcCtrlChipGen = 16'h 0000,
   parameter logic [15:0] LcCtrlChipRev = 16'h 0000,
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
@@ -1441,6 +1442,7 @@ module top_earlgrey #(
   );
   lc_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:16]),
+    .SecVolatileRawUnlockEn(SecLcCtrlVolatileRawUnlockEn),
     .RndCnstLcKeymgrDivInvalid(RndCnstLcCtrlLcKeymgrDivInvalid),
     .RndCnstLcKeymgrDivTestDevRma(RndCnstLcCtrlLcKeymgrDivTestDevRma),
     .RndCnstLcKeymgrDivProduction(RndCnstLcCtrlLcKeymgrDivProduction),


### PR DESCRIPTION
Addresses https://github.com/lowRISC/opentitan/issues/18246

This solution still uses KMAC token hashing, but the overall RTL diff is larger.