### PR TITLE
[manuf] fix race condition in `manuf_cp_yield_test` and re-enable external clk transition

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -324,23 +324,37 @@ opentitan_functest(
     for i in range(0, 8)
 ]
 
-opentitan_functest(
+[
+    opentitan_functest(
+        name = "manuf_cp_yield_test_functest_{}".format(lc_state.lower()),
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
+        cw310 = cw310_params(
+            bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            tags = ["jtag"],
+            test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS + [
+                "--initial-lc-state=\"{}\"".format(lc_state),
+            ],
+        ),
+        data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+        targets = ["cw310_rom"],
+        test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
+    )
+    for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+]
+
+test_suite(
     name = "manuf_cp_yield_test_functest",
-    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
-    cw310 = cw310_params(
-        bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
-        tags = ["jtag"],
-        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
-    ),
-    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
-    deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+    tags = ["manual"],
+    tests = [
+        ":manuf_cp_yield_test_functest_{}".format(lc_state.lower())
+        for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -296,37 +296,6 @@ opentitan_functest(
     ],
 )
 
-opentitan_functest(
-    name = "manuf_cp_yield_test_functest",
-    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
-        tags = ["jtag"],
-        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
-    ),
-    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
-    deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
-    ],
-)
-
-cc_library(
-    name = "isolated_flash_partition",
-    srcs = ["isolated_flash_partition.c"],
-    hdrs = ["isolated_flash_partition.h"],
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
-    ],
-)
-
 # This is the same as rom_otp_test_unlocked* but with ROM execution disabled.
 [
     otp_image(
@@ -354,6 +323,37 @@ cc_library(
     )
     for i in range(0, 8)
 ]
+
+opentitan_functest(
+    name = "manuf_cp_yield_test_functest",
+    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
+    cw310 = cw310_params(
+        bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
+        tags = ["jtag"],
+        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
+    ),
+    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+    targets = ["cw310_rom"],
+    test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+    ],
+)
+
+cc_library(
+    name = "isolated_flash_partition",
+    srcs = ["isolated_flash_partition.c"],
+    hdrs = ["isolated_flash_partition.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+    ],
+)
 
 opentitan_ram_binary(
     name = "sram_device_info_flash_wr_functest",

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -17,7 +17,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::execute_test;
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
-//use opentitanlib::test_utils::extclk::{ClockSpeed, ExternalClock};
+use opentitanlib::test_utils::extclk::{ClockSpeed, ExternalClock};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::wait_for_status;
 use top_earlgrey::top_earlgrey_memory;
@@ -42,8 +42,7 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
     jtag.connect(JtagTap::RiscvTap)
         .context("failed to connect to RISCV TAP over JTAG")?;
 
-    // TODO(#18403): switching to external clock does not succeed. Clkmgr fails to ACK switch.
-    //ExternalClock::enable(&*jtag, ClockSpeed::High).context("failed to enable external clock")?;
+    ExternalClock::enable(&*jtag, ClockSpeed::High).context("failed to enable external clock")?;
 
     // Read and write memory to verify connection.
 

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -29,6 +29,13 @@ struct Opts {
 
     #[structopt(flatten)]
     jtag: JtagParams,
+
+    #[structopt(
+        long, parse(try_from_str = DifLcCtrlState::parse_lc_state_str),
+        default_value = "test_unlocked0",
+        help = "LC state to expect the chip to be initialized in."
+    )]
+    initial_lc_state: DifLcCtrlState,
 }
 
 fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
@@ -56,7 +63,7 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
     )?;
     assert_eq!(
         encoded_lc_state[0],
-        DifLcCtrlState::TestUnlocked0.redundant_encoding()
+        opts.initial_lc_state.redundant_encoding()
     );
 
     // Without resetting, change TAP strapping to the LC and reconnect.
@@ -70,7 +77,7 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
 
     // Read and write LC state register to verify connection.
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
-    assert_eq!(state, DifLcCtrlState::TestUnlocked0.redundant_encoding());
+    assert_eq!(state, opts.initial_lc_state.redundant_encoding());
 
     jtag.disconnect().context("failed to disconnect JTAG")?;
 


### PR DESCRIPTION
The `manuf_cp_yield_test` was not loading an OTP image with ROM execution disabled, nor bootstrapping anything into flash. As a result there was a race condition between when the JTAG operations would complete and when ROM would start resetting the chip due to a failed boot operation.

This updates the `manuf_cp_yield_test` to use an OTP image with ROM execution disabled to remove this race condition. Additionally, this updates the test to run in all `test_unlocked*` LC states, and adds a test_suite that groups all individual tests.

This fixes #18403.