### PR TITLE
SUPERSEDED: Iso/Interrupt streaming changes to usb_testutils

### DIFF
--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -275,10 +275,12 @@ status_t usb_testutils_transfer_send(usb_testutils_ctx_t *ctx, uint8_t ep,
 }
 
 status_t usb_testutils_in_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep, void *ep_ctx,
-    usb_testutils_tx_done_handler_t tx_done,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t ep_type,
+    void *ep_ctx, usb_testutils_tx_done_handler_t tx_done,
     usb_testutils_tx_flush_handler_t flush,
     usb_testutils_reset_handler_t reset) {
+  // Store callback handler information before we enable the endpoint
+  ctx->in[ep].ep_type = ep_type;
   ctx->in[ep].ep_ctx = ep_ctx;
   ctx->in[ep].tx_done_callback = tx_done;
   ctx->in[ep].flush = flush;
@@ -291,15 +293,24 @@ status_t usb_testutils_in_endpoint_setup(
 
   TRY(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint, kDifToggleDisabled));
 
+  // Specify whether this is an Isochronous endpoint (no acknowledgement/retry)
+  dif_toggle_t iso = kDifToggleDisabled;
+  if (ep_type == kUsbTransferTypeIsochronous) {
+    iso = kDifToggleEnabled;
+  }
+  CHECK_DIF_OK(dif_usbdev_endpoint_iso_enable(ctx->dev, endpoint, iso));
+
   // Enable IN traffic from device to host
   TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, kDifToggleEnabled));
   return OK_STATUS();
 }
 
 status_t usb_testutils_out_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t ep_type,
     usb_testutils_out_transfer_mode_t out_mode, void *ep_ctx,
     usb_testutils_rx_handler_t rx, usb_testutils_reset_handler_t reset) {
+  // Store callback handler information before we enable the endpoint
+  ctx->out[ep].ep_type = ep_type;
   ctx->out[ep].ep_ctx = ep_ctx;
   ctx->out[ep].rx_callback = rx;
   ctx->out[ep].reset = reset;
@@ -310,6 +321,13 @@ status_t usb_testutils_out_endpoint_setup(
   };
 
   TRY(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint, kDifToggleDisabled));
+
+  // Specify whether this is an Isochronous endpoint (no acknowledgement/retry)
+  dif_toggle_t iso = kDifToggleDisabled;
+  if (ep_type == kUsbTransferTypeIsochronous) {
+    iso = kDifToggleEnabled;
+  }
+  CHECK_DIF_OK(dif_usbdev_endpoint_iso_enable(ctx->dev, endpoint, iso));
 
   // Enable/disable the endpoint and reception of OUT packets?
   dif_toggle_t enabled = kDifToggleEnabled;
@@ -323,23 +341,27 @@ status_t usb_testutils_out_endpoint_setup(
     nak = kDifToggleEnabled;
   }
 
-  TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, enabled));
   TRY(dif_usbdev_endpoint_out_enable(ctx->dev, ep, enabled));
   TRY(dif_usbdev_endpoint_set_nak_out_enable(ctx->dev, ep, nak));
+  // Now we may enable the OUT endpoint
+  TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, enabled));
   return OK_STATUS();
 }
 
 status_t usb_testutils_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t in_type,
+    usb_testutils_transfer_type_t out_type,
     usb_testutils_out_transfer_mode_t out_mode, void *ep_ctx,
     usb_testutils_tx_done_handler_t tx_done, usb_testutils_rx_handler_t rx,
     usb_testutils_tx_flush_handler_t flush,
     usb_testutils_reset_handler_t reset) {
-  TRY(usb_testutils_in_endpoint_setup(ctx, ep, ep_ctx, tx_done, flush, reset));
+  TRY(usb_testutils_in_endpoint_setup(ctx, ep, in_type, ep_ctx, tx_done, flush,
+                                      reset));
 
   // Note: register the link reset handler only on the IN endpoint so that it
   // does not get invoked twice
-  return usb_testutils_out_endpoint_setup(ctx, ep, out_mode, ep_ctx, rx, NULL);
+  return usb_testutils_out_endpoint_setup(ctx, ep, out_type, out_mode, ep_ctx,
+                                          rx, NULL);
 }
 
 status_t usb_testutils_in_endpoint_remove(usb_testutils_ctx_t *ctx,
@@ -410,8 +432,9 @@ status_t usb_testutils_init(usb_testutils_ctx_t *ctx, bool pinflip,
 
   // Set up context
   for (int i = 0; i < USBDEV_NUM_ENDPOINTS; i++) {
-    TRY(usb_testutils_endpoint_setup(ctx, i, kUsbdevOutDisabled, NULL, NULL,
-                                     NULL, NULL, NULL));
+    TRY(usb_testutils_endpoint_setup(
+        ctx, i, kUsbTransferTypeControl, kUsbTransferTypeControl,
+        kUsbdevOutDisabled, NULL, NULL, NULL, NULL, NULL));
   }
 
   // All about polling...

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -401,8 +401,9 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
                                       const uint8_t *test_dscr,
                                       size_t test_dscr_len) {
   ctctx->ctx = ctx;
-  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutMessage, ctctx,
-                                   ctrl_tx_done, ctrl_rx, NULL, ctrl_reset));
+  TRY(usb_testutils_endpoint_setup(
+      ctx, ep, kUsbTransferTypeControl, kUsbTransferTypeControl,
+      kUsbdevOutMessage, ctctx, ctrl_tx_done, ctrl_rx, NULL, ctrl_reset));
   ctctx->ep = ep;
   ctctx->ctrlstate = kUsbTestutilsCtIdle;
   ctctx->cfg_dscr = cfg_dscr;

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -410,8 +410,11 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
   ctctx->cfg_dscr_len = cfg_dscr_len;
   ctctx->test_dscr = test_dscr;
   ctctx->test_dscr_len = test_dscr_len;
