### PR TITLE
[chip,dv] Add proper initial value to 'select_jtag'

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_lc_disabled_vseq.sv
@@ -38,7 +38,7 @@ class chip_rv_dm_lc_disabled_vseq extends chip_stub_cpu_base_vseq;
 
   virtual task pre_start();
     // Select RV_DM TAP via the TAP straps.
-    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    cfg.select_jtag = JtagTapRvDm;
     super.pre_start();
     max_outstanding_accesses = 1;
   endtask


### PR DESCRIPTION
Fix issue #18450
chip_rv_dm_lc_disabled_vseq didn't have select_jtag value. It has to be set to proper value before it drives tap_starts for all chip_stub_cpu inhereted tests.