### PR TITLE
Silence some warnings that come out when building OTBN tests

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -332,7 +332,7 @@ interface otbn_trace_if
         ((u_otbn_alu_bignum.alu_predec_bignum_i.flags_adder_update[i_fg] |
           u_otbn_alu_bignum.alu_predec_bignum_i.flags_logic_update[i_fg] |
           u_otbn_alu_bignum.alu_predec_bignum_i.flags_mac_update[i_fg] |
-          |u_otbn_alu_bignum.alu_predec_bignum_i.flags_ispr_wr) &
+          (|u_otbn_alu_bignum.alu_predec_bignum_i.flags_ispr_wr)) &
           u_otbn_alu_bignum.operation_commit_i)) & ~ispr_init;
     assign flags_write_data[i_fg] = u_otbn_alu_bignum.flags_d[i_fg];
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `mod_intg_q` to be used", UVM_LOW)
     cfg.alu_bignum_vif.wait_for_mod_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.alu_bignum_vif.mod_intg_q,
                                                         '{default: 50},
                                                         corrupted_words);
@@ -29,7 +29,7 @@ class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.alu_bignum_vif.release_mod_intg_q();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `ispr_rdata_intg` to be used", UVM_LOW)
     cfg.controller_vif.wait_for_ispr_rdata_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     int unsigned corrupt_word_pct[otbn_pkg::BaseWordsPerWLEN];
     bit [otbn_pkg::ExtWLEN-1:0] new_data;
 
@@ -43,7 +43,7 @@ class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.controller_vif.release_ispr_rdata_intg_i();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -36,10 +36,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_wr_en", wr_en);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_wr_en", wr_en));
           end while(!wr_en);
         )
-        uvm_hdl_read(err_path, good_addr);
+        void'(uvm_hdl_read(err_path, good_addr));
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
         bad_addr = good_addr ^ mask;
@@ -52,10 +52,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_rd_en_i", rd_en);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_rd_en_i", rd_en));
           end while(!rd_en);
         )
-        uvm_hdl_read(err_path, good_addr);
+        void'(uvm_hdl_read(err_path, good_addr));
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
         bad_addr = good_addr ^ mask;
@@ -69,10 +69,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.alu_bignum_operation_valid", op_valid);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.alu_bignum_operation_valid", op_valid));
           end while(!op_valid);
         )
-        uvm_hdl_read(err_path, good_op);
+        void'(uvm_hdl_read(err_path, good_op));
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_op,
                                            bad_op != good_op;
                                            bad_op != otbn_pkg::AluOpBignumNone;);
@@ -87,10 +87,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_controller.insn_valid_i", insn_valid);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_controller.insn_valid_i", insn_valid));
           end while(!insn_valid);
         )
-        uvm_hdl_read(err_path, insn_dec_shared_i);
+        void'(uvm_hdl_read(err_path, insn_dec_shared_i));
         `DV_CHECK_STD_RANDOMIZE_FATAL(choose_err)
         case(choose_err)
           0: begin
@@ -113,7 +113,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid));
           end while(!insn_valid);
         )
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(choose_err, choose_err inside {[0:2]};)
@@ -122,7 +122,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [31:0] bad_rf_ren_a;
             bit [31:0] good_rf_ren_a;
             err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_a";
-            uvm_hdl_read(err_path, good_rf_ren_a);
+            void'(uvm_hdl_read(err_path, good_rf_ren_a));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_a,  $countones(bad_rf_ren_a) == 1;
                                                bad_rf_ren_a != good_rf_ren_a;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_rf_ren_a) == 1);
@@ -131,7 +131,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [31:0] bad_rf_ren_b;
             bit [31:0] good_rf_ren_b;
             err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_b";
-            uvm_hdl_read(err_path, good_rf_ren_b);
+            void'(uvm_hdl_read(err_path, good_rf_ren_b));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_b,  $countones(bad_rf_ren_b) == 1;
                                                bad_rf_ren_b != good_rf_ren_b;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_rf_ren_b) == 1);
@@ -140,7 +140,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [8:0] bad_ispr_rd_en;
             bit [8:0] good_ispr_rd_en;
             err_path = "tb.dut.u_otbn_core.ispr_predec_bignum.ispr_rd_en";
-            uvm_hdl_read(err_path, good_ispr_rd_en);
+            void'(uvm_hdl_read(err_path, good_ispr_rd_en));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_ispr_rd_en,  $countones(bad_ispr_rd_en) == 1;
                                                bad_ispr_rd_en != good_ispr_rd_en;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_ispr_rd_en) == 1);
@@ -163,13 +163,13 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid);
+            void'(uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid));
           end while(!insn_valid);
         )
         case(choose_err)
           0: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i";
-            uvm_hdl_read(err_path, mac_en);
+            void'(uvm_hdl_read(err_path, mac_en));
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, !mac_en) == 1);
           end
           1: begin
@@ -178,10 +178,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             `DV_SPINWAIT(
               do begin
                 @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i", mac_en);
+                void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i", mac_en));
               end while(!mac_en);
             )
-            uvm_hdl_read(err_path, zero_acc);
+            void'(uvm_hdl_read(err_path, zero_acc));
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, !zero_acc) == 1);
           end
           default: begin
