### PR TITLE
[top_earlgrey][spi_device] Add SPI constraints and remove hold timing failures

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -34,10 +34,19 @@ module spi_cmdparse
   output io_mode_e io_mode_o,
 
   // Activate downstream modules
+  // sel_dp_o is a function of registered outputs, latched on posedge SCK
+  // cmd_only_* pins are combinatorial functions of inputs, selecting modules
+  //   before the 8th posedge SCK, for example. They are available for commands
+  //   that may complete with only the command's 8 cycles and no more. They must
+  //   NOT be used to drive direct outputs, nor calculate inputs for flops on
+  //   negedge SCK.
   // cmd_info_o is a registered output, latched at 8th posedge SCK
   output sel_datapath_e          sel_dp_o,
+  output sel_datapath_e          cmd_only_sel_dp_o,
   output cmd_info_t              cmd_info_o,
   output logic [CmdInfoIdxW-1:0] cmd_info_idx_o,
+  output cmd_info_t              cmd_only_info_o,
+  output logic [CmdInfoIdxW-1:0] cmd_only_info_idx_o,
 
   // CFG: Intercept
   input cfg_intercept_en_status_i,
@@ -136,6 +145,10 @@ module spi_cmdparse
   assign sel_dp_o = sel_dp;
   `ASSERT_KNOWN(SelDpKnown_A, sel_dp_o)
 
+  sel_datapath_e cmd_only_sel_dp;
+  assign cmd_only_sel_dp_o = cmd_only_sel_dp;
+  `ASSERT_KNOWN(CmdOnlySelDpKnown_A, cmd_only_sel_dp_o)
+
   // FSM asserts latching enable signal for cmd_info in 8th opcode cycle.
   logic                   latch_cmdinfo;
   cmd_info_t              cmd_info_d,     cmd_info_q;
@@ -232,6 +245,8 @@ module spi_cmdparse
   // cmd_info & cmd_info_idx are registered output in the cmdparse module.
   // The upload module in SPI_DEVICE uses cmd_info to determine if the address
   // field exists or not.
+  assign cmd_info_o     = cmd_info_q;
+  assign cmd_info_idx_o = cmd_info_idx_q;
 
   // The cmd_info value arrives to the rest of the module one clock late. It
   // results in the upload module to assume the command does not have the
@@ -239,13 +254,17 @@ module spi_cmdparse
 
   // This commit pulls in the cmd_info one clock early. It leads to longer
   // datapath as cmdparse cannot register the data.
-  always_comb begin : cmd_info_output
-    cmd_info_o     = cmd_info_q;
-    cmd_info_idx_o = cmd_info_idx_q;
+  always_comb begin : cmd_only_info_output
+    cmd_only_info_o = '{
+      payload_dir: payload_dir_e'(PayloadIn),
+      addr_mode: addr_mode_e'(0),
+      default: '0
+    };
+    cmd_only_info_idx_o = '0;
 
     if ((st == StIdle) && module_active && data_valid_i) begin
-      cmd_info_o     = cmd_info_d;
-      cmd_info_idx_o = cmd_info_idx_d;
+      cmd_only_info_o     = cmd_info_d;
+      cmd_only_info_idx_o = cmd_info_idx_d;
     end
   end
 
@@ -286,6 +305,7 @@ module spi_cmdparse
     st_d = st;
 
     sel_dp = DpNone;
+    cmd_only_sel_dp = DpNone;
 
     latch_cmdinfo = 1'b 0;
 
@@ -342,36 +362,21 @@ module spi_cmdparse
 
             upload: begin
               st_d = StUpload;
-
-              // Reason to select dp here is for Opcode-only commands such as
-              // ChipErase. As no further SCK is given after 8th bit, need to
-              // write the command to FIFO at the same cycle.
-              //
-              // May sel_dp have glitch. As Opcode isn't yet fully stable, it
-              // has a chance to select datapath to Upload and back to None.
-              // If we can write opcode in negedge of SCK, then selecting DP
-              // at 8th posedge of SCK is also possible.
-              //
-              // If not, then we may end up latch `sel_dp` at negedge of SCK.
-              // Then when 8th bit is visible here (`data_valid_i`), the
-              // sel_dp may change. But the output of sel_dp affects only when
-              // 8th negedge of SCK.
-
-              sel_dp = DpUpload;
+              cmd_only_sel_dp = DpUpload;
             end
 
             opcode_en4b, opcode_ex4b: begin
               st_d = StAddr4B;
 
               // opcode only commands. Need to assert DP before transition
