### PR TITLE
Aon timer dv fixes

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -118,8 +118,8 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
         // INTR_EN register does not exists in AON timer because the interrupts are
         // enabled as long as timers are enabled.
         if (cfg.en_cov && data_phase_read) begin
-          cov.intr_cg.sample(WKUP, wkup_en, item.d_data);
-          cov.intr_cg.sample(WDOG, wdog_en, item.d_data);
+          cov.intr_cg.sample(WKUP, wkup_en, item.d_data[WKUP]);
+          cov.intr_cg.sample(WDOG, wdog_en, item.d_data[WDOG]);
         end
       end
       "wkup_ctrl": begin

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -120,9 +120,18 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     cfg.aon_clk_rst_vif.drive_rst_pin(1);
   endtask
 
-  task wait_for_interrupt();
+  task wait_for_interrupt(bit intr_state_read = 1);
     if (cfg.aon_clk_rst_vif.rst_n && !cfg.aon_intr_vif.pins) begin
+      uvm_reg_data_t intr_state_value;
+
       @(negedge cfg.aon_clk_rst_vif.rst_n or cfg.aon_intr_vif.pins);
+
+      if (intr_state_read) begin
+        // Wait 2 clocks to ensure interrupt is visible on intr_state read
+        cfg.aon_clk_rst_vif.wait_clks(2);
+        csr_utils_pkg::csr_rd(ral.intr_state, intr_state_value);
+      end
+
       // If we are getting an interrupt, let's asssume sleep signal immediately goes low.
       if (cfg.aon_intr_vif.pins) begin
         cfg.sleep_vif.drive(0);

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
@@ -8,7 +8,7 @@ class aon_timer_stress_all_vseq extends aon_timer_base_vseq;
   `uvm_object_new
 
   constraint num_trans_c {
-    num_trans inside {[3:6]};
+    num_trans inside {[15:20]};
   }
 
   task body();


### PR DESCRIPTION
Whilst investigating the coverage holes highlighted in https://github.com/lowRISC/opentitan/issues/17499 I discovered the primary checking logic of the aon_timer testbench was immediately terminating itself, leaving little in the way of checking for the tests! This was due to a missing '!' on an expression involving a reset, so it triggered when the design was out of reset rather than in reset.

With this fixed I discovered a few other issues in the checking logic itself which are also fixed in this PR.

Haven't had a chance to run a full nightly regression against this yet but a cut-down one (max 10 seeds per test) looks promising, a couple of rare failures that can likely be put down to tricky corner cases.