### PR TITLE
[dif] Add glen limit to csrng commands.

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -230,6 +230,16 @@ OT_WARN_UNUSED_RESULT
 static status_t csrng_send_app_cmd(uint32_t reg_address,
                                    entropy_csrng_cmd_t cmd,
                                    bool check_completion) {
+  enum {
+    // This is to maintain full compliance with NIST SP 800-90A, which requires
+    // the max generate output to be constrained to gen < 2 ^ 12 bits or 0x800
+    // 128-bit blocks.
+    kMaxGenerateSizeIn128BitBlocks = 0x800,
+  };
+  if (cmd.generate_len > kMaxGenerateSizeIn128BitBlocks) {
+    return OUT_OF_RANGE();
+  }
+
   uint32_t reg;
   bool cmd_ready;
   do {

--- a/sw/device/lib/crypto/drivers/entropy.h
+++ b/sw/device/lib/crypto/drivers/entropy.h
@@ -125,7 +125,8 @@ status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len);
  * There is not additional entropy loaded from hardware.
  * @param buf A buffer to fill with words from the CSRNG output buffer.
  * @param len The number of words to read into `buf`.
- * @return Operation status in `status_t` format.
+ * @return Operation status in `status_t` format. OutOfRange if the `len`
+ * parameter results in a 128bit block level size greater than 0x800.
  */
 OT_WARN_UNUSED_RESULT
 status_t entropy_csrng_generate(const entropy_seed_material_t *seed_material,

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -398,6 +398,8 @@ dif_result_t dif_csrng_update(const dif_csrng_t *csrng,
  *
  * @param csrng A CSRNG handle.
  * @param len Number of uint32_t words to generate.
+ * @return The result of the operation. KDifOutOfRange if the `len` parameter
+ * results in a 128bit block level size greater than 0x800.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_csrng_generate_start(const dif_csrng_t *csrng, size_t len);

--- a/sw/device/lib/dif/dif_csrng_shared.c
+++ b/sw/device/lib/dif/dif_csrng_shared.c
@@ -44,6 +44,16 @@ dif_result_t csrng_send_app_cmd(mmio_region_t base_addr, ptrdiff_t offset,
     return kDifBadArg;
   }
 
+  enum {
+    // This is to maintain full compliance with NIST SP 800-90A, which requires
+    // the max generate output to be constrained to gen < 2 ^ 12 bits or 0x800
+    // 128-bit blocks.
+    kMaxGenerateSizeIn128BitBlocks = 0x800,
+  };
+  if (cmd.generate_len > kMaxGenerateSizeIn128BitBlocks) {
+    return kDifOutOfRange;
+  }
+
   mmio_region_write32(base_addr, offset,
                       csrng_cmd_header_build(cmd.id, cmd.entropy_src_enable,
                                              cmd_len, cmd.generate_len));

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -300,6 +300,16 @@ TEST_F(CommandTest, GenerateBadArgs) {
   EXPECT_DIF_BADARG(dif_csrng_generate_start(&csrng_, /*len=*/0));
 }
 
+TEST_F(CommandTest, GenerateOutOfRange) {
+  enum {
+    // The maximum allowed is 0x800 128-bit blocks. Multiply by 4 to get the
+    // number of uint32 words and add one to trigger the error.
+    kGenerateLenOutOfRange = 0x800 * 4 + 1,
+  };
+  EXPECT_DIF_OUTOFRANGE(
+      dif_csrng_generate_start(&csrng_, kGenerateLenOutOfRange));
+}
+
 TEST_F(CommandTest, UninstantiateOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000005 | kMultiBitBool4False << 8);

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -393,6 +393,8 @@ dif_result_t dif_edn_update(const dif_edn_t *edn,
  *
  * @param edn An EDN handle.
  * @param len Number of uint32_t words to generate.
+ * @return The result of the operation. KDifOutOfRange if the `len` parameter
+ * results in a 128bit block level size greater than 0x800.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_edn_generate_start(const dif_edn_t *edn, size_t len);

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -377,6 +377,15 @@ TEST_F(CommandTest, GenerateBadArgs) {
   EXPECT_DIF_BADARG(dif_edn_generate_start(&edn_, /*len=*/0));
 }
 
+TEST_F(CommandTest, GenerateOutOfRange) {
+  enum {
+    // The maximum allowed is 0x800 128-bit blocks. Multiply by 4 to get the
+    // number of uint32 words and add one to trigger the error.
+    kGenerateLenOutOfRange = 0x800 * 4 + 1,
+  };
+  EXPECT_DIF_OUTOFRANGE(dif_edn_generate_start(&edn_, kGenerateLenOutOfRange));
+}
+
 TEST_F(CommandTest, UninstantiateOk) {
   EXPECT_WRITE32(EDN_SW_CMD_REQ_REG_OFFSET,
                  0x00000005 | kMultiBitBool4False << 8);

--- a/sw/device/lib/dif/dif_test_base.h
+++ b/sw/device/lib/dif/dif_test_base.h
@@ -35,4 +35,9 @@
  */
 #define ASSERT_DIF_BADARG(expr_) ASSERT_EQ(expr_, kDifBadArg)
 
+/**
+ * Creates a test expectataion for `expr` to evaluate to `kDifOutOfRange`.
+ */
+#define EXPECT_DIF_OUTOFRANGE(expr_) EXPECT_EQ(expr_, kDifOutOfRange)
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_TEST_BASE_H_


### PR DESCRIPTION
Return `kDifOutOfRange` errors if the glen command is equivalent to a value greater than 0x800 128 bit blocks.

This is part of #18334.