### PR TITLE
[xbar/dv] Enable CDC in simulation

### DIFF
--- a/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
@@ -43,4 +43,7 @@
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
+
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
 }


### PR DESCRIPTION
Enabling this does not seem to have any adverse effects in the nightly regression.

