### PR TITLE
[crypto] Add RSA key generation top-level entrypoint.

### DIFF
--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -142,6 +142,22 @@ otbn_library(
     ],
 )
 
+otbn_binary(
+    name = "run_rsa_keygen",
+    srcs = [
+        "run_rsa_keygen.s",
+    ],
+    deps = [
+        ":div",
+        ":gcd",
+        ":lcm",
+        ":montmul",
+        ":mul",
+        ":primality",
+        ":rsa_keygen",
+    ],
+)
+
 otbn_library(
     name = "rsa_verify",
     srcs = [

--- a/sw/otbn/crypto/mul.s
+++ b/sw/otbn/crypto/mul.s
@@ -35,7 +35,7 @@
  * @param[out] dmem[x12..x12+(n*2*32)]: result, a*b
  *
  * clobbered registers: x2 to x8, x20 to x23, w20 to w23
- * clobbered flag groups: None
+ * clobbered flag groups: FG0
  */
 bignum_mul:
   /* Zeroize output buffer.

--- a/sw/otbn/crypto/run_rsa_keygen.s
+++ b/sw/otbn/crypto/run_rsa_keygen.s
@@ -1,0 +1,79 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * RSA key generation.
+ */
+
+/**
+ * Mode magic values generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 4 -n 11 \
+ *    --avoid-zero -s 561689407
+ *
+ * Call the same utility with the same arguments and a higher -m to generate
+ * additional value(s) without changing the others or sacrificing mutual HD.
+ *
+ * TODO(#17727): in some places the OTBN assembler support for .equ directives
+ * is lacking, so they cannot be used in bignum instructions or pseudo-ops such
+ * as `li`. If support is added, we could use 32-bit values here instead of
+ * 11-bit.
+ */
+.equ MODE_RSA_2048, 0x3b7
+.equ MODE_RSA_3072, 0x4fa
+.equ MODE_RSA_4096, 0x74d
+
+.section .text.start
+start:
+  /* Init all-zero register. */
+  bn.xor  w31, w31, w31
+
+  /* Read the mode and tail-call the requested operation. */
+  la      x2, mode
+  lw      x2, 0(x2)
+
+  addi    x3, x0, MODE_RSA_2048
+  beq     x2, x3, rsa_keygen_2048
+
+  addi    x3, x0, MODE_RSA_3072
+  beq     x2, x3, rsa_keygen_3072
+
+  addi    x3, x0, MODE_RSA_4096
+  beq     x2, x3, rsa_keygen_4096
+
+  /* Unsupported mode; fail. */
+  unimp
+  unimp
+  unimp
+
+rsa_keygen_2048:
+  /* Set the number of limbs for the primes (2048 / 2 / 256). */
+  li      x30, 4
+
+  /* Generate a key (results in dmem[rsa_n] and dmem[rsa_d]). */
+  jal     x1, rsa_keygen
+  ecall
+
+rsa_keygen_3072:
+  /* Set the number of limbs for the primes (3072 / 2 / 256). */
+  li      x30, 6
+
+  /* Generate a key (results in dmem[rsa_n] and dmem[rsa_d]). */
+  jal     x1, rsa_keygen
+  ecall
+
+rsa_keygen_4096:
+  /* Set the number of limbs for the primes (4096 / 2 / 256). */
+  li      x30, 8
+
+  /* Generate a key (results in dmem[rsa_n] and dmem[rsa_d]). */
+  jal     x1, rsa_keygen
+  ecall
+
+.bss
+
+/* Operational mode. */
+.globl mode
+.balign 4
+mode:
+  .zero 4

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -565,7 +565,11 @@ otbn_sim_test(
     ],
     exp = "relprime_f4_test.exp",
     deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
         "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
         "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:rsa_keygen",
     ],
@@ -591,7 +595,11 @@ otbn_sim_test(
     ],
     exp = "rsa_keygen_checkpq_test.exp",
     deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
         "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
         "//sw/otbn/crypto:primality",
         "//sw/otbn/crypto:rsa_keygen",
     ],


### PR DESCRIPTION
Final steps for the OTBN RSA keygen implementation:
- Add a top-level function that strings together generation of primes p and q and derivation of the private exponent d
- Add a binary entrypoint for Ibex programs

After this, we just need an Ibex program to call it :tada: (spoiler: I already tried it locally and generated at least one valid RSA-2048 key!)

Right now, the full keygen takes ~20s (with wide variance depending how lucky you get with the RNG). There's definitely some low-hanging fruit for making it faster -- specifically, a filter for composites that are divisible by small primes will probably improve performance by about 70-80%, and generating primes with a restriction that they be 3 or 7 mod 8 will speed up Miller-Rabin a bit (this is newly allowed when FIPS 186-5 came out a few months ago, so BoringSSL doesn't have it yet). But I'm focusing on getting something working end-to-end first before I optimize.