### PR TITLE
[bazel] Update CRT version (enable ratified bitmanip extensions)

### DIFF
--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.0.tar.gz",
-            sha256 = "46fd2569c7bc0272401c41eed79283a8ded9485ffa3c14917dfcb4df61bc4add",
-            strip_prefix = "crt-0.4.0",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.1.tar.gz",
+            sha256 = "abc985cbc88acb1fa7b1d1e6dfe7fefdc57e722967444e51a69232e92eb33feb",
+            strip_prefix = "crt-0.4.1",
         )


### PR DESCRIPTION
This effectively enables the Zba, Zbb, Zbc, and Zbs bit manipulation extensions.