### PR TITLE
[chip_sw_usbdev] USB streaming regression test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -319,7 +319,7 @@
               correcly.
             '''
       stage: V3
-      tests: []
+      tests: ["chip_sw_usbdev_stream"]
     }
     {
       name: chip_sw_usb_vbus

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -541,6 +541,15 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_stream
+      uvm_test_seq: chip_sw_usbdev_stream_vseq
+      sw_images: ["//sw/device/tests:usbdev_stream_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1", "+sw_test_timeout_ns=60_000_000"]
+      run_timeout_mins: 120
+      reseed: 1
+    }
+    {
       name: chip_sw_inject_scramble_seed
       uvm_test_seq: chip_sw_inject_scramble_seed_vseq
       sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -122,6 +122,7 @@ filesets:
       - seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usb_ast_clk_calib_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_usbdev_dpi_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_usbdev_stream_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_device_tpm_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_stream_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_stream_vseq.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_usbdev_stream_vseq extends chip_sw_usbdev_dpi_vseq;
+  `uvm_object_utils(chip_sw_usbdev_stream_vseq)
+
+  `uvm_object_new
+
+  // TODO: introduce randomization to make this test more useful; candidates:
+  // - number of endpoints
+  // - response timing of DPI model
+  // - stream test flags (transfer direction(s), variable/max-length packets...)
+
+  virtual task body();
+    super.body();
+  endtask
+
+endclass : chip_sw_usbdev_stream_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -77,6 +77,7 @@
 `include "chip_sw_csrng_lc_hw_debug_en_vseq.sv"
 `include "chip_sw_usb_ast_clk_calib_vseq.sv"
 `include "chip_sw_usbdev_dpi_vseq.sv"
+`include "chip_sw_usbdev_stream_vseq.sv"
 `include "chip_sw_i2c_tx_rx_vseq.sv"
 `include "chip_sw_i2c_host_tx_rx_vseq.sv"
 `include "chip_sw_i2c_device_tx_rx_vseq.sv"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1984,6 +1984,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "dv",
     ],
     verilator = verilator_params(
         timeout = "long",

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -43,8 +43,11 @@
 // This is appropriate for a Verilator chip simulation with 15 min timeout
 #define TRANSFER_BYTES_VERILATOR 0x2400U
 
+// For top-level DV simulation (regression runs, deterministic behavior)
+#define TRANSFER_BYTES_DVSIM 0x800U
+
 // This is about the amount that we can transfer within a 1 hour 'eternal' test
-//#define TRANSFER_BYTES_LONG (0xD0U << 20)
+// #define TRANSFER_BYTES_LONG (0xD0U << 20)
 
 /**
  * Configuration values for USB.
@@ -189,8 +192,16 @@ bool test_main(void) {
 
   // Decide upon the number of bytes to be transferred for the entire test
   uint32_t transfer_bytes = TRANSFER_BYTES_FPGA;
-  if (kDeviceType == kDeviceSimVerilator) {
-    transfer_bytes = TRANSFER_BYTES_VERILATOR;
+  switch (kDeviceType) {
+    case kDeviceSimVerilator:
+      transfer_bytes = TRANSFER_BYTES_VERILATOR;
+      break;
+    case kDeviceSimDV:
+      transfer_bytes = TRANSFER_BYTES_DVSIM;
+      break;
+    default:
+      CHECK(kDeviceType == kDeviceFpgaCw310);
+      break;
   }
   transfer_bytes = (transfer_bytes + nstreams - 1) / nstreams;
   LOG_INFO(" - %u stream(s), 0x%x bytes each", nstreams, transfer_bytes);


### PR DESCRIPTION
Add a second regression test for the USB.

This streaming test sets up multiple endpoints, and sends LFSR-generated Bulk Transfer streams to the DPI model and back, with retrying of transfers, LFSR-generated packet sizes and checking of the returned data against expectations.

Data volume and thus test duration reduced for DV sim because the behavior/timing is not randomized and this top-level test has been used extensively in Verilator and on FPGA already.