### PR TITLE
[lc_ctrl] Add raw unlock bypass for test chips

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -51,6 +51,23 @@
   ////////////////
 
   param_list: [
+    // Secure parameters
+    { name:    "SecVolatileRawUnlockEn",
+      type:    "bit",
+      default: "1'b0",
+      desc:    '''
+        Disable (0) or enable (1) volatile RAW UNLOCK capability.
+        If enabled, it is possible to perform a volatile RAW -> TEST_UNLOCKED0 transition
+        without programming the OTP. This is a useful fallback mode in case the OTP is
+        not working correctly.
+
+        IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+        to 0 in production tapeouts since this weakens the security posture of the RAW
+        UNLOCK mechanism.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
     // Random netlist constants
     { name:      "RndCnstLcKeymgrDivInvalid",
       desc:      "Compile-time random bits for lc state group diversification value",
@@ -382,6 +399,19 @@
       act:     "req",
       package: "lc_ctrl_pkg",
       default: "'0"
+    },
+    // Strap sampling override pulse.
+    { struct:  "logic",
+      type:    "uni",
+      name:    "strap_en_override",
+      act:     "req",
+      desc:    '''
+               This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+               The signal stays at 1 until reset.
+               Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+               Otherwise this signal is tied off to 0.
+               ''',
+      default: "1'b0"
     },
   ] // inter_signal_list
 
@@ -718,6 +748,24 @@
           desc: '''
           When set to 1, the OTP clock will be switched to an externally supplied clock right away when the
           device is in a non-PROD life cycle state. The clock mux will remain switched until the next system reset.
+          '''
+        }
+        { bits: "1",
+          name: "VOLATILE_RAW_UNLOCK",
+          swaccess: "rw",
+          desc: '''
+          When set to 1, LC_CTRL performs a volatile lifecycle transition from RAW -> TEST_UNLOCKED0.
+          No state update will be written to OTP, and no reset will be needed after the transition has succeeded.
+          Note that the token to be provided has to be the hashed unlock token, since in this case the token is NOT passed through KMAC before performing the comparison.
+
+          After a successful VOLATILE_RAW_UNLOCK transition from RAW -> TEST_UNLOCKED0, the LC_CTRL FSM will go back to the IdleSt and set the STATUS.TRANSITION_SUCCESSFUL bit.
+          The LC_CTRL accepts further transition commands in this state.
+
+          IMPORTANT NOTE: this feature is intended for test chips only in order to mitigate the risks of a malfunctioning
+          OTP macro. Production devices will permanently disable this feature at compile time via the SecVolatileRawUnlockEn parameter.
+
+          Software can check whether VOLATILE_RAW_UNLOCK is available by writing 1 and reading back
+          the register value. If the register reads back as 1 the mechanism is available, and if it reads back 0 it is not.
           '''
         }
       ]

--- a/hw/ip/lc_ctrl/doc/programmers_guide.md
+++ b/hw/ip/lc_ctrl/doc/programmers_guide.md
@@ -1,20 +1,21 @@
 # Programmer's Guide
 
 The register layout and offsets shown in the [register table](../data/lc_ctrl.hjson#registers) below are identical for both the CSR and JTAG TAP interfaces.
-Hence the following programming sequence applies to both SW running on the device and SW running on the test appliance that accesses life cycle through the TAP.
+Hence the following programming sequences apply to both SW running on the device and SW running on the test appliance that accesses life cycle through the TAP.
+
+## Regular Life Cycle Transitions
 
 1. In order to perform a life cycle transition, SW should first check whether the life cycle controller has successfully initialized and is ready to accept a transition command by making sure that the [`STATUS.READY`](../data/lc_ctrl.hjson#status) bit is set to 1, and that all other status and error bits in [`STATUS`](../data/lc_ctrl.hjson#status) are set to 0.
 
 2. Read the [`LC_STATE`](../data/lc_ctrl.hjson#lc_state) and [`LC_TRANSITION_CNT`](../data/lc_ctrl.hjson#lc_transition_cnt) registers to determine which life cycle state the device currently is in, and how many transition attempts are still available.
 
-3. Claim exclusive access to the transition interface by writing kMuBi8True to the [`CLAIM_TRANSITION_IF`](../data/lc_ctrl.hjson#claim_transition_if) register, and reading it back. If the value read back equals to kMuBi8True, the hardware mutex has successfully been claimed and SW can proceed to step 4. If the value read back equals to 0, the mutex has already been claimed by the other interface (either CSR or TAP), and SW should try claiming the mutex again.
+3. Claim exclusive access to the transition interface by writing `kMuBi8True` to the [`CLAIM_TRANSITION_IF`](../data/lc_ctrl.hjson#claim_transition_if) register, and reading it back. If the value read back equals to `kMuBi8True`, the hardware mutex has successfully been claimed and SW can proceed to step 4. If the value read back equals to 0, the mutex has already been claimed by the other interface (either CSR or TAP), and SW should try claiming the mutex again.
 Note that all transition interface registers are protected by the hardware-governed [`TRANSITION_REGWEN`](../data/lc_ctrl.hjson#transition_regwen) register, which will only be set to 1 if the mutex has been claimed successfully.
 
-4. If required, enable the external clock and other vendor-specific OTP settings in the [`OTP_VENDOR_TEST_CTRL`](../data/lc_ctrl.hjson#otp_vendor_test_ctrl) register.
-Note that these settings only take effect in RAW, TEST* and RMA life cycle states.
-They are ignored in the PROD* and DEV states.
+4. If required, software can switch to the external clock via the [`OTP_VENDOR_TEST_CTRL.EXT_CLK_EN`](../data/lc_ctrl.hjson#otp_vendor_test_ctrl#ext_clk_en) register in `RAW`, `TEST*` and `RMA` life cycle states.
+   This setting is ignored in the `PROD*` and `DEV` states.
 
-5. Write the desired target state to [`TRANSITION_TARGET`](../data/lc_ctrl.hjson#transition_target). For conditional transitions, the corresponding token has to be written to [`TRANSITION_TOKEN_0`](../data/lc_ctrl.hjson#transition_token_0). For all unconditional transitions, the token registers have to be set to zero.
+5. Write the desired target state to [`TRANSITION_TARGET`](../data/lc_ctrl.hjson#transition_target). For conditional transitions, the corresponding token has to be written to [`TRANSITION_TOKEN`](../data/lc_ctrl.hjson#transition_token). For all unconditional transitions, the token registers have to be set to zero.
 
 6. An optional, but recommended step is to read back and verify the values written in steps 4. and 5. before proceeding with step 7.
 
@@ -23,11 +24,45 @@ They are ignored in the PROD* and DEV states.
 8. Poll the [`STATUS`](../data/lc_ctrl.hjson#status) register and wait until either [`STATUS.TRANSITION_SUCCESSFUL`](../data/lc_ctrl.hjson#status) or any of the error bits is asserted.
 The [`TRANSITION_REGWEN`](../data/lc_ctrl.hjson#transition_regwen) register will be set to 0 while a transition is in progress in order to prevent any accidental modifications of the transition interface registers during this phase.
 
-Note that any life cycle state transition - no matter whether successful or not - increments the LC_TRANSITION_CNT and moves the life cycle state into the temporary POST_TRANSITION state.
+9. Reset the device so that the new life cycle state becomes effective.
+
+Note that all life cycle state transition increments the `LC_TRANSITION_CNT` and moves the life cycle state into the temporary POST_TRANSITION state - even if the transition was unsuccessful.
 Hence, step 8. cannot be carried out in case device SW is used to implement the programming sequence above, since the processor is disabled in the POST_TRANSITION life cycle state.
 
 This behavior is however not of concern, since access to the transition interface via the CSRs is considered a convenience feature for bringup in the lab.
 It is expected that the JTAG TAP interface is used to access the life cycle transition interface in production settings.
+
+## Volatile `RAW` -> `TEST_UNLOCKED0` Transition
+
+Note that this functionality is only available on test chips where the design is compiled with SecVolatileRawUnlockEn = 1.
+On production silicon this option will be disabled.
+
+1. In order to perform a volatile `RAW` -> `TEST_UNLOCKED0` life cycle transition, SW should first check whether the life cycle controller has successfully initialized and is ready to accept a transition command by making sure that the [`STATUS.READY`](../data/lc_ctrl.hjson#status) bit is set to 1, and that all other status and error bits in [`STATUS`](../data/lc_ctrl.hjson#status) are set to 0.
+
+2. Read the [`LC_STATE`](../data/lc_ctrl.hjson#lc_state) and [`LC_TRANSITION_CNT`](../data/lc_ctrl.hjson#lc_transition_cnt) registers and make sure that the device is in the `RAW` life cycle state.
+
+3. Claim exclusive access to the transition interface by writing `kMuBi8True` to the [`CLAIM_TRANSITION_IF`](../data/lc_ctrl.hjson#claim_transition_if) register, and reading it back.
+   If the value read back equals to `kMuBi8True`, the hardware mutex has successfully been claimed and SW can proceed to step 4. If the value read back equals to 0, the mutex has already been claimed by the other interface (either CSR or TAP), and SW should try claiming the mutex again.
+   Note that all transition interface registers are protected by the hardware-governed [`TRANSITION_REGWEN`](../data/lc_ctrl.hjson#transition_regwen) register, which will only be set to 1 if the mutex has been claimed successfully.
+
+4. To request a volatile `RAW` -> `TEST_UNLOCKED0` transition SW should set the [`OTP_VENDOR_TEST_CTRL.VOLATILE_RAW_UNLOCK`](../data/lc_ctrl.hjson#otp_vendor_test_ctrl#volatile_raw_unlock) to 1.
+   Software can check whether volatile unlock is supported by reading the register after writing 1 to it.
+   If the mechanism is available, the register reads back as 1, otherwise it reads back 0.
+
+5. If required, software can switch to the external clock via the [`OTP_VENDOR_TEST_CTRL.EXT_CLK_EN`](../data/lc_ctrl.hjson#otp_vendor_test_ctrl#ext_clk_en) register.
+
+6. Write `TEST_UNLOCKED0` to [`TRANSITION_TARGET`](../data/lc_ctrl.hjson#transition_target).
+   The [`TRANSITION_TOKEN`](../data/lc_ctrl.hjson#transition_token) needs to be set to the **hashed** unlock token value, since the value written will not be passed through KMAC in this case.
+
+7. An optional, but recommended step is to read back and verify the values written in steps 4. - 6. before proceeding with step 8.
+
+8. Write 1 to the [`TRANSITION_CMD.START`](../data/lc_ctrl.hjson#transition_cmd) register to initiate the life cycle transition.
+
+9. Poll the [`STATUS`](../data/lc_ctrl.hjson#status) register and wait until either [`STATUS.TRANSITION_SUCCESSFUL`](../data/lc_ctrl.hjson#status) or any of the error bits is asserted.
+   The [`TRANSITION_REGWEN`](../data/lc_ctrl.hjson#transition_regwen) register will be set to 0 while a transition is in progress in order to prevent any accidental modifications of the transition interface registers during this phase.
+
+Note that if a volatile `RAW` unlock operation has been performed, it is not necessary to reset the chip and the life cycle controller accepts further transition commands.
+The `LC_TRANSITION_CNT`  will not be incremented and the life cycle state will not be moved to the temporary POST_TRANSITION state.
 
 ## Device Interface Functions (DIFs)
 

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -26,6 +26,14 @@ module tb;
     LcKeymgrDivWidth'({(LcKeymgrDivWidth/8){8'h5a}});
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction =
     LcKeymgrDivWidth'({(LcKeymgrDivWidth/8){8'ha5}});
+  // ---------- VOLATILE_TEST_UNLOCKED CODE SECTION START ----------
+  // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+  // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED VIA
+  // SecVolatileRawUnlockEn AT COMPILETIME FOR PRODUCTION DEVICES.
+  // ---------------------------------------------------------------
+  // TODO(#18250): The SecVolatileRawUnlockEn configuration should be tested separately for PROD.
+  parameter bit SecVolatileRawUnlockEn = 1;
+  // ----------- VOLATILE_TEST_UNLOCKED CODE SECTION END -----------
 
   // macro includes
   `include "uvm_macros.svh"
@@ -100,7 +108,8 @@ module tb;
     .RndCnstLcKeymgrDivTestDevRma(RndCnstLcKeymgrDivTestDevRma),
     .RndCnstLcKeymgrDivProduction(RndCnstLcKeymgrDivProduction),
     .ChipGen(LcCtrlChipGen[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0]),
-    .ChipRev(LcCtrlChipRev[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0])
+    .ChipRev(LcCtrlChipRev[lc_ctrl_reg_pkg::HwRevFieldWidth-1:0]),
+    .SecVolatileRawUnlockEn(SecVolatileRawUnlockEn)
   ) dut (
     .clk_i (clk),
     .rst_ni(rst_n),
@@ -126,6 +135,7 @@ module tb;
 
     .pwr_lc_i(pwr_lc[LcPwrInitReq]),
     .pwr_lc_o(pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
+    .strap_en_override_o( /** TODO: hook this signal up */ ),
 
     .lc_otp_vendor_test_o(otp_vendor_test_ctrl),
     .lc_otp_vendor_test_i(otp_vendor_test_status),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -51,8 +51,14 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_reg2hw_transition_cmd_reg_t;
 
   typedef struct packed {
-    logic        q;
-    logic        qe;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ext_clock_en;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } volatile_raw_unlock;
   } lc_ctrl_reg2hw_transition_ctrl_reg_t;
 
   typedef struct packed {
@@ -115,7 +121,12 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_transition_regwen_reg_t;
 
   typedef struct packed {
-    logic        d;
+    struct packed {
+      logic        d;
+    } ext_clock_en;
+    struct packed {
+      logic        d;
+    } volatile_raw_unlock;
   } lc_ctrl_hw2reg_transition_ctrl_reg_t;
 
   typedef struct packed {
@@ -165,10 +176,10 @@ package lc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [214:209]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [208:200]
-    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [199:198]
-    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [197:196]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [216:211]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [210:202]
+    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [201:200]
+    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [199:196]
     lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [195:64]
     lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [63:33]
     lc_ctrl_reg2hw_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [32:0]
@@ -176,10 +187,10 @@ package lc_ctrl_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [853:843]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [842:835]
-    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [834:834]
-    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [833:833]
+    lc_ctrl_hw2reg_status_reg_t status; // [854:844]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [843:836]
+    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [835:835]
+    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [834:833]
     lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [832:705]
     lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [704:675]
     lc_ctrl_hw2reg_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [674:643]
@@ -239,7 +250,7 @@ package lc_ctrl_reg_pkg;
   parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_TRANSITION_REGWEN_TRANSITION_REGWEN_RESVAL = 1'h 0;
   parameter logic [0:0] LC_CTRL_TRANSITION_CMD_RESVAL = 1'h 0;
-  parameter logic [0:0] LC_CTRL_TRANSITION_CTRL_RESVAL = 1'h 0;
+  parameter logic [1:0] LC_CTRL_TRANSITION_CTRL_RESVAL = 2'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_0_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_1_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -192,6 +192,18 @@
     },
     { struct:  "logic",
       type:    "uni",
+      name:    "strap_en_override",
+      act:     "rcv",
+      desc:    '''
+               This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+               The signal must stay at 1 until reset.
+               Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+               Otherwise this signal is unused.
+               ''',
+      default: "1'b0"
+    },
+    { struct:  "logic",
+      type:    "uni",
       name:    "pin_wkup_req",
       act:     "req",
       package: "",
@@ -308,6 +320,21 @@
   ]
 
   param_list: [
+    // Secure parameters
+    { name:    "SecVolatileRawUnlockEn",
+      type:    "bit",
+      default: "1'b0",
+      desc:    '''
+        Disable (0) or enable (1) volatile RAW UNLOCK capability.
+        If enabled, the strap_en_override_i input can be used to re-sample the straps at runtime.
+
+        IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+        to 0 in production tapeouts since this weakens the security posture of the RAW
+        UNLOCK mechanism.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
     { name: "AttrDw",
       desc: "Pad attribute data width",
       type: "int",

--- a/hw/ip/pinmux/fpv/tb/pinmux_bind_fpv.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_bind_fpv.sv
@@ -8,7 +8,8 @@ module pinmux_bind_fpv;
 
   bind pinmux pinmux_assert_fpv #(
     .TargetCfg(TargetCfg),
-    .AlertAsyncOn(AlertAsyncOn)
+    .AlertAsyncOn(AlertAsyncOn),
+    .SecVolatileRawUnlockEn(SecVolatileRawUnlockEn)
   ) i_pinmux_assert_fpv (
     .clk_i,
     .rst_ni,
@@ -20,6 +21,7 @@ module pinmux_bind_fpv;
     .usb_wkup_req_o,
     .sleep_en_i,
     .strap_en_i,
+    .strap_en_override_i,
     .lc_dft_en_i,
     .lc_hw_debug_en_i,
     .lc_check_byp_en_i,

--- a/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
@@ -22,7 +22,8 @@ module pinmux_tb
   parameter int DioUsbdevDp = 9,
   parameter int DioUsbdevDn = 10,
   parameter int MioInUsbdevSense = 11,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter bit SecVolatileRawUnlockEn = 1
 ) (
   input  clk_i,
   input  rst_ni,
@@ -34,6 +35,7 @@ module pinmux_tb
   output logic usb_wkup_req_o,
   input  sleep_en_i,
   input  strap_en_i,
+  input  strap_en_override_i,
   input lc_ctrl_pkg::lc_tx_t lc_dft_en_i,
   input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
   input lc_ctrl_pkg::lc_tx_t lc_check_byp_en_i,
@@ -97,7 +99,8 @@ module pinmux_tb
 
   pinmux #(
     .TargetCfg(PinmuxTargetCfg),
-    .AlertAsyncOn(AlertAsyncOn)
+    .AlertAsyncOn(AlertAsyncOn),
+    .SecVolatileRawUnlockEn(SecVolatileRawUnlockEn)
   ) dut (.*);
 
 endmodule : pinmux_tb

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1533,6 +1533,7 @@
       }
       param_decl:
       {
+        SecVolatileRawUnlockEn: top_pkg::SecVolatileRawUnlockEn
         ChipGen: 16'h 0000
         ChipRev: 16'h 0000
         IdcodeValue: jtag_id_pkg::JTAG_IDCODE
@@ -1549,6 +1550,24 @@
       memory: {}
       param_list:
       [
+        {
+          name: SecVolatileRawUnlockEn
+          desc:
+            '''
+            Disable (0) or enable (1) volatile RAW UNLOCK capability.
+            If enabled, it is possible to perform a volatile RAW -> TEST_UNLOCKED0 transition
+            without programming the OTP. This is a useful fallback mode in case the OTP is
+            not working correctly.
+
+            IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+            to 0 in production tapeouts since this weakens the security posture of the RAW
+            UNLOCK mechanism.
+            '''
+          type: bit
+          default: top_pkg::SecVolatileRawUnlockEn
+          expose: "true"
+          name_top: SecLcCtrlVolatileRawUnlockEn
+        }
         {
           name: RndCnstLcKeymgrDivInvalid
           desc: Compile-time random bits for lc state group diversification value
@@ -2019,6 +2038,27 @@
           width: 1
           default: "'0"
           inst_name: lc_ctrl
+          index: -1
+        }
+        {
+          name: strap_en_override
+          desc:
+            '''
+            This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+            The signal stays at 1 until reset.
+            Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+            Otherwise this signal is tied off to 0.
+            '''
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          default: 1'b0
+          inst_name: lc_ctrl
+          package: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: lc_ctrl_strap_en_override
           index: -1
         }
         {
@@ -3675,15 +3715,34 @@
         Aon
       ]
       attr: templated
+      param_decl:
+      {
+        SecVolatileRawUnlockEn: top_pkg::SecVolatileRawUnlockEn
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_aon_i: clkmgr_aon_clocks.clk_aon_powerup
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
+        {
+          name: SecVolatileRawUnlockEn
+          desc:
+            '''
+            Disable (0) or enable (1) volatile RAW UNLOCK capability.
+            If enabled, the strap_en_override_i input can be used to re-sample the straps at runtime.
+
+            IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+            to 0 in production tapeouts since this weakens the security posture of the RAW
+            UNLOCK mechanism.
+            '''
+          type: bit
+          default: top_pkg::SecVolatileRawUnlockEn
+          expose: "true"
+          name_top: SecPinmuxAonVolatileRawUnlockEn
+        }
         {
           name: TargetCfg
           desc: Target specific pinmux configuration.
@@ -3872,6 +3931,25 @@
           inst_name: pinmux_aon
           package: ""
           top_signame: pwrmgr_aon_strap
+          index: -1
+        }
+        {
+          name: strap_en_override
+          desc:
+            '''
+            This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+            The signal must stay at 1 until reset.
+            Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+            Otherwise this signal is unused.
+            '''
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          default: 1'b0
+          inst_name: pinmux_aon
+          package: ""
+          top_signame: lc_ctrl_strap_en_override
           index: -1
         }
         {
@@ -8169,6 +8247,10 @@
       lc_ctrl.lc_keymgr_div:
       [
         keymgr.lc_keymgr_div
+      ]
+      lc_ctrl.strap_en_override:
+      [
+        pinmux_aon.strap_en_override
       ]
       lc_ctrl.lc_dft_en:
       [
@@ -16040,6 +16122,27 @@
         index: -1
       }
       {
+        name: strap_en_override
+        desc:
+          '''
+          This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+          The signal stays at 1 until reset.
+          Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+          Otherwise this signal is tied off to 0.
+          '''
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        default: 1'b0
+        inst_name: lc_ctrl
+        package: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: lc_ctrl_strap_en_override
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -17246,6 +17349,25 @@
         inst_name: pinmux_aon
         package: ""
         top_signame: pwrmgr_aon_strap
+        index: -1
+      }
+      {
+        name: strap_en_override
+        desc:
+          '''
+          This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+          The signal must stay at 1 until reset.
+          Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+          Otherwise this signal is unused.
+          '''
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        default: 1'b0
+        inst_name: pinmux_aon
+        package: ""
+        top_signame: lc_ctrl_strap_en_override
         index: -1
       }
       {
@@ -21481,6 +21603,17 @@
         act: req
         suffix: ""
         default: "'0"
+      }
+      {
+        package: ""
+        struct: logic
+        signame: lc_ctrl_strap_en_override
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: 1'b0
       }
       {
         package: lc_ctrl_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -304,6 +304,10 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "lc"},
       base_addr: "0x40140000",
       param_decl: {
+        // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+        // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
+        // PRODUCTION DEVICES.
+        SecVolatileRawUnlockEn: "top_pkg::SecVolatileRawUnlockEn",
         ChipGen: "16'h 0000",
         ChipRev: "16'h 0000",
         IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
@@ -480,6 +484,12 @@
       domain: ["Aon"],
       base_addr: "0x40460000",
       attr: "templated",
+      param_decl: {
+        // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+        // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
+        // PRODUCTION DEVICES.
+        SecVolatileRawUnlockEn: "top_pkg::SecVolatileRawUnlockEn",
+      }
     },
     { name: "aon_timer_aon",
       type: "aon_timer",
@@ -966,6 +976,9 @@
 
       // Diversification constant coming from life cycle
       'lc_ctrl.lc_keymgr_div'  : ['keymgr.lc_keymgr_div'],
+
+      // Strap enable override signal, only used when SecVolatileRawUnlockEn = 1.
+      'lc_ctrl.strap_en_override'  : ['pinmux_aon.strap_en_override'],
 
       // LC function control signal broadcast
       'lc_ctrl.lc_dft_en'          : ['otp_ctrl.lc_dft_en',

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -188,6 +188,18 @@
     },
     { struct:  "logic",
       type:    "uni",
+      name:    "strap_en_override",
+      act:     "rcv",
+      desc:    '''
+               This signal transitions from 0 -> 1 by the lc_ctrl manager after volatile RAW_UNLOCK in order to re-sample the HW straps.
+               The signal must stay at 1 until reset.
+               Note that this is only used in test chips when SecVolatileRawUnlockEn = 1.
+               Otherwise this signal is unused.
+               ''',
+      default: "1'b0"
+    },
+    { struct:  "logic",
+      type:    "uni",
       name:    "pin_wkup_req",
       act:     "req",
       package: "",
@@ -304,6 +316,21 @@
   ]
 
   param_list: [
+    // Secure parameters
+    { name:    "SecVolatileRawUnlockEn",
+      type:    "bit",
+      default: "1'b0",
+      desc:    '''
+        Disable (0) or enable (1) volatile RAW UNLOCK capability.
+        If enabled, the strap_en_override_i input can be used to re-sample the straps at runtime.
+
+        IMPORTANT NOTE: This should only be used in test chips. The parameter must be set
+        to 0 in production tapeouts since this weakens the security posture of the RAW
+        UNLOCK mechanism.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
     { name: "AttrDw",
       desc: "Pad attribute data width",
       type: "int",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -28,6 +28,7 @@ module top_earlgrey #(
   // parameters for otp_ctrl
   parameter OtpCtrlMemInitFile = "",
   // parameters for lc_ctrl
+  parameter bit SecLcCtrlVolatileRawUnlockEn = top_pkg::SecVolatileRawUnlockEn,
   parameter logic [15:0] LcCtrlChipGen = 16'h 0000,
   parameter logic [15:0] LcCtrlChipRev = 16'h 0000,
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
@@ -46,6 +47,7 @@ module top_earlgrey #(
   // parameters for adc_ctrl_aon
   // parameters for pwm_aon
   // parameters for pinmux_aon
+  parameter bit SecPinmuxAonVolatileRawUnlockEn = top_pkg::SecVolatileRawUnlockEn,
   parameter pinmux_pkg::target_cfg_t PinmuxAonTargetCfg = pinmux_pkg::DefaultTargetCfg,
   // parameters for aon_timer_aon
   // parameters for sensor_ctrl
@@ -591,6 +593,7 @@ module top_earlgrey #(
   otp_ctrl_pkg::lc_otp_vendor_test_req_t       lc_ctrl_lc_otp_vendor_test_req;
   otp_ctrl_pkg::lc_otp_vendor_test_rsp_t       lc_ctrl_lc_otp_vendor_test_rsp;
   lc_ctrl_pkg::lc_keymgr_div_t       lc_ctrl_lc_keymgr_div;
+  logic       lc_ctrl_strap_en_override;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_dft_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_nvm_debug_en;
   lc_ctrl_pkg::lc_tx_t       lc_ctrl_lc_hw_debug_en;
@@ -1441,6 +1444,7 @@ module top_earlgrey #(
   );
   lc_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:16]),
+    .SecVolatileRawUnlockEn(SecLcCtrlVolatileRawUnlockEn),
     .RndCnstLcKeymgrDivInvalid(RndCnstLcCtrlLcKeymgrDivInvalid),
     .RndCnstLcKeymgrDivTestDevRma(RndCnstLcCtrlLcKeymgrDivTestDevRma),
     .RndCnstLcKeymgrDivProduction(RndCnstLcCtrlLcKeymgrDivProduction),
@@ -1492,6 +1496,7 @@ module top_earlgrey #(
       .otp_device_id_i(lc_ctrl_otp_device_id),
       .otp_manuf_state_i(lc_ctrl_otp_manuf_state),
       .hw_rev_o(),
+      .strap_en_override_o(lc_ctrl_strap_en_override),
       .tl_i(lc_ctrl_tl_req),
       .tl_o(lc_ctrl_tl_rsp),
       .scanmode_i,
@@ -1896,6 +1901,7 @@ module top_earlgrey #(
   );
   pinmux #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[30:30]),
+    .SecVolatileRawUnlockEn(SecPinmuxAonVolatileRawUnlockEn),
     .TargetCfg(PinmuxAonTargetCfg)
   ) u_pinmux_aon (
       // [30]: fatal_fault
@@ -1918,6 +1924,7 @@ module top_earlgrey #(
       .dft_hold_tap_sel_i(dft_hold_tap_sel_i),
       .sleep_en_i(pwrmgr_aon_low_power),
       .strap_en_i(pwrmgr_aon_strap),
+      .strap_en_override_i(lc_ctrl_strap_en_override),
       .pin_wkup_req_o(pwrmgr_aon_wakeups[2]),
       .usbdev_dppullup_en_i(usbdev_usb_dp_pullup),
       .usbdev_dnpullup_en_i(usbdev_usb_dn_pullup),

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -14,4 +14,9 @@ localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
+// NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
+// THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
+// PRODUCTION DEVICES.
+localparam int SecVolatileRawUnlockEn = 1;
+
 endpackage


### PR DESCRIPTION
This adds a volatile RAW -> TEST_UNLOCKED0 mechanism for test chips.

This solution does NOT use KMAC token hashing, hence the RTL diff is smaller. An alternative implementation with KMAC hashing is drafted in #18238 for reference. This has been discussed with @cdgori and we decided not to  pursue that since the RTL diff is too big and would add significant risk. The direct comparison without hashing is acceptable since the mechanism will not be compiled into PROD silicon.

Note that the modifications in pinmux are needed so that the hardware straps can be re-sampled in order to ungate the DFT and RISC-V TAPs.

Addresses https://github.com/lowRISC/opentitan/issues/18246

