### PR TITLE
[sw/silicon_creator] Add extensions table and related types

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -11,10 +11,10 @@ CONST = struct(
     # Must match the definitions in chip.h.
     ROM_EXT = 0x4552544f,
     OWNER = 0x3042544f,
-    MANIFEST_SIZE = 8784,
-    ROM_EXT_SIZE_MIN = 8784,
+    MANIFEST_SIZE = 8852,
+    ROM_EXT_SIZE_MIN = 8852,
     ROM_EXT_SIZE_MAX = 0x10000,
-    BL0_SIZE_MIN = 8784,
+    BL0_SIZE_MIN = 8852,
     BL0_SIZE_MAX = 0x70000,
     DEFAULT_USAGE_CONSTRAINTS = 0xa5a5a5a5,
     # Must match the definition in spx_verify.h

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -13,7 +13,12 @@
 /**
  * Manifest size for boot stages stored in flash (in bytes).
  */
-#define CHIP_MANIFEST_SIZE 8788
+#define CHIP_MANIFEST_SIZE 8852
+
+/**
+ * Number of entries in the manifest extensions table.
+ */
+#define CHIP_MANIFEST_EXT_TABLE_ENTRY_COUNT 8
 
 /**
  * ROM_EXT manifest identifier (ASCII "OTRE").

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -85,6 +85,7 @@ enum module_ {
   X(kErrorManifestBadEntryPoint,      ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadCodeRegion,      ERROR_(2, kModuleManifest, kInternal)), \
   X(kErrorManifestBadSignedRegion,    ERROR_(3, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadExtension,       ERROR_(4, kModuleManifest, kInternal)), \
   \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadClass,              ERROR_(2, kModuleAlertHandler, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -26,3 +26,8 @@ extern manifest_digest_region_t manifest_digest_region_get(
     const manifest_t *manifest);
 extern epmp_region_t manifest_code_region_get(const manifest_t *manifest);
 extern uintptr_t manifest_entry_point_get(const manifest_t *manifest);
+extern rom_error_t manifest_get_ext_spx_key(
+    const manifest_t *manifest, const manifest_ext_spx_key_t **spx_key);
+extern rom_error_t manifest_get_ext_spx_signature(
+    const manifest_t *manifest,
+    const manifest_ext_spx_signature_t **spx_signature);

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -104,6 +104,33 @@ enum {
 };
 
 /**
+ * Manifest extensions table entry.
+ *
+ * An extension with index `i` exists if the `identifier` of the `i`th entry in
+ * the extension table matches the `identifier` of the extension and its
+ * `offset` is greater than zero.
+ */
+typedef struct manifest_ext_table_entry {
+  /**
+   * Extension identifier.
+   *
+   * Must match the `identifier` value in the extension's header.
+   */
+  uint32_t identifier;
+  /**
+   * Offset of this extension relative to the start of the manifest.
+   */
+  uint32_t offset;
+} manifest_ext_table_entry_t;
+
+/**
+ * Manifest extensions table.
+ */
+typedef struct manifest_ext_table {
+  manifest_ext_table_entry_t entries[CHIP_MANIFEST_EXT_TABLE_ENTRY_COUNT];
+} manifest_ext_table_t;
+
+/**
  * Manifest for boot stage images stored in flash.
  *
  * OpenTitan secure boot, at a minimum, consists of three boot stages: ROM,
@@ -225,6 +252,10 @@ typedef struct manifest {
    * the manifest in bytes.
    */
   uint32_t entry_point;
+  /**
+   * Extensions.
+   */
+  manifest_ext_table_t extensions;
 } manifest_t;
 
 OT_ASSERT_MEMBER_OFFSET(manifest_t, spx_signature, 0);
