### PR TITLE
[otbn, rtl] Add missing blanking assertions

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -170,6 +170,10 @@ module otbn_alu_bignum
     .out_o (selected_flags)
   );
 
+  `ASSERT(BlankingSelectedFlags_A, expected_flag_group_sel == '0 |-> selected_flags == '0, clk_i,
+    !rst_ni || alu_predec_error_o  || !operation_commit_i)
+
+
   logic                  flag_mux_in [FlagsWidth];
   logic [FlagsWidth-1:0] flag_mux_sel;
   assign flag_mux_in = '{selected_flags.C,
@@ -192,6 +196,9 @@ module otbn_alu_bignum
     .sel_i (flag_mux_sel),
     .out_o (selection_flag_o)
   );
+
+  `ASSERT(BlankingSelectionFlag_A, expected_flag_sel == '0 |-> selection_flag_o == '0, clk_i,
+    !rst_ni || alu_predec_error_o  || !operation_commit_i)
 
   //////////////////
   // Flags Update //

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1038,6 +1038,10 @@ module otbn_controller
     .out_o(rf_bignum_rd_data_b_intg_blanked)
   );
 
+  `ASSERT(BlankingBignumRdDataBSel,
+    ~(insn_valid_i & insn_dec_bignum_i.sel_insn) |-> rf_bignum_rd_data_b_intg_blanked == '0,
+    clk_i, !rst_ni || ctrl_predec_error || !insn_executing)
+
   assign selection_result =
     ~ctrl_flow_predec_i.sel_insn | alu_bignum_selection_flag_i ? rf_bignum_rd_data_a_intg_i :
                                                                  rf_bignum_rd_data_b_intg_blanked;


### PR DESCRIPTION
All other blanked signals have similar such assertions but these weren't added with the most recent blanking additions.