### PR TITLE
[util] Clear strong_random buffer before loading entropy file

### DIFF
--- a/util/topgen/strong_random.py
+++ b/util/topgen/strong_random.py
@@ -35,7 +35,8 @@ class strong_random():
             log.error("Entropy buffer " + input_file +
                       " can't be loaded twice.")
             sys.exit(1)
-
+        # Clear buffer before loading a file.
+        self.buffer.clear()
         with open(input_file, 'r') as fp:
             for line in fp:
                 x = int(line)


### PR DESCRIPTION
Clears entropy buffer before loading entropy from a file. This is necessary in case that unsecure_generate_from_seed() has previously filled the buffer with unsecured data.