### PR TITLE
[crypto] Connect SHA-256 OTBN implementation to API.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl/sha2:sha256",
         "//sw/device/lib/crypto/impl/sha2:sha512",
         "//sw/device/lib/crypto/include:datatypes",
     ],

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -10,21 +10,39 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 /**
+ * Two-block test data.
+ *
+ * Test from:
+ * https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHA256.pdf
+ *
+ * SHA256('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq')
+ *  = 0x248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
+ */
+static const unsigned char kTwoBlockMessage[] =
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+static const uint8_t kTwoBlockExpDigest[] = {
+    0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8, 0xe5, 0xc0, 0x26,
+    0x93, 0x0c, 0x3e, 0x60, 0x39, 0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff,
+    0x21, 0x67, 0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1};
+
+/**
  * Call the `otcrypto_hash` API and check the resulting digest.
  *
  * @param msg Input message.
  * @param exp_digest Expected digest (256 bits).
  */
-static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_digest) {
+static status_t run_test(crypto_const_uint8_buf_t msg,
+                         const uint32_t *exp_digest) {
   uint32_t act_digest[kHmacDigestNumWords];
   crypto_uint8_buf_t digest_buf = {
       .data = (unsigned char *)act_digest,
       .len = sizeof(act_digest),
   };
   crypto_status_t status = otcrypto_hash(msg, kHashModeSha256, &digest_buf);
-  CHECK(status == kCryptoStatusOK, "Error during hash operation: 0x%08x",
-        status);
-  CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
+  TRY_CHECK(status == kCryptoStatusOK, "Error during hash operation: 0x%08x",
+            status);
+  TRY_CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
+  return OK_STATUS();
 }
 
 /**
@@ -33,7 +51,7 @@ static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_digest) {
  * SHA256('Test message.')
  *   = 0xb2da997a966ee07c43e1f083807ce5884bc0a4cad13b02cadc72a11820b50917
  */
-static void simple_test(void) {
+static status_t simple_test(void) {
   const char plaintext[] = "Test message.";
   crypto_const_uint8_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
@@ -43,7 +61,7 @@ static void simple_test(void) {
       0x20b50917, 0xdc72a118, 0xd13b02ca, 0x4bc0a4ca,
       0x807ce588, 0x43e1f083, 0x966ee07c, 0xb2da997a,
   };
-  run_test(msg_buf, exp_digest);
+  return run_test(msg_buf, exp_digest);
 }
 
 /**
@@ -52,7 +70,7 @@ static void simple_test(void) {
  * SHA256('')
  *   = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  */
-static void empty_test(void) {
+static status_t empty_test(void) {
   const uint32_t exp_digest[kHmacDigestNumWords] = {
       0x7852b855, 0xa495991b, 0x649b934c, 0x27ae41e4,
       0x996fb924, 0x9afbf4c8, 0x98fc1c14, 0xe3b0c442,
@@ -61,14 +79,48 @@ static void empty_test(void) {
       .data = NULL,
       .len = 0,
   };
-  run_test(msg_buf, exp_digest);
+  return run_test(msg_buf, exp_digest);
+}
+
+/**
+ * Test streaming API with a two-block message.
+ */
+static status_t streaming_test(void) {
+  hash_context_t ctx;
+  TRY_CHECK(otcrypto_hash_init(&ctx, kHashModeSha256) == kCryptoStatusOK);
+
+  // Send 0 bytes, then 1, then 2, etc. until message is done.
+  const unsigned char *next = kTwoBlockMessage;
+  size_t len = sizeof(kTwoBlockMessage) - 1;
+  size_t update_size = 0;
+  while (len > 0) {
+    update_size = len <= update_size ? len : update_size;
+    crypto_const_uint8_buf_t msg_buf = {
+        .data = next,
+        .len = update_size,
+    };
+    next += update_size;
+    len -= update_size;
+    update_size++;
+    TRY_CHECK(otcrypto_hash_update(&ctx, msg_buf) == kCryptoStatusOK);
+  }
+  uint8_t act_digest[ARRAYSIZE(kTwoBlockExpDigest)];
+  crypto_uint8_buf_t digest_buf = {
+      .data = act_digest,
+      .len = sizeof(act_digest),
+  };
+  TRY_CHECK(otcrypto_hash_final(&ctx, &digest_buf) == kCryptoStatusOK);
+  TRY_CHECK_ARRAYS_EQ(act_digest, kTwoBlockExpDigest,
+                      ARRAYSIZE(kTwoBlockExpDigest));
+  return OK_STATUS();
 }
 
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  simple_test();
-  empty_test();
-
-  return true;
+  status_t test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, simple_test);
+  EXECUTE_TEST(test_result, empty_test);
+  EXECUTE_TEST(test_result, streaming_test);
+  return status_ok(test_result);
 }


### PR DESCRIPTION
This change adds support for SHA-256 with save/restore to the cryptolib.
- Hooks up the SHA-256 OTBN interface to the top-level API's SHA-256 streaming interface (one-shot SHA-256 still uses the HMAC hardware block).
- Adds a test that uses the streaming interface.
- Fixes the `const` arguments for `sha{384,512}_{save,restore}` in `hash.c` as discussed in https://github.com/lowRISC/opentitan/pull/18461#discussion_r1188979319
