### PR TITLE
[hw,rv_dm,dv] Skip updates to monitor state machine if tck_en is low

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -34,6 +34,7 @@ class jtag_monitor extends dv_base_monitor #(
 
     forever begin
       @(`MON_CB);
+      if(!cfg.vif.tck_en) continue;
       if (!cfg.vif.trst_n) begin
         jtag_state = JtagResetState;
         wait(cfg.vif.trst_n == 1);


### PR DESCRIPTION
Skip updates to internal state machine in `jtag_monitor.sv`, if `tck_en` is set to low