### PR TITLE
[Spi host]  Test flash 4byte addressing mode

### DIFF
--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -394,3 +394,12 @@ status_t spi_flash_testutils_enter_4byte_address_mode(dif_spi_host_t *spih) {
   TRY(dif_spi_host_transaction(spih, /*cs_id=*/0, &op, 1));
   return OK_STATUS();
 }
+
+status_t spi_flash_testutils_exit_4byte_address_mode(dif_spi_host_t *spih) {
+  dif_spi_host_segment_t op = {
+      .type = kDifSpiHostSegmentTypeOpcode,
+      .opcode = kSpiDeviceFlashOpExit4bAddr,
+  };
+  TRY(dif_spi_host_transaction(spih, /*cs_id=*/0, &op, 1));
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -385,3 +385,12 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
   }
   return OK_STATUS();
 }
+
+status_t spi_flash_testutils_enter_4byte_address_mode(dif_spi_host_t *spih) {
+  dif_spi_host_segment_t op = {
+      .type = kDifSpiHostSegmentTypeOpcode,
+      .opcode = kSpiDeviceFlashOpEnter4bAddr,
+  };
+  TRY(dif_spi_host_transaction(spih, /*cs_id=*/0, &op, 1));
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -258,4 +258,13 @@ status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
  */
 OT_WARN_UNUSED_RESULT
 status_t spi_flash_testutils_enter_4byte_address_mode(dif_spi_host_t *spih);
+
+/**
+ * Disables 4-bytes addressing mode.
+ *
+ * @param spih A SPI host handle.
+ * @return status_t containing either OK or an error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t spi_flash_testutils_exit_4byte_address_mode(dif_spi_host_t *spih);
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_TESTUTILS_H_

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -43,6 +43,7 @@ typedef struct spi_flash_testutils_parameter_header {
 // JESD216F, section 6.4.18:
 // The Quad Enable mechanism is bits 20:23 of the 15th dword.
 #define SPI_FLASH_QUAD_ENABLE ((bitfield_field32_t){.mask = 7, .index = 20})
+#define SPI_FLASH_ADDRESS_MODE ((bitfield_field32_t){.mask = 3, .index = 17})
 
 /**
  * Read out the JEDEC ID from the SPI flash.

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -250,5 +250,12 @@ status_t spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
 OT_WARN_UNUSED_RESULT
 status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
                                          bool enable);
-
+/**
+ * Enables 4-bytes addressing mode.
+ *
+ * @param spih  A SPI host handle.
+ * @return status_t containing either OK or an error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t spi_flash_testutils_enter_4byte_address_mode(dif_spi_host_t *spih);
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_FLASH_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1805,9 +1805,6 @@ opentitan_functest(
 opentitan_functest(
     name = "sensor_ctrl_alert_test",
     srcs = ["sensor_ctrl_alerts.c"],
-    verilator = verilator_params(
-        timeout = "eternal",
-    ),
     deps = [
         "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -72,8 +72,8 @@ status_t test_read_sfdp(void) {
   return OK_STATUS();
 }
 
-status_t test_chip_erase(void) {
-  TRY(spi_flash_testutils_erase_chip(&spi_host));
+status_t test_erase(void) {
+  TRY(spi_flash_testutils_erase_sector(&spi_host, 0, false));
 
   // Check that the first page of flash actually got erased.
   uint8_t buf[256] = {0};
@@ -165,6 +165,7 @@ status_t test_4bytes_address(void) {
                 "Should be at the beginning of the sector.");
 
   TRY(spi_flash_testutils_enter_4byte_address_mode(&spi_host));
+  TRY(spi_flash_testutils_erase_sector(&spi_host, kAddress, true));
 
   TRY(spi_flash_testutils_program_page(&spi_host, kGettysburgPrelude,
                                        sizeof(kGettysburgPrelude), kAddress,
@@ -196,7 +197,7 @@ bool test_main(void) {
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, test_software_reset);
   EXECUTE_TEST(result, test_read_sfdp);
-  EXECUTE_TEST(result, test_chip_erase);
+  EXECUTE_TEST(result, test_erase);
   EXECUTE_TEST(result, test_enable_quad_mode);
   EXECUTE_TEST(result, test_page_program);
   if (is_4_bytes_address_mode_supported()) {


### PR DESCRIPTION
This test needs a larger flash installed in the FPGA, so this PR won't pass on CI until we update the CI hardware. 


## Open questions:
1. Should we remove the chip erase test, since it will jump from 21 seconds to 115 seconds?
2. Should we randomize the addresses tested to simulate a Wear-leveling and maximize the flash life-span on CI?