### PR TITLE
[ci] Obtain Lychee with Bazel (@lychee//:lychee)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,10 @@ lint_repos()
 load("//third_party/lint:deps.bzl", "lint_deps")
 lint_deps()
 
+# Lychee link checker.
+load("//third_party/lychee:repos.bzl", "lychee_repos")
+lychee_repos()
+
 # Python Toolchain + PIP Dependencies
 load("//third_party/python:repos.bzl", "python_repos")
 python_repos()

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -142,20 +142,5 @@ sw/vendor/rustup/rustup-init.sh -y \
     --default-toolchain "${RUST_VERSION}"
 export PATH=$HOME/.cargo/bin:$PATH
 
-# Install lychee
-LYCHEE_VERSION="v0.11.1"
-LYCHEE_BASE_URL="https://github.com/lycheeverse/lychee/releases/download"
-LYCHEE_TARBALL="lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-LYCHEE_URL="${LYCHEE_BASE_URL}/${LYCHEE_VERSION}/${LYCHEE_TARBALL}"
-LYCHEE_DOWNLOAD="$TMPDIR/lychee.tar.gz"
-
-curl -f -Ls -o "$LYCHEE_DOWNLOAD" "${LYCHEE_URL}" || {
-    error "Failed to download lychee from ${LYCHEE_URL}"
-}
-sudo mkdir -p /tools/lychee
-sudo chmod 777 /tools/lychee
-tar -C /tools/lychee -xf "$LYCHEE_DOWNLOAD"
-export PATH=/tools/lychee:$PATH
-
 # Propagate PATH changes to all subsequent steps of the job
 echo "##vso[task.setvariable variable=PATH]$PATH"

--- a/ci/scripts/check-links.sh
+++ b/ci/scripts/check-links.sh
@@ -11,7 +11,7 @@ set -e
 rm -f sw/vendor/eembc_coremark/docs/html/index/General2.html
 
 # Run Offline Link Check
-lychee hw/ sw/ doc/ util/ \
+ci/bazelisk.sh run @lychee//:lychee -- hw/ sw/ doc/ util/ \
     --offline --no-progress \
     --exclude-path sw/vendor \
     --exclude-path util/i2csvg/smbus/SMBus.md \

--- a/third_party/lychee/BUILD
+++ b/third_party/lychee/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/lychee/repos.bzl
+++ b/third_party/lychee/repos.bzl
@@ -5,7 +5,7 @@
 load("//rules:repo.bzl", "http_archive_or_local")
 
 def lychee_repos(local = None):
-    LYCHEE_VERSION = "v0.11.1"
+    LYCHEE_VERSION = "v0.12.0"
 
     url = "/".join([
         "https://github.com/lycheeverse/lychee/releases/download",
@@ -21,5 +21,5 @@ def lychee_repos(local = None):
 package(default_visibility = ["//visibility:public"])
 exports_files(glob(["**"]))
 """,
-        sha256 = "2cb75e6bcaf97f049d4e0260433938a77c60d39bd347d704502ae96c1e6f481c",
+        sha256 = "83f9857c233f753d2bd874486d818ff0f64b91fefef5b6fff96d9973a518080a",
     )

--- a/third_party/lychee/repos.bzl
+++ b/third_party/lychee/repos.bzl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def lychee_repos(local = None):
+    LYCHEE_VERSION = "v0.11.1"
+
+    url = "/".join([
+        "https://github.com/lycheeverse/lychee/releases/download",
+        LYCHEE_VERSION,
+        "lychee-{}-x86_64-unknown-linux-gnu.tar.gz".format(LYCHEE_VERSION),
+    ])
+
+    http_archive_or_local(
+        name = "lychee",
+        url = url,
+        local = local,
+        build_file_content = """
+package(default_visibility = ["//visibility:public"])
+exports_files(glob(["**"]))
+""",
+        sha256 = "2cb75e6bcaf97f049d4e0260433938a77c60d39bd347d704502ae96c1e6f481c",
+    )


### PR DESCRIPTION
This commit makes it possible to run ci/scripts/check-links.sh without worrying which version of Lychee is installed locally.