### PR TITLE
[clkmgr/top] Updates regarding external clock in DEV

### DIFF
--- a/hw/ip/clkmgr/doc/theory_of_operation.md
+++ b/hw/ip/clkmgr/doc/theory_of_operation.md
@@ -203,7 +203,7 @@ It may be added for future more complex systems where there is a need to tightly
 
 Clock manager supports the ability to request root clocks switch to an external clock.
 There are two occasions where this is required:
--  Life cycle transition from `Raw` / `Test_locked` to `Test_unlocked` [states](../../lc_ctrl/README.md#clk_byp_req).
+-  Life cycle transition from `RAW` / `TEST_LOCKED*` to `TEST_UNLOCKED*` [states](../../lc_ctrl/README.md#clk_byp_req).
 -  Software request for external clocks during normal functional mode.
 
 
@@ -246,12 +246,12 @@ There is currently no support in hardware to dynamically synchronize a threshold
 
 The table below summarises the valid modes and the settings required.
 
-| Mode                                            | `lc_clk_byp_req_i`     | `extclk_ctrl.sel` | `extclk_ctrl.hi_speed_sel`  | life cycle state        |
-| -------------                                   | ---------------------  | ----------------- | ----------------------------| ----------------------- |
-| Life cycle in RAW, TEST* and RMA states         | `lc_ctrl_pkg::On`      | `kMultiBit4False` | Don't care                  | Controlled by `lc_ctrl` |
-| Internal Clocks                                 | `lc_ctrl_pkg::Off`     | `kMultiBit4False` | Don't care                  | All                     |
-| Software external high speed                    | `lc_ctrl_pkg::Off`     | `kMultiBit4True`  | `kMultiBit4True`            | TEST_UNLOCKED, RMA      |
-| Software external low speed                     | `lc_ctrl_pkg::Off`     | `kMultiBit4True`  | `kMultiBit4False`           | TEST_UNLOCKED, RMA      |
+| Mode                                            | `lc_clk_byp_req_i`     | `extclk_ctrl.sel` | `extclk_ctrl.hi_speed_sel`  | life cycle state               |
+| -------------                                   | ---------------------  | ----------------- | ----------------------------| -------------------------------|
+| Life cycle in `RAW`, `TEST*` and `RMA` states   | `lc_ctrl_pkg::On`      | `kMultiBit4False` | Don't care                  | Controlled by `lc_ctrl`        |
+| Internal Clocks                                 | `lc_ctrl_pkg::Off`     | `kMultiBit4False` | Don't care                  | All                            |
+| Software external high speed                    | `lc_ctrl_pkg::Off`     | `kMultiBit4True`  | `kMultiBit4True`            | `TEST_UNLOCKED*`, `DEV`, `RMA` |
+| Software external low speed                     | `lc_ctrl_pkg::Off`     | `kMultiBit4True`  | `kMultiBit4False`           | `TEST_UNLOCKED*`, `DEV`, `RMA` |
 
 The table below summarizes the frequencies in each mode.
 This table assumes that the internal clock source is 96MHz.

--- a/hw/ip/clkmgr/rtl/clkmgr_byp.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_byp.sv
@@ -107,11 +107,11 @@ module clkmgr_byp
   );
 
   // software switch request handling
-  mubi4_t dft_en;
-  assign dft_en = lc_ctrl_pkg::lc_to_mubi4(en);
+  mubi4_t debug_en;
+  assign debug_en = lc_ctrl_pkg::lc_to_mubi4(en);
 
   mubi4_t all_clk_byp_req_d;
-  assign all_clk_byp_req_d = mubi4_and_hi(byp_req_i, dft_en);
+  assign all_clk_byp_req_d = mubi4_and_hi(byp_req_i, debug_en);
 
   prim_mubi4_sender #(
     .AsyncOn(1),

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -930,8 +930,12 @@
             Use the clkmgr count measurement feature to verify clock division.
             '''
       stage: V2
-      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
-              "chip_sw_clkmgr_external_clk_src_for_sw_slow",
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0",
+              "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
+              "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",
               "chip_sw_clkmgr_external_clk_src_for_lc"]
     }
     {
@@ -959,8 +963,12 @@
             X-ref with chip_sw_uart_tx_rx_alt_clk_freq, which needs to deal with this as well.
             '''
       stage: V2
-      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
-              "chip_sw_clkmgr_external_clk_src_for_sw_slow"]
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0",
+              "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
+              "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma"]
     }
     {
       name: chip_sw_clkmgr_jitter
@@ -1753,8 +1761,12 @@
         "chip_tap_straps_prod",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
         "chip_tap_straps_rma",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
         "chip_sw_rom_ctrl_integrity_check",            // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast", // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow", // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",            // lc_hw_debug_en_o: clkmgr
         "chip_sw_sram_ctrl_execution_main",            // lc_hw_debug_en_o: sram_ctrl main
         "chip_rv_dm_lc_disabled"                       // lc_hw_debug_en_o: rv_dm
         "chip_sw_keymgr_key_derivation",               // lc_keymgr_en_o: keymgr

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1513,18 +1513,58 @@
       run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz", "+calibrate_usb_clk=1"]
     }
     {
-      name: chip_sw_clkmgr_external_clk_src_for_sw_fast
+      name: chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+chip_clock_source=ChipClockSourceExternal96Mhz", "+calibrate_usb_clk=1"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal96Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStTestUnlocked0"]
     }
     {
-      name: chip_sw_clkmgr_external_clk_src_for_sw_slow
+      name: chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz", "+calibrate_usb_clk=1"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStTestUnlocked0"]
+    }
+    {
+      name: chip_sw_clkmgr_external_clk_src_for_sw_fast_dev
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal96Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStDev"]
+    }
+    {
+      name: chip_sw_clkmgr_external_clk_src_for_sw_slow_dev
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStDev"]
+    }
+    {
+      name: chip_sw_clkmgr_external_clk_src_for_sw_fast_rma
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal96Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStRma"]
+    }
+    {
+      name: chip_sw_clkmgr_external_clk_src_for_sw_slow_rma
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz",
+                 "+calibrate_usb_clk=1",
+                 "+src_dec_state=DecLcStRma"]
     }
     {
       name: chip_sw_clkmgr_reset_frequency


### PR DESCRIPTION
The `clkmgr` has been updated to allow switching to an external clock source in DEV already a while ago in https://github.com/lowRISC/opentitan/pull/9347.

This PR updates the table in the clkmgr to make clear that this is supported.

Also, this PR updates the top-level tests to run the external clock tests not only in `RMA`, but also in `DEV` and `TEST_UNLOCKED0`.