### PR TITLE
[ci] Add warning to check-generated.sh

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,9 @@ jobs:
   - bash:  ci/scripts/check_bazel_target_names.py
     displayName: Check Bazel target names (Experimental)
     continueOnError: True
-  - bash: ci/scripts/check-generated.sh
+  # Define OT_DESTRUCTIVE=1 to enable ci/scripts/check-generated.sh to delete
+  # uncommitted changes.
+  - bash: OT_DESTRUCTIVE=1 ci/scripts/check-generated.sh
     displayName: Check Generated
     # Ensure all generated files are clean and up-to-date
   - bash: ci/bazelisk.sh test //quality:buildifier_check --test_output=streamed


### PR DESCRIPTION
I just accidentally trashed some local work because I didn't realize `ci/scripts/check-generated.sh` would run `git clean`. This PR adds a safeguard in front of the destructive behavior.