### PR TITLE
[dv/pwrmgr] Fix miscellaneous failures

### DIFF
--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -92,7 +92,7 @@ class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
 
       // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
       // This read will not work in the chip, since the processor will be asleep.
-      cfg.slow_clk_rst_vif.wait_clks(4);
+      cfg.slow_clk_rst_vif.wait_clks(5);
       check_wake_status(wakeups & wakeups_en);
       `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", wakeups & wakeups_en), UVM_MEDIUM)
       wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_invalid_vseq.sv
@@ -52,7 +52,7 @@ class pwrmgr_reset_invalid_vseq extends pwrmgr_base_vseq;
       fork
         create_any_reset_event();
         begin
-          int wait_time_ns = 10000;
+          int wait_time_ns = 20000;
           `DV_SPINWAIT(wait(cfg.pwrmgr_vif.fast_state == dv2rtl_st(reset_index));, $sformatf(
                        "Timed out waiting for state %s", reset_index.name), wait_time_ns)
 

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -95,12 +95,12 @@
     {
       name: pwrmgr_sec_cm_lc_ctrl_intersig_mubi
       uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
-      run_opts: ["+test_timeout_ns=2000000", "+pwrmgr_mubi_mode=PwrmgrMubiLcCtrl"]
+      run_opts: ["+test_timeout_ns=3000000", "+pwrmgr_mubi_mode=PwrmgrMubiLcCtrl"]
     }
     {
       name: pwrmgr_sec_cm_rom_ctrl_intersig_mubi
       uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
-      run_opts: ["+test_timeout_ns=2000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
+      run_opts: ["+test_timeout_ns=3000000", "+pwrmgr_mubi_mode=PwrmgrMubiRomCtrl"]
     }
     {
       name: pwrmgr_sec_cm_rstmgr_intersig_mubi

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -85,7 +85,7 @@ module pwrmgr_sec_cm_checker_assert
   `ASSERT(RstreqChkEsctimeout_A,
           $rose(
               slow_esc_rst_req
-          ) ##1 slow_esc_rst_req |-> ##[0:2] pwr_rst_o.rstreqs[ResetEscIdx],
+          ) ##1 slow_esc_rst_req |-> ##[0:10] pwr_rst_o.rstreqs[ResetEscIdx],
           clk_i, reset_or_disable)
 
 // sec_cm_fsm_terminal
@@ -94,14 +94,14 @@ module pwrmgr_sec_cm_checker_assert
 
   `ASSERT(RstreqChkFsmterm_A,
           $rose(slow_fsm_invalid) || $rose(fast_fsm_invalid)
-          |=> ##[1:10] $rose(pwr_rst_o.rst_lc_req & pwr_rst_o.rst_sys_req),
+          |-> ##[0:10] $rose(pwr_rst_o.rst_lc_req & pwr_rst_o.rst_sys_req),
           clk_i, reset_or_disable)
 
 // sec_cm_ctrl_flow_global_esc
 // if esc_rst_req is set, pwr_rst_o.rstreqs[ResetEscIdx] should be asserted.
   `ASSERT(RstreqChkGlbesc_A,
           $rose(slow_esc_rst_req) ##1 slow_esc_rst_req |->
-          ##[0:2] (pwr_rst_o.rstreqs[ResetEscIdx] | !rst_esc_ni),
+          ##[0:10] (pwr_rst_o.rstreqs[ResetEscIdx] | !rst_esc_ni),
           clk_i, reset_or_disable)
 
 // sec_cm_main_pd_rst_local_esc


### PR DESCRIPTION
Fix SVA cycles that were too tight.
Break the assertions for escalation reset to input to fast fsm into an assertion in the slow clock and one in the fast clock domains. Increase some test timeouts.