### PR TITLE
[dv/clkmgr] Clean up compilation warnings

### DIFF
--- a/hw/ip/clkmgr/dv/cov/clkmgr_cov_bind.sv
+++ b/hw/ip/clkmgr/dv/cov/clkmgr_cov_bind.sv
@@ -5,9 +5,21 @@
 // Description:
 // Clock manager coverage bindings for multi bus input
 module clkmgr_cov_bind;
-  bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_idle_mubi_cov_if (
+  bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_idle_0_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (idle_i)
+    .mubi   (idle_i[0])
+  );
+  bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_idle_1_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (idle_i[1])
+  );
+  bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_idle_2_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (idle_i[2])
+  );
+  bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_idle_3_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (idle_i[3])
   );
 
   bind clkmgr cip_lc_tx_cov_if u_lc_hw_debug_en_mubi_cov_if (

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -372,7 +372,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   // This checks that when calibration is lost regwen should be re-enabled and measurements
   // disabled.
   task calibration_lost_checks();
-    ral.measure_ctrl_regwen.predict(1);
+    void'(ral.measure_ctrl_regwen.predict(1));
     csr_rd_check(.ptr(ral.measure_ctrl_regwen), .compare_value(1));
     foreach (ExpectedCounts[clk]) begin
       clk_mesr_e clk_mesr = clk_mesr_e'(clk);


### PR DESCRIPTION
Fix bind of cip_mubi_cov_if to `idle_i`: idle_i is a vector of 4 individual mubi4, so this binds one cip_mubi_cov_if to each.
Cast to void a ral predict call, as is common practice in DV.

Fixes #18430