### PR TITLE
[openocd] update JTAG ID codes in config files

### DIFF
--- a/util/openocd/target/lowrisc-earlgrey-lc.cfg
+++ b/util/openocd/target/lowrisc-earlgrey-lc.cfg
@@ -20,7 +20,8 @@ if { [info exists CHIPNAME] } {
 if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
-   set _CPUTAPID 0x04f5484d
+   # Defined in `hw/top_earlgrey/rtl/jtag_id_pkg.sv`.
+   set _CPUTAPID 0x10002cdf
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID -ignore-bypass

--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -13,7 +13,8 @@ if { [info exists CHIPNAME] } {
 if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
-   set _CPUTAPID 0x04f5484d
+   # Defined in `hw/top_earlgrey/rtl/jtag_id_pkg.sv`.
+   set _CPUTAPID 0x10001cdf
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID


### PR DESCRIPTION
The ID codes were updated in the HW in #18445, but not in the config file, which resulted in error messages when connecting OpenOCD to JTAG in manufacturing tests.