### PR TITLE
[hw,i2c,dv] Add a sequence to introduce glitch in all uncovered target FSM states

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -53,8 +53,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   bit       valid_addr;
   bit       is_read;
 
-  // reset agent only without resetting dut
-  bit       agent_rst = 0;
+  // reset driver only without resetting dut
+  bit       driver_rst = 0;
+  // reset monitor only without resetting dut
+  bit       monitor_rst = 0;
 
   `uvm_object_utils_begin(i2c_agent_cfg)
     `uvm_field_int(en_monitor,                                UVM_DEFAULT)

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -259,12 +259,12 @@ class i2c_monitor extends dv_base_monitor #(
   endtask : monitor_ready_to_end
 
   // Handle agent reset and set stop bit to indicate completion of the current transaction
-  task handle_agent_rst(input string task_name);
+  task handle_monitor_rst(input string task_name);
     int wait_timeout_ns = 1_000_000; // 1 ms
-    if (cfg.agent_rst) begin
+    if (cfg.monitor_rst) begin
       @(cfg.vif.cb);
       mon_dut_item.clear_all();
-      `DV_WAIT((!cfg.agent_rst), , wait_timeout_ns, $sformatf("%s:agent reset de-assert",
+      `DV_WAIT((!cfg.monitor_rst), , wait_timeout_ns, $sformatf("%s:monitor reset de-assert",
                task_name));
       cfg.got_stop = 1;
       `uvm_info(`gfn, $sformatf("monitor forceout from %s", task_name), UVM_MEDIUM)
@@ -312,8 +312,8 @@ class i2c_monitor extends dv_base_monitor #(
          end
          begin // agent reset thread
            bit rst_detected = 0;
-           wait(cfg.agent_rst);
-           handle_agent_rst("target_addr");
+           wait(cfg.monitor_rst);
+           handle_monitor_rst("target_addr");
            do_skip = 1; // Skip processing rest of the transaction
          end
        join_any
@@ -374,8 +374,8 @@ class i2c_monitor extends dv_base_monitor #(
         begin
           // This is undeterministic event so cannot set the timeout,
           // but this thread will be terminated by the other thread.
-          wait((cfg.allow_ack_stop & mon_rstart) | cfg.agent_rst);
-          handle_agent_rst("target_read");
+          wait((cfg.allow_ack_stop & mon_rstart) | cfg.monitor_rst);
+          handle_monitor_rst("target_read");
         end
       join_any
       disable fork;
@@ -416,8 +416,8 @@ class i2c_monitor extends dv_base_monitor #(
           end
         end
         begin
