### PR TITLE
[crypto] Add C interface to call OTBN RSA key generation.

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/BUILD
+++ b/sw/device/lib/crypto/impl/rsa/BUILD
@@ -7,11 +7,32 @@ package(default_visibility = ["//visibility:public"])
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 
 cc_library(
+    name = "rsa_datatypes",
+    hdrs = ["rsa_datatypes.h"],
+)
+
+cc_library(
+    name = "rsa_keygen",
+    srcs = ["rsa_keygen.c"],
+    hdrs = ["rsa_keygen.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":rsa_datatypes",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:run_rsa_keygen",
+    ],
+)
+
+cc_library(
     name = "rsa_3072_verify",
     srcs = ["rsa_3072_verify.c"],
     hdrs = ["rsa_3072_verify.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":rsa_datatypes",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",

--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.h
@@ -11,41 +11,12 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-enum {
-  /* Length of the RSA-3072 modulus is 3072 bits */
-  kRsa3072NumBits = 3072,
-  /* Length of the RSA-3072 modulus in bytes */
-  kRsa3072NumBytes = kRsa3072NumBits / 8,
-  /* Length of the RSA-3072 modulus in words */
-  kRsa3072NumWords = kRsa3072NumBytes / sizeof(uint32_t),
-};
-
-/**
- * A type that holds an element of the RSA-3072 finite field (i.e. a 3072-bit
- * number).
- *
- * This type can be used for RSA-3072 signatures, keys, and intermediate values
- * during modular exponentiation.
- */
-typedef struct rsa_3072_int_t {
-  uint32_t data[kRsa3072NumWords];
-} rsa_3072_int_t;
-
-/**
- * A type that holds an RSA-3072 public key.
- *
- * The public key consists of a 3072-bit modulus n and a public exponent e.
- */
-typedef struct rsa_3072_public_key_t {
-  rsa_3072_int_t n;
-  uint32_t e;
-} rsa_3072_public_key_t;
 
 /**
  * A type that holds precomputed Montgomery constants for a RSA-3072 public

--- a/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_datatypes.h
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_DATATYPES_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_DATATYPES_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /* Length of the RSA-2048 modulus and private exponent in bits. */
+  kRsa2048NumBits = 2048,
+  /* Length of the RSA-2048 modulus in bytes */
+  kRsa2048NumBytes = kRsa2048NumBits / 8,
+  /* Length of the RSA-2048 modulus in words */
+  kRsa2048NumWords = kRsa2048NumBytes / sizeof(uint32_t),
+  /* Length of the RSA-3072 modulus and private exponent in bits. */
+  kRsa3072NumBits = 3072,
+  /* Length of the RSA-3072 modulus in bytes */
+  kRsa3072NumBytes = kRsa3072NumBits / 8,
+  /* Length of the RSA-3072 modulus in words */
+  kRsa3072NumWords = kRsa3072NumBytes / sizeof(uint32_t),
+  /* Length of the RSA-4096 modulus and private exponent in bits. */
+  kRsa4096NumBits = 4096,
+  /* Length of the RSA-4096 modulus in bytes */
+  kRsa4096NumBytes = kRsa4096NumBits / 8,
+  /* Length of the RSA-4096 modulus in words */
+  kRsa4096NumWords = kRsa4096NumBytes / sizeof(uint32_t),
+};
+
+/**
+ * A type that holds a 2048-bit number.
+ *
+ * This type can be used for RSA-2048 signatures, moduli, private exponents,
+ * and intermediate values.
+ */
+typedef struct rsa_2048_int_t {
+  uint32_t data[kRsa2048NumWords];
+} rsa_2048_int_t;
+
+/**
+ * A type that holds a 3072-bit number.
+ *
+ * This type can be used for RSA-3072 signatures, moduli, private exponents,
+ * and intermediate values.
+ */
+typedef struct rsa_3072_int_t {
+  uint32_t data[kRsa3072NumWords];
+} rsa_3072_int_t;
+
+/**
+ * A type that holds a 4096-bit number.
+ *
+ * This type can be used for RSA-4096 signatures, moduli, private exponents,
+ * and intermediate values.
+ */
+typedef struct rsa_4096_int_t {
+  uint32_t data[kRsa4096NumWords];
+} rsa_4096_int_t;
+
+/**
+ * A type that holds an RSA-2048 public key.
+ *
+ * The public key consists of a 2048-bit modulus n and a public exponent e.
+ */
+typedef struct rsa_2048_public_key_t {
+  rsa_2048_int_t n;
+  uint32_t e;
+} rsa_2048_public_key_t;
+
+/**
+ * A type that holds an RSA-3072 public key.
+ *
+ * The public key consists of a 3072-bit modulus n and a public exponent e.
+ */
+typedef struct rsa_3072_public_key_t {
+  rsa_3072_int_t n;
+  uint32_t e;
+} rsa_3072_public_key_t;
+
+/**
+ * A type that holds an RSA-4096 public key.
+ *
+ * The public key consists of a 4096-bit modulus n and a public exponent e.
+ */
+typedef struct rsa_4096_public_key_t {
+  rsa_4096_int_t n;
+  uint32_t e;
+} rsa_4096_public_key_t;
+
+/**
+ * A type that holds an RSA-2048 private key.
+ *
+ * The private key consists of a 2048-bit private exponent d and a public
+ * modulus n.
+ */
+typedef struct rsa_2048_private_key_t {
+  rsa_2048_int_t d;
+  rsa_2048_int_t n;
+} rsa_2048_private_key_t;
+
+/**
+ * A type that holds an RSA-3072 private key.
+ *
+ * The private key consists of a 3072-bit private exponent d and a public
+ * modulus n.
+ */
+typedef struct rsa_3072_private_key_t {
+  rsa_3072_int_t d;
+  rsa_3072_int_t n;
+} rsa_3072_private_key_t;
+
+/**
+ * A type that holds an RSA-4096 private key.
+ *
+ * The private key consists of a 4096-bit private exponent d and a public
+ * modulus n.
+ */
+typedef struct rsa_4096_private_key_t {
+  rsa_4096_int_t d;
+  rsa_4096_int_t n;
+} rsa_4096_private_key_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_DATATYPES_H_

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/rsa/rsa_keygen.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('r', 'k', 'g')
+
+OTBN_DECLARE_APP_SYMBOLS(run_rsa_keygen);         // The OTBN RSA keygen binary.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, mode);   // Application mode.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_n);  // Public exponent n.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_d);  // Private exponent d.
+
+static const otbn_app_t kOtbnAppRsaKeygen = OTBN_APP_T_INIT(run_rsa_keygen);
+static const otbn_addr_t kOtbnVarRsaMode =
+    OTBN_ADDR_T_INIT(run_rsa_keygen, mode);
+static const otbn_addr_t kOtbnVarRsaN = OTBN_ADDR_T_INIT(run_rsa_keygen, rsa_n);
+static const otbn_addr_t kOtbnVarRsaD = OTBN_ADDR_T_INIT(run_rsa_keygen, rsa_d);
+
+enum {
+  /* Fixed public exponent for generated keys. This exponent is 2^16 + 1, also
+     known as "F4" because it's the fourth Fermat number. */
+  kFixedPublicExponent = 65537,
+  /* Number of words used to represent the application mode. */
+  kOtbnRsaModeWords = 1,
+};
+
+// Available application modes. Must match the values from `run_rsa_keygen.s`.
+// TODO: I think it's possible to pull these values directly from symbols in
+// the binary. See:
+//   hw/ip/otbn/util/otbn_objdump.py -t run_rsa_keygen.rv32embed.o
+enum {
+  kOtbnRsaMode2048 = 0x3b7,
+  kOtbnRsaMode3072 = 0x4fa,
+  kOtbnRsaMode4096 = 0x74d,
+}
+
+/**
+ * Start the OTBN key generation program.
+ *
+ * @param mode Mode parameter for keygen.
+ * @return Result of the operation.
+ */
+static status_t
+keygen_start(uint32_t mode) {
+  // Load the RSA key generation app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppRsaKeygen));
+
+  // Set mode and start OTBN.
+  HARDENED_TRY(otbn_dmem_write(kOtbnRsaModeWords, &mode, kOtbnVarRsaMode));
+  return otbn_execute();
+}
+
+/**
+ * Finalize a key generation operation and read back the modulus and private
+ * exponent.
+ *
+ * @param num_words Number of words for modulus and private exponent.
+ * @param[out] n Buffer for the modulus.
+ * @param[out] d Buffer for the private exponent.
+ */
+static status_t keygen_finalize(size_t num_words, uint32_t *n, uint32_t *d) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the public modulus (n) from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
+
+  // Read the private exponent (d) from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaD, d));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}
+
+status_t rsa_keygen_2048_start(void) { return keygen_start(kOtbnRsaMode2048); }
+
+status_t rsa_keygen_2048_finalize(rsa_2048_public_key_t *public_key,
+                                  rsa_2048_private_key_t *private_key) {
+  HARDENED_TRY(keygen_finalize(kRsa2048NumWords, private_key->n.data,
+                               private_key->d.data));
+
+  // Copy the modulus to the public key.
+  hardened_memcpy(public_key->n.data, private_key->n.data,
+                  ARRAYSIZE(private_key->n.data));
+
+  // Set the public exponent to F4, the only exponent our key generation
+  // algorithm supports.
+  public_key->e = kFixedPublicExponent;
+
+  return OTCRYPTO_OK;
+}
+
+status_t rsa_keygen_3072_start(void) { return keygen_start(kOtbnRsaMode3072); }
+
+status_t rsa_keygen_3072_finalize(rsa_3072_public_key_t *public_key,
+                                  rsa_3072_private_key_t *private_key) {
+  HARDENED_TRY(keygen_finalize(kRsa3072NumWords, private_key->n.data,
+                               private_key->d.data));
+
+  // Copy the modulus to the public key.
+  hardened_memcpy(public_key->n.data, private_key->n.data,
+                  ARRAYSIZE(private_key->n.data));
+
+  // Set the public exponent to F4, the only exponent our key generation
+  // algorithm supports.
+  public_key->e = kFixedPublicExponent;
+
+  return OTCRYPTO_OK;
+}
+
+status_t rsa_keygen_4096_start(void) { return keygen_start(kOtbnRsaMode4096); }
+
+status_t rsa_keygen_4096_finalize(rsa_4096_public_key_t *public_key,
+                                  rsa_4096_private_key_t *private_key) {
+  HARDENED_TRY(keygen_finalize(kRsa4096NumWords, private_key->n.data,
+                               private_key->d.data));
+
+  // Copy the modulus to the public key.
+  hardened_memcpy(public_key->n.data, private_key->n.data,
+                  ARRAYSIZE(private_key->n.data));
+
+  // Set the public exponent to F4, the only exponent our key generation
+  // algorithm supports.
+  public_key->e = kFixedPublicExponent;
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.h
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_KEYGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_KEYGEN_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Starts an RSA-2048 key generation operation; returns immediately.
+ *
+ * The key exponent is always F4=65537; no other exponents are supported.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_2048_start(void);
+
+/**
+ * Waits for an RSA-2048 key generation to complete.
+ *
+ * Should be invoked only after `rsa_2048_verify_start`. Blocks until OTBN is
+ * done processing.
+ *
+ * @param[out] public_key Generated public key (n, e).
+ * @param[out] private_key Generated private key (d, e).
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_2048_finalize(rsa_2048_public_key_t *public_key,
+                                  rsa_2048_private_key_t *private_key);
+
+/**
+ * Starts an RSA-3072 key generation operation; returns immediately.
+ *
+ * The key exponent is always F4=65537; no other exponents are supported.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_3072_start(void);
+
+/**
+ * Waits for an RSA-3072 key generation to complete.
+ *
+ * Should be invoked only after `rsa_3072_verify_start`. Blocks until OTBN is
+ * done processing.
+ *
+ * @param[out] public_key Generated public key (n, e).
+ * @param[out] private_key Generated private key (d, e).
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_3072_finalize(rsa_3072_public_key_t *public_key,
+                                  rsa_3072_private_key_t *private_key);
+
+/**
+ * Starts an RSA-4096 key generation operation; returns immediately.
+ *
+ * The key exponent is always F4=65537; no other exponents are supported.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_4096_start(void);
+
+/**
+ * Waits for an RSA-4096 key generation to complete.
+ *
+ * Should be invoked only after `rsa_4096_verify_start`. Blocks until OTBN is
+ * done processing.
+ *
+ * @param[out] public_key Generated public key (n, e).
+ * @param[out] private_key Generated private key (d, e).
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_keygen_4096_finalize(rsa_4096_public_key_t *public_key,
+                                  rsa_4096_private_key_t *private_key);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_RSA_RSA_KEYGEN_H_


### PR DESCRIPTION
- Move some RSA-3072 typedefs and enum constants from `rsa_3072_verify.h` to a new `rsa_datatypes.h` so that RSA-3072 keygen can use them too
- Create async calls to start/finalize RSA keygen for all supported key lengths