### PR TITLE
[DO NOT MERGE] Cryptolib status compatibility

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -814,10 +814,6 @@ def opentitan_binary(
     side_targets = []
 
     native_binary_name = "{}.elf".format(name)
-    if 'status' in name:
-      print('\n\n\n\n\n\n')
-      print(kwargs)
-      print('\n\n\n\n\n\n')
     native.cc_binary(
         name = native_binary_name,
         deps = deps,

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -814,6 +814,10 @@ def opentitan_binary(
     side_targets = []
 
     native_binary_name = "{}.elf".format(name)
+    if 'status' in name:
+      print('\n\n\n\n\n\n')
+      print(kwargs)
+      print('\n\n\n\n\n\n')
     native.cc_binary(
         name = native_binary_name,
         deps = deps,
@@ -1163,10 +1167,6 @@ def opentitan_flash_binary(
             device = device,
             testonly = testonly,
         )
-
-        for k in kwargs.keys():
-          print(k)
-        print('defines' in kwargs)
 
         # Generate ELF, Binary, Disassembly, and (maybe) sim_dv logs database
         dev_targets.extend(opentitan_binary(

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -1164,6 +1164,10 @@ def opentitan_flash_binary(
             testonly = testonly,
         )
 
+        for k in kwargs.keys():
+          print(k)
+        print('defines' in kwargs)
+
         # Generate ELF, Binary, Disassembly, and (maybe) sim_dv logs database
         dev_targets.extend(opentitan_binary(
             name = devname,

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -321,6 +321,7 @@ def opentitan_functest(
         sh_test                named: {name}_fpga_cw310
         test_suite             named: {name}
     """
+    print(kwargs)
 
     deps = kwargs.pop("deps", [])
     all_tests = []
@@ -393,6 +394,7 @@ def opentitan_functest(
 
     # Generate SW artifacts for the tests.
     if not ot_flash_binary:
+        print(kwargs)
         # Set the linker script for the specified slot.
         if slot not in _FLASH_SLOTS:
             fail("Invalid slot: {}. Valid slots are: silicon_creator_{a,b,virtual}".format(slot))
@@ -617,6 +619,26 @@ def opentitan_functest(
             # For more see https://bazel.build/reference/be/general#test_suite.tags
         ],
     )
+opentitan_functest = rule(
+  implementation = _opentitan_functest_impl,
+  attrs = {
+    '''
+        targets = VALID_TARGETS,
+        args = [],
+        data = [],
+        test_in_rom = False,
+        ot_flash_binary = None,
+        signed = True,
+        manifest = "@//sw/device/silicon_creator/rom_ext:manifest_standard",
+        slot = "silicon_creator_a",
+        test_harness = "@//sw/host/opentitantool",
+        keyset = RSA_ONLY_KEYSETS[0],
+        logging = "info",
+        dv = None,
+        verilator = None,
+        cw310 = None,
+        **kwargs):
+        '''
 
 def _manual_test_impl(ctx):
     executable = ctx.actions.declare_file("manual_test_wrapper")

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -270,6 +270,7 @@ def opentitan_functest(
         targets = VALID_TARGETS,
         args = [],
         data = [],
+        defines = [],
         test_in_rom = False,
         ot_flash_binary = None,
         signed = True,
@@ -321,8 +322,6 @@ def opentitan_functest(
         sh_test                named: {name}_fpga_cw310
         test_suite             named: {name}
     """
-    print(kwargs)
-
     deps = kwargs.pop("deps", [])
     all_tests = []
     target_params = {}
@@ -394,7 +393,6 @@ def opentitan_functest(
 
     # Generate SW artifacts for the tests.
     if not ot_flash_binary:
-        print(kwargs)
         # Set the linker script for the specified slot.
         if slot not in _FLASH_SLOTS:
             fail("Invalid slot: {}. Valid slots are: silicon_creator_{a,b,virtual}".format(slot))
@@ -419,6 +417,7 @@ def opentitan_functest(
             devices = devices_to_build_for,
             manifest = manifest,
             testonly = True,
+            defines = defines,
             **kwargs
         )
 
@@ -619,26 +618,6 @@ def opentitan_functest(
             # For more see https://bazel.build/reference/be/general#test_suite.tags
         ],
     )
-opentitan_functest = rule(
-  implementation = _opentitan_functest_impl,
-  attrs = {
-    '''
-        targets = VALID_TARGETS,
-        args = [],
-        data = [],
-        test_in_rom = False,
-        ot_flash_binary = None,
-        signed = True,
-        manifest = "@//sw/device/silicon_creator/rom_ext:manifest_standard",
-        slot = "silicon_creator_a",
-        test_harness = "@//sw/host/opentitantool",
-        keyset = RSA_ONLY_KEYSETS[0],
-        logging = "info",
-        dv = None,
-        verilator = None,
-        cw310 = None,
-        **kwargs):
-        '''
 
 def _manual_test_impl(ctx):
     executable = ctx.actions.declare_file("manual_test_wrapper")

--- a/sw/device/lib/base/hardened_status.h
+++ b/sw/device/lib/base/hardened_status.h
@@ -28,17 +28,20 @@ extern "C" {
 /**
  * Hardened version of the `TRY` macro from `status.h`.
  *
+ * Additionally forces the error bit to 1 if `hardened_status_ok` does not
+ * pass.
+ *
  * @param expr_ An expression that evaluates to a `status_t`.
  * @return The enclosed OK value.
  */
-#define HARDENED_TRY(expr_)                                 \
-  ({                                                        \
-    status_t status_ = expr_;                               \
-    if (hardened_status_ok(status_) != kHardenedBoolTrue) { \
-      return status_;                                       \
-    }                                                       \
-    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);    \
-    status_.value;                                          \
+#define HARDENED_TRY(expr_)                                            \
+  ({                                                                   \
+    status_t status_ = expr_;                                          \
+    if (hardened_status_ok(status_) != kHardenedBoolTrue) {            \
+      return (status_t){.value = status_.value | (int32_t)0x80000000}; \
+    }                                                                  \
+    HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);               \
+    status_.value;                                                     \
   })
 
 /**

--- a/sw/device/lib/base/hardened_status_unittest.cc
+++ b/sw/device/lib/base/hardened_status_unittest.cc
@@ -36,5 +36,32 @@ TEST(HardenedStatus, NormalOkIsNotHardenedOk) {
   EXPECT_EQ(hardened_status_ok(OK_STATUS()), kHardenedBoolFalse);
 }
 
+/**
+ * Run `HARDENED_TRY` and return a non-hardened `OK` if it passes.
+ *
+ * @param status status code to try.
+ */
+__attribute__((noinline)) status_t do_hardened_try(status_t status) {
+  HARDENED_TRY(status);
+  return OK_STATUS();
+}
+
+TEST(HardenedStatus, HardenedTryOfNonHardenedOkIsError) {
+  EXPECT_EQ(status_ok(do_hardened_try(OK_STATUS())), false);
+}
+
+TEST(HardenedStatus, HardenedTryOfHardenedOkIsOk) {
+  EXPECT_EQ(status_ok(do_hardened_try(HARDENED_OK_STATUS)), true);
+}
+
+TEST(HardenedStatus, HardenedTryOfErrorIsError) {
+  EXPECT_EQ(status_ok(do_hardened_try(INVALID_ARGUMENT())), false);
+}
+
+TEST(HardenedStatus, HardenedTryOfErrorWithTruthyArgIsError) {
+  EXPECT_EQ(status_ok(do_hardened_try(INVALID_ARGUMENT(kHardenedBoolTrue))),
+            false);
+}
+
 }  // namespace
 }  // namespace hardened_status_unittest

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -50,6 +50,7 @@ cc_library(
     hdrs = [
         "//sw/device/lib/crypto/include:hash.h",
     ],
+    defines = ["OTCRYPTO_STATUS_DEBUG"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":status",

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -132,6 +132,18 @@ cc_library(
     ],
 )
 
+# Status-code unit tests with debugging information ON.
+cc_test(
+    name = "status_debug_unittest",
+    srcs = ["status_debug_unittest.cc"],
+    defines = ["OTCRYPTO_STATUS_DEBUG"],
+    deps = [
+        ":status",
+        "@googletest//:gtest_main",
+    ],
+)
+
+# Status-code unit tests with debugging information OFF.
 cc_test(
     name = "status_unittest",
     srcs = ["status_unittest.cc"],

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -50,7 +50,6 @@ cc_library(
     hdrs = [
         "//sw/device/lib/crypto/include:hash.h",
     ],
-    defines = ["OTCRYPTO_STATUS_DEBUG"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":status",

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -288,6 +288,10 @@ crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
 
 crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
                                    hash_mode_t hash_mode) {
+  if (ctx == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
   ctx->mode = hash_mode;
   switch (hash_mode) {
     case kHashModeSha256: {
@@ -318,7 +322,7 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
 
 crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
                                      crypto_const_uint8_buf_t input_message) {
-  if (input_message.data == NULL && input_message.len != 0) {
+  if (ctx == NULL || (input_message.data == NULL && input_message.len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -357,7 +361,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
 
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
                                     crypto_uint8_buf_t *digest) {
-  if (digest == NULL || digest->data == NULL) {
+  if (ctx == NULL || digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -392,5 +392,5 @@ crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
       return OTCRYPTO_BAD_ARGS;
   }
 
-  return OTCRYPTO_BAD_ARGS;
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -196,18 +196,18 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
                               hash_mode_t hash_mode,
                               crypto_uint8_buf_t *digest) {
   if (input_message.data == NULL && input_message.len != 0) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   if (digest == NULL || digest->data == NULL) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   // Check `digest->len` is consistent with `hash_mode`
   size_t expected_digest_len;
   OTCRYPTO_TRY_INTERPRET(get_digest_size(hash_mode, &expected_digest_len));
   if (expected_digest_len != digest->len) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   switch (hash_mode) {
@@ -237,10 +237,10 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
       break;
     default:
       // Unrecognized hash mode.
-      return kCryptoStatusBadArgs;
+      return OTCRYPTO_BAD_ARGS;
   }
 
-  return kCryptoStatusOK;
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
@@ -251,7 +251,7 @@ crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
                              crypto_uint8_buf_t *digest) {
   // TODO: (#16410) Add error checks
   if (required_output_len != digest->len) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   // According to NIST SP 800-185 Section 3.2, cSHAKE call should use SHAKE, if
@@ -280,10 +280,10 @@ crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
           input_message, function_name_string, customization_string, digest));
       break;
     default:
-      return kCryptoStatusBadArgs;
+      return OTCRYPTO_BAD_ARGS;
   }
 
-  return kCryptoStatusOK;
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
@@ -310,16 +310,16 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
     }
     default:
       // Unrecognized or unsupported hash mode.
-      return kCryptoStatusBadArgs;
+      return OTCRYPTO_BAD_ARGS;
   }
 
-  return kCryptoStatusOK;
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
                                      crypto_const_uint8_buf_t input_message) {
   if (input_message.data == NULL && input_message.len != 0) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   switch (ctx->mode) {
@@ -349,23 +349,23 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
     }
     default:
       // Unrecognized or unsupported hash mode.
-      return kCryptoStatusBadArgs;
+      return OTCRYPTO_BAD_ARGS;
   }
 
-  return kCryptoStatusOK;
+  return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
                                     crypto_uint8_buf_t *digest) {
   if (digest == NULL || digest->data == NULL) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   // Check `digest->len` is consistent with `ctx->mode`
   size_t expected_digest_len;
   OTCRYPTO_TRY_INTERPRET(get_digest_size(ctx->mode, &expected_digest_len));
   if (expected_digest_len != digest->len) {
-    return kCryptoStatusBadArgs;
+    return OTCRYPTO_BAD_ARGS;
   }
 
   switch (ctx->mode) {
@@ -384,13 +384,13 @@ crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
     case kHashModeSha512: {
       sha512_state_t state;
       sha512_state_restore(ctx, &state);
-      OTCRYPTO_TRY_INTERPRET(sha512_final(&state, digest->data));
+      HARDENED_TRY(sha512_final(&state, digest->data));
       break;
     }
     default:
       // Unrecognized or unsupported hash mode.
-      return kCryptoStatusBadArgs;
+      return OTCRYPTO_BAD_ARGS;
   }
 
-  return kCryptoStatusOK;
+  return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -392,5 +392,5 @@ crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
       return OTCRYPTO_BAD_ARGS;
   }
 
-  return OTCRYPTO_OK;
+  return OTCRYPTO_BAD_ARGS;
 }

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -9,57 +9,12 @@
 #include "sw/device/lib/crypto/include/datatypes.h"
 
 crypto_status_t crypto_status_interpret(status_t status) {
-  // First, check for a hardened-ok status.
-  hardened_bool_t is_ok = hardened_status_ok(status);
-  if (launder32(is_ok) == kHardenedBoolTrue) {
-    HARDENED_CHECK_EQ(is_ok, kHardenedBoolTrue);
-    return launder32(status.value);
+  // Force the error bit to 1 if `hardened_status_ok` does not pass. Cryptolib
+  // status codes are bit-compatible with `status_t`, so we can simply cast the
+  // `value` parameter and return.
+  if (hardened_status_ok(status) != kHardenedBoolTrue) {
+    return (crypto_status_t)(status.value | 0x80000000);
   }
-  HARDENED_CHECK_NE(is_ok, kHardenedBoolTrue);
-
-  switch (status_err(status)) {
-    case kOk:
-      // This status indicates OK but the hardened value doesn't match; return
-      // an error.
-      return kCryptoStatusInternalError;
-    case kInvalidArgument:
-      return kCryptoStatusBadArgs;
-    case kUnavailable:
-      return kCryptoStatusAsyncIncomplete;
-    case kCancelled:
-      return kCryptoStatusInternalError;
-    case kDeadlineExceeded:
-      return kCryptoStatusInternalError;
-    case kNotFound:
-      return kCryptoStatusInternalError;
-    case kAlreadyExists:
-      return kCryptoStatusInternalError;
-    case kPermissionDenied:
-      return kCryptoStatusInternalError;
-    case kResourceExhausted:
-      return kCryptoStatusInternalError;
-    case kAborted:
-      return kCryptoStatusInternalError;
-    case kOutOfRange:
-      return kCryptoStatusInternalError;
-    case kUnimplemented:
-      return kCryptoStatusNotImplemented;
-    case kUnauthenticated:
-      return kCryptoStatusInternalError;
-    case kUnknown:
-      return kCryptoStatusFatalError;
-    case kFailedPrecondition:
-      return kCryptoStatusFatalError;
-    case kInternal:
-      return kCryptoStatusFatalError;
-    case kDataLoss:
-      return kCryptoStatusFatalError;
-    default:
-      // Conservatively return a fatal error in case we encounter something
-      // unexpected.
-      return kCryptoStatusFatalError;
-  }
-
-  HARDENED_UNREACHABLE();
-  return kCryptoStatusFatalError;
+  HARDENED_CHECK_EQ(status.value, kHardenedBoolTrue);
+  return (crypto_status_t)status.value;
 }

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -8,22 +8,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
-/**
- * Call `HARDENED_TRY` on the status, and return it if the try passes.
- *
- * `HARDENED_TRY` forces the error bit to 1 if the value doesn't pass the
- * hardened check, so this routine ensures that values which are not exactly
- * the hardened-OK value will be errors.
- *
- * @param status Status to check
- * @return Same status with error bit always set if `HARDENED_TRY` failed.
- */
-static status_t do_hardened_try(status_t status) {
+crypto_status_t crypto_status_interpret(status_t status) {
   HARDENED_TRY(status);
   return status;
-}
-
-crypto_status_t crypto_status_interpret(status_t status) {
-  status = do_hardened_try(status);
-  return (crypto_status_t) status.value;
 }

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -17,11 +17,17 @@ extern "C" {
  * Values in `status_t` that are guaranteed to correspond to each
  * `crypto_status_t` value.
  *
+ * If `OTCRYPTO_STATUS_DEBUG` is set, full line-number and module information
+ * is included to ease debugging. Otherwise, we use the cryptolib error codes
+ * directly.
+ *
  * Note: These values bypass `status_create` to avoid having a function call in
  * error cases, where we may be under attack and complexity should be
  * minimized.
  */
 #define OTCRYPTO_OK HARDENED_OK_STATUS
+#ifdef OTCRYPTO_STATUS_DEBUG
+
 #define OTCRYPTO_RECOV_ERR                                \
   ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kAborted)})
@@ -39,6 +45,19 @@ extern "C" {
 #define OTCRYPTO_NOT_IMPLEMENTED                          \
   ((status_t){.value = (int32_t)(0x80000000 | MODULE_ID | \
                                  ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
+#else
+
+#define OTCRYPTO_RECOV_ERR \
+  ((status_t){.value = (int32_t)kCryptoStatusInternalError})
+#define OTCRYPTO_FATAL_ERR \
+  ((status_t){.value = (int32_t)kCryptoStatusFatalError})
+#define OTCRYPTO_BAD_ARGS ((status_t){.value = (int32_t)kCryptoStatusBadArgs})
+#define OTCRYPTO_ASYNC_INCOMPLETE \
+  ((status_t){.value = (int32_t)kCryptoStatusAsyncIncomplete})
+#define OTCRYPTO_NOT_IMPLEMENTED \
+  ((status_t){.value = (int32_t)kCryptoStatusNotImplemented})
+
+#endif
 
 /**
  * Convert a `status_t` into a `crypto_status_t`.

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -62,32 +62,10 @@ extern "C" {
 /**
  * Convert a `status_t` into a `crypto_status_t`.
  *
- * For OK statuses, this routine will only convert to `kCryptoStatusOK` if the
- * `hardened_status_ok` passes. An OK status with a different value will be
- * rejected and result in `kCryptoStatusInternalError`.
- *
- * The status mapping is as follows:
- *
- *   | status code         | cryptolib status code        |
- *   |---------------------|------------------------------|
- *   | kOk                 | kCryptoStatusOK OR           |
- *   |                     |   kCryptoStatusInternalError |
- *   | kInvalidArgument    | kCryptoStatusBadArgs         |
- *   | kUnavailable        | kCryptoStatusAsyncIncomplete |
- *   | kCancelled          | kCryptoStatusInternalError   |
- *   | kDeadlineExceeded   | kCryptoStatusInternalError   |
- *   | kNotFound           | kCryptoStatusInternalError   |
- *   | kAlreadyExists      | kCryptoStatusInternalError   |
- *   | kPermissionDenied   | kCryptoStatusInternalError   |
- *   | kResourceExhausted  | kCryptoStatusInternalError   |
- *   | kAborted            | kCryptoStatusInternalError   |
- *   | kOutOfRange         | kCryptoStatusInternalError   |
- *   | kUnimplemented      | kCryptoStatusNotImplemented  |
- *   | kUnauthenticated    | kCryptoStatusInternalError   |
- *   | kUnknown            | kCryptoStatusFatalError      |
- *   | kFailedPrecondition | kCryptoStatusFatalError      |
- *   | kInternal           | kCryptoStatusFatalError      |
- *   | kDataLoss           | kCryptoStatusFatalError      |
+ * Use the OTCRYPTO_* macros and turn off OTCRYPTO_STATUS_DEBUG to ensure valid
+ * `crypto_status_t` results. Otherwise, it is possible to get values that are
+ * not members of the enum; since cryptolib status codes are bit-compatible
+ * with `status_t`, we just cast and return them.
  *
  * @param status Initial `status_t` value.
  * @return Equivalent `crypto_status_t` error code.

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -47,15 +47,11 @@ extern "C" {
                                  ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
 #else
 
-#define OTCRYPTO_RECOV_ERR \
-  ((status_t){.value = (int32_t)kCryptoStatusInternalError})
-#define OTCRYPTO_FATAL_ERR \
-  ((status_t){.value = (int32_t)kCryptoStatusFatalError})
-#define OTCRYPTO_BAD_ARGS ((status_t){.value = (int32_t)kCryptoStatusBadArgs})
-#define OTCRYPTO_ASYNC_INCOMPLETE \
-  ((status_t){.value = (int32_t)kCryptoStatusAsyncIncomplete})
-#define OTCRYPTO_NOT_IMPLEMENTED \
-  ((status_t){.value = (int32_t)kCryptoStatusNotImplemented})
+#define OTCRYPTO_RECOV_ERR ((status_t) { .value = kCryptoStatusInternalError})
+#define OTCRYPTO_FATAL_ERR ((status_t) { .value = kCryptoStatusFatalError})
+#define OTCRYPTO_BAD_ARGS ((status_t) { .value = kCryptoStatusBadArgs})
+#define OTCRYPTO_ASYNC_INCOMPLETE ((status_t) {.value = kCryptoStatusAsyncIncomplete})
+#define OTCRYPTO_NOT_IMPLEMENTED ((status_t) {.value = kCryptoStatusNotImplemented})
 
 #endif
 

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -47,11 +47,13 @@ extern "C" {
                                  ((__LINE__ & 0x7ff) << 5) | kUnimplemented)})
 #else
 
-#define OTCRYPTO_RECOV_ERR ((status_t) { .value = kCryptoStatusInternalError})
-#define OTCRYPTO_FATAL_ERR ((status_t) { .value = kCryptoStatusFatalError})
-#define OTCRYPTO_BAD_ARGS ((status_t) { .value = kCryptoStatusBadArgs})
-#define OTCRYPTO_ASYNC_INCOMPLETE ((status_t) {.value = kCryptoStatusAsyncIncomplete})
-#define OTCRYPTO_NOT_IMPLEMENTED ((status_t) {.value = kCryptoStatusNotImplemented})
+#define OTCRYPTO_RECOV_ERR ((status_t){.value = kCryptoStatusInternalError})
+#define OTCRYPTO_FATAL_ERR ((status_t){.value = kCryptoStatusFatalError})
+#define OTCRYPTO_BAD_ARGS ((status_t){.value = kCryptoStatusBadArgs})
+#define OTCRYPTO_ASYNC_INCOMPLETE \
+  ((status_t){.value = kCryptoStatusAsyncIncomplete})
+#define OTCRYPTO_NOT_IMPLEMENTED \
+  ((status_t){.value = kCryptoStatusNotImplemented})
 
 #endif
 

--- a/sw/device/lib/crypto/impl/status_debug_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_debug_unittest.cc
@@ -36,21 +36,6 @@ TEST(Status, ErrorMacrosNotHardenedOk) {
   EXPECT_EQ(hardened_status_ok(OTCRYPTO_ASYNC_INCOMPLETE), kHardenedBoolFalse);
 }
 
-// Run this test only if extra debugging information is off.
-#ifndef OTCRYPTO_STATUS_DEBUG
-TEST(Status, InterpretErrorMacros) {
-  // Error macros should translate to the crypto status implied by their name.
-  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_OK), kCryptoStatusOK);
-  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_BAD_ARGS), kCryptoStatusBadArgs);
-  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_RECOV_ERR),
-            kCryptoStatusInternalError);
-  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_FATAL_ERR),
-            kCryptoStatusFatalError);
-  EXPECT_EQ(crypto_status_interpret(OTCRYPTO_ASYNC_INCOMPLETE),
-            kCryptoStatusAsyncIncomplete);
-}
-#endif
-
 __attribute__((noinline)) crypto_status_t try_interpret(status_t status) {
   OTCRYPTO_TRY_INTERPRET(status);
   return kCryptoStatusOK;
@@ -64,15 +49,6 @@ TEST(Status, TryInterpretOk) {
 TEST(Status, TryInterpretNonHardenedOk) {
   // Non-hardened OK should result in an error.
   EXPECT_NE(try_interpret(OK_STATUS()), kCryptoStatusOK);
-}
-
-TEST(Status, TryInterpretErrors) {
-  // Error macros should result in non-OK statuses.
-  EXPECT_EQ(try_interpret(OTCRYPTO_BAD_ARGS), kCryptoStatusBadArgs);
-  EXPECT_EQ(try_interpret(OTCRYPTO_RECOV_ERR), kCryptoStatusInternalError);
-  EXPECT_EQ(try_interpret(OTCRYPTO_FATAL_ERR), kCryptoStatusFatalError);
-  EXPECT_EQ(try_interpret(OTCRYPTO_ASYNC_INCOMPLETE),
-            kCryptoStatusAsyncIncomplete);
 }
 
 constexpr char kTestModId[3] = {'X', 'Y', 'Z'};

--- a/sw/device/lib/crypto/impl/status_debug_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_debug_unittest.cc
@@ -2,59 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/crypto/impl/status.h"
-
 #include <array>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "sw/device/lib/crypto/impl/status.h"
 
 // NOTE: This test does not verify hardening measures; it only checks that the
 // "normal" contract of the functions is upheld.
 
 namespace status_unittest {
 namespace {
-
-TEST(Status, OkIsHardenedTrue) {
-  EXPECT_EQ(kCryptoStatusOK, kHardenedBoolTrue);
-}
-
-int HammingDistance(uint32_t a, uint32_t b) {
-  // The hamming distance is the number of bits different between the two words.
-  return bitfield_popcount32(a ^ b);
-}
-
-// Check the Hamming distances of the top-level error codes.
-constexpr int kMinimumHammingDistance = 5;
-TEST(Status, TopLevelStatusHammingDistance) {
-  std::array<crypto_status_t, 5> error_codes = {
-      kCryptoStatusBadArgs, kCryptoStatusInternalError, kCryptoStatusFatalError,
-      kCryptoStatusAsyncIncomplete, kCryptoStatusNotImplemented};
-
-  // Expect the "OK" code to have a significant Hamming distance from 0.
-  EXPECT_GE(HammingDistance(kCryptoStatusOK, 0), kMinimumHammingDistance)
-      << "The 'OK' status code " << kCryptoStatusOK << " is too close to zero.";
-
-  for (const crypto_status_t status1 : error_codes) {
-    // Expect a significant Hamming distance from 0.
-    EXPECT_GE(HammingDistance(status1, 0), kMinimumHammingDistance)
-        << "Error code " << status1 << " is too close to zero.";
-    // Expect an extra significant Hamming distance from the "OK" code.
-    EXPECT_GE(HammingDistance(status1, kCryptoStatusOK),
-              kMinimumHammingDistance)
-        << "Error code " << status1 << " is too close to the 'OK' value ("
-        << kCryptoStatusOK << ").";
-
-    // Expect a significant Hamming distance from all other error codes.
-    for (const crypto_status_t status2 : error_codes) {
-      if (status1 != status2) {
-        EXPECT_GE(HammingDistance(status1, status2), kMinimumHammingDistance)
-            << "Error codes " << status1 << " and " << status2
-            << " are too close to each other.";
-      }
-    }
-  }
-}
 
 TEST(Status, OkIsHardenedOk) {
   EXPECT_EQ(hardened_status_ok(OTCRYPTO_OK), kHardenedBoolTrue);
@@ -109,12 +67,76 @@ TEST(Status, TryInterpretNonHardenedOk) {
 }
 
 TEST(Status, TryInterpretErrors) {
-  // Error macros should result in error statuses.
+  // Error macros should result in non-OK statuses.
   EXPECT_EQ(try_interpret(OTCRYPTO_BAD_ARGS), kCryptoStatusBadArgs);
   EXPECT_EQ(try_interpret(OTCRYPTO_RECOV_ERR), kCryptoStatusInternalError);
   EXPECT_EQ(try_interpret(OTCRYPTO_FATAL_ERR), kCryptoStatusFatalError);
   EXPECT_EQ(try_interpret(OTCRYPTO_ASYNC_INCOMPLETE),
             kCryptoStatusAsyncIncomplete);
+}
+
+constexpr char kTestModId[3] = {'X', 'Y', 'Z'};
+#define MODULE_ID MAKE_MODULE_ID(kTestModId[0], kTestModId[1], kTestModId[2])
+
+TEST(Status, ExtractStatusFieldsBadArgs) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "InvalidArgument";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_BAD_ARGS, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsRecovErr) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "Aborted";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_RECOV_ERR, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsFatalErr) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "FailedPrecondition";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_FATAL_ERR, &code, &line, mod_id), true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
+}
+
+TEST(Status, ExtractStatusFieldsAsyncIncomplete) {
+  const char *code = NULL;
+  char mod_id[3] = {0};
+  int32_t line = 0;
+  const char expected_code[] = "Unavailable";
+  int32_t expected_line = __LINE__ + 1;
+  EXPECT_EQ(status_extract(OTCRYPTO_ASYNC_INCOMPLETE, &code, &line, mod_id),
+            true);
+
+  // Check the fields to ensure that the format of cryptolib errors matches the
+  // error format from the main status library.
+  EXPECT_EQ(memcmp(code, expected_code, ARRAYSIZE(expected_code)), 0);
+  EXPECT_THAT(mod_id, testing::ElementsAreArray(kTestModId));
+  EXPECT_EQ(line, expected_line);
 }
 
 }  // namespace

--- a/sw/device/lib/crypto/impl/status_unittest.cc
+++ b/sw/device/lib/crypto/impl/status_unittest.cc
@@ -28,7 +28,8 @@ int HammingDistance(int32_t a, int32_t b) {
 constexpr int kMinimumHammingDistance = 5;
 TEST(Status, TopLevelStatusHammingDistance) {
   std::array<crypto_status_t, 5> error_codes = {
-    OTCRYPTO_BAD_ARGS, OTCRYPTO_RECOV_ERR, OTCRYPTO_FATAL_ERR, OTCRYPTO_ASYNC_INCOMPLETE, OTCRYPTO_NOT_IMPLEMENTED};
+      OTCRYPTO_BAD_ARGS, OTCRYPTO_RECOV_ERR, OTCRYPTO_FATAL_ERR,
+      OTCRYPTO_ASYNC_INCOMPLETE, OTCRYPTO_NOT_IMPLEMENTED};
 
   // Expect the "OK" code to have a significant Hamming distance from 0.
   EXPECT_GE(HammingDistance(kCryptoStatusOK, 0), kMinimumHammingDistance)
@@ -47,7 +48,8 @@ TEST(Status, TopLevelStatusHammingDistance) {
     // Expect a significant Hamming distance from all other error codes.
     for (const crypto_status_t status2 : error_codes) {
       if (status1.value != status2.value) {
-        EXPECT_GE(HammingDistance(status1.value, status2.value), kMinimumHammingDistance)
+        EXPECT_GE(HammingDistance(status1.value, status2.value),
+                  kMinimumHammingDistance)
             << "Error codes " << status1.value << " and " << status2.value
             << " are too close to each other.";
       }

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -23,22 +23,31 @@ extern "C" {
 /**
  * Enum to handle return values of the crypto API.
  *
- * Values are hardened.
+ * Values are built to be bit-compatible with OpenTitan's internal `status_t`
+ * datatypes. The highest (sign) bit indicates if the value is an error (1) or
+ * not (0). For non-error statuses, the rest can be anything; in cryptolib
+ * status codes it is always `kHardenedBoolTrue`. For errors:
+ *   - The next 15 bits are a module identifier, which is always 0 in the
+ *     cryptolib status codes
+ *   - The next 11 bits are a line number or other information; in the
+ *     cryptolib status codes, it is a hardened value created to have high
+ *     Hamming distance with the other valid status codes
+ *   - The final 5 bits are an Abseil-compatible error code
  */
 typedef enum crypto_status {
   // Status is OK; no errors.
   kCryptoStatusOK = 0x739,
   // Invalid input arguments; wrong length or invalid type.
-  kCryptoStatusBadArgs = 0xb07,
+  kCryptoStatusBadArgs = 0x8000b073,
   // Error after which it is OK to retry (e.g. timeout).
-  kCryptoStatusInternalError = 0x5c3,
+  kCryptoStatusInternalError = 0x80005c3a,
   // Error after which it is not OK to retry (e.g. integrity check).
-  kCryptoStatusFatalError = 0xf5c,
+  kCryptoStatusFatalError = 0x8000f5c9,
   // An asynchronous operation is still in progress.
-  kCryptoStatusAsyncIncomplete = 0xae1,
+  kCryptoStatusAsyncIncomplete = 0x8000ae1e,
   // TODO: remove all instances of this error before release; it is to track
   // implementations that are not yet complete.
-  kCryptoStatusNotImplemented = 0xff,
+  kCryptoStatusNotImplemented = 0x80001fec,
 } crypto_status_t;
 
 /**

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -46,18 +46,18 @@ extern "C" {
 typedef status_t crypto_status_t;
 typedef enum crypto_status_value {
   // Status is OK; no errors.
-  kCryptoStatusOK = (int32_t) 0x739,
+  kCryptoStatusOK = (int32_t)0x739,
   // Invalid input arguments; wrong length or invalid type.
-  kCryptoStatusBadArgs = (int32_t) 0x8000fea3,
+  kCryptoStatusBadArgs = (int32_t)0x8000fea3,
   // Error after which it is OK to retry (e.g. timeout).
-  kCryptoStatusInternalError = (int32_t) 0x8000534a,
+  kCryptoStatusInternalError = (int32_t)0x8000534a,
   // Error after which it is not OK to retry (e.g. integrity check).
-  kCryptoStatusFatalError = (int32_t) 0x80006d89,
+  kCryptoStatusFatalError = (int32_t)0x80006d89,
   // An asynchronous operation is still in progress.
-  kCryptoStatusAsyncIncomplete = (int32_t) 0x8000ea4e,
+  kCryptoStatusAsyncIncomplete = (int32_t)0x8000ea4e,
   // TODO: remove all instances of this error before release; it is to track
   // implementations that are not yet complete.
-  kCryptoStatusNotImplemented = (int32_t) 0x80008d2c,
+  kCryptoStatusNotImplemented = (int32_t)0x80008d2c,
 } crypto_status_value_t;
 
 /**

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -34,22 +34,30 @@ extern "C" {
  *     cryptolib status codes, it is a hardened value created to have high
  *     Hamming distance with the other valid status codes
  *   - The final 5 bits are an Abseil-compatible error code
+ *
+ * The hardened values for error codes were generated with:
+ * $ ./util/design/sparse-fsm-encode.py -d 5 -m 5 -n 11 \
+ *      -s 4232058530 --language=sv --avoid-zero
+ *
+ * Use the same seed value and a larger `-m` argument to generate new values
+ * without changing all error codes. Remove the seed (-s argument) to generate
+ * completely new 11-bit values.
  */
 typedef status_t crypto_status_t;
 typedef enum crypto_status_value {
   // Status is OK; no errors.
-  kCryptoStatusOK = 0x739,
+  kCryptoStatusOK = (int32_t) 0x739,
   // Invalid input arguments; wrong length or invalid type.
-  kCryptoStatusBadArgs = 0x8000b073,
+  kCryptoStatusBadArgs = (int32_t) 0x8000fea3,
   // Error after which it is OK to retry (e.g. timeout).
-  kCryptoStatusInternalError = 0x80005c3a,
+  kCryptoStatusInternalError = (int32_t) 0x8000534a,
   // Error after which it is not OK to retry (e.g. integrity check).
-  kCryptoStatusFatalError = 0x8000f5c9,
+  kCryptoStatusFatalError = (int32_t) 0x80006d89,
   // An asynchronous operation is still in progress.
-  kCryptoStatusAsyncIncomplete = 0x8000ae1e,
+  kCryptoStatusAsyncIncomplete = (int32_t) 0x8000ea4e,
   // TODO: remove all instances of this error before release; it is to track
   // implementations that are not yet complete.
-  kCryptoStatusNotImplemented = 0x80001fec,
+  kCryptoStatusNotImplemented = (int32_t) 0x80008d2c,
 } crypto_status_value_t;
 
 /*

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -60,22 +60,6 @@ typedef enum crypto_status_value {
   kCryptoStatusNotImplemented = (int32_t) 0x80008d2c,
 } crypto_status_value_t;
 
-/*
-// Status is OK; no errors.
-const crypto_status_t kCryptoStatusOK = { .value = 0x739};
-// Invalid input arguments; wrong length or invalid type.
-const crypto_status_t kCryptoStatusBadArgs = { .value = 0x8000b073};
-// Error after which it is OK to retry (e.g. timeout).
-const crypto_status_t kCryptoStatusInternalError = { .value = 0x80005c3a};
-// Error after which it is not OK to retry (e.g. integrity check).
-const crypto_status_t kCryptoStatusFatalError = { .value = 0x8000f5c9};
-// An asynchronous operation is still in progress.
-const crypto_status_t kCryptoStatusAsyncIncomplete = { .value = 0x8000ae1e};
-// TODO: remove all instances of this error before release; it is to track
-// implementations that are not yet complete.
-const crypto_status_t kCryptoStatusNotImplemented = { .value = 0x80001fec};
-*/
-
 /**
  * Struct to handle crypto data buffer with pointer and length.
  * Note: If the crypto_uint8_buf_t is used for output data, it is

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/status.h"
 
 /**
  * @file
@@ -34,7 +35,8 @@ extern "C" {
  *     Hamming distance with the other valid status codes
  *   - The final 5 bits are an Abseil-compatible error code
  */
-typedef enum crypto_status {
+typedef status_t crypto_status_t;
+typedef enum crypto_status_value {
   // Status is OK; no errors.
   kCryptoStatusOK = 0x739,
   // Invalid input arguments; wrong length or invalid type.
@@ -48,7 +50,23 @@ typedef enum crypto_status {
   // TODO: remove all instances of this error before release; it is to track
   // implementations that are not yet complete.
   kCryptoStatusNotImplemented = 0x80001fec,
-} crypto_status_t;
+} crypto_status_value_t;
+
+/*
+// Status is OK; no errors.
+const crypto_status_t kCryptoStatusOK = { .value = 0x739};
+// Invalid input arguments; wrong length or invalid type.
+const crypto_status_t kCryptoStatusBadArgs = { .value = 0x8000b073};
+// Error after which it is OK to retry (e.g. timeout).
+const crypto_status_t kCryptoStatusInternalError = { .value = 0x80005c3a};
+// Error after which it is not OK to retry (e.g. integrity check).
+const crypto_status_t kCryptoStatusFatalError = { .value = 0x8000f5c9};
+// An asynchronous operation is still in progress.
+const crypto_status_t kCryptoStatusAsyncIncomplete = { .value = 0x8000ae1e};
+// TODO: remove all instances of this error before release; it is to track
+// implementations that are not yet complete.
+const crypto_status_t kCryptoStatusNotImplemented = { .value = 0x80001fec};
+*/
 
 /**
  * Struct to handle crypto data buffer with pointer and length.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:opentitan.bzl", "opentitan_flash_binary")
 load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
 load("//rules:autogen.bzl", "autogen_cryptotest_header")
 load("@ot_python_deps//:requirements.bzl", "requirement")
@@ -238,11 +239,10 @@ opentitan_functest(
 opentitan_functest(
     name = "sha512_functest",
     srcs = ["sha512_functest.c"],
+    defines = ["OTCRYPTO_STATUS_DEBUG"],
     verilator = verilator_params(
         timeout = "long",
     ),
-    defines = ["OTCRYPTO_STATUS_DEBUG"],
-    foo = "bar",
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:status",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "opentitan_flash_binary")
 load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest", "verilator_params")
 load("//rules:autogen.bzl", "autogen_cryptotest_header")
 load("@ot_python_deps//:requirements.bzl", "requirement")

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -241,6 +241,7 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
     ),
+    defines = ["OTCRYPTO_STATUS_DEBUG"],
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -242,8 +242,10 @@ opentitan_functest(
         timeout = "long",
     ),
     defines = ["OTCRYPTO_STATUS_DEBUG"],
+    foo = "bar",
     deps = [
         "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -56,8 +56,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
-  TRY_CHECK(otcrypto_hash(input_message, kHashModeSha512, &actual_digest) ==
-            kCryptoStatusOK);
+  TRY(otcrypto_hash(input_message, kHashModeSha512, &actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
@@ -72,7 +71,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
 status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
                                const uint8_t *expected_digest) {
   hash_context_t ctx;
-  TRY_CHECK(otcrypto_hash_init(&ctx, kHashModeSha512) == kCryptoStatusOK);
+  TRY(otcrypto_hash_init(&ctx, kHashModeSha512));
 
   // Send the message 5 bytes at a time.
   size_t num_updates = msg_len / 5;
@@ -85,7 +84,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
     };
     msg += len;
     msg_len -= len;
-    TRY_CHECK(otcrypto_hash_update(&ctx, input_message) == kCryptoStatusOK);
+    TRY(otcrypto_hash_update(&ctx, input_message));
   }
 
   // Allocate space for the computed digest.
@@ -94,7 +93,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
-  TRY_CHECK(otcrypto_hash_final(&ctx, &actual_digest) == kCryptoStatusOK);
+  TRY(otcrypto_hash_final(&ctx, &actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -46,7 +46,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
                      const uint8_t *expected_digest) {
   // Construct a buffer for the message.
   crypto_const_uint8_buf_t input_message = {
-      .data = NULL, // msg,
+      .data = NULL,  // msg,
       .len = msg_len,
   };
 

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -46,7 +46,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
                      const uint8_t *expected_digest) {
   // Construct a buffer for the message.
   crypto_const_uint8_buf_t input_message = {
-      .data = msg,
+      .data = NULL, // msg,
       .len = msg_len,
   };
 
@@ -90,16 +90,14 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[512 / 8];
   crypto_uint8_buf_t actual_digest = {
-      .data = NULL, // (unsigned char *)actual_digest_data,
+      .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
-  status_t err = otcrypto_hash_final(&ctx, &actual_digest);
-  LOG_INFO("Err: 0x%08x", err);
-  // TRY(otcrypto_hash_final(&ctx, &actual_digest));
+  TRY(otcrypto_hash_final(&ctx, &actual_digest));
 
   // Check that the expected and actual digests match.
-  //TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-  //                    ARRAYSIZE(actual_digest_data));
+  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
+                      ARRAYSIZE(actual_digest_data));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -90,14 +90,16 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[512 / 8];
   crypto_uint8_buf_t actual_digest = {
-      .data = (unsigned char *)actual_digest_data,
+      .data = NULL, // (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
-  TRY(otcrypto_hash_final(&ctx, &actual_digest));
+  status_t err = otcrypto_hash_final(&ctx, &actual_digest);
+  LOG_INFO("Err: 0x%08x", err);
+  // TRY(otcrypto_hash_final(&ctx, &actual_digest));
 
   // Check that the expected and actual digests match.
-  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-                      ARRAYSIZE(actual_digest_data));
+  //TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
+  //                    ARRAYSIZE(actual_digest_data));
 
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
I'm trying to get one of the options from https://github.com/lowRISC/opentitan/issues/17803 working, so that cryptolib status codes are compatible with `status_t` and provide extra information if a value called `OTCRYPTO_STATUS_DEBUG` is defined. However, I can't seem to get the define to work. I added logic that passes the `defines` argument to `cc_binary` from the `opentitan_functest` rule, and I understand from the Bazel docs that this should mean the same defines get passed to dependencies, including theoretically `status.h` in this case. But it doesn't seem to happen.

I've set up the SHA-512 test to deliberately pass in a `NULL` pointer to trigger an error. Whether or not I set `defines = ['OTCRYPTO_STATUS_DEBUG']` in the `opentitan_functest()` rule for `//sw/device/tests/crypto:sha512_functest`, I get an error message using the non-debug error codes, which looks like:
```
I00001 sha512_functest.c:125] Starting test one_block_test...
E00002 sha512_functest.c:125] Finished test one_block_test: InvalidArgument:["@@@",2037].
```
However, if I set `defines = ['OTCRYPTO_STATUS_DEBUG']` in any other dependency, such as the `cc_library()` rules for `//sw/device/lib/crypto/impl:hash` , `//sw/device/lib/crypto/impl:status`, or  `//sw/device/lib/crypto/impl/sha2:sha512`, then I get the debuggable error message I want, which looks like:
```
I00001 sha512_functest.c:125] Starting test one_block_test...
E00002 sha512_functest.c:125] Finished test one_block_test: InvalidArgument:["HAS",199].
``` 
I don't understand why the `defines` propagates to dependencies from `cc_library` but not from `opentitan_functest`/`cc_binary`. At this point, I'm a bit stuck. @cfrantz, do you have any advice?