### PR TITLE
[chip-test] Add ext_clk request to volatile raw unlock

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3491,9 +3491,13 @@
              - Enable ROM execution via rv_dm, and perform POR.
              - Initiate a second transition to test_unlocked0 using VOLATILE_RAW_UNLOCK.
              - Verify that the CPU is able to execute.
+
+             Test ext_clk injection before enabling ROM execution.
              '''
       stage: V2
       tests: ["chip_sw_lc_ctrl_volatile_raw_unlock",
+              "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz",
+              "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_96mhz",
               "rom_volatile_raw_unlock"]
     }
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -862,6 +862,26 @@
       run_timeout_mins: 120
     }
     {
+      name: chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz
+      uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_volatile_raw_unlock_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+use_otp_image=OtpTypeLcStRaw",
+        "+chip_clock_source=ChipClockSourceExternal48Mhz"]
+      run_timeout_mins: 120
+    }
+    {
+      name: chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_96mhz
+      uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
+      sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_volatile_raw_unlock_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+use_otp_image=OtpTypeLcStRaw",
+        "+chip_clock_source=ChipClockSourceExternal96Mhz"]
+      run_timeout_mins: 120
+    }
+    {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["//sw/device/tests/sim_dv:lc_walkthrough_test:1"]

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
@@ -20,7 +20,7 @@ class chip_sw_lc_volatile_raw_unlock_vseq extends chip_sw_base_vseq;
   // reset jtag interface
   virtual task reset_jtag_tap();
     cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
-    #1000ns;
+    #2000ns;
     cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
   endtask
 
@@ -62,6 +62,7 @@ class chip_sw_lc_volatile_raw_unlock_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 0;
     apply_reset();
+    reset_jtag_tap();
 
     // Second VOLATILE_RAW_UNLOCK does not change the TAP interface to rv_dm
     // so that we can check the completion status through that interface.


### PR DESCRIPTION
Add additional test cases with ext_clk configurations (48mhz, 96mhz).