### PR TITLE
[dv, chip-test, pin] Update chip_sw_sleep_pin_wake test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sleep_pin_wake_vseq.sv
@@ -70,10 +70,10 @@ class chip_sw_sleep_pin_wake_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.disconnect_all_interfaces(.disconnect_default_pulls(0));
 
     periph_to_dio_oe = '0;
-    periph_to_mio_oe = '0;    
+    periph_to_mio_oe = '0;
     // Disabling output enables for pads so they can be driven on without contradictions.
     void'(cfg.chip_vif.signal_probe_pinmux_periph_to_dio_oe_i(SignalProbeForce, periph_to_dio_oe));
-    void'(cfg.chip_vif.signal_probe_pinmux_periph_to_mio_oe_i(SignalProbeForce, periph_to_mio_oe));    
+    void'(cfg.chip_vif.signal_probe_pinmux_periph_to_mio_oe_i(SignalProbeForce, periph_to_mio_oe));
     drive_pad(pad_type, pad_idx, 0);
     `DV_WAIT(cfg.chip_vif.pwrmgr_low_power);
     #(exit_delay * 1ns);


### PR DESCRIPTION
Updating the test as follows:

1- Disabled output enablers that are connected to the pinmux, so that pads are driven without any issues (pad's violation).
2- Driving the pads on the mios_if to 0 before driving the sw_straps_if, so that the pins values are consistent.