@@ -245,6 +276,7 @@ OT_ASSERT_MEMBER_OFFSET(manifest_t, max_key_version, 8772);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, code_start, 8776);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, code_end, 8780);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, entry_point, 8784);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, extensions, 8788);
 OT_ASSERT_SIZE(manifest_t, CHIP_MANIFEST_SIZE);
 
 /**

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -11,9 +11,6 @@
 #![deny(unused)]
 #![deny(unsafe_code)]
 
-use std::mem::size_of;
-
-use memoffset::offset_of;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
@@ -181,30 +178,37 @@ pub struct ManifestExtTable {
     pub entries: [ManifestExtTableEntry; CHIP_MANIFEST_EXT_TABLE_COUNT as usize],
 }
 
-/// Checks the layout of the manifest struct.
-///
-/// Implemented as a function because using `offset_of!` at compile-time
-/// requires a nightly compiler.
-/// TODO(#6915): Convert this to a unit test after we start running rust tests during our builds.
-pub fn check_manifest_layout() {
-    assert_eq!(offset_of!(Manifest, spx_signature), 0);
-    assert_eq!(offset_of!(Manifest, rsa_signature), 7856);
-    assert_eq!(offset_of!(Manifest, usage_constraints), 8240);
-    assert_eq!(offset_of!(Manifest, spx_key), 8288);
-    assert_eq!(offset_of!(Manifest, rsa_modulus), 8320);
-    assert_eq!(offset_of!(Manifest, address_translation), 8704);
-    assert_eq!(offset_of!(Manifest, identifier), 8708);
-    assert_eq!(offset_of!(Manifest, signed_region_end), 8712);
-    assert_eq!(offset_of!(Manifest, length), 8716);
-    assert_eq!(offset_of!(Manifest, version_major), 8720);
-    assert_eq!(offset_of!(Manifest, version_minor), 8724);
-    assert_eq!(offset_of!(Manifest, security_version), 8728);
-    assert_eq!(offset_of!(Manifest, timestamp), 8732);
-    assert_eq!(offset_of!(Manifest, binding_value), 8740);
-    assert_eq!(offset_of!(Manifest, max_key_version), 8772);
-    assert_eq!(offset_of!(Manifest, code_start), 8776);
-    assert_eq!(offset_of!(Manifest, code_end), 8780);
-    assert_eq!(offset_of!(Manifest, entry_point), 8784);
-    assert_eq!(offset_of!(Manifest, extensions), 8788);
-    assert_eq!(size_of::<Manifest>(), CHIP_MANIFEST_SIZE as usize);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use memoffset::offset_of;
+    use std::mem::size_of;
+
+    /// Checks the layout of the manifest struct.
+    ///
+    /// Implemented as a function because using `offset_of!` at compile-time
+    /// requires a nightly compiler.
+    #[test]
+    pub fn test_manifest_layout() {
+        assert_eq!(offset_of!(Manifest, spx_signature), 0);
+        assert_eq!(offset_of!(Manifest, rsa_signature), 7856);
+        assert_eq!(offset_of!(Manifest, usage_constraints), 8240);
+        assert_eq!(offset_of!(Manifest, spx_key), 8288);
+        assert_eq!(offset_of!(Manifest, rsa_modulus), 8320);
+        assert_eq!(offset_of!(Manifest, address_translation), 8704);
+        assert_eq!(offset_of!(Manifest, identifier), 8708);
+        assert_eq!(offset_of!(Manifest, signed_region_end), 8712);
+        assert_eq!(offset_of!(Manifest, length), 8716);
+        assert_eq!(offset_of!(Manifest, version_major), 8720);
+        assert_eq!(offset_of!(Manifest, version_minor), 8724);
+        assert_eq!(offset_of!(Manifest, security_version), 8728);
+        assert_eq!(offset_of!(Manifest, timestamp), 8732);
+        assert_eq!(offset_of!(Manifest, binding_value), 8740);
+        assert_eq!(offset_of!(Manifest, max_key_version), 8772);
+        assert_eq!(offset_of!(Manifest, code_start), 8776);
+        assert_eq!(offset_of!(Manifest, code_end), 8780);
+        assert_eq!(offset_of!(Manifest, entry_point), 8784);
+        assert_eq!(offset_of!(Manifest, extensions), 8788);
+        assert_eq!(size_of::<Manifest>(), CHIP_MANIFEST_SIZE as usize);
+    }
 }

--- a/sw/host/opentitanlib/src/image/testdata/manifest.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest.hjson
@@ -167,4 +167,14 @@
    * the manifest in bytes.
    */
   entry_point: "0x00000000"
+  extensions: [
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+    {identifier: "0x00000000", offset: "0x00000000"},
+  ]
 }


### PR DESCRIPTION
This PR
* Adds the manifest extensions table,
* Adds extensions for SPHINCS+ public key and signature, and
* Updates the manifest definition in opentitanlib.