-          wait(cfg.agent_rst);
-          handle_agent_rst("target_write");
+          wait(cfg.monitor_rst);
+          handle_monitor_rst("target_write");
         end
       join_any
       disable fork;

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -303,6 +303,23 @@
       tests: ["i2c_target_unexp_stop"]
     }
     {
+      name: target_glitch
+      desc: '''
+            Test I2C FSM state transitions in target mode of operation.
+
+            Stimulus:
+              - Configure DUT/Agent in Target/Host mode respectively
+              - Program timing parameters
+              - Assert start_det and stop_det variables in i2c_fsm.sv
+                to trigger transition to AcquireStart and Idle states
+            Checking:
+              - Ensure DUT captures ACQ FIFO data as expected
+              - After every glitch, issue a simple transaction to check if DUT is behaving as expected
+            '''
+      stage: V2
+      tests: ["i2c_target_glitch"]
+    }
+    {
       name: target_stress_all
       desc: '''
             Support vseq (context) switching with random reset in between.

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/i2c_target_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_hrst_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_mode_toggle_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_glitch_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -1,0 +1,514 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequence that forces internal variables, triggering internal FSM state transition to
+// AcquireStart or Idle states
+// Check if the state transitions are as expected
+// Check if DUT is behaving as expected after glitch using a basic transaction
+class i2c_glitch_vseq extends i2c_target_smoke_vseq;
+
+  `uvm_object_utils(i2c_glitch_vseq)
+  `uvm_object_new
+  // Number of cycles sequence wait before all of the address states are executed
+  parameter uint ADDR_STATE_WAIT_TIMEOUT_CYCLES = 20;
+  // Number of cycles sequence wait before all of the write states are executed
+  parameter uint WRITE_STATE_WAIT_TIMEOUT_CYCLES = 40;
+  // Number of cycles sequence wait before all of the read states are executed
+  parameter uint READ_STATE_WAIT_TIMEOUT_CYCLES = 40;
+  // ACQ FIFO size in bytes
+  parameter uint ACQ_FIFO_SIZE = 64;
+  // Period of SCL clock depending on timing parameters
+  uint scl_period;
+
+  // Variable used to detect start internally
+  string start_detected_path = "tb.dut.i2c_core.u_i2c_fsm.start_det";
+  // Variable used to detect Stop internally
+  string stop_detected_path = "tb.dut.i2c_core.u_i2c_fsm.stop_det";
+  // Internal FSM variable
+  string fsm_state_path = "tb.dut.i2c_core.u_i2c_fsm.state_q";
+
+  // State definitions
+  typedef enum logic [5:0] {
+    Idle,
+    ///////////////////////
+    // Host function states
+    ///////////////////////
+    Active, PopFmtFifo,
+    // Host function starts a transaction
+    SetupStart, HoldStart, ClockStart,
+    // Host function stops a transaction
+    SetupStop, HoldStop, ClockStop,
+    // Host function transmits a bit to the external target
+    ClockLow, ClockPulse, HoldBit,
+    // Host function recevies an ack from the external target
+    ClockLowAck, ClockPulseAck, HoldDevAck,
+    // Host function reads a bit from the external target
+    ReadClockLow, ReadClockPulse, ReadHoldBit,
+    // Host function transmits an ack to the external target
+    HostClockLowAck, HostClockPulseAck, HostHoldBitAck,
+
+    /////////////////////////
+    // Target function states
+    /////////////////////////
+
+    // Target function receives start and address from external host
+    AcquireStart, AddrRead,
+    // Target function acknowledges the address and returns an ack to external host
+    AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold,
+    // Target function sends read data to external host-receiver
+    TransmitWait, TransmitSetup, TransmitPulse, TransmitHold,
+    // Target function receives ack from external host
+    TransmitAck, TransmitAckPulse, WaitForStop,
+    // Target function receives write data from the external host
+    AcquireByte,
+    // Target function sends ack to external host
+    AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
+    // Target function clock stretch handling.
+    StretchAddr,
+    StretchTx, StretchTxSetup,
+    StretchAcqFull
+  } state_e;
+
+  // initialize the states in which glitch is to be introduced
+  // Ignore state transitions covered in other testcases
+  // WaitForStop -> Idle and WaitForStop -> AcquireStart
+  // TransmitAckPulse -> Idle and TransmitAckPulse -> AcquireStart
+  // AcquireByte -> Idle and AcquireByte -> AcquireStart
+  state_e read_states[]  = '{TransmitWait, TransmitSetup, TransmitPulse, TransmitHold, TransmitAck,
+                            TransmitAckPulse, StretchTx, StretchTxSetup};
+  state_e write_states[] = '{AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
+                             StretchAcqFull};
+  state_e addr_states[]  = '{StretchAddr, AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold};
+
+  // Common steps for DUT initialization
+  virtual task setup();
+    initialization();
+    get_timing_values();
+    print_time_property();
+    program_registers();
+    // Set maximum and minimum number of transactions to 1 since
+    // only once sequence can be used to test behaviour of DUT after glitch
+    cfg.seq_cfg.i2c_min_num_trans = 1;
+    cfg.seq_cfg.i2c_max_num_trans = 1;
+    cfg.min_data = 1;
+    cfg.max_data = 5;
+    cfg.rs_pct = 0;
+    scl_period = t_f + t_r + thigh + tlow + tsu_dat + thd_dat;
+    `uvm_info(`gfn, $sformatf("Setting scl_period to %0d", scl_period), UVM_MEDIUM)
+  endtask
+
+  virtual task body();
+    // Initialize DUT in device mode and agent in host mode based on if_mode set using run argument
+    if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
+      i2c_target_base_seq m_i2c_target_seq;
+      i2c_item txn_q[$];
+      `uvm_info(`gfn, "Initializing DUT in Target mode", UVM_LOW)
+      setup();
+      target_mode_address_glitch(start_detected_path, AcquireStart);
+      target_mode_address_glitch(stop_detected_path, Idle);
+      target_mode_write_glitch(start_detected_path, AcquireStart);
+      target_mode_write_glitch(stop_detected_path, Idle);
+      target_mode_read_glitch(start_detected_path, AcquireStart);
+      target_mode_read_glitch(stop_detected_path, Idle);
+    end else begin
+      `uvm_fatal(`gfn, "Host mode glitches not supported")
+      setup();
+    end
+  endtask
+
+  // Task to issue a basic smoke test sequence to DUT
+  task target_basic_smoke();
+    i2c_target_base_seq m_i2c_target_seq;
+    i2c_item req;
+    uvm_reg_data_t data;
+    bit[7:0] wdata;
+    bit[6:0] addr;
+    int temp;
+    state_e state_int;
+    cfg.clk_rst_vif.wait_clks(1);
+    clear_fifo();
+    // Check internal state of DUT
+    `DV_CHECK_FATAL(uvm_hdl_read(fsm_state_path, temp), "Failed to read fsm_state")
+    state_int = state_e'(temp);
+    `uvm_info(`gfn, $sformatf("DUT internal state is %s", state_int.name()), UVM_MEDIUM)
+    // Create sequence object
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_target_seq)
+    // Add start to the transaction
+    `uvm_create_obj(i2c_item, req)
+    append_start(req, m_i2c_target_seq.req_q);
+    // Add address the transaction
+    `uvm_create_obj(i2c_item, req)
+    append_address(req, m_i2c_target_seq.req_q, 1'b0);
+    addr = req.wdata[7:1];
+    // Add data item to transaction
+    `uvm_create_obj(i2c_item, req)
+    append_data(req, m_i2c_target_seq.req_q);
+    wdata = req.wdata;
+    // Add Stop to the transaction
+    `uvm_create_obj(i2c_item, req)
+    req.wdata = $urandom_range(1, 127);
+    req.drv_type = HostStop;
+    m_i2c_target_seq.req_q.push_back(req);
+    // Start sequence and inject glitch once the required state is observed
+    m_i2c_target_seq.start(p_sequencer.i2c_sequencer_h);
+    // Check ACQ FIFO after sequence is completed
+    // Check Rstart in case of AcquireStart
+    if (state_int == AcquireStart) begin
+      csr_rd(.ptr(ral.acqdata), .value(data));
+      `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
+      `DV_CHECK_EQ_FATAL(data[9:8], 2'b11, "RStart condition not detected")
+    end
+    // Read Start address condition
+    csr_rd(.ptr(ral.acqdata), .value(data));
+    `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
+    `DV_CHECK_EQ_FATAL(data[9:8], 2'b01, "Start condition not detected")
+    `DV_CHECK_EQ_FATAL(data[7:1], addr, $sformatf("Incorrect address detected;Expected %0h", addr))
+    `DV_CHECK_EQ_FATAL(data[0], 1'b0, "Incorrect RW bit detected")
+    // Read Write data
+    csr_rd(.ptr(ral.acqdata), .value(data));
+    `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
+    `DV_CHECK_EQ_FATAL(data[7:0], wdata, "Incorrect data detected")
+    // Read Stop condition
+    csr_rd(.ptr(ral.acqdata), .value(data));
+    `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
+    `DV_CHECK_EQ_FATAL(data[9:8], 2'b10, "Stop condition not detected")
+  endtask
+
+  // Task to wait for a particular state to be observed in internal FSM of DUT
+  // state_path: Path to internal FSM state variable
+  // state_expected: Expected state to be observed
+  // wait_timeout: Number of cycles to wait before timeout
+  task wait_for_state(string state_path, state_e state_expected, uint wait_timeout);
+    bit state_detected = 0;
+    // Wait for the required state to be observed
+    for(int i = 0; i < wait_timeout; i++) begin
+        int temp;
+        state_e state_int;
+        `DV_CHECK_FATAL(uvm_hdl_read(state_path, temp), "Failed to read fsm_state")
+        state_int = state_e'(temp);
+        `uvm_info(`gfn, $sformatf("observed State: %s", state_int.name()), UVM_HIGH)
+        if (state_int == state_expected) begin
+          state_detected = 1;
+          break;
+        end else begin
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+      end
+      if (!state_detected) begin
+        `uvm_error(`gfn, $sformatf("timed out waiting for state: %s", state_expected.name()))
+      end else begin
+        `uvm_info(`gfn, $sformatf("observed State: %s", state_expected.name()), UVM_MEDIUM)
+      end
+  endtask
+
+  // Task to introduce glitch by forcing internal signal
+  // and issue reset to testbench components
+  // fsm_state_path: Path to internal FSM state variable
+  // var_path: Path to internal signal to be forced
+  // timeout: Number of cycles to wait before timeout
+  // state_desired: Expected state to be observed after glitch
+  task inject_glitch(string fsm_state_path,
+    string var_path,
+    uint timeout,
+    state_e state_desired = AcquireStart);
+    int res;
+      // Introduce glitch by forcing internal signal
+    `DV_CHECK_FATAL(uvm_hdl_force(var_path, 1'b1), "Failed to force variable")
+    cfg.m_i2c_agent_cfg.driver_rst = 1;
+    // Reset agent
+    cfg.clk_rst_vif.wait_clks(1);
+    `DV_CHECK_FATAL(uvm_hdl_release(var_path), "Failed to release variable")
+    // Check if FSM transitions to desired_state
+    `DV_CHECK_FATAL(uvm_hdl_read(fsm_state_path, res), "Failed to read fsm_state")
+    `DV_CHECK_EQ_FATAL(state_e'(res), state_desired,
+      $sformatf("FSM did not transition to %s state", state_desired.name()))
+    cfg.m_i2c_agent_cfg.driver_rst = 0;
+    `uvm_info(`gfn, "Stop SCL from driver", UVM_MEDIUM)
+    // Stop driving SCL from driver
+    cfg.m_i2c_agent_cfg.host_scl_stop = 1;
+    cfg.m_i2c_agent_cfg.host_scl_force_high = 1;
+    cfg.clk_rst_vif.wait_clks(2);
+    cfg.m_i2c_agent_cfg.host_scl_stop = 0;
+    cfg.m_i2c_agent_cfg.host_scl_force_high = 0;
+    // SCL will be driven by Driver once a new transaction is issued
+  endtask
+
+  // Task to wait for a particular internal FSM state and introduce a
+  // glitch on the provided variable once the state is observed
+  // fsm_state_path: Path to internal FSM state variable
+  // var_path: Path to internal signal to be forced
+  // timeout: Number of cycles to wait before timeout
+  // state_expected: Expected state to be observed
+  // state_desired: Expected state to be observed after glitch
+  task wait_and_inject_glitch(string fsm_state_path,
+    string var_path,
+    uint timeout,
+    state_e state_expected = Idle,
+    state_e state_desired = AcquireStart);
+    // Wait for the required state to be observed
+    wait_for_state(fsm_state_path, state_expected, timeout);
+    inject_glitch(fsm_state_path, var_path, timeout, state_desired);
+  endtask
+
+  // Task to clear ACQ and TX FIFOs
+  task clear_fifo();
+    csr_wr(.ptr(ral.fifo_ctrl.acqrst), .value(1'b1));
+    csr_wr(.ptr(ral.fifo_ctrl.txrst), .value(1'b1));
+  endtask
+
+  // Function to append i2c_item with Start condition to driver queue
+  function void append_start(ref i2c_item req, ref i2c_item driver_q[$]);
+    req.drv_type = HostStart;
+    driver_q.push_back(req);
+  endfunction
+
+  // Function to append address such that it always matches target address programmed
+  // and read/write bit based on the input value provided
+  function void append_address(ref i2c_item req,
+                               ref i2c_item driver_q[$],
+                               input bit rw_bit);
+      req.wdata[7:1] = target_addr0;
+      req.drv_type = HostData;
+      req.wdata[0] = rw_bit; // Read transaction
+      req.read = rw_bit;
+      driver_q.push_back(req);
+  endfunction
+
+  // Function to append i2c_item with data byte to driver queue
+  function void append_data(ref i2c_item req, ref i2c_item driver_q[$]);
+    req.wdata = $urandom_range(1, 127);
+    req.drv_type = HostData;
+    driver_q.push_back(req);
+  endfunction
+
+  // Task to force variable in internal FSM that trigger a transition to AcquireStart/Idle
+  // Then check if design behaves as expected
+  // var_hdl_path: Path to internal signal to be forced
+  // state_expected: Expected state to be observed after glitch
+  task target_mode_address_glitch(string var_hdl_path,
+    state_e target_state = AcquireStart);
+    // Update driver request queue with a single address transaction
+    // followed by a single data transaction depending on the state
+    // in which glitch is to be introduced
+    i2c_item req;
+    i2c_target_base_seq m_i2c_target_seq;
+    // Timeout for state to be observed
+    uint timeout = ADDR_STATE_WAIT_TIMEOUT_CYCLES * scl_period;
+    // Create sequence object
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_target_seq)
+    // Inject glitch in address states
+    foreach(addr_states[i]) begin
+      `uvm_info(`gfn,
+        $sformatf("Start: %s -> %s test", addr_states[i].name(), target_state.name()),
+        UVM_LOW)
+      // Add start to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_start(req, m_i2c_target_seq.req_q);
+      // Add address to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_address(req, m_i2c_target_seq.req_q, 1'b0);
+      // Override the driver type based on the state in which glitch is to be introduced
+      case (addr_states[i])
+        AddrAckWait: req.drv_type = HostDataNoWaitForACK;
+        default: req.drv_type = HostData;
+      endcase
+      // Add data items to transaction enter StretchAddr state
+      if (addr_states[i] == StretchAddr) begin
+        // one transaction for start address and another for stop condition
+        repeat(ACQ_FIFO_SIZE - 2) begin
+          `uvm_create_obj(i2c_item, req)
+          append_data(req, m_i2c_target_seq.req_q);
+        end
+        // Add stop to the transaction
+        `uvm_create_obj(i2c_item, req)
+        req.drv_type = HostStop;
+        m_i2c_target_seq.req_q.push_back(req);
+        // Create transaction that triggers StretchAddr state
+        // Add Start to the transaction
+        `uvm_create_obj(i2c_item, req)
+        append_start(req, m_i2c_target_seq.req_q);
+        // Add address to the transaction
+        `uvm_create_obj(i2c_item, req)
+        append_address(req, m_i2c_target_seq.req_q, 1'b0);
+        timeout = (((ACQ_FIFO_SIZE + 2) * 9) + ADDR_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+      end
+      fork
+        begin
+          // Start sequence and inject glitch once the required state is observed
+          m_i2c_target_seq.start(p_sequencer.i2c_sequencer_h);
+        end
+        begin
+          wait_and_inject_glitch(
+            .fsm_state_path(fsm_state_path),
+            .var_path(var_hdl_path),
+            .timeout(timeout),
+            .state_expected(addr_states[i]),
+            .state_desired(target_state));
+        end
+      join
+      // Check if ACQ FIFO has any data
+      // for address state glitches, there should not be any data in ACQ FIFO
+      begin
+        bit acq_fifo_empty;
+        csr_rd(.ptr(ral.status.acqempty), .value(acq_fifo_empty));
+        `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b0, "ACQ FIFO is not empty for address glitch")
+      end
+      `uvm_info(`gfn, $sformatf("Start target smoke after glitch in %s ", addr_states[i].name()),
+        UVM_MEDIUM)
+      target_basic_smoke();
+      `uvm_info(`gfn, $sformatf("End target smoke after glitch in %s ", addr_states[i].name()),
+        UVM_MEDIUM)
+      `uvm_info(`gfn,
+        $sformatf("End: %s -> %s test pass", addr_states[i].name(), target_state.name()),
+        UVM_LOW)
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    clear_fifo();
+  endtask
+
+  // Task to force variable in write states of internal FSM that
+  // triggers a transition to AcquireStart/Idle state and check if design behaves as expected
+  // var_hdl_path: Path to internal signal to be forced
+  // state_expected: Expected state to be observed after glitch
+  task target_mode_write_glitch(string var_hdl_path,
+    state_e target_state = AcquireStart);
+    // Update driver request queue with a single address transaction followed by write data
+    // transactions depending on the state in which glitch is to be introduced
+    i2c_item req;
+    i2c_target_base_seq m_i2c_target_seq;
+    // Timeout for state to be observed
+    uint timeout = WRITE_STATE_WAIT_TIMEOUT_CYCLES * scl_period;
+    // Create sequence object
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_target_seq)
+    // Inject glitch in address states
+    foreach(write_states[i]) begin
+      `uvm_info(`gfn,
+        $sformatf("Start: %s -> %s test", write_states[i].name(), target_state.name()),
+        UVM_LOW)
+      // Add start to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_start(req, m_i2c_target_seq.req_q);
+      // Add address to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_address(req, m_i2c_target_seq.req_q, 1'b0);
+      // Add data items to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_data(req, m_i2c_target_seq.req_q);
+      if (write_states[i] == StretchAcqFull) begin
+        // Create ACQ FIFO full condition
+        repeat(ACQ_FIFO_SIZE) begin
+          `uvm_create_obj(i2c_item, req)
+          append_data(req, m_i2c_target_seq.req_q);
+        end
+        // Each byte requires 9 scl cycles to be transmitted
+        timeout = ((ACQ_FIFO_SIZE * 9)+ WRITE_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+      end
+      fork
+          begin
+            // Start sequence and inject glitch once the required state is observed
+            m_i2c_target_seq.start(p_sequencer.i2c_sequencer_h);
+          end
+          begin
+            wait_and_inject_glitch(
+              .fsm_state_path(fsm_state_path),
+              .var_path(var_hdl_path),
+              .timeout(timeout),
+              .state_expected(write_states[i]),
+              .state_desired(target_state));
+          end
+      join
+      `uvm_info(`gfn, $sformatf("Start target smoke after glitch in %s ", write_states[i].name()),
+        UVM_MEDIUM)
+      target_basic_smoke();
+      `uvm_info(`gfn, $sformatf("End target smoke after glitch in %s ", write_states[i].name()),
+        UVM_MEDIUM)
+      `uvm_info(`gfn,
+        $sformatf("End: %s -> %s test pass", write_states[i].name(), target_state.name()),
+        UVM_LOW)
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    clear_fifo();
+  endtask
+
+  // Task to force variable in read states of internal FSM that
+  // triggers a transition to AcquireStart/Idle state and check if design behaves as expected
+  task target_mode_read_glitch(string var_hdl_path,
+    state_e target_state = AcquireStart);
+    // Update driver request queue with a single address transaction
+    // followed by a single data transaction depending on the state
+    // in which glitch is to be introduced
+    i2c_item req;
+    i2c_target_base_seq m_i2c_target_seq;
+    // Create sequence object
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_target_seq)
+    // Inject glitch in address states
+    foreach(read_states[i]) begin
+      bit sequence_done = 0;
+      `uvm_info(`gfn,
+        $sformatf("Start: %s -> %s test", read_states[i].name(), target_state.name()),
+        UVM_LOW)
+      // Add start to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_start(req, m_i2c_target_seq.req_q);
+      // Add address to the transaction
+      `uvm_create_obj(i2c_item, req)
+      append_address(req, m_i2c_target_seq.req_q, 1'b1);
+      // Add read data items to the transaction
+      `uvm_create_obj(i2c_item, req)
+      req.drv_type = HostAck;
+      m_i2c_target_seq.req_q.push_back(req);
+      clear_fifo();
+      // Update TXDATA register
+      program_tx_fifo(1);
+      fork
+          begin
+            // Start sequence and inject glitch once the required state is observed
+            m_i2c_target_seq.start(p_sequencer.i2c_sequencer_h);
+            sequence_done = 1;
+          end
+          begin
+            // To transition from StretchTx to StretchSetup
+            // Wait for StretchTx state and add entry in TXDATA FIFO
+            if (read_states[i] == StretchTxSetup) begin
+              // Wait for StretchTx state
+              wait_for_state(
+                .state_path(fsm_state_path),
+                .state_expected(StretchTx),
+                .wait_timeout(READ_STATE_WAIT_TIMEOUT_CYCLES * scl_period));
+              // Add entry in TXDATA FIFO
+              program_tx_fifo(1);
+            end
+          end
+          begin
+            wait_and_inject_glitch(
+              .fsm_state_path(fsm_state_path),
+              .var_path(var_hdl_path),
+              .timeout(READ_STATE_WAIT_TIMEOUT_CYCLES * scl_period),
+              .state_expected(read_states[i]),
+              .state_desired(target_state));
+          end
+          begin // read ACQ FIFO data
+            uvm_reg_data_t data;
+            while(!sequence_done) begin
+              if (cfg.intr_vif.pins[TxStretch]) begin
+                csr_rd(.ptr(ral.acqdata), .value(data));
+              end
+              cfg.clk_rst_vif.wait_clks(1);
+            end
+          end
+      join
+      `uvm_info(`gfn, $sformatf("Start target smoke after glitch in %s ", read_states[i].name()),
+        UVM_MEDIUM)
+      target_basic_smoke();
+      `uvm_info(`gfn, $sformatf("End target smoke after glitch in %s ", read_states[i].name()),
+        UVM_MEDIUM)
+      `uvm_info(`gfn,
+        $sformatf("End: %s -> %s test pass", read_states[i].name(), target_state.name()),
+        UVM_LOW)
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    clear_fifo();
+  endtask
+
+endclass : i2c_glitch_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -34,3 +34,4 @@
 `include "i2c_target_stress_all_vseq.sv"
 `include "i2c_target_hrst_vseq.sv"
 `include "i2c_host_mode_toggle_vseq.sv"
+`include "i2c_glitch_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -118,6 +118,12 @@
       uvm_test_seq: i2c_host_stress_all_vseq
     }
     {
+      name: i2c_target_glitch
+      uvm_test_seq: i2c_glitch_vseq
+      run_opts: ["+i2c_agent_mode=Host", "+en_scb=0"]
+      reseed: 2 // Directed testcase
+    }
+    {
       name: i2c_target_smoke
       uvm_test_seq: i2c_target_smoke_vseq
       run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=100_000_000"]


### PR DESCRIPTION
- Update i2c_driver to clear item queue once `driver_rst` is received
- Add sequence to trigger FSM state transition to `AcquireStart` or Idle using `start_det` or `stop_det` in `i2c_fsm.sv` 
- After each glitch check if the FSM is in expected internal state
- Issue a basic target sequence to check if DUT is behaving as expected after introducing glitch

- Following FSM transitions are observed

initial state | next state
------------- | -------------
`StretchAddr`     | `AcquireStart`, `Idle` 
`AddrAckWait`     | `AcquireStart`, `Idle` 
`AddrAckSetup`    | `AcquireStart`, `Idle` 
`AddrAckPulse`    | `AcquireStart`, `Idle` 
`AddrAckHold`     | `AcquireStart`, `Idle` 
`TransmitWait`    | `AcquireStart`, `Idle` 
`TransmitSetup`   | `AcquireStart`, `Idle` 
`TransmitPulse`   | `AcquireStart`, `Idle` 
`TransmitHold`    | `AcquireStart`, `Idle` 
`TransmitAck`     | `AcquireStart`, `Idle`
`StretchTx`       | `AcquireStart`, `Idle` 
`StretchTxSetup`  | `AcquireStart`, `Idle` 
`AcquireAckWait`  | `AcquireStart`, `Idle` 
`AcquireAckSetup` | `AcquireStart`, `Idle` 
`AcquireAckPulse` | `AcquireStart`, `Idle` 
`AcquireAckHold`  | `AcquireStart`, `Idle`
`StretchAcqFull`  | `AcquireStart`, `Idle`

- Replace `agent_rst` with `monitor_rst` variable in `agent_cfg` to make sure only monitor gets resets in `i2c_target_hrst` sequence
- Define two separate variables(`monitor_rst` and `driver_rst`) to control monitor and driver reset independently from sequences
