### PR TITLE
[chip] Wait for rom_ctrl init before accessing tap

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -25,6 +25,10 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset();
+    // Wait for `rom_ctrl` to complete the ROM check. This will give the dut
+    // enough time to configure the TAP interface before any JTAG agents send
+    // any commands.
+    wait_rom_check_done();
     set_otp_creator_sw_cfg_rom_exec_en(1);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -29,6 +29,10 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset();
+    // Wait for `rom_ctrl` to complete the ROM check. This will give the dut
+    // enough time to configure the TAP interface before any JTAG agents send
+    // any commands.
+    wait_rom_check_done();
     set_otp_creator_sw_cfg_rom_exec_en(1);
   endtask
 


### PR DESCRIPTION
This commit updates `chip_sw_lc_walkthrough_vseq` to wait for rom_ctrl check done before attempting to access the JTAG interface after applying dut reset.

Addresses #18490 
Addresses [#18467](https://github.com/lowRISC/opentitan/issues/18467)