### PR TITLE
[manuf] complete `manuf_cp_device_info_flash_wr` test

### DIFF
--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -110,7 +110,7 @@
             In pre-silicon, they can be part of the same program.
 
             - Switch to LC TAP at runtime.
-            - Request transition to DEV or PROD state (test both cases).
+            - Request transition to PROD or PROD_END state (test both cases).
             - Perform reset by toggling POR pin.
             - Verify isolated flash info partition expected data.
             '''

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -50,6 +50,11 @@ _MISSION_MODE_LC_ITEMS = get_lc_items(
     CONST.LCV.RMA,
 )
 
+_PROD_LC_ITEMS = get_lc_items(
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+)
+
 _ALL_LC_ITEMS = (
     _TEST_LOCKED_LC_ITEMS +
     _TEST_UNLOCKED_LC_ITEMS +
@@ -487,16 +492,20 @@ opentitan_ram_binary(
 
 [
     opentitan_functest(
-        name = "manuf_cp_device_info_flash_wr_{}_functest".format(lc_state.lower()),
+        name = "manuf_cp_device_info_flash_wr_{}_to_{}_functest".format(
+            init_lc_state.lower(),
+            target_lc_state.lower(),
+        ),
         srcs = ["flash_device_info_flash_wr_functest.c"],
         cw310 = cw310_params(
-            bitstream = "bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            bitstream = "bitstream_rom_exec_disabled_{}".format(init_lc_state.lower()),
             tags = ["cw310_rom"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",
                 "--bitstream=\"$(rootpath {bitstream})\"",
                 "--bootstrap=\"$(location {flash})\"",
+                "--target-lc-state=\"{}\"".format(target_lc_state),
                 "--vmem=\"$(rootpath :sram_device_info_flash_wr_functest_fpga_cw310_vmem)\"",
                 # the following values come from the sram linker script
                 "--load-addr=0x10001fc4",
@@ -524,14 +533,19 @@ opentitan_ram_binary(
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+    for init_lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+    for target_lc_state, _ in _PROD_LC_ITEMS
 ]
 
 test_suite(
     name = "manuf_cp_device_info_flash_wr_functest",
     tags = ["manual"],
     tests = [
-        ":manuf_cp_device_info_flash_wr_{}_functest".format(lc_state.lower())
-        for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+        ":manuf_cp_device_info_flash_wr_{}_to_{}_functest".format(
+            init_lc_state.lower(),
+            target_lc_state.lower(),
+        )
+        for init_lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+        for target_lc_state, _ in _PROD_LC_ITEMS
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -365,6 +365,8 @@ otp_json(
                 # These match their cSHAKE-128 (w/ "LC_CTRL" customization string)
                 # preimage counterpart of: 0x1111_1111_1111_1111_1111_1111_1111_1111,
                 # which is hardcoded into the test that use this overlay.
+                # The script that generated this token is:
+                # //sw/host/tests/manuf/manuf_cp_device_info_flash_wr:gen_test_exit_token
                 "TEST_UNLOCK_TOKEN": "0xde0a1f1e0d6a649fd35fadb75ec82674",
                 "TEST_EXIT_TOKEN": "0xde0a1f1e0d6a649fd35fadb75ec82674",
             },

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -499,7 +499,7 @@ opentitan_ram_binary(
         srcs = ["flash_device_info_flash_wr_functest.c"],
         cw310 = cw310_params(
             bitstream = "bitstream_rom_exec_disabled_{}".format(init_lc_state.lower()),
-            tags = ["cw310_rom"],
+            tags = ["jtag"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -17,8 +17,7 @@ load(
 )
 load("//rules:const.bzl", "CONST", "get_lc_items")
 load("//rules:lc.bzl", "lc_raw_unlock_token")
-load("//rules:opentitan.bzl", "opentitan_ram_binary")
-load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_alert_digest", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "otp_image", "otp_json", "otp_partition")
 load("//rules:splice.bzl", "bitstream_splice")
 
 package(default_visibility = ["//visibility:public"])
@@ -272,7 +271,7 @@ test_suite(
     name = "manuf_scrap_functest",
     tags = ["manual"],
     tests = [
-        ":manuf_scrap_functest_{}".format(lc_state)
+        ":manuf_scrap_functest_{}".format(lc_state.lower())
         for lc_state, _ in _ALL_LC_ITEMS
     ],
 )
@@ -318,13 +317,70 @@ opentitan_ram_binary(
     ],
 )
 
+# We are using a bitstream with disabled execution so the content of the flash
+# does not matter but opentitan_functest() is unhappy if we don't provide one.
+# Since execution in the ROM is disabled, bootstrap is not possible so we need
+# to make sure that the test does not try to bootstrap
+#
+# FIXME: for now it seems running the expected test fails because the OTP reading
+# fails after reading 6 words, probably some init is missing. If we run it after the
+# ROM booted normally, it works. Until we find the problem, use an idle functest.
+opentitan_functest(
+    name = "manuf_cp_ast_test_execution_functest",
+    srcs = ["idle_functest.c"],
+    cw310 = cw310_params(
+        #bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
+        bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
+        tags = ["cw310_rom"],
+        test_cmds = [
+            "--rom-kind=rom",
+            "--bitstream=\"$(rootpath {bitstream})\"",
+            "--bootstrap=\"$(rootpath {flash})\"",
+            "--vmem=\"$(rootpath :sram_exec_test_fpga_cw310_vmem)\"",
+            # the following values come from the sram linker script
+            "--load-addr=0x10001fc4",
+            "--stack-pointer=0x10020000",
+            "--stack-size=1024",
+            "--global-pointer=0x100027C4",  # sram_load_addr + 2048;
+        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+    ),
+    data = [
+        ":sram_exec_test_fpga_cw310_vmem",
+    ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
+    targets = ["cw310_rom"],
+    test_harness = "//sw/host/tests/manuf/manuf_cp_ast_test_execution",
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+otp_json(
+    name = "otp_json_fixed_secret0",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                # These match their cSHAKE-128 (w/ "LC_CTRL" customization string)
+                # preimage counterpart of: 0x1111_1111_1111_1111_1111_1111_1111_1111,
+                # which is hardcoded into the test that use this overlay.
+                "TEST_UNLOCK_TOKEN": "0xde0a1f1e0d6a649fd35fadb75ec82674",
+                "TEST_EXIT_TOKEN": "0xde0a1f1e0d6a649fd35fadb75ec82674",
+            },
+            lock = True,
+        ),
+    ],
+    visibility = ["//visibility:private"],
+)
+
 # This is the same as rom_otp_test_unlocked* but with ROM execution disabled.
 [
     otp_image(
         name = "otp_img_rom_exec_disabled_test_unlocked{}".format(i),
         src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked{}".format(i),
         overlays = [
-            "//hw/ip/otp_ctrl/data:otp_json_secret0",
+            ":otp_json_fixed_secret0",
             "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
         ],
         visibility = ["//visibility:private"],
@@ -391,22 +447,36 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "test_wafer_auth_secret",
+    srcs = ["test_wafer_auth_secret.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":isolated_flash_partition",
+    ],
+)
+
 opentitan_ram_binary(
     name = "sram_device_info_flash_wr_functest",
     srcs = ["sram_device_info_flash_wr_functest.c"],
     hdrs = ["sram_device_info_flash_wr_functest.h"],
     archive_symbol_prefix = "sram_device_info_flash_wr_functest",
     deps = [
+        ":individualize_preop",
         ":isolated_flash_partition",
+        ":test_wafer_auth_secret",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/examples/sram_program:sram_program_linker_script",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:status",
@@ -415,16 +485,17 @@ opentitan_ram_binary(
 
 [
     opentitan_functest(
-        name = "manuf_cp_device_info_flash_wr_test_unlocked{}_functest".format(i),
-        srcs = ["empty_functest.c"],
+        name = "manuf_cp_device_info_flash_wr_{}_functest".format(lc_state.lower()),
+        srcs = ["flash_device_info_flash_wr_functest.c"],
         cw310 = cw310_params(
-            bitstream = "bitstream_rom_exec_disabled_test_unlocked{}".format(i),
+            bitstream = "bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
             tags = ["cw310_rom"],
             test_cmds = [
+                "--clear-bitstream",
                 "--rom-kind=rom",
                 "--bitstream=\"$(rootpath {bitstream})\"",
+                "--bootstrap=\"$(location {flash})\"",
                 "--vmem=\"$(rootpath :sram_device_info_flash_wr_functest_fpga_cw310_vmem)\"",
-                "--adapter-speed-khz=400",
                 # the following values come from the sram linker script
                 "--load-addr=0x10001fc4",
                 "--stack-pointer=0x10020000",
@@ -435,51 +506,30 @@ opentitan_ram_binary(
         data = [
             ":sram_device_info_flash_wr_functest_fpga_cw310_vmem",
         ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
+        # We select the PROD key since the SRAM test program does an LC transition to DEV.
+        key_struct = filter_key_structs_for_lc_state(
+            RSA_ONLY_KEY_STRUCTS,
+            CONST.LCV.PROD,
+        )[0],
         targets = ["cw310_rom"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_device_info_flash_wr",
         deps = [
+            ":isolated_flash_partition",
+            ":test_wafer_auth_secret",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:lc_ctrl",
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for i in range(0, 8)
+    for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
 ]
 
-# We are using a bitstream with disabled execution so the content of the flash
-# does not matter but opentitan_functest() is unhappy if we don't provide one.
-# Since execution in the ROM is disabled, bootstrap is not possible so we need
-# to make sure that the test does not try to bootstrap
-#
-# FIXME: for now it seems running the expected test fails because the OTP reading
-# fails after reading 6 words, probably some init is missing. If we run it after the
-# ROM booted normally, it works. Until we find the problem, use an idle functest.
-opentitan_functest(
-    name = "manuf_cp_ast_test_execution_functest",
-    srcs = ["idle_functest.c"],
-    cw310 = cw310_params(
-        #bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
-        bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
-        tags = ["cw310_rom"],
-        test_cmds = [
-            "--rom-kind=rom",
-            "--bitstream=\"$(rootpath {bitstream})\"",
-            "--bootstrap=\"$(rootpath {flash})\"",
-            "--vmem=\"$(rootpath :sram_exec_test_fpga_cw310_vmem)\"",
-            # the following values come from the sram linker script
-            "--load-addr=0x10001fc4",
-            "--stack-pointer=0x10020000",
-            "--stack-size=1024",
-            "--global-pointer=0x100027C4",  # sram_load_addr + 2048;
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
-    ),
-    data = [
-        ":sram_exec_test_fpga_cw310_vmem",
-    ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/manuf/manuf_cp_ast_test_execution",
-    deps = [
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:otp_ctrl_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
+test_suite(
+    name = "manuf_cp_device_info_flash_wr_functest",
+    tags = ["manual"],
+    tests = [
+        ":manuf_cp_device_info_flash_wr_{}_functest".format(lc_state.lower())
+        for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/flash_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_device_info_flash_wr_functest.c
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/manuf/lib/isolated_flash_partition.h"
+#include "sw/device/silicon_creator/manuf/lib/test_wafer_auth_secret.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_flash_ctrl_state_t flash_ctrl_state;
+static dif_lc_ctrl_t lc_ctrl;
+
+/**
+ * Initializes all DIF handles used in this test.
+ */
+static status_t peripheral_handles_init(void) {
+  TRY(dif_flash_ctrl_init_state(
+      &flash_ctrl_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR),
+                       &lc_ctrl));
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  CHECK_STATUS_OK(peripheral_handles_init());
+
+  LOG_INFO("Executing from flash.");
+
+  // Read LC state.
+  dif_lc_ctrl_state_t lc_state = kDifLcCtrlStateInvalid;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
+
+  uint32_t actual_wafer_auth_secret[kWaferAuthSecretSizeInWords] = {0};
+
+  switch (lc_state) {
+    case kDifLcCtrlStateProd:
+    case kDifLcCtrlStateProdEnd:
+      LOG_INFO("Reading the isolated flash partition.");
+      CHECK_STATUS_OK(isolated_flash_partition_read(&flash_ctrl_state,
+                                                    kWaferAuthSecretSizeInWords,
+                                                    actual_wafer_auth_secret));
+      CHECK_ARRAYS_EQ(actual_wafer_auth_secret, kExpectedWaferAuthSecret,
+                      kWaferAuthSecretSizeInWords);
+      LOG_INFO("Done.");
+      break;
+    default:
+      LOG_ERROR("Unexpected LC state.");
+      return false;
+  }
+
+  return true;
+}

--- a/sw/device/silicon_creator/manuf/lib/isolated_flash_partition.c
+++ b/sw/device/silicon_creator/manuf/lib/isolated_flash_partition.c
@@ -33,7 +33,6 @@ enum {
 status_t isolated_flash_partition_read(dif_flash_ctrl_state_t *flash_ctrl_state,
                                        size_t num_words,
                                        uint32_t *wafer_auth_secret) {
-  // Enable read access to the flash isolated partition.
   uint32_t byte_address = 0;
   TRY(flash_ctrl_testutils_info_region_setup_properties(
       flash_ctrl_state, /*page_id=*/kFlashInfoPageIdWaferAuthSecret,
@@ -46,33 +45,18 @@ status_t isolated_flash_partition_read(dif_flash_ctrl_state_t *flash_ctrl_state,
           .rd_en = kMultiBitBool4True,
           .scramble_en = kMultiBitBool4False},
       &byte_address));
-
   TRY(flash_ctrl_testutils_read(
       flash_ctrl_state, byte_address,
       /*partition_id=*/kFlashInfoPartitionId, wafer_auth_secret,
       /*partition_type=*/kDifFlashCtrlPartitionTypeInfo, num_words,
       /*delay_micros=*/0));
 
-  // Disable read access to the flash isolated partition.
-  TRY(flash_ctrl_testutils_info_region_setup_properties(
-      flash_ctrl_state, /*page_id=*/kFlashInfoPageIdWaferAuthSecret,
-      /*bank=*/kFlashInfoBankId, /*partition_id=*/kFlashInfoPartitionId,
-      (dif_flash_ctrl_region_properties_t){
-          .ecc_en = kMultiBitBool4True,
-          .high_endurance_en = kMultiBitBool4False,
-          .erase_en = kMultiBitBool4False,
-          .prog_en = kMultiBitBool4False,
-          .rd_en = kMultiBitBool4False,
-          .scramble_en = kMultiBitBool4False},
-      NULL));
-
   return OK_STATUS();
 }
 
 status_t isolated_flash_partition_write(
-    dif_flash_ctrl_state_t *flash_ctrl_state, uint32_t *wafer_auth_secret,
+    dif_flash_ctrl_state_t *flash_ctrl_state, const uint32_t *wafer_auth_secret,
     size_t num_words) {
-  // Enable write access to the flash isolated partition.
   uint32_t byte_address = 0;
   TRY(flash_ctrl_testutils_info_region_setup_properties(
       flash_ctrl_state, /*page_id=*/kFlashInfoPageIdWaferAuthSecret,
@@ -80,29 +64,15 @@ status_t isolated_flash_partition_write(
       (dif_flash_ctrl_region_properties_t){
           .ecc_en = kMultiBitBool4True,
           .high_endurance_en = kMultiBitBool4False,
-          .erase_en = kMultiBitBool4False,
+          .erase_en = kMultiBitBool4True,
           .prog_en = kMultiBitBool4True,
           .rd_en = kMultiBitBool4False,
           .scramble_en = kMultiBitBool4False},
       &byte_address));
-
-  TRY(flash_ctrl_testutils_write(
+  TRY(flash_ctrl_testutils_erase_and_write_page(
       flash_ctrl_state, byte_address,
       /*partition_id=*/kFlashInfoPartitionId, wafer_auth_secret,
-      /*partition_type=*/kDifFlashCtrlPartitionTypeInfo, num_words));
-
-  // Disable write access to the flash isolated partition.
-  TRY(flash_ctrl_testutils_info_region_setup_properties(
-      flash_ctrl_state, /*page_id=*/kFlashInfoPageIdWaferAuthSecret,
-      /*bank=*/kFlashInfoBankId, /*partition_id=*/kFlashInfoPartitionId,
-      (dif_flash_ctrl_region_properties_t){
-          .ecc_en = kMultiBitBool4True,
-          .high_endurance_en = kMultiBitBool4False,
-          .erase_en = kMultiBitBool4False,
-          .prog_en = kMultiBitBool4False,
-          .rd_en = kMultiBitBool4False,
-          .scramble_en = kMultiBitBool4False},
-      NULL));
+      kDifFlashCtrlPartitionTypeInfo, num_words));
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/lib/isolated_flash_partition.h
+++ b/sw/device/silicon_creator/manuf/lib/isolated_flash_partition.h
@@ -43,7 +43,7 @@ status_t isolated_flash_partition_read(dif_flash_ctrl_state_t *flash_ctrl_state,
  * @return OK_STATUS on success.
  */
 status_t isolated_flash_partition_write(
-    dif_flash_ctrl_state_t *flash_ctrl_state, uint32_t *wafer_auth_secret,
+    dif_flash_ctrl_state_t *flash_ctrl_state, const uint32_t *wafer_auth_secret,
     size_t num_words);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_ISOLATED_FLASH_PARTITION_H_

--- a/sw/device/silicon_creator/manuf/lib/sram_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/sram_device_info_flash_wr_functest.c
@@ -4,19 +4,27 @@
 
 #include <stdint.h>
 
+#include "otp_img_sku_earlgrey_a0_stage_individualize.h"  // Generated.
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/silicon_creator/manuf/lib/individualize_preop.h"
 #include "sw/device/silicon_creator/manuf/lib/isolated_flash_partition.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_img.h"
+#include "sw/device/silicon_creator/manuf/lib/test_wafer_auth_secret.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"  // Generated.
 
 static dif_uart_t uart;
+static dif_otp_ctrl_t otp_ctrl;
 static dif_pinmux_t pinmux;
 static dif_flash_ctrl_state_t flash_ctrl_state;
 static dif_lc_ctrl_t lc_ctrl;
@@ -30,6 +38,8 @@ static status_t peripheral_handles_init(void) {
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR),
                        &lc_ctrl));
+  TRY(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
   TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR),
                       &pinmux));
   TRY(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
@@ -37,7 +47,7 @@ static status_t peripheral_handles_init(void) {
   return OK_STATUS();
 }
 
-void sram_main(void) {
+bool sram_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
 
   // Initialize UART (for console, since we do not have the OTTF).
@@ -53,17 +63,13 @@ void sram_main(void) {
                                 }));
   base_uart_stdout(&uart);
 
-  // Generated expected wafer authentication secret to write to the flash
-  // isolated partition in this test.
-  uint32_t actual_wafer_auth_secret[kWaferAuthSecretSizeInWords] = {0};
-  uint32_t expected_wafer_auth_secret[kWaferAuthSecretSizeInWords];
-  for (size_t i = 0; i < kWaferAuthSecretSizeInWords; ++i) {
-    expected_wafer_auth_secret[i] = 0xdeadbeef;
-  }
+  LOG_INFO("Executing from SRAM.");
 
   // Read LC state.
   dif_lc_ctrl_state_t lc_state = kDifLcCtrlStateInvalid;
   CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
+
+  uint32_t actual_wafer_auth_secret[kWaferAuthSecretSizeInWords] = {0};
 
   switch (lc_state) {
     case kDifLcCtrlStateTestUnlocked0:
@@ -76,29 +82,19 @@ void sram_main(void) {
     case kDifLcCtrlStateTestUnlocked7:
       LOG_INFO("Writing to the isolated flash partition.");
       CHECK_STATUS_OK(isolated_flash_partition_write(
-          &flash_ctrl_state, expected_wafer_auth_secret,
+          &flash_ctrl_state, kExpectedWaferAuthSecret,
           kWaferAuthSecretSizeInWords));
       LOG_INFO("Attempting to read back what was written.");
       CHECK_STATUS_NOT_OK(isolated_flash_partition_read(
           &flash_ctrl_state, kWaferAuthSecretSizeInWords,
           actual_wafer_auth_secret));
-      // TODO: perform LC transition to DEV, PROD, or PROD_END.
-      LOG_INFO("Done.");
-      break;
-    case kDifLcCtrlStateDev:
-    case kDifLcCtrlStateProd:
-    case kDifLcCtrlStateProdEnd:
-      LOG_INFO("Reading the isolated flash partition.");
-      CHECK_STATUS_OK(isolated_flash_partition_read(&flash_ctrl_state,
-                                                    kWaferAuthSecretSizeInWords,
-                                                    actual_wafer_auth_secret));
-      // TODO: check wafer authentication secret is what is expected.
-      LOG_INFO("Done.");
+      LOG_INFO("Enabling ROM execution to enable bootstrap after reset.");
+      CHECK_STATUS_OK(individualize_preop_otp_write(&otp_ctrl));
+      LOG_INFO("Done. Perform an LC transition and run flash stage.");
       break;
     default:
-      test_status_set(kTestStatusFailed);
-      break;
+      return false;
   }
 
-  test_status_set(kTestStatusPassed);
+  return true;
 }

--- a/sw/device/silicon_creator/manuf/lib/sram_device_info_flash_wr_functest.h
+++ b/sw/device/silicon_creator/manuf/lib/sram_device_info_flash_wr_functest.h
@@ -10,6 +10,6 @@
 /**
  * Type alias for the SRAM program entrypoint.
  */
-typedef void sram_main(void);
+typedef bool sram_main(void);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_SRAM_DEVICE_INFO_FLASH_WR_FUNCTEST_H_

--- a/sw/device/silicon_creator/manuf/lib/test_wafer_auth_secret.h
+++ b/sw/device/silicon_creator/manuf/lib/test_wafer_auth_secret.h
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_TEST_WAFER_AUTH_SECRET_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_TEST_WAFER_AUTH_SECRET_H_
+
+#include "sw/device/silicon_creator/manuf/lib/isolated_flash_partition.h"
+
+// Expected wafer authentication secret to write to the flash
+const uint32_t kExpectedWaferAuthSecret[kWaferAuthSecretSizeInWords] = {
+    0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
+    0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
+};
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_TEST_WAFER_AUTH_SECRET_H_

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
@@ -20,3 +20,10 @@ rust_binary(
         "@crate_index//:structopt",
     ],
 )
+
+py_binary(
+    name = "gen_test_exit_token",
+    srcs = [
+        "gen_test_exit_token.py",
+    ],
+)

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/gen_test_exit_token.py
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/gen_test_exit_token.py
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from Crypto.Hash import cSHAKE128
+
+TOKEN_LEN = 16
+TOKEN_PREIMAGE = b'\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11'
+
+if __name__ == '__main__':
+    hash_obj = cSHAKE128.new(data=TOKEN_PREIMAGE, custom=b'LC_CTRL')
+    digest_bytes = hash_obj.read(TOKEN_LEN)
+    digest_int = int.from_bytes(digest_bytes, byteorder='little')
+
+    preimage_literal = '[' + ','.join(hex(byte)
+                                      for byte in TOKEN_PREIMAGE) + ']'
+    literal = f'0x{digest_int:032x}'
+    print(f'preimage literal: {preimage_literal}')
+    print(f'postimage literal: {literal}')

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -32,6 +32,13 @@ struct Opts {
     sram_program: SramProgramParams,
 
     #[structopt(
+        long, parse(try_from_str = DifLcCtrlState::parse_lc_state_str),
+        default_value = "prod",
+        help = "LC state to transition to from TEST_UNLOCKED*."
+    )]
+    target_lc_state: DifLcCtrlState,
+
+    #[structopt(
         long, parse(try_from_str=humantime::parse_duration),
         default_value = "600s",
         help = "Console receive timeout",
@@ -84,7 +91,7 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
     trigger_lc_transition(
         transport,
         jtag.clone(),
-        DifLcCtrlState::Prod,
+        opts.target_lc_state,
         Some(TEST_EXIT_TOKEN),
         /*use_external_clk=*/ true,
         opts.init.bootstrap.options.reset_delay,

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -9,9 +9,12 @@ use regex::Regex;
 use structopt::StructOpt;
 
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::backend;
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::execute_test;
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
 use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::lc_transition::{trigger_lc_transition, wait_for_status};
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
 };
@@ -45,14 +48,14 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
 
     // Reset and halt the CPU to ensure we are in a known state, and clear out any ROM messages
     // printed over the console.
-    jtag.reset(false)?;
+    jtag.reset(/*run=*/ false)?;
     let uart = transport.uart("console")?;
     uart.clear_rx_buffer()?;
 
-    // Load the SRAM program that contains the test code.
+    // Load and execute the SRAM program that contains the test code.
     match opts
         .sram_program
-        .load_and_execute(&jtag, ExecutionMode::Jump)?
+        .load_and_execute(&jtag, ExecutionMode::Call(opts.timeout))?
     {
         ExecutionResult::CallReturned => {
             log::info!("SRAM program loaded and executed successfully.")
@@ -60,7 +63,48 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
         res => log::info!("SRAM program execution failed: {:?}.", res),
     }
 
-    // Wait for test status pass over the UART.
+    // Once the SRAM program has printed a message over the console, we can continue with a LC
+    // transition initiated on the host side.
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Done. Perform an LC transition and run flash stage.",
+        opts.timeout,
+    )?;
+
+    // Reset and halt the CPU to ensure we are in a known state again, clear out any ROM
+    // messages printed over the console, and switch to the LC TAP to perform LC transition.
+    jtag.reset(/*run=*/ false)?;
+    jtag.disconnect()?;
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
+    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+    jtag.connect(JtagTap::LcTap)?;
+
+    // Issue an LC transition.
+    const TEST_EXIT_TOKEN: [u32; 4] = [0x11111111, 0x11111111, 0x11111111, 0x11111111];
+    trigger_lc_transition(
+        transport,
+        jtag.clone(),
+        DifLcCtrlState::Prod,
+        Some(TEST_EXIT_TOKEN),
+        /*use_external_clk=*/ true,
+        opts.init.bootstrap.options.reset_delay,
+    )?;
+
+    // Check the LC state is Prod.
+    // We must wait for the lc_ctrl to initialize before the LC state is exposed.
+    wait_for_status(&jtag, Duration::from_secs(3), LcCtrlStatus::INITIALIZED)?;
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?,
+        opts.target_lc_state.redundant_encoding(),
+        "Failed to transition out of TestUnlocked*.",
+    );
+    jtag.disconnect()?;
+
+    // Bootstrap test program into flash and wait for test status pass over the UART.
+    uart.clear_rx_buffer()?;
+    opts.init.bootstrap.init(transport)?;
+
+    // Reset chip, run flash stage, and wait for test status pass over the UART.
     let mut console = UartConsole {
         timeout: Some(opts.timeout),
         exit_success: Some(Regex::new(r"PASS.*\n")?),
@@ -100,7 +144,12 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
 fn main() -> Result<()> {
     let opts = Opts::from_args();
     opts.init.init_logging();
-    let transport = opts.init.init_target()?;
+
+    // We call the below functions, instead of calling `opts.init.init_target()` since we do not
+    // want to perform bootstrap yet.
+    let transport = backend::create(&opts.init.backend_opts)?;
+    transport.apply_default_configuration()?;
+    InitializeTest::print_result("load_bitstream", opts.init.load_bitstream.init(&transport))?;
 
     execute_test!(manuf_cp_device_info_flash_wr, &opts, &transport);
 


### PR DESCRIPTION
This completes the `manuf_cp_device_info_flash_wr` test, which has been updated to run in 3 stages:
- stage one runs in SRAM in the TEST_UNLOCKED* LC state, and provisions the isolated flash partition page, then unlocks ROM execution to enable bootstrap,
- stage two runs on the host side, and use JTAG to perform an LC transition to PROD(_END), lastly
- stage three runs in flash and attempts to read the isolated flash partition page that was programmed by the earlier run SRAM program.

This test now covers:
1. running an SRAM program that provisions OTP to unlock ROM execution
2. performs a test exit LC transition, and
3. bootstraps a program on a fresh (partially-)provisioned chip.

This resolves #17389 and #17391.