### PR TITLE
[dif/csrng] fix csrng DIFs for m2.5 signoff

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -205,6 +205,7 @@ cc_library(
     ],
     deps = [
         ":base",
+        "//hw/ip/csrng/data:csrng_regs",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -468,21 +468,9 @@ dif_result_t dif_csrng_get_recoverable_alerts(const dif_csrng_t *csrng,
     return kDifBadArg;
   }
 
-  *alerts = 0;
-  uint32_t reg =
+  *alerts =
       mmio_region_read32(csrng->base_addr, CSRNG_RECOV_ALERT_STS_REG_OFFSET);
-  *alerts =
-      bitfield_bit32_copy(*alerts, kDifCsrngRecoverableAlertBadEnable, reg,
-                          CSRNG_RECOV_ALERT_STS_ENABLE_FIELD_ALERT_BIT);
-  *alerts =
-      bitfield_bit32_copy(*alerts, kDifCsrngRecoverableAlertBadSwAppEnable, reg,
-                          CSRNG_RECOV_ALERT_STS_SW_APP_ENABLE_FIELD_ALERT_BIT);
-  *alerts =
-      bitfield_bit32_copy(*alerts, kDifCsrngRecoverableAlertBadIntState, reg,
-                          CSRNG_RECOV_ALERT_STS_READ_INT_STATE_FIELD_ALERT_BIT);
-  *alerts =
-      bitfield_bit32_copy(*alerts, kDifCsrngRecoverableAlertRepeatedGenBits,
-                          reg, CSRNG_RECOV_ALERT_STS_CS_BUS_CMP_ALERT_BIT);
+
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -405,6 +405,11 @@ dif_result_t dif_csrng_get_internal_state(
   uint32_t reg = bitfield_field32_write(
       0, CSRNG_INT_STATE_NUM_INT_STATE_NUM_FIELD, instance_id);
   mmio_region_write32(csrng->base_addr, CSRNG_INT_STATE_NUM_REG_OFFSET, reg);
+  uint32_t actual_reg =
+      mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_NUM_REG_OFFSET);
+  if (reg != actual_reg) {
+    return kDifError;
+  }
 
   // Read the internal state.
   state->reseed_counter =

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -16,6 +16,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
 
+#include "csrng_regs.h"  // Generated
 #include "sw/device/lib/dif/autogen/dif_csrng_autogen.h"
 
 #ifdef __cplusplus
@@ -286,22 +287,38 @@ typedef enum dif_csrng_recoverable_alert {
    * Indicates a bad value was written to the ENABLE field of the control
    * register.
    */
-  kDifCsrngRecoverableAlertBadEnable,
+  kDifCsrngRecoverableAlertBadEnable =
+      1U << CSRNG_RECOV_ALERT_STS_ENABLE_FIELD_ALERT_BIT,
   /**
    * Indicates a bad value was written to the SW_APP_ENABLE field of the control
    * register.
    */
-  kDifCsrngRecoverableAlertBadSwAppEnable,
+  kDifCsrngRecoverableAlertBadSwAppEnable =
+      1U << CSRNG_RECOV_ALERT_STS_SW_APP_ENABLE_FIELD_ALERT_BIT,
   /**
    * Indicates a bad value was written to the READ_INT_STATE field of the
    * control register.
    */
-  kDifCsrngRecoverableAlertBadIntState,
+  kDifCsrngRecoverableAlertBadIntState =
+      1U << CSRNG_RECOV_ALERT_STS_READ_INT_STATE_FIELD_ALERT_BIT,
+  /**
+   * Indicates the FLAG0 field in the Application Command is set to a value
+   * other than kMultiBitBool4True or kMultiBitBool4False.
+   */
+  kDifCsrngRecoverableAlertBadFlag0 =
+      1U << CSRNG_RECOV_ALERT_STS_ACMD_FLAG0_FIELD_ALERT_BIT,
   /**
    * Indicates the genbits bus saw two identical values, indicating a possible
    * attack.
    */
-  kDifCsrngRecoverableAlertRepeatedGenBits,
+  kDifCsrngRecoverableAlertRepeatedGenBits =
+      1U << CSRNG_RECOV_ALERT_STS_CS_BUS_CMP_ALERT_BIT,
+  /**
+   * Indicates an unsupported CSRNG command is being processed, causing the main
+   * FSM to hang unless the module enable field is set to the disabled state.
+   */
+  kDifCsrngRecoverableAlertBadCsrngCmd =
+      1U << CSRNG_RECOV_ALERT_STS_CS_MAIN_SM_ALERT_BIT,
 } dif_csrng_recoverable_alert_t;
 
 /**

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -462,8 +462,8 @@ TEST_F(AlertTest, Get) {
                     {CSRNG_RECOV_ALERT_STS_CS_BUS_CMP_ALERT_BIT, true},
                 });
   EXPECT_DIF_OK(dif_csrng_get_recoverable_alerts(&csrng_, &out));
-  EXPECT_EQ(out, BitSet(kDifCsrngRecoverableAlertBadEnable,
-                        kDifCsrngRecoverableAlertRepeatedGenBits));
+  EXPECT_EQ(out, kDifCsrngRecoverableAlertBadEnable |
+                     kDifCsrngRecoverableAlertRepeatedGenBits);
 }
 
 TEST_F(AlertTest, Clear) {

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -346,6 +346,11 @@ TEST_F(GetInternalStateTest, GetInternalStateOk) {
                      {CSRNG_INT_STATE_NUM_INT_STATE_NUM_OFFSET,
                       static_cast<uint32_t>(instance_id)},
                  });
+  EXPECT_READ32(CSRNG_INT_STATE_NUM_REG_OFFSET,
+                {
+                    {CSRNG_INT_STATE_NUM_INT_STATE_NUM_OFFSET,
+                     static_cast<uint32_t>(instance_id)},
+                });
 
   dif_csrng_internal_state_t expected = {
       .reseed_counter = 1,
@@ -371,6 +376,23 @@ TEST_F(GetInternalStateTest, GetInternalStateOk) {
   EXPECT_THAT(got.v, ElementsAreArray(expected.v));
   EXPECT_EQ(got.instantiated, expected.instantiated);
   EXPECT_EQ(got.fips_compliance, expected.fips_compliance);
+}
+
+TEST_F(GetInternalStateTest, BadIntStateNumWrite) {
+  EXPECT_WRITE32(CSRNG_INT_STATE_NUM_REG_OFFSET,
+                 {
+                     {CSRNG_INT_STATE_NUM_INT_STATE_NUM_OFFSET,
+                      static_cast<uint32_t>(kCsrngInternalStateIdSw)},
+                 });
+  EXPECT_READ32(CSRNG_INT_STATE_NUM_REG_OFFSET,
+                {
+                    {CSRNG_INT_STATE_NUM_INT_STATE_NUM_OFFSET, 0},
+                });
+
+  dif_csrng_internal_state_t got;
+  EXPECT_EQ(
+      dif_csrng_get_internal_state(&csrng_, kCsrngInternalStateIdSw, &got),
+      kDifError);
 }
 
 TEST_F(GetInternalStateTest, GetInternalStateBadArgs) {


### PR DESCRIPTION
@vogelpi identified gaps in the CSRNG DIF library from the HW since the DIF library was originally written. This updates the DIF library to match the HW, specifically:
1. we now read back the INT_STATE_NUM register after writing to it to confirm it was successfully written (as recommended in the programmers guide)
2. add missing recoverable alert bits