### PR TITLE
[manuf] fix bugs in `manuf_cp_yield_test`

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -297,14 +297,12 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
-        tags = [
-            "jtag",
-        ],
-        test_cmds = OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        tags = ["jtag"],
+        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
     targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test:manuf_cp_yield_test",
+    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -72,6 +72,8 @@ pub trait Jtag {
     fn connect(&self, tap: JtagTap) -> Result<()>;
     /// Disconnect from the TAP.
     fn disconnect(&self) -> Result<()>;
+    /// Get TAP we are currently connected too.
+    fn get_tap(&self) -> Option<JtagTap>;
 
     // Commands
 

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -363,6 +363,10 @@ impl Jtag for OpenOcdServer {
         self.stop()
     }
 
+    fn get_tap(&self) -> Option<JtagTap> {
+        self.jtag_tap.get()
+    }
+
     fn read_lc_ctrl_reg(&self, reg: &LcCtrlReg) -> Result<u32> {
         ensure!(
             matches!(self.jtag_tap.get().unwrap(), JtagTap::LcTap),

--- a/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/BUILD
@@ -15,6 +15,7 @@ rust_binary(
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
+        "@crate_index//:log",
         "@crate_index//:structopt",
     ],
 )

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -8,79 +8,83 @@
 //! Both interfaces are used to check they're accessible. This is only possible
 //! in some lifecycle states: `TEST_UNLOCKED0` is used in this case.
 
-use anyhow::Context;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
 use structopt::StructOpt;
 
-use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
+use opentitanlib::execute_test;
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
-use opentitanlib::test_utils::extclk::{ClockSpeed, ExternalClock};
+//use opentitanlib::test_utils::extclk::{ClockSpeed, ExternalClock};
 use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::lc_transition::wait_for_status;
 use top_earlgrey::top_earlgrey_memory;
 
 #[derive(Debug, StructOpt)]
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
+
     #[structopt(flatten)]
     jtag: JtagParams,
 }
 
-fn main() -> anyhow::Result<()> {
-    let opts = Opts::from_args();
-    opts.init.init_target()?;
-
-    let transport = opts.init.init_target()?;
-
-    // Begin with the TAP straps set for the CPU.
+fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Reset the chip, select the CPU TAP, and connect to it.
     transport
         .pin_strapping("PINMUX_TAP_RISCV")?
         .apply()
         .context("failed to apply RISCV TAP strapping")?;
-    transport
-        .reset_target(opts.init.bootstrap.options.reset_delay, true)
-        .context("failed to reset")?;
-
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
     let jtag = transport.jtag(&opts.jtag)?;
-
-    // Connect to the CPU over JTAG.
     jtag.connect(JtagTap::RiscvTap)
         .context("failed to connect to RISCV TAP over JTAG")?;
 
-    ExternalClock::enable(&*jtag, ClockSpeed::High).context("failed to enable external clock")?;
+    // TODO(#18403): switching to external clock does not succeed. Clkmgr fails to ACK switch.
+    //ExternalClock::enable(&*jtag, ClockSpeed::High).context("failed to enable external clock")?;
 
     // Read and write memory to verify connection.
 
-    // Check the lifecycle state via its memory map.
-    let mut reset_info_buf = [0];
+    // Check we can read the MMIO system memory region by reading the LC state.
+    // We must wait for the lc_ctrl to initialize before the LC state is exposed.
+    wait_for_status(&jtag, Duration::from_secs(3), LcCtrlStatus::INITIALIZED)?;
+    let mut encoded_lc_state = [0u32];
     jtag.read_memory32(
         top_earlgrey_memory::TOP_EARLGREY_LC_CTRL_BASE_ADDR as u32 + LcCtrlReg::LcState as u32,
-        &mut reset_info_buf,
+        &mut encoded_lc_state,
     )?;
-
     assert_eq!(
-        reset_info_buf[0],
+        encoded_lc_state[0],
         DifLcCtrlState::TestUnlocked0.redundant_encoding()
     );
 
-    // Without resetting, changing TAP strapping to the LC and reconnect JTAG.
-
+    // Without resetting, change TAP strapping to the LC and reconnect.
     jtag.disconnect().context("failed to disconnect JTAG")?;
-
     transport
         .pin_strapping("PINMUX_TAP_LC")?
         .apply()
         .context("failed to apply LC TAP strapping")?;
-
     jtag.connect(JtagTap::LcTap)
         .context("failed to connect to LC TAP over JTAG")?;
 
-    // Read and write registers to verify connection.
-
-    // Check the LC state is `TEST_UNLOCKED0`.
+    // Read and write LC state register to verify connection.
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     assert_eq!(state, DifLcCtrlState::TestUnlocked0.redundant_encoding());
 
     jtag.disconnect().context("failed to disconnect JTAG")?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    opts.init.init_target()?;
+    let transport = opts.init.init_target()?;
+
+    execute_test!(manuf_cp_yield_test, &opts, &transport);
 
     Ok(())
 }


### PR DESCRIPTION
There were several bugs in the `manuf_cp_yield_test`, that were causing it to fail consistently in CI, including:
1. the external clock enablement is causing the chip to freeze up, so it has been temporarily commented out,
2. the convention for writing host tests with opentitanlib was not followed (convention is to use the `execute_test!` macro so test code can be reused between tests if needed,
3. logging was not initialized, so we couldn't tell what was happening in the test, and
4. we did not check the lc_ctrl status was INITIALIZED before reading the LC state over the system bus (causing additional test flakiness on top of the JTAG flakiness that already exists).

CC: @jwnrt since any FPGA tests that use JTAG are not currently blocking in CI, due to the JTAG flakiness, its important to test them locally several times before merging them for now.

**_Note: this depends on #18381. Only review the last 3 commits._**