### PR TITLE
[dv,chip_level,lc_ctrl] Fix handling of external clock

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -38,19 +38,19 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task body();
+    bit [7:0] ext_clock_en_array[1];
     super.body();
-    `uvm_info(`gfn, $sformatf("Will run for %d iterations", num_trans), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Will run for %0d iterations", num_trans), UVM_MEDIUM)
+    sw_symbol_backdoor_read("kExternalClockEnable", ext_clock_en_array);
     for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
-      // sw_symbol_backdoor takes arrays as the input.
+      // sw_symbol_backdoor accesses take arrays as the input and output.
       bit [7:0] trans_i_array[] = {trans_i};
       bit [TL_DW-1:0] ext_clock_en;
-      bit [7:0] ext_clock_en_array[1];
 
-      sw_symbol_backdoor_read("kExternalClockEnable", ext_clock_en_array);
       sw_symbol_backdoor_overwrite("kTestIterationCount", trans_i_array);
 
       if (trans_i > 1) begin
-        `uvm_info(`gfn, $sformatf("Applying reset and otp override for trans %d", trans_i),
+        `uvm_info(`gfn, $sformatf("Applying reset and otp override for trans %0d", trans_i),
                   UVM_MEDIUM)
         apply_reset();
         backdoor_override_otp();
@@ -67,10 +67,23 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       wait_lc_ready(.allow_err(1));
 
       fork
-        begin
-          // TEST_LOCKED* LC states do not allow ROM code execution -> IO clock calibration values aren't
-          // copied from OTP to AST -> internal clock isn't calibrated -> use external clock
+        begin : isolation_fork_lc
+          bit external_clock_was_activated = 1'b0;
+
+          // Detect windows when the AST selects ext_clk to drive the io_clk, to verify the external
+          // clock, and not the io oscillator, is actually used for these lc_ctrl transitions.
+          fork
+            begin
+              `uvm_info(`gfn, "Start detection of ext_clk active window", UVM_MEDIUM)
+              cfg.ast_ext_clk_vif.span_external_clock_active_window();
+              external_clock_was_activated = 1'b1;
+            end
+          join_none
+
+          // TEST_LOCKED* LC states do not allow ROM code execution -> IO clock calibration values
+          // aren't copied from OTP to AST -> internal clock isn't calibrated -> use external clock
           // to perform LC transition
+
           // activate the external source clock with 48MHz
           switch_to_external_clock();
 
