### PR TITLE
[sw/silicon_creator] Add signed_region_end field to manifest_t

### DIFF
--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -13,7 +13,7 @@
 /**
  * Manifest size for boot stages stored in flash (in bytes).
  */
-#define CHIP_MANIFEST_SIZE 8784
+#define CHIP_MANIFEST_SIZE 8788
 
 /**
  * ROM_EXT manifest identifier (ASCII "OTRE").

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -84,6 +84,7 @@ enum module_ {
   \
   X(kErrorManifestBadEntryPoint,      ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadCodeRegion,      ERROR_(2, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadSignedRegion,    ERROR_(3, kModuleManifest, kInternal)), \
   \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadClass,              ERROR_(2, kModuleAlertHandler, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -192,7 +192,7 @@ typedef struct manifest {
    * Unix timestamp that gives the creation time of the image, seconds since
    * 00:00:00 on January 1, 1970 UTC (the Unix Epoch).
    */
-  uint64_t timestamp;
+  uint32_t timestamp[2];
   /**
    * Binding value used by key manager to derive secret values.
    *

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -14,6 +14,7 @@ class ManifestTest : public rom_test::RomTest {
  protected:
   ManifestTest() {
     manifest_.length = sizeof(manifest_t) + 0x1000;
+    manifest_.signed_region_end = sizeof(manifest_t) + 0x900;
     manifest_.code_start = sizeof(manifest_t);
     manifest_.code_end = sizeof(manifest_t) + 0x800;
     manifest_.entry_point = 0x500;
@@ -26,13 +27,14 @@ TEST_F(ManifestTest, DigestRegionGet) {
   manifest_digest_region_t digest_region =
       manifest_digest_region_get(&manifest_);
 
-  // Digest region starts immediately after `usage_constraints` and ends at the
-  // end of the image.
+  // Digest region starts immediately after `usage_constraints` and ends at
+  // `signed_region_end`.
   size_t digest_region_offset = offsetof(manifest_t, usage_constraints) +
                                 sizeof(manifest_t::usage_constraints);
   EXPECT_EQ(digest_region.start,
             reinterpret_cast<const char *>(&manifest_) + digest_region_offset);
-  EXPECT_EQ(digest_region.length, manifest_.length - digest_region_offset);
+  EXPECT_EQ(digest_region.length,
+            manifest_.signed_region_end - digest_region_offset);
 }
 
 TEST_F(ManifestTest, CodeRegionGet) {

--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -168,6 +168,15 @@ impl Image {
         Ok(self.size)
     }
 
+    /// Updates the `signed_reion_end` field
+    pub fn update_signed_region(&mut self) -> Result<usize> {
+        // TODO(#18496): Should depend on extensions.
+        let signed_region_end = self.size as u32;
+        let m = self.borrow_manifest_mut()?;
+        m.signed_region_end = signed_region_end;
+        Ok(self.size)
+    }
+
     /// Operates on the signed region of the image.
     pub fn map_signed_region<F, R>(&self, f: F) -> R
     where

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -29,13 +29,13 @@ use zerocopy::FromBytes;
 //      -- -I./ -Isw/device/lib/base/freestanding
 // TODO: Generate some constants as hex if possible, replacing manually for now.
 
-pub const CHIP_MANIFEST_SIZE: u32 = 8784;
+pub const CHIP_MANIFEST_SIZE: u32 = 8788;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
 pub const CHIP_BL0_IDENTIFIER: u32 = 0x3042544f;
-pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8784;
+pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8788;
 pub const CHIP_ROM_EXT_SIZE_MAX: u32 = 0x10000;
-pub const CHIP_BL0_SIZE_MIN: u32 = 8784;
+pub const CHIP_BL0_SIZE_MIN: u32 = 8788;
 pub const CHIP_BL0_SIZE_MAX: u32 = 0x70000;
 
 /// Manifest for boot stage images stored in flash.
@@ -49,6 +49,7 @@ pub struct Manifest {
     pub rsa_modulus: SigverifyRsaBuffer,
     pub address_translation: u32,
     pub identifier: u32,
+    pub signed_region_end: u32,
     pub length: u32,
     pub version_major: u32,
     pub version_minor: u32,
@@ -154,15 +155,16 @@ pub fn check_manifest_layout() {
     assert_eq!(offset_of!(Manifest, rsa_modulus), 8320);
     assert_eq!(offset_of!(Manifest, address_translation), 8704);
     assert_eq!(offset_of!(Manifest, identifier), 8708);
-    assert_eq!(offset_of!(Manifest, length), 8712);
-    assert_eq!(offset_of!(Manifest, version_major), 8716);
-    assert_eq!(offset_of!(Manifest, version_minor), 8720);
-    assert_eq!(offset_of!(Manifest, security_version), 8724);
-    assert_eq!(offset_of!(Manifest, timestamp), 8728);
-    assert_eq!(offset_of!(Manifest, binding_value), 8736);
-    assert_eq!(offset_of!(Manifest, max_key_version), 8768);
-    assert_eq!(offset_of!(Manifest, code_start), 8772);
-    assert_eq!(offset_of!(Manifest, code_end), 8776);
-    assert_eq!(offset_of!(Manifest, entry_point), 8780);
+    assert_eq!(offset_of!(Manifest, signed_region_end), 8712);
+    assert_eq!(offset_of!(Manifest, length), 8716);
+    assert_eq!(offset_of!(Manifest, version_major), 8720);
+    assert_eq!(offset_of!(Manifest, version_minor), 8724);
+    assert_eq!(offset_of!(Manifest, security_version), 8728);
+    assert_eq!(offset_of!(Manifest, timestamp), 8732);
+    assert_eq!(offset_of!(Manifest, binding_value), 8740);
+    assert_eq!(offset_of!(Manifest, max_key_version), 8772);
+    assert_eq!(offset_of!(Manifest, code_start), 8776);
+    assert_eq!(offset_of!(Manifest, code_end), 8780);
+    assert_eq!(offset_of!(Manifest, entry_point), 8784);
     assert_eq!(size_of::<Manifest>(), CHIP_MANIFEST_SIZE as usize);
 }

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -53,7 +53,7 @@ pub struct Manifest {
     pub version_major: u32,
     pub version_minor: u32,
     pub security_version: u32,
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
     pub binding_value: KeymgrBindingValue,
     pub max_key_version: u32,
     pub code_start: u32,
@@ -126,6 +126,13 @@ impl Default for ManifestUsageConstraints {
             life_cycle_state: MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL,
         }
     }
+}
+
+/// Manifest timestamp
+#[repr(C)]
+#[derive(FromBytes, AsBytes, Debug, Default)]
+pub struct Timestamp {
+    pub data: [u32; 2usize],
 }
 
 #[repr(C)]

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -258,11 +258,12 @@ manifest_def! {
         rsa_modulus: ManifestRsaBigInt,
         address_translation: ManifestSmallInt<u32>,
         identifier: ManifestSmallInt<u32>,
+        signed_region_end: ManifestSmallInt<u32>,
         length: ManifestSmallInt<u32>,
         version_major: ManifestSmallInt<u32>,
         version_minor: ManifestSmallInt<u32>,
         security_version: ManifestSmallInt<u32>,
-        timestamp: ManifestSmallInt<u64>,
+        timestamp: [ManifestSmallInt<u32>; 2],
         binding_value: [ManifestSmallInt<u32>; 8],
         max_key_version: ManifestSmallInt<u32>,
         code_start: ManifestSmallInt<u32>,
@@ -384,6 +385,14 @@ impl TryFrom<[u32; 8]> for KeymgrBindingValue {
     }
 }
 
+impl TryFrom<[u32; 2]> for Timestamp {
+    type Error = anyhow::Error;
+
+    fn try_from(words: [u32; 2]) -> Result<Timestamp> {
+        Ok(Timestamp { data: words })
+    }
+}
+
 impl TryFrom<[u32; 8]> for LifecycleDeviceId {
     type Error = anyhow::Error;
 
@@ -454,6 +463,11 @@ where
 
 impl From<&KeymgrBindingValue> for [ManifestSmallInt<u32>; 8] {
     fn from(o: &KeymgrBindingValue) -> [ManifestSmallInt<u32>; 8] {
+        o.data.map(|v| ManifestSmallInt(Some(HexEncoded(v))))
+    }
+}
+impl From<&Timestamp> for [ManifestSmallInt<u32>; 2] {
+    fn from(o: &Timestamp) -> [ManifestSmallInt<u32>; 2] {
         o.data.map(|v| ManifestSmallInt(Some(HexEncoded(v))))
     }
 }

--- a/sw/host/opentitanlib/src/image/testdata/manifest.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest.hjson
@@ -110,6 +110,10 @@
    */
   identifier: "0x00000000"
   /**
+   * Offset to the end of the signed region relative to the start of the manifest.
+   */
+  signed_region_end: "0x00000000"
+  /**
    * Length of the image including the manifest in bytes.
    *
    * Note that the length includes the signature but the signature is excluded

--- a/sw/host/opentitanlib/src/image/testdata/manifest.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest.hjson
@@ -134,7 +134,7 @@
    * Unix timestamp that gives the creation time of the image, seconds since
    * 00:00:00 on January 1, 1970 UTC (the Unix Epoch).
    */
-  timestamp: "0x00000000"
+  timestamp: ["0x00000000", "0x00000000"]
   /**
    * Binding value used by key manager to derive secret values.
    *

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -170,6 +170,10 @@ impl CommandDispatch for ManifestUpdateCommand {
                 spx_private_key = Some(SpxKey::Private(private));
             }
         }
+
+        // Update `signed_area_end` after adding all the signed extensions.
+        image.update_signed_region()?;
+
         // Sign the image
         if let Some(key) = rsa_private_key {
             image.update_rsa_signature(key.sign(&image.compute_digest())?)?;


### PR DESCRIPTION
This PR adds the `signed_region_end` field to the manifest. See #18496 for details.