### PR TITLE
SUPERSEDED: Iso/Interrupt streaming changes to DPI

### DIFF
--- a/hw/dv/dpi/usbdpi/usb_transfer.c
+++ b/hw/dv/dpi/usbdpi/usb_transfer.c
@@ -169,7 +169,9 @@ void transfer_send(usbdpi_ctx_t *ctx, usbdpi_transfer_t *transfer) {
   assert(transfer->num_bytes > 0U &&
          transfer->num_bytes <= sizeof(transfer->data));
 
-  // Set this as the current in-progress transfer
+  // Set this as the current in-progress transfer, checking that we're not
+  // losing track of a buffer by doing so.
+  assert(!ctx->sending || ctx->sending == transfer);
   ctx->sending = transfer;
 
   // Prepare for transmission of the first byte, following the implicit SYNC
@@ -189,7 +191,9 @@ void transfer_status(usbdpi_ctx_t *ctx, usbdpi_transfer_t *transfer,
 
   transfer->data_start = USBDPI_NO_DATA_STAGE;
 
-  // Set this as the current in-progress transfer
+  // Set this as the current in-progress transfer, checking that we're not
+  // losing track of a buffer by doing so.
+  assert(!ctx->sending || ctx->sending == transfer);
   ctx->sending = transfer;
 
   // Prepare for transmission of the first byte, following the implicit SYNC
@@ -199,7 +203,7 @@ void transfer_status(usbdpi_ctx_t *ctx, usbdpi_transfer_t *transfer,
 }
 
 // Diagnostic utility function to dump out the contents of a transfer descriptor
-void transfer_dump(usbdpi_transfer_t *transfer, FILE *out) {
+void transfer_dump(const usbdpi_transfer_t *transfer, FILE *out) {
   fprintf(out, "[usbdpi] Transfer descriptor at %p\n", transfer);
   fprintf(out, "[usbdpi] num_bytes 0x%x data_start 0x%x\n", transfer->num_bytes,
           transfer->data_start);

--- a/hw/dv/dpi/usbdpi/usb_transfer.h
+++ b/hw/dv/dpi/usbdpi/usb_transfer.h
@@ -14,12 +14,21 @@
 #endif
 
 // Maximal length of a byte sequence to be transmitted/receive without
-// interruption or pause (Start Of Frame, Setup packet, OUT Data packet
-// and End Of Frame all back-to-back?)
-#define USBDPI_MAX_DATA (3U + 3U + 1U + USBDEV_MAX_PACKET_SIZE + 2U + 1U)
+// interruption or pause (Start Of Frame, Setup packet, OUT Data packet,
+// all back-to-back)
+#define USBDPI_MAX_DATA                          \
+  (3U +                              /* SOF */   \
+   3U +                              /* SETUP */ \
+   1U + USBDEV_MAX_PACKET_SIZE + 2U) /* DATA PID, field, CRC16 */
 
 // Special value that denotes that this transfer does not include a data stage
 #define USBDPI_NO_DATA_STAGE ((uint8_t)~0U)
+
+// USB Transfer Types (Standard Endpoint Descriptor)
+#define USB_TRANSFER_TYPE_CONTROL 0U
+#define USB_TRANSFER_TYPE_ISOCHRONOUS 1U
+#define USB_TRANSFER_TYPE_BULK 2U
+#define USB_TRANSFER_TYPE_INTERRUPT 3U
 
 /**
  * Forwards reference to usbpdi state context
@@ -218,6 +227,6 @@ inline uint32_t transfer_length(const usbdpi_transfer_t *transfer) {
  * @param  transfer  Transfer descriptor
  * @param  out       Stream to receive diagnostic output
  */
-void transfer_dump(usbdpi_transfer_t *transfer, FILE *out);
+void transfer_dump(const usbdpi_transfer_t *transfer, FILE *out);
 
 #endif  // OPENTITAN_HW_DV_DPI_USBDPI_USB_TRANSFER_H_

--- a/hw/dv/dpi/usbdpi/usb_utils.c
+++ b/hw/dv/dpi/usbdpi/usb_utils.c
@@ -5,6 +5,7 @@
 #include "usb_utils.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 static const char *pid_names[] = {
     "Rsvd",     //         0000b

--- a/hw/dv/dpi/usbdpi/usb_utils.h
+++ b/hw/dv/dpi/usbdpi/usb_utils.h
@@ -4,6 +4,7 @@
 
 #ifndef OPENTITAN_HW_DV_DPI_USBDPI_USB_UTILS_H_
 #define OPENTITAN_HW_DV_DPI_USBDPI_USB_UTILS_H_
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -29,7 +29,7 @@ static const char *hs_states[] = {
     "HS_DS_SENDACK 4", "HS_DONEDADR 5",  "HS_REQDATA 6",       "HS_WAITDATA 7",
     "HS_SENDACK 8",    "HS_WAIT_PKT 9",  "HS_ACKIFDATA 10",    "HS_SENDHI 11",
     "HS_EMPTYDATA 12", "HS_WAITACK2 13", "HS_STREAMOUT 14",    "HS_STREAMIN 15",
-    "HS_NEXTFRAME 16"};
+    "HS_NEXTFRAME 16", "HS_ERROR 17"};
 
 static const char *decode_usb[] = {"SE0", "0-K", "1-J", "SE1"};
 
@@ -179,9 +179,9 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
         printf(
             "[usbdpi] frame 0x%x tick_bits 0x%x error state %s hs %s and "
             "device "
-            "drives\n",
+            "drives 0x%x\n",
             ctx->frame, ctx->tick_bits, st_states[ctx->state],
-            hs_states[ctx->hostSt]);
+            hs_states[ctx->hostSt], d2p);
         // TODO: stop the test
         break;
 
@@ -195,13 +195,14 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
 
       case ST_IDLE:
         // Nothing to do
-        ctx->state = ST_GET;
         break;
 
       default:
         assert(!"Invalid/unknown state");
         break;
     }
+
+    ctx->state = ST_GET;
   } else {
     if (ctx->state == ST_GET) {
       ctx->state = ST_IDLE;
@@ -260,6 +261,11 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
         ctx->bus_state = kUsbControlStatusOutAck;
         break;
 
+      // Isochronous Transfers
+      case kUsbIsoInToken:
+        ctx->bus_state = kUsbIsoInData;
+        break;
+
       // Bulk Transfers
       case kUsbBulkOut:
         ctx->bus_state = kUsbBulkOutAck;
@@ -268,6 +274,16 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
         ctx->bus_state = kUsbBulkInData;
         break;
 
+      // Interrupt Transfers
+      case kUsbInterruptOut:
+        ctx->bus_state = kUsbInterruptOutAck;
+        break;
+      case kUsbInterruptInToken:
+        ctx->bus_state = kUsbInterruptInData;
+        break;
+
+      // TODO - this shall become an error condition; we're not expecting
+      //        a transmission from the device, and thus no EOP either
       default:
         break;
     }
@@ -284,13 +300,15 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
 void usbdpi_data_callback(void *ctx_v, usbmon_data_type_t type, uint8_t d) {
   usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)ctx_v;
   assert(ctx);
-  if (!ctx->recving) {
-    ctx->recving = transfer_alloc(ctx);
-  }
 
   // We are interested only in the packets from device to host
   if (ctx->state != ST_GET) {
     return;
+  }
+
+  // Ensure that we have a buffer available for packet reception
+  if (!ctx->recving) {
+    ctx->recving = transfer_alloc(ctx);
   }
 
   usbdpi_transfer_t *tr = ctx->recving;
@@ -598,7 +616,7 @@ void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len) {
       ctx->hostSt = HS_REQDATA;
       break;
     case HS_REQDATA:
-      // TODO - we must wait before trying the IN because we currently
+      // TODO: we must wait before trying the IN because we currently
       // do not retry after a NAK response, but the CPU software can be tardy
       if (ctx->tick_bits >= ctx->wait &&
           ctx->bus_state == kUsbControlSetupAck) {
@@ -619,14 +637,11 @@ void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len) {
           case USB_PID_DATA1: {
             usbdpi_transfer_t *rx = ctx->recving;
             assert(rx);
-            // TODO - check the length of the received data field!
+            // TODO: check the length of the received data field!
             uint8_t *dp = transfer_data_field(rx);
             assert(dp);
             // Validate the first part of the test descriptor
             printf("[usbdpi] Test descriptor 0x%.8X\n", get_le32(dp));
-
-            transfer_dump(rx, stdout);
-
             // Check the header signature
             const uint8_t test_sig_head[] = {0x7eu, 0x57u, 0xc0u, 0xf1u};
             const uint8_t test_sig_tail[] = {0x1fu, 0x0cu, 0x75u, 0xe7u};
@@ -651,7 +666,7 @@ void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len) {
           } break;
 
           case USB_PID_NAK:
-            // TODO - we should retry the request in this case
+            // TODO: we should retry the request in this case
             printf("[usbdpi] Unable to retrieve test config\n");
             assert(!"DPI is unable to retrieve test config");
             ctx->hostSt = HS_NEXTFRAME;
@@ -1173,11 +1188,9 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
     // Host state machine advances when the bit-level activity is idle
     case ST_IDLE: {
       // Ensure that a buffer is available for constructing a transfer
-      usbdpi_transfer_t *tr = ctx->sending;
-      if (!tr) {
-        tr = transfer_alloc(ctx);
-        assert(tr);
-        ctx->sending = tr;
+      if (!ctx->sending) {
+        ctx->sending = transfer_alloc(ctx);
+        assert(ctx->sending);
       }
 
       switch (ctx->step) {
@@ -1303,7 +1316,7 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       break;
 
     case ST_SEND: {
-      usbdpi_transfer_t *sending = ctx->sending;
+      const usbdpi_transfer_t *sending = ctx->sending;
       assert(sending);
       if ((ctx->linebits & 0x3f) == 0x3f &&
           !INSERT_ERR_BITSTUFF) {  // sent 6 ones
@@ -1344,7 +1357,7 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
         ctx->driving = set_driving(ctx, d2p, P2D_DP, true);  // J
       }
       if (ctx->bit == 8) {
-        usbdpi_transfer_t *sending = ctx->sending;
+        const usbdpi_transfer_t *sending = ctx->sending;
         assert(sending);
         // Stop driving: host pulldown to SE0 unless there is a pullup on DP
         ctx->driving =
@@ -1383,9 +1396,7 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
 void usbdpi_diags(void *ctx_void, svBitVecVal *diags) {
   usbdpi_ctx_t *ctx = (usbdpi_ctx_t *)ctx_void;
 
-  // Check for overflow, which would cause confusion in waveform interpretation;
-  // if an assertion fires, the mapping from fields to svBitVecVal will need
-  // to be changed, both here and in usbdpi.sv
+  // Check for overflow, which would cause confusion in waveform interpretation.
   assert(ctx->state <= 0xfU);
   assert(ctx->hostSt <= 0x1fU);
   assert(ctx->bus_state <= 0x3fU);

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -21,6 +21,7 @@ typedef uint32_t svBitVecVal;
 #endif
 #include "usb_monitor.h"
 #include "usb_transfer.h"
+#include "usb_utils.h"
 #include "usbdpi_stream.h"
 
 // Shall we employ a proper simulation of the frame interval (1ms)?
@@ -143,7 +144,7 @@ typedef uint32_t svBitVecVal;
 // Maximum number of simultaneous transfer descriptors
 //   (The host model may simply avoid polling for further IN transfers
 //    whilst there are no further desciptors available)
-#define USBDPI_MAX_TRANSFERS 0x10U
+#define USBDPI_MAX_TRANSFERS 0x20U
 
 // Time intervals for common transactions, in bits
 // (allowing for bit stuffing and bus turnaround etc; for setting timeouts)
@@ -235,7 +236,8 @@ typedef enum {
   HS_WAITACK2 = 13,
   HS_STREAMOUT = 14,
   HS_STREAMIN = 15,
-  HS_NEXTFRAME = 16
+  HS_NEXTFRAME = 16,
+  HS_ERROR = 17,
 } usbdpi_host_state_t;
 
 typedef enum usbdpi_bus_state {
@@ -253,15 +255,23 @@ typedef enum usbdpi_bus_state {
   kUsbControlDataInAck,
   kUsbControlStatusOut,
   kUsbControlStatusOutAck,
-  kUsbIsoToken,
-  kUsbIsoDataIn,
-  kUsbIsoDataOut,
 
+  // Isochronous Transfers
+  kUsbIsoOut,
+  kUsbIsoInToken,
+  kUsbIsoInData,
+
+  // Bulk Transfers
   kUsbBulkOut,
   kUsbBulkOutAck,
   kUsbBulkInToken,
   kUsbBulkInData,
-  kUsbBulkInAck,
+
+  // Interrupt transfers
+  kUsbInterruptOut,
+  kUsbInterruptOutAck,
+  kUsbInterruptInToken,
+  kUsbInterruptInData,
 } usbdpi_bus_state_t;
 
 /**

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -95,7 +95,8 @@ module usbdpi #(
     HS_WAITACK2 = 13,
     HS_STREAMOUT = 14,
     HS_STREAMIN = 15,
-    HS_NEXTFRAME = 16
+    HS_NEXTFRAME = 16,
+    HS_ERROR = 17
   } usbdpi_host_state_t;
 
   // Bus state
@@ -115,15 +116,23 @@ module usbdpi #(
     kUsbControlDataInAck,
     kUsbControlStatusOut,
     kUsbControlStatusOutAck,  // 0xc
-    kUsbIsoToken,
-    kUsbIsoDataIn,
-    kUsbIsoDataOut,
 
+    // Isochronous Transfers
+    kUsbIsoOut,
+    kUsbIsoInToken,
+    kUsbIsoInData,
+
+    // Bulk Transfers
     kUsbBulkOut,  // 0x10
     kUsbBulkOutAck,
     kUsbBulkInToken,
     kUsbBulkInData,
-    kUsbBulkInAck
+
+    // Interrupt transfers
+    kUsbInterruptOut,  // 0x14
+    kUsbInterruptOutAck,
+    kUsbInterruptInToken,
+    kUsbInterruptInData
   } usbdpi_bus_state_t;
 
   // USB monitor state

--- a/hw/dv/dpi/usbdpi/usbdpi_stream.c
+++ b/hw/dv/dpi/usbdpi/usbdpi_stream.c
@@ -25,11 +25,15 @@
 #define STREAM_SIGNATURE_HEAD 0x579EA01AU
 #define STREAM_SIGNATURE_TAIL 0x160AE975U
 
+// Size of stream signature
+#define SIZEOF_STREAM_SIGNATURE 0x10U
+
 // Verbose logging/diagnostic reporting
-// TODO - consider folding this into the existing log level
+// TODO: consider folding this into the existing log level
 static const bool verbose = false;
 
-static const bool expect_sig = true;
+// Single letter prefix indicating the transfer type
+static const char xfr_sym[] = {'C', 'X', 'B', 'I'};
 
 // Determine the next stream for which IN data packets shall be requested
 static inline unsigned in_stream_next(usbdpi_ctx_t *ctx);
@@ -39,7 +43,8 @@ static inline unsigned out_stream_next(usbdpi_ctx_t *ctx);
 
 // Check a data packet received from the test software (usbdev_stream_test)
 static bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
-                              const usbdpi_transfer_t *rx, bool accept);
+                              const usbdpi_transfer_t *rx, unsigned offset,
+                              bool accept);
 
 // Generate a data packet as if it had been received from the device
 static usbdpi_transfer_t *stream_data_gen(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
@@ -77,8 +82,9 @@ inline unsigned out_stream_next(usbdpi_ctx_t *ctx) {
 }
 
 // Initialize streaming state for the given number of streams
-bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams, bool retrieve,
-                  bool checking, bool retrying, bool send) {
+bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams,
+                  const uint8_t xfr_types[], bool retrieve, bool checking,
+                  bool retrying, bool send) {
   assert(ctx);
 
   // Can we support the requested number of streams?
@@ -100,20 +106,29 @@ bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams, bool retrieve,
   ctx->stream_out = nstreams - 1U;
 
   for (unsigned id = 0U; id < nstreams; id++) {
+    // Remember the Stream IDentifier
+    ctx->stream[id].id = id;
     // Poll device for IN packets in streaming test?
     ctx->stream[id].retrieve = retrieve;
     // Attempt to sent OUT packets to device in streaming test?
     ctx->stream[id].send = send;
     // Checking of received data against expected LFSR output
     ctx->stream[id].checking = checking;
+    // We are expecting a stream signature in the first packet
+    ctx->stream[id].sig_expected = true;
     // Request retrying of IN packets, feigning error
     ctx->stream[id].retrying = retrying;
+    // Transfer type
+    ctx->stream[id].xfr_type = xfr_types[id];
     // Endpoints to be used by this stream
     ctx->stream[id].ep_in = 1U + id;
     ctx->stream[id].ep_out = 1U + id;
+    // Expected sequence number of first packet
+    ctx->stream[id].tst_seq = 0U;
     // LFSR state for this byte stream
     ctx->stream[id].tst_lfsr = USBTST_LFSR_SEED(id);
     ctx->stream[id].dpi_lfsr = USBDPI_LFSR_SEED(id);
+    ctx->stream[id].dpi_rewind_lfsr = ctx->stream[id].dpi_lfsr;
     // LFSR-controlled packet retrying state
     ctx->stream[id].retry_lfsr = RETRY_LFSR_SEED(id);
     ctx->stream[id].nretries = 0U;
@@ -125,7 +140,8 @@ bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams, bool retrieve,
 
 // Check a data packet received from the test software (usbdev_stream_test)
 bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
-                       const usbdpi_transfer_t *rx, bool accept) {
+                       const usbdpi_transfer_t *rx, unsigned offset,
+                       bool accept) {
   assert(rx);
 
   // The byte count _includes_ the DATAx PID and the two CRC bytes
@@ -139,7 +155,7 @@ bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
   bool ok = false;
 
   // Validate the received packet - data length valid and checksum present
-  if (num_bytes >= sizeof(rx->data) || idx + 2u > num_bytes) {
+  if (num_bytes >= sizeof(rx->data) || idx + 1u + offset > num_bytes) {
     printf("[usbdpi] Unexpected/malformed data packet (0x%x 0x%x)\n", idx,
            num_bytes);
   } else {
@@ -172,6 +188,11 @@ bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
       // Iff running a performance investigation, checking may be undesired
       // because it causes us to reject and retry the transmission
       if (s->checking) {
+        // Advance to the start of the data to be checked; for Isochronous
+        // traffic there will be a signature at the start of every packet
+        sp += offset;
+        num_bytes -= offset;
+
         // Note: use a local copy of the LFSR so that we can check the data
         //       field even on those packets that we choose to reject
         uint8_t tst_lfsr = s->tst_lfsr;
@@ -179,9 +200,9 @@ bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
           uint8_t recvd = *sp++;
           if (recvd != tst_lfsr) {
             printf(
-                "[usbdpi] Mismatched data from device 0x%02x, "
+                "[usbdpi] %c%u: Mismatched data from device 0x%02x, "
                 "expected 0x%02x\n",
-                recvd, tst_lfsr);
+                xfr_sym[s->xfr_type], s->id, recvd, tst_lfsr);
             ok = false;
           }
           // Advance our local LFSR
@@ -205,6 +226,7 @@ bool stream_data_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
 // Generate a data packet as if it had been received from the device
 usbdpi_transfer_t *stream_data_gen(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
                                    unsigned len) {
+  // TODO: this code presesntly does not support Isochronous streams
   usbdpi_transfer_t *tr = transfer_alloc(ctx);
   if (tr) {
     // Pretend that we have successfully received the packet with the correct
@@ -234,12 +256,13 @@ usbdpi_transfer_t *stream_data_process(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
   assert(rx);
 
   // The byte count _includes_ the DATAx PID and the two CRC bytes
-  unsigned num_bytes = rx->num_bytes;
-  unsigned idx = rx->data_start + 1u;  // Skip past the DATAx PID
+  unsigned num_bytes = transfer_length(rx);
+  num_bytes -= 3u;
 
   // Data field within received packet
-  const uint8_t *sp = &rx->data[idx];
-  num_bytes -= 3u;
+  const uint8_t *sp = transfer_data_field(rx);
+  if (!sp)
+    return NULL;
 
   // Allocate a new buffer for the reply
   usbdpi_transfer_t *reply = transfer_alloc(ctx);
@@ -253,6 +276,30 @@ usbdpi_transfer_t *stream_data_process(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
       transfer_data_start(reply, ctx->ep_out[ep_out].next_data, num_bytes);
   assert(dp);
 
+  // For Isochronous streams each packet commences with a signature that
+  // specifies the packet sequence number and the device-side LFSR; we must
+  // replace the LFSR value with our own so that the device is able to check
+  // the returned packet data.
+
+  if (s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS) {
+    // If this is not the case, we should not have accepted the packet.
+    assert(num_bytes >= SIZEOF_STREAM_SIGNATURE);
+
+    // Copy the signature bytes across, supplying our starting LFSR value so
+    // that the device software may run forwards, past any packets that may have
+    // been dropped.
+    memcpy(dp, sp, SIZEOF_STREAM_SIGNATURE);
+    dp[4] = s->dpi_lfsr;
+    dp += SIZEOF_STREAM_SIGNATURE;
+    sp += SIZEOF_STREAM_SIGNATURE;
+
+    num_bytes -= SIZEOF_STREAM_SIGNATURE;
+  }
+
+  // Keep a record of the LFSR, so that we may rewind in the event of a delivery
+  // failure
+  s->dpi_rewind_lfsr = s->dpi_lfsr;
+
   while (num_bytes-- > 0U) {
     uint8_t recvd = *sp++;
 
@@ -262,12 +309,7 @@ usbdpi_transfer_t *stream_data_process(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
       printf("[usbdpi] 0x%02x <- 0x%02x ^ 0x%02x\n", *(dp - 1), recvd,
              s->dpi_lfsr);
     }
-
-    // Advance our LFSR
-    //
-    // TODO - decide whether we want to do this here; if the device
-    // responds with a NAK, requiring us to retry, or we decide to
-    // resend the packet, then we don't want to advance again
+    // Advance our local copy of the LFSR
     s->dpi_lfsr = LFSR_ADVANCE(s->dpi_lfsr);
   }
 
@@ -279,8 +321,17 @@ usbdpi_transfer_t *stream_data_process(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
 // Check the stream signature
 bool stream_sig_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
                       usbdpi_transfer_t *rx) {
-  // Packet should be PID, data field and CRC16
-  if (transfer_length(rx) == 3U + 0x10U) {
+  // Packet should be PID, data field and CRC16 for non-Isochronous,
+  // or at least that for Isochronous; Iso streams carry a signature in every
+  // packet.
+  const size_t min_len = 3U + 0x10U;
+  size_t len = transfer_length(rx);
+  bool ok = (len == min_len);
+
+  if (s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS) {
+    ok = (len >= min_len);
+  }
+  if (ok) {
     const uint8_t *sig = transfer_data_field(rx);
     if (sig) {
       // Signature format:
@@ -288,7 +339,7 @@ bool stream_sig_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
       //   32   head signature
       //   8    initial vaue of LFSR
       //   8    stream number
-      //   16   reserved, SBZ
+      //   16   sequence number
       //   32   number of bytes to be transferred
       //   32   tail signature
       // Note: all 32-bit quantities are in little endian order
@@ -304,12 +355,50 @@ bool stream_sig_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
           get_le32(&sig[12]) == STREAM_SIGNATURE_TAIL &&
           // sanity check on transfer length, though we rely upon the CPU
           // software to send, receive and count the number of bytes
-          num_bytes > 0U && num_bytes < 0x10000000U && !sig[6] && !sig[7]) {
-        // Signature includes the initial value of the device-side LFSR
-        s->tst_lfsr = sig[4];
-        // Update data toggle
-        uint8_t pid = transfer_data_pid(rx);
-        ctx->ep_in[s->ep_in].next_data = DATA_TOGGLE_ADVANCE(pid);
+          num_bytes > 0U && num_bytes < 0x10000000U) {
+        // For Isochronous streams the sequence number identifies the packet
+        // (and informs us whether any have been dropped), and crucially it
+        // also specifies the intiial value of the device-side LFSR for  _this_
+        // packet.
+        uint16_t seq = get_le16(&sig[6]);
+        if (s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS) {
+          if (verbose) {
+            printf("[usbdpi] S#%u: seq 0x%04x\n", s->id, seq);
+          }
+          if (seq < s->tst_seq) {
+            printf(
+                "[usbdpi] Iso stream packets out of order (expected seq 0x%x"
+                " received 0x%x)\n",
+                s->tst_seq, seq);
+            return false;
+          } else if (seq > s->tst_seq) {
+            printf("[usbdpi] Iso stream #%u dropped %u packet(s)\n", s->id,
+                   seq - s->tst_seq);
+          }
+          // Next sequence number expected
+          s->tst_seq = seq + 1U;
+          // Initial device-side LFSR for this packet
+          s->tst_lfsr = sig[4];
+          // Data toggle synchronization is not used for Iso streams
+          ctx->ep_in[s->ep_in].next_data = USB_PID_DATA0;
+        } else {
+          // This check is only performed on the first packet, since the non-Iso
+          // streams have only a single signature
+          if (seq != s->tst_seq) {
+            printf(
+                "[usbdpi] Unexpected stream packet (expected seq 0x%x"
+                " received 0x%x)\n",
+                s->tst_seq, seq);
+            return false;
+          }
+          // Advance our sequence number
+          s->tst_seq++;
+          // Signature includes the initial value of the device-side LFSR
+          s->tst_lfsr = sig[4];
+          // Update data toggle
+          uint8_t pid = transfer_data_pid(rx);
+          ctx->ep_in[s->ep_in].next_data = DATA_TOGGLE_ADVANCE(pid);
+        }
         return true;
       }
     }
@@ -318,6 +407,7 @@ bool stream_sig_check(usbdpi_ctx_t *ctx, usbdpi_stream_t *s,
 }
 
 // Service streaming data (usbdev_stream_test)
+// TODO: this function should probably be split into multiple functions now...
 void streams_service(usbdpi_ctx_t *ctx) {
   if (verbose) {
     //    printf("[usbdpi] streams_service hostSt %u in %u out %u\n",
@@ -338,31 +428,49 @@ void streams_service(usbdpi_ctx_t *ctx) {
       // Decide whether we have enough time within this frame to attempt
       // another transmission
       uint32_t next_frame = ctx->frame_start + FRAME_INTERVAL;
-      if ((next_frame - ctx->tick_bits) > min_time_left) {  // HACK
+      if ((next_frame - ctx->tick_bits) > min_time_left) {
         unsigned id = out_stream_next(ctx);
         usbdpi_stream_t *s = &ctx->stream[id];
+        if (verbose) {
+          printf("[usbdpi] OUT considering #%u received %p send %u\n", id,
+                 s->received, s->send ? 1 : 0);
+        }
+        // Default to 'nothing to send, try receiving'...
+        ctx->hostSt = HS_STREAMIN;
+
         if (s->send) {
           // Start by trying to transmit a data packet that we've received, if
           // any
           if (s->received) {
             if (ctx->sending) {
               transfer_release(ctx, ctx->sending);
+              ctx->sending = NULL;
             }
 
             // Scramble the oldest received packet with our LFSR-generated byte
             // stream and send it to the device
             usbdpi_transfer_t *reply = stream_data_process(ctx, s, s->received);
-            transfer_send(ctx, reply);
-
-            uint32_t max_bits =
-                transfer_length(ctx->sending) * 10 + 160;  // HACK
-            ctx->wait = USBDPI_TIMEOUT(ctx, max_bits);
-            ctx->bus_state = kUsbBulkOut;
-            ctx->lastrxpid = 0;
-            ctx->hostSt = HS_WAITACK;
-          } else {
-            // Nothing to send, try receiving...
-            ctx->hostSt = HS_STREAMIN;
+            if (reply) {
+              ctx->bus_state = kUsbBulkOut;
+              switch (s->xfr_type) {
+                case USB_TRANSFER_TYPE_INTERRUPT:
+                  ctx->bus_state = kUsbInterruptOut;
+                  break;
+                case USB_TRANSFER_TYPE_BULK:
+                  ctx->bus_state = kUsbBulkOut;
+                  break;
+                default:
+                  assert(s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS);
+                  ctx->bus_state = kUsbIsoOut;
+                  break;
+              }
+              uint32_t max_bits = transfer_length(reply) * 10 + 160;  // HACK
+              transfer_send(ctx, reply);
+              ctx->wait = USBDPI_TIMEOUT(ctx, max_bits);
+              // Sending...
+              ctx->lastrxpid = 0;
+              ctx->hostSt = HS_WAITACK;
+            }
           }
         } else {
           // We're not sending anything - discard any received data
@@ -371,7 +479,6 @@ void streams_service(usbdpi_ctx_t *ctx) {
             s->received = tr->next;
             transfer_release(ctx, tr);
           }
-          ctx->hostSt = HS_STREAMIN;
         }
       } else {
         // Wait until the next bus frame
@@ -380,7 +487,8 @@ void streams_service(usbdpi_ctx_t *ctx) {
     } break;
 
     // Await acknowledgement of the packet that we just transmitted
-    case HS_WAITACK:
+    case HS_WAITACK: {
+      usbdpi_stream_t *s = &ctx->stream[ctx->stream_out];
       if (ctx->sending) {
         // Forget reference to the buffer we just tried to send; the received
         // packet remains in the list of received buffers to try again later
@@ -388,51 +496,82 @@ void streams_service(usbdpi_ctx_t *ctx) {
         ctx->sending = NULL;
       }
 
-      if (ctx->bus_state == kUsbBulkOutAck) {
-        bool proceed = false;
+      // Bulk transfer stream?
+      bool bulk = false;
+      // Was the data packet accepted?
+      bool accepted = false;
 
-        if (verbose) {
-          printf("[usbdpi] OUT - response is PID 0x%02x from device (%s)\n",
-                 ctx->lastrxpid, decode_pid(ctx->lastrxpid));
-        }
+      switch (s->xfr_type) {
+        case USB_TRANSFER_TYPE_BULK:
+          bulk = true;
+          // no break
+        case USB_TRANSFER_TYPE_INTERRUPT:
+          if (ctx->bus_state == (bulk ? kUsbBulkOutAck : kUsbInterruptOutAck)) {
+            if (verbose) {
+              printf("[usbdpi] OUT - response is PID 0x%02x from device (%s)\n",
+                     ctx->lastrxpid, decode_pid(ctx->lastrxpid));
+            }
 
-        switch (ctx->lastrxpid) {
-          case USB_PID_ACK: {
-            // Transmitted packet was accepted, so we can retire it...
-            usbdpi_stream_t *s = &ctx->stream[ctx->stream_out];
-            usbdpi_transfer_t *rx = s->received;
-            assert(rx);
-            s->received = rx->next;
-            transfer_release(ctx, rx);
+            switch (ctx->lastrxpid) {
+              case USB_PID_ACK: {
+                accepted = true;
+              } break;
 
-            uint8_t ep_out = s->ep_out;
-            ctx->ep_out[ep_out].next_data =
-                DATA_TOGGLE_ADVANCE(ctx->ep_out[ep_out].next_data);
-            proceed = true;
-          } break;
+              // We may receive a NAK from the device if it is unable to receive
+              // the packet right now
+              case USB_PID_NAK:
+                // Rewind the LFSR in preparation for trying again
+                s->dpi_lfsr = s->dpi_rewind_lfsr;
+                // TODO: we should have counting code here to kill the test if
+                // transmission is rejected too many times; at present, however,
+                // we will try too rapidly and would give up too soon.
+                printf(
+                    "[usbdpi] frame 0x%x tick_bits 0x%x NAK received "
+                    "from device\n",
+                    ctx->frame, ctx->tick_bits);
+                ctx->hostSt = HS_STREAMIN;
+                break;
 
-          // We may receive a NAK from the device if it is unable to receive the
-          // packet right now
-          case USB_PID_NAK:
-            printf(
-                "[usbdpi] frame 0x%x tick_bits 0x%x NAK received from device\n",
-                ctx->frame, ctx->tick_bits);
-            proceed = true;
-            break;
-
-          default:
-            printf("[usbdpi] Unexpected PID 0x%02x from device (%s)\n",
-                   ctx->lastrxpid, decode_pid(ctx->lastrxpid));
-            ctx->hostSt = HS_NEXTFRAME;
-            break;
-        }
-
-        ctx->hostSt = proceed ? HS_STREAMIN : HS_NEXTFRAME;
-      } else if (ctx->tick_bits >= ctx->wait) {
-        printf("[usbdpi] Timed out waiting for OUT response\n");
-        ctx->hostSt = HS_NEXTFRAME;
+              default:
+                printf("[usbdpi] Unexpected PID 0x%02x from device (%s)\n",
+                       ctx->lastrxpid, decode_pid(ctx->lastrxpid));
+                ctx->hostSt = HS_ERROR;
+                break;
+            }
+          } else if (ctx->tick_bits >= ctx->wait) {
+            printf("[usbdpi] Timed out waiting for OUT response\n");
+            ctx->hostSt = HS_ERROR;
+          }
+          break;
+        default:
+          assert(s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS);
+          // No response expected for Isochronous
+          if (ctx->bus_state == kUsbIsoOut) {
+            accepted = true;
+          } else {
+            printf("[usbdpi] Unexpected device response to Iso OUT %u\n",
+                   ctx->bus_state);
+            ctx->hostSt = HS_ERROR;
+          }
+          break;
       }
-      break;
+
+      if (accepted) {
+        // Transmitted packet was accepted, so we can retire it...
+        usbdpi_stream_t *s = &ctx->stream[ctx->stream_out];
+        usbdpi_transfer_t *rx = s->received;
+        assert(rx);
+        s->received = rx->next;
+        transfer_release(ctx, rx);
+        // No data toggling for Isochronous
+        if (s->xfr_type != USB_TRANSFER_TYPE_ISOCHRONOUS) {
+          uint8_t ep_out = s->ep_out;
+          ctx->ep_out[ep_out].next_data =
+              DATA_TOGGLE_ADVANCE(ctx->ep_out[ep_out].next_data);
+        }
+        ctx->hostSt = HS_STREAMIN;
+      }
+    } break;
 
     // ---------------------------------------------
     // Try to collect a data packet from the device
@@ -441,28 +580,44 @@ void streams_service(usbdpi_ctx_t *ctx) {
       // Decide whether we have enough time within this frame to attempt
       // another fetch
       //
-      // TODO - find out what the host behaviour should be at this point;
+      // TODO:  find out what the host behaviour should be at this point;
       //        the device must be required to respond within a certain
       //        time interval, and then the bus transmission speed
       //        determines the maximum delay
       uint32_t next_frame = ctx->frame_start + FRAME_INTERVAL;
-      if ((next_frame - ctx->tick_bits) > min_time_left) {  // HACK
+      if ((next_frame - ctx->tick_bits) > min_time_left) {
         unsigned id = in_stream_next(ctx);
         usbdpi_stream_t *s = &ctx->stream[id];
+        if (verbose) {
+          printf("[usbdpi] IN considering #%u retrieve %u\n", id,
+                 s->retrieve ? 1 : 0);
+        }
         if (s->retrieve) {
           // Ensure that a buffer is available for constructing a transfer
           usbdpi_transfer_t *tr = ctx->sending;
           if (!tr) {
             tr = transfer_alloc(ctx);
             assert(tr);
-
             ctx->sending = tr;
           }
 
           transfer_token(tr, USB_PID_IN, ctx->dev_address, s->ep_in);
 
           transfer_send(ctx, tr);
-          ctx->bus_state = kUsbBulkInToken;
+
+          switch (s->xfr_type) {
+            case USB_TRANSFER_TYPE_INTERRUPT:
+              ctx->bus_state = kUsbInterruptInToken;
+              break;
+            case USB_TRANSFER_TYPE_BULK:
+              ctx->bus_state = kUsbBulkInToken;
+              break;
+            default:
+              assert(s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS);
+              ctx->bus_state = kUsbIsoInToken;
+              break;
+          }
+
           ctx->hostSt = HS_WAIT_PKT;
           ctx->lastrxpid = 0;
         } else {
@@ -487,63 +642,115 @@ void streams_service(usbdpi_ctx_t *ctx) {
       ctx->wait = ctx->tick_bits + 18 + 8 + 8 + 64 * 8 + 16;
       ctx->hostSt = HS_ACKIFDATA;
       break;
-    case HS_ACKIFDATA:
-      if (ctx->bus_state == kUsbBulkInData && ctx->recving) {
+
+    case HS_ACKIFDATA: {
+      unsigned id = ctx->stream_in;
+      usbdpi_stream_t *s = &ctx->stream[id];
+
+      // Have we received a reply?
+      bool got_reply = false;
+      switch (s->xfr_type) {
+        case USB_TRANSFER_TYPE_BULK:
+          got_reply = ctx->recving && ctx->bus_state == kUsbBulkInData;
+          break;
+        case USB_TRANSFER_TYPE_INTERRUPT:
+          got_reply = ctx->recving && ctx->bus_state == kUsbInterruptInData;
+          break;
+        case USB_TRANSFER_TYPE_ISOCHRONOUS:
+          got_reply = ctx->recving && ctx->bus_state == kUsbIsoInData;
+          break;
+        default:
+          // TODO: we do NOT support control transfers at present!
+          assert(s->xfr_type == USB_TRANSFER_TYPE_CONTROL);
+          printf("[usbdpi] Control Transfer type not yet supported");
+          ctx->hostSt = HS_ERROR;
+          break;
+      }
+
+      if (got_reply) {
         // We have a response from the device
         switch (ctx->lastrxpid) {
           case USB_PID_DATA0:
           case USB_PID_DATA1: {
             // Steal the received packet; it belongs to the stream
             usbdpi_transfer_t *rx = ctx->recving;
+            assert(rx);
             ctx->recving = NULL;
+
             // Decide whether we want to ACK or NAK this packet
-            unsigned id = ctx->stream_in;
-            usbdpi_stream_t *s = &ctx->stream[id];
-            bool accept = false;
-            if (s->retrying && s->nretries) {
-              s->nretries--;
+            bool accept;
+            if (s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS) {
+              // The device will return a zero length packet if there is no
+              // pending data for this Isochronous IN endpoint
+              // Note: a ZLP still implies a transfer of PID and CRC16 bytes
+              accept = (transfer_length(rx) > 3U);
             } else {
-              // Decide the number of retries for the next data packet
-              // Note: by randomizing the number of retries, rather than
-              // independently deciding each accept/reject, we guarantee an
-              // upper bound on the run time
-              switch (s->retry_lfsr & 7U) {
-                case 7U:
-                  s->nretries = 3U;
-                  break;
-                case 6U:
-                case 5U:
-                  s->nretries = 2U;
-                  break;
-                case 4U:
-                  s->nretries = 1U;
-                  break;
-                default:
-                  s->nretries = 0U;
-                  break;
+              if (s->retrying && s->nretries) {
+                accept = false;
+                s->nretries--;
+              } else {
+                // Decide the number of retries for the next data packet
+                // Note: by randomizing the number of retries, rather than
+                // independently deciding each accept/reject, we guarantee an
+                // upper bound on the run time
+                switch (s->retry_lfsr & 7U) {
+                  case 7U:
+                    s->nretries = 3U;
+                    break;
+                  case 6U:
+                  case 5U:
+                    s->nretries = 2U;
+                    break;
+                  case 4U:
+                    s->nretries = 1U;
+                    break;
+                  default:
+                    s->nretries = 0U;
+                    break;
+                }
+                s->retry_lfsr = LFSR_ADVANCE(s->retry_lfsr);
+                accept = true;
               }
-              s->retry_lfsr = LFSR_ADVANCE(s->retry_lfsr);
-              accept = true;
-            }
-            if (!accept) {
-              printf("[usbdpi] Requesting resend of data\n");
-              usb_monitor_log(ctx->mon, "[usbdpi] Requesting resend of data\n");
+
+              if (!accept) {
+                printf("[usbdpi] Requesting resend of data\n");
+                usb_monitor_log(ctx->mon,
+                                "[usbdpi] Requesting resend of data\n");
+              }
             }
 
-            if (expect_sig && !s->sig_recvd) {
-              // Note: the stream signature is primarily of use on a physical
-              // USB connection to a host since the endpoint to port mapping is
-              // variable. With t-l sim we can rely upon the first packet being
-              // the signature and nothing else
-              accept = stream_sig_check(ctx, s, rx);
-              transfer_release(ctx, rx);
-              // TODO - run time error, signal test failure to the software
-              assert(accept);
-              if (accept) {
-                s->sig_recvd = true;
+            if (accept) {
+              // Offset of LFSR byte stream within packet
+              unsigned offset = 0U;
+
+              if (s->sig_expected) {
+                accept = stream_sig_check(ctx, s, rx);
+                if (accept) {
+                  offset = SIZEOF_STREAM_SIGNATURE;
+                  if (s->xfr_type != USB_TRANSFER_TYPE_ISOCHRONOUS) {
+                    // For non-Isochronous streams, we can rely upon the first
+                    // packet being just the signature, identifying the stream.
+                    transfer_release(ctx, rx);
+                    rx = NULL;
+                  }
+                } else {
+                  printf("[usbdpi] sig check failed\n");
+                  // TODO: should probably transition to error state here?
+                  accept = false;
+                }
               }
-            } else {
-              if (stream_data_check(ctx, s, rx, accept)) {
+
+              // Check the remaining bytes of the packet, if any
+              if (rx && offset < transfer_length(rx)) {
+                if (!stream_data_check(ctx, s, rx, offset, accept)) {
+                  accept = false;
+                }
+              }
+            }
+
+            // Not yet handled this packet?
+            if (rx) {
+              if (accept) {
                 // Collect the received packets in preparation for later
                 // transmission with modification back to the device
                 usbdpi_transfer_t *tr = s->received;
@@ -556,21 +763,34 @@ void streams_service(usbdpi_ctx_t *ctx) {
                 }
               } else {
                 transfer_release(ctx, rx);
-                accept = false;
               }
             }
 
-            usbdpi_transfer_t *tr = ctx->sending;
-            assert(tr);
+            // For non-isochronous transfers, we now ACK/NAK the data, and we
+            // expect no further signatures if we've accepted the data.
+            if (s->xfr_type != USB_TRANSFER_TYPE_ISOCHRONOUS) {
+              usbdpi_transfer_t *tr = ctx->sending;
+              assert(tr);
 
-            transfer_status(ctx, tr, accept ? USB_PID_ACK : USB_PID_NAK);
+              transfer_status(ctx, tr, accept ? USB_PID_ACK : USB_PID_NAK);
+
+              if (accept) {
+                s->sig_expected = false;
+              }
+            }
 
             ctx->hostSt = HS_STREAMOUT;
           } break;
 
           case USB_PID_NAK:
-            // No data available
-            ctx->hostSt = HS_STREAMOUT;
+            if (s->xfr_type == USB_TRANSFER_TYPE_ISOCHRONOUS) {
+              // Isochronous streams should not be receiving any ACKs/NAKs
+              printf("[usbdpi] NAK response from Iso stream");
+              ctx->hostSt = HS_ERROR;
+            } else {
+              // No data available
+              ctx->hostSt = HS_STREAMOUT;
+            }
             break;
 
           default:
@@ -581,11 +801,19 @@ void streams_service(usbdpi_ctx_t *ctx) {
         }
       } else if (ctx->tick_bits >= ctx->wait) {
         printf("[usbdpi] Timed out waiting for IN response\n");
-        ctx->hostSt = HS_NEXTFRAME;
+        ctx->hostSt = HS_ERROR;
       }
+    } break;
+
+    case HS_ERROR:
+      // TODO: report failure (#17259)
+      assert(!"Unexpected behavior in streaming test");
+      ctx->hostSt = HS_NEXTFRAME;
       break;
 
     default:
+      assert(ctx->hostSt == HS_NEXTFRAME);
+      ctx->hostSt = HS_NEXTFRAME;
       break;
   }
 }

--- a/hw/dv/dpi/usbdpi/usbdpi_stream.h
+++ b/hw/dv/dpi/usbdpi/usbdpi_stream.h
@@ -15,6 +15,10 @@ typedef struct usbdpi_ctx usbdpi_ctx_t;
 // Context for streaming data test (usbdev_stream_test)
 typedef struct usbdpi_stream {
   /**
+   * Stream IDentifier
+   */
+  uint8_t id;
+  /**
    * Test requires polling device for IN packets
    */
   bool retrieve;
@@ -32,9 +36,13 @@ typedef struct usbdpi_stream {
    */
   bool checking;
   /**
-   * Have we received the stream signature yet?
+   * Are we expecting a stream signature at the beginning of the next packet?
    */
-  bool sig_recvd;
+  bool sig_expected;
+  /**
+   * USB transfer type of this _stream_ (so _Control is not meaningful)
+   */
+  uint8_t xfr_type;
   /**
    * Device endpoint from which IN packets are retrieved
    */
@@ -43,6 +51,13 @@ typedef struct usbdpi_stream {
    * Device endpoint to which OUT packets are sent
    */
   uint8_t ep_out;
+  /**
+   * Device-side sequence number of next packet expected.
+   *
+   * This allows us to detect packet dropping which is acceptable only for
+   * Isochronous Transfers.
+   */
+  uint16_t tst_seq;
   /**
    * Device-generated LFSR; predicts data expected from usbdev_stream_test
    */
@@ -59,7 +74,12 @@ typedef struct usbdpi_stream {
    * Number of times (still) to retry before accepting the current data packet
    */
   uint8_t nretries;
-  /***
+  /**
+   * LFSR state prior to the construction of the current OUT packet; this is
+   * so that we may easily rewind it in the event of a delivery failure, eg. NAK
+   */
+  uint8_t dpi_rewind_lfsr;
+  /**
    * Linked-list of received transfers
    */
   usbdpi_transfer_t *received;
@@ -70,14 +90,16 @@ typedef struct usbdpi_stream {
  *
  * @param  ctx       USBDPI context state
  * @param  nstreams  Number of concurrent byte streams
+ * @param  xfr_types Transfer types of the streams
  * @param  retrieve  Retrieve IN packets from device
  * @param  checking  Checking of received data against expected LFSR output
  * @param  retrying  Request retrying of IN packets, feigning error
  * @param  send      Attempt to send OUT packets to device
  * @return           true iff initialized successfully
  */
-bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams, bool retrieve,
-                  bool checking, bool retrying, bool send);
+bool streams_init(usbdpi_ctx_t *ctx, unsigned nstreams,
+                  const uint8_t xfr_types[], bool retrieve, bool checking,
+                  bool retrying, bool send);
 
 /**
  * Service streaming data (usbdev_stream_test)

--- a/hw/dv/dpi/usbdpi/usbdpi_test.h
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.h
@@ -6,6 +6,14 @@
 #define OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_
 #include "usbdpi.h"
 
+// DPI test numbers
+typedef enum usb_testutils_test_number {
+  kUsbTestNumberSmoke = 0,
+  kUsbTestNumberStreams,
+  kUsbTestNumberIso,
+  kUsbTestNumberMixed
+} usb_testutils_test_number_t;
+
 // Test-specific initialization
 void usbdpi_test_init(usbdpi_ctx_t *ctx);
 

--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -275,10 +275,12 @@ status_t usb_testutils_transfer_send(usb_testutils_ctx_t *ctx, uint8_t ep,
 }
 
 status_t usb_testutils_in_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep, void *ep_ctx,
-    usb_testutils_tx_done_handler_t tx_done,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t ep_type,
+    void *ep_ctx, usb_testutils_tx_done_handler_t tx_done,
     usb_testutils_tx_flush_handler_t flush,
     usb_testutils_reset_handler_t reset) {
+  // Store callback handler information before we enable the endpoint
+  ctx->in[ep].ep_type = ep_type;
   ctx->in[ep].ep_ctx = ep_ctx;
   ctx->in[ep].tx_done_callback = tx_done;
   ctx->in[ep].flush = flush;
@@ -291,15 +293,24 @@ status_t usb_testutils_in_endpoint_setup(
 
   TRY(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint, kDifToggleDisabled));
 
+  // Specify whether this is an Isochronous endpoint (no acknowledgement/retry)
+  dif_toggle_t iso = kDifToggleDisabled;
+  if (ep_type == kUsbTransferTypeIsochronous) {
+    iso = kDifToggleEnabled;
+  }
+  CHECK_DIF_OK(dif_usbdev_endpoint_iso_enable(ctx->dev, endpoint, iso));
+
   // Enable IN traffic from device to host
   TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, kDifToggleEnabled));
   return OK_STATUS();
 }
 
 status_t usb_testutils_out_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t ep_type,
     usb_testutils_out_transfer_mode_t out_mode, void *ep_ctx,
     usb_testutils_rx_handler_t rx, usb_testutils_reset_handler_t reset) {
+  // Store callback handler information before we enable the endpoint
+  ctx->out[ep].ep_type = ep_type;
   ctx->out[ep].ep_ctx = ep_ctx;
   ctx->out[ep].rx_callback = rx;
   ctx->out[ep].reset = reset;
@@ -310,6 +321,13 @@ status_t usb_testutils_out_endpoint_setup(
   };
 
   TRY(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint, kDifToggleDisabled));
+
+  // Specify whether this is an Isochronous endpoint (no acknowledgement/retry)
+  dif_toggle_t iso = kDifToggleDisabled;
+  if (ep_type == kUsbTransferTypeIsochronous) {
+    iso = kDifToggleEnabled;
+  }
+  CHECK_DIF_OK(dif_usbdev_endpoint_iso_enable(ctx->dev, endpoint, iso));
 
   // Enable/disable the endpoint and reception of OUT packets?
   dif_toggle_t enabled = kDifToggleEnabled;
@@ -323,23 +341,27 @@ status_t usb_testutils_out_endpoint_setup(
     nak = kDifToggleEnabled;
   }
 
-  TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, enabled));
   TRY(dif_usbdev_endpoint_out_enable(ctx->dev, ep, enabled));
   TRY(dif_usbdev_endpoint_set_nak_out_enable(ctx->dev, ep, nak));
+  // Now we may enable the OUT endpoint
+  TRY(dif_usbdev_endpoint_enable(ctx->dev, endpoint, enabled));
   return OK_STATUS();
 }
 
 status_t usb_testutils_endpoint_setup(
-    usb_testutils_ctx_t *ctx, uint8_t ep,
+    usb_testutils_ctx_t *ctx, uint8_t ep, usb_testutils_transfer_type_t in_type,
+    usb_testutils_transfer_type_t out_type,
     usb_testutils_out_transfer_mode_t out_mode, void *ep_ctx,
     usb_testutils_tx_done_handler_t tx_done, usb_testutils_rx_handler_t rx,
     usb_testutils_tx_flush_handler_t flush,
     usb_testutils_reset_handler_t reset) {
-  TRY(usb_testutils_in_endpoint_setup(ctx, ep, ep_ctx, tx_done, flush, reset));
+  TRY(usb_testutils_in_endpoint_setup(ctx, ep, in_type, ep_ctx, tx_done, flush,
+                                      reset));
 
   // Note: register the link reset handler only on the IN endpoint so that it
   // does not get invoked twice
-  return usb_testutils_out_endpoint_setup(ctx, ep, out_mode, ep_ctx, rx, NULL);
+  return usb_testutils_out_endpoint_setup(ctx, ep, out_type, out_mode, ep_ctx,
+                                          rx, NULL);
 }
 
 status_t usb_testutils_in_endpoint_remove(usb_testutils_ctx_t *ctx,
@@ -410,8 +432,9 @@ status_t usb_testutils_init(usb_testutils_ctx_t *ctx, bool pinflip,
 
   // Set up context
   for (int i = 0; i < USBDEV_NUM_ENDPOINTS; i++) {
-    TRY(usb_testutils_endpoint_setup(ctx, i, kUsbdevOutDisabled, NULL, NULL,
-                                     NULL, NULL, NULL));
+    TRY(usb_testutils_endpoint_setup(
+        ctx, i, kUsbTransferTypeControl, kUsbTransferTypeControl,
+        kUsbdevOutDisabled, NULL, NULL, NULL, NULL, NULL));
   }
 
   // All about polling...

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -401,8 +401,9 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
                                       const uint8_t *test_dscr,
                                       size_t test_dscr_len) {
   ctctx->ctx = ctx;
-  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutMessage, ctctx,
-                                   ctrl_tx_done, ctrl_rx, NULL, ctrl_reset));
+  TRY(usb_testutils_endpoint_setup(
+      ctx, ep, kUsbTransferTypeControl, kUsbTransferTypeControl,
+      kUsbdevOutMessage, ctctx, ctrl_tx_done, ctrl_rx, NULL, ctrl_reset));
   ctctx->ep = ep;
   ctctx->ctrlstate = kUsbTestutilsCtIdle;
   ctctx->cfg_dscr = cfg_dscr;

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -410,8 +410,11 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
   ctctx->cfg_dscr_len = cfg_dscr_len;
   ctctx->test_dscr = test_dscr;
   ctctx->test_dscr_len = test_dscr_len;
-  TRY(dif_usbdev_interface_enable(ctx->dev, kDifToggleEnabled));
   ctctx->device_state = kUsbTestutilsDeviceDefault;
+
+  // Indicate the device presence, at which point we can expect to start
+  // receiving control transfers from the host
+  TRY(dif_usbdev_interface_enable(ctx->dev, kDifToggleEnabled));
 
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -11,6 +11,13 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/usb_testutils.h"
 
+// DPI test numbers
+typedef enum usb_testutils_test_number {
+  kUsbTestNumberSmoke = 0,
+  kUsbTestNumberStreams,
+  kUsbTestNumberIso
+} usb_testutils_test_number_t;
+
 typedef enum usb_testutils_ctstate {
   kUsbTestutilsCtIdle,
   kUsbTestutilsCtWaitIn,      // Queued IN data stage, waiting ack
@@ -126,7 +133,7 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
   USB_EP_DSCR_LEN,                 /* bLength                              */ \
       5,                           /* bDescriptorType                      */ \
       (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
-      0x02,                        /* bmAttributes (0x02=bulk, data)       */ \
+      kUsbTransferTypeBulk,        /* bmAttributes (0x02=bulk, data)       */ \
       (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
       (interval)                   /* bInterval                            */

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -15,7 +15,8 @@
 typedef enum usb_testutils_test_number {
   kUsbTestNumberSmoke = 0,
   kUsbTestNumberStreams,
-  kUsbTestNumberIso
+  kUsbTestNumberIso,
+  kUsbTestNumberMixed
 } usb_testutils_test_number_t;
 
 typedef enum usb_testutils_ctstate {

--- a/sw/device/lib/testing/usb_testutils_simpleserial.c
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.c
@@ -78,8 +78,9 @@ status_t usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
 status_t usb_testutils_simpleserial_init(usb_testutils_ss_ctx_t *ssctx,
                                          usb_testutils_ctx_t *ctx, int ep,
                                          void (*got_byte)(uint8_t)) {
-  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutStream, ssctx, ss_tx_done,
-                                   ss_rx, ss_flush, NULL));
+  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbTransferTypeBulk,
+                                   kUsbTransferTypeBulk, kUsbdevOutStream,
+                                   ssctx, ss_tx_done, ss_rx, ss_flush, NULL));
   ssctx->ctx = ctx;
   ssctx->ep = ep;
   ssctx->sending = false;

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -32,6 +32,51 @@ static const enum {
  */
 static bool log_traffic = false;
 
+// Determine the length of the next packet in the data stream, _including_
+// any required signature.
+static unsigned packet_length(const usbdev_stream_t *s, uint32_t bytes_done,
+                              uint8_t *bufsz_lfsr) {
+  // For non-Isochronous streams the packet size is also constrained by the
+  // total size of the transfer. For Isochronous streams we just keep
+  // transmitting to account for the possibility of packet loss.
+  uint8_t bytes_left = USBDEV_MAX_PACKET_SIZE;
+
+  if (s->xfr_type != kUsbTransferTypeIsochronous) {
+    if (bytes_done < s->transfer_bytes &&
+        s->transfer_bytes - bytes_done < bytes_left) {
+      bytes_left = s->transfer_bytes - bytes_done;
+    }
+  }
+
+  // Length of packet
+  unsigned num_bytes;
+
+  if (s->flags & kUsbdevStreamFlagMaxPackets) {
+    num_bytes = bytes_left;
+  } else {
+    // Vary the amount of data sent per buffer
+    if (s->sig_required) {
+      const unsigned sig_bytes = sizeof(usbdev_stream_sig_t);
+      switch (s->xfr_type) {
+        case kUsbTransferTypeIsochronous: {
+          // For Isochronous streams, and the first packet of other transfers,
+          // we must constrain the minimum packet size
+          const unsigned max_bytes = USBDEV_MAX_PACKET_SIZE - sig_bytes;
+          num_bytes = sig_bytes + (*bufsz_lfsr % (max_bytes + 1u));
+        } break;
+        default:
+          num_bytes = sig_bytes;
+          break;
+      }
+    } else {
+      num_bytes = *bufsz_lfsr % (bytes_left + 1u);
+    }
+    *bufsz_lfsr = LFSR_ADVANCE(*bufsz_lfsr);
+  }
+
+  return num_bytes;
+}
+
 // Dump a sequence of bytes as hexadecimal and ASCII for diagnostic purposes
 static void buffer_dump(const uint8_t *data, size_t n) {
   base_hexdump_fmt_t fmt = {
@@ -47,15 +92,29 @@ static void buffer_dump(const uint8_t *data, size_t n) {
 static uint32_t buffer_sig_create(usb_testutils_streams_ctx_t *ctx,
                                   usbdev_stream_t *s,
                                   dif_usbdev_buffer_t *buf) {
-  usbdev_stream_sig_t sig;
+  // Number of bytes left to be transmitted
+  // - for non-Isochronous streams this is just the total number of bytes to be
+  //   transmitted, and there's a single signature at the start of the stream
+  // - for Isochronous this provideds a down count, and it will wrap around
+  //   upon reaching zero, in the event of packet loss and prolonged
+  //   transmission
+  uint32_t tx_left = s->transfer_bytes - (s->tx_bytes % s->transfer_bytes);
 
+  usbdev_stream_sig_t sig;
   sig.head_sig = USBDEV_STREAM_SIGNATURE_HEAD;
   sig.init_lfsr = s->tx_lfsr;
   sig.stream = s->id | (uint8_t)s->flags;
-  sig.reserved1 = 0U;
-  sig.reserved2 = 0U;
-  sig.num_bytes = s->transfer_bytes;
+  sig.seq_lo = (uint8_t)s->tx_seq;
+  sig.seq_hi = (uint8_t)(s->tx_seq >> 8);
+  sig.num_bytes = tx_left;
   sig.tail_sig = USBDEV_STREAM_SIGNATURE_TAIL;
+
+  // Advance sequence counter
+  s->tx_seq++;
+
+  if (s->verbose && log_traffic) {
+    buffer_dump((uint8_t *)&sig, sizeof(sig));
+  }
 
   size_t bytes_written;
   CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->usbdev->dev, buf, (uint8_t *)&sig,
@@ -63,8 +122,87 @@ static uint32_t buffer_sig_create(usb_testutils_streams_ctx_t *ctx,
   CHECK(bytes_written == sizeof(sig));
 
   // Note: stream signature is not included in the count of bytes transferred
-
+  // so we do not advance tx_bytes
   return bytes_written;
+}
+
+// Check a stream signature
+//
+// Note: Only Isochronous streams are expected to receive signatures; in order
+// to keep the device and host ends synchronized in the presence of packet-
+// dropping, a signature occurs at the start of each packet. Each signature
+// includes a packet sequence number and the intiial value of the sender's LFSR
+static bool buffer_sig_check(usb_testutils_streams_ctx_t *ctx,
+                             usbdev_stream_t *s, const usbdev_stream_sig_t *sig,
+                             uint8_t len) {
+  // Validate the signature
+  if (sig->head_sig != USBDEV_STREAM_SIGNATURE_HEAD ||
+      sig->tail_sig != USBDEV_STREAM_SIGNATURE_TAIL ||
+      // Returned to the correct stream?
+      (sig->stream & 0xfU) != s->id) {
+    LOG_INFO("buffer_sig_check failed: ");
+    return false;
+  }
+
+  // Sequence number not regressed?
+  uint16_t seq = (sig->seq_hi << 8) | sig->seq_lo;
+  if (seq < s->rx_seq) {
+    LOG_INFO("buffer_sig_check: sequence number regressed from 0x%x to 0x%x",
+             s->rx_seq, seq);
+    return false;
+  }
+
+  // Current LFSR state and sequence number
+  uint16_t rx_seq = s->rx_seq;
+  uint8_t rx_lfsr = s->rx_lfsr;
+  uint8_t rxtx_lfsr = s->rxtx_lfsr;
+
+  // Skip past any packets that appear to have been dropped; this is
+  // permissible for Isochronous transfers which prioritize service/real-time
+  // delivery over reliable transmission.
+  while (rx_seq < seq) {
+    // Determine the length of the missing packet
+    uint8_t len = packet_length(s, s->rx_bytes, &s->rx_buf_size);
+    len -= sizeof(*sig);
+    // Advance the LFSR states to account for the missing packet
+    while (len-- > 0U) {
+      rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
+      rx_lfsr = LFSR_ADVANCE(rx_lfsr);
+    }
+    // The updated host-side LFSR has been supplied in the packet signature
+    rx_seq++;
+  }
+
+  // For 'rx_buf_size' to track the 'tx_buf_size' used when the packets were
+  // created and transmitted, we must also ascertain the expected length of the
+  // packet that we have just received; we thus check that the length of this
+  // packet has not changed either.
+
+  uint8_t exp_len = packet_length(s, s->rx_bytes, &s->rx_buf_size);
+  if (len != exp_len) {
+    LOG_INFO(
+        "buffer_sig_check: S%u unexpected packet length (0x%x but expected "
+        "0x%x)",
+        s->id, len, exp_len);
+    return false;
+  }
+
+  // Similarly, our expectation of the host/DPI LFSR should now match the
+  // value that it has supplied in the modified packet.
+  if (rx_lfsr != sig->init_lfsr) {
+    LOG_INFO(
+        "buffer_sig_check: S%u unexpected LFSR value (0x%x but expected 0x%x)",
+        s->id, sig->init_lfsr, rx_lfsr);
+    return true;
+  }
+
+  // Expected sequence number of next packet
+  s->rx_seq = rx_seq + 1U;
+  // Update the LFSR states
+  s->rxtx_lfsr = rxtx_lfsr;
+  s->rx_lfsr = rx_lfsr;
+
+  return true;
 }
 
 // Fill a buffer with LFSR-generated data
@@ -129,35 +267,59 @@ static void buffer_check(usb_testutils_streams_ctx_t *ctx, usbdev_stream_t *s,
                                         data, len, &bytes_read));
     CHECK(bytes_read == len);
 
-    if (log_traffic) {
+    if (s->verbose && log_traffic) {
       buffer_dump(data, bytes_read);
     }
 
-    // Check received data against expected LFSR-generated byte stream;
-    // keep this brief so that we can reduce our latency in responding to
-    // USB events (usb_testutils employs polling at present)
-    uint8_t rxtx_lfsr = s->rxtx_lfsr;
-    uint8_t rx_lfsr = s->rx_lfsr;
+    // Byte offset of LFSR-generated byte stream
+    size_t offset = 0U;
 
-    const uint8_t *esp = &data[bytes_read];
-    const uint8_t *sp = data;
-    while (sp < esp) {
-      // Received data should be the XOR of two LFSR-generated PRND streams -
-      // ours on the
-      //   transmission side, and that of the DPI model
-      uint8_t expected = rxtx_lfsr ^ rx_lfsr;
-      CHECK(expected == *sp,
-            "S%u: Unexpected received data 0x%02x : (LFSRs 0x%02x 0x%02x)",
-            s->id, *sp, rxtx_lfsr, rx_lfsr);
+    switch (s->xfr_type) {
+      case kUsbTransferTypeIsochronous: {
+        // Check the packet signature, advance the LFSRs and drop through to
+        // check the remainder of the packet
+        const usbdev_stream_sig_t *sig = (usbdev_stream_sig_t *)data;
+        bool ok = buffer_sig_check(ctx, s, sig, len);
+        CHECK(ok, "S%u: Received packet invalid", s->id);
 
-      rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
-      rx_lfsr = LFSR_ADVANCE(rx_lfsr);
-      sp++;
+        offset = sizeof(*sig);
+      }  // no break
+      case kUsbTransferTypeInterrupt:
+      case kUsbTransferTypeBulk: {
+        // Check received data against expected LFSR-generated byte stream;
+        // keep this brief so that we can reduce our latency in responding to
+        // USB events (usb_testutils employs polling at present)
+        uint8_t rxtx_lfsr = s->rxtx_lfsr;
+        uint8_t rx_lfsr = s->rx_lfsr;
+
+        const uint8_t *esp = &data[bytes_read];
+        const uint8_t *sp = &data[offset];
+        while (sp < esp) {
+          // Received data should be the XOR of two LFSR-generated PRND streams
+          // - ours on the
+          //   transmission side, and that of the DPI model
+          uint8_t expected = rxtx_lfsr ^ rx_lfsr;
+          CHECK(expected == *sp,
+                "S%u: Unexpected received data 0x%02x : (LFSRs 0x%02x 0x%02x)",
+                s->id, *sp, rxtx_lfsr, rx_lfsr);
+
+          rxtx_lfsr = LFSR_ADVANCE(rxtx_lfsr);
+          rx_lfsr = LFSR_ADVANCE(rx_lfsr);
+          sp++;
+        }
+
+        // Update the LFSRs for the next packet
+        s->rxtx_lfsr = rxtx_lfsr;
+        s->rx_lfsr = rx_lfsr;
+
+        // Update the count of LFSR bytes received
+        s->rx_bytes += bytes_read - offset;
+      } break;
+
+      default:
+        CHECK(s->xfr_type == kUsbTransferTypeControl);
+        break;
     }
-
-    // Update the LFSRs for the next packet
-    s->rxtx_lfsr = rxtx_lfsr;
-    s->rx_lfsr = rx_lfsr;
   } else {
     // In the event that we've received a zero-length data packet, we still
     // must return the buffer to the pool
@@ -251,9 +413,9 @@ static status_t strm_rx(void *stream_v, dif_usbdev_rx_packet_info_t packet_info,
       // Just discard the data, without reading it; peak OUT performance
       TRY(dif_usbdev_buffer_return(usbdev->dev, usbdev->buffer_pool, &buf));
     }
-  }
 
-  s->rx_bytes += packet_info.length;
+    s->rx_bytes += packet_info.length;
+  }
 
   return OK_STATUS();
 }
@@ -273,6 +435,35 @@ static status_t rx_show(void *stream_v, dif_usbdev_rx_packet_info_t packet_info,
   buffer_dump(data, bytes_read);
 
   return OK_STATUS();
+}
+
+// Set the count of already-initialized streams, and apportion the available
+// tx buffers among the streams.
+bool usb_testutils_streams_count_set(usb_testutils_streams_ctx_t *ctx,
+                                     unsigned nstreams) {
+  // Too many streams?
+  if (nstreams > USBUTILS_STREAMS_MAX) {
+    return false;
+  }
+
+  // Decide how many buffers each endpoint may queue up for transmission;
+  // we must ensure that there are buffers available for reception, and we
+  // do not want any endpoint to starve another
+  for (unsigned s = 0U; s < nstreams; s++) {
+    // This is slightly overspending the available buffers, leaving the
+    //   endpoints to vie for the final few buffers, so it's important that
+    //   we limit the total number of buffers across all endpoints too
+    unsigned ep = ctx->streams[s].tx_ep;
+    ctx->tx_bufs_queued[ep] = 0U;
+    ctx->tx_bufs_limit[ep] =
+        (USBUTILS_STREAMS_TXBUF_MAX + nstreams - 1) / nstreams;
+  }
+  ctx->tx_queued_total = 0U;
+
+  // Remember the stream count
+  ctx->nstreams = nstreams;
+
+  return true;
 }
 
 // Returns an indication of whether a stream has completed its data transfer
@@ -303,6 +494,9 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   s->id = id;
   s->flags = flags;
 
+  // Remember the stream transfer type
+  s->xfr_type = xfr_type;
+
   // Remember whether verbose reporting is required
   s->verbose = verbose;
 
@@ -311,12 +505,16 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   s->generating = ((flags & kUsbdevStreamFlagCheck) != 0U);
 
   // Not yet sent stream signature
-  s->sent_sig = false;
+  s->sig_required = true;
 
   // Initialize the transfer state
   s->tx_bytes = 0u;
   s->rx_bytes = 0u;
   s->transfer_bytes = transfer_bytes;
+
+  // Sequence number to be used for first packet
+  s->tx_seq = 0u;
+  s->rx_seq = s->tx_seq;
 
   // Initialize the LFSR state for transmission and reception sides
   // - we use a simple LFSR to generate a PRND stream to transmit to the USBPI
@@ -329,6 +527,7 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
 
   // Packet size randomization
   s->tx_buf_size = BUFSZ_LFSR_SEED(id);
+  s->rx_buf_size = s->tx_buf_size;
 
   // Set up the endpoint for IN transfers (TO host)
   //
@@ -364,7 +563,12 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
   uint8_t tx_ep = s->tx_ep;
   uint8_t nqueued = ctx->tx_bufs_queued[tx_ep];
 
-  if (s->tx_bytes < s->transfer_bytes &&      // More bytes to transfer?
+  // Isochronous streams never cease transmission because packets are expected
+  // to get dropped; let the reception side decided test completion
+  bool tx_more = (s->xfr_type == kUsbTransferTypeIsochronous) ||
+                 (s->tx_bytes < s->transfer_bytes);
+
+  if (tx_more &&                              // More bytes to transfer?
       nqueued < ctx->tx_bufs_limit[tx_ep] &&  // Endpoint allowed buffer?
       ctx->tx_queued_total <
           USBUTILS_STREAMS_TXBUF_MAX) {  // Total buffers not exceeded?
@@ -377,31 +581,33 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
       // This is just for reporting the number of buffers presented to the
       // USB device, as a progress indicator
       static unsigned bufs_sent = 0u;
+      uint32_t bytes_added = 0u;
       uint32_t num_bytes;
 
-      if (s->sent_sig) {
-        if (s->flags & kUsbdevStreamFlagMaxPackets) {
-          num_bytes = USBDEV_MAX_PACKET_SIZE;
-        } else {
-          // Vary the amount of data sent per buffer
-          num_bytes = s->tx_buf_size % (USBDEV_MAX_PACKET_SIZE + 1u);
-          s->tx_buf_size = LFSR_ADVANCE(s->tx_buf_size);
-        }
-        uint32_t tx_left = s->transfer_bytes - s->tx_bytes;
-        if (num_bytes > tx_left) {
-          num_bytes = tx_left;
-        }
-        buffer_fill(ctx, s, &buf, num_bytes);
-      } else {
-        // Construct a signature to send to the host-side software,
-        // identifying the stream and its properties
-        num_bytes = buffer_sig_create(ctx, s, &buf);
-        s->sent_sig = true;
+      // Decide upon the packet length, _including_ any signature bytes.
+      num_bytes = packet_length(s, s->tx_bytes, &s->tx_buf_size);
+
+      // Construct a signature to send to the host-side software,
+      // identifying the stream and its properties?
+      if (s->sig_required) {
+        bytes_added = buffer_sig_create(ctx, s, &buf);
+        // If we're 'not sending' then we still send the stream signature once
+        // but only the signature; it allows the host/DPI model to receive the
+        // stream flags and discover that no further data is to be expected.
         if (!s->sending) {
-          // If not required to send, we send only the stream signature
-          // identifying the test properties
           s->tx_bytes = s->transfer_bytes;
         }
+        // Signature required for each packet of an Isochronous stream, but only
+        // at the stream start for other transfer types
+        if (!s->sending || s->xfr_type != kUsbTransferTypeIsochronous) {
+          // First packet is just the stream signature
+          s->sig_required = false;
+        }
+      }
+
+      // How many LFSR-generated bytes are to be included?
+      if (bytes_added < num_bytes) {
+        buffer_fill(ctx, s, &buf, num_bytes - bytes_added);
       }
 
       // Remember the buffer until we're informed that it has been
@@ -439,9 +645,6 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
                                     usbdev_stream_flags_t flags, bool verbose) {
   TRY_CHECK(nstreams <= USBUTILS_STREAMS_MAX);
 
-  // Remember the stream count
-  ctx->nstreams = nstreams;
-
   // Initialize the state of each stream
   for (unsigned id = 0U; id < nstreams; id++) {
     // Which endpoint are we using for the IN transfers to the host?
@@ -452,19 +655,9 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
                                   num_bytes, flags, verbose));
   }
 
-  // Decide how many buffers each endpoint may queue up for transmission;
-  // we must ensure that there are buffers available for reception, and we
-  // do not want any endpoint to starve another
-  for (unsigned s = 0U; s < nstreams; s++) {
-    // This is slightly overspending the available buffers, leaving the
-    //   endpoints to vie for the final few buffers, so it's important that
-    //   we limit the total number of buffers across all endpoints too
-    unsigned ep = ctx->streams[s].tx_ep;
-    ctx->tx_bufs_queued[ep] = 0U;
-    ctx->tx_bufs_limit[ep] =
-        (USBUTILS_STREAMS_TXBUF_MAX + nstreams - 1) / nstreams;
-  }
-  ctx->tx_queued_total = 0U;
+  // Remember the stream count and apportion the available tx buffers
+  TRY_CHECK(usb_testutils_streams_count_set(ctx, nstreams));
+
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -287,6 +287,7 @@ bool usb_testutils_stream_completed(const usb_testutils_streams_ctx_t *ctx,
 
 // Initialize a stream, preparing it for use
 status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
+                                   usb_testutils_transfer_type_t xfr_type,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t transfer_bytes,
                                    usbdev_stream_flags_t flags, bool verbose) {
@@ -335,16 +336,17 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
   // transfers
   usb_testutils_rx_handler_t rx = (ep_in == ep_out) ? strm_rx : rx_show;
 
-  s->tx_ep = ep_in;
-  CHECK_STATUS_OK(usb_testutils_endpoint_setup(
-      ctx->usbdev, ep_in, kUsbdevOutStream, s, strm_tx_done, rx, NULL, NULL));
-
   s->rx_ep = ep_out;
-  if (ep_out != ep_in) {
-    // Set up the endpoint for OUT transfers (FROM host)
-    CHECK_STATUS_OK(usb_testutils_endpoint_setup(
-        ctx->usbdev, ep_out, kUsbdevOutStream, s, NULL, strm_rx, NULL, NULL));
-  }
+  s->tx_ep = ep_in;
+
+  // Set up the endpoint for IN transfers (TO host)
+  CHECK_STATUS_OK(usb_testutils_in_endpoint_setup(ctx->usbdev, ep_in, xfr_type,
+                                                  s, strm_tx_done, NULL, NULL));
+
+  // Set up the endpoint for OUT transfers (FROM host)
+  CHECK_STATUS_OK(usb_testutils_out_endpoint_setup(
+      ctx->usbdev, ep_out, xfr_type, kUsbdevOutStream, s, strm_rx, NULL));
+
   return OK_STATUS();
 }
 
@@ -431,7 +433,9 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
 }
 
 status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
-                                    unsigned nstreams, uint32_t num_bytes,
+                                    unsigned nstreams,
+                                    usb_testutils_transfer_type_t xfr_types[],
+                                    uint32_t num_bytes,
                                     usbdev_stream_flags_t flags, bool verbose) {
   TRY_CHECK(nstreams <= USBUTILS_STREAMS_MAX);
 
@@ -444,8 +448,8 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
     const uint8_t ep_in = 1u + id;
     // Which endpoint are we using for the OUT transfers from the host?
     const uint8_t ep_out = 1u + id;
-    TRY(usb_testutils_stream_init(ctx, id, ep_in, ep_out, num_bytes, flags,
-                                  verbose));
+    TRY(usb_testutils_stream_init(ctx, id, xfr_types[id], ep_in, ep_out,
+                                  num_bytes, flags, verbose));
   }
 
   // Decide how many buffers each endpoint may queue up for transmission;

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -81,6 +81,8 @@ typedef struct __attribute__((packed)) usbdev_stream_sig {
   uint32_t head_sig;
   /**
    * Initial value of LFSR
+   * Note: for Isochronous Transfers, this is the initial value of the sender's
+   *       LFSR for _this packet_
    */
   uint8_t init_lfsr;
   /**
@@ -88,12 +90,18 @@ typedef struct __attribute__((packed)) usbdev_stream_sig {
    */
   uint8_t stream;
   /**
-   * Reserved fields; should be zero
+   * Sequence number, low part; for non-Isochronous streams this will always be
+   * zero because a signature is used only at the start of the data stream.
    */
-  uint8_t reserved1;
-  uint8_t reserved2;
+  uint8_t seq_lo;
   /**
-   * Number of bytes to be transferred
+   * Sequence number, high part; for non-Isochronous streams this will always be
+   * zero because a signature is used only at the start of the data stream.
+   */
+  uint8_t seq_hi;
+  /**
+   * Number of bytes to be transferred; for Isochronous streams this
+   * is the count of remaining bytes and it wraps when reaching zero
    */
   uint32_t num_bytes;
   /**
@@ -119,13 +127,21 @@ typedef struct usbdev_stream {
    */
   uint8_t id;
   /**
-   * Has the stream signature been sent yet?
+   * USB transfer type
    */
-  bool sent_sig;
+  usb_testutils_transfer_type_t xfr_type;
+  /**
+   * Is a signature required at the start of the next packet?
+   */
+  bool sig_required;
   /**
    * USB device endpoint being used for data transmission
    */
   uint8_t tx_ep;
+  /**
+   * Transmission Sequence Number (for Isochronous streams)
+   */
+  uint16_t tx_seq;
   /**
    * Transmission Linear Feedback Shift Register (for PRND data generation)
    */
@@ -143,6 +159,10 @@ typedef struct usbdev_stream {
    */
   uint8_t rx_ep;
   /**
+   * Reception Sequence Number (for Isochronous streams)
+   */
+  uint16_t rx_seq;
+  /**
    * Reception-side LFSR state (mirrors USBDPI generation of PRND data)
    */
   uint8_t rx_lfsr;
@@ -154,6 +174,11 @@ typedef struct usbdev_stream {
    * Total number of bytes received from the USB device
    */
   uint32_t rx_bytes;
+  /**
+   * Reception-side LFSR for determination of expected buffer size
+   * (for Isochronous streams where packets may be dropped)
+   */
+  uint8_t rx_buf_size;
   /**
    * Size of transfer in bytes
    */
@@ -274,6 +299,17 @@ status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t num_bytes,
                                    usbdev_stream_flags_t flags, bool verbose);
+
+/**
+ * Specify the number of already-initialized streams, and apportion the
+ * available tx buffers among them. To be called after usb_testutils_stream_init
+ *
+ * @param  ctx       Context state for streaming test.
+ * @param  nstreams  Number of streams.
+ * @return           Success or otherwise of the request.
+ */
+bool usb_testutils_streams_count_set(usb_testutils_streams_ctx_t *ctx,
+                                     unsigned nstreams);
 
 /**
  * Service the given stream, preparing and/or sending any data that we can.

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -220,6 +220,7 @@ struct usb_testutils_streams_ctx {
  *
  * @param  ctx       Context state for streaming test
  * @param  nstreams  Number of streams
+ * @param  xfr_types Transfer types to be used for the individual streams
  * @param  num_bytes Number of bytes to be transferred by each stream
  * @param  flags     Stream/test flags to be used for each stream
  * @param  verbose   Whether to perform verbose logging for each stream
@@ -227,7 +228,9 @@ struct usb_testutils_streams_ctx {
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
-                                    unsigned nstreams, uint32_t num_bytes,
+                                    unsigned nstreams,
+                                    usb_testutils_transfer_type_t xfr_types[],
+                                    uint32_t num_bytes,
                                     usbdev_stream_flags_t flags, bool verbose);
 
 /**
@@ -257,6 +260,7 @@ bool usb_testutils_streams_completed(const usb_testutils_streams_ctx_t *ctx);
  *
  * @param  ctx       Context state for streaming test
  * @param  id        Stream identifier (0-based)
+ * @param  xfr_type  Transfer type to be usd for this stream
  * @param  ep_in     Endpoint to be used for IN traffic (to host)
  * @param  ep_out    Endpoint to be used for OUT traffic (from host)
  * @param  num_bytes Number of bytes to be transferred by stream
@@ -266,6 +270,7 @@ bool usb_testutils_streams_completed(const usb_testutils_streams_ctx_t *ctx);
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_stream_init(usb_testutils_streams_ctx_t *ctx, uint8_t id,
+                                   usb_testutils_transfer_type_t xfr_type,
                                    uint8_t ep_in, uint8_t ep_out,
                                    uint32_t num_bytes,
                                    usbdev_stream_flags_t flags, bool verbose);

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -270,8 +270,14 @@ bool test_main(void) {
   LOG_INFO("USB sent 0x%x byte(s), received and checked 0x%x byte(s)", tx_bytes,
            rx_bytes);
 
-  CHECK(tx_bytes == nstreams * transfer_bytes,
-        "Unexpected count of byte(s) sent to USB host");
+  if (sending) {
+    CHECK(tx_bytes == nstreams * transfer_bytes,
+          "Unexpected count of byte(s) sent to USB host");
+  }
+  if (recving) {
+    CHECK(rx_bytes == nstreams * transfer_bytes,
+          "Unexpected count of byte(s) received from USB host");
+  }
 
   return true;
 }

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -44,7 +44,7 @@
 #define TRANSFER_BYTES_VERILATOR 0x2400U
 
 // This is about the amount that we can transfer within a 1 hour 'eternal' test
-//#define TRANSFER_BYTES_LONG (0xD0U << 20)
+// #define TRANSFER_BYTES_LONG (0xD0U << 20)
 
 /**
  * Configuration values for USB.
@@ -207,9 +207,11 @@ bool test_main(void) {
                (generating ? kUsbdevStreamFlagCheck : 0U) |
                (retrying ? kUsbdevStreamFlagRetry : 0U) |
                (recving ? kUsbdevStreamFlagSend : 0U) |
+               // Note: the 'max_packets' test flag is not required by the DPI
                (max_packets ? kUsbdevStreamFlagMaxPackets : 0U);
 
   // Initialize the test descriptor
+  // Note: the 'max packets' test flag is not required by the DPI model
   const uint8_t desc[] = {
       USB_TESTUTILS_TEST_DSCR(1, NUM_STREAMS | (uint8_t)test_flags, 0, 0, 0)};
   memcpy(test_descriptor, desc, sizeof(test_descriptor));
@@ -231,9 +233,17 @@ bool test_main(void) {
     CHECK_STATUS_OK(usb_testutils_poll(ctx->usbdev));
   }
 
+  // Describe the transfer type of each stream;
+  // Note: for now we support only Bulk Transfer streams but this should change
+  // in future, eg. in response to test configuration.
+  usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX];
+  for (unsigned s = 0U; s < nstreams; s++) {
+    xfr_types[s] = kUsbTransferTypeBulk;
+  }
+
   // Initialise the state of the streams
-  CHECK_STATUS_OK(usb_testutils_streams_init(ctx, nstreams, transfer_bytes,
-                                             test_flags, verbose));
+  CHECK_STATUS_OK(usb_testutils_streams_init(
+      ctx, nstreams, xfr_types, transfer_bytes, test_flags, verbose));
 
   if (verbose) {
     LOG_INFO("Commencing data transfer...");


### PR DESCRIPTION
Building on PR #18419 -

- Corresponding DPI changes are introduced to handle the absence of ACK/NAK responses on Isochronous streams, and to correct buffer management faults that were exposed by the increased/modified traffic. The number of buffers is increased to cope with the additional load.

Part of #18305, completing the changes to the device and DPI ends of the streams, without adding new tests or altering the behavior of existing tests.