### PR TITLE
[dv/lc_ctrl] clean up dv code

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -127,7 +127,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
     kmac_pkg::rsp_digest_t kmac_digest;
     // No token for InvalidTokenIdx
     lc_ctrl_state_pkg::lc_token_t tokens_a[NumTokens-1];
-    tokens_a[ZeroTokenIdx]       = 0;
+    tokens_a[ZeroTokenIdx]       = lc_ctrl_state_pkg::AllZeroTokenHashed;
     tokens_a[RawUnlockTokenIdx]  = lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed;
     tokens_a[TestUnlockTokenIdx] = cfg.lc_ctrl_vif.otp_i.test_unlock_token;
     tokens_a[TestExitTokenIdx]   = cfg.lc_ctrl_vif.otp_i.test_exit_token;

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
@@ -52,21 +52,18 @@ class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_smoke_vseq;
   endtask : body
 
   virtual task transition_to_next_valid_state(bit volatile_raw_unlock_success);
+    lc_ctrl_state_pkg::lc_token_t token_val = get_random_token();
     lc_ctrl_pkg::token_idx_e token;
     randomize_next_lc_state(next_state);
     lc_state = encode_lc_state(next_state);
-    token = get_exp_token(dec_lc_state(lc_state), next_lc_state);
     set_hashed_token();
     `uvm_info(`gfn, $sformatf("start another transition after volatile unlock: from %0s to %0s",
               next_state.name,  next_lc_state.name), UVM_LOW)
-    sw_transition_req(next_lc_state, token);
+    sw_transition_req(next_lc_state, token_val);
     csr_spinwait(.ptr(ral.status.transition_successful), .exp_data(1), .timeout_ns(100_000));
   endtask
 
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);
-    bit trigger_alert;
-    bit [TL_DW-1:0] status_val;
-    uvm_reg_data_t val;
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
     if ($urandom_range(0, 1)) csr_wr(ral.transition_ctrl, $urandom_range(0, 1));
     csr_wr(ral.transition_target, {DecLcStateNumRep{next_lc_state[DecLcStateWidth-1:0]}});


### PR DESCRIPTION
1). fix a lc_ctrl dv constant, the zero token value should be hashed. 2). fix lc_ctrl_volatile_test redundant variables and token logic.