### PR TITLE
[crypto] Add SHA-384 mode and tests.

### DIFF
--- a/sw/device/lib/crypto/impl/sha2/sha512.h
+++ b/sw/device/lib/crypto/impl/sha2/sha512.h
@@ -14,6 +14,18 @@ extern "C" {
 
 enum {
   /**
+   * SHA-384 digest size in bits.
+   */
+  kSha384DigestBits = 384,
+  /**
+   * SHA-384 digest size in bytes.
+   */
+  kSha384DigestBytes = kSha384DigestBits / 8,
+  /**
+   * SHA-384 digest size in words.
+   */
+  kSha384DigestWords = kSha384DigestBytes / sizeof(uint32_t),
+  /**
    * SHA-512 message block size in bits.
    */
   kSha512MessageBlockBits = 1024,
@@ -97,6 +109,78 @@ typedef struct sha512_state {
    */
   sha512_message_length_t total_len;
 } sha512_state_t;
+
+/**
+ * A type that holds the context for an ongoing SHA-384 operation.
+ *
+ * Since SHA-384 uses the same internal process as SHA-512, just with a
+ * different initial value, the context structs are the same.
+ */
+typedef sha512_state_t sha384_state_t;
+
+/**
+ * One-shot SHA-384 hash computation.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param msg Input message
+ * @param msg_len Input message length in bytes
+ * @param[out] digest Output buffer for digest.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha384(const uint8_t *msg, const size_t msg_len, uint8_t *digest);
+
+/**
+ * Set up a SHA-384 hash computation.
+ *
+ * Initializes the hash state; doesn't process anything.
+ *
+ * This interface expects the following sequence of calls:
+ * - one call to sha384_init()
+ * - zero or more calls to sha384_update()
+ * - one call to sha384_final()
+ *
+ * @param[out] state Hash context object to initialize.
+ * @return Result of the operation (OK or error).
+ */
+void sha384_init(sha384_state_t *state);
+
+/**
+ * Process new message data for a SHA-384 hash computation.
+ *
+ * Incorporates the new message data into the hash context.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param state Hash context object; updated in-place.
+ * @param msg Input message.
+ * @param msg_len Input message length in bytes.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha384_update(sha384_state_t *state, const uint8_t *msg,
+                       const size_t msg_len);
+
+/**
+ * Finish a SHA-384 hash computation.
+ *
+ * Incorporates the new message data into the hash context, constructs the
+ * message padding and performs the final hash computation.
+ *
+ * The caller must ensure that at least `kSha384DigestBytes` bytes of space are
+ * available at the location pointed to by `digest`.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param state Hash context object.
+ * @param msg Input message
+ * @param msg_len Input message length in bytes
+ * @param[out] digest Output buffer for digest.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha384_final(sha384_state_t *state, uint8_t *digest);
 
 /**
  * One-shot SHA-512 hash computation.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -223,6 +223,19 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sha384_functest",
+    srcs = ["sha384_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "sha512_functest",
     srcs = ["sha512_functest.c"],
     verilator = verilator_params(

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -1,0 +1,125 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+/**
+ * First test from:
+ * https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA384.pdf
+ */
+static const unsigned char kOneBlockMessage[] = "abc";
+static const size_t kOneBlockMessageLen = 3;
+static const uint8_t kOneBlockExpDigest[] = {
+    0xcb, 0x00, 0x75, 0x3f, 0x45, 0xa3, 0x5e, 0x8b, 0xb5, 0xa0, 0x3d, 0x69,
+    0x9a, 0xc6, 0x50, 0x07, 0x27, 0x2c, 0x32, 0xab, 0x0e, 0xde, 0xd1, 0x63,
+    0x1a, 0x8b, 0x60, 0x5a, 0x43, 0xff, 0x5b, 0xed, 0x80, 0x86, 0x07, 0x2b,
+    0xa1, 0xe7, 0xcc, 0x23, 0x58, 0xba, 0xec, 0xa1, 0x34, 0xc8, 0x25, 0xa7};
+
+/**
+ * Second test from:
+ * https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA384.pdf
+ */
+static const unsigned char kTwoBlockMessage[] =
+    "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjk"
+    "lmnopqklmnopqrlmnopqrsmnopqrstnopqrstu";
+static const size_t kTwoBlockMessageLen = sizeof(kTwoBlockMessage) - 1;
+static const uint8_t kTwoBlockExpDigest[] = {
+    0x09, 0x33, 0x0c, 0x33, 0xf7, 0x11, 0x47, 0xe8, 0x3d, 0x19, 0x2f, 0xc7,
+    0x82, 0xcd, 0x1b, 0x47, 0x53, 0x11, 0x1b, 0x17, 0x3b, 0x3b, 0x05, 0xd2,
+    0x2f, 0xa0, 0x80, 0x86, 0xe3, 0xb0, 0xf7, 0x12, 0xfc, 0xc7, 0xc7, 0x1a,
+    0x55, 0x7e, 0x2d, 0xb9, 0x66, 0xc3, 0xe9, 0xfa, 0x91, 0x74, 0x60, 0x39};
+
+/**
+ * Run a single one-shot SHA-384 test.
+ */
+status_t sha384_test(const unsigned char *msg, const size_t msg_len,
+                     const uint8_t *expected_digest) {
+  // Construct a buffer for the message.
+  crypto_const_uint8_buf_t input_message = {
+      .data = msg,
+      .len = msg_len,
+  };
+
+  // Allocate space for the computed digest.
+  uint8_t actual_digest_data[384 / 8];
+  crypto_uint8_buf_t actual_digest = {
+      .data = (unsigned char *)actual_digest_data,
+      .len = sizeof(actual_digest_data),
+  };
+  TRY_CHECK(otcrypto_hash(input_message, kHashModeSha384, &actual_digest) ==
+            kCryptoStatusOK);
+
+  // Check that the expected and actual digests match.
+  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
+                      ARRAYSIZE(actual_digest_data));
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Run a test using the SHA-384 streaming API.
+ */
+status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
+                               const uint8_t *expected_digest) {
+  hash_context_t ctx;
+  TRY_CHECK(otcrypto_hash_init(&ctx, kHashModeSha384) == kCryptoStatusOK);
+
+  // Send the message 5 bytes at a time.
+  size_t num_updates = msg_len / 5;
+  while (msg_len > 0) {
+    // Construct a buffer for the next update.
+    size_t len = (msg_len <= 5) ? msg_len : 5;
+    crypto_const_uint8_buf_t input_message = {
+        .data = msg,
+        .len = len,
+    };
+    msg += len;
+    msg_len -= len;
+    TRY_CHECK(otcrypto_hash_update(&ctx, input_message) == kCryptoStatusOK);
+  }
+
+  // Allocate space for the computed digest.
+  uint8_t actual_digest_data[384 / 8];
+  crypto_uint8_buf_t actual_digest = {
+      .data = (unsigned char *)actual_digest_data,
+      .len = sizeof(actual_digest_data),
+  };
+  TRY_CHECK(otcrypto_hash_final(&ctx, &actual_digest) == kCryptoStatusOK);
+
+  // Check that the expected and actual digests match.
+  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
+                      ARRAYSIZE(actual_digest_data));
+
+  return OTCRYPTO_OK;
+}
+
+static status_t one_block_test(void) {
+  return sha384_test(kOneBlockMessage, kOneBlockMessageLen, kOneBlockExpDigest);
+}
+
+static status_t two_block_test(void) {
+  return sha384_test(kTwoBlockMessage, kTwoBlockMessageLen, kTwoBlockExpDigest);
+}
+
+static status_t streaming_test(void) {
+  return sha384_streaming_test(kTwoBlockMessage, kTwoBlockMessageLen,
+                               kTwoBlockExpDigest);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Holds the test result.
+static volatile status_t test_result;
+
+bool test_main(void) {
+  test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, one_block_test);
+  EXECUTE_TEST(test_result, two_block_test);
+  EXECUTE_TEST(test_result, streaming_test);
+  return status_ok(test_result);
+}


### PR DESCRIPTION
SHA-384 is just SHA-512 with different initial values and a truncated digest, so it's pretty straightforward to add on top of SHA-512.