### PR TITLE
[chip,dv] move external clock window check to right place

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1521,7 +1521,7 @@
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
       sw_images: ["//sw/device/tests/sim_dv:clkmgr_external_clk_src_for_lc_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz", "+calibrate_usb_clk=1"]
+      run_opts: ["+chip_clock_source=ChipClockSourceExternal48Mhz"]
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0

--- a/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_ext_clk_if.sv
@@ -8,7 +8,7 @@ interface ast_ext_clk_if ();
   import uvm_pkg::*;
 
   // A timeout in case something holds the expected change.
-  localparam int WaitForExctClkSelChangeInNs = 100_000;
+  localparam int WaitForExctClkSelChangeInNs = 10_000_000;
 
   // This task returns once the external clock has gone through an active cycle.
   // Notice it will fail if the active cycle has already started.
@@ -24,7 +24,7 @@ interface ast_ext_clk_if ();
   endtask
 
   // Returns 1 if the external clock is in use.
-  function automatic bit is_ext_clk_in_use();
+  function automatic logic is_ext_clk_in_use();
     return u_ast.u_ast_clks_byp.u_io_clk_byp_en.out_o;
   endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -604,6 +604,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
                                                 input bit does_not_exist_ok = 0);
 
     sw_symbol_backdoor_access(symbol, data, sw_type, does_not_exist_ok, 0);
+    `uvm_info(`gfn, $sformatf("sw_symbol_backdoor_read gets %p", data), UVM_MEDIUM)
   endfunction
 
   // Backdoor-override a const symbol in SW to modify the behavior of the test.

--- a/sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test.c
+++ b/sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test.c
@@ -9,6 +9,9 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
+// Track the value of the external clock enable CSR written by software.
+static volatile const uint8_t kExternalClockEnable = 0x1;
+
 bool test_main(void) {
-  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/true);
+  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/kExternalClockEnable);
 }

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -89,12 +89,13 @@ bool execute_lc_ctrl_transition_test(bool use_ext_clk) {
       token.data[i] = kLcExitToken[i];
     }
     CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
+    LOG_INFO("Acquired lc_ctrl mutex by software");
     CHECK_DIF_OK(
         dif_lc_ctrl_configure(&lc, kDifLcCtrlStateDev, use_ext_clk, &token),
         "LC transition configuration failed!");
     CHECK_DIF_OK(dif_lc_ctrl_transition(&lc), "LC transition failed!");
-
-    LOG_INFO("Waiting for LC transtition done and reboot.");
+    CHECK_DIF_OK(dif_lc_ctrl_mutex_release(&lc));
+    LOG_INFO("Waiting for LC transition done and reboot.");
     wait_for_interrupt();
 
   } else {

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -9,6 +9,9 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
+// Track the value of the external clock enable CSR written by software.
+static volatile const uint8_t kExternalClockEnable = 0x0;
+
 bool test_main(void) {
-  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/false);
+  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/kExternalClockEnable);
 }


### PR DESCRIPTION
 - Coordinate with #18147. Move 'external_clock_active_window' checker to parallel thread with 'switch_to_external_clock'
 - Add plusarg to share the sequence with 'ext_clk enable by sw' test.
 - Address #18140 