### PR TITLE
[rtl, rv_dm] Trial fix for tap tdo_oe - DO NOT MERGE

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // jtag interface with default 50MHz tck
-interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 20_000) ();
+interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 100_000) ();
 
   // interface pins
   // TODO; make these wires and add `_oe` versions to internally control the driving of these

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -315,7 +315,6 @@ module rv_dm
   logic tck_muxed;
   logic trst_n_muxed;
   prim_clock_mux2 #(
-    .NoFpgaBufG(1'b1)
   ) u_prim_clock_mux2 (
     .clk0_i(jtag_in_int.tck),
     .clk1_i(clk_i),
@@ -324,7 +323,6 @@ module rv_dm
   );
 
   prim_clock_mux2 #(
-    .NoFpgaBufG(1'b1)
   ) u_prim_rst_n_mux2 (
     .clk0_i(jtag_in_int.trst_n),
     .clk1_i(scan_rst_ni),

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1742,6 +1742,13 @@
       run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }
     {
+      name: chip_rv_dm_connect_stress
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "chip_rv_dm_connect_stress_vseq"
+      en_run_modes: ["stub_cpu_mode"]
+      run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
+    }
+    {
       name: chip_sw_rv_core_ibex_address_translation
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests:rv_core_ibex_address_translation_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -118,6 +118,7 @@ filesets:
       - seq_lib/chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rv_dm_access_after_escalation_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_lc_disabled_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_rv_dm_connect_stress_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_entropy_src_fuse_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_connect_stress_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_connect_stress_vseq.sv
@@ -16,7 +16,9 @@
 // check is performed.
 
 class chip_rv_dm_connect_stress_vseq extends chip_stub_cpu_base_vseq;
-  `uvm_object_utils(chip_rv_dm_lc_disabled_vseq)
+  `uvm_object_utils(chip_rv_dm_connect_stress_vseq)
+
+  parameter uint RV_DM_JTAG_IDCODE = 32'h10001cdf;
 
   `uvm_object_new
   jtag_dmi_reg_block jtag_dmi_ral;
@@ -30,7 +32,7 @@ class chip_rv_dm_connect_stress_vseq extends chip_stub_cpu_base_vseq;
   // Add constraint to avoid lc_escalate_en being broadcasted and causes fatal alerts.
   constraint lc_state_c {
     lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2, LcStTestUnlocked3,
-        LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6, LcStTestUnlocked7}
+        LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6, LcStTestUnlocked7};
   }
 
   virtual function void set_handles();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_connect_stress_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rv_dm_connect_stress_vseq.sv
@@ -1,0 +1,182 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence accesses the rv_dm mem interface via JTAG and the TL-UL bus with randomly
+// backdoor-loaded LC state. If the LC state gates the rv_dm mem interface (via lc_debug_en), we
+// are expecting to see a d_error on the TL-UL bus and on JTAG we expect a read-write test to an RW
+// reg to fail.
+//
+// Note that although this sequence runs in stub CPU mode, it still backdoor loads a valid ROM image
+// so that the ROM check can complete successfully. This is needed since the TAP straps are
+// currently sampled after the ROM check succeeds.
+//
+// TODO(#15624): the ROM dependency can be removed once the pwrmgr FSM has been simplified (due
+// to the reset domain reorg). The strap sampling pulse will then be issued earlier, before the ROM
+// check is performed.
+
+class chip_rv_dm_connect_stress_vseq extends chip_stub_cpu_base_vseq;
+  `uvm_object_utils(chip_rv_dm_lc_disabled_vseq)
+
+  `uvm_object_new
+  jtag_dmi_reg_block jtag_dmi_ral;
+  jtag_dtm_reg_block jtag_dtm_ral;
+  rand lc_state_e lc_state;
+
+  constraint num_trans_c {
+    num_trans inside {[5:10]};
+  }
+
+  // Add constraint to avoid lc_escalate_en being broadcasted and causes fatal alerts.
+  constraint lc_state_c {
+    lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2, LcStTestUnlocked3,
+        LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6, LcStTestUnlocked7}
+  }
+
+  virtual function void set_handles();
+    super.set_handles();
+    jtag_dmi_ral = cfg.jtag_dmi_ral;
+    jtag_dtm_ral = cfg.m_jtag_agent_cfg.jtag_dtm_ral;
+  endfunction
+
+  virtual task pre_start();
+    // Select RV_DM TAP via the TAP straps.
+    //`uvm_info(`gfn, $sformatf("Driving the TAP straps to %x", JtagTapRvDm), UVM_LOW)
+    //cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    super.pre_start();
+    max_outstanding_accesses = 1;
+  endtask
+
+  virtual task apply_reset(string kind = "HARD");
+    fork
+      if (kind inside {"HARD", "TRST"}) begin
+        jtag_dmi_ral.reset("HARD");
+      end
+      super.apply_reset(kind);
+    join
+  endtask
+
+  //virtual task dut_init(string reset_kind = "HARD");
+  //  super.dut_init(reset_kind);
+  //  `uvm_info(`gfn, $sformatf("DUT Init with lc_state %0s", lc_state.name), UVM_LOW)
+
+  //  // TODO(#15624): remove this part later.
+  //  // We already wait for the ROM check to complete in the post_apply_reset sequence of
+  //  // chip_stub_cpu_base_vseq. However, we need to wait a few additional cycles here since
+  //  // the strap sampling pulse is released a few cycles after the ROM check completes.
+  //  cfg.clk_rst_vif.wait_clks(100);
+
+  //  `uvm_info(`gfn, "Attempt to activate RV_DM via JTAG.", UVM_MEDIUM)
+  //  // RV_DM needs to be activated for the registers to work properly.
+  //  // We always attempt to write this via the JTAG - even in states where the RV_DM is locked
+  //  // so that incorrect gating behavior is not masked by the RV_DM being disabled.
+  //  csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+  //  cfg.clk_rst_vif.wait_clks(5);
+  //endtask
+
+  virtual function void backdoor_override_otp();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(lc_state)
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(lc_state);
+  endfunction
+
+  virtual function void initialize_otp_sig_verify();
+    backdoor_override_otp();
+    super.initialize_otp_sig_verify();
+  endfunction
+
+  // Returns true if the RV_DM is accessible in a certain life cycle state.
+  virtual function bit allow_rv_dm_access();
+    if (lc_state inside {LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2,
+        LcStTestUnlocked3, LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6,
+        LcStTestUnlocked7, LcStRma, LcStDev}) begin
+      return 1;
+    end else begin
+      return 0;
+    end
+  endfunction
+
+  // Access check via JTAG.
+  virtual task rv_dm_jtag_access_check(bit gated);
+    uvm_reg_data_t wdata = $urandom();
+    uvm_reg_data_t exp_data, rdata;
+    // Write a random 32bit value to the sbaddress0 register.
+    csr_wr(.ptr(jtag_dmi_ral.sbaddress0), .value(wdata), .blocking(1), .predict(~gated));
+    cfg.clk_rst_vif.wait_clks(5);
+    // Expected readback data is all-zero if the JTAG interface is gated.
+    exp_data = gated ? '0 : wdata;
+    `uvm_info(`gfn, $sformatf("RV_DM sbaddress0 write data %0h, expected readback data %0h",
+              wdata, exp_data), UVM_HIGH)
+    // Read back and compare
+    csr_rd(.ptr(jtag_dmi_ral.sbaddress0), .value(rdata), .blocking(1));
+    `DV_CHECK_EQ(rdata, exp_data, $sformatf(
+                 "RV_DM sbaddress0 read back check failed, got 0x%x, expected 0x%x",
+                 rdata, exp_data))
+    cfg.clk_rst_vif.wait_clks(5);
+  endtask
+
+  // Access check via TL-UL bus.
+  virtual task rw_csr_addr_with_gating(uvm_reg csr, bit gated);
+    dv_base_reg dv_reg;
+    dv_base_reg_field flds[$];
+    bit [TL_AW-1:0] addr = csr.get_address();
+    bit [TL_DW-1:0] data = $urandom();
+    `downcast(dv_reg, csr)
+    dv_reg.get_dv_base_reg_fields(flds);
+    if (flds[0].get_access() inside {"RW", "WO"}) begin
+      `uvm_info(`gfn, $sformatf("Write addr %0h, write adata %0h, exp error %0d",
+                addr, data, gated), UVM_HIGH);
+      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
+    end
+    // Most RV_DM registers cannot be predicted correctly.
+    // We hence only check whether the accesses below error out or not.
+    // In case of an error, the data read back must be all ones.
+    if (flds[0].get_access() inside {"RW", "RO"}) begin
+      `uvm_info(`gfn, $sformatf("Read addr %0h, exp error %0d",
+                addr, gated), UVM_HIGH);
+      tl_access(.addr(addr), .write(0), .data(data), .exp_err_rsp(gated), .exp_data('1),
+                .check_exp_data(gated));
+    end
+  endtask
+
+  virtual task rv_dm_jtag_connect();
+    uvm_reg_data_t rdata;
+
+    cfg.chip_vif.tap_straps_if.drive(JtagTapRvDm);
+    cfg.clk_rst_vif.wait_clks(5);
+    csr_rd(.ptr(jtag_dtm_ral.idcode), .value(rdata), .blocking(1));
+
+    `DV_CHECK_EQ(rdata, RV_DM_JTAG_IDCODE,
+      $sformatf("IDCODE read failed got 0x%x, expected, 0x%x", rdata, RV_DM_JTAG_IDCODE))
+  endtask
+
+  virtual task rand_rw_regs(uvm_reg regs[$], bit gated);
+    `DV_CHECK_NE(regs.size(), 0)
+    regs.shuffle();
+    foreach (regs[i]) rw_csr_addr_with_gating(regs[i], gated);
+  endtask
+
+  virtual task body();
+    for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
+      if (trans_i > 1 && $urandom_range(0, 4)) dut_init();
+
+      rv_dm_jtag_connect();
+      //uvm_reg rv_dm_mem_regs[$];
+      //// Re-randomize the life cycle state in most iterations.
+      //if (trans_i > 1 && $urandom_range(0, 4)) dut_init();
+      //`uvm_info(`gfn, $sformatf("Run iterations %0d/%0d with lc_state %0s", trans_i, num_trans,
+      //          lc_state.name), UVM_LOW)
+      //// Check the RV_DM gating via JTAG. Since the serial JTAG interface wires are gated with the
+      //// lc_dft_en signal, it is sufficient to check an RW'able register to verify whether the
+      //// gating works or not.
+      //if ($urandom_range(0, 1)) begin
+      //  rv_dm_jtag_access_check(~allow_rv_dm_access());
+      //end
+      //// Check RV_DM gating via the TL-UL bus.
+      //if ($urandom_range(0, 1)) begin
+      //  ral.rv_dm_mem.get_registers(rv_dm_mem_regs);
+      //  rand_rw_regs(rv_dm_mem_regs, ~allow_rv_dm_access());
+      //end
+    end
+  endtask : body
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -69,6 +69,7 @@
 `include "chip_sw_rv_dm_ndm_reset_when_cpu_halted_vseq.sv"
 `include "chip_sw_rv_dm_access_after_escalation_reset_vseq.sv"
 `include "chip_rv_dm_lc_disabled_vseq.sv"
+`include "chip_rv_dm_connect_stress_vseq.sv"
 `include "chip_sw_alert_handler_shorten_ping_wait_cycle_vseq.sv"
 `include "chip_sw_alert_handler_lpg_clkoff_vseq.sv"
 `include "chip_sw_alert_handler_escalation_vseq.sv"

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -361,6 +361,8 @@ assign clk_sys_pd_n  = scan_mode || !deep_sleep;
 
 logic sys_io_osc_cal;
 
+assign sys_io_osc_cal = 1'b1;
+
 assign clk_sys_en = clk_src_sys_en_i;
 
 `ifdef AST_BYPASS_CLK
@@ -874,13 +876,13 @@ always_ff @( posedge clk_ast_tlul_i, negedge regal_rst_n ) begin
   end
 end
 
-always_ff @( posedge clk_ast_tlul_i, negedge rst_ast_tlul_ni ) begin
-  if ( !rst_ast_tlul_ni ) begin
-    sys_io_osc_cal <= 1'b0;
-  end else if ( regal_we ) begin
-    sys_io_osc_cal <= 1'b1;
-  end
-end
+//always_ff @( posedge clk_ast_tlul_i, negedge rst_ast_tlul_ni ) begin
+//  if ( !rst_ast_tlul_ni ) begin
+//    sys_io_osc_cal <= 1'b0;
+//  end else if ( regal_we ) begin
+//    sys_io_osc_cal <= 1'b1;
+//  end
+//end
 
 always_ff @( posedge clk_ast_tlul_i, negedge vcaon_pok_por ) begin
   if ( !vcaon_pok_por ) begin

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
@@ -189,8 +189,7 @@ module dmi_jtag_tap #(
   logic tck_n;
 
   prim_clock_inv #(
-    .HasScanMode(1'b1),
-    .NoFpgaBufG(1'b1)
+    .HasScanMode(1'b1)
   ) i_tck_inv (
     .clk_i      ( tck_i      ),
     .clk_no     ( tck_n      ),
@@ -201,12 +200,13 @@ module dmi_jtag_tap #(
   always_ff @(posedge tck_n, negedge trst_ni) begin : p_tdo_regs
     if (!trst_ni) begin
       td_o     <= 1'b0;
-      tdo_oe_o <= 1'b0;
+      //tdo_oe_o <= 1'b0;
     end else begin
       td_o     <= tdo_mux;
-      tdo_oe_o <= ~jtag_idle;
+      //tdo_oe_o <= ~jtag_idle;
     end
   end
+  assign tdo_oe_o = 1'b1;
   // ----------------
   // TAP FSM
   // ----------------


### PR DESCRIPTION
Rather than enabling output precisely when it's valid this enables for the entire period the JTAG state machine is active.