### PR TITLE
[otlib] Improve console output for test harnesses

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/bootstrap.rs
+++ b/sw/host/opentitanlib/src/test_utils/bootstrap.rs
@@ -31,7 +31,11 @@ impl Bootstrap {
     pub fn load(&self, transport: &TransportWrapper, file: &Path) -> Result<()> {
         let payload = std::fs::read(file)?;
         let progress = StagedProgressBar::new();
-        bootstrap::Bootstrap::update_with_progress(transport, &self.options, &payload, &progress)?;
+        let mut options = self.options.clone();
+        if options.clear_uart.is_none() {
+            options.clear_uart = Some(true);
+        }
+        bootstrap::Bootstrap::update_with_progress(transport, &options, &payload, &progress)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -38,6 +38,8 @@ impl<T: DeserializeOwned> UartRecv for T {
     {
         let mut console = UartConsole {
             timeout: Some(timeout),
+            timestamp: true,
+            newline: true,
             exit_success: Some(Regex::new(r"RESP_OK:(.*)\r")?),
             exit_failure: Some(Regex::new(r"RESP_ERR:(.*)\r")?),
             ..Default::default()
@@ -50,6 +52,7 @@ impl<T: DeserializeOwned> UartRecv for T {
             None
         };
         let result = console.interact(uart, None, out)?;
+        println!();
         match result {
             ExitStatus::ExitSuccess => {
                 let cap = console

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -184,9 +184,9 @@ impl UartConsole {
         for i in 0..len {
             if self.timestamp && self.newline {
                 let t = humantime::format_rfc3339_millis(SystemTime::now());
-                stdout
-                    .as_mut()
-                    .map_or(Ok(()), |out| out.write_fmt(format_args!("[{}]", t)))?;
+                stdout.as_mut().map_or(Ok(()), |out| {
+                    out.write_fmt(format_args!("[{}  console]", t))
+                })?;
                 self.newline = false;
             }
             self.newline = buf[i] == b'\n';
@@ -294,12 +294,15 @@ impl UartConsole {
         T: ConsoleDevice + ?Sized,
     {
         let mut console = UartConsole {
+            timestamp: true,
+            newline: true,
             timeout: Some(timeout),
             exit_success: Some(Regex::new(rx)?),
             ..Default::default()
         };
         let mut stdout = std::io::stdout();
         let result = console.interact(device, None, Some(&mut stdout))?;
+        println!();
         match result {
             ExitStatus::ExitSuccess => {
                 let cap = console.captures(ExitStatus::ExitSuccess).expect("capture");


### PR DESCRIPTION
1. Clear the uart during bootstrap (unless explicitly configured otherwise).
2. Print console timestamps for `UartConsole::wait_for` and `UartRec::recv`.
3. Explicitly log console output as coming from the console.