### PR TITLE
[opentitanlib] improve SRAM loading and execute functionality 

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2379,6 +2379,11 @@ SRAM_JTAG_INJECTION_GDB_SCRIPT = """
                 "--rom-kind=rom",
                 "--bitstream=\"$(rootpath {bitstream})\"",
                 "--vmem=\"$(rootpath //sw/device/examples/sram_program:sram_program_fpga_cw310_vmem)\"",
+                # the following values come from the sram linker script
+                "--load-addr=0x10001fc4",
+                "--stack-pointer=0x10020000",
+                "--stack-size=1024",
+                "--global-pointer=0x100027C4",  # sram_load_addr + 2048;
             ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
         ),
         data = [

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -133,6 +133,7 @@ pub enum JtagTap {
 pub enum RiscvGpr {
     GP,
     SP,
+    RA,
 }
 
 /// List of useful RISC-V control and status registers

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -99,6 +99,9 @@ pub trait Jtag {
     /// Halt execution.
     fn halt(&self) -> Result<()>;
 
+    /// Wait until the target halt. This does NOT halt the target on timeout.
+    fn wait_halt(&self, timeout: Duration) -> Result<()>;
+
     /// Resume execution at its current code position.
     fn resume(&self) -> Result<()>;
     /// Resume execution at the specified address.

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -300,6 +300,7 @@ impl OpenOcdServer {
             RiscvReg::GprByName(gpr) => match gpr {
                 RiscvGpr::GP => "gp",
                 RiscvGpr::SP => "sp",
+                RiscvGpr::RA => "ra",
             },
             RiscvReg::CsrByName(csr) => match csr {
                 RiscvCsr::DPC => "dpc",

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -445,6 +445,19 @@ impl Jtag for OpenOcdServer {
         Ok(())
     }
 
+    fn wait_halt(&self, timeout: Duration) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
+            JtagError::Tap(self.jtag_tap.get().unwrap())
+        );
+        let cmd = format!("wait_halt {}", timeout.as_millis());
+        let response = self.send_tcl_cmd(cmd.as_str())?;
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+        Ok(())
+    }
+
     fn resume(&self) -> Result<()> {
         ensure!(
             matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),

--- a/sw/host/tests/chip/jtag/src/sram_load.rs
+++ b/sw/host/tests/chip/jtag/src/sram_load.rs
@@ -12,7 +12,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::load_sram_program::SramProgramParams;
+use opentitanlib::test_utils::load_sram_program::{ExecutionMode, SramProgramParams};
 use opentitanlib::uart::console::UartConsole;
 
 // use top_earlgrey::top_earlgrey_memory;
@@ -41,7 +41,8 @@ fn test_sram_load(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     log::info!("Halting core");
     jtag.halt()?;
 
-    opts.sram_program.load_and_execute(&jtag)?;
+    opts.sram_program
+        .load_and_execute(&jtag, ExecutionMode::Jump)?;
 
     const CONSOLE_TIMEOUT: Duration = Duration::from_secs(5);
     let mut console = UartConsole {


### PR DESCRIPTION
This contains several commits from #18330 written by @pamaury that are being used to write other manuf tests as well (namely #17389), hence they are split off into a separate PR so they can be merged sooner to unblock development. These commits improve the SRAM loading / execute testutils in opentitanlib.