### PR TITLE
[chip,dv] Add delay prior to drive jtag

### DIFF
--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -162,7 +162,7 @@ class spi_host_driver extends spi_driver;
     bit [7:0] cmd_addr_bytes[$];
     bit [7:0] dummy_return_q[$]; // nothing to return for flash cmd, addr and write
 
-    `uvm_info(`gfn, $sformatf("Driving flash item: \n%s", req.sprint()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Driving flash item: \n%s", req.sprint()), UVM_HIGH)
     cfg.vif.csb[active_csb] <= 1'b0;
 
     cmd_addr_bytes = {req.opcode, req.address_q};
@@ -204,7 +204,7 @@ class spi_host_driver extends spi_driver;
                         .csb_id(active_csb), .data(data));
           rsp.payload_q.push_back(data);
         end
-        `uvm_info(`gfn, $sformatf("collect read data for flash: 0x%p", rsp.payload_q), UVM_MEDIUM)
+        `uvm_info(`gfn, $sformatf("collect read data for flash: 0x%p", rsp.payload_q), UVM_HIGH)
       end
     end
 

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -236,7 +236,7 @@ class spi_monitor extends dv_base_monitor#(
     cfg.extract_cmd_info_from_opcode(item.opcode,
         // output
         num_addr_bytes, item.write_command, item.num_lanes, item.dummy_cycles);
-    `uvm_info(`gfn, $sformatf("sampled flash opcode: 0x%0h", item.opcode), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("sampled flash opcode: 0x%0h", item.opcode), UVM_HIGH)
 
     sample_address(num_addr_bytes, item.address_q);
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_exit_test_unlocked_bootstrap_vseq.sv
@@ -51,6 +51,8 @@ class chip_sw_exit_test_unlocked_bootstrap_vseq extends chip_sw_base_vseq;
     // Now program ROM_EXEC_EN for next power cycle.
     cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
 
+    // Add delay before drive jtag after strap switch.
+    cfg.clk_rst_vif.wait_clks(5);
     jtag_dm_activation_seq.start(p_sequencer.jtag_sequencer_h);
     `uvm_info(`gfn, $sformatf("rv_dm_activated: %0d", cfg.m_jtag_riscv_agent_cfg.rv_dm_activated),
               UVM_LOW)


### PR DESCRIPTION
This PR fixes 'chip_sw_exit_test_unlocked_bootstrap' test fail.
- After switch straps to Jtag, add some delay before jtag drive start.
- Increase verbosity of spi agent for frequent printing.