-              sel_dp = (opcode_en4b) ? DpEn4B : DpEx4B ;
+              cmd_only_sel_dp = (opcode_en4b) ? DpEn4B : DpEx4B ;
             end
 
             opcode_wren, opcode_wrdi: begin
               st_d = StWrEn;
 
               // opcode only commands. Need to assert DP before transition
-              sel_dp = (opcode_wren) ? DpWrEn : DpWrDi ;
+              cmd_only_sel_dp = (opcode_wren) ? DpWrEn : DpWrDi ;
             end
 
             default: begin

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -272,7 +272,7 @@ module spi_device
   logic [31:0] readbuf_addr_busclk;
 
   // CMD interface
-  sel_datapath_e cmd_dp_sel, cmd_dp_sel_outclk;
+  sel_datapath_e cmd_dp_sel, cmd_only_dp_sel;
 
   // Mailbox in Passthrough needs to take SPI if readcmd hits mailbox address
   logic intercept_en;
@@ -308,6 +308,10 @@ module spi_device
   // and latches the cmd_info and broadcast to submodules
   cmd_info_t                  cmd_info_broadcast;
   logic [CmdInfoIdxW-1:0]     cmd_info_idx_broadcast;
+  // Combinatorial output of selected cmd_info, to be used with modules that
+  // need the values before the 8th posedge of the command.
+  cmd_info_t                  cmd_only_info_broadcast;
+  logic [CmdInfoIdxW-1:0]     cmd_only_info_idx_broadcast;
 
   // CSb edge detector in the system clock and SPI input clock
   // SYS clock assertion can be detected but no usage for the event yet.
@@ -1167,11 +1171,6 @@ module spi_device
     else            io_mode_outclk <= io_mode;
   end
 
-  always_ff @(posedge clk_spi_out_buf or negedge rst_spi_n) begin
-    if (!rst_spi_n) cmd_dp_sel_outclk <= DpNone;
-    else            cmd_dp_sel_outclk <= cmd_dp_sel;
-  end
-
   // SCK clock domain MUX for SRAM access for Flash and Passthrough
   always_comb begin
     flash_sram_l2m = '{ default: '0 };
@@ -1198,8 +1197,14 @@ module spi_device
       end
 
       default: begin
-        // DpNone, DpReadStatus, DpReadJEDEC
-        flash_sram_l2m = '{default: '0 };
+        if (cmd_only_dp_sel == DpUpload) begin
+          // Be ready to upload commands on the 8th command bit, when directed
+          flash_sram_l2m = sub_sram_l2m[IoModeUpload];
+          sub_sram_m2l[IoModeUpload] = flash_sram_m2l;
+        end else begin
+          // DpNone, DpReadStatus, DpReadJEDEC
+          flash_sram_l2m = '{default: '0 };
+        end
       end
     endcase
   end
@@ -1244,7 +1249,7 @@ module spi_device
         mem_b_l2m = flash_sram_l2m;
         flash_sram_m2l = mem_b_m2l;
 
-        unique case (cmd_dp_sel_outclk)
+        unique case (cmd_dp_sel)
           DpNone: begin
             io_mode = sub_iomode[IoModeCmdParse];
 
@@ -1467,9 +1472,12 @@ module spi_device
 
     .io_mode_o    (sub_iomode[IoModeCmdParse]),
 
-    .sel_dp_o       (cmd_dp_sel),
-    .cmd_info_o     (cmd_info_broadcast),
-    .cmd_info_idx_o (cmd_info_idx_broadcast),
+    .sel_dp_o          (cmd_dp_sel),
+    .cmd_only_sel_dp_o (cmd_only_dp_sel),
+    .cmd_info_o        (cmd_info_broadcast),
+    .cmd_info_idx_o    (cmd_info_idx_broadcast),
+    .cmd_only_info_o     (cmd_only_info_broadcast),
+    .cmd_only_info_idx_o (cmd_only_info_idx_broadcast),
 
     .cfg_intercept_en_status_i (cfg_intercept_en.status),
     .cfg_intercept_en_jedec_i  (cfg_intercept_en.jedec),
@@ -1543,8 +1551,8 @@ module spi_device
   assign hw2reg.flash_status.busy.d   = readstatus_d[0];
   assign hw2reg.flash_status.status.d = readstatus_d[23:1];
 
