### PR TITLE
[opentitantool] Fix intermittent SPI issues

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -779,6 +779,7 @@ impl Target for HyperdebugSpiTarget {
             // perform operation using basic SPI read/write.
             return eeprom::default_run_eeprom_transactions(self, transactions);
         }
+        self.select_my_spi_bus()?;
         let mut stream_state = StreamState::NoPending;
         loop {
             match transactions {


### PR DESCRIPTION
HyperDebug supports controlling multiple SPI busses through a single USB interface, a "select SPI bus" command is meant to be sent before any batch of data transfers.

When a separate function for exposing SPI EEPROM functionality was added, this call to select spi bus was accidentally omitted.  This meant that the working depended on the correct SPI bus already being selected "by accident", which unfortunately happened frequently enough that the bug was not immediately apparent.

This CL adds the call similarly to how it is done for non-EEPROM SPI communication.