### PR TITLE
[dv] Explicitly tie +use_spi_load_bootstrap to first boot

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -14,7 +14,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;
 
-  // use spi or backdoor to load bootstrap
+  // use spi or backdoor to load bootstrap on the next boot
   bit                 use_spi_load_bootstrap = 0;
 
   // chip top interfaces

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -111,6 +111,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       if (cfg.use_spi_load_bootstrap) begin
         `uvm_info(`gfn, "Initializing SPI flash bootstrap", UVM_MEDIUM)
         spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+        cfg.use_spi_load_bootstrap = 1'b0;
       end else begin
         cfg.mem_bkdr_util_h[FlashBank0Data].load_mem_from_file(
             {cfg.sw_images[SwTypeTestSlotA], ".64.scr.vmem"});

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
@@ -71,6 +71,7 @@ class chip_sw_inject_scramble_seed_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, "Received C side acknowledgement", UVM_LOW)
 
     spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+    cfg.use_spi_load_bootstrap = 1'b0;
 
     // After bootstrap, we need to write the expected values again,
     // since the boot-strap process wiped out the previous version.

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -48,7 +48,8 @@ class chip_base_test extends cip_base_test #(
     // Knob to set the sw_test_timeout_ns (set to 12ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
 
-    // Knob to use SPI to load image via ROM bootstrap.
+    // Knob to use SPI to load image via ROM bootstrap on first boot.
+    // cfg.use_spi_load_bootstrap will be reset to 0 upon completion.
     void'($value$plusargs("use_spi_load_bootstrap=%0b", cfg.use_spi_load_bootstrap));
 
     // Knob to indicate what build device to use (DV, Verilator or FPGA).


### PR DESCRIPTION
Now that the use_spi_load_bootstrap cfg member controls how a forked thread behaves, explicitly tie the plusarg to the first boot and make that bootstrap instance reset use_spi_load_bootstrap to 0.

This should eliminate the continuously active bootstrap configuration for chip_sw_uart_tx_rx_bootstrap.