### PR TITLE
[doc] Add contribution header pages

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -433,7 +433,7 @@
   - [Bazel Notes](./doc/contributing/bazel_notes.md)
   - [Using the Container](./util/container/README.md)
 
-- [Contributing to Hardware]()
+- [Contributing to Hardware](./doc/contributing/hw/README.md)
   - [Comportability](./doc/contributing/hw/comportability/README.md)
   - [Hardware Design](./doc/contributing/hw/design.md)
   - [Design Methodology](./doc/contributing/hw/methodology.md)
@@ -441,12 +441,12 @@
   - [Linting](./hw/lint/README.md)
   - [Synthesis Flow](./hw/syn/README.md)
 
-- [Contributing to Verification]()
+- [Contributing to Verification](./doc/contributing/dv/README.md)
   - [Verification Methodology](./doc/contributing/dv/methodology/README.md)
   - [Security Countermeasure Verification Framework](./doc/contributing/dv/sec_cm_dv_framework/README.md)
   - [Assertions](./hw/formal/README.md)
 
-- [Contributing to Software]()
+- [Contributing to Software](./doc/contributing/sw/README.md)
   - [Device Interface Functions](./doc/contributing/sw/device_interface_functions.md)
   - [Writing and Building Software for OTBN](./doc/contributing/sw/otbn_sw.md)
 
@@ -459,7 +459,7 @@
   - [OTBN Assembly](./doc/contributing/style_guides/otbn_style_guide.md)
   - [Guidance for Volatile](./doc/contributing/style_guides/guidance_for_volatile.md)
 
-- [Developing on an FPGA]()
+- [Developing on an FPGA](./doc/contributing/fpga/README.md)
   - [Get a Board](./doc/contributing/fpga/get_a_board.md)
   - [FPGA Reference Manual](./doc/contributing/fpga/ref_manual_fpga.md)
 

--- a/doc/contributing/dv/README.md
+++ b/doc/contributing/dv/README.md
@@ -1,0 +1,7 @@
+# Contributing to Verification
+
+Verification is an essential part of making OpenTitan a system that can be used confidently for both research and industrial applications.
+Please have a look at the following pages for more information:
+- [Verification Methodology](./methodology/README.md)
+- [Security Countermeasure Verification Framework](./sec_cm_dv_framework/README.md)
+- [Assertions](../../../hw/formal/README.md)

--- a/doc/contributing/fpga/README.md
+++ b/doc/contributing/fpga/README.md
@@ -1,0 +1,7 @@
+# Developing on an FPGA
+
+We can do a lot of developing and testing using simulations, but sometimes it is useful to test on a platform that is closer to hardware.
+Field programmable gate arrays (FPGAs) provide exactly this sort of platform with reconfigurable hardware.
+To learn more about how to develop OpenTitan using an FPGA, consult the following links:
+- [Get a Board](./get_a_board.md)
+- [FPGA Reference Manual](./ref_manual_fpga.md)

--- a/doc/contributing/hw/README.md
+++ b/doc/contributing/hw/README.md
@@ -1,0 +1,10 @@
+# Contributing to Hardware
+
+OpenTitan is an open-source silicon project, so naturally there are lots of aspects of the hardware design to contribute to.
+Please start by having a look at the following pages:
+- [Comportability](./comportability/README.md)
+- [Hardware Design](./design.md)
+- [Design Methodology](./methodology.md)
+- [Vendoring in Hardware](./vendor.md)
+- [Linting](../../../hw/lint/README.md)
+- [Synthesis Flow](../../../hw/syn/README.md)

--- a/doc/contributing/sw/README.md
+++ b/doc/contributing/sw/README.md
@@ -1,0 +1,7 @@
+# Contributing to Software
+
+Software is an important part of testing and deploying OpenTitan.
+One important distinction when discussing software is that there are multiple [cores](../../../hw/doc/cores.md) in OpenTitan that can run software, as well as software that runs on an accompanying PC for test and development purposes.
+For more information about contributing to OpenTitan software see the following pages:
+- [Device Interface Functions](./device_interface_functions.md)
+- [Writing and Building Software for OTBN](./otbn_sw.md)

--- a/hw/doc/cores.md
+++ b/hw/doc/cores.md
@@ -1,4 +1,9 @@
 # Cores
 
-* [Ibex](../ip/rv_core_ibex/README.md)
-* [OTBN](../ip/otbn/README.md)
+Cores in OpenTitan are processing units that can run programs.
+
+Currently, there are two cores in OpenTitan:
+* [Ibex](../ip/rv_core_ibex/README.md) (RV32IMCB)
+* [OTBN](../ip/otbn/README.md) (programmable coprocessor for asymmetric cryptographic algorithms, 256-bit datapath)
+
+Since cores are the interface between hardware and software, please also consult the [software resources](../../sw/README.md).


### PR DESCRIPTION
I added header pages for the pages in the contribution chapter. I also fleshed out the cores page a bit more, since it seemed a bit bare.

One nice thing about adding the header pages is that I think it looks visually better in the book.

Before:
![image](https://user-images.githubusercontent.com/34654485/235172265-509b2884-acb4-4c30-972f-592b9cd5b9a4.png)

After:
![image](https://user-images.githubusercontent.com/34654485/235172160-ec8c7b8a-66b4-4484-94e9-dbaae4220683.png)
