### PR TITLE
[i2c target] Add I2C target tests 

### DIFF
--- a/hw/top_earlgrey/data/pins_cw310.xdc
+++ b/hw/top_earlgrey/data/pins_cw310.xdc
@@ -43,8 +43,8 @@ set_property -dict { PACKAGE_PIN R26  IOSTANDARD LVCMOS33 } [get_ports { IOA5 }]
 # GPIO (PMOD1)
 set_property -dict { PACKAGE_PIN R25  IOSTANDARD LVCMOS33 } [get_ports { IOA6 }]; # PMOD1_IO5 (INT)
 # I2C (PMOD1)
-set_property -dict { PACKAGE_PIN P23  IOSTANDARD LVCMOS33 } [get_ports { IOA7 }]; # PMOD1_IO7 (SCL)
-set_property -dict { PACKAGE_PIN T23  IOSTANDARD LVCMOS33 }  [get_ports { IOA8 }]; # PMOD1_IO8 (SDA)
+set_property -dict { PACKAGE_PIN T23  IOSTANDARD LVCMOS33 } [get_ports { IOA7 }]; # PMOD1_IO8 (SDA)
+set_property -dict { PACKAGE_PIN P23  IOSTANDARD LVCMOS33 } [get_ports { IOA8 }]; # PMOD1_IO7 (SCL)
 
 ## IOB bank
 # Aux SPI host

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -521,12 +521,12 @@ interface chip_if;
 
   // {ioa7, ioa8}, {iob9, iob10}, {iob11, iob12} are the i2c connections
   localparam int AssignedI2cSclIos [NUM_I2CS]  = {
-    top_earlgrey_pkg::MioPadIoa7,
+    top_earlgrey_pkg::MioPadIoa8,
     top_earlgrey_pkg::MioPadIob9,
     top_earlgrey_pkg::MioPadIob11
   };
   localparam int AssignedI2cSdaIos [NUM_I2CS] = {
-    top_earlgrey_pkg::MioPadIoa8,
+    top_earlgrey_pkg::MioPadIoa7,
     top_earlgrey_pkg::MioPadIob10,
     top_earlgrey_pkg::MioPadIob12
   };

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -42,10 +42,16 @@ const i2c_connect_conf_t i2c_conf[] = {
     {.pins_mio_out = {kTopEarlgreyPinmuxMioOutIoa7,
                       kTopEarlgreyPinmuxMioOutIoa8},
      .pins_insel = {kTopEarlgreyPinmuxInselIoa7, kTopEarlgreyPinmuxInselIoa8},
-     .pins_peripheral_in = {kTopEarlgreyPinmuxPeripheralInI2c0Scl,
-                            kTopEarlgreyPinmuxPeripheralInI2c0Sda},
-     .pins_outsel = {kTopEarlgreyPinmuxOutselI2c0Scl,
-                     kTopEarlgreyPinmuxOutselI2c0Sda}},
+     .pins_peripheral_in =
+         {
+             kTopEarlgreyPinmuxPeripheralInI2c0Sda,
+             kTopEarlgreyPinmuxPeripheralInI2c0Scl,
+         },
+     .pins_outsel =
+         {
+             kTopEarlgreyPinmuxOutselI2c0Sda,
+             kTopEarlgreyPinmuxOutselI2c0Scl,
+         }},
     {.pins_mio_out = {kTopEarlgreyPinmuxMioOutIob9,
                       kTopEarlgreyPinmuxMioOutIob10},
      .pins_insel = {kTopEarlgreyPinmuxInselIob9, kTopEarlgreyPinmuxInselIob10},

--- a/sw/device/lib/testing/json/BUILD
+++ b/sw/device/lib/testing/json/BUILD
@@ -30,6 +30,13 @@ cc_library(
 )
 
 cc_library(
+    name = "i2c_target",
+    srcs = ["i2c_target.c"],
+    hdrs = ["i2c_target.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "pinmux",
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -14,6 +14,9 @@ extern "C" {
     value(_, ChipStartup) \
     value(_, GpioSet) \
     value(_, GpioGet) \
+    value(_, I2cTargetAddress) \
+    value(_, I2cReadTransaction) \
+    value(_, I2cWriteTransaction) \
     value(_, PinmuxConfig) \
     value(_, SpiConfigureJedecId) \
     value(_, SpiReadStatus) \

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -17,6 +17,7 @@ extern "C" {
     value(_, I2cTargetAddress) \
     value(_, I2cReadTransaction) \
     value(_, I2cWriteTransaction) \
+    value(_, I2cWriteTransactionSlow) \
     value(_, PinmuxConfig) \
     value(_, SpiConfigureJedecId) \
     value(_, SpiReadStatus) \

--- a/sw/device/lib/testing/json/i2c_target.c
+++ b/sw/device/lib/testing/json/i2c_target.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sw/device/lib/testing/json/i2c_target.h"

--- a/sw/device/lib/testing/json/i2c_target.h
+++ b/sw/device/lib/testing/json/i2c_target.h
@@ -18,9 +18,16 @@ extern "C" {
 UJSON_SERDE_STRUCT(I2cTargetAddress, i2c_target_address_t, STRUCT_I2C_TARGET_ADDRESS);
 
 #define STRUCT_I2C_TRANSACTION(field, string) \
-    field(length, uint16_t) \
+    field(length, uint8_t) \
+    field(address, uint8_t) \
+    field(continuation, uint8_t) \
     field(data, uint8_t, 256)
-UJSON_SERDE_STRUCT(I2cTransaction, i2c_transaction_t, STRUCT_I2C_TARGET_ADDRESS);
+UJSON_SERDE_STRUCT(I2cTransaction, i2c_transaction_t, STRUCT_I2C_TRANSACTION);
+
+#define STRUCT_I2C_RX_RESULT(field, string) \
+    field(address, uint8_t) \
+    field(continuation, uint8_t)
+UJSON_SERDE_STRUCT(I2cRxResult, i2c_rx_result_t, STRUCT_I2C_RX_RESULT);
 
 // clang-format on
 #ifdef __cplusplus

--- a/sw/device/lib/testing/json/i2c_target.h
+++ b/sw/device/lib/testing/json/i2c_target.h
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_I2C_TARGET_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_I2C_TARGET_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+#define STRUCT_I2C_TARGET_ADDRESS(field, string) \
+    field(id0, uint8_t) \
+    field(mask0, uint8_t) \
+    field(id1, uint8_t) \
+    field(mask1, uint8_t)
+UJSON_SERDE_STRUCT(I2cTargetAddress, i2c_target_address_t, STRUCT_I2C_TARGET_ADDRESS);
+
+#define STRUCT_I2C_TRANSACTION(field, string) \
+    field(length, uint16_t) \
+    field(data, uint8_t, 256)
+UJSON_SERDE_STRUCT(I2cTransaction, i2c_transaction_t, STRUCT_I2C_TARGET_ADDRESS);
+
+// clang-format on
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_I2C_TARGET_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2364,8 +2364,8 @@ opentitan_functest(
         "i2c_target_test.c",
     ],
     cw310 = cw310_params(
-        # This test will need hyperdebug once we start using multi-lane
-        # SPI modes.
+        # This test needs hyperdebug to serve as I2C host to OpenTitan's
+        # I2C target device.
         interface = "hyper310",
         tags = ["manual"],
         test_cmds = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2357,3 +2357,35 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "i2c_target_test",
+    srcs = [
+        "i2c_target_test.c",
+    ],
+    cw310 = cw310_params(
+        # This test will need hyperdebug once we start using multi-lane
+        # SPI modes.
+        interface = "hyper310",
+        tags = ["manual"],
+        test_cmds = [
+            "--rom-kind=testrom",
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
+    targets = [
+        "cw310_test_rom",
+    ],
+    test_harness = "//sw/host/tests/chip/i2c_target",
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/testing:i2c_testutils",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:i2c_target",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+    ],
+)

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/lib/testing/json/i2c_target.h"
+
+#include <assert.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/i2c_testutils.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "i2c_regs.h"  // Generated.
+
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "This test assumes the target platform is little endian.");
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_pinmux_t pinmux;
+static dif_i2c_t i2c;
+
+status_t configure_device_address(ujson_t *uj, dif_i2c_t *i2c) {
+  i2c_target_address_t address;
+  TRY(ujson_deserialize_i2c_target_address_t(uj, &address));
+  TRY(dif_i2c_device_set_enabled(i2c, kDifToggleDisabled));
+  dif_i2c_id_t id0 = {
+      .mask = address.mask0,
+      .address = address.id0,
+  };
+  dif_i2c_id_t id1 = {
+      .mask = address.mask1,
+      .address = address.id1,
+  };
+  TRY(dif_i2c_set_device_id(i2c, &id0, &id1));
+  TRY(dif_i2c_device_set_enabled(i2c, kDifToggleEnabled));
+  return RESP_OK_STATUS(uj);
+}
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandI2cTargetAddress:
+        RESP_ERR(uj, configure_device_address(uj, &i2c));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  // We should never reach here.
+  return INTERNAL();
+}
+
+static status_t test_init(void) {
+  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  TRY(dif_i2c_init(base_addr, &i2c));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
+  TRY(dif_pinmux_init(base_addr, &pinmux));
+
+  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+
+  TRY(dif_i2c_device_set_enabled(&i2c, kDifToggleEnabled));
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t test_result;
+  CHECK_STATUS_OK(test_init());
+
+  ujson_t uj = ujson_ottf_console();
+  status_t s = command_processor(&uj);
+  LOG_INFO("status = %r", s);
+  return status_ok(s);
+}

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -396,17 +396,17 @@ static void configure_pinmux(void) {
                                         kTopEarlgreyPinmuxOutselUart3Tx));
 
   // I2C0:
-  //    SCL on IOA7
-  //    SDA on IOA8
+  //    SDA on IOA7
+  //    SCL on IOA8
   CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
                                        kTopEarlgreyPinmuxPeripheralInI2c0Scl,
-                                       kTopEarlgreyPinmuxInselIoa7));
+                                       kTopEarlgreyPinmuxInselIoa8));
   CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
                                        kTopEarlgreyPinmuxPeripheralInI2c0Sda,