-  assign sck_status_wr_set = (cmd_dp_sel == DpWrEn);
-  assign sck_status_wr_clr = (cmd_dp_sel == DpWrDi);
+  assign sck_status_wr_set = (cmd_only_dp_sel == DpWrEn);
+  assign sck_status_wr_clr = (cmd_only_dp_sel == DpWrDi);
 
   spid_status u_spid_status (
     .clk_i  (clk_spi_in_buf),
@@ -1641,7 +1649,8 @@ module spi_device
     .sck_csb_asserted_pulse_i   (sck_csb_asserted_pulse),
     .sys_csb_deasserted_pulse_i (sys_csb_deasserted_pulse),
 
-    .sel_dp_i (cmd_dp_sel),
+    .sel_dp_i          (cmd_dp_sel),
+    .cmd_only_sel_dp_i (cmd_only_dp_sel),
 
     .sck_sram_o (sub_sram_l2m[IoModeUpload]),
     .sck_sram_i (sub_sram_m2l[IoModeUpload]),
@@ -1676,8 +1685,8 @@ module spi_device
 
     .cfg_addr_4b_en_i (cfg_addr_4b_en),
 
-    .cmd_info_i     (cmd_info_broadcast),
-    .cmd_info_idx_i (cmd_info_idx_broadcast),
+    .cmd_only_info_i     (cmd_only_info_broadcast),
+    .cmd_only_info_idx_i (cmd_only_info_idx_broadcast),
 
     .io_mode_o (sub_iomode[IoModeUpload]),
 
@@ -1730,8 +1739,8 @@ module spi_device
   // End:   Upload ---------------------------------------------------
 
   // Begin: Address 3B/4B Tracker ====================================
-  assign cmd_en4b_pulse = cmd_dp_sel == DpEn4B;
-  assign cmd_ex4b_pulse = cmd_dp_sel == DpEx4B;
+  assign cmd_en4b_pulse = cmd_only_dp_sel == DpEn4B;
+  assign cmd_ex4b_pulse = cmd_only_dp_sel == DpEx4B;
   spid_addr_4b u_spid_addr_4b (
     .sys_clk_i  (clk_i ),
     .sys_rst_ni (rst_ni),

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -5,6 +5,12 @@
 ## Clock Signal
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
+## Rename MMCM outputs for less bug-prone parsing.
+## Some auto-derived clocks can have names that include brackets.
+create_generated_clock -name clk_main [get_pin clkgen/pll/CLKOUT0]
+create_generated_clock -name clk_usb_48 [get_pin clkgen/pll/CLKOUT1]
+create_generated_clock -name clk_aon [get_pin clkgen/pll/CLKOUT4]
+
 ## Clock Domain Crossings
 set clks_10_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT0]]
 set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
@@ -16,12 +22,24 @@ set clks_aon_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT4]]
 
 set u_pll clkgen/pll
 set u_div2 top_*/u_clkmgr_aon/u_no_scan_io_div2_div
-create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 2 [get_pin ${u_div2}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
+create_generated_clock -name clk_io_div2 -source [get_pins ${u_pll}/CLKOUT0] -divide_by 2 [get_pin ${u_div2}/gen_div2.u_div2/gen_xilinx.u_impl_xilinx/q_o[0]]
 
 # TODO: Use pin names explicitly exist from the source instead of the ones
 # after synthesis.
 set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -divide_by 4 -source [get_pins ${u_div4}/gen_div.clk_int_reg/C] [get_pins ${u_div4}/gen_div.clk_int_reg/Q]
+
+
+set ast_src_io u_ast/u_ast_clks_byp/u_no_scan_clk_src_io_d1ord2
+#create_generated_clock -name clk_src_io -divide_by 1 -source [get_pins ${u_pll}/CLKOUT0] \
+#  [get_pins ${ast_src_io}/gen_div2.u_div2/gen_xilinx.u_impl_xilinx/q_o[0]]
+
+set_clock_sense -positive \
+  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
+    [get_nets -segments -of_objects \
+      [get_pins ${ast_src_io}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/I] \
+    ] \
+  ]
 
 # the step-down mux is implemented with a LUT right now and the mux switches on the falling edge.
 # therefore, Vivado propagates both clock edges down the clock network.
