### PR TITLE
[chip-test] Add `volatile_raw_unlock` test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3481,6 +3481,21 @@
               "chip_sw_lc_walkthrough_testunlocks"]
     }
     {
+      name: chip_sw_lc_ctrl_volatile_raw_unlock
+      desc: '''Configure VOLATILE_RAW_UNLOCK via LC TAP interface and enable CPU execution.
+
+             - Pre-load OTP image with RAW lc_state.
+             - Initiate the LC transition to test_unlocked0 state using the
+               VOLATILE_RAW_UNLOCK mode of operation.
+             - As part of the transition to test_unlocked0, switch the TAP interface to rv_dm.
+             - Enable ROM execution via rv_dm, and perform POR.
+             - Initiate a second transition to test_unlocked0 using VOLATILE_RAW_UNLOCK.
+             - Verify that the CPU is able to execute.
+             '''
+      stage: V2
+      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock"]
+    }
+    {
       name: chip_sw_power_max_load
       desc: '''Concurrency test modeling maximum load conditions.
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -845,6 +845,14 @@
                  "+use_otp_image=OtpTypeLcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
+      name: chip_sw_lc_ctrl_volatile_raw_unlock
+      uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_volatile_raw_unlock_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStRaw"]
+      run_timeout_mins: 10
+    }
+    {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -93,6 +93,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_lc_volatile_raw_unlock_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_lc_volatile_raw_unlock_vseq)
+
+  `uvm_object_new
+
+  virtual task pre_start();
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
+    super.pre_start();
+  endtask
+
+  // reset jtag interface
+  virtual task reset_jtag_tap();
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
+    #1000ns;
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
+  endtask
+
+  virtual task body();
+    bit [TokenWidthBit-1:0] otp_exit_token_bits, otp_unlock_token_bits, otp_rma_token_bits;
+    bit [7:0] selected_dest_state[];
+
+    jtag_riscv_dm_activation_seq jtag_dm_activation_seq =
+        jtag_riscv_dm_activation_seq::type_id::create("jtag_dm_activation_seq");
+
+    super.body();
+
+    wait_lc_ready(1);
+
+    // VOLATILE_RAW_UNLOCK does not require a reset after completion.
+    // Applying a reset will move the device back to RAW state in this case.
+    jtag_lc_state_volatile_raw_unlock(JtagTapRvDm);
+    reset_jtag_tap();
+
+    // In RAW state the ROM should halt as RomExecEn is not set yet.
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRomHalt)
+
+    // Use the frontend interface to configure the RomExecEn OTP value. A
+    // reset is required to have otp_ctrl sample the new OTP value.
+    `uvm_info(`gfn, "Configuring RomExecEng", UVM_LOW)
+    jtag_dm_activation_seq.start(p_sequencer.jtag_sequencer_h);
+    `uvm_info(`gfn, $sformatf("rv_dm_activated: %0d", cfg.m_jtag_riscv_agent_cfg.rv_dm_activated),
+            UVM_LOW)
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
+    jtag_otp_program32(otp_ctrl_reg_pkg::CreatorSwCfgRomExecEnOffset, 1);
+
+    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 0;
+    apply_reset();
+
+    // Second VOLATILE_RAW_UNLOCK does not change the TAP interface to rv_dm
+    // so that we can check the completion status through that interface.
+    // After this, the rest of the test should proceed.
+    jtag_lc_state_volatile_raw_unlock(JtagTapLc);
+
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -39,6 +39,7 @@
 `include "chip_sw_flash_rma_unlocked_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_lc_ctrl_scrap_vseq.sv"
+`include "chip_sw_lc_volatile_raw_unlock_vseq.sv"
 `include "chip_sw_lc_walkthrough_vseq.sv"
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"
 `include "chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -333,6 +333,23 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "lc_ctrl_volatile_raw_unlock_test",
+    srcs = ["lc_ctrl_volatile_raw_unlock_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "lc_walkthrough_test",
     srcs = ["lc_walkthrough_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/lc_ctrl_volatile_raw_unlock_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_volatile_raw_unlock_test.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_lc_ctrl_t lc_ctrl;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  dif_lc_ctrl_state_t state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &state));
+  CHECK(state == kDifLcCtrlStateTestUnlocked0);
+  return true;
+}


### PR DESCRIPTION
This commit modifies the `lc_walkthrough` sv to suport a `volatile_raw_unlock` +arg, which is used to test said functionality. A new test point and test case is added to the top level test plan to cover transitions from RAW to prodend.