### PR TITLE
[opentitantool] Support setting I2C bus speed

### DIFF
--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -15,11 +15,17 @@ use crate::impl_serializable_error;
 pub struct I2cParams {
     #[structopt(long, help = "I2C instance", default_value = "0")]
     pub bus: String,
+
+    #[structopt(long, help = "I2C bus speed (typically: 100000, 400000, 1000000)")]
+    pub speed: Option<u32>,
 }
 
 impl I2cParams {
     pub fn create(&self, transport: &TransportWrapper) -> Result<Rc<dyn Bus>> {
         let i2c = transport.i2c(&self.bus)?;
+        if let Some(speed) = self.speed {
+            i2c.set_max_speed(speed)?;
+        }
         Ok(i2c)
     }
 }

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230419_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "c0057273ae05a9970245256c376a719d01a53981ae3081e8282541e319081370",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230505_02/hyperdebug-firmware.tar.gz"],
+        sha256 = "b0d30a237316b969085637c7ee155d2ffa1028d2f89a0af63a633a25914f8d6c",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
With this change the speed of I2C busses can be controlled.  Either by adding a declaration similar to the below to a json configuration file, and then running `ott transport init`, or by explicitly setting speed such as `ott i2c --bus I2C1 --speed 1000000 --addr 80 tpm read-register DID_VID`.

```
"i2c": [
  {
    "name": "TPM",
    "bits_per_sec": 400000,
    "alias_of": "I2C1"
  }
],
```
