### PR TITLE
[spi_device,doc] Update TODOs with linked issues, Icebox, cleanup

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -190,11 +190,12 @@ module spi_cmdparse
   end
 
   // cmd_info latch
-  // TODO: This can be furthur optimized. At 7th beat, check the opcode[7:1]
-  // with cmd_info[NumCmdInfo-1:0].opcode[7:1]. Unless SW configures more than
-  // one cmd_info slots with same opcode, at most two slots match with the
-  // opcode[7:1]. The two can be latched then at 8th beat, only the last bit
-  // of the opcode in the two cmd_info entries can be compared.
+  // TODO(#18354): This can be further optimized as follows:
+  // At 7th beat, check the opcode[7:1] with cmd_info[NumCmdInfo-1:0].opcode[7:1].
+  // Unless SW configures more than one cmd_info slots with same opcode,
+  // at most two slots match with the opcode[7:1].
+  // The two can be latched then at 8th beat, only the last bit of the opcode
+  // in the two cmd_info entries can be compared.
   //
   // It reduces the logic from 8bit compare with 24 logic depth into 1bit
   // compare with 1 logic depth.

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -201,7 +201,7 @@ module spi_device
 
   logic abort;  // Abort current operations (txf only at this time)
                 // Think how FW knows abort is done.
-  //logic abort_done; // TODO: Not implemented yet
+  //logic abort_done; // ICEBOX(#18357): Not implemented yet
 
   logic sys_csb_syncd;
 
@@ -248,12 +248,10 @@ module spi_device
   logic rxf_full_syncd, txf_empty_syncd; // sync signals
 
   // SPI S2P signals
-  // io_mode: Determine s2p/p2s behavior. As of now, only fwmode exists.
-  // TODO: Add FlashMode IO, passthrough IO
-  // based on the SPI protocol, the mode should be changed at the negedge of
-  // SPI_CLK. The sub_iomode value is changed based on the input of SPI,
-  // it is latched by clk_spi_out.
-  // TODO: Add this path to DC constraint
+  // io_mode: Determine s2p/p2s behavior.
+  // io_mode is changed at the negedge of SPI_CLK (based on the SPI protocol).
+  // sub_iomode is changed based on the input of SPI, and latched by clk_spi_out.
+  // TODO(#18359): Add this path (sub_iomode) to CDC constraint
   io_mode_e           io_mode, io_mode_outclk;
   io_mode_e           sub_iomode[IoModeEnd];
   logic               s2p_data_valid;
@@ -701,11 +699,6 @@ module spi_device
     .intr_o                 (intr_readbuf_flip_o              )
   );
 
-  // cmdaddr_notempty is a level signal. Issue has been discussed in
-  //   https://github.com/lowRISC/opentitan/issues/15282.
-  //
-  // TODO: Remove `prim_intr_hw` and ditect connect from status(level)
-  // assign intr_o = (status | test) & enable;
   prim_intr_hw #(
     .Width (1       ),
     .IntrT ("Status")

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -501,7 +501,6 @@ module spi_passthrough
   end
 
   // Based on AddrCnt, the logic swap.
-  // TODO: Handle the DualIO, QuadIO cases
   logic addr_swap;
   assign addr_swap = cfg_addr_mask_i[addrcnt_outclk]
                    ? cfg_addr_value_i[addrcnt_outclk]
@@ -605,7 +604,6 @@ module spi_passthrough
     if (!rst_ni) begin
       mbyte_cnt <= '0;
     end else if (mbyte_set) begin
-      // TODO: check addr enable and update mbyte_cnt to 3 or 1
       mbyte_cnt <= 2'h 3;
     end else if (st == StMByte) begin
       mbyte_cnt <= mbyte_cnt - 1'b 1;

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -376,7 +376,6 @@ module spi_readcmd
     addr_d = addr_q; // default value. In 3B mode, upper most byte is 0
     addr_latch_en = 1'b0;
 
