### PR TITLE
[dv/clk_rst_if] Avoid freeze due to rst undriven

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -302,10 +302,13 @@ interface clk_rst_if #(
     if (drive_clk) begin
       fork
         begin
-          wait_for_reset(.wait_posedge(1'b0));
+          // Only wait for reset if driving it, otherwise it may never come.
+          if (drive_rst_n) begin
+            wait_for_reset(.wait_posedge(1'b0));
 
-          // Wait a short time after reset before starting to drive the clock.
-          #1ps;
+            // Wait a short time after reset before starting to drive the clock.
+            #1ps;
+          end
           o_clk = 1'b0;
 
           done = 1'b1;

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -100,16 +100,8 @@ initial begin
     $asserton(0, tb.dut.top_earlgrey.u_xbar_main);
     $asserton(0, tb.dut.top_earlgrey.u_xbar_peri);
 
-    clk_rst_if_main.set_active(.drive_rst_n_val(0));
-    clk_rst_if_main.set_freq_khz(100000000 / 1000);
-    clk_rst_if_io.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io.set_freq_khz(96000000 / 1000);
-    clk_rst_if_usb.set_active(.drive_rst_n_val(0));
-    clk_rst_if_usb.set_freq_khz(48000000 / 1000);
-    clk_rst_if_io_div2.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io_div2.set_freq_khz(48000000 / 1000);
-    clk_rst_if_io_div4.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io_div4.set_freq_khz(24000000 / 1000);
+
+    // These are all zero-time: anything that consumes time go at the end.
 
     // bypass clkmgr, force clocks directly
     force tb.dut.top_earlgrey.u_xbar_main.clk_main_i = clk_main;
@@ -180,6 +172,25 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(sysrst_ctrl_aon, sysrst_ctrl_aon, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(adc_ctrl_aon, adc_ctrl_aon, tl)
     `DRIVE_CHIP_TL_EXT_DEVICE_IF(ast, ast, tl)
+
+
+    // And this can consume time, so they go at the end of this block.
+
+    // Wait for a negedge of rst_n, or else we will have clock edges before
+    // reset, which could capture 'X values.
+    xbar_clk_rst_if.wait_for_reset(.wait_posedge(1'b0));
+
+    clk_rst_if_main.set_active(.drive_rst_n_val(0));
+    clk_rst_if_main.set_freq_khz(100000000 / 1000);
+    clk_rst_if_io.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io.set_freq_khz(96000000 / 1000);
+    clk_rst_if_usb.set_active(.drive_rst_n_val(0));
+    clk_rst_if_usb.set_freq_khz(48000000 / 1000);
+    clk_rst_if_io_div2.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io_div2.set_freq_khz(48000000 / 1000);
+    clk_rst_if_io_div4.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io_div4.set_freq_khz(24000000 / 1000);
+
   end
 end
 

--- a/util/topgen/templates/tb__xbar_connect.sv.tpl
+++ b/util/topgen/templates/tb__xbar_connect.sv.tpl
@@ -79,10 +79,8 @@ initial begin
     $asserton(0, tb.dut.top_${top["name"]}.u_xbar_${xbar["name"]});
 % endfor
 
-% for c in clk_freq.keys():
-    clk_rst_if_${c}.set_active(.drive_rst_n_val(0));
-    clk_rst_if_${c}.set_freq_khz(${clk_freq[c]} / 1000);
-% endfor
+
+    // These are all zero-time: anything that consumes time go at the end.
 
     // bypass clkmgr, force clocks directly
 % for xbar in top["xbar"]:
@@ -116,6 +114,19 @@ sig_name = inst_sig_list[0][2]
     % endif
   % endfor
 % endfor
+
+
+    // And this can consume time, so they go at the end of this block.
+
+    // Wait for a negedge of rst_n, or else we will have clock edges before
+    // reset, which could capture 'X values.
+    xbar_clk_rst_if.wait_for_reset(.wait_posedge(1'b0));
+
+% for c in clk_freq.keys():
+    clk_rst_if_${c}.set_active(.drive_rst_n_val(0));
+    clk_rst_if_${c}.set_freq_khz(${clk_freq[c]} / 1000);
+% endfor
+
   end
 end
 


### PR DESCRIPTION
If the clk_rst_if is not driving rst_n it is possible it will never go active. In these cases it is safe to just start the clock without waiting.