### PR TITLE
[hw,i2c,dv] Update constraint for override sequence

### DIFF
--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -385,6 +385,19 @@ class i2c_scoreboard extends cip_base_scoreboard #(
               cov.intr_test_cg.sample(intr, item.a_data[i], intr_en[i], intr_exp[i]);
             end
           end
+          if (cfg.en_cov) begin
+            cov.interrupts_cg.sample(.intr_state(ral.intr_state.get_mirrored_value()),
+                                     .intr_enable(ral.intr_enable.get_mirrored_value()),
+                                     .intr_test(item.a_data));
+          end
+        end
+
+        "intr_enable" : begin
+          if (cfg.en_cov) begin
+            cov.interrupts_cg.sample(.intr_state(ral.intr_state.get_mirrored_value()),
+                                     .intr_enable(item.a_data),
+                                     .intr_test(ral.intr_test.get_mirrored_value()));
+          end
         end
 
         "txdata": begin
@@ -465,8 +478,22 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             end
           end
           if (cfg.en_cov) begin
-            cov.interrupts_cg.sample(.intr_state(intr_en),
+            cov.interrupts_cg.sample(.intr_state(item.a_data),
                                      .intr_enable(ral.intr_enable.get_mirrored_value()),
+                                     .intr_test(ral.intr_test.get_mirrored_value()));
+          end
+        end
+        "intr_test" : begin
+          if (cfg.en_cov) begin
+            cov.interrupts_cg.sample(.intr_state(ral.intr_state.get_mirrored_value()),
+                                     .intr_enable(ral.intr_enable.get_mirrored_value()),
+                                     .intr_test(item.a_data));
+          end
+        end
+        "intr_enable" : begin
+          if (cfg.en_cov) begin
+            cov.interrupts_cg.sample(.intr_state(ral.intr_state.get_mirrored_value()),
+                                     .intr_enable(item.a_data),
                                      .intr_test(ral.intr_test.get_mirrored_value()));
           end
         end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_override_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_override_vseq.sv
@@ -10,7 +10,9 @@ class i2c_host_override_vseq extends i2c_base_vseq;
   local rand bit sdaval;
   local rand bit txovrden;
 
-  constraint txovrden_c { txovrden dist {1 :/ 3, 0 :/ 1}; }
+  constraint txovrden_c { txovrden dist {1 := 1, 0 := 1}; }
+  constraint sclval_c { sclval dist {1 := 1, 0 := 1}; }
+  constraint sdaval_c { sdaval dist {1 := 1, 0 := 1}; }
 
   task pre_start();
     super.pre_start();
@@ -25,7 +27,9 @@ class i2c_host_override_vseq extends i2c_base_vseq;
     initialization(.mode(Host));
     `uvm_info(`gfn, "\n--> start of i2c_host_override_vseq", UVM_DEBUG)
     for (uint i = 1; i <= num_trans; i++) begin
+      bit [TL_DW-1:0] reg_val;
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_trans), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("override val = %0d",{txovrden,sclval,sdaval}), UVM_MEDIUM)
       // program to enable OVRD reg
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sclval)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sdaval)
@@ -47,6 +51,8 @@ class i2c_host_override_vseq extends i2c_base_vseq;
               cfg.m_i2c_agent_cfg.vif.sda_i, sdaval), UVM_DEBUG)
         end
       end
+      // Read override register values
+      csr_rd(.ptr(ral.ovrd), .value(reg_val));
     end
     `uvm_info(`gfn, "\n--> end of i2c_host_override_vseq", UVM_DEBUG)
   endtask : body


### PR DESCRIPTION
- Modify constraint for `txovrden` such that all possible values of {`txovrden`, `sclval`, `sdaval`} are covered
- Update sample calls for `interrupts_cg` to cover `intr_test` register read and write in scoreboard