### PR TITLE
[manuf] Add test for the manuf_cp_yield_test testpoint

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -279,3 +279,24 @@ opentitan_functest(
         "//sw/device/silicon_creator/lib/drivers:otp",
     ],
 )
+
+opentitan_functest(
+    name = "manuf_cp_yield_test_functest",
+    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
+        tags = [
+            "jtag",
+        ],
+        test_cmds = OPENTITANTOOL_OPENOCD_TEST_CMDS,
+    ),
+    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+    targets = ["cw310_rom"],
+    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test:manuf_cp_yield_test",
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+    ],
+)

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -65,6 +65,7 @@ rust_library(
         "src/crypto/rsa.rs",
         "src/crypto/sha256.rs",
         "src/crypto/spx.rs",
+        "src/dif/clkmgr.rs",
         "src/dif/lc_ctrl.rs",
         "src/dif/rstmgr.rs",
         "src/dif/mod.rs",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -102,6 +102,7 @@ rust_library(
         "src/test_utils/bootstrap.rs",
         "src/test_utils/e2e_command.rs",
         "src/test_utils/epmp.rs",
+        "src/test_utils/extclk.rs",
         "src/test_utils/gpio.rs",
         "src/test_utils/init.rs",
         "src/test_utils/lc_transition.rs",
@@ -211,6 +212,7 @@ rust_library(
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
     },
     deps = [
+        "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib/bindgen",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -11,6 +11,7 @@ cc_library(
     name = "difs",
     hdrs = ["difs.h"],
     deps = [
+        "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:rstmgr",
     ],
@@ -34,6 +35,10 @@ rust_bindgen_library(
 rust_bindgen_library(
     name = "dif",
     bindgen_flags = [
+        "--allowlist-var=CLKMGR_.*_BIT",
+        "--allowlist-var=CLKMGR_.*_REG_OFFSET",
+        "--allowlist-var=CLKMGR_.*_MASK",
+        "--allowlist-var=CLKMGR_.*_OFFSET",
         "--allowlist-type=dif_lc_ctrl_state",
         "--allowlist-type=dif_lc_ctrl_token",
         "--allowlist-var=LC_CTRL_.*_BIT",

--- a/sw/host/opentitanlib/bindgen/difs.h
+++ b/sw/host/opentitanlib/bindgen/difs.h
@@ -5,9 +5,11 @@
 #ifndef OPENTITAN_SW_HOST_OPENTITANLIB_BINDGEN_DIFS_H_
 #define OPENTITAN_SW_HOST_OPENTITANLIB_BINDGEN_DIFS_H_
 
+#include "sw/device/lib/dif/dif_clkmgr.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 
+#include "clkmgr_regs.h"   // Generated.
 #include "lc_ctrl_regs.h"  // Generated.
 
 #endif  // OPENTITAN_SW_HOST_OPENTITANLIB_BINDGEN_DIFS_H_

--- a/sw/host/opentitanlib/src/dif/clkmgr.rs
+++ b/sw/host/opentitanlib/src/dif/clkmgr.rs
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use bitflags::bitflags;
+
+use bindgen::dif;
+
+use crate::util::bitfield::BitField;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ClkmgrReg {
+    AlertTest = dif::CLKMGR_ALERT_TEST_REG_OFFSET,
+    ExtclkCtrlRegwen = dif::CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET,
+    ExtclkCtrl = dif::CLKMGR_EXTCLK_CTRL_REG_OFFSET,
+    ExtclkStatus = dif::CLKMGR_EXTCLK_STATUS_REG_OFFSET,
+    JitterRegwen = dif::CLKMGR_JITTER_REGWEN_REG_OFFSET,
+    JitterEnable = dif::CLKMGR_JITTER_ENABLE_REG_OFFSET,
+    ClkEnables = dif::CLKMGR_CLK_ENABLES_REG_OFFSET,
+    ClkHints = dif::CLKMGR_CLK_HINTS_REG_OFFSET,
+    ClkHintsStatus = dif::CLKMGR_CLK_HINTS_STATUS_REG_OFFSET,
+    MeasureCtrlRegwen = dif::CLKMGR_MEASURE_CTRL_REGWEN_REG_OFFSET,
+    IoMeasCtrlEn = dif::CLKMGR_IO_MEAS_CTRL_EN_REG_OFFSET,
+    IoMeasCtrlShadowed = dif::CLKMGR_IO_MEAS_CTRL_SHADOWED_REG_OFFSET,
+    IoDiv2MeasCtrlEn = dif::CLKMGR_IO_DIV2_MEAS_CTRL_EN_REG_OFFSET,
+    IoDiv2MeasCtrlShadowed = dif::CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_REG_OFFSET,
+    IoDiv4MeasCtrlEn = dif::CLKMGR_IO_DIV4_MEAS_CTRL_EN_REG_OFFSET,
+    IoDiv4MeasCtrlShadowed = dif::CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_REG_OFFSET,
+    MainMeasCtrlEn = dif::CLKMGR_MAIN_MEAS_CTRL_EN_REG_OFFSET,
+    MainMeasCtrlShadowed = dif::CLKMGR_MAIN_MEAS_CTRL_SHADOWED_REG_OFFSET,
+    UsbMeasCtrlEn = dif::CLKMGR_USB_MEAS_CTRL_EN_REG_OFFSET,
+    UsbMeasCtrlShadowed = dif::CLKMGR_USB_MEAS_CTRL_SHADOWED_REG_OFFSET,
+    RecovErrCode = dif::CLKMGR_RECOV_ERR_CODE_REG_OFFSET,
+    FatalErrCode = dif::CLKMGR_FATAL_ERR_CODE_REG_OFFSET,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct ClkmgrExtclkCtrlRegwen: u32 {
+        const EN = 0b1 << dif::CLKMGR_EXTCLK_CTRL_REGWEN_EN_BIT;
+    }
+}
+
+/// BitFields for the CLKMGR_EXTCLK_CTRL register.
+pub struct ClkmgrExtclkCtrl;
+
+impl ClkmgrExtclkCtrl {
+    pub const HI_SPEED_SEL: BitField = BitField {
+        offset: dif::CLKMGR_EXTCLK_CTRL_HI_SPEED_SEL_OFFSET,
+        // Relies on mask being continuous
+        size: dif::CLKMGR_EXTCLK_CTRL_HI_SPEED_SEL_MASK.count_ones(),
+    };
+
+    pub const SEL: BitField = BitField {
+        offset: dif::CLKMGR_EXTCLK_CTRL_SEL_OFFSET,
+        // Relies on mask being continuous
+        size: dif::CLKMGR_EXTCLK_CTRL_SEL_MASK.count_ones(),
+    };
+}

--- a/sw/host/opentitanlib/src/dif/mod.rs
+++ b/sw/host/opentitanlib/src/dif/mod.rs
@@ -2,5 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod clkmgr;
 pub mod lc_ctrl;
 pub mod rstmgr;

--- a/sw/host/opentitanlib/src/test_utils/extclk.rs
+++ b/sw/host/opentitanlib/src/test_utils/extclk.rs
@@ -1,0 +1,126 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utilities for enabling or disabling external clock injection through JTAG to the clock manager.
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+use top_earlgrey::top_earlgrey_memory;
+
+use crate::chip::boolean::MultiBitBool4;
+use crate::dif::clkmgr::{ClkmgrExtclkCtrl, ClkmgrReg};
+use crate::io::jtag::Jtag;
+use crate::test_utils::poll;
+
+/// Available speeds for the external clock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClockSpeed {
+    /// Approximately 1/2 of nominal frequency.
+    Low,
+    /// Approximately nominal frequency.
+    High,
+}
+
+/// Controls for enabling or disabling external clock injection.
+pub struct ExternalClock;
+
+impl ExternalClock {
+    /// Base address of the clock manager.
+    const CLKMGR_BASE_ADDR: u32 = top_earlgrey_memory::TOP_EARLGREY_CLKMGR_AON_BASE_ADDR as u32;
+
+    /// Addresses of clock manager registers in memory.
+    const EXTCLK_CTRL_REGWEN_ADDR: u32 =
+        Self::CLKMGR_BASE_ADDR + ClkmgrReg::ExtclkCtrlRegwen as u32;
+    const EXTCLK_CTRL_ADDR: u32 = Self::CLKMGR_BASE_ADDR + ClkmgrReg::ExtclkCtrl as u32;
+    const EXTCLK_STATUS_ADDR: u32 = Self::CLKMGR_BASE_ADDR + ClkmgrReg::ExtclkStatus as u32;
+
+    /// Durations for polling of the STATUS register.
+    const POLL_TIMEOUT: Duration = Duration::from_millis(500);
+    const POLL_DELAY: Duration = Duration::from_millis(5);
+
+    /// Enable the external clock at the given speed.
+    pub fn enable(jtag: &dyn Jtag, speed: ClockSpeed) -> Result<(), ExternalClockError> {
+        if !Self::write_enabled(jtag)? {
+            return Err(ExternalClockError::WriteDisabled);
+        }
+
+        // Fields and their values for the EXTCLK_CTRL register.
+        let hi_speed = match speed {
+            ClockSpeed::Low => MultiBitBool4::False,
+            ClockSpeed::High => MultiBitBool4::True,
+        };
+        let fields = [
+            (ClkmgrExtclkCtrl::SEL, MultiBitBool4::True),
+            (ClkmgrExtclkCtrl::HI_SPEED_SEL, hi_speed),
+        ];
+
+        // OR the fields together to get the register value.
+        let extclk_ctrl = fields.into_iter().fold(0, |acc, (field, value)| {
+            acc | field.emplace(u8::from(value) as u32)
+        });
+
+        // Set the EXTCLK_CTRL register.
+        jtag.write_memory32(Self::EXTCLK_CTRL_ADDR, &[extclk_ctrl])
+            .map_err(|source| ExternalClockError::Jtag { source })?;
+
+        Self::wait_for_ack(jtag)?;
+
+        Ok(())
+    }
+
+    /// Disable the external clock.
+    pub fn disable(jtag: &dyn Jtag) -> Result<(), ExternalClockError> {
+        if !Self::write_enabled(jtag)? {
+            return Err(ExternalClockError::WriteDisabled);
+        }
+
+        // Set the EXTCLK_CTRL register.
+        let extclk_ctrl = ClkmgrExtclkCtrl::SEL.emplace(u8::from(MultiBitBool4::False) as u32);
+        jtag.write_memory32(Self::EXTCLK_CTRL_ADDR, &[extclk_ctrl])
+            .map_err(|source| ExternalClockError::Jtag { source })?;
+
+        Self::wait_for_ack(jtag)?;
+
+        Ok(())
+    }
+
+    /// Returns the CLKMGR_EXTCLK_REGWEN setting which shows whether the
+    /// `EXTCLK_CTRL` register can be written.
+    fn write_enabled(jtag: &dyn Jtag) -> Result<bool, ExternalClockError> {
+        let mut buf = [0];
+        jtag.read_memory32(Self::EXTCLK_CTRL_REGWEN_ADDR, &mut buf)
+            .map_err(|source| ExternalClockError::Jtag { source })?;
+
+        Ok(buf[0] & 1 == 1)
+    }
+
+    /// Wait until the clock manager reports that the clock has changed to the external source.
+    fn wait_for_ack(jtag: &dyn Jtag) -> Result<(), ExternalClockError> {
+        poll::poll_until(Self::POLL_TIMEOUT, Self::POLL_DELAY, || {
+            // Check the status register.
+            let mut status_buf = [0];
+            jtag.read_memory32(Self::EXTCLK_STATUS_ADDR, &mut status_buf)
+                .map_err(|source| ExternalClockError::Jtag { source })?;
+
+            Ok(status_buf[0] == u8::from(MultiBitBool4::True) as u32)
+        })
+        .map_err(|source| ExternalClockError::Nack { source })
+    }
+}
+
+/// Failures when setting the external clock.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ExternalClockError {
+    #[error("failed to communicate over JTAG")]
+    Jtag { source: anyhow::Error },
+
+    #[error("did not read ACK for external clock change")]
+    Nack { source: anyhow::Error },
+
+    #[error("writing to external clock registers is disabled")]
+    WriteDisabled,
+}

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -5,6 +5,7 @@
 pub mod bootstrap;
 pub mod e2e_command;
 pub mod epmp;
+pub mod extclk;
 pub mod gpio;
 pub mod init;
 pub mod lc_transition;

--- a/sw/host/opentitanlib/src/util/bitfield.rs
+++ b/sw/host/opentitanlib/src/util/bitfield.rs
@@ -2,18 +2,47 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Represents a single field of bits within a u32 word.
 pub struct BitField {
+    /// Number of bits into the word that the field starts.
     pub offset: u32,
+    /// Length in bits of the field.
     pub size: u32,
 }
 
 impl BitField {
-    pub fn new(offset: u32, size: u32) -> BitField {
+    /// Create a new BitField with the given offset and length.
+    pub const fn new(offset: u32, size: u32) -> BitField {
         BitField { offset, size }
     }
 
-    pub fn extract(&self, word: u32) -> u32 {
+    /// Extract a value of this field from a word.
+    pub const fn extract(&self, word: u32) -> u32 {
+        (word & self.mask()) >> self.offset
+    }
+
+    /// Emplace a value into this field within a word.
+    pub const fn emplace(&self, value: u32) -> u32 {
+        (value << self.offset) & self.mask()
+    }
+
+    /// Returns the bit-mask of this bitfield.
+    pub const fn mask(&self) -> u32 {
         let mask = (1 << self.size) - 1;
-        (word >> self.offset) & mask
+        mask << self.offset
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let bitfield = BitField { offset: 2, size: 3 };
+
+        assert_eq!(bitfield.mask(), 0b0011100);
+        assert_eq!(bitfield.extract(0b1110111), 0b101);
+        assert_eq!(bitfield.emplace(0b101), 0b0010100);
     }
 }

--- a/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "manuf_cp_yield_test",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This test checks that we can change TAP strapping from CPU to the LC_CTRL
+//! and still use the interface without resetting.
+//!
+//! Both interfaces are used to check they're accessible. This is only possible
+//! in some lifecycle states: `TEST_UNLOCKED0` is used in this case.
+
+use anyhow::Context;
+use structopt::StructOpt;
+
+use opentitanlib::chip::boolean::MultiBitBool4;
+use opentitanlib::dif::clkmgr::{ClkmgrExtclkCtrl, ClkmgrReg};
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::test_utils::init::InitializeTest;
+use top_earlgrey::top_earlgrey_memory;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+    #[structopt(flatten)]
+    jtag: JtagParams,
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_target()?;
+
+    let transport = opts.init.init_target()?;
+
+    // Begin with the TAP straps set for the CPU.
+    transport
+        .pin_strapping("PINMUX_TAP_RISCV")?
+        .apply()
+        .context("failed to apply RISCV TAP strapping")?;
+    transport
+        .reset_target(opts.init.bootstrap.options.reset_delay, true)
+        .context("failed to reset")?;
+
+    let jtag = transport.jtag(&opts.jtag)?;
+
+    // Connect to the CPU over JTAG.
+    jtag.connect(JtagTap::RiscvTap)
+        .context("failed to connect to RISCV TAP over JTAG")?;
+
+    // Enable the external clock through JTAG.
+
+    let clkmgr_base_addr = top_earlgrey_memory::TOP_EARLGREY_CLKMGR_AON_BASE_ADDR as u32;
+
+    // Enable writing to the external clock register.
+    let extclk_ctrl_regwen_addr = clkmgr_base_addr + ClkmgrReg::ExtclkCtrlRegwen as u32;
+    jtag.write_memory32(extclk_ctrl_regwen_addr, &[1])
+        .context("failed to set EXTCLK_CTRL_REGWEN")?;
+
+    // Enable the external clock.
+    let extclk_ctrl_addr = clkmgr_base_addr + ClkmgrReg::ExtclkCtrl as u32;
+    let extclk_enable = ClkmgrExtclkCtrl::SEL.emplace(u8::from(MultiBitBool4::True) as u32);
+    jtag.write_memory32(extclk_ctrl_addr, &[extclk_enable])
+        .context("failed to set EXTCLK_CTRL_SET bitfield")?;
+
+    // Read and write memory to verify connection.
+
+    // Check the lifecycle state via its memory map.
+    let mut reset_info_buf = [0];
+    jtag.read_memory32(
+        top_earlgrey_memory::TOP_EARLGREY_LC_CTRL_BASE_ADDR as u32 + LcCtrlReg::LcState as u32,
+        &mut reset_info_buf,
+    )?;
+
+    assert_eq!(
+        reset_info_buf[0],
+        DifLcCtrlState::TestUnlocked0.redundant_encoding()
+    );
+
+    // Without resetting, changing TAP strapping to the LC and reconnect JTAG.
+
+    jtag.disconnect().context("failed to disconnect JTAG")?;
+
+    transport
+        .pin_strapping("PINMUX_TAP_LC")?
+        .apply()
+        .context("failed to apply LC TAP strapping")?;
+
+    jtag.connect(JtagTap::LcTap)
+        .context("failed to connect to LC TAP over JTAG")?;
+
+    // Read and write registers to verify connection.
+
+    // Check the LC state is `TEST_UNLOCKED0`.
+    let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
+    assert_eq!(state, DifLcCtrlState::TestUnlocked0.redundant_encoding());
+
+    jtag.disconnect().context("failed to disconnect JTAG")?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This PR adds a test for `manuf_cp_yield_test`. Resolves https://github.com/lowRISC/opentitan/issues/17387.

As per the test plan:

* OTP preloaded with `TEST_UNLOCKED`
* External clock enabled via the `CLKMGR_EXTCLK_CTRL` register.
* Connects to CPU TAP, reads the start of the ROM to test the connection.
* Switches to the LC TAP without a reset, reads the `LC_CTRL_STATE` register to test the connection.

## Unresolved:

* Do writes need testing, too? Can't hurt, but need to select some memory to write to.
* Is reading the start of the ROM okay, or is there some other known-value I should look for instead?