### PR TITLE
[csrng/rtl] Restrict `glen` to 12 bit (thus <= 4095)

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_item.sv
+++ b/hw/dv/sv/csrng_agent/csrng_item.sv
@@ -12,7 +12,7 @@ class csrng_item extends uvm_sequence_item;
   rand acmd_e       acmd;
   rand mubi4_t      flags;
   rand bit [3:0]    clen;
-  rand bit [18:0]   glen;
+  rand bit [11:0]   glen;
   rand bit [31:0]   cmd_data_q[$];
 
   bit               fips;

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -71,7 +71,7 @@ class csrng_monitor extends dv_base_monitor #(
               end else begin
                 cs_item.flags = MuBi4False;
               end
-              cs_item.glen  = item.h_data[30:12];
+              cs_item.glen  = item.h_data[23:12];
               cs_item.cmd_data_q.delete();
             end else begin
               cs_item.cmd_data_q.push_back(item.h_data);
@@ -125,7 +125,7 @@ class csrng_monitor extends dv_base_monitor #(
           cs_item.flags = MuBi4False;
         end
         if (cs_item.acmd == csrng_pkg::GEN) begin
-          cs_item.glen = cfg.vif.mon_cb.cmd_req.csrng_req_bus[30:12];
+          cs_item.glen = cfg.vif.mon_cb.cmd_req.csrng_req_bus[23:12];
         end
 
         `DV_SPINWAIT_EXIT(

--- a/hw/ip/csrng/doc/theory_of_operation.md
+++ b/hw/ip/csrng/doc/theory_of_operation.md
@@ -194,17 +194,17 @@ Below is a description of the fields of this header:
     </td>
   </tr>
   <tr>
-    <td>24:12</td>
+    <td>23:12</td>
     <td>glen</td>
     <td> Generate Length: Only defined for the generate command, this field is the total number of cryptographic entropy blocks requested.
          Each unit represents 128 bits of entropy returned.
-         The NIST reference name is <tt>max_number_of_bit_per_request</tt>, and this field size supports the maximum size of 2<sup>19</sup> bits.
-         For the maximum size, this field should be set to 4096, resulting in a <tt>max_number_of_bit_per_request</tt> value of 4096 x 128 bits.
-         For a smaller example, a value of 8 would return a total of 1024 bits.
+         This field allows values between 1 and 4095.
+         A value of 1 returns 1 * 128 bits of entropy.
+         A value of 4095 returns 4095 * 128 bits of entropy, which is less than the 2<sup>19</sup> bits allowed by NIST (referenced to as <tt>max_number_of_bit_per_request</tt>).
     </td>
   </tr>
   <tr>
-    <td>31:25</td>
+    <td>31:24</td>
     <td>resv</td>
     <td> Unused and reserved.
     </td>

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -274,7 +274,7 @@ interface csrng_cov_if (
                                                 acmd_e                 acmd,
                                                 bit[3:0]               clen,
                                                 bit[3:0]               flags,
-                                                bit[18:0]              glen
+                                                bit[11:0]              glen
                                                );
     option.name         = "csrng_cmds_cg";
     option.per_instance = 1;

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -181,7 +181,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
             else begin
               cs_item[SW_APP].flags = MuBi4False;
             end
-            cs_item[SW_APP].glen  = item.a_data[30:12];
+            cs_item[SW_APP].glen  = item.a_data[23:12];
 
             more_cmd_data = cs_item[SW_APP].clen;
           end
@@ -414,7 +414,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   function void ctr_drbg_generate(uint app,
-                                  bit [18:0] glen,
+                                  bit [11:0] glen,
                                   bit [CSRNG_BUS_WIDTH-1:0] additional_input = 'h0);
 
     bit [GENBITS_BUS_WIDTH-1:0]   genbits, hw_genbits;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -14,7 +14,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
   rand bit    flag0_flip_ins_cmd;
   rand acmd_e illegal_command;
   rand [3:0]  clen;
-  rand [12:0] glen;
+  rand [11:0] glen;
 
   task body();
     int           first_index;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -50,7 +50,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   // Genbits parameters.
   localparam int GenBitsFifoWidth = 1+128;
   localparam int GenBitsFifoDepth = 1;
-  localparam int GenBitsCntrWidth = 13;
+  localparam int GenBitsCntrWidth = 12;
 
   // Command FIFO.
   logic [CmdFifoWidth-1:0] sfifo_cmd_rdata;
@@ -81,7 +81,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   logic                    cmd_gen_inc_req;
   logic                    cmd_gen_cnt_last;
   logic                    cmd_final_ack;
-  logic [GenBitsCntrWidth-1:0] cmd_gen_cnt; // max_number_of_bits_per_request = 2^13
+  logic [GenBitsCntrWidth-1:0] cmd_gen_cnt;
 
   // Flops.
   logic                    cmd_ack_q, cmd_ack_d;
@@ -187,7 +187,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rst_ni,
     .clr_i(!cs_enable_i),
     .set_i(cmd_gen_1st_req),
-    .set_cnt_i(sfifo_cmd_rdata[24:12]),
+    .set_cnt_i(sfifo_cmd_rdata[12+:GenBitsCntrWidth]),
     .incr_en_i(1'b0),
     .decr_en_i(cmd_gen_cnt_dec), // Count down.
     .step_i(GenBitsCntrWidth'(1)),
@@ -284,7 +284,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
           cmd_gen_1st_req = 1'b1;
           cmd_arb_sop_o = 1'b1;
           cmd_fifo_pop = 1'b1;
-          if (sfifo_cmd_rdata[24:12] == GenBitsCntrWidth'(1)) begin
+          if (sfifo_cmd_rdata[12+:GenBitsCntrWidth] == GenBitsCntrWidth'(1)) begin
             cmd_gen_cnt_last = 1'b1;
           end
           if (cmd_len == '0) begin


### PR DESCRIPTION
Prior to this commit, the `glen` field, which defines the number of 128-bit entropy block each Generate command returns, had a width of 13 bit (`[24:12]`) and thus took a maximum value of 2^13 - 1 = 8191.  This is problematic because it would have led CSRNG to return up to 8191 * 128 bit, which is larger than the maximum number of bit per request allowed by NIST (2^19) bit, for one Generate command (#18334).

This commit reduces the width of the `glen` field to 12 bit, so that its maximum value is now 4095, thereby reducing the upper bound of bit per request below the maximum stipulated by NIST.  This commit thus resolves the HW part of #18334.

The upper bound is now 128 bit lower than the allowed maximum, which could have been avoided if the `glen` field was kept at a width of 13 bit and CSRNG instead checked its value and returned an error if it exceeded 2^12.  Such an error response mechanism is currently not implemented, however, and implementing one from scratch was out of scope for this change.

This change was tested by setting `glen` to 4095 in `csrng_smoke_test`; the test passed and a manual inspection of the waves looked correct. This change was further tested with a full block-level regression run (which had nominal pass rates), although randomization of `glen` is currently limited to the range [1:32]; this will be resolved separately (due to deadline constraints).