### PR TITLE
[opentitanlib] Add utility for programming and reading OTP parameters

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -483,3 +483,38 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+otp_image(
+    name = "otp_img_otp_ctrl_functest",
+    src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
+    visibility = ["//visibility:private"],
+)
+
+bitstream_splice(
+    name = "bitstream_otp_ctrl_functest",
+    src = "//hw/bitstream:rom",
+    data = "otp_img_otp_ctrl_functest",
+    meminfo = "//hw/bitstream:otp_mmi",
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+
+opentitan_functest(
+    name = "otp_ctrl_functest",
+    srcs = ["//sw/device/silicon_creator/manuf/lib:empty_functest.c"],
+    cw310 = cw310_params(
+        bitstream = ":bitstream_otp_ctrl_functest",
+        tags = ["jtag"],
+        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
+    ),
+    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+    targets = ["cw310_rom"],
+    test_harness = "//sw/host/tests/manuf/otp_ctrl:otp_ctrl",
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+    ],
+)

--- a/sw/device/silicon_creator/manuf/lib/empty_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/empty_functest.c
@@ -14,5 +14,10 @@ bool test_main(void) {
 #ifdef EMPTY_TEST_MSG
   LOG_INFO(EMPTY_TEST_MSG);
 #endif
+  // Wait in a loop so that OpenOCD can connect to the TAP without the ROM
+  // resetting the chip.
+  while (1) {
+    // Do nothing
+  }
   return true;
 }

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -110,6 +110,7 @@ rust_library(
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/load_sram_program.rs",
         "src/test_utils/mod.rs",
+        "src/test_utils/otp_ctrl.rs",
         "src/test_utils/poll.rs",
         "src/test_utils/rpc.rs",
         "src/test_utils/spi_passthru.rs",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -67,6 +67,7 @@ rust_library(
         "src/crypto/spx.rs",
         "src/dif/clkmgr.rs",
         "src/dif/lc_ctrl.rs",
+        "src/dif/otp_ctrl.rs",
         "src/dif/rstmgr.rs",
         "src/dif/mod.rs",
         "src/image/image.rs",

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -13,6 +13,7 @@ cc_library(
     deps = [
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
     ],
 )
@@ -43,6 +44,9 @@ rust_bindgen_library(
         "--allowlist-type=dif_lc_ctrl_token",
         "--allowlist-var=LC_CTRL_.*_BIT",
         "--allowlist-var=LC_CTRL_.*_REG_OFFSET",
+        "--allowlist-var=OTP_CTRL_.*_BIT",
+        "--allowlist-var=OTP_CTRL_.*_OFFSET",
+        "--allowlist-var=OTP_CTRL_.*_SIZE",
         "--allowlist-type=dif_rstmgr_reset_info",
     ],
     cc_lib = ":difs",

--- a/sw/host/opentitanlib/bindgen/difs.h
+++ b/sw/host/opentitanlib/bindgen/difs.h
@@ -9,7 +9,8 @@
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 
-#include "clkmgr_regs.h"   // Generated.
-#include "lc_ctrl_regs.h"  // Generated.
+#include "clkmgr_regs.h"    // Generated.
+#include "lc_ctrl_regs.h"   // Generated.
+#include "otp_ctrl_regs.h"  // Generated.
 
 #endif  // OPENTITAN_SW_HOST_OPENTITANLIB_BINDGEN_DIFS_H_

--- a/sw/host/opentitanlib/src/dif/mod.rs
+++ b/sw/host/opentitanlib/src/dif/mod.rs
@@ -4,4 +4,5 @@
 
 pub mod clkmgr;
 pub mod lc_ctrl;
+pub mod otp_ctrl;
 pub mod rstmgr;

--- a/sw/host/opentitanlib/src/dif/otp_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/otp_ctrl.rs
@@ -78,6 +78,23 @@ bitflags! {
         const SECRET2_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_SECRET2_ERROR_BIT;
         const TIMEOUT_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_TIMEOUT_ERROR_BIT;
         const VENDOR_TEST_ERROR     = 0b1 << dif::OTP_CTRL_STATUS_VENDOR_TEST_ERROR_BIT;
+
+        const ERRORS =
+            Self::BUS_INTEG_ERROR.bits() |
+            Self::CREATOR_SW_CFG_ERROR.bits() |
+            Self::DAI_ERROR.bits() |
+            Self::HW_CFG_ERROR.bits() |
+            Self::KEY_DERIV_FSM_ERROR.bits() |
+            Self::LCI_ERROR.bits() |
+            Self::LFSR_FSM_ERROR.bits() |
+            Self::LIFE_CYCLE_ERROR.bits() |
+            Self::OWNER_SW_CFG_ERROR.bits() |
+            Self::SCRAMBLING_FSM_ERROR.bits() |
+            Self::SECRET0_ERROR.bits() |
+            Self::SECRET1_ERROR.bits() |
+            Self::SECRET2_ERROR.bits() |
+            Self::TIMEOUT_ERROR.bits() |
+            Self::VENDOR_TEST_ERROR.bits();
     }
 }
 

--- a/sw/host/opentitanlib/src/dif/otp_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/otp_ctrl.rs
@@ -1,0 +1,280 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use bitflags::bitflags;
+
+use bindgen::dif;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum OtpCtrlReg {
+    IntrState = dif::OTP_CTRL_INTR_STATE_REG_OFFSET,
+    IntrEnable = dif::OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+    IntrTest = dif::OTP_CTRL_INTR_TEST_REG_OFFSET,
+    AlertTest = dif::OTP_CTRL_ALERT_TEST_REG_OFFSET,
+    Status = dif::OTP_CTRL_STATUS_REG_OFFSET,
+    ErrCode = dif::OTP_CTRL_ERR_CODE_REG_OFFSET,
+    DirectAccessRegwen = dif::OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+    DirectAccessCmd = dif::OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
+    DirectAccessAddress = dif::OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+    DirectAccessWdata0 = dif::OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET,
+    DirectAccessWdata1 = dif::OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET,
+    DirectAccessRdata0 = dif::OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+    DirectAccessRdata1 = dif::OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
+    CheckTriggerRegwen = dif::OTP_CTRL_CHECK_TRIGGER_REGWEN_REG_OFFSET,
+    CheckTrigger = dif::OTP_CTRL_CHECK_TRIGGER_REG_OFFSET,
+    CheckRegwen = dif::OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
+    CheckTimeout = dif::OTP_CTRL_CHECK_TIMEOUT_REG_OFFSET,
+    IntegrityCheckPeriod = dif::OTP_CTRL_INTEGRITY_CHECK_PERIOD_REG_OFFSET,
+    ConsistencyCheckPeriod = dif::OTP_CTRL_CONSISTENCY_CHECK_PERIOD_REG_OFFSET,
+    VendorTestReadLock = dif::OTP_CTRL_VENDOR_TEST_READ_LOCK_REG_OFFSET,
+    CreatorSwCfgReadLock = dif::OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET,
+    OwnerSwCfgReadLock = dif::OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET,
+    VendorTestDigest0 = dif::OTP_CTRL_VENDOR_TEST_DIGEST_0_REG_OFFSET,
+    VendorTestDigest1 = dif::OTP_CTRL_VENDOR_TEST_DIGEST_1_REG_OFFSET,
+    CreatorSwCfgDigest0 = dif::OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_REG_OFFSET,
+    CreatorSwCfgDigest1 = dif::OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_REG_OFFSET,
+    OwnerSwCfgDigest0 = dif::OTP_CTRL_OWNER_SW_CFG_DIGEST_0_REG_OFFSET,
+    OwnerSwCfgDigest1 = dif::OTP_CTRL_OWNER_SW_CFG_DIGEST_1_REG_OFFSET,
+    HwCfgDigest0 = dif::OTP_CTRL_HW_CFG_DIGEST_0_REG_OFFSET,
+    HwCfgDigest1 = dif::OTP_CTRL_HW_CFG_DIGEST_1_REG_OFFSET,
+    Secret0Digest0 = dif::OTP_CTRL_SECRET0_DIGEST_0_REG_OFFSET,
+    Secret0Digest1 = dif::OTP_CTRL_SECRET0_DIGEST_1_REG_OFFSET,
+    Secret1Digest0 = dif::OTP_CTRL_SECRET1_DIGEST_0_REG_OFFSET,
+    Secret1Digest1 = dif::OTP_CTRL_SECRET1_DIGEST_1_REG_OFFSET,
+    Secret2Digest0 = dif::OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET,
+    Secret2Digest1 = dif::OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET,
+    SwCfgWindow = dif::OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct DirectAccessCmd: u32 {
+        const DIGEST = 0b1 << dif::OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT;
+        const RD     = 0b1 << dif::OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT;
+        const WR     = 0b1 << dif::OTP_CTRL_DIRECT_ACCESS_CMD_WR_BIT;
+    }
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct OtpCtrlStatus: u32 {
+        const BUS_INTEG_ERROR       = 0b1 << dif::OTP_CTRL_STATUS_BUS_INTEG_ERROR_BIT;
+        const CHECK_PENDING         = 0b1 << dif::OTP_CTRL_STATUS_CHECK_PENDING_BIT;
+        const CREATOR_SW_CFG_ERROR  = 0b1 << dif::OTP_CTRL_STATUS_CREATOR_SW_CFG_ERROR_BIT;
+        const DAI_ERROR             = 0b1 << dif::OTP_CTRL_STATUS_DAI_ERROR_BIT;
+        const DAI_IDLE              = 0b1 << dif::OTP_CTRL_STATUS_DAI_IDLE_BIT;
+        const HW_CFG_ERROR          = 0b1 << dif::OTP_CTRL_STATUS_HW_CFG_ERROR_BIT;
+        const KEY_DERIV_FSM_ERROR   = 0b1 << dif::OTP_CTRL_STATUS_KEY_DERIV_FSM_ERROR_BIT;
+        const LCI_ERROR             = 0b1 << dif::OTP_CTRL_STATUS_LCI_ERROR_BIT;
+        const LFSR_FSM_ERROR        = 0b1 << dif::OTP_CTRL_STATUS_LFSR_FSM_ERROR_BIT;
+        const LIFE_CYCLE_ERROR      = 0b1 << dif::OTP_CTRL_STATUS_LIFE_CYCLE_ERROR_BIT;
+        const OWNER_SW_CFG_ERROR    = 0b1 << dif::OTP_CTRL_STATUS_OWNER_SW_CFG_ERROR_BIT;
+        const SCRAMBLING_FSM_ERROR  = 0b1 << dif::OTP_CTRL_STATUS_SCRAMBLING_FSM_ERROR_BIT;
+        const SECRET0_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_SECRET0_ERROR_BIT;
+        const SECRET1_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_SECRET1_ERROR_BIT;
+        const SECRET2_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_SECRET2_ERROR_BIT;
+        const TIMEOUT_ERROR         = 0b1 << dif::OTP_CTRL_STATUS_TIMEOUT_ERROR_BIT;
+        const VENDOR_TEST_ERROR     = 0b1 << dif::OTP_CTRL_STATUS_VENDOR_TEST_ERROR_BIT;
+    }
+}
+
+pub struct Partition {
+    /// Granularity of accesses at this address.
+    pub access_granule: Granularity,
+
+    /// Starting address of this partition within the OTP in bytes.
+    pub byte_addr: u32,
+
+    /// Digest MMAP for this partition.
+    ///
+    /// Must be accessed with 64-bit granularity, regardless of this
+    /// partition's `access_granule`.
+    pub digest: OtpParamMmap,
+}
+
+impl Partition {
+    // TODO: Take granularities from the `.hjson` instead of hardcoding.
+
+    pub const HW_CFG: Self = Self {
+        access_granule: Granularity::B32,
+        byte_addr: dif::OTP_CTRL_PARAM_HW_CFG_OFFSET,
+        digest: OtpParamMmap {
+            byte_addr: dif::OTP_CTRL_PARAM_HW_CFG_DIGEST_OFFSET,
+            size: dif::OTP_CTRL_PARAM_HW_CFG_DIGEST_SIZE,
+        },
+    };
+
+    pub const SECRET0: Self = Self {
+        access_granule: Granularity::B64,
+        byte_addr: dif::OTP_CTRL_PARAM_SECRET0_OFFSET,
+        digest: OtpParamMmap {
+            byte_addr: dif::OTP_CTRL_PARAM_SECRET0_DIGEST_OFFSET,
+            size: dif::OTP_CTRL_PARAM_SECRET0_DIGEST_SIZE,
+        },
+    };
+
+    pub const SECRET1: Self = Self {
+        access_granule: Granularity::B64,
+        byte_addr: dif::OTP_CTRL_PARAM_SECRET1_OFFSET,
+        digest: OtpParamMmap {
+            byte_addr: dif::OTP_CTRL_PARAM_SECRET1_DIGEST_OFFSET,
+            size: dif::OTP_CTRL_PARAM_SECRET1_DIGEST_SIZE,
+        },
+    };
+
+    pub const SECRET2: Self = Self {
+        access_granule: Granularity::B64,
+        byte_addr: dif::OTP_CTRL_PARAM_SECRET2_OFFSET,
+        digest: OtpParamMmap {
+            byte_addr: dif::OTP_CTRL_PARAM_SECRET2_DIGEST_OFFSET,
+            size: dif::OTP_CTRL_PARAM_SECRET2_DIGEST_SIZE,
+        },
+    };
+}
+
+/// Granularities of memory accesses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Granularity {
+    /// 32-bit.
+    B32,
+    /// 64-bit.
+    B64,
+}
+
+/// Represents an OTP parameter's mapping in the "direct access memory".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OtpParamMmap {
+    /// Byte address of this OTP parameter.
+    pub byte_addr: u32,
+
+    /// Size in bytes.
+    pub size: u32,
+}
+
+/// Parameters accessible via Direct Access Interface (DAI).
+///
+/// The `CREATOR_SW_CFG` and `OWNER_SW_CFG` partitions are omitted for brevity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DaiParam {
+    // HW_CFG
+    DeviceId,
+    ManufState,
+    EnSramIfetch,
+    EnCsrngSwAppRead,
+    EnEntropySrcFwRead,
+    EnEntropySrcFwOver,
+    // SECRET0
+    TestUnlockToken,
+    TestExitToken,
+    // SECRET1
+    FlashAddrKeySeed,
+    FlashDataKeySeed,
+    SramDataKeySeed,
+    // SECRET2
+    RmaToken,
+    CreatorRootKeyShare0,
+    CreatorRootKeyShare1,
+}
+
+impl DaiParam {
+    // These constants should be generated by `reggen` in the future.
+    pub const DEVICE_ID: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_DEVICE_ID_OFFSET,
+        size: dif::OTP_CTRL_PARAM_DEVICE_ID_SIZE,
+    };
+    pub const MANUF_STATE: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_MANUF_STATE_OFFSET,
+        size: dif::OTP_CTRL_PARAM_MANUF_STATE_SIZE,
+    };
+    pub const EN_SRAM_IFETCH: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_EN_SRAM_IFETCH_OFFSET,
+        size: dif::OTP_CTRL_PARAM_EN_SRAM_IFETCH_SIZE,
+    };
+    pub const EN_CSRNG_SW_APP_READ: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_OFFSET,
+        size: dif::OTP_CTRL_PARAM_EN_CSRNG_SW_APP_READ_SIZE,
+    };
+    pub const EN_ENTROPY_SRC_FW_READ: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_READ_OFFSET,
+        size: dif::OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_READ_SIZE,
+    };
+    pub const EN_ENTROPY_SRC_FW_OVER: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_OVER_OFFSET,
+        size: dif::OTP_CTRL_PARAM_EN_ENTROPY_SRC_FW_OVER_SIZE,
+    };
+    pub const TEST_UNLOCK_TOKEN: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_OFFSET,
+        size: dif::OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_SIZE,
+    };
+    pub const TEST_EXIT_TOKEN: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_TEST_EXIT_TOKEN_OFFSET,
+        size: dif::OTP_CTRL_PARAM_TEST_EXIT_TOKEN_SIZE,
+    };
+    pub const FLASH_ADDR_KEY_SEED: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_FLASH_ADDR_KEY_SEED_OFFSET,
+        size: dif::OTP_CTRL_PARAM_FLASH_ADDR_KEY_SEED_SIZE,
+    };
+    pub const FLASH_DATA_KEY_SEED: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_FLASH_DATA_KEY_SEED_OFFSET,
+        size: dif::OTP_CTRL_PARAM_FLASH_DATA_KEY_SEED_SIZE,
+    };
+    pub const SRAM_DATA_KEY_SEED: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_SRAM_DATA_KEY_SEED_OFFSET,
+        size: dif::OTP_CTRL_PARAM_SRAM_DATA_KEY_SEED_SIZE,
+    };
+    pub const RMA_TOKEN: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_RMA_TOKEN_OFFSET,
+        size: dif::OTP_CTRL_PARAM_RMA_TOKEN_SIZE,
+    };
+    pub const CREATOR_ROOT_KEY_SHARE0: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_OFFSET,
+        size: dif::OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_SIZE,
+    };
+    pub const CREATOR_ROOT_KEY_SHARE1: OtpParamMmap = OtpParamMmap {
+        byte_addr: dif::OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_OFFSET,
+        size: dif::OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_SIZE,
+    };
+
+    /// Returns the mmap'd field of this DAI parameter.
+    pub const fn mmap(&self) -> OtpParamMmap {
+        match self {
+            Self::DeviceId => Self::DEVICE_ID,
+            Self::ManufState => Self::MANUF_STATE,
+            Self::EnSramIfetch => Self::EN_SRAM_IFETCH,
+            Self::EnCsrngSwAppRead => Self::EN_CSRNG_SW_APP_READ,
+            Self::EnEntropySrcFwRead => Self::EN_ENTROPY_SRC_FW_READ,
+            Self::EnEntropySrcFwOver => Self::EN_ENTROPY_SRC_FW_OVER,
+            Self::TestUnlockToken => Self::TEST_UNLOCK_TOKEN,
+            Self::TestExitToken => Self::TEST_EXIT_TOKEN,
+            Self::FlashAddrKeySeed => Self::FLASH_ADDR_KEY_SEED,
+            Self::FlashDataKeySeed => Self::FLASH_DATA_KEY_SEED,
+            Self::SramDataKeySeed => Self::SRAM_DATA_KEY_SEED,
+            Self::RmaToken => Self::RMA_TOKEN,
+            Self::CreatorRootKeyShare0 => Self::CREATOR_ROOT_KEY_SHARE0,
+            Self::CreatorRootKeyShare1 => Self::CREATOR_ROOT_KEY_SHARE1,
+        }
+    }
+
+    /// Returns the partition that this DAI parameter belongs to.
+    pub const fn partition(&self) -> Partition {
+        match self {
+            Self::DeviceId => Partition::HW_CFG,
+            Self::ManufState => Partition::HW_CFG,
+            Self::EnSramIfetch => Partition::HW_CFG,
+            Self::EnCsrngSwAppRead => Partition::HW_CFG,
+            Self::EnEntropySrcFwRead => Partition::HW_CFG,
+            Self::EnEntropySrcFwOver => Partition::HW_CFG,
+            Self::TestUnlockToken => Partition::SECRET0,
+            Self::TestExitToken => Partition::SECRET0,
+            Self::FlashAddrKeySeed => Partition::SECRET1,
+            Self::FlashDataKeySeed => Partition::SECRET1,
+            Self::SramDataKeySeed => Partition::SECRET1,
+            Self::RmaToken => Partition::SECRET2,
+            Self::CreatorRootKeyShare0 => Partition::SECRET2,
+            Self::CreatorRootKeyShare1 => Partition::SECRET2,
+        }
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -11,6 +11,7 @@ pub mod init;
 pub mod lc_transition;
 pub mod load_bitstream;
 pub mod load_sram_program;
+pub mod otp_ctrl;
 // The "english breakfast" variant of the chip doesn't have the same
 // set of IO and pinmux constants as the "earlgrey" chip.
 #[cfg(not(feature = "english_breakfast"))]

--- a/sw/host/opentitanlib/src/test_utils/otp_ctrl.rs
+++ b/sw/host/opentitanlib/src/test_utils/otp_ctrl.rs
@@ -1,0 +1,258 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains code for programming and reading OTP parameters
+//! through the Direct Access Interface.
+//!
+//! Beware that OTP parameters can only be written once and can be corrupted if
+//! written again.
+
+use std::mem;
+use std::time::Duration;
+
+use anyhow::{bail, Context};
+use thiserror::Error;
+
+use top_earlgrey::top_earlgrey_memory;
+
+use crate::dif::otp_ctrl::{
+    DaiParam, DirectAccessCmd, Granularity, OtpCtrlReg, OtpCtrlStatus, OtpParamMmap, Partition,
+};
+use crate::io::jtag::Jtag;
+use crate::test_utils::poll;
+
+/// Controls for reading and writing OTP parameters.
+pub struct OtpParam;
+impl OtpParam {
+    /// Read a parameter from OTP into an output buffer.
+    pub fn read_param(jtag: &dyn Jtag, param: DaiParam, out_buf: &mut [u32]) -> OtpDaiResult<()> {
+        let OtpParamMmap { byte_addr, size } = param.mmap();
+
+        if mem::size_of_val(out_buf) < size as usize {
+            let err = OtpDaiError::BufSize {
+                buf_size: mem::size_of_val(out_buf),
+                param_size: size,
+            };
+            return Err(err);
+        }
+
+        let Partition { access_granule, .. } = param.partition();
+
+        match access_granule {
+            Granularity::B32 => {
+                let out_iter = out_buf.iter_mut().take(size as usize);
+                for (idx, out_word) in out_iter.enumerate() {
+                    let addr = byte_addr + (idx * mem::size_of::<u32>()) as u32;
+                    let [lower, _] = OtpDai::read(jtag, addr, access_granule)?;
+                    *out_word = lower;
+                }
+            }
+            Granularity::B64 => {
+                let out_iter = out_buf.chunks_mut(2).take(size as usize / 2);
+                for (idx, out_words) in out_iter.enumerate() {
+                    let addr = byte_addr + (idx * mem::size_of::<u64>()) as u32;
+                    let otp_words = OtpDai::read(jtag, addr, access_granule)?;
+                    out_words[0] = otp_words[0];
+                    out_words[1] = otp_words[1];
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Write a value from a buffer to an OTP parameter.
+    pub fn write_param(jtag: &dyn Jtag, param: DaiParam, data: &[u32]) -> OtpDaiResult<()> {
+        let OtpParamMmap { byte_addr, size } = param.mmap();
+
+        if mem::size_of_val(data) > size as usize {
+            let err = OtpDaiError::BufSize {
+                buf_size: mem::size_of_val(data),
+                param_size: size,
+            };
+            return Err(err);
+        }
+
+        let Partition { access_granule, .. } = param.partition();
+
+        match access_granule {
+            Granularity::B32 => {
+                let data_iter = data.iter().take(size as usize);
+                for (idx, data_word) in data_iter.enumerate() {
+                    let addr = byte_addr + (idx * mem::size_of::<u32>()) as u32;
+                    OtpDai::write(jtag, addr, access_granule, [*data_word, 0x00])?;
+                }
+            }
+            Granularity::B64 => {
+                let data_iter = data.chunks(2).take(size as usize / 2);
+                for (idx, data_words) in data_iter.enumerate() {
+                    let addr = byte_addr + (idx * mem::size_of::<u64>()) as u32;
+                    OtpDai::write(jtag, addr, access_granule, [data_words[0], data_words[1]])?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Commands for operating on OTP partitions.
+pub struct OtpPartition;
+impl OtpPartition {
+    /// Lock the given partition by calculating its digest.
+    pub fn lock(jtag: &dyn Jtag, partition: Partition) -> OtpDaiResult<()> {
+        OtpDai::lock(jtag, partition.byte_addr)
+    }
+
+    /// Read back this partition's digest from the OTP.
+    ///
+    /// This goes via the DAI, but partitions are also exposed via CSRs after reset.
+    pub fn read_digest(jtag: &dyn Jtag, partition: Partition) -> OtpDaiResult<[u32; 2]> {
+        let OtpParamMmap { byte_addr, size } = partition.digest;
+        assert_eq!(size, 8, "OTP partition digests should be 2 words in size");
+
+        OtpDai::read(jtag, byte_addr, Granularity::B64)
+    }
+}
+
+/// Direct Access Interface to the OTP.
+struct OtpDai;
+impl OtpDai {
+    /// Base address of the OTP controller in memory.
+    const OTP_CTRL_BASE_ADDR: u32 =
+        top_earlgrey_memory::TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR as u32;
+
+    // Polling timeout and delay while waiting on statuses.
+    const POLL_TIMEOUT: Duration = Duration::from_millis(500);
+    const POLL_DELAY: Duration = Duration::from_millis(5);
+
+    /// Perform a single read over the Direct Access Interface.
+    ///
+    /// On success, returns an array of words `[lower, upper]` where `upper` is non-zero
+    /// for 64-bit granularity reads.
+    pub fn read(jtag: &dyn Jtag, byte_addr: u32, granule: Granularity) -> OtpDaiResult<[u32; 2]> {
+        Self::wait_for_idle(jtag)?;
+
+        // Set the DAI address to read from.
+        let dai_address_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessAddress as u32;
+        jtag.write_memory32(dai_address_addr, &[byte_addr])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        // Trigger a read command.
+        let dai_cmd_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessCmd as u32;
+        jtag.write_memory32(dai_cmd_addr, &[DirectAccessCmd::RD.bits()])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        Self::wait_for_idle(jtag)?;
+
+        let dai_rdata0_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessRdata0 as u32;
+        let dai_rdata1_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessRdata1 as u32;
+
+        let mut rdata = [0x00; 2];
+
+        jtag.read_memory32(dai_rdata0_addr, &mut rdata[0..=0])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        if granule == Granularity::B64 {
+            jtag.read_memory32(dai_rdata1_addr, &mut rdata[1..=1])
+                .map_err(|source| OtpDaiError::Jtag { source })?;
+        }
+
+        Ok(rdata)
+    }
+
+    /// Perform a single write over the Direct Access Interface.
+    pub fn write(
+        jtag: &dyn Jtag,
+        byte_addr: u32,
+        granule: Granularity,
+        values: [u32; 2],
+    ) -> OtpDaiResult<()> {
+        Self::wait_for_idle(jtag)?;
+
+        // Set the DAI address to write to.
+        let dai_address_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessAddress as u32;
+        jtag.write_memory32(dai_address_addr, &[byte_addr])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        let dai_wdata0_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessWdata0 as u32;
+        let dai_wdata1_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessWdata1 as u32;
+
+        jtag.write_memory32(dai_wdata0_addr, &[values[0]])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        if granule == Granularity::B64 {
+            jtag.write_memory32(dai_wdata1_addr, &[values[1]])
+                .map_err(|source| OtpDaiError::Jtag { source })?;
+        }
+
+        // Trigger a write command.
+        let dai_cmd_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessCmd as u32;
+        jtag.write_memory32(dai_cmd_addr, &[DirectAccessCmd::WR.bits()])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        Self::wait_for_idle(jtag)?;
+
+        Ok(())
+    }
+
+    /// Lock the partition starting at offset `byte_addr`.
+    pub fn lock(jtag: &dyn Jtag, byte_addr: u32) -> OtpDaiResult<()> {
+        Self::wait_for_idle(jtag)?;
+
+        // Set the DAI address to the start of the partition.
+        let dai_address_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessAddress as u32;
+        jtag.write_memory32(dai_address_addr, &[byte_addr])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        // Trigger a digest calculation command.
+        let dai_cmd_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::DirectAccessCmd as u32;
+        jtag.write_memory32(dai_cmd_addr, &[DirectAccessCmd::DIGEST.bits()])
+            .map_err(|source| OtpDaiError::Jtag { source })?;
+
+        Self::wait_for_idle(jtag)?;
+
+        Ok(())
+    }
+
+    /// Wait for the OTP controller's status to read `DAI_IDLE`, showing it's
+    /// ready to accept commands.
+    pub fn wait_for_idle(jtag: &dyn Jtag) -> Result<(), OtpDaiError> {
+        let otp_status_addr = Self::OTP_CTRL_BASE_ADDR + OtpCtrlReg::Status as u32;
+
+        poll::poll_until(Self::POLL_TIMEOUT, Self::POLL_DELAY, || {
+            let mut status = [0];
+            jtag.read_memory32(otp_status_addr, &mut status)
+                .map_err(|source| OtpDaiError::Jtag { source })?;
+
+            let status =
+                OtpCtrlStatus::from_bits(status[0]).context("status has invalid bits set")?;
+
+            if status.intersects(OtpCtrlStatus::ERRORS) {
+                bail!("status {status:#b} has error bits set");
+            }
+
+            Ok(status.contains(OtpCtrlStatus::DAI_IDLE))
+        })
+        .map_err(|source| OtpDaiError::WaitForIdle { source })
+    }
+}
+
+pub type OtpDaiResult<T> = Result<T, OtpDaiError>;
+
+/// Failures to write OTP parameters through the Direct Access Interface.
+#[derive(Debug, Error)]
+pub enum OtpDaiError {
+    #[error("provided buffer has invalid size {buf_size} for parameter of size {param_size}")]
+    BufSize { buf_size: usize, param_size: u32 },
+
+    #[error("failed to communicate over JTAG")]
+    Jtag { source: anyhow::Error },
+
+    #[error("failed to wait for otp_ctrl DAI to be idle")]
+    WaitForIdle { source: anyhow::Error },
+
+    #[error("writing to otp_ctrl direct access registers is disabled")]
+    WriteDisabled,
+}

--- a/sw/host/tests/manuf/otp_ctrl/BUILD
+++ b/sw/host/tests/manuf/otp_ctrl/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "otp_ctrl",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/manuf/otp_ctrl/src/main.rs
+++ b/sw/host/tests/manuf/otp_ctrl/src/main.rs
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This test performs a lifecycle transition from `RAW` to `TEST_UNLOCKED0`.
+
+use anyhow::Context;
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::otp_ctrl::{DaiParam, Partition};
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::otp_ctrl::{OtpParam, OtpPartition};
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+    #[structopt(flatten)]
+    jtag: JtagParams,
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+
+    execute_test!(program_readback, &opts, &transport);
+    execute_test!(lock_partition, &opts, &transport);
+
+    Ok(())
+}
+
+/// Program an OTP parameter and read it back to confirm the write.
+fn program_readback(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> {
+    // Set the TAP straps for the CPU and reset.
+    transport
+        .pin_strapping("PINMUX_TAP_RISCV")?
+        .apply()
+        .context("failed to apply RISCV TAP strapping")?;
+    transport
+        .reset_target(opts.init.bootstrap.options.reset_delay, true)
+        .context("failed to reset")?;
+
+    // Connect to the RISCV TAP via JTAG.
+    let jtag = transport.jtag(&opts.jtag)?;
+    jtag.connect(JtagTap::RiscvTap)
+        .context("failed to connect to RISCV TAP over JTAG")?;
+
+    // Program and then read back `MANUF_STATE`.
+    let write_data = [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF];
+    OtpParam::write_param(&*jtag, DaiParam::ManufState, &write_data)
+        .context("failed to write MANUF_STATE")?;
+
+    let mut read_data = [0xff; 8];
+    OtpParam::read_param(&*jtag, DaiParam::ManufState, &mut read_data)
+        .context("failed to read MANUF_STATE")?;
+
+    assert_eq!(read_data, write_data);
+
+    jtag.disconnect()?;
+
+    Ok(())
+}
+
+/// Lock a partition and check its digest.
+fn lock_partition(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> {
+    // Set the TAP straps for the CPU and reset.
+    transport
+        .pin_strapping("PINMUX_TAP_RISCV")?
+        .apply()
+        .context("failed to apply RISCV TAP strapping")?;
+    transport
+        .reset_target(opts.init.bootstrap.options.reset_delay, true)
+        .context("failed to reset")?;
+
+    // Connect to the RISCV TAP via JTAG.
+    let jtag = transport.jtag(&opts.jtag)?;
+    jtag.connect(JtagTap::RiscvTap)
+        .context("failed to connect to RISCV TAP over JTAG")?;
+
+    // Read the HW_CFG partition's digest, which should be 0 (unlocked):
+    let digest = OtpPartition::read_digest(&*jtag, Partition::HW_CFG)
+        .context("failed to read HW_CFG partition's digest")?;
+
+    assert_eq!(digest, [0x00; 2]);
+
+    // Lock the partition.
+    OtpPartition::lock(&*jtag, Partition::HW_CFG).context("failed to lock HW_CFG partition")?;
+
+    // Read the digest again to see if it's been calculated (locked):
+    let digest = OtpPartition::read_digest(&*jtag, Partition::HW_CFG)
+        .context("failed to read HW_CFG partition's digest")?;
+
+    assert_ne!(digest, [0x00; 2]);
+
+    jtag.disconnect()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This is a WIP for programming and reading OTP parameters through opentitanlib.

Needed for the https://github.com/lowRISC/opentitan/issues/17390 and https://github.com/lowRISC/opentitan/issues/17391 manufacturing tests which need to provision tokens.

The docs for programming and reading the OTP are [here](https://opentitan.org/book/hw/ip/otp_ctrl/doc/programmers_guide.html#readout-sequence).

This PR includes a functest at `//sw/device/silicon_creator/manuf/lib:otp_ctrl_functest` which writes to and reads back the `MANUF_STATE` OTP parameter to test programming and reading.