### PR TITLE
[chip-test] Enable ext_clk check in volatile unlock test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -771,11 +771,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `DV_CHECK_FATAL(transition_ctrl & (1 << 1), {"VOLATILE_RAW_UNLOCK is not supported by this ",
                     "top level. Check the SecVolatileRawUnlockEn parameter configuration."})
 
-    // The status bit propagated from the clkmgr does not seem to toggle when
-    // checked with `wait_lc_ext_clk_switched()`, so we only check that the ext_clk
-    // bit in the `transition_ctrl` register is sticky.
-    // Check expected external clock value.
-    `DV_CHECK(transition_ctrl & 1'b1 == use_ext_clk);
+    if (use_ext_clk) begin
+      wait_lc_ext_clk_switched();
+    end
 
     begin
       bit [TL_DW-1:0] token_csr_vals[4] = {<< 32 {{>> 8 {RndCnstRawUnlockTokenHashed}}}};

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_volatile_raw_unlock_vseq.sv
@@ -64,6 +64,11 @@ class chip_sw_lc_volatile_raw_unlock_vseq extends chip_sw_base_vseq;
     apply_reset();
     reset_jtag_tap();
 
+    // Wait for `rom_ctrl` to complete the ROM check. This will give the dut
+    // enough time to configure the TAP interface before any JTAG agents send
+    // any commands.
+    wait_rom_check_done();
+
     // Second VOLATILE_RAW_UNLOCK does not change the TAP interface to rv_dm
     // so that we can check the completion status through that interface.
     // After this, the rest of the test should proceed.


### PR DESCRIPTION
Enables lc_ctrl.status LcExtClockSwitched check during volatile_raw_unlock transition.