### PR TITLE
[site] hardcode links on opentitan.org/documentation

### DIFF
--- a/site/landing/content/documentation.md
+++ b/site/landing/content/documentation.md
@@ -6,30 +6,30 @@ title: "Documentation"
 
 ## Introduction to OpenTitan
 
-[OpenTitan](https://opentitan.org/) is an open source silicon Root of Trust (RoT) project. OpenTitan will make the silicon RoT design and implementation more transparent, trustworthy, and secure for enterprises, platform providers, and chip manufacturers. OpenTitan is administered by lowRISC CIC as a [collaborative project]({{< doc-url >}}doc/project_governance{{< /doc-url >}}) to produce high quality, open IP for instantiation as a full-featured product. This repository exists to enable collaboration across partners participating in the OpenTitan project.
+[OpenTitan](https://opentitan.org/) is an open source silicon Root of Trust (RoT) project. OpenTitan will make the silicon RoT design and implementation more transparent, trustworthy, and secure for enterprises, platform providers, and chip manufacturers. OpenTitan is administered by lowRISC CIC as a [collaborative project](https://opentitan.org/book/doc/project_governance) to produce high quality, open IP for instantiation as a full-featured product. This repository exists to enable collaboration across partners participating in the OpenTitan project.
 
 {{< earlgrey-block-diagram >}}
 
 ## Getting Started
 
-To get started with OpenTitan, see the [Getting Started](/guides/getting_started) page. For additional resources when working with OpenTitan, see the [contribution guide]({{< doc-url >}}doc/contributing{{< /doc-url >}}) and the [tools guide]({{< doc-url >}}util{{< /doc-url >}}). Lastly, the [Hardware book]({{< doc-url >}}hw{{< /doc-url >}}) contains technical documentation on the SoC, the Ibex processor core, and the individual IP blocks. For questions about how the project is organized, see the [project landing spot]({{< doc-url >}}doc/project_governance{{< /doc-url >}}) for more information.
+To get started with OpenTitan, see the [Getting Started](/guides/getting_started) page. For additional resources when working with OpenTitan, see the [contribution guide](https://opentitan.org/book/doc/contributing) and the [tools guide](https://opentitan.org/book/util). Lastly, the [Hardware book](https://opentitan.org/book/hw) contains technical documentation on the SoC, the Ibex processor core, and the individual IP blocks. For questions about how the project is organized, see the [project landing spot](https://opentitan.org/book/doc/project_governance) for more information.
 
 ## Understanding OpenTitan
 
-- [Use Cases]({{< doc-url >}}doc/use_cases{{< /doc-url >}})
-- [Security]({{< doc-url >}}doc/security/{{< /doc-url >}})
+- [Use Cases](https://opentitan.org/book/doc/use_cases)
+- [Security](https://opentitan.org/book/doc/security/)
 
 ## Datasheets
 
-- [OpenTitan Earl Grey Chip Datasheet]({{< doc-url >}}hw/top_earlgrey/{{< /doc-url >}})
+- [OpenTitan Earl Grey Chip Datasheet](https://opentitan.org/book/hw/top_earlgrey/)
 
 ## Documentation
 
-- [Hardware]({{< doc-url >}}hw{{< /doc-url >}})
-- [Software]({{< doc-url >}}sw{{< /doc-url >}})
+- [Hardware](https://opentitan.org/book/hw)
+- [Software](https://opentitan.org/book/sw)
 
 ## Development
 
 - [Getting Started](/guides/getting_started)
-- [Contributing]({{< doc-url >}}doc/contributing{{< /doc-url >}})
-- [Tools]({{< doc-url >}}util{{< /doc-url >}})
+- [Contributing](https://opentitan.org/book/doc/contributing)
+- [Tools](https://opentitan.org/book/util)

--- a/site/landing/layouts/shortcodes/doc-url.txt
+++ b/site/landing/layouts/shortcodes/doc-url.txt
@@ -1,1 +1,0 @@
-{{ .Site.Params.docsUrl }}/{{ .Inner }}

--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -93,7 +93,6 @@ getURLs () {
 getURLs
 
 # Export some environment variables that tools will pick up
-export HUGO_PARAMS_DOCSURL="${base_url}/book" # hugo
 export URL_ROOT="${base_url}/book" # earlgrey_diagram
 
 # Build up doxygen command


### PR DESCRIPTION
Due to the previous breakage of the site-builder container, at some point the hugo build broke such that it was not correctly resolving these links, and it was not noticed until the container issues were resolved (recently).
For now, hardcode the links. When the root-cause has been determined and fixed, revert this commit/PR.