### PR TITLE
[dv/keymgr] Fix edn wait time assertion error

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -56,6 +56,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
 
+    cfg.keymgr_vif.update_edn_toleranc_cycs(cfg.edn_clk_freq_mhz, cfg.clk_freq_mhz);
     op_before_enable_keymgr();
 
     cfg.keymgr_vif.init(do_rand_otp_key, do_invalid_otp_key);


### PR DESCRIPTION
EDN assertions currently allows a 20 main clock cycle difference. This assertion constraint does not work well if the frequency difference between edn and main clock is too large.