### PR TITLE
[top/i2c] Increase clock frequency of I2C blocks for testing

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -486,7 +486,7 @@
         sw: true
         path: rstmgr_aon_resets.rst_i2c0_n
         parent: lc_src
-        clock: io_div4
+        clock: io_div2
       }
       {
         name: i2c1
@@ -500,7 +500,7 @@
         sw: true
         path: rstmgr_aon_resets.rst_i2c1_n
         parent: lc_src
-        clock: io_div4
+        clock: io_div2
       }
       {
         name: i2c2
@@ -514,7 +514,7 @@
         sw: true
         path: rstmgr_aon_resets.rst_i2c2_n
         parent: lc_src
-        clock: io_div4
+        clock: io_div2
       }
     ]
   }
@@ -872,7 +872,7 @@
       type: i2c
       clock_srcs:
       {
-        clk_i: io_div4
+        clk_i: io_div2
       }
       clock_group: peri
       reset_connections:
@@ -885,7 +885,7 @@
       }
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_peri
+        clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain:
       [
@@ -919,7 +919,7 @@
       type: i2c
       clock_srcs:
       {
-        clk_i: io_div4
+        clk_i: io_div2
       }
       clock_group: peri
       reset_connections:
@@ -932,7 +932,7 @@
       }
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_peri
+        clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain:
       [
@@ -966,7 +966,7 @@
       type: i2c
       clock_srcs:
       {
-        clk_i: io_div4
+        clk_i: io_div2
       }
       clock_group: peri
       reset_connections:
@@ -979,7 +979,7 @@
       }
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_peri
+        clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain:
       [
@@ -9630,6 +9630,7 @@
       clock_srcs:
       {
         clk_peri_i: io_div4
+        clk_i2c_i: io_div2
       }
       clock_group: infra
       reset: rst_peri_ni
@@ -9640,10 +9641,16 @@
           name: lc_io_div4
           domain: "0"
         }
+        rst_i2c_i:
+        {
+          name: lc_io_div2
+          domain: "0"
+        }
       }
       clock_connections:
       {
         clk_peri_i: clkmgr_aon_clocks.clk_io_div4_infra
+        clk_i2c_i: clkmgr_aon_clocks.clk_io_div2_infra
       }
       domain:
       [
@@ -9771,8 +9778,8 @@
         {
           name: i2c0
           type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
+          clock: clk_i2c_i
+          reset: rst_i2c_i
           pipeline: false
           inst_type: i2c
           addr_range:
@@ -9789,8 +9796,8 @@
         {
           name: i2c1
           type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
+          clock: clk_i2c_i
+          reset: rst_i2c_i
           pipeline: false
           inst_type: i2c
           addr_range:
@@ -9807,8 +9814,8 @@
         {
           name: i2c2
           type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
+          clock: clk_i2c_i
+          reset: rst_i2c_i
           pipeline: false
           inst_type: i2c
           addr_range:
@@ -14719,7 +14726,7 @@
           clk_aon_peri: aon
         }
       }
-      clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
+      clock_connection: clkmgr_aon_clocks.clk_io_div2_peri
       reset_connection:
       {
         name: i2c0
@@ -14743,7 +14750,7 @@
           clk_aon_peri: aon
         }
       }
-      clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
+      clock_connection: clkmgr_aon_clocks.clk_io_div2_peri
       reset_connection:
       {
         name: i2c1
@@ -14767,7 +14774,7 @@
           clk_aon_peri: aon
         }
       }
-      clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
+      clock_connection: clkmgr_aon_clocks.clk_io_div2_peri
       reset_connection:
       {
         name: i2c2

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -157,9 +157,9 @@
       { name: "spi_host1",      gen: true,  type: "top", parent: "lc_src", clk: "io_div2", sw: true }
       { name: "usb",            gen: true,  type: "top", parent: "lc_src", clk: "usb",     sw: true }
       { name: "usb_aon",        gen: true,  type: "top", parent: "lc_src", clk: "aon",     sw: true }
-      { name: "i2c0",           gen: true,  type: "top", parent: "lc_src", clk: "io_div4", sw: true },
-      { name: "i2c1",           gen: true,  type: "top", parent: "lc_src", clk: "io_div4", sw: true },
-      { name: "i2c2",           gen: true,  type: "top", parent: "lc_src", clk: "io_div4", sw: true },
+      { name: "i2c0",           gen: true,  type: "top", parent: "lc_src", clk: "io_div2", sw: true },
+      { name: "i2c1",           gen: true,  type: "top", parent: "lc_src", clk: "io_div2", sw: true },
+      { name: "i2c2",           gen: true,  type: "top", parent: "lc_src", clk: "io_div2", sw: true },
     ]
   }
 
