### PR TITLE
Add `HARDENED_TRAP` to avoid coalesced `unimp` instructions

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -551,6 +551,11 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
     asm volatile(HARDENED_UNIMP_SEQUENCE_()); \
     __builtin_unreachable();                  \
   } while (false)
+
+#define HARDENED_TRAP_()                      \
+  do {                                        \
+    asm volatile(HARDENED_UNIMP_SEQUENCE_()); \
+  } while (false)
 #else  // OT_PLATFORM_RV32
 #include <assert.h>
 
@@ -564,6 +569,8 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
 #define HARDENED_CHECK_(op_, a_, b_) assert((uint64_t)(a_)op_(uint64_t)(b_))
 
 #define HARDENED_UNREACHABLE_() assert(false)
+
+#define HARDENED_TRAP_() __builtin_trap()
 #endif  // OT_PLATFORM_RV32
 
 /**
@@ -573,6 +580,12 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
  * If it is reached anyways, an illegal instruction will be executed.
  */
 #define HARDENED_UNREACHABLE() HARDENED_UNREACHABLE_()
+
+/**
+ * If the following code is (unexpectedly) reached a trap instruction will be
+ * executed.
+ */
+#define HARDENED_TRAP() HARDENED_TRAP_()
 
 /**
  * Compare two values in a way that is *manifestly* true: that is, under normal

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -304,7 +304,7 @@ static void rom_pre_boot_check(void) {
   // Check cached life cycle state against the value reported by hardware.
   lifecycle_state_t lc_state_check = lifecycle_state_get();
   if (launder32(lc_state_check) != lc_state) {
-    HARDENED_UNREACHABLE();
+    HARDENED_TRAP();
   }
   HARDENED_CHECK_EQ(lc_state_check, lc_state);
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 3);
@@ -312,7 +312,7 @@ static void rom_pre_boot_check(void) {
   // Check cached boot data.
   rom_error_t boot_data_ok = boot_data_check(&boot_data);
   if (launder32(boot_data_ok) != kErrorOk) {
-    HARDENED_UNREACHABLE();
+    HARDENED_TRAP();
   }
   HARDENED_CHECK_EQ(boot_data_ok, kErrorOk);
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 4);
@@ -326,7 +326,7 @@ static void rom_pre_boot_check(void) {
   // (bits 6 and 7) in the check.
   cpuctrl_csr = bitfield_bit32_write(cpuctrl_csr, 8, false);
   if (launder32(cpuctrl_csr) != cpuctrl_otp) {
-    HARDENED_UNREACHABLE();
+    HARDENED_TRAP();
   }
   HARDENED_CHECK_EQ(cpuctrl_csr, cpuctrl_otp);
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 5);
@@ -397,7 +397,7 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolFalse);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // Unlock execution of ROM_EXT executable code (text) sections.


### PR DESCRIPTION
This is an alternative to `HARDENED_UNREACHABLE` macro function. It is meant to address the issue of the `unimp` trap instructions being lumped at the end of functions. That behavior is caused by an optimization of the branch folder compiler pass, made possible by the `__builtin_unreachable` used in `HARDENED_UNREACHABLE`. By avoiding that builtin the basic block containing the `unimp` instructions will have successors, so the optimization won't apply.