-                                       kTopEarlgreyPinmuxInselIoa8));
-  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIoa7,
-                                        kTopEarlgreyPinmuxOutselI2c0Scl));
+                                       kTopEarlgreyPinmuxInselIoa7));
   CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIoa8,
+                                        kTopEarlgreyPinmuxOutselI2c0Scl));
+  CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIoa7,
                                         kTopEarlgreyPinmuxOutselI2c0Sda));
 
   // I2C1:

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -153,15 +153,15 @@ void config_i2c_with_index(void) {
 
       CHECK_DIF_OK(dif_pinmux_input_select(
           &pinmux, kTopEarlgreyPinmuxPeripheralInI2c0Scl,
-          kTopEarlgreyPinmuxInselIoa7));
+          kTopEarlgreyPinmuxInselIoa8));
       CHECK_DIF_OK(dif_pinmux_input_select(
           &pinmux, kTopEarlgreyPinmuxPeripheralInI2c0Sda,
-          kTopEarlgreyPinmuxInselIoa8));
-      CHECK_DIF_OK(dif_pinmux_output_select(&pinmux,
-                                            kTopEarlgreyPinmuxMioOutIoa7,
-                                            kTopEarlgreyPinmuxOutselI2c0Scl));
+          kTopEarlgreyPinmuxInselIoa7));
       CHECK_DIF_OK(dif_pinmux_output_select(&pinmux,
                                             kTopEarlgreyPinmuxMioOutIoa8,
+                                            kTopEarlgreyPinmuxOutselI2c0Scl));
+      CHECK_DIF_OK(dif_pinmux_output_select(&pinmux,
+                                            kTopEarlgreyPinmuxMioOutIoa7,
                                             kTopEarlgreyPinmuxOutselI2c0Sda));
       break;
     case 1:

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -20,6 +20,12 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "i2c_target",
+    srcs = ["//sw/device/lib/testing/json:i2c_target"],
+    defines = ["opentitanlib=crate"],
+)
+
+ujson_rust(
     name = "pinmux_config",
     srcs = ["//sw/device/lib/testing/json:pinmux_config"],
     defines = ["opentitanlib=crate"],
@@ -104,6 +110,7 @@ rust_library(
         "src/test_utils/epmp.rs",
         "src/test_utils/extclk.rs",
         "src/test_utils/gpio.rs",
+        "src/test_utils/i2c_target.rs",
         "src/test_utils/init.rs",
         "src/test_utils/lc_transition.rs",
         "src/test_utils/load_bitstream.rs",
@@ -189,6 +196,7 @@ rust_library(
     compile_data = [
         ":config",
         ":gpio",
+        ":i2c_target",
         ":e2e_command",
         ":pinmux_config",
         ":spi_passthru",
@@ -208,6 +216,7 @@ rust_library(
     rustc_env = {
         "e2e_command": "$(location :e2e_command)",
         "gpio": "$(location :gpio)",
+        "i2c_target": "$(location :i2c_target)",
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+include!(env!("i2c_target"));
+
+impl I2cTargetAddress {
+    pub fn write(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::I2cTargetAddress.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}
+
+impl I2cTransaction {
+    pub fn read(uart: &dyn Uart) -> Result<Self> {
+        TestCommand::I2cReadTransaction.send(uart)?;
+        Self::recv(uart, Duration::from_secs(300), false)
+    }
+
+    pub fn write(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::I2cWriteTransaction.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -23,15 +23,34 @@ impl I2cTargetAddress {
 }
 
 impl I2cTransaction {
-    pub fn read(uart: &dyn Uart) -> Result<Self> {
-        TestCommand::I2cReadTransaction.send(uart)?;
-        Self::recv(uart, Duration::from_secs(300), false)
+    pub fn new(content: &[u8]) -> Self {
+        let mut a = arrayvec::ArrayVec::<u8, 256>::new();
+        a.try_extend_from_slice(content)
+            .expect("fewer than 256 bytes");
+        Self {
+            length: a.len() as u8,
+            address: 0,
+            continuation: 0,
+            data: a,
+        }
     }
 
-    pub fn write(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::I2cWriteTransaction.send(uart)?;
+    pub fn execute_read<F>(&self, uart: &dyn Uart, f: F) -> Result<I2cRxResult>
+    where
+        F: FnOnce() -> Result<()>,
+    {
+        TestCommand::I2cReadTransaction.send(uart)?;
         self.send(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
-        Ok(())
+        f()?;
+        I2cRxResult::recv(uart, Duration::from_secs(300), false)
+    }
+
+    pub fn execute_write<F>(uart: &dyn Uart, command: TestCommand, f: F) -> Result<Self>
+    where
+        F: FnOnce() -> Result<()>,
+    {
+        command.send(uart)?;
+        f()?;
+        Self::recv(uart, Duration::from_secs(300), false)
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -7,6 +7,7 @@ pub mod e2e_command;
 pub mod epmp;
 pub mod extclk;
 pub mod gpio;
+pub mod i2c_target;
 pub mod init;
 pub mod lc_transition;
 pub mod load_bitstream;

--- a/sw/host/tests/chip/i2c_target/BUILD
+++ b/sw/host/tests/chip/i2c_target/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "i2c_target",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde_json",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -8,10 +8,10 @@ use structopt::StructOpt;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::i2c::Transfer;
+use opentitanlib::test_utils::e2e_command::TestCommand;
+use opentitanlib::test_utils::i2c_target::{I2cTargetAddress, I2cTransaction};
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::i2c_target::{
-    I2cTargetAddress, I2cTransaction,
-};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, StructOpt)]
@@ -34,18 +34,73 @@ struct Opts {
     i2c: String,
 }
 
+// A data pattern to send across the I2C bus:
+// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
+const GETTYSBURG: &str = r#"Four score and seven years ago our fathers brought forth on this
+continent, a new nation, conceived in Liberty, and dedicated to the
+proposition that all men are created equal."#;
+
 fn test_set_target_address(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     //let i2c = transport.i2c(&opts.i2c)?;
     let address = I2cTargetAddress {
-        // Respond to address 0x50.
-        id0: 0x50,
+        // Respond to address 0x33.
+        id0: 0x33,
         mask0: 0x7f,
         // Respond to addressess 0x70-0x73.
         id1: 0x70,
         mask1: 0x7c,
     };
     address.write(&*uart)?;
+    Ok(())
+}
+
+fn test_read_transaction(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let i2c = transport.i2c(&opts.i2c)?;
+
+    log::info!("Testing read transaction at I2C address {address:02x}");
+    let txn = I2cTransaction::new(b"Hello");
+    let mut result = vec![0u8; txn.length as usize];
+    let rx_result = txn.execute_read(&*uart, || {
+        i2c.run_transaction(address, &mut [Transfer::Read(&mut result)])
+    })?;
+    assert_eq!(result.as_slice(), txn.data.as_slice());
+    assert_eq!(rx_result.address, address);
+    assert_eq!(rx_result.continuation, 0);
+    Ok(())
+}
+
+fn test_write_transaction(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let i2c = transport.i2c(&opts.i2c)?;
+    log::info!("Testing write transaction at I2C address {address:02x}");
+    let result = I2cTransaction::execute_write(&*uart, TestCommand::I2cWriteTransaction, || {
+        i2c.run_transaction(address, &mut [Transfer::Write(b"Hello World")])
+    })?;
+    let len = result.length as usize;
+    assert_eq!(&result.data[0..len], b"Hello World");
+    assert_eq!(result.address, address);
+    assert_eq!(result.continuation, 0);
+    Ok(())
+}
+
+fn test_write_transaction_slow(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    address: u8,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let i2c = transport.i2c(&opts.i2c)?;
+    log::info!("Testing slow write transaction at I2C address {address:02x}");
+    let result =
+        I2cTransaction::execute_write(&*uart, TestCommand::I2cWriteTransactionSlow, || {
+            i2c.run_transaction(address, &mut [Transfer::Write(GETTYSBURG.as_bytes())])
+        })?;
+    let len = result.length as usize;
+    assert_eq!(&result.data[0..len], GETTYSBURG.as_bytes());
+    assert_eq!(result.address, address);
+    assert_eq!(result.continuation, 0);
     Ok(())
 }
 
@@ -60,5 +115,12 @@ fn main() -> Result<()> {
     uart.clear_rx_buffer()?;
 
     execute_test!(test_set_target_address, &opts, &transport);
+    execute_test!(test_read_transaction, &opts, &transport, 0x33);
+    execute_test!(test_read_transaction, &opts, &transport, 0x70);
+    execute_test!(test_read_transaction, &opts, &transport, 0x71);
+    execute_test!(test_read_transaction, &opts, &transport, 0x72);
+    execute_test!(test_read_transaction, &opts, &transport, 0x73);
+    execute_test!(test_write_transaction, &opts, &transport, 0x33);
+    execute_test!(test_write_transaction_slow, &opts, &transport, 0x33);
     Ok(())
 }

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::i2c_target::{
+    I2cTargetAddress, I2cTransaction,
+};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(
+        long, parse(try_from_str=humantime::parse_duration),
+        default_value = "600s",
+        help = "Console receive timeout",
+    )]
+    timeout: Duration,
+
+    #[structopt(
+        long,
+        default_value = "0",
+        help = "Name of the debugger's I2C interface"
+    )]
+    i2c: String,
+}
+
+fn test_set_target_address(_opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    //let i2c = transport.i2c(&opts.i2c)?;
+    let address = I2cTargetAddress {
+        // Respond to address 0x50.
+        id0: 0x50,
+        mask0: 0x7f,
+        // Respond to addressess 0x70-0x73.
+        id1: 0x70,
+        mask1: 0x7c,
+    };
+    address.write(&*uart)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    uart.clear_rx_buffer()?;
+
+    execute_test!(test_set_target_address, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
1. Assign addresses 0x33 and [0x70..0x73] to the address filter.
2. Check a short I2C read against all valid addresses.
3. Check a short I2C write.
4. Check a long write with a large delay to cause clock stretching.

Signed-off-by: Chris Frantz <cfrantz@google.com>