### PR TITLE
[hw,i2c,dv] Update task to drive SDA signal

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -274,8 +274,8 @@ interface i2c_if(
 
   task automatic host_data(ref timing_cfg_t tc, input bit bit_i);
     wait(scl_i === 1'b0);
-    sda_o = bit_i;
     wait_for_dly(tc.tClockLow);
+    sda_o = bit_i;
     wait_for_dly(tc.tSetupBit);
     wait(scl_i === 1'b1);
     wait_for_dly(tc.tClockPulse);


### PR DESCRIPTION
In the current implementation of `host_data` task, `sda` is toggled at the negedge of `scl` which can cause glitches and is not allowed as per I2C protocol.

SDA should be held for `thd_dat` cycles from negedge of SCL

Update task to drive SDA after SCL negedge

i2c timing diagram for reference
![image](https://github.com/lowRISC/opentitan/assets/124047397/c01e3fc1-01c7-409c-a43c-114f16a317d2)

This PR resolves #18315  and #18410 