-    // TODO: Handle the case of IO command
     if (addr_ready_in_word) begin
       // Return word based address, but should not latch
       addr_d = {addr_q[23:0], s2p_byte_i[5:0], 2'b00};
@@ -438,7 +437,6 @@ module spi_readcmd
       // already counts one beat.
       addr_cnt_d = (cmdinfo_addr_mode == Addr4B) ? 5'd 31 : 5'd 23;
 
-      // TODO: Dual IO/ Quad IO case
     end else if (addr_cnt_q == '0) begin
       addr_cnt_d = addr_cnt_q;
     end else if (addr_shift_en) begin
@@ -559,7 +557,6 @@ module spi_readcmd
   end
 
   // readbuf_flip
-  // TODO: implement. Below is temporary.
   assign readbuf_flip = (main_st == MainOutput && addr_q[9:0] == '1);
 
   //- END:   Double Buffering -------------------------------------------------
@@ -613,7 +610,6 @@ module spi_readcmd
       MainAddress: begin
         addr_shift_en = 1'b 1;
 
-        // TODO: DualIO/ QuadIO case
         if (addr_ready_in_word) begin
           sram_req = 1'b 1;
         end
@@ -645,8 +641,6 @@ module spi_readcmd
             2'b 1?: begin
               // Regardless of Dummy
               main_st_d = MainMByte;
-
-              // TODO: Set MByte latency (3 or 1)
             end
 
             default: begin
@@ -698,7 +692,6 @@ module spi_readcmd
 
           // sent all words
           bitcnt_update = 1'b 1;
-          // TODO: FIFO pop here?
           fifo_pop = 1'b 1;
         end
       end
@@ -739,7 +732,7 @@ module spi_readcmd
 
     .sram_read_req_i   (sram_req),
     .addr_latched_i    (addr_latched),
-    .current_address_i (addr_d), // TODO: Change it
+    .current_address_i (addr_d),
 
     .mailbox_en_i,
     .mailbox_addr_i,

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -167,8 +167,6 @@ module spi_tpm
     12'h F00, // F03:F00 DID_VID
     12'h F04  // F04:F04 RID
   };
-  // TODO: internal reset (sys_rst_ni & csb_i)
-  // Do we really need the csb reset for TPM?
 
   ////////////////
   // Definition //
@@ -1038,9 +1036,9 @@ module spi_tpm
 
           if (~|sck_wrfifo_wdepth) begin
             // Write command and FIFO is empty. Ready to push
-            // TODO: Change the state machine to send start byte at
-            //       cmdaddr_bitcnt == 5'h 17 if write command and FIFO is
-            //       empty, then the state can go to StWrite directly.
+            // ICEBOX(#18354): Change the state machine to send start byte at
+            //                 cmdaddr_bitcnt == 5'h 17 if write command and FIFO is
+            //                 empty, then the state can go to StWrite directly.
             sck_st_d = StStartByte;
           end else begin
             // FIFO is not empty. Move to StWait and waits for the empty write
@@ -1084,9 +1082,9 @@ module spi_tpm
         sck_p2s_valid = 1'b 1;
         sck_data_sel  = SelRdFifo;
 
-        // TODO: RdFifo rready (sck --> isck)
+        // ICEBOX(#18354): RdFifo rready (sck --> isck)
 
-        // TODO: check xfer_size handling
+        // ICEBOX(#18354): check xfer_size handling
         if (isck_p2s_sent && xfer_size_met) begin
           sck_st_d = StEnd;
         end
@@ -1107,7 +1105,7 @@ module spi_tpm
         wrdata_shift_en = 1'b 1;
         // Processed by the logic. Does not have to do
 
-        // TODO: check xfer_size handling
+        // ICEBOX(#18354): check xfer_size handling
         if (sck_wrfifo_wvalid && xfer_size_met) begin
           sck_st_d = StEnd;
         end
@@ -1122,8 +1120,8 @@ module spi_tpm
       end // StInvalid
 
       StEnd: begin // TERMINAL_STATE
-        // TODO: Check if open pull-up cancel the transaction?
-        //       If yes, then drive 0x00 for the read command
+        // TODO(##18355): Check if open pull-up cancel the transaction?
+        // If yes, then drive 0x00 for the read command
         if (cmd_type == Read) begin
           sck_p2s_valid = 1'b 1;
           sck_data_sel  = SelWait; // drive 0x00

--- a/hw/ip/spi_device/rtl/spid_readsram.sv
+++ b/hw/ip/spi_device/rtl/spid_readsram.sv
@@ -273,7 +273,7 @@ module spid_readsram
 
       StActive: begin
         // Assume the SRAM logic is faster than update of current_address_i.
-        // TODO: Put assertion.
+        // ICEBOX(#18352): Put assertion.
         addr_sel = AddrContinuous; // Pointing to next_address to check mailbox hit
         if (!sram_fifo_full) begin
           st_d = StPush;
@@ -341,7 +341,7 @@ module spid_readsram
     .err_o    ()
   );
 
-  // TODO: Handle SRAM integrity errors
+  // ICEBOX(#18353): Handle SRAM integrity errors
   sram_err_t unused_sram_rerror;
   assign unused_sram_rerror = sram_m2l_i.rerror;
 

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -503,7 +503,7 @@ module spid_upload
   // Instance //
   //////////////
 
-  // TODO: Merge two FIFOs into one.
+  // TODO(#18354): Merge two FIFOs into one.
   // Design a module that has one SRAM Read port / one SRAM write port
   // and compile-time configurable # of FIFO ports + N of SramBase Address
   // (Preferrably variable width)


### PR DESCRIPTION
- Delete obsolete TODOs
- Add linked issues to remaining TODO / convert to ICEBOX

Many TODOs are related to DIO/QIO or QPI, hence delete [as unsupported](https://opentitan.org/book/hw/ip/spi_device/#:~:text=This%20version%20of%20IP%20does%20not%20support%20Dual%20IO%2C%20Quad%20IO%2C%20QPI%20commands.).
```
# SPI Protocol Variations
#     DIO/QIO (Dual and Quad IO modes)    -> xfer address over dual/quad lanes
#     QPI (Quad Peripheral Interface)     -> xfer opcode using four lanes
```