### PR TITLE
[flash_ctrl,dv] Clean up staled covergroup

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -113,7 +113,7 @@
             Perform following sequences of operations: read/program/read and read/erase/read in
             order to test read buffer eviction properly. Read should be executed by both Software
             and Host interface. All combinations should be tested. Covergroup for this hazardous
-            behavior is rd_buff_evict_cg.
+            behavior is eviction_cg.
             '''
       stage: V2
       tests: ["flash_ctrl_rd_buff_evict"]
@@ -436,14 +436,6 @@
             Covers that all possible fifo statuses generate interrupts for operations READ/PROGRAM.
             Covers both boundary values 0 and 31. Also covers acceptable distributions within
             ranges.
-            '''
-    }
-    {
-      name: rd_buff_evict_cg
-      desc: '''
-            Covers that all possible combinations for following sequences of operations
-            READ/PROGRAM/READ and READ/ERASE/READ are executed. Software Interface can perform all
-            three operations READ/PROGRAM/ERASE while Host Interface can perform direct READ.
             '''
     }
     {

--- a/hw/ip/flash_ctrl/dv/README.md
+++ b/hw/ip/flash_ctrl/dv/README.md
@@ -115,8 +115,6 @@ The following covergroups have been developed to prove that the test intent has 
   Check if request of erase suspension occurred.
 * msgfifo_level_cg
   Covers all possible fifo status to generate interrupt for read / program.
-* rd_buff_evict_cg
-  Check sequence of operation to trigger read eviction.
 * eviction_cg
   Check whether eviction happens at all 4 caches with write / erase operation.
   Also check each address belongs to randomly enabled scramble and ecc.


### PR DESCRIPTION
Remove rd_buff_evict covergroup because it is covered by eviction_cg.