### PR TITLE
[hw,csrng,sv] Update coverpoints for CSRNG

### DIFF
--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -35,10 +35,6 @@
       tests: ["csrng_intr"]
     }
     {
-      //TODO For the following untested features add it to the test or create explicit coverpoints in csrng_cmd_cg:
-      //TODO - Invalid MuBi values for flag0 are currently untested.
-      //TODO - Illegal commands are currently untested.
-      //TODO - Fatal alerts are currently untested.
       name: alerts
       desc: '''
             Verify recov_alert asserts when recov_alert_sts becomes non-zero.
@@ -69,9 +65,6 @@
       tests: ["csrng_err"]
     }
     {
-      //TODO For the following untested features add it to the test or create explicit coverpoints in csrng_cmd_cg:
-      //TODO - Verification of otp_en_csrng_sw_app_read is currently untested.
-      //TODO - FIPS bit going low from entropy source is currently untested.
       name: cmds
       desc: '''
             Verify all csrng commands req/status behave as predicted on all applications: HW0, HW1 and SW.
@@ -110,7 +103,6 @@
 
   covergroups: [
     {
-      //TODO Configuration for enable is currently not covered.
       name: csrng_cfg_cg
       desc: '''
             Covers that all csrng configuration options have been tested.
@@ -181,6 +173,24 @@
             - hw0_cmd_push_cross, hw1_cmd_push_cross, sw_cmd_push_cross : command FIFO fill status x command FIFO write valid x command FIFO write ready
             - hw0_cmd_pop_cross, hw1_cmd_pop_cross, sw_cmd_pop_cross : command FIFO fill status x command FIFO read ready
             - hw0_genbits_pop_cross, hw1_genbits_pop_cross, sw_genbits_pop_cross : genbits FIFO fill status x genbits FIFO read valid x genbits FIFO read ready
+            '''
+    }
+    {
+      name: csrng_otp_en_sw_app_read_cg
+      desc: '''
+            Covers otp_en_csrng_sw_app_read feature
+            - read_int_state_val_cp : Covers read of INT_STATE_VAL register
+            - read_genbits_reg_cp : Covers for read of GENBITS register
+            - cp_sw_app_read : Covers values supported by otp_en_csrng_sw_app_read
+            - cp_read_int_state_x_sw_app_enable : Cross register read of INT_STATE_VAL in combination with read_int_state field and otp_en_csrng_sw_app_read
+            - cp_read_genbits_x_sw_app_enable : Cross register read of GENBITS  in combination with read_int_state field and otp_en_csrng_sw_app_read
+            '''
+    }
+    {
+      name: csrng_genbits_cg
+      desc: '''
+            Covers FIPS/CC bit in genbits_vld register
+            genbits_fips_cp: Covers GENBITS_FIPS in GENBITS_VLD register
             '''
     }
   ]

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -175,12 +175,12 @@ interface csrng_cov_if (
     cp_sw_app_read:    coverpoint otp_en_cs_sw_app_read {
       bins mubi_true  = { MuBi8True };
       bins mubi_false = { MuBi8False };
-      bins mubi_inval = {[0:$]} with (!(item inside {MuBi8True, MuBi8False}));
+      bins mubi_inval = { [0:$] } with (!(item inside { MuBi8True, MuBi8False }));
     }
     cp_lc_hw_debug_en: coverpoint lc_hw_debug_en {
       bins lc_on    = { lc_ctrl_pkg::On };
       bins lc_off   = { lc_ctrl_pkg::Off };
-      bins lc_inval = {[0:$]} with (!(item inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off}));
+      bins lc_inval = { [0:$] } with (!(item inside { lc_ctrl_pkg::On, lc_ctrl_pkg::Off }));
     }
     cp_sw_app_enable:  coverpoint sw_app_enable;
     cp_read_int_state: coverpoint read_int_state;
@@ -219,7 +219,7 @@ interface csrng_cov_if (
 
     cp_err_codes: coverpoint err_code_bit{
       // This is covered separately as it's about reporting the type of SFIFO failure
-      ignore_bins fifo_type = {FIFO_WRITE_ERR, FIFO_READ_ERR, FIFO_STATE_ERR};
+      ignore_bins fifo_type = { FIFO_WRITE_ERR, FIFO_READ_ERR, FIFO_STATE_ERR };
     }
 
     cp_fifo_err_type: coverpoint fifo_err_type{
@@ -232,16 +232,16 @@ interface csrng_cov_if (
     fifo_err_type_cross: cross cp_err_codes, cp_fifo_err_type{
       // If ERR_CODE register has SFIFO related field set, it also needs to set at least one
       // FIFO_*_ERR field.
-      illegal_bins illegal = !binsof(cp_err_codes) intersect {CMD_STAGE_SM_ERR, MAIN_SM_ERR,
-                                                              DRBG_GEN_SM_ERR, DRBG_UPDBE_SM_ERR,
-                                                              DRBG_UPDOB_SM_ERR, AES_CIPHER_SM_ERR,
-                                                              CMD_GEN_CNT_ERR} &&
-                             binsof(cp_fifo_err_type) intersect {0};
+      illegal_bins illegal = !binsof(cp_err_codes) intersect { CMD_STAGE_SM_ERR, MAIN_SM_ERR,
+                                                               DRBG_GEN_SM_ERR, DRBG_UPDBE_SM_ERR,
+                                                               DRBG_UPDOB_SM_ERR, AES_CIPHER_SM_ERR,
+                                                               CMD_GEN_CNT_ERR } &&
+                             binsof(cp_fifo_err_type) intersect { 0 };
 
-      ignore_bins ignore = binsof(cp_err_codes) intersect {CMD_STAGE_SM_ERR, MAIN_SM_ERR,
-                                                           DRBG_GEN_SM_ERR, DRBG_UPDBE_SM_ERR,
-                                                           DRBG_UPDOB_SM_ERR, AES_CIPHER_SM_ERR,
-                                                           CMD_GEN_CNT_ERR};
+      ignore_bins ignore = binsof(cp_err_codes) intersect { CMD_STAGE_SM_ERR, MAIN_SM_ERR,
+                                                            DRBG_GEN_SM_ERR, DRBG_UPDBE_SM_ERR,
+                                                            DRBG_UPDOB_SM_ERR, AES_CIPHER_SM_ERR,
+                                                            CMD_GEN_CNT_ERR };
     }
 
     cp_csrng_aes_fsm_err: coverpoint
@@ -270,11 +270,11 @@ interface csrng_cov_if (
     recov_alert_sts_cp: coverpoint recov_alert;
   endgroup : csrng_recov_alert_sts_cg
 
-  covergroup csrng_cmds_cg with function sample(bit[NUM_HW_APPS-1:0]   app,
-                                                acmd_e                 acmd,
-                                                bit[3:0]               clen,
-                                                bit[3:0]               flags,
-                                                bit[11:0]              glen
+  covergroup csrng_cmds_cg with function sample(bit [NUM_HW_APPS-1:0] app,
+                                                acmd_e                acmd,
+                                                bit [3:0]             clen,
+                                                bit [3:0]             flags,
+                                                bit [11:0]            glen
                                                );
     option.name         = "csrng_cmds_cg";
     option.per_instance = 1;
@@ -329,35 +329,35 @@ interface csrng_cov_if (
     acmd_glen_cross:  cross cp_acmd, cp_glen;
     flags_clen_acmd_cross:  cross cp_acmd, cp_flags, cp_clen {
       // Use only Entropy Source seed
-      bins ins_only_entropy_src_seed = binsof(cp_flags) intersect {MuBi4False} &&
-                                       binsof(cp_clen) intersect {0} &&
-                                       binsof(cp_acmd) intersect {INS};
-      bins res_only_entropy_src_seed = binsof(cp_flags) intersect {MuBi4False} &&
-                                       binsof(cp_clen) intersect {0} &&
-                                       binsof(cp_acmd) intersect {RES};
+      bins ins_only_entropy_src_seed = binsof(cp_flags) intersect { MuBi4False } &&
+                                       binsof(cp_clen)  intersect { 0 } &&
+                                       binsof(cp_acmd)  intersect { INS };
+      bins res_only_entropy_src_seed = binsof(cp_flags) intersect { MuBi4False } &&
+                                       binsof(cp_clen)  intersect { 0 } &&
+                                       binsof(cp_acmd)  intersect { RES };
       // Use Entropy Source Seed ^ Additional Data (clen)
-      bins ins_xored_entropy_src_seed = binsof(cp_flags) intersect {MuBi4False} &&
-                                        binsof(cp_clen) intersect {[1:$]} &&
-                                        binsof(cp_acmd) intersect {INS};
-      bins res_xored_entropy_src_seed = binsof(cp_flags) intersect {MuBi4False} &&
-                                        binsof(cp_clen) intersect {[1:$]} &&
-                                        binsof(cp_acmd) intersect {RES};
+      bins ins_xored_entropy_src_seed = binsof(cp_flags) intersect { MuBi4False } &&
+                                        binsof(cp_clen)  intersect { [1:$] } &&
+                                        binsof(cp_acmd)  intersect { INS };
+      bins res_xored_entropy_src_seed = binsof(cp_flags) intersect { MuBi4False } &&
+                                        binsof(cp_clen)  intersect { [1:$] } &&
+                                        binsof(cp_acmd)  intersect { RES };
       // Use zero as seed
-      bins ins_zero_seed = binsof(cp_flags) intersect {MuBi4True} &&
-                           binsof(cp_clen) intersect {0} &&
-                           binsof(cp_acmd) intersect {INS};
-      bins res_zero_seed = binsof(cp_flags) intersect {MuBi4True} &&
-                           binsof(cp_clen) intersect {0} &&
-                           binsof(cp_acmd) intersect {RES};
+      bins ins_zero_seed = binsof(cp_flags) intersect { MuBi4True } &&
+                           binsof(cp_clen)  intersect { 0 } &&
+                           binsof(cp_acmd)  intersect { INS };
+      bins res_zero_seed = binsof(cp_flags) intersect { MuBi4True } &&
+                           binsof(cp_clen)  intersect { 0 } &&
+                           binsof(cp_acmd)  intersect { RES };
       // Use Additional Data (clen) as seed
-      bins ins_add_data_seed = binsof(cp_flags) intersect {MuBi4True} &&
-                               binsof(cp_clen) intersect {[1:$]} &&
-                               binsof(cp_acmd) intersect {INS};
-      bins res_add_data_seed = binsof(cp_flags) intersect {MuBi4True} &&
-                               binsof(cp_clen) intersect {[1:$]} &&
-                               binsof(cp_acmd) intersect {RES};
+      bins ins_add_data_seed = binsof(cp_flags) intersect { MuBi4True } &&
+                               binsof(cp_clen)  intersect { [1:$] } &&
+                               binsof(cp_acmd)  intersect { INS };
+      bins res_add_data_seed = binsof(cp_flags) intersect { MuBi4True } &&
+                               binsof(cp_clen)  intersect { [1:$] } &&
+                               binsof(cp_acmd)  intersect { RES };
       // Since other modes are not related with flag0, ignore them in this cross.
-      ignore_bins ignore = binsof(cp_acmd) intersect {UPD, UNI, GEN};
+      ignore_bins ignore = binsof(cp_acmd) intersect { UPD, UNI, GEN };
     }
   endgroup : csrng_cmds_cg
 
@@ -372,14 +372,14 @@ interface csrng_cov_if (
   // Sample functions needed for xcelium
   function automatic void cg_cfg_sample(csrng_env_cfg cfg);
     csrng_cfg_cg_inst.sample(cfg.otp_en_cs_sw_app_read,
-                              cfg.lc_hw_debug_en,
-                              cfg.sw_app_enable,
-                              cfg.read_int_state,
-                              cfg.regwen
-                             );
+                             cfg.lc_hw_debug_en,
+                             cfg.sw_app_enable,
+                             cfg.read_int_state,
+                             cfg.regwen
+                            );
   endfunction
 
-  function automatic void cg_cmds_sample(bit[NUM_HW_APPS-1:0] hwapp, csrng_item cs_item);
+  function automatic void cg_cmds_sample(bit [NUM_HW_APPS-1:0] hwapp, csrng_item cs_item);
     csrng_cmds_cg_inst.sample(hwapp,
                               cs_item.acmd,
                               cs_item.clen,

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -251,8 +251,23 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       end
       "genbits_vld": begin
         do_read_check = 1'b0;
+        if (data_phase_read) begin
+          cov_vif.cg_csrng_genbits_sample(
+            .genbits_valid(item.a_data[0]),
+            .genbits_fips(item.a_data[1]));
+        end
       end
       "genbits": begin
+        if (data_phase_read) begin
+          uvm_reg ctrl = cfg.ral_models[ral_name].get_reg_by_name("ctrl");
+          cov_vif.cg_csrng_otp_en_sw_app_read_sample(
+            .read_int_state_val_reg(1'b0),
+            .read_genbits_reg(1'b1),
+            .otp_en_cs_sw_app_read(cfg.otp_en_cs_sw_app_read),
+            .read_int_state(ctrl.get_field_by_name("read_int_state").get_mirrored_value()),
+            .sw_app_enable(ctrl.get_field_by_name("sw_app_enable").get_mirrored_value())
+          );
+        end
         do_read_check = 1'b0;
         if (data_phase_read) begin
           hw_genbits_reg_q.push_back(item.d_data);
@@ -282,6 +297,16 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       end
       "int_state_val": begin
         do_read_check = 1'b0;
+        if (data_phase_read) begin
+          uvm_reg ctrl = cfg.ral_models[ral_name].get_reg_by_name("ctrl");
+          cov_vif.cg_csrng_otp_en_sw_app_read_sample(
+            .read_int_state_val_reg(1'b1),
+            .read_genbits_reg(1'b0),
+            .otp_en_cs_sw_app_read(cfg.otp_en_cs_sw_app_read),
+            .read_int_state(ctrl.get_field_by_name("read_int_state").get_mirrored_value()),
+            .sw_app_enable(ctrl.get_field_by_name("sw_app_enable").get_mirrored_value())
+          );
+        end
       end
       "hw_exc_sts": begin
       end


### PR DESCRIPTION
- Covergroup updates
  - Update coverpoints for `acmd` to cover all values supported by the field
  - Update `cp_flags` to include invalid values of `flags0` field
  - Add a covergroup for fatal and recover alerts
  - Add a covergroup for efuse tieoff `otp_en_sw_app_read`
  - Add a covergroup for fips bit in `genbits_vld` register
  - Add sample calls for newly added covergroups in scoreboard

- Remove `TODO` that get resolved by newly added covergroups
- Update covergroup descriptions in testplan

This PR resolves https://github.com/lowRISC/opentitan/issues/17418 by adding covergroups for TODO comments