@@ -30,20 +48,20 @@ create_generated_clock -name clk_io_div4 -divide_by 4 -source [get_pins ${u_div4
 set_clock_sense -positive \
   [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
     [get_nets -segments -of_objects \
-      [get_pins top_*/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/I] \
+      [get_pins top_*/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/I] \
     ] \
   ]
 
 ## JTAG clocks and I/O delays
 # Create clocks for the various TAPs.
 create_clock -add -name jtag_tck -period 100.00 -waveform {0 50} [get_ports IOR3]
-create_generated_clock -name lc_jtag_tck -source [get_ports IOR3] -divide_by 1 [get_pin top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_lc/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
-create_generated_clock -name rv_jtag_tck -source [get_ports IOR3] -divide_by 1 [get_pin top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_rv/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
+create_generated_clock -name lc_jtag_tck -source [get_ports IOR3] -divide_by 1 [get_pins top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_lc/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
+create_generated_clock -name rv_jtag_tck -source [get_ports IOR3] -divide_by 1 [get_pins top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_rv/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/O]
 
 set lc_jtag_tck_inv_pin  \
   [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
     [get_nets -segments -of_objects \
-      [get_pins top_earlgrey/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_rv/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/I]]]
+      [get_pins top_earlgrey/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_lc/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufg.bufg_i/I]]]
 set rv_jtag_tck_inv_pin  \
   [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
     [get_nets -segments -of_objects \
@@ -72,39 +90,166 @@ set_input_delay  -add_delay -clock_fall -clock jtag_tck -min  0.0 [get_ports {IO
 set_input_delay  -add_delay -clock_fall -clock jtag_tck -max 15.0 [get_ports {IOR0 IOR2}]
 
 ## SPI clocks
-create_clock -add -name clk_spi  -period 100.00 -waveform {0 50} [get_ports SPI_DEV_CLK]
-set_input_delay -clock clk_spi 5 [get_ports SPI_DEV_D0]
-set_input_delay -clock clk_spi 5 [get_ports SPI_DEV_D1]
-set_output_delay -clock clk_spi 5 [get_ports SPI_DEV_D0] -add_delay
-set_output_delay -clock clk_spi 5 [get_ports SPI_DEV_D1] -add_delay
+set spi_dev_period 100.0
+set spi_dev_half_period [expr ${spi_dev_period} / 2]
+# Max board skew between signals
+set spi_dev_board_skew  0.5
+# Max board delay
+set spi_dev_board_delay 0.6
+# Board skew affects input path for sampling
+set spi_dev_in_delay_min [expr -2.0 - ${spi_dev_board_skew}]
+set spi_dev_in_delay_max [expr  3.0 + ${spi_dev_board_skew}]
+# The board delay affects time remaining on the output path.
+set spi_dev_out_hold      -5.0
+set spi_dev_out_setup     [expr  5.0 + 2 * ${spi_dev_board_delay}]
 
-# set clock sense on the input to spi buffers to help the tool understand the clocks are shifted versions of each other
-# This can also be accomplished through create_genearted_clocks.
+create_clock -add -name clk_spi  -period ${spi_dev_period} \
+    -waveform "0 ${spi_dev_half_period}" [get_ports SPI_DEV_CLK]
+# CSB must act as a clock, in addition to data and a reset.
+create_clock -name clk_spid_csb -period ${spi_dev_period} \
+    -waveform "${spi_dev_half_period} [expr ${spi_dev_half_period} + 1]" \
+    [get_ports SPI_DEV_CS_L]
+set_clock_latency -source -min ${spi_dev_in_delay_min} [get_ports SPI_DEV_CS_L]
+set_clock_latency -source -max ${spi_dev_in_delay_max} [get_ports SPI_DEV_CS_L]
 
-## set clock sense approach
-##set_clock_sense -negative \
-##  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
-##    [get_nets -segments -of_objects \
-##      [get_pins top_*/u_spi_device/gen_fpga_buf.gen_bufr.bufr_i_i_1/I] \
-##    ] \
-##  ] \
-##  -clocks clk_spi
-##
-##set_clock_sense -positive \
-##  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
-##    [get_nets -segments -of_objects \
-##      [get_pins top_*/u_spi_device/gen_fpga_buf.gen_bufr.bufr_i_i_1__0/I] \
-##    ] \
-##  ] \
-##  -clocks clk_spi
+set spi_dev_data [get_ports {SPI_DEV_D0 SPI_DEV_D1 SPI_DEV_D2 SPI_DEV_D3}]
+set_input_delay -clock clk_spi -clock_fall -min ${spi_dev_in_delay_min} ${spi_dev_data}
+set_input_delay -clock clk_spi -clock_fall -max ${spi_dev_in_delay_max} ${spi_dev_data} -add_delay
 
-## create_generated_clock appraoch
-## create_generated_clock is preferred since the buffer cell used here is hand-instantiated, while the set_clock_sense point is simply a LUT
+## For half-cycle
+#set_output_delay -clock clk_spi -min ${spi_dev_out_hold}  ${spi_dev_data} -add_delay
+#set_output_delay -clock clk_spi -max ${spi_dev_out_setup} ${spi_dev_data} -add_delay
+
+## For full-cycle
+set_output_delay -clock clk_spi -clock_fall -min ${spi_dev_out_hold}  ${spi_dev_data} -add_delay
+set_output_delay -clock clk_spi -clock_fall -max ${spi_dev_out_setup} ${spi_dev_data} -add_delay
+
+## set clock sense on the input to spi buffers to help the tool understand the
+## clocks are shifted versions of each other
+set_clock_sense -positive \
+  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
+    [get_nets -segments -of_objects \
+      [get_pins top_earlgrey/u_spi_device/u_passthrough/u_pt_sck_cg/gen_xilinx.u_impl_xilinx/gen_gate.gen_bufgce.u_bufgce/I0] \
+    ] \
+  ] \
+  -clocks clk_spi
+
+set_clock_sense -negative \
+  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
+    [get_nets -segments -of_objects \
+      [get_pins top_earlgrey/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/I] \
+    ] \
+  ] \
+  -clocks clk_spi
+
+set_clock_sense -positive \
+  [get_pins -filter {DIRECTION == OUT && IS_LEAF} -of_objects \
+    [get_nets -segments -of_objects \
+      [get_pins top_earlgrey/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/I] \
+    ] \
+  ] \
+  -clocks clk_spi
+
 create_generated_clock -name clk_spi_in  -divide_by 1 -source [get_ports SPI_DEV_CLK] [get_pins top_*/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/O]
 create_generated_clock -name clk_spi_out -divide_by 1 -source [get_ports SPI_DEV_CLK] [get_pins top_*/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.gen_bufr.bufr_i/O] -invert
 
+## SPI Passthrough constraints
+create_generated_clock -name clk_spi_pt -divide_by 1 -source [get_ports SPI_DEV_CLK] [get_ports SPI_HOST_CLK]
+
+set spi_pt_data [get_ports {SPI_HOST_D0 SPI_HOST_D1 SPI_HOST_D2 SPI_HOST_D3}]
+set spi_host_board_skew 0.5
+set spi_host_board_delay 0.6
+set spi_host_out_hold      [expr -3.0 - ${spi_host_board_skew}]
+set spi_host_out_setup     [expr  3.0 + ${spi_host_board_skew}]
+set spi_host_in_delay_min 0
+set spi_host_in_delay_max [expr  9.0 + 2 * ${spi_host_board_delay}]
+
+set_output_delay -clock clk_spi_pt -min ${spi_host_out_hold}  ${spi_pt_data} -add_delay
+set_output_delay -clock clk_spi_pt -max ${spi_host_out_setup} ${spi_pt_data} -add_delay
+set_output_delay -clock clk_spi_pt -min ${spi_host_out_hold}  [get_ports SPI_HOST_CS_L] -add_delay
+set_output_delay -clock clk_spi_pt -max ${spi_host_out_setup} [get_ports SPI_HOST_CS_L] -add_delay
+
+set_input_delay  -clock clk_spi_pt -clock_fall -min ${spi_host_in_delay_min} \
+    ${spi_pt_data} -add_delay
+set_input_delay  -clock clk_spi_pt -clock_fall -max ${spi_host_in_delay_max} \
+    ${spi_pt_data} -add_delay
+
+
+## SPI Host constraints
+# SPI Host clock origin buffer
+set spi_host_0_peri [get_pins top_earlgrey/u_clkmgr_aon/u_clk_io_peri_cg/gen_xilinx.u_impl_xilinx/gen_gate.gen_bufgce.u_bufgce/O]
+
+# Even though it's 2x the max possible frequency, keep the peripheral clock
+# frequency for the output. This will enable shifting the latch edge for hold
+# analysis by the proper amount to effect "half-cycle sampling" of SPI.
+create_generated_clock -name clk_spi_host0 -divide_by 1 -add \
+  -source ${spi_host_0_peri} \
+  -master_clock [get_clocks -of_objects ${spi_host_0_peri}] \
+  [get_ports SPI_HOST_CLK]
+
+set spi_host_0_data [get_ports {SPI_HOST_D0 SPI_HOST_D1 SPI_HOST_D2 SPI_HOST_D3 SPI_HOST_CS_L}]
+set_output_delay -clock clk_spi_host0 -min ${spi_host_out_hold} \
+    ${spi_host_0_data} -add_delay
+set_output_delay -clock clk_spi_host0 -max ${spi_host_out_setup} \
+    ${spi_host_0_data} -add_delay
+set_input_delay  -clock clk_spi_host0 -clock_fall -min ${spi_host_in_delay_min} \
+    ${spi_host_0_data} -add_delay
+set_input_delay  -clock clk_spi_host0 -clock_fall -max ${spi_host_in_delay_max} \
+    ${spi_host_0_data} -add_delay
+
+# The setup analysis is already correct for half-cycle sampling: If the first
+# posedge of the peripheral clock represents the negedge of SPI_HOST_CLK, then
+# the next posedge of the peripheral clock is when data should be latched, the
+# posedge of SPI_HOST_CLK.
+# However, the latch edge for hold analysis represents the same edge and needs
+# to be advanced by one cycle of the peripheral clock (half a cycle of
+# SPI_HOST_CLK).
+set_multicycle_path -hold -end \
+  -from [get_clocks -of_objects ${spi_host_0_peri}] \
+  -to [get_clocks clk_spi_host0] 1
+
 ## Set asynchronous clock groups
-set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_aon_unbuf} -group clk_io_div2 -group clk_io_div4 -group [get_clocks -include_generated_clocks jtag_tck] -group {clk_spi clk_spi_in clk_spi_out} -group sys_clk_pin -asynchronous
+set_clock_groups -asynchronous \
+    -group {clk_main clk_spi_host0} \
+    -group clk_usb_48 \
+    -group clk_aon \
+    -group clk_io_div2 \
+    -group clk_io_div4 \
+    -group [get_clocks -include_generated_clocks jtag_tck] \
+    -group {clk_spi clk_spi_in clk_spi_out clk_spi_pt clk_spid_csb} \
+    -group sys_clk_pin
+
+# CSB to SPI_DEV output enables. Primarily affects generic mode with CPHA=0
+# and the first bit.
+# Because SPI_DEV_CS_L is a clock pin, various constraint styles will not take.
+# Use output delay to constrain the allowed CSB-to-Q outputs.
+set spi_dev_csb_clk_q_min -5.0
+set spi_dev_csb_clk_q_max 25.0
+set spi_dev_csb_out_delay_min [expr 0 - ${spi_dev_csb_clk_q_min}]
+set spi_dev_csb_out_delay_max [expr ${spi_dev_period} - ${spi_dev_csb_clk_q_max}]
+set_output_delay -clock clk_spid_csb -add_delay -min ${spi_dev_csb_out_delay_min} \
+set_output_delay -clock clk_spid_csb -add_delay -max ${spi_dev_csb_out_delay_max} \
+    ${spi_dev_data}
+
+# Then mark the paths using other clocks as false paths. CSB does notactually
+# sample these clocks.
+set_clock_groups -logically_exclusive -group clk_spi -group clk_spid_csb
+set_false_path -from [get_clocks {clk_spi_in clk_spi_out clk_spi_pt}] -through ${spi_dev_data} \
+    -to [get_clocks clk_spid_csb]
+
+# clk_spid_csb is not active with clk_spi_out, and it should not switch
+# passthrough off while SPI_HOST is active. However, delays need to be limited
+# to avoid blocking passthrough on the first bit.
+set_max_delay -datapath_only -from [get_clocks clk_spid_csb] -to [get_clocks clk_spi_host0] \
+    [expr ${spi_dev_half_period} / 2]
+
+# CSB-clocked status bits to various negedge-triggered flops, especially in the
+# serializer. Also may include the path to something for passthrough...
+# Advance the hold edge by one cycle, since CSB changes nominally on the same
+# edge as clk_spi_out, but clk_spi_out isn't actually toggling.
+set_multicycle_path -hold -end -from [get_clocks clk_spid_csb] \
+    -to [get_clocks clk_spi_out] 1
+
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.


### PR DESCRIPTION
Add timing constraints for SPI host, device, and passthrough.

Split off early datapath selection from output calculation.
The datapath selection signal had two different timing modes multiplexed
on top of a single signal, one where it would depend on flops that
change on posedge SCK and another that depended directly on SPI inputs.
Because there were negedge-triggered flops whose inputs depended on that
signal, this signal represented a high risk of hold timing failures.

Split off the function that selects a datapath to trigger internal
updates on the 8th posedge (the last clock edge for commands that are
command-only). Make this a separate signal that feeds the modules that
need it, and restore the original datapath selection signal to be purely
driven from internal flops.