### PR TITLE
[site] Fix mangers -> managers typo in block diagram tooltip

### DIFF
--- a/util/site/blocks.json
+++ b/util/site/blocks.json
@@ -1,6 +1,6 @@
 {
     "high-speed-crossbar": {
-        "name": "High Speed CrossBar",
+        "name": "High Speed Crossbar",
         "data_file": "hw/ip/tlul/data/tlul.prj.hjson",
         "href": "/hw/ip/tlul#top",
         "report": "/hw/top_earlgrey/ip/xbar_main/dv/autogen"
@@ -198,7 +198,7 @@
         "report": "/hw/ip/aon_timer/dv"
     },
     "clkrst-managers": {
-        "name": "CLK/RST Mangers",
+        "name": "CLK/RST Managers",
         "data_file": "hw/ip/clkmgr/data/clkmgr.hjson",
         "href": "/hw/ip/clkmgr#top",
         "report": "/hw/ip/clkmgr/dv"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105280833/235633396-944399bb-5766-486c-a086-c1be81f104fb.png)

Did a quick sweep for other typos and only saw `CrossBar` -> `Crossbar`.

As an aside, this block covers both the clock manager and reset manager, but the tooltip test coverage and link are only for the clock manager. 

I'm not sure there's a way of fixing that without splitting out this block in the diagram, which we don't really have space for.