### PR TITLE
[dv] fix rom_e2e tests in nightlies

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -41,8 +41,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -57,8 +57,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -73,8 +73,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -89,8 +89,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -105,8 +105,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -121,8 +121,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -137,8 +137,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -153,8 +153,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -169,8 +169,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -185,8 +185,8 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -201,8 +201,8 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -217,8 +217,8 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -233,8 +233,8 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -249,8 +249,8 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -265,8 +265,8 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -281,8 +281,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -297,8 +297,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_dev
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -313,8 +313,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -329,8 +329,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -345,8 +345,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_rma
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -362,7 +362,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -378,7 +378,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -394,7 +394,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -410,7 +410,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -426,7 +426,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -442,7 +442,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:rsa_fake_test_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -458,7 +458,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:rsa_fake_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -474,7 +474,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -490,7 +490,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -506,7 +506,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -521,7 +521,7 @@
       name: rom_e2e_asm_init_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -535,7 +535,7 @@
       name: rom_e2e_asm_init_dev
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -549,7 +549,7 @@
       name: rom_e2e_asm_init_prod
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -563,7 +563,7 @@
       name: rom_e2e_asm_init_prod_end
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -577,7 +577,7 @@
       name: rom_e2e_asm_init_rma
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_e2e_bootstrap_entry_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -727,7 +727,7 @@
       name: rom_e2e_sigverify_mod_exp_test_unlocked0_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -741,7 +741,7 @@
       name: rom_e2e_sigverify_mod_exp_test_unlocked0_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_test_unlocked0_sw:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -755,7 +755,7 @@
       name: rom_e2e_sigverify_mod_exp_dev_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -769,7 +769,7 @@
       name: rom_e2e_sigverify_mod_exp_dev_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_dev_sw:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -783,7 +783,7 @@
       name: rom_e2e_sigverify_mod_exp_prod_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -797,7 +797,7 @@
       name: rom_e2e_sigverify_mod_exp_prod_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_sw:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -811,7 +811,7 @@
       name: rom_e2e_sigverify_mod_exp_prod_end_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -825,7 +825,7 @@
       name: rom_e2e_sigverify_mod_exp_prod_end_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_prod_end_sw:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -839,7 +839,7 @@
       name: rom_e2e_sigverify_mod_exp_rma_otbn
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]
@@ -853,7 +853,7 @@
       name: rom_e2e_sigverify_mod_exp_rma_sw
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:fake_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_sigverify_mod_exp:1:ot_flash_binary:signed:rsa_fake_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_sw:4",
       ]
       en_run_modes: ["sw_test_mode_rom"]

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -418,15 +418,15 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           // suffix to the image name.
           if ("signed" inside {sw_image_flags[i]}) begin
             // Options match DEFAULT_SIGNING_KEYS in `rules/opentitan.bzl`.
-            if ("fake_dev_key_0" inside {sw_image_flags[i]}) begin
-              sw_images[i] = $sformatf("%0s.fake_dev_key_0.signed", sw_images[i]);
-            end else if ("fake_prod_key_0" inside {sw_image_flags[i]}) begin
-              sw_images[i] = $sformatf("%0s.fake_prod_key_0.signed", sw_images[i]);
+            if ("rsa_fake_dev_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.rsa_fake_dev_key_0.signed", sw_images[i]);
+            end else if ("rsa_fake_prod_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.rsa_fake_prod_key_0.signed", sw_images[i]);
             end else begin
               // We default to "fake_test_key_0" if no key name is provided in the
               // SW image tags (or if the key name provided is "fake_test_key_0"),
               // as this works in the RMA LC state, which is the default OTP image.
-              sw_images[i] = $sformatf("%0s.fake_test_key_0.signed", sw_images[i]);
+              sw_images[i] = $sformatf("%0s.rsa_fake_test_key_0.signed", sw_images[i]);
             end
           end
         end else if (i == SwTypeOtp) begin


### PR DESCRIPTION
After #18219 renamed the signed VMEM files, the nightly regressions broke since the testbench expects the VMEM files to have a specific name. This fixes the names of said files in the testbench.