-  TRY(dif_usbdev_interface_enable(ctx->dev, kDifToggleEnabled));
   ctctx->device_state = kUsbTestutilsDeviceDefault;
+
+  // Indicate the device presence, at which point we can expect to start
+  // receiving control transfers from the host
+  TRY(dif_usbdev_interface_enable(ctx->dev, kDifToggleEnabled));
 
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -11,6 +11,13 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/usb_testutils.h"
 
+// DPI test numbers
+typedef enum usb_testutils_test_number {
+  kUsbTestNumberSmoke = 0,
+  kUsbTestNumberStreams,
+  kUsbTestNumberIso
+} usb_testutils_test_number_t;
+
 typedef enum usb_testutils_ctstate {
   kUsbTestutilsCtIdle,
   kUsbTestutilsCtWaitIn,      // Queued IN data stage, waiting ack
@@ -126,7 +133,7 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
   USB_EP_DSCR_LEN,                 /* bLength                              */ \
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
-      0x02,                        /* bmAttributes (0x02=bulk, data)       */ \
+      kUsbTransferTypeBulk,        /* bmAttributes (0x02=bulk, data)       */ \
       (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -15,7 +15,8 @@
 typedef enum usb_testutils_test_number {
   kUsbTestNumberSmoke = 0,
   kUsbTestNumberStreams,
-  kUsbTestNumberIso
+  kUsbTestNumberIso,
+  kUsbTestNumberMixed
 } usb_testutils_test_number_t;
 
 typedef enum usb_testutils_ctstate {

--- a/sw/device/lib/testing/usb_testutils_simpleserial.c
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.c
@@ -78,8 +78,9 @@ status_t usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
 status_t usb_testutils_simpleserial_init(usb_testutils_ss_ctx_t *ssctx,
                                          usb_testutils_ctx_t *ctx, int ep,
                                          void (*got_byte)(uint8_t)) {
-  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutStream, ssctx, ss_tx_done,
-                                   ss_rx, ss_flush, NULL));
+  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbTransferTypeBulk,
+                                   kUsbTransferTypeBulk, kUsbdevOutStream,
+                                   ssctx, ss_tx_done, ss_rx, ss_flush, NULL));
   ssctx->ctx = ctx;
   ssctx->ep = ep;
   ssctx->sending = false;

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -32,6 +32,51 @@ static const enum {
  */
 static bool log_traffic = false;
 
+// Determine the length of the next packet in the data stream, _including_
+// any required signature.
+static unsigned packet_length(const usbdev_stream_t *s, uint32_t bytes_done,
+                              uint8_t *bufsz_lfsr) {
+  // For non-Isochronous streams the packet size is also constrained by the
+  // total size of the transfer. For Isochronous streams we just keep
+  // transmitting to account for the possibility of packet loss.
+  uint8_t bytes_left = USBDEV_MAX_PACKET_SIZE;
+
+  if (s->xfr_type != kUsbTransferTypeIsochronous) {
+    if (bytes_done < s->transfer_bytes &&
+        s->transfer_bytes - bytes_done < bytes_left) {
+      bytes_left = s->transfer_bytes - bytes_done;
+    }
+  }
+
+  // Length of packet
+  unsigned num_bytes;
+
+  if (s->flags & kUsbdevStreamFlagMaxPackets) {
+    num_bytes = bytes_left;
+  } else {
+    // Vary the amount of data sent per buffer
+    if (s->sig_required) {
+      const unsigned sig_bytes = sizeof(usbdev_stream_sig_t);
+      switch (s->xfr_type) {
+        case kUsbTransferTypeIsochronous: {
+          // For Isochronous streams, and the first packet of other transfers,
+          // we must constrain the minimum packet size
+          const unsigned max_bytes = USBDEV_MAX_PACKET_SIZE - sig_bytes;
+          num_bytes = sig_bytes + (*bufsz_lfsr % (max_bytes + 1u));
+        } break;
+        default:
+          num_bytes = sig_bytes;
+          break;
+      }
+    } else {
+      num_bytes = *bufsz_lfsr % (bytes_left + 1u);
+    }
+    *bufsz_lfsr = LFSR_ADVANCE(*bufsz_lfsr);
+  }
+
+  return num_bytes;
+}
+
 // Dump a sequence of bytes as hexadecimal and ASCII for diagnostic purposes
 static void buffer_dump(const uint8_t *data, size_t n) {
   base_hexdump_fmt_t fmt = {
@@ -47,15 +92,29 @@ static void buffer_dump(const uint8_t *data, size_t n) {
 static uint32_t buffer_sig_create(usb_testutils_streams_ctx_t *ctx,
                                   usbdev_stream_t *s,
                                   dif_usbdev_buffer_t *buf) {
-  usbdev_stream_sig_t sig;
+  // Number of bytes left to be transmitted
+  // - for non-Isochronous streams this is just the total number of bytes to be
+  //   transmitted, and there's a single signature at the start of the stream
+  // - for Isochronous this provideds a down count, and it will wrap around
+  //   upon reaching zero, in the event of packet loss and prolonged
+  //   transmission
+  uint32_t tx_left = s->transfer_bytes - (s->tx_bytes % s->transfer_bytes);
 
+  usbdev_stream_sig_t sig;
   sig.head_sig = USBDEV_STREAM_SIGNATURE_HEAD;
   sig.init_lfsr = s->tx_lfsr;
   sig.stream = s->id | (uint8_t)s->flags;
-  sig.reserved1 = 0U;
-  sig.reserved2 = 0U;
-  sig.num_bytes = s->transfer_bytes;
+  sig.seq_lo = (uint8_t)s->tx_seq;
+  sig.seq_hi = (uint8_t)(s->tx_seq >> 8);
+  sig.num_bytes = tx_left;
   sig.tail_sig = USBDEV_STREAM_SIGNATURE_TAIL;
+
+  // Advance sequence counter
+  s->tx_seq++;
+
+  if (s->verbose && log_traffic) {
+    buffer_dump((uint8_t *)&sig, sizeof(sig));
+  }
 
   size_t bytes_written;
   CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->usbdev->dev, buf, (uint8_t *)&sig,
@@ -63,8 +122,87 @@ static uint32_t buffer_sig_create(usb_testutils_streams_ctx_t *ctx,
   CHECK(bytes_written == sizeof(sig));
 
   // Note: stream signature is not included in the count of bytes transferred
-
+  // so we do not advance tx_bytes
   return bytes_written;
+}
+
+// Check a stream signature
+//
+// Note: Only Isochronous streams are expected to receive signatures; in order
+// to keep the device and host ends synchronized in the presence of packet-
+// dropping, a signature occurs at the start of each packet. Each signature
+// includes a packet sequence number and the intiial value of the sender's LFSR
+static bool buffer_sig_check(usb_testutils_streams_ctx_t *ctx,
+                             usbdev_stream_t *s, const usbdev_stream_sig_t *sig,
+                             uint8_t len) {
+  // Validate the signature
+  if (sig->head_sig != USBDEV_STREAM_SIGNATURE_HEAD ||
+      sig->tail_sig != USBDEV_STREAM_SIGNATURE_TAIL ||
+      // Returned to the correct stream?
+      (sig->stream & 0xfU) != s->id) {
+    LOG_INFO("buffer_sig_check failed: ");
+    return false;
+  }
+
+  // Sequence number not regressed?
+  uint16_t seq = (sig->seq_hi << 8) | sig->seq_lo;
+  if (seq < s->rx_seq) {
+    LOG_INFO("buffer_sig_check: sequence number regressed from 0x%x to 0x%x",
+             s->rx_seq, seq);
+    return false;
+  }
+
+  // Current LFSR state and sequence number
+  uint16_t rx_seq = s->rx_seq;
+  uint8_t rx_lfsr = s->rx_lfsr;
+  uint8_t rxtx_lfsr = s->rxtx_lfsr;
+
+  // Skip past any packets that appear to have been dropped; this is
+  // permissible for Isochronous transfers which prioritize service/real-time
+  // delivery over reliable transmission.
+  while (rx_seq < seq) {
+    // Determine the length of the missing packet
+    uint8_t len = packet_length(s, s->rx_bytes, &s->rx_buf_size);
+    len -= sizeof(*sig);
+    // Advance the LFSR states to account for the missing packet
+    while (len-- > 0U) {
+      rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
+      rx_lfsr = LFSR_ADVANCE(rx_lfsr);
+    }
+    // The updated host-side LFSR has been supplied in the packet signature
+    rx_seq++;
+  }
+
+  // For 'rx_buf_size' to track the 'tx_buf_size' used when the packets were
+  // created and transmitted, we must also ascertain the expected length of the
+  // packet that we have just received; we thus check that the length of this
+  // packet has not changed either.
+
+  uint8_t exp_len = packet_length(s, s->rx_bytes, &s->rx_buf_size);
+  if (len != exp_len) {
+    LOG_INFO(
+        "buffer_sig_check: S%u unexpected packet length (0x%x but expected "
+        "0x%x)",
+        s->id, len, exp_len);
+    return false;
+  }
+
+  // Similarly, our expectation of the host/DPI LFSR should now match the
+  // value that it has supplied in the modified packet.
+  if (rx_lfsr != sig->init_lfsr) {
+    LOG_INFO(
+        "buffer_sig_check: S%u unexpected LFSR value (0x%x but expected 0x%x)",
+        s->id, sig->init_lfsr, rx_lfsr);
+    return true;
+  }
+
+  // Expected sequence number of next packet
+  s->rx_seq = rx_seq + 1U;
+  // Update the LFSR states
+  s->rxtx_lfsr = rxtx_lfsr;
+  s->rx_lfsr = rx_lfsr;
+
+  return true;
 }
 
 // Fill a buffer with LFSR-generated data
@@ -129,35 +267,59 @@ static void buffer_check(usb_testutils_streams_ctx_t *ctx, usbdev_stream_t *s,
                                         data, len, &bytes_read));
     CHECK(bytes_read == len);
 
-    if (log_traffic) {
+    if (s->verbose && log_traffic) {
       buffer_dump(data, bytes_read);
     }
 
-    // Check received data against expected LFSR-generated byte stream;
-    // keep this brief so that we can reduce our latency in responding to
-    // USB events (usb_testutils employs polling at present)
-    uint8_t rxtx_lfsr = s->rxtx_lfsr;
-    uint8_t rx_lfsr = s->rx_lfsr;
+    // Byte offset of LFSR-generated byte stream
+    size_t offset = 0U;
 
-    const uint8_t *esp = &data[bytes_read];
-    const uint8_t *sp = data;
-    while (sp < esp) {
-      // Received data should be the XOR of two LFSR-generated PRND streams -
-      // ours on the
-      //   transmission side, and that of the DPI model
-      uint8_t expected = rxtx_lfsr ^ rx_lfsr;
-      CHECK(expected == *sp,
-            "S%u: Unexpected received data 0x%02x : (LFSRs 0x%02x 0x%02x)",
-            s->id, *sp, rxtx_lfsr, rx_lfsr);
+    switch (s->xfr_type) {
+      case kUsbTransferTypeIsochronous: {
+        // Check the packet signature, advance the LFSRs and drop through to
+        // check the remainder of the packet
+        const usbdev_stream_sig_t *sig = (usbdev_stream_sig_t *)data;
+        bool ok = buffer_sig_check(ctx, s, sig, len);
+        CHECK(ok, "S%u: Received packet invalid", s->id);
 
-      rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
-      rx_lfsr = LFSR_ADVANCE(rx_lfsr);
-      sp++;
+        offset = sizeof(*sig);
+      }  // no break
+      case kUsbTransferTypeInterrupt:
+      case kUsbTransferTypeBulk: {
+        // Check received data against expected LFSR-generated byte stream;
+        // keep this brief so that we can reduce our latency in responding to
+        // USB events (usb_testutils employs polling at present)
+        uint8_t rxtx_lfsr = s->rxtx_lfsr;
+        uint8_t rx_lfsr = s->rx_lfsr;
+
+        const uint8_t *esp = &data[bytes_read];
+        const uint8_t *sp = &data[offset];
+        while (sp < esp) {
+          // Received data should be the XOR of two LFSR-generated PRND streams
+          // - ours on the
+          //   transmission side, and that of the DPI model
+          uint8_t expected = rxtx_lfsr ^ rx_lfsr;
+          CHECK(expected == *sp,
+                "S%u: Unexpected received data 0x%02x : (LFSRs 0x%02x 0x%02x)",
+                s->id, *sp, rxtx_lfsr, rx_lfsr);
+
+          rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
+          rx_lfsr = LFSR_ADVANCE(rx_lfsr);
+          sp++;
+        }
+
+        // Update the LFSRs for the next packet
+        s->rxtx_lfsr = rxtx_lfsr;
+        s->rx_lfsr = rx_lfsr;
+
+        // Update the count of LFSR bytes received
+        s->rx_bytes += bytes_read - offset;
+      } break;
+
+      default:
+        CHECK(s->xfr_type == kUsbTransferTypeControl);
+        break;
     }
-
-    // Update the LFSRs for the next packet
-    s->rxtx_lfsr = rxtx_lfsr;
-    s->rx_lfsr = rx_lfsr;
   } else {
     // In the event that we've received a zero-length data packet, we still
     // must return the buffer to the pool
@@ -251,9 +413,9 @@ static status_t strm_rx(void *stream_v, dif_usbdev_rx_packet_info_t packet_info,
       // Just discard the data, without reading it; peak OUT performance
       TRY(dif_usbdev_buffer_return(usbdev->dev, usbdev->buffer_pool, &buf));
     }
-  }
 
-  s->rx_bytes += packet_info.length;
+    s->rx_bytes += packet_info.length;
+  }
 
   return OK_STATUS();
 }
@@ -273,6 +435,35 @@ static status_t rx_show(void *stream_v, dif_usbdev_rx_packet_info_t packet_info,
   buffer_dump(data, bytes_read);
 
   return OK_STATUS();
+}
+
+// Set the count of already-initialized streams, and apportion the available
+// tx buffers among the streams.
+bool usb_testutils_streams_count_set(usb_testutils_streams_ctx_t *ctx,
+                                     unsigned nstreams) {
+  // Too many streams?
+  if (nstreams > USBUTILS_STREAMS_MAX) {
+    return false;
+  }
+
+  // Decide how many buffers each endpoint may queue up for transmission;
+  // we must ensure that there are buffers available for reception, and we
+  // do not want any endpoint to starve another
+  for (unsigned s = 0U; s < nstreams; s++) {
+    // This is slightly overspending the available buffers, leaving the
+    //   endpoints to vie for the final few buffers, so it's important that
+    //   we limit the total number of buffers across all endpoints too
+    unsigned ep = ctx->streams[s].tx_ep;
+    ctx->tx_bufs_queued[ep] = 0U;
+    ctx->tx_bufs_limit[ep] =
+        (USBUTILS_STREAMS_TXBUF_MAX + nstreams - 1) / nstreams;
+  }
+  ctx->tx_queued_total = 0U;
+
+  // Remember the stream count
+  ctx->nstreams = nstreams;
+
+  return true;
 }
 
 // Returns an indication of whether a stream has completed its data transfer
@@ -303,6 +494,9 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   s->id = id;
   s->flags = flags;
 
+  // Remember the stream transfer type
+  s->xfr_type = xfr_type;
+
   // Remember whether verbose reporting is required
   s->verbose = verbose;
 
@@ -311,12 +505,16 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   s->generating = ((flags & kUsbdevStreamFlagCheck) != 0U);
 
   // Not yet sent stream signature
-  s->sent_sig = false;
+  s->sig_required = true;
 
   // Initialize the transfer state
   s->tx_bytes = 0u;
   s->rx_bytes = 0u;
   s->transfer_bytes = transfer_bytes;
+
+  // Sequence number to be used for first packet
+  s->tx_seq = 0u;
+  s->rx_seq = s->tx_seq;
 
   // Initialize the LFSR state for transmission and reception sides
   // - we use a simple LFSR to generate a PRND stream to transmit to the USBPI
@@ -329,6 +527,7 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
 
   // Packet size randomization
   s->tx_buf_size = BUFSZ_LFSR_SEED(id);
+  s->rx_buf_size = s->tx_buf_size;
 
   // Set up the endpoint for IN transfers (TO host)
   //
@@ -364,7 +563,12 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
   uint8_t tx_ep = s->tx_ep;
   uint8_t nqueued = ctx->tx_bufs_queued[tx_ep];
 
-  if (s->tx_bytes < s->transfer_bytes &&      // More bytes to transfer?
+  // Isochronous streams never cease transmission because packets are expected
+  // to get dropped; let the reception side decided test completion
+  bool tx_more = (s->xfr_type == kUsbTransferTypeIsochronous) ||
+                 (s->tx_bytes < s->transfer_bytes);
+
+  if (tx_more &&                              // More bytes to transfer?
       nqueued < ctx->tx_bufs_limit[tx_ep] &&  // Endpoint allowed buffer?
       ctx->tx_queued_total <
           USBUTILS_STREAMS_TXBUF_MAX) {  // Total buffers not exceeded?
@@ -377,31 +581,33 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
       // This is just for reporting the number of buffers presented to the
       // USB device, as a progress indicator
       static unsigned bufs_sent = 0u;
+      uint32_t bytes_added = 0u;
       uint32_t num_bytes;
 
-      if (s->sent_sig) {
-        if (s->flags & kUsbdevStreamFlagMaxPackets) {
-          num_bytes = USBDEV_MAX_PACKET_SIZE;
-        } else {
-          // Vary the amount of data sent per buffer
-          num_bytes = s->tx_buf_size % (USBDEV_MAX_PACKET_SIZE + 1u);
-          s->tx_buf_size = LFSR_ADVANCE(s->tx_buf_size);
-        }
-        uint32_t tx_left = s->transfer_bytes - s->tx_bytes;
-        if (num_bytes > tx_left) {
-          num_bytes = tx_left;
-        }
-        buffer_fill(ctx, s, &buf, num_bytes);
-      } else {
-        // Construct a signature to send to the host-side software,
-        // identifying the stream and its properties
-        num_bytes = buffer_sig_create(ctx, s, &buf);
-        s->sent_sig = true;
+      // Decide upon the packet length, _including_ any signature bytes.
+      num_bytes = packet_length(s, s->tx_bytes, &s->tx_buf_size);
+
+      // Construct a signature to send to the host-side software,
+      // identifying the stream and its properties?
+      if (s->sig_required) {
+        bytes_added = buffer_sig_create(ctx, s, &buf);
+        // If we're 'not sending' then we still send the stream signature once
+        // but only the signature; it allows the host/DPI model to receive the
+        // stream flags and discover that no further data is to be expected.
         if (!s->sending) {
-          // If not required to send, we send only the stream signature
-          // identifying the test properties
           s->tx_bytes = s->transfer_bytes;
         }
+        // Signature required for each packet of an Isochronous stream, but only
+        // at the stream start for other transfer types
+        if (!s->sending || s->xfr_type != kUsbTransferTypeIsochronous) {
+          // First packet is just the stream signature
+          s->sig_required = false;
+        }
+      }
+
+      // How many LFSR-generated bytes are to be included?
+      if (bytes_added < num_bytes) {
+        buffer_fill(ctx, s, &buf, num_bytes - bytes_added);
       }
 
       // Remember the buffer until we're informed that it has been
@@ -439,9 +645,6 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
                                     usbdev_stream_flags_t flags, bool verbose) {
   TRY_CHECK(nstreams <= USBUTILS_STREAMS_MAX);
 
-  // Remember the stream count
-  ctx->nstreams = nstreams;
-
   // Initialize the state of each stream
   for (unsigned id = 0U; id < nstreams; id++) {
     // Which endpoint are we using for the IN transfers to the host?
@@ -452,19 +655,9 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
                                   num_bytes, flags, verbose));
   }
 
-  // Decide how many buffers each endpoint may queue up for transmission;
-  // we must ensure that there are buffers available for reception, and we
-  // do not want any endpoint to starve another
-  for (unsigned s = 0U; s < nstreams; s++) {
-    // This is slightly overspending the available buffers, leaving the
-    //   endpoints to vie for the final few buffers, so it's important that
-    //   we limit the total number of buffers across all endpoints too
-    unsigned ep = ctx->streams[s].tx_ep;
-    ctx->tx_bufs_queued[ep] = 0U;
-    ctx->tx_bufs_limit[ep] =
-        (USBUTILS_STREAMS_TXBUF_MAX + nstreams - 1) / nstreams;
-  }
-  ctx->tx_queued_total = 0U;
+  // Remember the stream count and apportion the available tx buffers
+  TRY_CHECK(usb_testutils_streams_count_set(ctx, nstreams));
+
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -287,6 +287,7 @@ bool usb_testutils_stream_completed(const usb_testutils_streams_ctx_t *ctx,
 
 // Initialize a stream, preparing it for use
 status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
+                                   usb_testutils_transfer_type_t xfr_type,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t transfer_bytes,
                                    usbdev_stream_flags_t flags, bool verbose) {
@@ -335,16 +336,17 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   // transfers
   usb_testutils_rx_handler_t rx = (ep_in == ep_out) ? strm_rx : rx_show;
 
-  s->tx_ep = ep_in;
-  CHECK_STATUS_OK(usb_testutils_endpoint_setup(
-      ctx->usbdev, ep_in, kUsbdevOutStream, s, strm_tx_done, rx, NULL, NULL));
-
   s->rx_ep = ep_out;
-  if (ep_out != ep_in) {
-    // Set up the endpoint for OUT transfers (FROM host)
-    CHECK_STATUS_OK(usb_testutils_endpoint_setup(
-        ctx->usbdev, ep_out, kUsbdevOutStream, s, NULL, strm_rx, NULL, NULL));
-  }
+  s->tx_ep = ep_in;
+
+  // Set up the endpoint for IN transfers (TO host)
+  CHECK_STATUS_OK(usb_testutils_in_endpoint_setup(ctx->usbdev, ep_in, xfr_type,
+                                                  s, strm_tx_done, NULL, NULL));
+
+  // Set up the endpoint for OUT transfers (FROM host)
+  CHECK_STATUS_OK(usb_testutils_out_endpoint_setup(
+      ctx->usbdev, ep_out, xfr_type, kUsbdevOutStream, s, strm_rx, NULL));
+
   return OK_STATUS();
 }
 
@@ -431,7 +433,9 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
 }
 
 status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
-                                    unsigned nstreams, uint32_t num_bytes,
+                                    unsigned nstreams,
+                                    usb_testutils_transfer_type_t xfr_types[],
+                                    uint32_t num_bytes,
                                     usbdev_stream_flags_t flags, bool verbose) {
   TRY_CHECK(nstreams <= USBUTILS_STREAMS_MAX);
 
@@ -444,8 +448,8 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
     const uint8_t ep_in = 1u + id;
     // Which endpoint are we using for the OUT transfers from the host?
     const uint8_t ep_out = 1u + id;
-    TRY(usb_testutils_stream_init(ctx, id, ep_in, ep_out, num_bytes, flags,
-                                  verbose));
+    TRY(usb_testutils_stream_init(ctx, id, xfr_types[id], ep_in, ep_out,
+                                  num_bytes, flags, verbose));
   }
 
   // Decide how many buffers each endpoint may queue up for transmission;

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -81,6 +81,8 @@ typedef struct __attribute__((packed)) usbdev_stream_sig {
   uint32_t head_sig;
   /**
    * Initial value of LFSR
+   * Note: for Isochronous Transfers, this is the initial value of the sender's
+   *       LFSR for _this packet_
    */
   uint8_t init_lfsr;
   /**
@@ -88,12 +90,18 @@ typedef struct __attribute__((packed)) usbdev_stream_sig {
    */
   uint8_t stream;
   /**
-   * Reserved fields; should be zero
+   * Sequence number, low part; for non-Isochronous streams this will always be
+   * zero because a signature is used only at the start of the data stream.
    */
-  uint8_t reserved1;
-  uint8_t reserved2;
+  uint8_t seq_lo;
   /**
-   * Number of bytes to be transferred
+   * Sequence number, high part; for non-Isochronous streams this will always be
+   * zero because a signature is used only at the start of the data stream.
+   */
+  uint8_t seq_hi;
+  /**
+   * Number of bytes to be transferred; for Isochronous streams this
+   * is the count of remaining bytes and it wraps when reaching zero
    */
   uint32_t num_bytes;
   /**
@@ -119,13 +127,21 @@ typedef struct usbdev_stream {
    */
   uint8_t id;
   /**
-   * Has the stream signature been sent yet?
+   * USB transfer type
    */
-  bool sent_sig;
+  usb_testutils_transfer_type_t xfr_type;
+  /**
+   * Is a signature required at the start of the next packet?
+   */
+  bool sig_required;
   /**
    * USB device endpoint being used for data transmission
    */
   uint8_t tx_ep;
+  /**
+   * Transmission Sequence Number (for Isochronous streams)
+   */
+  uint16_t tx_seq;
   /**
    * Transmission Linear Feedback Shift Register (for PRND data generation)
    */
@@ -143,6 +159,10 @@ typedef struct usbdev_stream {
    */
   uint8_t rx_ep;
   /**
+   * Reception Sequence Number (for Isochronous streams)
+   */
+  uint16_t rx_seq;
+  /**
    * Reception-side LFSR state (mirrors USBDPI generation of PRND data)
    */
   uint8_t rx_lfsr;
@@ -154,6 +174,11 @@ typedef struct usbdev_stream {
    * Total number of bytes received from the USB device
    */
   uint32_t rx_bytes;
+  /**
+   * Reception-side LFSR for determination of expected buffer size
+   * (for Isochronous streams where packets may be dropped)
+   */
+  uint8_t rx_buf_size;
   /**
    * Size of transfer in bytes
    */
@@ -274,6 +299,17 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t num_bytes,
                                    usbdev_stream_flags_t flags, bool verbose);
+
+/**
+ * Specify the number of already-initialized streams, and apportion the
+ * available tx buffers among them. To be called after usb_testutils_stream_init
+ *
+ * @param  ctx       Context state for streaming test.
+ * @param  nstreams  Number of streams.
+ * @return           Success or otherwise of the request.
+ */
+bool usb_testutils_streams_count_set(usb_testutils_streams_ctx_t *ctx,
+                                     unsigned nstreams);
 
 /**
  * Service the given stream, preparing and/or sending any data that we can.

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -220,6 +220,7 @@ struct usb_testutils_streams_ctx {
  *
  * @param  ctx       Context state for streaming test
  * @param  nstreams  Number of streams
+ * @param  xfr_types Transfer types to be used for the individual streams
  * @param  num_bytes Number of bytes to be transferred by each stream
  * @param  flags     Stream/test flags to be used for each stream
  * @param  verbose   Whether to perform verbose logging for each stream
@@ -227,7 +228,9 @@ struct usb_testutils_streams_ctx {
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
-                                    unsigned nstreams, uint32_t num_bytes,
+                                    unsigned nstreams,
+                                    usb_testutils_transfer_type_t xfr_types[],
+                                    uint32_t num_bytes,
                                     usbdev_stream_flags_t flags, bool verbose);
 
 /**
@@ -257,6 +260,7 @@ bool usb_testutils_streams_completed(const usb_testutils_streams_ctx_t *ctx);
  *
  * @param  ctx       Context state for streaming test
  * @param  id        Stream identifier (0-based)
+ * @param  xfr_type  Transfer type to be usd for this stream
  * @param  ep_in     Endpoint to be used for IN traffic (to host)
  * @param  ep_out    Endpoint to be used for OUT traffic (from host)
  * @param  num_bytes Number of bytes to be transferred by stream
@@ -266,6 +270,7 @@ bool usb_testutils_streams_completed(const usb_testutils_streams_ctx_t *ctx);
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
+                                   usb_testutils_transfer_type_t xfr_type,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t num_bytes,
                                    usbdev_stream_flags_t flags, bool verbose);

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -270,8 +270,14 @@ bool test_main(void) {
   LOG_INFO("USB sent 0x%x byte(s), received and checked 0x%x byte(s)", tx_bytes,
            rx_bytes);
 
-  CHECK(tx_bytes == nstreams * transfer_bytes,
-        "Unexpected count of byte(s) sent to USB host");
+  if (sending) {
+    CHECK(tx_bytes == nstreams * transfer_bytes,
+          "Unexpected count of byte(s) sent to USB host");
+  }
+  if (recving) {
+    CHECK(rx_bytes == nstreams * transfer_bytes,
+          "Unexpected count of byte(s) received from USB host");
+  }
 
   return true;
 }

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -44,7 +44,7 @@
 #define TRANSFER_BYTES_VERILATOR 0x2400U
 
 // This is about the amount that we can transfer within a 1 hour 'eternal' test
-//#define TRANSFER_BYTES_LONG (0xD0U << 20)
+// #define TRANSFER_BYTES_LONG (0xD0U << 20)
 
 /**
  * Configuration values for USB.
@@ -207,9 +207,11 @@ bool test_main(void) {
                (generating ? kUsbdevStreamFlagCheck : 0U) |
                (retrying ? kUsbdevStreamFlagRetry : 0U) |
                (recving ? kUsbdevStreamFlagSend : 0U) |
+               // Note: the 'max_packets' test flag is not required by the DPI
                (max_packets ? kUsbdevStreamFlagMaxPackets : 0U);
 
   // Initialize the test descriptor
+  // Note: the 'max packets' test flag is not required by the DPI model
   const uint8_t desc[] = {
       USB_TESTUTILS_TEST_DSCR(1, NUM_STREAMS | (uint8_t)test_flags, 0, 0, 0)};
   memcpy(test_descriptor, desc, sizeof(test_descriptor));
@@ -231,9 +233,17 @@ bool test_main(void) {
     CHECK_STATUS_OK(usb_testutils_poll(ctx->usbdev));
   }
 
+  // Describe the transfer type of each stream;
+  // Note: for now we support only Bulk Transfer streams but this should change
+  // in future, eg. in response to test configuration.
+  usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX];
+  for (unsigned s = 0U; s < nstreams; s++) {
+    xfr_types[s] = kUsbTransferTypeBulk;
+  }
+
   // Initialise the state of the streams
-  CHECK_STATUS_OK(usb_testutils_streams_init(ctx, nstreams, transfer_bytes,
-                                             test_flags, verbose));
+  CHECK_STATUS_OK(usb_testutils_streams_init(
+      ctx, nstreams, xfr_types, transfer_bytes, test_flags, verbose));
 
   if (verbose) {
     LOG_INFO("Commencing data transfer...");


### PR DESCRIPTION
This PR extends the streaming code in usb_testutils and the DPI model to handle Interrupt Transfers and Isochronous Transfers.

- Support for different Transfer Types to endpoints is introduced in usb_testutils.c/h. To keep the changes minimal, it is unfortunately necessary to have information duplicated in the _controlep.c/h code which describes the configuration(s) to the host and in the usb_testutils.c/h code which manages the endpoints; at some point these should be reconciled.
- Streaming code to support Isochronous streams is incorporated because of the potential for packet loss with Isochronous streams. The existing streaming code is modified to supply a signature at the start of each packet and not just at the start of the data stream. All data is still checked at both ends of the connection.

This is the first part of #18305 and stands alone, implementing the device end of the required functionality.