### PR TITLE
[usb20_usbdpi] Fixes for usb smoke test

### DIFF
--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -44,7 +44,7 @@
 #define TRANSFER_BYTES_VERILATOR 0x2400U
 
 // This is about the amount that we can transfer within a 1 hour 'eternal' test
-//#define TRANSFER_BYTES_LONG (0xD0U << 20)
+// #define TRANSFER_BYTES_LONG (0xD0U << 20)
 
 /**
  * Configuration values for USB.
@@ -221,7 +221,7 @@ bool test_main(void) {
   // simulation has finished all of the printing, which takes a while
   // if `--trace` was passed in.
   CHECK_STATUS_OK(usb_testutils_init(ctx->usbdev, /*pinflip=*/false,
-                                     /*en_diff_rcvr=*/false,
+                                     /*en_diff_rcvr=*/true,
                                      /*tx_use_d_se0=*/false));
   CHECK_STATUS_OK(usb_testutils_controlep_init(
       &usbdev_control, ctx->usbdev, 0, config_descriptors,

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -111,7 +111,7 @@ bool test_main(void) {
   // simulation has finished all of the printing, which takes a while
   // if `--trace` was passed in.
   CHECK_STATUS_OK(usb_testutils_init(&usbdev, /*pinflip=*/false,
-                                     /*en_diff_rcvr=*/false,
+                                     /*en_diff_rcvr=*/true,
                                      /*tx_use_d_se0=*/false));
   CHECK_STATUS_OK(usb_testutils_controlep_init(
       &usbdev_control, &usbdev, 0, config_descriptors,


### PR DESCRIPTION
Enable the differential receiver in ASIC top level for smoke test and streaming test; remains functional for Verilator and FPGA.
Fix generation of device Dn enable; usb_monitor needs to see J as well as SE0. This wasn't leading to test failure, but the monitor was showing CRC errors and garbled logs because it had failed to return to MS_IDLE after an ACK response from the device.

Leaving as draft for now because I want to re-run all tests to successful completion and check the logs (since dpi/monitor cannot yet signal test failure directly). -A