@@ -202,10 +202,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             `DV_SPINWAIT(
               do begin
                 @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_en_i[1:0]", en);
+                void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_en_i[1:0]", en));
               end while(!en);
             )
-            uvm_hdl_read(err_path, addr);
+            void'(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
@@ -216,10 +216,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             `DV_SPINWAIT(
               do begin
                 @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_a_i", en);
+                void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_a_i", en));
               end while(!en);
             )
-            uvm_hdl_read(err_path, addr);
+            void'(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
@@ -230,10 +230,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             `DV_SPINWAIT(
               do begin
                 @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_b_i", en);
+                void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_b_i", en));
               end while(!en);
             )
-            uvm_hdl_read(err_path, addr);
+            void'(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `acc_intg_q` to be used", UVM_LOW)
     cfg.mac_bignum_vif.wait_for_acc_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.mac_bignum_vif.acc_intg_q,
                                                         '{default: 50},
                                                         corrupted_words);
@@ -29,7 +29,7 @@ class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.mac_bignum_vif.release_acc_intg_q();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -35,7 +35,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_dmem.req_i", req);
+            void'(uvm_hdl_read("tb.dut.u_dmem.req_i", req));
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)
@@ -45,7 +45,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_imem.req_i", req);
+            void'(uvm_hdl_read("tb.dut.u_imem.req_i", req));
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
@@ -32,13 +32,13 @@ class otbn_pc_ctrl_flow_redun_vseq extends otbn_single_vseq;
 
     do begin
       @(cfg.clk_rst_vif.cb);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.imem_rvalid_i", imem_rvalid);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_fetch_req_valid_raw_i",
-                    insn_fetch_req_valid);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.prefetch_ignore_errs_i",
-                    prefetch_ignore_err);
+      void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.imem_rvalid_i", imem_rvalid));
+      void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_fetch_req_valid_raw_i",
+                         insn_fetch_req_valid));
+      void'(uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.prefetch_ignore_errs_i",
+                         prefetch_ignore_err));
     end while(!(imem_rvalid & insn_fetch_req_valid & !prefetch_ignore_err));
-    uvm_hdl_read(addr_path, good_addr);
+    void'(uvm_hdl_read(addr_path, good_addr));
     // Mask to corrupt 1 to 2 bits of the prefetch addr
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
     bad_addr = good_addr ^ mask;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
@@ -11,7 +11,7 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
   `uvm_object_new
   rand bit insert_intg_err_to_a;
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     logic rd_en;
     used_words = '0;
     `uvm_info(`gfn, "Waiting for selected RF to be used", UVM_LOW)
@@ -26,8 +26,8 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
     )
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     logic [otbn_pkg::ExtWLEN-1:0] orig_data;
     bit   [otbn_pkg::ExtWLEN-1:0] new_data;
 
@@ -47,7 +47,7 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     if (insert_intg_err_to_a) begin
       cfg.trace_vif.release_rf_bignum_rd_data_a_intg();
     end else begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
@@ -53,11 +53,11 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
     `DV_SPINWAIT(
       do begin
         @(cfg.clk_rst_vif.cb);
-        uvm_hdl_read(top_valid_path, top_valid);
+        void'(uvm_hdl_read(top_valid_path, top_valid));
       end while (!top_valid);
     )
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
-    uvm_hdl_read(top_valid_path, top_valid);
+    void'(uvm_hdl_read(top_valid_path, top_valid));
     if (top_valid) begin
       fork
         begin: isolation_fork
@@ -67,7 +67,7 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
                 `DV_SPINWAIT(
                   do begin
                     @(cfg.clk_rst_vif.cb);
-                    uvm_hdl_read(stack_read_path, stack_read);
+                    void'(uvm_hdl_read(stack_read_path, stack_read));
                   end while (!stack_read);
                 )
                 cfg.model_agent_cfg.vif.send_err_escalation(err_val);
@@ -84,7 +84,7 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
                 `DV_SPINWAIT(
                   do begin
                     @(cfg.clk_rst_vif.cb);
-                    uvm_hdl_read(stack_write_path, stack_write);
+                    void'(uvm_hdl_read(stack_write_path, stack_write));
                   end while (!stack_write);
                 )
                 @(cfg.clk_rst_vif.cb);
@@ -107,18 +107,18 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
     bit [38:0] bad_data;
     bit [31:0] mask;
     bit [31:0] err_val = 32'd1 << 20;
-    uvm_hdl_read(stack_wr_idx_path, stack_wr_idx);
+    void'(uvm_hdl_read(stack_wr_idx_path, stack_wr_idx));
     if (stack_wr_idx != 0) begin
       if (err_type) begin
         $sformat(err_path, "tb.dut.u_otbn_core.u_otbn_rf_base.u_call_stack.stack_storage[%0d]",
                  (stack_wr_idx-1));
       end else begin
-        uvm_hdl_read(stack_wr_idx_path, stack_wr_idx);
+        void'(uvm_hdl_read(stack_wr_idx_path, stack_wr_idx));
         $sformat(err_path,
     "tb.dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.stack_storage[%0d]"
                  , (stack_wr_idx - 1));
       end
-      uvm_hdl_read(err_path, good_data);
+      void'(uvm_hdl_read(err_path, good_data));
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
       bad_data = good_data ^ mask;
       `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_data))


### PR DESCRIPTION
These were rather cluttering up the `build.log`, hiding the (very reasonable!) messages where Xcelium was trying to tell me that I'd locally done something silly. Let's get rid of the chatter for everyone else.