### PR TITLE
[dv/keymgr] exclude prim_secded_inv_72_64_dec cov

### DIFF
--- a/hw/ip/keymgr/dv/cov/keymgr_cover.cfg
+++ b/hw/ip/keymgr/dv/cov/keymgr_cover.cfg
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+// The modules below are preverified in FPV testbench.
+// There are many conditional coverage and hard to them all.
+-moduletree prim_secded_inv_72_64_dec
+
+begin tgl
+  +module prim_secded_inv_72_64_dec
+end

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -43,8 +43,16 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  // Add UART specific exclusion files.
+  // Add keymgr specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/keymgr/dv/cov/keymgr_cov_excl.el"]
+
+  overrides: [
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/keymgr/dv/cov/keymgr_cover.cfg"
+    }
+  ]
+
 
   // Default UVM test and seq class name.
   uvm_test: keymgr_base_test


### PR DESCRIPTION
This PR excludes prim_secded_inv_72_64_dec module cov and only keeps the toggle coverage.
The prim_secded_inv_72_64_dec module is pre-verified and it takes too much efforts to hit every possible condition cov for this module.