@@ -257,21 +257,21 @@
     },
     { name: "i2c0",
       type: "i2c",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c0"},
       base_addr: "0x40080000",
     },
     { name: "i2c1",
       type: "i2c",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c1"},
       base_addr: "0x40090000",
     },
     { name: "i2c2",
       type: "i2c",
-      clock_srcs: {clk_i: "io_div4"},
+      clock_srcs: {clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c2"},
       base_addr: "0x400A0000",
@@ -1165,10 +1165,10 @@
                           rst_spi_host1_ni: "lc_io_div2"}
     },
     { name: "peri",
-      clock_srcs: {clk_peri_i: "io_div4", },
+      clock_srcs: {clk_peri_i: "io_div4", clk_i2c_i: "io_div2"},
       clock_group: "infra",
       reset: "lc_io_div4",
-      reset_connections: {rst_peri_ni: "lc_io_div4"},
+      reset_connections: {rst_peri_ni: "lc_io_div4", rst_i2c_i: "lc_io_div2"},
     }
   ],
 

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -4,9 +4,9 @@
 { name: "peri",
   type: "xbar",
   clock_primary: "clk_peri_i", // Main clock, used in sockets
-  other_clock_list: [] // Secondary clocks used by specific nodes
+  other_clock_list: ["clk_i2c_i"] // Secondary clocks used by specific nodes
   reset_primary: "rst_peri_ni", // Main reset, used in sockets
-  other_reset_list: [] // Secondary resets used by specific nodes
+  other_reset_list: ["rst_i2c_i"] // Secondary resets used by specific nodes
 
   nodes: [
     { name:  "main",
@@ -43,20 +43,20 @@
     },
     { name:      "i2c0",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_i2c_i",
+      reset:     "rst_i2c_i",
       pipeline:  false
     },
     { name:      "i2c1",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_i2c_i",
+      reset:     "rst_i2c_i",
       pipeline:  false
     },
     { name:      "i2c2",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_i2c_i",
+      reset:     "rst_i2c_i",
       pipeline:  false
     },
     { name:      "pattgen",

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -68,9 +68,9 @@ tl_if uart0_tl_if(clk_io_div4, rst_n);
 tl_if uart1_tl_if(clk_io_div4, rst_n);
 tl_if uart2_tl_if(clk_io_div4, rst_n);
 tl_if uart3_tl_if(clk_io_div4, rst_n);
-tl_if i2c0_tl_if(clk_io_div4, rst_n);
-tl_if i2c1_tl_if(clk_io_div4, rst_n);
-tl_if i2c2_tl_if(clk_io_div4, rst_n);
+tl_if i2c0_tl_if(clk_io_div2, rst_n);
+tl_if i2c1_tl_if(clk_io_div2, rst_n);
+tl_if i2c2_tl_if(clk_io_div2, rst_n);
 tl_if pattgen_tl_if(clk_io_div4, rst_n);
 tl_if pwm_aon_tl_if(clk_io_div4, rst_n);
 tl_if gpio_tl_if(clk_io_div4, rst_n);
@@ -118,6 +118,7 @@ initial begin
     force tb.dut.top_earlgrey.u_xbar_main.clk_spi_host0_i = clk_io;
     force tb.dut.top_earlgrey.u_xbar_main.clk_spi_host1_i = clk_io_div2;
     force tb.dut.top_earlgrey.u_xbar_peri.clk_peri_i = clk_io_div4;
+    force tb.dut.top_earlgrey.u_xbar_peri.clk_i2c_i = clk_io_div2;
 
     // bypass rstmgr, force resets directly
     force tb.dut.top_earlgrey.u_xbar_main.rst_main_ni = rst_n;
@@ -126,6 +127,7 @@ initial begin
     force tb.dut.top_earlgrey.u_xbar_main.rst_spi_host0_ni = rst_n;
     force tb.dut.top_earlgrey.u_xbar_main.rst_spi_host1_ni = rst_n;
     force tb.dut.top_earlgrey.u_xbar_peri.rst_peri_ni = rst_n;
+    force tb.dut.top_earlgrey.u_xbar_peri.rst_i2c_i = rst_n;
 
     `DRIVE_CHIP_TL_HOST_IF(rv_core_ibex__corei, rv_core_ibex, corei_tl_h)
     `DRIVE_CHIP_TL_HOST_IF(rv_core_ibex__cored, rv_core_ibex, cored_tl_h)

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -1088,7 +1088,7 @@ module rstmgr
   ) u_d0_i2c0 (
     .clk_i,
     .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
+    .leaf_clk_i(clk_io_div2_i),
     .parent_rst_ni(rst_lc_src_n[Domain0Sel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[I2C0].q),
     .scan_rst_ni,
@@ -1122,7 +1122,7 @@ module rstmgr
   ) u_d0_i2c1 (
     .clk_i,
     .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
+    .leaf_clk_i(clk_io_div2_i),
     .parent_rst_ni(rst_lc_src_n[Domain0Sel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[I2C1].q),
     .scan_rst_ni,
@@ -1156,7 +1156,7 @@ module rstmgr
   ) u_d0_i2c2 (
     .clk_i,
     .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
+    .leaf_clk_i(clk_io_div2_i),
     .parent_rst_ni(rst_lc_src_n[Domain0Sel]),
     .sw_rst_req_ni(reg2hw.sw_rst_ctrl_n[I2C2].q),
     .scan_rst_ni,

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -11,6 +11,7 @@
   clock_srcs:
   {
     clk_peri_i: io_div4
+    clk_i2c_i: io_div2
   }
   clock_group: infra
   reset: rst_peri_ni
@@ -21,10 +22,16 @@
       name: lc_io_div4
       domain: "0"
     }
+    rst_i2c_i:
+    {
+      name: lc_io_div2
+      domain: "0"
+    }
   }
   clock_connections:
   {
     clk_peri_i: clkmgr_aon_clocks.clk_io_div4_infra
+    clk_i2c_i: clkmgr_aon_clocks.clk_io_div2_infra
   }
   domain:
   [
@@ -152,8 +159,8 @@
     {
       name: i2c0
       type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
+      clock: clk_i2c_i
+      reset: rst_i2c_i
       pipeline: false
       inst_type: i2c
       addr_range:
@@ -170,8 +177,8 @@
     {
       name: i2c1
       type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
+      clock: clk_i2c_i
+      reset: rst_i2c_i
       pipeline: false
       inst_type: i2c
       addr_range:
@@ -188,8 +195,8 @@
     {
       name: i2c2
       type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
+      clock: clk_i2c_i
+      reset: rst_i2c_i
       pipeline: false
       inst_type: i2c
       addr_range:

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -7,11 +7,14 @@
 xbar_peri dut();
 
 `DRIVE_CLK(clk_peri_i)
+`DRIVE_CLK(clk_i2c_i)
 
 initial force dut.clk_peri_i = clk_peri_i;
+initial force dut.clk_i2c_i = clk_i2c_i;
 
 // TODO, all resets tie together
 initial force dut.rst_peri_ni = rst_n;
+initial force dut.rst_i2c_i = rst_n;
 
 // Host TileLink interface connections
 `CONNECT_TL_HOST_IF(main, dut, clk_peri_i, rst_n)
@@ -21,9 +24,9 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(uart1, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(uart2, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(uart3, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(i2c0, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(i2c1, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(i2c2, dut, clk_peri_i, rst_n)
+`CONNECT_TL_DEVICE_IF(i2c0, dut, clk_i2c_i, rst_n)
+`CONNECT_TL_DEVICE_IF(i2c1, dut, clk_i2c_i, rst_n)
+`CONNECT_TL_DEVICE_IF(i2c2, dut, clk_i2c_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pattgen, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pwm_aon, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(gpio, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -39,20 +39,20 @@ module xbar_peri_bind;
     .d2h    (tl_uart3_i)
   );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_i2c0 (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
+    .clk_i  (clk_i2c_i),
+    .rst_ni (rst_i2c_i),
     .h2d    (tl_i2c0_o),
     .d2h    (tl_i2c0_i)
   );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_i2c1 (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
+    .clk_i  (clk_i2c_i),
+    .rst_ni (rst_i2c_i),
     .h2d    (tl_i2c1_o),
     .d2h    (tl_i2c1_i)
   );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_i2c2 (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
+    .clk_i  (clk_i2c_i),
+    .rst_ni (rst_i2c_i),
     .h2d    (tl_i2c2_o),
     .d2h    (tl_i2c2_i)
   );

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -12,9 +12,12 @@
 //     -> uart1
 //     -> uart2
 //     -> uart3
-//     -> i2c0
-//     -> i2c1
-//     -> i2c2
+//     -> asf_29
+//       -> i2c0
+//     -> asf_30
+//       -> i2c1
+//     -> asf_31
+//       -> i2c2
 //     -> pattgen
 //     -> gpio
 //     -> spi_device
@@ -38,7 +41,9 @@
 
 module xbar_peri (
   input clk_peri_i,
+  input clk_i2c_i,
   input rst_peri_ni,
+  input rst_i2c_i,
 
   // Host interfaces
   input  tlul_pkg::tl_h2d_t tl_main_i,
@@ -121,6 +126,21 @@ module xbar_peri (
   // Create steering signal
   logic [4:0] dev_sel_s1n_28;
 
+  tl_h2d_t tl_asf_29_us_h2d ;
+  tl_d2h_t tl_asf_29_us_d2h ;
+  tl_h2d_t tl_asf_29_ds_h2d ;
+  tl_d2h_t tl_asf_29_ds_d2h ;
+
+  tl_h2d_t tl_asf_30_us_h2d ;
+  tl_d2h_t tl_asf_30_us_d2h ;
+  tl_h2d_t tl_asf_30_ds_h2d ;
+  tl_d2h_t tl_asf_30_ds_d2h ;
+
+  tl_h2d_t tl_asf_31_us_h2d ;
+  tl_d2h_t tl_asf_31_us_d2h ;
+  tl_h2d_t tl_asf_31_ds_h2d ;
+  tl_d2h_t tl_asf_31_ds_d2h ;
+
 
 
   assign tl_uart0_o = tl_s1n_28_ds_h2d[0];
@@ -135,14 +155,14 @@ module xbar_peri (
   assign tl_uart3_o = tl_s1n_28_ds_h2d[3];
   assign tl_s1n_28_ds_d2h[3] = tl_uart3_i;
 
-  assign tl_i2c0_o = tl_s1n_28_ds_h2d[4];
-  assign tl_s1n_28_ds_d2h[4] = tl_i2c0_i;
+  assign tl_asf_29_us_h2d = tl_s1n_28_ds_h2d[4];
+  assign tl_s1n_28_ds_d2h[4] = tl_asf_29_us_d2h;
 
-  assign tl_i2c1_o = tl_s1n_28_ds_h2d[5];
-  assign tl_s1n_28_ds_d2h[5] = tl_i2c1_i;
+  assign tl_asf_30_us_h2d = tl_s1n_28_ds_h2d[5];
+  assign tl_s1n_28_ds_d2h[5] = tl_asf_30_us_d2h;
 
-  assign tl_i2c2_o = tl_s1n_28_ds_h2d[6];
-  assign tl_s1n_28_ds_d2h[6] = tl_i2c2_i;
+  assign tl_asf_31_us_h2d = tl_s1n_28_ds_h2d[6];
+  assign tl_s1n_28_ds_d2h[6] = tl_asf_31_us_d2h;
 
   assign tl_pattgen_o = tl_s1n_28_ds_h2d[7];
   assign tl_s1n_28_ds_d2h[7] = tl_pattgen_i;
@@ -206,6 +226,15 @@ module xbar_peri (
 
   assign tl_s1n_28_us_h2d = tl_main_i;
   assign tl_main_o = tl_s1n_28_us_d2h;
+
+  assign tl_i2c0_o = tl_asf_29_ds_h2d;
+  assign tl_asf_29_ds_d2h = tl_i2c0_i;
+
+  assign tl_i2c1_o = tl_asf_30_ds_h2d;
+  assign tl_asf_30_ds_d2h = tl_i2c1_i;
+
+  assign tl_i2c2_o = tl_asf_31_ds_h2d;
+  assign tl_asf_31_ds_d2h = tl_i2c2_i;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
@@ -336,6 +365,45 @@ end
     .tl_d_o       (tl_s1n_28_ds_h2d),
     .tl_d_i       (tl_s1n_28_ds_d2h),
     .dev_select_i (dev_sel_s1n_28)
+  );
+  tlul_fifo_async #(
+    .ReqDepth        (1),
+    .RspDepth        (1)
+  ) u_asf_29 (
+    .clk_h_i      (clk_peri_i),
+    .rst_h_ni     (rst_peri_ni),
+    .clk_d_i      (clk_i2c_i),
+    .rst_d_ni     (rst_i2c_i),
+    .tl_h_i       (tl_asf_29_us_h2d),
+    .tl_h_o       (tl_asf_29_us_d2h),
+    .tl_d_o       (tl_asf_29_ds_h2d),
+    .tl_d_i       (tl_asf_29_ds_d2h)
+  );
+  tlul_fifo_async #(
+    .ReqDepth        (1),
+    .RspDepth        (1)
+  ) u_asf_30 (
+    .clk_h_i      (clk_peri_i),
+    .rst_h_ni     (rst_peri_ni),
+    .clk_d_i      (clk_i2c_i),
+    .rst_d_ni     (rst_i2c_i),
+    .tl_h_i       (tl_asf_30_us_h2d),
+    .tl_h_o       (tl_asf_30_us_d2h),
+    .tl_d_o       (tl_asf_30_ds_h2d),
+    .tl_d_i       (tl_asf_30_ds_d2h)
+  );
+  tlul_fifo_async #(
+    .ReqDepth        (1),
+    .RspDepth        (1)
+  ) u_asf_31 (
+    .clk_h_i      (clk_peri_i),
+    .rst_h_ni     (rst_peri_ni),
+    .clk_d_i      (clk_i2c_i),
+    .rst_d_ni     (rst_i2c_i),
+    .tl_h_i       (tl_asf_31_us_h2d),
+    .tl_h_o       (tl_asf_31_us_d2h),
+    .tl_d_o       (tl_asf_31_ds_h2d),
+    .tl_d_i       (tl_asf_31_ds_d2h)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -837,13 +837,13 @@ module top_earlgrey #(
   assign lpg_cg_en[1] = clkmgr_aon_cg_en.io_div4_peri;
   assign lpg_rst_en[1] = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::Domain0Sel];
   // peri_i2c0_0
-  assign lpg_cg_en[2] = clkmgr_aon_cg_en.io_div4_peri;
+  assign lpg_cg_en[2] = clkmgr_aon_cg_en.io_div2_peri;
   assign lpg_rst_en[2] = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::Domain0Sel];
   // peri_i2c1_0
-  assign lpg_cg_en[3] = clkmgr_aon_cg_en.io_div4_peri;
+  assign lpg_cg_en[3] = clkmgr_aon_cg_en.io_div2_peri;
   assign lpg_rst_en[3] = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::Domain0Sel];
   // peri_i2c2_0
-  assign lpg_cg_en[4] = clkmgr_aon_cg_en.io_div4_peri;
+  assign lpg_cg_en[4] = clkmgr_aon_cg_en.io_div2_peri;
   assign lpg_rst_en[4] = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::Domain0Sel];
   // timers_lc_io_div4_0
   assign lpg_cg_en[5] = clkmgr_aon_cg_en.io_div4_timers;
@@ -1246,7 +1246,7 @@ module top_earlgrey #(
       .tl_o(i2c0_tl_rsp),
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
+      .clk_i (clkmgr_aon_clocks.clk_io_div2_peri),
       .rst_ni (rstmgr_aon_resets.rst_i2c0_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
@@ -1288,7 +1288,7 @@ module top_earlgrey #(
       .tl_o(i2c1_tl_rsp),
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
+      .clk_i (clkmgr_aon_clocks.clk_io_div2_peri),
       .rst_ni (rstmgr_aon_resets.rst_i2c1_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
@@ -1330,7 +1330,7 @@ module top_earlgrey #(
       .tl_o(i2c2_tl_rsp),
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
+      .clk_i (clkmgr_aon_clocks.clk_io_div2_peri),
       .rst_ni (rstmgr_aon_resets.rst_i2c2_n[rstmgr_pkg::Domain0Sel])
   );
   pattgen #(
@@ -2903,7 +2903,9 @@ module top_earlgrey #(
   );
   xbar_peri u_xbar_peri (
     .clk_peri_i (clkmgr_aon_clocks.clk_io_div4_infra),
+    .clk_i2c_i (clkmgr_aon_clocks.clk_io_div2_infra),
     .rst_peri_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
+    .rst_i2c_i (rstmgr_aon_resets.rst_lc_io_div2_n[rstmgr_pkg::Domain0Sel]),
 
     // port: tl_main
     .tl_main_i(main_tl_peri_req),


### PR DESCRIPTION
This doubles the frequency of the i2c blocks for testing purposes.
Note that the SW constants still have to be adapted.

This is not intended to be merged!