@@ -90,71 +103,58 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
                                               p_sequencer.jtag_sequencer_h, ext_clock_en);
           `DV_CHECK(ext_clock_en,
                     "jtag read lc_ctrl.transition_ctrl should be 1");
+
           // LC state transition requires a chip reset.
-          // After reset state goes to Unlocked2 state.
-          `uvm_info(`gfn, $sformatf("Applying reset after lc transition for trans %d", trans_i),
+          `uvm_info(`gfn, $sformatf("Applying reset after lc transition for trans %0d", trans_i),
                     UVM_MEDIUM)
           apply_reset();
-        end // fork begin
-        begin
-          `uvm_info(`gfn, "Start detection of ext_clk active window", UVM_MEDIUM)
-          cfg.ast_ext_clk_vif.span_external_clock_active_window();
-        end
+
+          `DV_CHECK(external_clock_was_activated, "External clock should be enabled");
+
+          disable fork;
+        end : isolation_fork_lc
       join
 
+      // At this point the LC_CTRL state should be TEST_UNLOCKED2.
       // Wait for SW to finish power on set up.
       `DV_WAIT(cfg.sw_logger_vif.printed_log == "Waiting for LC transition done and reboot.")
 
-      if (ext_clock_en_array[0]) begin
-        fork
-          begin : isolation_fork
-             bit external_clock_was_activated = 1'b0;
-            // Detect windows when the AST selects ext_clk to drive the io_clk,
-            // to verify the external clock, and not the io oscillator,
-            // is actually used for these lc_ctrl transitions.
-            fork
-              begin
-                `uvm_info(`gfn, "Start detection of ext_clk active window", UVM_MEDIUM)
-                cfg.ast_ext_clk_vif.span_external_clock_active_window();
-                external_clock_was_activated = 1'b1;
-              end
-            join_none
+      fork
+        begin : isolation_fork_sw
+          bit external_clock_was_activated = 1'b0;
 
-            // Get the interface back to jtag.
-            claim_transition_interface();
+          // Detect windows when the AST selects ext_clk to drive the io_clk, to verify the external
+          // clock, and not the io oscillator, is actually used for these lc_ctrl transitions.
+          fork
+            begin
+              `uvm_info(`gfn, "Start detection of ext_clk active window", UVM_MEDIUM)
+              cfg.ast_ext_clk_vif.span_external_clock_active_window();
+              external_clock_was_activated = 1'b1;
+            end
+          join_none
 
-            // Wait for LC_CTRL state transition finish from TLUL interface.
-            wait_lc_status(LcTransitionSuccessful);
+          // Get the interface back to jtag.
+          claim_transition_interface();
 
-            // JTAG read out if LC_CTRL is configured to use external clock.
-            jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.transition_ctrl.get_offset(),
-                                                p_sequencer.jtag_sequencer_h, ext_clock_en);
+          // Wait for LC_CTRL state transition finish from TLUL interface.
+          wait_lc_status(LcTransitionSuccessful);
 
-            `uvm_info(`gfn,
-                      $sformatf("Before second apply_reset, ext_clock_en=%x, from array=%p",
-                                ext_clock_en, ext_clock_en_array), UVM_MEDIUM)
-            `DV_CHECK(ext_clock_en_array[0] == ext_clock_en);
+          // JTAG read out if LC_CTRL is configured to use external clock.
+          jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.transition_ctrl.get_offset(),
+                                              p_sequencer.jtag_sequencer_h, ext_clock_en);
+          // Check external clock is as expected by software.
+          `DV_CHECK(ext_clock_en == ext_clock_en_array[0]);
 
-            // LC_CTRL state transition requires a chip reset.
-            apply_reset();
-            `uvm_info(`gfn, "Second apply_reset done", UVM_MEDIUM)
+          // LC_CTRL state transition requires a chip reset.
+          apply_reset();
+          `uvm_info(`gfn, "Second apply_reset done", UVM_MEDIUM)
 
-            `DV_CHECK(external_clock_was_activated == ext_clock_en,
-                      $sformatf("External clock should be %0s", ext_clock_en ? "on" : "off"));
-            external_clock_was_activated = 1'b0;
+          `DV_CHECK(external_clock_was_activated == ext_clock_en, $sformatf(
+                    "Expected external clock %0s activated", ext_clock_en ? "was" : "wasn't"));
+          disable fork;
+        end : isolation_fork_sw
+      join
 
-            disable fork;
-          end
-        join
-      end else begin
-        // Wait for LC_CTRL state transition finish from TLUL interface.
-        wait_lc_status(LcTransitionSuccessful);
-
-        // LC_CTRL state transition requires a chip reset.
-        // After reset state goes to Dev State.
-        apply_reset();
-        `uvm_info(`gfn, "Second apply_reset done", UVM_MEDIUM)
-      end
       // Wait for SW test finishes with a pass/fail status.
       `DV_WAIT(
           cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed})

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -88,6 +88,7 @@ bool execute_lc_ctrl_transition_test(bool use_ext_clk) {
     for (int i = 0; i < LC_TOKEN_SIZE; i++) {
       token.data[i] = kLcExitToken[i];
     }
+    // Acquire the mutex, and release it after triggering the transition.
     CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));
     LOG_INFO("Acquired lc_ctrl mutex by software");
     CHECK_DIF_OK(


### PR DESCRIPTION
Fix lc_ctrl interface ownership handling.
Add more logging to help figure out the outcome of the test.