### PR TITLE
[dv/lc_ctrl] support volatile raw unlock [part1]

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -181,6 +181,27 @@
       tests: ["lc_ctrl_jtag_priority"]
     }
     {
+      name: lc_ctrl_volatile_unlock
+      desc: '''
+            This test covers lc_ctrl volatile_raw_unlock functionality.
+
+            **Stimulus**:
+            - Claim the mutex.
+            - Set volatile_raw_unlock to 1.
+            - Trigger a lc_transition.
+            - Trigger a second lc_transition without reset.
+
+            **Checks**:
+            - If the current state is RawState, and transition state is TestUnlocked0, and if the
+              input token is correct, expect the transition to be sucessful.
+            - Check status and volatile_raw_unlock output.
+            - If the raw unlock transition is successful, check the second lc_transition can be
+              performed without any error.
+            '''
+      stage: V2
+      tests: ["lc_ctrl_volatile_unlock_smoke"]
+    }
+    {
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence.

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/lc_ctrl_base_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_common_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_prog_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_state_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// set volatile unlock to 1 and check if raw -> unlock0 transition is successful.
+class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_jtag_access_vseq;
+
+  rand dec_lc_state_e next_state;
+  rand bit next_state_is_testunlock0;
+
+  `uvm_object_utils(lc_ctrl_volatile_unlock_smoke_vseq)
+  `uvm_object_new
+
+  constraint next_state_c {
+      if (next_state_is_testunlock0) next_state == DecLcStTestUnlocked0;
+      solve next_state_is_testunlock0 before next_state;
+   }
+
+  task body();
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+    // TODO: randomize that not always start with raw state.
+    drive_otp_i(0);
+    if (lc_cnt != LcCnt24) begin
+      lc_ctrl_state_pkg::lc_token_t token_val = lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed;
+      csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
+      csr_wr(ral.transition_ctrl.volatile_raw_unlock, 1);
+      csr_wr(ral.transition_target, {DecLcStateNumRep{next_state[DecLcStateWidth-1:0]}});
+      foreach (ral.transition_token[i]) begin
+        csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);
+        token_val = token_val >> TL_DW;
+      end
+      csr_wr(ral.transition_cmd, 'h01);
+
+      if (next_state == DecLcStTestUnlocked0) begin
+        `DV_SPINWAIT(while (1) begin
+            bit [TL_DW-1:0] status_val;
+            csr_rd(ral.status, status_val);
+            if (get_field_val(ral.status.transition_successful, status_val)) break;
+          end)
+          // TODO: check can keep programming next state.
+      end else begin
+        `DV_SPINWAIT(while (1) begin
+            bit [TL_DW-1:0] status_val;
+            csr_rd(ral.status, status_val);
+            if (get_field_val(ral.status.transition_error, status_val)) break;
+          end)
+      end
+    end
+
+  endtask : body
+
+endclass : lc_ctrl_volatile_unlock_smoke_vseq

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -17,5 +17,6 @@
 `include "lc_ctrl_sec_mubi_vseq.sv"
 `include "lc_ctrl_sec_token_mux_vseq.sv"
 `include "lc_ctrl_sec_token_digest_vseq.sv"
+`include "lc_ctrl_volatile_unlock_smoke_vseq.sv"
 `include "lc_ctrl_claim_transition_if_vseq.sv"
 `include "lc_ctrl_stress_all_vseq.sv"

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -78,6 +78,12 @@
     }
 
     {
+      name: lc_ctrl_volatile_unlock_smoke
+      uvm_test_seq: lc_ctrl_volatile_unlock_smoke_vseq
+      run_opts: ["+en_scb=0", "+create_jtag_riscv_map=1"]
+    }
+
+    {
       name: lc_ctrl_state_failure
       uvm_test_seq: lc_ctrl_state_failure_vseq
     }


### PR DESCRIPTION
This PR supports basic functions for raw volatile unlock.
This PR only focuses on issues a volatile raw unlock, and it will be successful if the transition meets the requirement.
If not we should see an error.
More TODOs will be finished by the coming PRs.