### PR TITLE
[otp] Cleanup various OTP image settings

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -242,16 +242,6 @@ otp_json(
 )
 
 otp_json(
-    name = "otp_json_secret0_empty_and_unlocked",
-    partitions = [
-        otp_partition(
-            name = "SECRET0",
-            lock = False,
-        ),
-    ],
-)
-
-otp_json(
     name = "otp_json_secret1",
     partitions = [
         otp_partition(
@@ -428,7 +418,10 @@ otp_image(
     otp_image(
         name = "img_test_locked{}".format(i),
         src = ":otp_json_test_locked{}".format(i),
-        overlays = STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS,
+        overlays = [
+            ":otp_json_secret0",
+            ":otp_json_creator_sw_cfg_test_unlocked",
+        ],
     )
     for i in range(0, 7)
 ]

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -73,22 +73,6 @@ otp_json(
             name = "CREATOR_SW_CFG",
             items = {
                 "CREATOR_SW_CFG_ROM_EXEC_EN": "0xffffffff",
-                # Enable use of entropy for countermeasures. See the definition
-                # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_RNG_EN": "0x739",
-                # Entropy source health check default values. This needs to be
-                # populated when `CREATOR_SW_CFG_RNG_EN` is set to true.
-                "CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_REPCNTS_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_ADAPTP_HI_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_ADAPTP_LO_THRESHOLDS": "0x0",
-                "CREATOR_SW_CFG_RNG_BUCKET_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_MARKOV_HI_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_MARKOV_LO_THRESHOLDS": "0x0",
-                "CREATOR_SW_CFG_RNG_EXTHT_HI_THRESHOLDS": "0xffffffff",
-                "CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS": "0x0",
-                "CREATOR_SW_CFG_RNG_ALERT_THRESHOLD": "0xfffd0002",
-                "CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST": "0x8264cf75",
             },
         ),
         otp_partition(


### PR DESCRIPTION
- Remove most default settings from test_locked* images to simulate post-si environment.
- Remove entropy_src health check settings from test_unlock* image used in rom e2e tests.