### PR TITLE
[chip/e2e] Add ROM volatile unlock

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -3493,7 +3493,8 @@
              - Verify that the CPU is able to execute.
              '''
       stage: V2
-      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock"]
+      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock",
+              "rom_volatile_raw_unlock"]
     }
     {
       name: chip_sw_power_max_load

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -864,6 +864,22 @@
       run_timeout_mins: 120
     }
 
+    // Life cycle transitions with production ROM.
+    {
+      name: rom_volatile_raw_unlock
+      uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary",
+      ]
+      en_run_modes: ["sw_test_mode_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=200_000_000",
+        "+use_otp_image=OtpTypeLcStRaw",
+        "+rom_prod_mode=1",
+      ]
+      run_timeout_mins: 480
+    }
+
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {
       name: chip_sw_uart_smoketest_signed

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -723,6 +723,17 @@ interface chip_if;
   assign probed_cpu_csrs.mcause =
       `CPU_CORE_HIER.u_ibex_core.cs_registers_i.u_mcause_csr.rd_data_o;
 
+  // Probed Ibex PC.
+  typedef struct packed {
+    logic [31:0] pc_if;
+    logic [31:0] pc_id;
+    logic [31:0] pc_wb;
+  } probed_cpu_pc_t;
+  wire probed_cpu_pc_t probed_cpu_pc;
+  assign probed_cpu_pc.pc_if = `CPU_CORE_HIER.u_ibex_core.pc_if;
+  assign probed_cpu_pc.pc_id = `CPU_CORE_HIER.u_ibex_core.pc_id;
+  assign probed_cpu_pc.pc_wb = `CPU_CORE_HIER.u_ibex_core.pc_wb;
+
   // Stub CPU envorinment.
   //
   // The initial value is sought from a plusarg. It can however, be set by the sequence on the fly


### PR DESCRIPTION
This commit adds volatile raw unlock test with the production ROM. It currently takes +6h to execute.