### PR TITLE
[chip-test] Increase volatile_raw_unlock timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -859,7 +859,7 @@
       sw_images: ["//sw/device/tests/sim_dv:lc_ctrl_volatile_raw_unlock_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=OtpTypeLcStRaw"]
-      run_timeout_mins: 10
+      run_timeout_mins: 120
     }
     {
       name: chip_sw_lc_walkthrough_rma


### PR DESCRIPTION
Increase timeout to 120 minutes. This may be shortened in the future once we get nightly regression results.