### PR TITLE
[dif/entropy_src] fix csrng DIFs for m2.5 signoff 

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -57,6 +57,19 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
     return kDifBadArg;
   }
 
+  // Check valid configuration if FIPS mode is selected.
+  // FIPS qualified entropy is only valid in non-single bit mode.
+  if (config.fips_enable &&
+      (config.single_bit_mode < kDifEntropySrcSingleBitModeDisabled)) {
+    return kDifBadArg;
+  }
+  // FIPS qualified entropy cannot be generated if both `route_to_firmware` and
+  // `bypass_conditioner` are enabled.
+  if (config.fips_enable && config.route_to_firmware &&
+      config.bypass_conditioner) {
+    return kDifBadArg;
+  }
+
   if (!mmio_region_read32(entropy_src->base_addr,
                           ENTROPY_SRC_REGWEN_REG_OFFSET)) {
     return kDifLocked;

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -126,12 +126,9 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
                       entropy_conf_reg);
 
   // Configure health test window.
-  // Conditioning bypass is hardcoded to disabled (see above). If we want to
-  // expose the ES_TYPE field in the future, we need to also configure the
-  // health test window size for bypass mode. Note however that the only
-  // supported bypass window size is the default value of 0x60 at the moment,
-  // hence even if the ES_TYPE field is exposed in the future, we should not
-  // change the bypass window size as this may break.
+  // Note: the only supported bypass window size is the default value of 0x60 at
+  // the moment, hence even if `bypass_conditioner` is set, we should not change
+  // the bypass window size.
   uint32_t health_test_window_sizes =
       bitfield_field32_write(ENTROPY_SRC_HEALTH_TEST_WINDOWS_REG_RESVAL,
                              ENTROPY_SRC_HEALTH_TEST_WINDOWS_FIPS_WINDOW_FIELD,
@@ -241,8 +238,6 @@ dif_result_t dif_entropy_src_health_test_configure(
       return kDifBadArg;
   }
 
-  // Conditioning bypass is hardcoded to disabled (see above). Therefore we only
-  // configure FIPS mode thresholds.
   mmio_region_write32(entropy_src->base_addr, high_thresholds_reg_offset,
                       config.high_threshold);
   if (low_thresholds_reg_offset != -1) {
@@ -364,8 +359,6 @@ dif_result_t dif_entropy_src_get_health_test_stats(
         return kDifError;
     }
 
-    // Conditioning bypass is hardcoded to disabled (see above). Therefore we
-    // only read FIPS mode stats.
     stats->high_watermark[i] =
         mmio_region_read32(entropy_src->base_addr, high_watermarks_reg_offset);
     stats->low_watermark[i] =

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -121,11 +121,14 @@ typedef struct dif_entropy_src_config {
    * If set, raw entropy will be sent to CSRNG, bypassing the conditioner block
    * and disabling the FIPS flag. Note that the FIPS flag is different from
    * running the block in FIPS mode. FIPS mode refers to running the entropy_src
-   * in continuous mode.
+   * in continuous mode. Also note that if `fips_enable` is set to `True`, then
+   * at most one of either `route_to_firmware` or `bypass_conditioner` may be
+   * set, but not both.
    */
   bool bypass_conditioner;
   /**
-   * Specifies which single-bit-mode to use, if any at all.
+   * Specifies which single-bit-mode to use, if any at all. `fips_enable` must
+   * be false to use any single-bit-mode`.
    */
   dif_entropy_src_single_bit_mode_t single_bit_mode;
   /**

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -216,11 +216,13 @@ typedef struct dif_entropy_src_health_test_config {
    */
   dif_entropy_src_test_t test_type;
   /**
-   * The high threshold for the health test.
+   * The high threshold for the health test (contains both FIPS and bypass
+   * thresholds).
    */
   uint32_t high_threshold;
   /**
-   * The low threshold for the health test.
+   * The low threshold for the health test (contains both FIPS and bypass
+   * thresholds).
    *
    * If the corresponding health test has no low threshold, set to 0, otherwise
    * `dif_entropy_src_health_test_configure()` will return `kDifBadArg`.
@@ -248,14 +250,16 @@ typedef struct dif_entropy_src_health_test_stats {
    */
   uint16_t high_watermark[kDifEntropySrcTestNumVariants];
   /**
-   * Low watermark indicating the lowest value emitted by a particular test.
+   * Low watermark indicating the lowest value emitted by a particular test
+   * (contains both FIPS and bypass watermarks).
    *
    * Note, some health tests do not emit a low watermark as there is no low
    * threshold. For these tests, this value will always be UINT16_MAX.
    */
   uint16_t low_watermark[kDifEntropySrcTestNumVariants];
   /**
-   * The number of times a particular test has failed above the high threshold.
+   * The number of times a particular test has failed above the high threshold
+   * (contains both FIPS and bypass watermarks).
    */
   uint32_t high_fails[kDifEntropySrcTestNumVariants];
   /**

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -420,11 +420,21 @@ typedef enum dif_entropy_src_alert_cause {
    */
   kDifEntropySrcAlertThresholdConfig = 1U << 14,
   /**
+   * Triggered when the packer FIFO has been written but was full at the time
+   * and we are in FW_OV_MODE and FW_OV_ENTROPY_INSERT modes.
+   */
+  kDifEntropySrcAlertFirmwareOverrideWrite = 1U << 15,
+  /**
+   * Triggered when FW_OV_SHA3_START has been set to kMultiBitBool4False,
+   * without waiting for the bypass packer FIFO to clear.
+   */
+  kDifEntropySrcAlertFirmwareOverrideDisable = 1U << 16,
+  /**
    * All alert reasons.
    *
    * This is useful when clearing all recoverable alerts at once.
    */
-  kDifEntropySrcAlertAllAlerts = (1U << 15) - 1,
+  kDifEntropySrcAlertAllAlerts = (1U << 17) - 1,
 } dif_entropy_src_alert_cause_t;
 
 /**

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -815,7 +815,7 @@ TEST_F(ClearRecoverableAlertsTest, NullHandle) {
 }
 
 TEST_F(ClearRecoverableAlertsTest, BadAlerts) {
-  uint32_t alerts = 1U << 15;
+  uint32_t alerts = 1U << 17;
   EXPECT_DIF_BADARG(
       dif_entropy_src_clear_recoverable_alerts(&entropy_src_, alerts));
 }

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -47,6 +47,26 @@ TEST_F(ConfigTest, BadSingleBitMode) {
       dif_entropy_src_configure(&entropy_src_, config_, kDifToggleEnabled));
 }
 
+TEST_F(ConfigTest, BadFipsEnabled) {
+  dif_entropy_src_config_t bad_fips_config_0 = {
+      .fips_enable = true,
+      .route_to_firmware = false,
+      .bypass_conditioner = false,
+      .single_bit_mode = kDifEntropySrcSingleBitMode3,
+      .health_test_window_size = 1};
+  EXPECT_DIF_BADARG(dif_entropy_src_configure(&entropy_src_, bad_fips_config_0,
+                                              kDifToggleEnabled));
+
+  dif_entropy_src_config_t bad_fips_config_1 = {
+      .fips_enable = true,
+      .route_to_firmware = true,
+      .bypass_conditioner = true,
+      .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+      .health_test_window_size = 1};
+  EXPECT_DIF_BADARG(dif_entropy_src_configure(&entropy_src_, bad_fips_config_1,
+                                              kDifToggleEnabled));
+}
+
 TEST_F(ConfigTest, Locked) {
   EXPECT_READ32(ENTROPY_SRC_REGWEN_REG_OFFSET, 0);
   EXPECT_EQ(
@@ -169,8 +189,8 @@ INSTANTIATE_TEST_SUITE_P(
         ConfigParams{false, false, false, kDifEntropySrcSingleBitMode0, false,
                      1, 2, kDifToggleDisabled},
         // Test all enabled.
-        ConfigParams{true, true, false, kDifEntropySrcSingleBitMode0, true, 32,
-                     2, kDifToggleEnabled}));
+        ConfigParams{true, true, false, kDifEntropySrcSingleBitModeDisabled,
+                     true, 32, 2, kDifToggleEnabled}));
 
 class FwOverrideConfigTest : public EntropySrcTest {
  protected:


### PR DESCRIPTION
@vogelpi identified changes in the entropy_src HW since the last design milestone. This updates the DIF library accordingly to:

- updated `dif_entropy_src_configure` DIF to check for invalid FIPS enable configs
- cleanup bypass mode TODOs
- add missing recoverable alerts
