### PR TITLE
[dv/pwrmgr] Address some M2.5 pending issues

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -213,7 +213,6 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     // process the csr req
     // for write, update local variable and fifo at address phase
     // for read, update predication at address phase and compare at data phase
-    // TODO handle more read checks.
     case (csr.get_name())
       // add individual case item for each csr
       "intr_state": begin

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -190,8 +190,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task dut_shutdown();
-    // check for pending pwrmgr operations and wait for them to complete
-    // TODO
+    // There are no known checks to perform here.
   endtask
 
   virtual task apply_reset(string kind = "HARD");

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -25,10 +25,9 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
 
   // Cause some delays for the rom_ctrl done and good inputs. Simple, enough to hold the
   // transition to active state.
-  // Consider adding SVA to monitor fast state transitions are compliant
-  // with "ROM Integrity Checks" at
-  // https://docs.opentitan.org/hw/ip/pwrmgr/doc/#fast-clock-domain-fsm
-  // TODO(maturana) https://github.com/lowRISC/opentitan/issues/10241
+  // ICEBOX(lowrisc/opentitan#18236) Consider adding checks to monitor fast state transitions are
+  // compliant with "ROM Integrity Checks" at
+  // https://opentitan.org/book/hw/ip/pwrmgr/doc/theory_of_operation.html#rom-integrity-checks
   virtual task twirl_rom_response();
     cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
     cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -24,7 +24,6 @@
   ral_spec: "{proj_root}/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
@@ -143,7 +142,6 @@
       uvm_test_seq: pwrmgr_lowpower_invalid_vseq
       run_opts: ["+test_timeout_ns=1000000"]
     }
-    // TODO: add more tests here
   ]
 
   // List of regressions.


### PR DESCRIPTION
Add reset_cause checks in pwrmgr_rstreqs_sva_if.
Add an ICEBOX to add monitoring for rom integrity effect on fast fsm. Improve disable_rom_integrity_check test to improve coverage. Remove irrelevant TODOs.

Partially addresses #17910 and #17500