### PR TITLE
[dv/lc] volatile_raw_unlock [part2]

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -226,5 +226,11 @@
         lc_ctrl_fsm states and arcs
       '''
     }
+    {
+      name: volatile_raw_unlock_cg
+      desc: '''
+        Cover volatile_raw_unlock transition success and fail cases.
+      '''
+    }
   ]
 }

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -35,6 +35,14 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
 
   // covergroups
 
+  // Volatile raw unlock coverpoint
+  covergroup volatile_raw_unlock_cg with function sample(bit success);
+    volatile_raw_unlock_cp: coverpoint success {
+      bins success = {1};
+      bins fail    = {0};
+    }
+  endgroup : volatile_raw_unlock_cg
+
   // Error injections
   covergroup err_inj_cg;
 
@@ -110,6 +118,7 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
   function new(string name, uvm_component parent);
     super.new(name, parent);
     err_inj_cg = new();
+    volatile_raw_unlock_cg = new();
   endfunction : new
 
   virtual function void sample_cov();

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -53,6 +53,8 @@ interface lc_ctrl_if (
   logic [OtpTestCtrlWidth-1:0] otp_vendor_test_ctrl_o;
   logic [OtpTestStatusWidth-1:0] otp_vendor_test_status_i;
 
+  logic strap_en_override_o;
+
   event lc_fsm_state_backdoor_write_ev;
   event lc_fsm_state_backdoor_read_ev;
   event kmac_fsm_state_backdoor_write_ev;

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // set volatile unlock to 1 and check if raw -> unlock0 transition is successful.
-class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_jtag_access_vseq;
+// TODO: csr checkings: include lc_cnt, and lc_state.
+class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_smoke_vseq;
 
   rand dec_lc_state_e next_state;
   rand bit next_state_is_testunlock0;
@@ -17,8 +18,12 @@ class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_jtag_access_vseq;
    }
 
   task body();
+    fork
+      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_flash_rma_rsp(flash_rma_error_rsp);
+    join_none
+
     `DV_CHECK_RANDOMIZE_FATAL(this)
-    // TODO: randomize that not always start with raw state.
     drive_otp_i(0);
     if (lc_cnt != LcCnt24) begin
       lc_ctrl_state_pkg::lc_token_t token_val = lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed;
@@ -32,21 +37,45 @@ class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_jtag_access_vseq;
       csr_wr(ral.transition_cmd, 'h01);
 
       if (next_state == DecLcStTestUnlocked0) begin
-        `DV_SPINWAIT(while (1) begin
-            bit [TL_DW-1:0] status_val;
-            csr_rd(ral.status, status_val);
-            if (get_field_val(ral.status.transition_successful, status_val)) break;
-          end)
-          // TODO: check can keep programming next state.
+        csr_spinwait(.ptr(ral.status.transition_successful), .exp_data(1), .timeout_ns(100_000));
+        cfg.clk_rst_vif.wait_clks(10);
+        `DV_CHECK_EQ(cfg.lc_ctrl_vif.strap_en_override_o, 1);
+        if (cfg.en_cov) cov.volatile_raw_unlock_cg.sample(1);
+        transition_to_next_valid_state(1);
       end else begin
-        `DV_SPINWAIT(while (1) begin
-            bit [TL_DW-1:0] status_val;
-            csr_rd(ral.status, status_val);
-            if (get_field_val(ral.status.transition_error, status_val)) break;
-          end)
+        csr_spinwait(.ptr(ral.status.transition_error), .exp_data(1), .timeout_ns(100_000));
+        `DV_CHECK_EQ(cfg.lc_ctrl_vif.strap_en_override_o, 0);
+        if (cfg.en_cov) cov.volatile_raw_unlock_cg.sample(0);
       end
     end
 
   endtask : body
 
+  virtual task transition_to_next_valid_state(bit volatile_raw_unlock_success);
+    lc_ctrl_pkg::token_idx_e token;
+    randomize_next_lc_state(next_state);
+    lc_state = encode_lc_state(next_state);
+    token = get_exp_token(dec_lc_state(lc_state), next_lc_state);
+    set_hashed_token();
+    `uvm_info(`gfn, $sformatf("start another transition after volatile unlock: from %0s to %0s",
+              next_state.name,  next_lc_state.name), UVM_LOW)
+    sw_transition_req(next_lc_state, token);
+    csr_spinwait(.ptr(ral.status.transition_successful), .exp_data(1), .timeout_ns(100_000));
+  endtask
+
+  virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);
+    bit trigger_alert;
+    bit [TL_DW-1:0] status_val;
+    uvm_reg_data_t val;
+    csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
+    if ($urandom_range(0, 1)) csr_wr(ral.transition_ctrl, $urandom_range(0, 1));
+    csr_wr(ral.transition_target, {DecLcStateNumRep{next_lc_state[DecLcStateWidth-1:0]}});
+    foreach (ral.transition_token[i]) begin
+      csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);
+      token_val = token_val >> TL_DW;
+    end
+
+    // Execute transition
+    csr_wr(ral.transition_cmd, 'h01);
+  endtask
 endclass : lc_ctrl_volatile_unlock_smoke_vseq

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -135,7 +135,7 @@ module tb;
 
     .pwr_lc_i(pwr_lc[LcPwrInitReq]),
     .pwr_lc_o(pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
-    .strap_en_override_o( /** TODO: hook this signal up */ ),
+    .strap_en_override_o(lc_ctrl_if.strap_en_override_o),
 
     .lc_otp_vendor_test_o(otp_vendor_test_ctrl),
     .lc_otp_vendor_test_i(otp_vendor_test_status),


### PR DESCRIPTION
1. create functional coverage to make sure both volatile raw unlock pass and fail are covered.
2. Check strap_en_override_o output.
3. Check after volatile raw unlock, the lc can continue program.