### PR TITLE
[fix] Fix `gpio_pinmux_test`

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_verilator.json
@@ -18,9 +18,18 @@
       { "name": "IOR12", "alias_of": "12" },
       { "name": "IOR13", "alias_of": "13" }
 
+      // SW_STRAPs
       { "name": "IOC0", "alias_of": "22" }
       { "name": "IOC1", "alias_of": "23" }
       { "name": "IOC2", "alias_of": "24" }
+
+      // TAP_STRAPs
+      { "name": "IOC5", "alias_of": "27" }
+      { "name": "IOC8", "alias_of": "30" }
+
+      // Hack: RESET isn't connected to the GPIO block on verilator, but we
+      // need a pin named RESET.  Connect to an invalid pin.
+      { "name": "RESET", "alias_of": "255" }
   ],
   "spi": [
     {

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde_annotate::Annotate;
@@ -107,8 +107,8 @@ impl Transport for Verilator {
     }
 
     fn gpio_pin(&self, instance: &str) -> Result<Rc<dyn GpioPin>> {
-        let pin = u8::from_str(instance)?;
-        ensure!(pin < 32, GpioError::InvalidPinNumber(pin));
+        let pin = u8::from_str(instance).with_context(|| format!("can't convert {instance:?}"))?;
+        ensure!(pin < 32 || pin == 255, GpioError::InvalidPinNumber(pin));
         let mut inner = self.inner.borrow_mut();
         Ok(Rc::clone(inner.gpio.pins.entry(pin).or_insert_with(|| {
             VerilatorGpioPin::new(Rc::clone(&self.inner), pin)


### PR DESCRIPTION
Opentitanlib wants to initialize the default state of all gpio pins during test initialization.  The verilator config did not have definitions for the TAP_STRAP pins IOC5/8 nor a definition for the RESET pin (doesn't exist on verilator).

1. Create pin mappings for IOC5/8 for the verilator config.
2. Map RESET to an invalid pin.  Make verilator emit a message when invalid gpio pins are manipulated.
3. Allow the verilator transport to accept pin 255 as the invalid pin (technically, we could allow the transport to use any invalid pins, but we should constrain their usage as much as possible).