### PR TITLE
[crypto] Add C interface for SHA-256 on OTBN.

### DIFF
--- a/sw/device/lib/crypto/impl/sha2/BUILD
+++ b/sw/device/lib/crypto/impl/sha2/BUILD
@@ -7,6 +7,21 @@ package(default_visibility = ["//visibility:public"])
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 
 cc_library(
+    name = "sha256",
+    srcs = ["sha256.c"],
+    hdrs = ["sha256.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:run_sha256",
+    ],
+)
+
+cc_library(
     name = "sha512",
     srcs = ["sha512.c"],
     hdrs = ["sha512.h"],

--- a/sw/device/lib/crypto/impl/sha2/sha256.c
+++ b/sw/device/lib/crypto/impl/sha2/sha256.c
@@ -1,0 +1,329 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/sha2/sha256.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('s', '2', '2')
+
+enum {
+  /**
+   * Maximum number of message chunks that the OTBN app can accept.
+   *
+   * This number is based on the DMEM size limit and usage by the SHA-256 app
+   * itself; see `run_sha256.s` for the detailed calculation.
+   */
+  kSha256MaxMessageChunksPerOtbnRun = 41,
+};
+
+/**
+ * A type to hold message blocks.
+ */
+typedef struct sha256_message_block {
+  uint32_t data[kSha256MessageBlockWords];
+} sha256_message_block_t;
+
+/**
+ * Context object for the OTBN message buffer.
+ */
+typedef struct sha256_otbn_ctx {
+  /**
+   * Number of message blocks currently loaded.
+   */
+  size_t num_blocks;
+} sha256_otbn_ctx_t;
+
+// Initial state for SHA-256 (see FIPS 180-4, section 5.3.3). The SHA-256 OTBN
+// app represents the state with little-endian words and in reverse word-order
+// compared with FIPS 180-4.
+static const uint32_t kSha256InitialState[kSha256StateWords] = {
+    0x5be0cd19, 0x1f83d9ab, 0x9b05688c, 0x510e527f,
+    0xa54ff53a, 0x3c6ef372, 0xbb67ae85, 0x6a09e667,
+};
+static_assert(sizeof(kSha256InitialState) == kSha256StateBytes,
+              "Initial state for SHA-256 has an unexpected size.");
+
+OTBN_DECLARE_APP_SYMBOLS(run_sha256);         // The OTBN SHA-256 app.
+OTBN_DECLARE_SYMBOL_ADDR(run_sha256, state);  // Hash state.
+OTBN_DECLARE_SYMBOL_ADDR(run_sha256, msg);    // Input message.
+OTBN_DECLARE_SYMBOL_ADDR(run_sha256,
+                         num_msg_chunks);  // Message length in blocks.
+
+static const otbn_app_t kOtbnAppSha256 = OTBN_APP_T_INIT(run_sha256);
+static const otbn_addr_t kOtbnVarSha256State =
+    OTBN_ADDR_T_INIT(run_sha256, state);
+static const otbn_addr_t kOtbnVarSha256Msg = OTBN_ADDR_T_INIT(run_sha256, msg);
+static const otbn_addr_t kOtbnVarSha256NumMsgChunks =
+    OTBN_ADDR_T_INIT(run_sha256, num_msg_chunks);
+
+void sha256_init(sha256_state_t *state) {
+  // Set the initial state.
+  hardened_memcpy(state->H, kSha256InitialState, kSha256StateWords);
+  // Set the partial block to 0 (the value is ignored).
+  memset(state->partial_block, 0, kSha256MessageBlockBytes);
+  // Set the message length so far to 0.
+  state->total_len = 0ull;
+}
+
+/**
+ * Pad the block as described in FIPS 180-4, section 5.1.2.
+ *
+ * Padding fills the current block and may require one additional block.
+ *
+ * The length of real data in the partial block should be the byte-length of
+ * the message so far (total_len >> 3) modulo `kSha256MessageBlockBytes`.
+ *
+ * @param total_len Total length of message so far.
+ * @param block Current (partial) block, updated in-place.
+ * @param[out] additional_block Buffer for an additional padding block.
+ * @return Length of padding added in bytes.
+ * @return Result of the operation.
+ */
+static size_t add_padding(const uint64_t total_len,
+                          sha256_message_block_t *block,
+                          sha256_message_block_t *additional_block) {
+  size_t partial_block_len = (total_len >> 3) % kSha256MessageBlockBytes;
+
+  // Get a byte-sized pointer to the end of the real data within the block.
+  unsigned char *data_end = (unsigned char *)block->data + partial_block_len;
+
+  // Fill the remainder of the block with zeroes.
+  size_t padding_len = kSha256MessageBlockBytes - partial_block_len;
+  memset(data_end, 0, padding_len);
+
+  // Set the last byte after the message to 0x80. There must be at least one
+  // unfilled byte in the partial block, since partial_block_len is always <
+  // kSha256MessageBlockBytes.
+  memset(data_end, 0x80, 1);
+
+  sha256_message_block_t *final_block = block;
+  if (partial_block_len + 1 + sizeof(total_len) > kSha256MessageBlockBytes) {
+    // We need the additional block; partial data + 0x80 + 8-byte encoding of
+    // length will not fit in the current block.
+    memset(additional_block, 0, kSha256MessageBlockBytes);
+    padding_len += kSha256MessageBlockBytes;
+    final_block = additional_block;
+  }
+
+  // Set the last 64 bits of the final block to the bit-length in big-endian
+  // form.
+  final_block->data[kSha256MessageBlockWords - 1] =
+      __builtin_bswap32(total_len & UINT32_MAX);
+  final_block->data[kSha256MessageBlockWords - 2] =
+      __builtin_bswap32(total_len >> 32);
+  return padding_len;
+}
+
+/**
+ * Run OTBN to process the data currently in DMEM.
+ *
+ * @param ctx OTBN message buffer context information (updated in place).
+ * @return Result of the operation.
+ */
+static status_t process_message_buffer(sha256_otbn_ctx_t *ctx) {
+  // Write the number of blocks to DMEM.
+  HARDENED_TRY(
+      otbn_dmem_write(1, &ctx->num_blocks, kOtbnVarSha256NumMsgChunks));
+
+  // Run the OTBN program.
+  HARDENED_TRY(otbn_execute());
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Reset the message buffer counter.
+  ctx->num_blocks = 0;
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Add a single message block to the processing buffer.
+ *
+ * Runs OTBN if the maximum number of message blocks has been reached.
+ *
+ * @param ctx OTBN message buffer context information (updated in place).
+ * @param block Block to write.
+ * @return Result of the operation.
+ */
+static status_t process_block(sha256_otbn_ctx_t *ctx,
+                              const sha256_message_block_t *block) {
+  // Calculate the offset within the message buffer.
+  size_t offset = ctx->num_blocks * kSha256MessageBlockBytes;
+  otbn_addr_t dst = kOtbnVarSha256Msg + offset;
+
+  // Copy the message block into DMEM.
+  otbn_dmem_write(kSha256MessageBlockWords, block->data, dst);
+  ctx->num_blocks += 1;
+
+  // If we've reached the maximum number of message chunks for a single run,
+  // then run the OTBN program to update the state in-place. Note that there
+  // is no need to read back and then re-write the state; it'll stay updated
+  // in DMEM for the next run.
+  if (ctx->num_blocks == kSha256MaxMessageChunksPerOtbnRun) {
+    HARDENED_TRY(process_message_buffer(ctx));
+  }
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Update the hash state to include new data, optionally adding padding.
+ *
+ * @param state Context object.
+ * @param msg Input message.
+ * @param msg_len Input message length in bytes.
+ * @param padding_needed Whether to pad the message.
+ * @return Result of the operation.
+ */
+static status_t process_message(sha256_state_t *state, const uint8_t *msg,
+                                size_t msg_len,
+                                hardened_bool_t padding_needed) {
+  // Load the SHA-256 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppSha256));
+
+  // Check the message length. SHA-256 messages must be less than 2^64 bits
+  // long in total.
+  uint64_t msg_bits = ((uint64_t)msg_len) << 3;
+  uint64_t max_msg_bits = UINT64_MAX - state->total_len;
+  if (msg_bits > max_msg_bits) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Calculate the new value of state->total_len. Do NOT update the state yet
+  // (because if we get an OTBN error, it would become out of sync).
+  sha256_state_t new_state;
+  new_state.total_len = state->total_len + msg_bits;
+
+  // Set the initial state if at least one block has been received before now.
+  if (state->total_len >= kSha256MessageBlockBytes) {
+    HARDENED_TRY(
+        otbn_dmem_write(kSha256StateWords, state->H, kOtbnVarSha256State));
+  }
+
+  // Start computing the first block for the hash computation by simply copying
+  // the partial block. We won't use the partial block directly to avoid
+  // contaminating the context object if this operation fails later.
+  sha256_message_block_t block;
+  size_t partial_block_len = (state->total_len >> 3) % kSha256MessageBlockBytes;
+  memcpy(block.data, state->partial_block, partial_block_len);
+
+  // Initialize the context for the OTBN message buffer.
+  sha256_otbn_ctx_t ctx = {.num_blocks = 0};
+
+  // Process the message one block at a time, including partial data if it is
+  // present (which is only possible on the first iteration).
+  while (msg_len >= kSha256MessageBlockBytes - partial_block_len) {
+    size_t available_len = kSha256MessageBlockBytes - partial_block_len;
+    memcpy((unsigned char *)block.data + partial_block_len, msg, available_len);
+    msg += available_len;
+    msg_len -= available_len;
+    HARDENED_TRY(process_block(&ctx, &block));
+    partial_block_len = 0;
+  }
+
+  // Copy remaining mesage data into the working block (after partial data, if
+  // it is present). Because of the loop condition above, this must not be a
+  // full block.
+  memcpy((unsigned char *)block.data + partial_block_len, msg, msg_len);
+
+  // Add padding if necessary.
+  if (padding_needed == kHardenedBoolTrue) {
+    sha256_message_block_t additional_block;
+    size_t padding_len =
+        add_padding(new_state.total_len, &block, &additional_block);
+    // We always fill `block`; process it.
+    HARDENED_TRY(process_block(&ctx, &block));
+    // Check if `additional_block` was used, and process it if so.
+    if (padding_len >= kSha256MessageBlockBytes) {
+      HARDENED_TRY(process_block(&ctx, &additional_block));
+    }
+  }
+
+  // If there are any unprocessed blocks currently in DMEM, run the program one
+  // final time.
+  if (ctx.num_blocks > 0) {
+    HARDENED_TRY(process_message_buffer(&ctx));
+  }
+
+  // Read the final state from OTBN dmem.
+  HARDENED_TRY(
+      otbn_dmem_read(kSha256StateWords, kOtbnVarSha256State, new_state.H));
+
+  // Clear OTBN's memory.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  // At this point, no more errors are possible; it is safe to update the
+  // context object.
+  hardened_memcpy(state->H, new_state.H, kSha256StateWords);
+  hardened_memcpy(state->partial_block, block.data, kSha256MessageBlockWords);
+  state->total_len = new_state.total_len;
+  return OTCRYPTO_OK;
+}
+
+status_t sha256_update(sha256_state_t *state, const uint8_t *msg,
+                       const size_t msg_len) {
+  // Process new data with no padding.
+  return process_message(state, msg, msg_len, kHardenedBoolFalse);
+}
+
+/**
+ * Replace sensitive data in a SHA-256 context with non-sensitive values.
+ *
+ * @param state The context object to shred.
+ */
+static void state_shred(sha256_state_t *state) {
+  hardened_memshred(state->H, kSha256StateWords);
+  hardened_memshred(state->partial_block, kSha256MessageBlockWords);
+  state->total_len = 0;
+}
+
+/**
+ * Copy the final digest as a byte-string.
+ *
+ * SHA-256 intermediate computations use words in little-endian format, but the
+ * FIPS 180-4 spec requires big-endian words (see section 3.1). Therefore, to
+ * get the right final byte-order, we need to reverse each word in the state.
+ *
+ * Also, in the SHA-256 computation, the order of the words is reversed
+ * compared to FIPS 180-4, so we switch the word order as well.
+ *
+ * @param state Context object.
+ * @param[out] digest Destination buffer for digest.
+ */
+static void digest_get(sha256_state_t *state, uint8_t *digest) {
+  for (size_t i = 0; i < kSha256StateWords / 2; i++) {
+    uint32_t tmp = __builtin_bswap32(state->H[i]);
+    state->H[i] = __builtin_bswap32(state->H[kSha256StateWords - 1 - i]);
+    state->H[kSha256StateWords - 1 - i] = tmp;
+  }
+  // TODO(#17711): this can be `hardened_memcpy` if `digest` is aligned.
+  memcpy(digest, state->H, kSha256StateBytes);
+}
+
+status_t sha256_final(sha256_state_t *state, uint8_t *digest) {
+  // Construct padding.
+  HARDENED_TRY(process_message(state, NULL, 0, kHardenedBoolTrue));
+
+  // Retrieve the final digest and destroy the state.
+  digest_get(state, digest);
+  state_shred(state);
+  return OTCRYPTO_OK;
+}
+
+status_t sha256(const uint8_t *msg, const size_t msg_len, uint8_t *digest) {
+  sha256_state_t state;
+  sha256_init(&state);
+
+  // Process data with padding enabled.
+  HARDENED_TRY(process_message(&state, msg, msg_len, kHardenedBoolTrue));
+
+  // Retrieve the final digest and destroy the state.
+  digest_get(&state, digest);
+  state_shred(&state);
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/sha2/sha256.h
+++ b/sw/device/lib/crypto/impl/sha2/sha256.h
@@ -1,0 +1,150 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_SHA2_SHA256_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_SHA2_SHA256_H_
+
+#include "stdint.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * SHA-256 message block size in bits.
+   */
+  kSha256MessageBlockBits = 512,
+  /**
+   * SHA-256 message block size in bytes.
+   */
+  kSha256MessageBlockBytes = kSha256MessageBlockBits / 8,
+  /**
+   * SHA-256 message block size in words.
+   */
+  kSha256MessageBlockWords = kSha256MessageBlockBytes / sizeof(uint32_t),
+  /**
+   * SHA-256 state buffer size in bits.
+   */
+  kSha256StateBits = 256,
+  /**
+   * SHA-256 state buffer size in bytes.
+   */
+  kSha256StateBytes = kSha256StateBits / 8,
+  /**
+   * SHA-256 state buffer size in words.
+   */
+  kSha256StateWords = kSha256StateBytes / sizeof(uint32_t),
+  /**
+   * SHA-256 digest size in bits.
+   */
+  kSha256DigestBits = 256,
+  /**
+   * SHA-256 digest size in bytes.
+   */
+  kSha256DigestBytes = kSha256DigestBits / 8,
+  /**
+   * SHA-256 digest size in words.
+   */
+  kSha256DigestWords = kSha256DigestBytes / sizeof(uint32_t),
+};
+
+/**
+ * A type that holds the context for an ongoing SHA-256 operation.
+ *
+ * IMPORTANT: Every member of this struct should be a word-aligned type and
+ * have a size divisible by `sizeof(uint32_t)`; otherwise `sha256_state_t` will
+ * not be suitable for `hardened_memcpy()`.
+ */
+typedef struct sha256_state {
+  /**
+   * Working state for a SHA-256 or SHA-384 computation.
+   */
+  uint32_t H[kSha256StateWords];
+  /**
+   * Partial block, if any.
+   *
+   * If we get an update() with a message that isn't an even number of blocks,
+   * there's no way to know if we should pad it or not until we get the next
+   * update() or final(). The length of actual data in this block is always
+   * (total_len % kSha256MessageBlockBytes) bytes.
+   */
+  uint32_t partial_block[kSha256MessageBlockWords];
+  /**
+   * Total message length so far, in bits.
+   */
+  uint64_t total_len;
+} sha256_state_t;
+
+/**
+ * One-shot SHA-256 hash computation.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param msg Input message
+ * @param msg_len Input message length in bytes
+ * @param[out] digest Output buffer for digest.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha256(const uint8_t *msg, const size_t msg_len, uint8_t *digest);
+
+/**
+ * Set up a SHA-256 hash computation.
+ *
+ * Initializes the hash state; doesn't process anything.
+ *
+ * This interface expects the following sequence of calls:
+ * - one call to sha256_init()
+ * - zero or more calls to sha256_update()
+ * - one call to sha256_final()
+ *
+ * @param[out] state Hash context object to initialize.
+ * @return Result of the operation (OK or error).
+ */
+void sha256_init(sha256_state_t *state);
+
+/**
+ * Process new message data for a SHA-256 hash computation.
+ *
+ * Incorporates the new message data into the hash context.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param state Hash context object; updated in-place.
+ * @param msg Input message.
+ * @param msg_len Input message length in bytes.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha256_update(sha256_state_t *state, const uint8_t *msg,
+                       const size_t msg_len);
+
+/**
+ * Finish a SHA-256 hash computation.
+ *
+ * Incorporates the new message data into the hash context, constructs the
+ * message padding and performs the final hash computation.
+ *
+ * The caller must ensure that at least `kSha256DigestBytes` bytes of space are
+ * available at the location pointed to by `digest`.
+ *
+ * Returns OTCRYPTO_ASYNC_INCOMPLETE if OTBN is busy.
+ *
+ * @param state Hash context object.
+ * @param msg Input message
+ * @param msg_len Input message length in bytes
+ * @param[out] digest Output buffer for digest.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t sha256_final(sha256_state_t *state, uint8_t *digest);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_SHA2_SHA256_H_

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -257,6 +257,16 @@ otbn_library(
     ],
 )
 
+otbn_binary(
+    name = "run_sha256",
+    srcs = [
+        "run_sha256.s",
+    ],
+    deps = [
+        ":sha256",
+    ],
+)
+
 otbn_library(
     name = "sha512",
     srcs = [

--- a/sw/otbn/crypto/run_sha256.s
+++ b/sw/otbn/crypto/run_sha256.s
@@ -1,0 +1,67 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+main:
+  /* Load the number of message chunks.
+       x30 <= dmem[num_msg_chunks] */
+  la     x2, num_msg_chunks
+  lw     x30, 0(x2)
+
+  /* Run the sha256 process and update the state.
+       dmem[state] = sha256(dmem[state], dmem[msg..msg+x30*64] */
+  la     x10, msg
+  jal    x1, sha256
+
+  ecall
+
+.bss
+
+/* Length of message (in chunks). */
+.balign 4
+.globl num_msg_chunks
+num_msg_chunks:
+.zero 4
+
+/**
+ * Input message (must already be padded).
+ *
+ * The message size is limited by available DMEM space. Out of a bus-accessible
+ * 3kiB, SHA-256 uses:
+ *  - 64*4 = 256 bytes for round constants
+ *  - 32 bytes for hash state
+ *  - 32 bytes for the byte-mask constant
+ *
+ * We need an additional 32 bytes for the message-length parameter (it's only 4
+ * bytes, but all other data needs 32-byte alignment). That leaves 2648 bytes
+ * for the message, or 41 64-byte message chunks.
+ */
+.balign 32
+.globl msg
+msg:
+.zero 2648
+
+.data
+
+/**
+ * Starting hash state.
+ *
+ * Represented in big-endian order to match FIPS 180-4, so the first word in
+ * this sequence is H[7] and the last is H[0].
+ *
+ * Defaults to the initial SHA-256 hash state. To save and later resume a
+ * partial hash computation, read the state and overwrite this buffer on the
+ * next call with the saved state.
+ */
+.balign 32
+.globl state
+state:
+.word 0x5be0cd19
+.word 0x1f83d9ab
+.word 0x9b05688c
+.word 0x510e527f
+.word 0xa54ff53a
+.word 0x3c6ef372
+.word 0xbb67ae85
+.word 0x6a09e667

--- a/sw/otbn/crypto/tests/sha256_test.s
+++ b/sw/otbn/crypto/tests/sha256_test.s
@@ -35,21 +35,21 @@ main:
 /* Message (already padded). */
 .balign 32
 msg:
-.word 0x61626364
-.word 0x62636465
-.word 0x63646566
-.word 0x64656667
-.word 0x65666768
-.word 0x66676869
-.word 0x6768696A
-.word 0x68696A6B
-.word 0x696A6B6C
-.word 0x6A6B6C6D
-.word 0x6B6C6D6E
-.word 0x6C6D6E6F
-.word 0x6D6E6F70
-.word 0x6E6F7071
-.word 0x80000000
+.word 0x64636261
+.word 0x65646362
+.word 0x66656463
+.word 0x67666564
+.word 0x68676665
+.word 0x69686766
+.word 0x6A696867
+.word 0x6B6A6968
+.word 0x6C6B6A69
+.word 0x6D6C6B6A
+.word 0x6E6D6C6B
+.word 0x6F6E6D6C
+.word 0x706F6E6D
+.word 0x71706F6E
+.word 0x00000080
 .word 0x00000000
 .word 0x00000000
 .word 0x00000000
@@ -66,7 +66,7 @@ msg:
 .word 0x00000000
 .word 0x00000000
 .word 0x00000000
-.word 0x000001C0
+.word 0xC0010000
 
 /**
  * Starting hash state (initial values for SHA-256).


### PR DESCRIPTION
The broad strokes are fairly similar to SHA-512, but there are some differences in how the two OTBN apps expect their input data to be formatted. I made a small change here on the OTBN side, allowing the message to be written in big-endian form. This matches FIPS and the message can be switched to little-endian more efficiently on OTBN than Ibex (about 1 instruction / 32b word, in fact).

Right now the state is little-endian on OTBN and in reversed word-order compared to FIPS. Changing the word order could be a good optimization, but I'll leave it for a follow-up since it's a bit involved. I think the little-endian words are worth it, though, even though it means swapping bytes on Ibex during `digest_get()` . Otherwise, the words would need to be swapped to big-endian and back on every `update()`, which would be more costly for multiple updates.