### PR TITLE
[lc_ctrl/dv] Enable CDC instrumentation

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -67,8 +67,8 @@
   uvm_test: lc_ctrl_base_test
   uvm_test_seq: lc_ctrl_base_vseq
 
-  // TODO(lowrisc/opentitan#16689): Enable cdc instrumentation.
-  run_opts: ["+cdc_instrumentation_enabled=0"]
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.
   tests: [


### PR DESCRIPTION
The `lc_ctrl` block-level DV environment has been cleaned up and should now tolerate skew introduced as part of the CDC instrumentation.

Refer to #16689 for context.
