### PR TITLE
[opentitantool] New HyperDebug firmware

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230505_02/hyperdebug-firmware.tar.gz"],
-        sha256 = "b0d30a237316b969085637c7ee155d2ffa1028d2f89a0af63a633a25914f8d6c",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230509_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "d25cffd7d5a1e6666855f4226064af644a43cc7372017cbb27787e0ae9306f6e",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Contains a fix so that open-drain mode is not lost on I2C pins during `transport init`.

https://github.com/lowRISC/hyperdebug-firmware/releases/tag/20230509_01
