### PR TITLE
[rtl, top] Use lowRISC ID and seperate IDCODES per TAP

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1536,7 +1536,7 @@
         SecVolatileRawUnlockEn: top_pkg::SecVolatileRawUnlockEn
         ChipGen: 16'h 0000
         ChipRev: 16'h 0000
-        IdcodeValue: jtag_id_pkg::JTAG_IDCODE
+        IdcodeValue: jtag_id_pkg::LC_CTRL_JTAG_IDCODE
       }
       clock_connections:
       {
@@ -1628,7 +1628,7 @@
           name: IdcodeValue
           desc: JTAG ID code.
           type: logic [31:0]
-          default: jtag_id_pkg::JTAG_IDCODE
+          default: jtag_id_pkg::LC_CTRL_JTAG_IDCODE
           expose: "true"
           name_top: LcCtrlIdcodeValue
         }
@@ -5123,7 +5123,7 @@
       }
       param_decl:
       {
-        IdcodeValue: jtag_id_pkg::JTAG_IDCODE
+        IdcodeValue: jtag_id_pkg::RV_DM_JTAG_IDCODE
       }
       base_addrs:
       {
@@ -5145,7 +5145,7 @@
           name: IdcodeValue
           desc: RISC-V debug module JTAG ID code.
           type: logic [31:0]
-          default: jtag_id_pkg::JTAG_IDCODE
+          default: jtag_id_pkg::RV_DM_JTAG_IDCODE
           expose: "true"
           name_top: RvDmIdcodeValue
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -310,7 +310,7 @@
         SecVolatileRawUnlockEn: "top_pkg::SecVolatileRawUnlockEn",
         ChipGen: "16'h 0000",
         ChipRev: "16'h 0000",
-        IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
+        IdcodeValue: "jtag_id_pkg::LC_CTRL_JTAG_IDCODE",
       },
     },
     { name: "alert_handler",
@@ -622,7 +622,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
       param_decl: {
-        IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
+        IdcodeValue: "jtag_id_pkg::RV_DM_JTAG_IDCODE",
       }
       // Note that this module also contains a bus host.
       base_addrs: {mem: "0x00010000", regs: "0x41200000"}

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -31,7 +31,7 @@ module top_earlgrey #(
   parameter bit SecLcCtrlVolatileRawUnlockEn = top_pkg::SecVolatileRawUnlockEn,
   parameter logic [15:0] LcCtrlChipGen = 16'h 0000,
   parameter logic [15:0] LcCtrlChipRev = 16'h 0000,
-  parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
+  parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::LC_CTRL_JTAG_IDCODE,
   // parameters for alert_handler
   // parameters for spi_host0
   // parameters for spi_host1
@@ -58,7 +58,7 @@ module top_earlgrey #(
   parameter int FlashCtrlProgFifoDepth = 4,
   parameter int FlashCtrlRdFifoDepth = 16,
   // parameters for rv_dm
-  parameter logic [31:0] RvDmIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
+  parameter logic [31:0] RvDmIdcodeValue = jtag_id_pkg::RV_DM_JTAG_IDCODE,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,

--- a/hw/top_earlgrey/rtl/jtag_id_pkg.sv
+++ b/hw/top_earlgrey/rtl/jtag_id_pkg.sv
@@ -5,13 +5,26 @@
 
 package jtag_id_pkg;
 
-  // This is the open source facing JTAG value that should be replaced
-  // by manufacturers of each OpenTitan
-  localparam logic [31:0] JTAG_IDCODE = {
-    4'h0,     // Version
-    16'h4F54, // Part Number: "OT"
-    11'h426,  // TODO: This should be replaced with Lowrisc Identity
-    1'b1      // (fixed)
+  // lowRISC JEDEC Manufacturer ID, bank 13 0xEF
+  localparam logic [10:0] JEDEC_MANUFACTURER_ID = {4'd12, 7'b110_1111};
+  localparam logic [3:0] JTAG_VERSION = 4'h1;
+
+  // These are the open source facing JTAG values that silicon creators may wish to replace We have
+  // two TAPs, one for rv_dm and the other for lc_ctrl, they each have their own JTAG_IDCODE.  They
+  // only differ in part number.
+
+  localparam logic [31:0] RV_DM_JTAG_IDCODE = {
+    JTAG_VERSION,          // Version
+    16'h1,                 // Part Number
+    JEDEC_MANUFACTURER_ID, // Manufacturer ID
+    1'b1                   // (fixed)
+  };
+
+  localparam logic [31:0] LC_CTRL_JTAG_IDCODE = {
+    JTAG_VERSION,          // Version
+    16'h2,                 // Part Number
+    JEDEC_MANUFACTURER_ID, // Manufacturer ID
+    1'b1                   // (fixed)
   };
 
 endpackage : jtag_id_pkg


### PR DESCRIPTION
Switching to use the lowRISC JEDEC ID and introduce a different part number for RV_DM and LC_CTRL JTAG_IDCODE as discussed in the silicon meeting.