### PR TITLE
[sigverify] Update SPHINCS+ to use aligned signatures and keys.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/fors.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/fors.c
@@ -22,7 +22,7 @@
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-static rom_error_t fors_sk_to_leaf(const uint8_t *sk, const spx_ctx_t *ctx,
+static rom_error_t fors_sk_to_leaf(const uint32_t *sk, const spx_ctx_t *ctx,
                                    spx_addr_t *fors_leaf_addr, uint32_t *leaf) {
   return thash(sk, /*inblocks=*/1, ctx, fors_leaf_addr, leaf);
 }
@@ -47,7 +47,7 @@ static void message_to_indices(const uint8_t *m, uint32_t *indices) {
   }
 }
 
-rom_error_t fors_pk_from_sig(const uint8_t *sig, const uint8_t *m,
+rom_error_t fors_pk_from_sig(const uint32_t *sig, const uint8_t *m,
                              const spx_ctx_t *ctx, const spx_addr_t *fors_addr,
                              uint32_t *pk) {
   // Initialize the FORS tree address.
@@ -73,16 +73,16 @@ rom_error_t fors_pk_from_sig(const uint8_t *sig, const uint8_t *m,
     // Derive the leaf from the included secret key part.
     uint32_t leaf[kSpxNWords];
     HARDENED_RETURN_IF_ERROR(fors_sk_to_leaf(sig, ctx, &fors_tree_addr, leaf));
-    sig += kSpxN;
+    sig += kSpxNWords;
 
     // Derive the corresponding root node of this tree.
     uint32_t *root = &roots[i * kSpxNWords];
-    HARDENED_RETURN_IF_ERROR(spx_utils_compute_root(
-        (unsigned char *)leaf, indices[i], idx_offset, sig, kSpxForsHeight, ctx,
-        &fors_tree_addr, root));
-    sig += kSpxN * kSpxForsHeight;
+    HARDENED_RETURN_IF_ERROR(
+        spx_utils_compute_root(leaf, indices[i], idx_offset, sig,
+                               kSpxForsHeight, ctx, &fors_tree_addr, root));
+    sig += kSpxNWords * kSpxForsHeight;
   }
 
   // Hash horizontally across all tree roots to derive the public key.
-  return thash((unsigned char *)roots, kSpxForsTrees, ctx, &fors_pk_addr, pk);
+  return thash(roots, kSpxForsTrees, ctx, &fors_pk_addr, pk);
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/fors.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/fors.h
@@ -33,7 +33,7 @@ extern "C" {
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t fors_pk_from_sig(const uint8_t *sig, const uint8_t *m,
+rom_error_t fors_pk_from_sig(const uint32_t *sig, const uint8_t *m,
                              const spx_ctx_t *ctx, const spx_addr_t *fors_addr,
                              uint32_t *pk);
 

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h
@@ -54,7 +54,7 @@ rom_error_t spx_hash_initialize(spx_ctx_t *ctx);
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t spx_hash_message(const uint8_t *R, const uint8_t *pk,
+rom_error_t spx_hash_message(const uint32_t *R, const uint32_t *pk,
                              const uint8_t *msg_prefix_1,
                              size_t msg_prefix_1_len,
                              const uint8_t *msg_prefix_2,

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
@@ -52,7 +52,7 @@ rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
   return kmac_shake256_configure();
 }
 
-rom_error_t spx_hash_message(const uint8_t *R, const uint8_t *pk,
+rom_error_t spx_hash_message(const uint32_t *R, const uint32_t *pk,
                              const uint8_t *msg_prefix_1,
                              size_t msg_prefix_1_len,
                              const uint8_t *msg_prefix_2,
@@ -63,8 +63,8 @@ rom_error_t spx_hash_message(const uint8_t *R, const uint8_t *pk,
   unsigned char *bufp = (unsigned char *)buf;
 
   HARDENED_RETURN_IF_ERROR(kmac_shake256_start());
-  kmac_shake256_absorb(R, kSpxN);
-  kmac_shake256_absorb(pk, kSpxPkBytes);
+  kmac_shake256_absorb_words(R, kSpxNWords);
+  kmac_shake256_absorb_words(pk, kSpxPkWords);
   kmac_shake256_absorb(msg_prefix_1, msg_prefix_1_len);
   kmac_shake256_absorb(msg_prefix_2, msg_prefix_2_len);
   kmac_shake256_absorb(msg, msg_len);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
@@ -135,6 +135,10 @@ enum {
    */
   kSpxNWords = kSpxN / sizeof(uint32_t),
   /**
+   * FORS signature size in words.
+   */
+  kSpxForsWords = kSpxForsBytes / sizeof(uint32_t),
+  /**
    * WOTS signature size in words.
    */
   kSpxWotsWords = kSpxWotsBytes / sizeof(uint32_t),
@@ -142,6 +146,10 @@ enum {
    * WOTS public key size in words.
    */
   kSpxWotsPkWords = kSpxWotsPkBytes / sizeof(uint32_t),
+  /**
+   * SPHINCS+ public key length in words.
+   */
+  kSpxPkWords = kSpxPkBytes / sizeof(uint32_t),
 };
 
 /**

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/fors_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/fors_test.c
@@ -15,7 +15,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 // Test signature and message. Populate before running test.
-static uint8_t kTestSig[kSpxForsBytes] = {0};
+static uint32_t kTestSig[kSpxForsWords] = {0};
 static uint8_t kTestMsg[kSpxForsMsgBytes] = {0};
 
 // Test context.
@@ -55,8 +55,9 @@ bool test_main() {
   LOG_INFO("Starting FORS test...");
 
   // Populate signature with {0, 1, 2, 3, ... }.
+  unsigned char *test_sig_bytes = (unsigned char *)kTestSig;
   for (size_t i = 0; i < kSpxForsBytes; i++) {
-    kTestSig[i] = i & 255;
+    test_sig_bytes[i] = i & 255;
   }
 
   // Populate message with { ..., 3, 2, 1, 0}.

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/sphincsplus_set_testvectors.py
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/sphincsplus_set_testvectors.py
@@ -30,6 +30,26 @@ def hex_to_hexbytes(x):
     return out
 
 
+def hex_to_hexwords(x):
+    '''Convert a hex string little-endian 32-bit words as hex strings.'''
+    if x.startswith('0x'):
+        x = x[2:]
+
+    # Double-check that length is divisible by 8.
+    if len(x) % 8 != 0:
+        raise ValueError(f'Hex string with length {len(x)} is not divisible by'
+                         f'word size (32 bits): {x}')
+
+    out = []
+    for i in range(0, len(x), 8):
+        # Reverse the order of bytes in each word.
+        word = '0x'
+        for j in range(i + 8, i, -2):
+            word += x[j - 2:j]
+        out.append(word)
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--hjsonfile', '-j',
@@ -56,9 +76,9 @@ def main() -> int:
 
     # Convert the values to hexadecimal bytes.
     for t in testvecs:
-        t['sig_hexbytes'] = hex_to_hexbytes(t['sig_hex'])
+        t['sig_hexwords'] = hex_to_hexwords(t['sig_hex'])
         t['msg_hexbytes'] = hex_to_hexbytes(t['msg_hex'])
-        t['pk_hexbytes'] = hex_to_hexbytes(t['pk_hex'])
+        t['pk_hexwords'] = hex_to_hexwords(t['pk_hex'])
 
     with args.template as template:
         with args.headerfile as header:

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/sphincsplus_shake_128s_simple_testvectors.h.tpl
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/sphincsplus_shake_128s_simple_testvectors.h.tpl
@@ -16,8 +16,8 @@ extern "C" {
 
 // A test vector for SPHINCS+ signature verification.
 typedef struct spx_verify_test_vector {
-  uint8_t sig[kSpxVerifySigBytes];  // Signature to verify.
-  uint8_t pk[kSpxVerifyPkBytes];    // Public key.
+  uint32_t sig[kSpxVerifySigWords];  // Signature to verify.
+  uint32_t pk[kSpxVerifyPkWords];    // Public key.
   size_t msg_len;                   // Length of message.
   uint8_t *msg;                     // Message.
 } spx_verify_test_vector_t;
@@ -42,14 +42,14 @@ static const spx_verify_test_vector_t spx_verify_tests[${len(tests)}] = {
     {
         .sig =
             {
-  % for i in range(0, len(t["sig_hexbytes"]), 10):
-                ${', '.join(t["sig_hexbytes"][i:i + 10])},
+  % for i in range(0, len(t["sig_hexwords"]), 4):
+                ${', '.join(t["sig_hexwords"][i:i + 4])},
   % endfor
             },
         .pk =
             {
-  % for i in range(0, len(t["pk_hexbytes"]), 10):
-                ${', '.join(t["pk_hexbytes"][i:i + 10])},
+  % for i in range(0, len(t["pk_hexwords"]), 4):
+                ${', '.join(t["pk_hexwords"][i:i + 4])},
   % endfor
             },
         .msg_len = ${t["msg_len"]},

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/wots_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/wots_test.c
@@ -17,11 +17,13 @@ OTTF_DEFINE_TEST_CONFIG();
 
 enum {
   kSpxWotsMsgBytes = ((kSpxWotsLen1 * kSpxWotsLogW + 7) / 8),
+  kSpxWotsMsgWords =
+      (kSpxWotsMsgBytes + sizeof(uint32_t) - 1) / sizeof(uint32_t),
 };
 
 // Test signature and message. Populate before running test.
-static uint8_t kTestSig[kSpxWotsBytes] = {0};
-static uint8_t kTestMsg[kSpxWotsMsgBytes] = {0};
+static uint32_t kTestSig[kSpxWotsWords] = {0};
+static uint32_t kTestMsg[kSpxWotsMsgWords] = {0};
 
 // Test context.
 static spx_ctx_t kTestCtx = {
@@ -84,13 +86,15 @@ bool test_main() {
   LOG_INFO("Starting WOTS test...");
 
   // Populate signature with {0, 1, 2, 3, ... }.
+  unsigned char *test_sig_bytes = (unsigned char *)kTestSig;
   for (size_t i = 0; i < kSpxWotsBytes; i++) {
-    kTestSig[i] = i & 255;
+    test_sig_bytes[i] = i & 255;
   }
 
   // Populate message with { ..., 3, 2, 1, 0}.
+  unsigned char *test_msg_bytes = (unsigned char *)kTestMsg;
   for (size_t i = 0; i < kSpxWotsMsgBytes; i++) {
-    kTestMsg[i] = (kSpxWotsMsgBytes - i) & 255;
+    test_msg_bytes[i] = (kSpxWotsMsgBytes - i) & 255;
   }
 
   EXECUTE_TEST(result, pk_from_sig_test);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h
@@ -35,7 +35,7 @@ extern "C" {
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t thash(const uint8_t *in, size_t inblocks, const spx_ctx_t *ctx,
+rom_error_t thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
                   const spx_addr_t *addr, uint32_t *out);
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_shake_simple.c
@@ -10,14 +10,14 @@
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
 
-rom_error_t thash(const uint8_t *in, size_t inblocks, const spx_ctx_t *ctx,
+rom_error_t thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
                   const spx_addr_t *addr, uint32_t *out) {
   // Uses the "simple" thash construction (Construction 7 in the SPHINCS+
   // paper): H(pk_seed, addr, in).
   HARDENED_RETURN_IF_ERROR(kmac_shake256_start());
   kmac_shake256_absorb_words(ctx->pub_seed, kSpxNWords);
   kmac_shake256_absorb_words(addr->addr, ARRAYSIZE(addr->addr));
-  kmac_shake256_absorb(in, inblocks * kSpxN);
+  kmac_shake256_absorb_words(in, inblocks * kSpxNWords);
   kmac_shake256_squeeze_start();
   return kmac_shake256_squeeze_end(out, kSpxNWords);
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.c
@@ -22,9 +22,9 @@ uint64_t spx_utils_bytes_to_u64(const uint8_t *in, size_t inlen) {
   return retval;
 }
 
-rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
+rom_error_t spx_utils_compute_root(const uint32_t *leaf, uint32_t leaf_idx,
                                    uint32_t idx_offset,
-                                   const uint8_t *auth_path,
+                                   const uint32_t *auth_path,
                                    uint8_t tree_height, const spx_ctx_t *ctx,
                                    spx_addr_t *addr, uint32_t *root) {
   // Initialize working buffer.
@@ -41,7 +41,7 @@ rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
     memcpy(buffer, leaf, kSpxN);
     memcpy(buffer_second, auth_path, kSpxN);
   }
-  auth_path += kSpxN;
+  auth_path += kSpxNWords;
 
   for (uint8_t i = 0; i < tree_height - 1; i++) {
     leaf_idx >>= 1;
@@ -63,7 +63,7 @@ rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
 
     // Copy the auth path while KMAC is processing for performance reasons.
     memcpy(auth_dst, auth_path, kSpxN);
-    auth_path += kSpxN;
+    auth_path += kSpxNWords;
 
     // Get the `thash` output.
     HARDENED_RETURN_IF_ERROR(kmac_shake256_squeeze_end(hash_dst, kSpxNWords));
@@ -74,5 +74,5 @@ rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
   idx_offset >>= 1;
   spx_addr_tree_height_set(addr, tree_height);
   spx_addr_tree_index_set(addr, leaf_idx + idx_offset);
-  return thash((unsigned char *)buffer, 2, ctx, addr, root);
+  return thash(buffer, 2, ctx, addr, root);
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/utils.h
@@ -49,9 +49,9 @@ uint64_t spx_utils_bytes_to_u64(const uint8_t *in, size_t inlen);
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t spx_utils_compute_root(const uint8_t *leaf, uint32_t leaf_idx,
+rom_error_t spx_utils_compute_root(const uint32_t *leaf, uint32_t leaf_idx,
                                    uint32_t idx_offset,
-                                   const uint8_t *auth_path,
+                                   const uint32_t *auth_path,
                                    uint8_t tree_height, const spx_ctx_t *ctx,
                                    spx_addr_t *addr, uint32_t *root);
 

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h
@@ -25,13 +25,21 @@ enum {
    */
   kSpxVerifyRootNumWords = kSpxNWords,
   /**
-   * Size of SPHINCS+ signature.
+   * Size of SPHINCS+ signature in bytes.
    */
   kSpxVerifySigBytes = kSpxBytes,
   /**
-   * Size of SPHINCS+ public key.
+   * Size of SPHINCS+ signature in words.
+   */
+  kSpxVerifySigWords = kSpxBytes / sizeof(uint32_t),
+  /**
+   * Size of SPHINCS+ public key in bytes.
    */
   kSpxVerifyPkBytes = kSpxPkBytes,
+  /**
+   * Size of SPHINCS+ public key in words.
+   */
+  kSpxVerifyPkWords = kSpxPkWords,
 };
 
 /**
@@ -53,10 +61,10 @@ enum {
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t spx_verify(const uint8_t *sig, const uint8_t *msg_prefix_1,
+rom_error_t spx_verify(const uint32_t *sig, const uint8_t *msg_prefix_1,
                        size_t msg_prefix_1_len, const uint8_t *msg_prefix_2,
                        size_t msg_prefix_2_len, const uint8_t *msg,
-                       size_t msg_len, const uint8_t *pk, uint32_t *root);
+                       size_t msg_len, const uint32_t *pk, uint32_t *root);
 
 /**
  * Extract the public key root.
@@ -65,7 +73,7 @@ rom_error_t spx_verify(const uint8_t *sig, const uint8_t *msg_prefix_1,
  * @param[out] root Buffer for the public key root (`kSpxVerifyRootNumWords`
  *                  words long).
  */
-void spx_public_key_root(const uint8_t *pk, uint32_t *root);
+void spx_public_key_root(const uint32_t *pk, uint32_t *root);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.c
@@ -35,7 +35,7 @@ static_assert(sizeof(uint8_t) <= kSpxWotsLogW,
  * @param[out] Output buffer (`kSpxNWords` words).
  * @return Error code indicating if the operation succeeded.
  */
-OT_WARN_UNUSED_RESULT static rom_error_t gen_chain(const uint8_t *in,
+OT_WARN_UNUSED_RESULT static rom_error_t gen_chain(const uint32_t *in,
                                                    uint8_t start,
                                                    const spx_ctx_t *ctx,
                                                    spx_addr_t *addr,
@@ -137,14 +137,14 @@ static void wots_checksum(const uint8_t *msg_base_w, uint8_t *csum_base_w) {
  * @param msg Input message.
  * @param[out] lengths Resulting chain lengths.
  */
-static void chain_lengths(const uint8_t *msg, uint8_t *lengths) {
-  base_w(msg, kSpxWotsLen1, lengths);
+static void chain_lengths(const uint32_t *msg, uint8_t *lengths) {
+  base_w((unsigned char *)msg, kSpxWotsLen1, lengths);
   wots_checksum(lengths, &lengths[kSpxWotsLen1]);
 }
 
 static_assert(kSpxWotsLen - 1 <= UINT8_MAX,
               "Maximum chain value must fit into a `uint8_t`");
-rom_error_t wots_pk_from_sig(const uint8_t *sig, const uint8_t *msg,
+rom_error_t wots_pk_from_sig(const uint32_t *sig, const uint32_t *msg,
                              const spx_ctx_t *ctx, spx_addr_t *addr,
                              uint32_t *pk) {
   uint8_t lengths[kSpxWotsLen];
@@ -152,9 +152,9 @@ rom_error_t wots_pk_from_sig(const uint8_t *sig, const uint8_t *msg,
 
   for (uint8_t i = 0; i < kSpxWotsLen; i++) {
     spx_addr_chain_set(addr, i);
-    size_t pk_idx = i * kSpxNWords;
+    size_t word_offset = i * kSpxNWords;
     HARDENED_RETURN_IF_ERROR(
-        gen_chain(sig + i * kSpxN, lengths[i], ctx, addr, &pk[pk_idx]));
+        gen_chain(sig + word_offset, lengths[i], ctx, addr, pk + word_offset));
   }
 
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.h
@@ -33,7 +33,7 @@ extern "C" {
  * @return Error code indicating if the operation succeeded.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t wots_pk_from_sig(const uint8_t *sig, const uint8_t *msg,
+rom_error_t wots_pk_from_sig(const uint32_t *sig, const uint32_t *msg,
                              const spx_ctx_t *ctx, spx_addr_t *addr,
                              uint32_t *pk);
 

--- a/sw/device/silicon_creator/lib/sigverify/spx_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/spx_verify.c
@@ -70,12 +70,11 @@ rom_error_t sigverify_spx_verify(
   rom_error_t error = kErrorSigverifyBadSpxSignature;
   if (launder32(spx_en) != kSigverifySpxDisabledOtp) {
     sigverify_spx_root_t expected_root;
-    spx_public_key_root((const uint8_t *)key, (uint32_t *)&expected_root);
+    spx_public_key_root(key->data, expected_root.data);
     sigverify_spx_root_t actual_root;
-    HARDENED_RETURN_IF_ERROR(
-        spx_verify((const uint8_t *)signature, msg_prefix_1, msg_prefix_1_len,
-                   msg_prefix_2, msg_prefix_2_len, msg, msg_len,
-                   (const uint8_t *)key, (uint32_t *)&actual_root));
+    HARDENED_RETURN_IF_ERROR(spx_verify(
+        signature->data, msg_prefix_1, msg_prefix_1_len, msg_prefix_2,
+        msg_prefix_2_len, msg, msg_len, key->data, actual_root.data));
 
     size_t i = 0;
     for (; launder32(i) < kSigverifySpxRootNumWords; ++i) {

--- a/sw/device/silicon_creator/lib/sigverify/spx_verify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/spx_verify_functest.c
@@ -418,10 +418,10 @@ static rom_error_t spx_success_to_ok_test(void) {
 static rom_error_t spx_verify_impl_test(void) {
   sigverify_spx_root_t expected_root;
   sigverify_spx_root_t actual_root;
-  spx_public_key_root((const uint8_t *)&kPubKey, expected_root.data);
-  rom_error_t error = spx_verify((const uint8_t *)&kSignature, NULL, 0, NULL, 0,
-                                 (const uint8_t *)kMessage, kMessageLen,
-                                 (const uint8_t *)&kPubKey, actual_root.data);
+  spx_public_key_root(kPubKey.data, expected_root.data);
+  rom_error_t error =
+      spx_verify(kSignature.data, NULL, 0, NULL, 0, (const uint8_t *)kMessage,
+                 kMessageLen, kPubKey.data, actual_root.data);
   if (memcmp(&expected_root, &actual_root, sizeof(sigverify_spx_root_t)) != 0) {
     return kErrorUnknown;
   }


### PR DESCRIPTION
Since ROM public keys and signatures are already required to be word-aligned, we can align a bunch of internal buffers in SPHINCS+ and remove a  bunch of casts-to-bytes in sigverify. The performance impact is basically nil (about 1000 cycles faster out of a total ~1M cycles), because I think the compiler already noticed that most of these were aligned.