### PR TITLE
DO-NOT-MERGE bug reproduce -- lc_walkthrough_testunlock

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -61,13 +61,14 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
       apply_reset();
 
       `uvm_info(`gfn, $sformatf("Current state %0s", curr_state.name), UVM_LOW)
-      wait_lc_ready(.allow_err(1));
       if (curr_state inside {DecLcStTestLocked0, DecLcStTestLocked1, DecLcStTestLocked2,
                              DecLcStTestLocked3, DecLcStTestLocked4, DecLcStTestLocked5,
                              DecLcStTestLocked6}) begin
         switch_to_external_clock();
+      end else begin
+        wait_lc_ready();
       end
-      switch_to_external_clock();
+
       jtag_lc_state_transition(curr_state, dec_lc_state_e'(curr_state + 1), {<<8{lc_unlock_token}});
       apply_reset();
       curr_state = dec_lc_state_e'(curr_state + 2);


### PR DESCRIPTION
@msfschaffner, One of lc state transition test fail because jtag read garbage value for lc_ctrl.status.

cmd:
./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_lc_walkthrough_testunlocks -r 1 -s 4200748378 -v m -w fsdb

![image](https://user-images.githubusercontent.com/99843637/237030298-ead0ede9-a9c7-41a5-b222-7bdb873679cd.png)
From the wave, it looks like jtag running with external clock but it switch to lc_ctrl by pinmux with tb.dut.top_earlgrey.u_lc_ctrl.u_lc_ctrl_fsm.clk_i
And lc_ctrl returns one of idcode_q value as lc_ctrl.status data.

Can you take a look?
