### PR TITLE
[ci] Increase airgapped build test timeout to 120 mins

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ jobs:
 
 - job: airgapped_bazel_build
   displayName: Test an airgapped Bazel build
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   dependsOn: checkout
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:


### PR DESCRIPTION
The CI job's run time is in the upper 80 mins when it passes, and PRs have been occasionally failing. Increase the timeout to match the current run time distribution.