### PR TITLE
[chip-test] Clarify exempted alerts from the NMI-only test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1162,7 +1162,10 @@
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
       sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+en_scb=0", "+sw_test_timeout_ns=3000_000_000", "+bypass_alert_ready_to_end_check=1", "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl,otp_ctrl"]
+      run_opts: ["+en_scb=0",
+                 "+sw_test_timeout_ns=3000_000_000",
+                 "+bypass_alert_ready_to_end_check=1",
+                 "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl*state_regs,otp_ctrl*u_otp_ctrl_dai"]
       run_timeout_mins: 240
       reseed: 90
     }


### PR DESCRIPTION
Add parsing of a special separator "*" that would signal a definition of both the IP and CM to exclude from the test.

For the exception list, target the specific errors from lc_ctrl and otp_ctrl that prevent software from continuing. Previously, the exception list only allowed targeting the "prim_we_reg_check" variety, but this didn't describe the needed set.