### PR TITLE
[dif] CSRNG allow other settings in FIPS mode

### DIFF
--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -57,19 +57,6 @@ dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
     return kDifBadArg;
   }
 
-  // Check valid configuration if FIPS mode is selected.
-  // FIPS qualified entropy is only valid in non-single bit mode.
-  if (config.fips_enable &&
-      (config.single_bit_mode < kDifEntropySrcSingleBitModeDisabled)) {
-    return kDifBadArg;
-  }
-  // FIPS qualified entropy cannot be generated if both `route_to_firmware` and
-  // `bypass_conditioner` are enabled.
-  if (config.fips_enable && config.route_to_firmware &&
-      config.bypass_conditioner) {
-    return kDifBadArg;
-  }
-
   if (!mmio_region_read32(entropy_src->base_addr,
                           ENTROPY_SRC_REGWEN_REG_OFFSET)) {
     return kDifLocked;

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -123,12 +123,13 @@ typedef struct dif_entropy_src_config {
    * running the block in FIPS mode. FIPS mode refers to running the entropy_src
    * in continuous mode. Also note that if `fips_enable` is set to `True`, then
    * at most one of either `route_to_firmware` or `bypass_conditioner` may be
-   * set, but not both.
+   * set, but will result in disabling the FIPS mode of operation from a
+   * hardware perspective.
    */
   bool bypass_conditioner;
   /**
-   * Specifies which single-bit-mode to use, if any at all. `fips_enable` must
-   * be false to use any single-bit-mode`.
+   * Specifies which single-bit-mode to use, if any at all. FIPS mode of
+   * operation is disabled in single-bit-mode of operation is selected.
    */
   dif_entropy_src_single_bit_mode_t single_bit_mode;
   /**

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -47,26 +47,6 @@ TEST_F(ConfigTest, BadSingleBitMode) {
       dif_entropy_src_configure(&entropy_src_, config_, kDifToggleEnabled));
 }
 
-TEST_F(ConfigTest, BadFipsEnabled) {
-  dif_entropy_src_config_t bad_fips_config_0 = {
-      .fips_enable = true,
-      .route_to_firmware = false,
-      .bypass_conditioner = false,
-      .single_bit_mode = kDifEntropySrcSingleBitMode3,
-      .health_test_window_size = 1};
-  EXPECT_DIF_BADARG(dif_entropy_src_configure(&entropy_src_, bad_fips_config_0,
-                                              kDifToggleEnabled));
-
-  dif_entropy_src_config_t bad_fips_config_1 = {
-      .fips_enable = true,
-      .route_to_firmware = true,
-      .bypass_conditioner = true,
-      .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
-      .health_test_window_size = 1};
-  EXPECT_DIF_BADARG(dif_entropy_src_configure(&entropy_src_, bad_fips_config_1,
-                                              kDifToggleEnabled));
-}
-
 TEST_F(ConfigTest, Locked) {
   EXPECT_READ32(ENTROPY_SRC_REGWEN_REG_OFFSET, 0);
   EXPECT_EQ(


### PR DESCRIPTION
FIPS mode of operation refers to: 1) continuous mode; 2) FIPS mode enablement. 2) depends on additional module settings to be true, but continuous mode may still be required with those settings.

This change updates the DIF documentation and removes some FIPS mode enablement constraints from `dif_entropy_src`.

This is a follow up from #18294.