### PR TITLE
[sw/silicon_creator] Replace HARDENED_UNREACHBLE() with HARDENED_TRAP()

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -546,12 +546,6 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
       ::"r"(a_), "r"(b_))
 // clang-format on
 
-#define HARDENED_UNREACHABLE_()               \
-  do {                                        \
-    asm volatile(HARDENED_UNIMP_SEQUENCE_()); \
-    __builtin_unreachable();                  \
-  } while (false)
-
 #define HARDENED_TRAP_()                      \
   do {                                        \
     asm volatile(HARDENED_UNIMP_SEQUENCE_()); \
@@ -568,18 +562,8 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
 
 #define HARDENED_CHECK_(op_, a_, b_) assert((uint64_t)(a_)op_(uint64_t)(b_))
 
-#define HARDENED_UNREACHABLE_() assert(false)
-
 #define HARDENED_TRAP_() __builtin_trap()
 #endif  // OT_PLATFORM_RV32
-
-/**
- * Indicates that the following code is unreachable; it should never be
- * reached at runtime.
- *
- * If it is reached anyways, an illegal instruction will be executed.
- */
-#define HARDENED_UNREACHABLE() HARDENED_UNREACHABLE_()
 
 /**
  * If the following code is (unexpectedly) reached a trap instruction will be

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -170,7 +170,7 @@ static status_t key_config_check(const ecc_curve_t *elliptic_curve,
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return OTCRYPTO_FATAL_ERR;
 }
 
@@ -207,7 +207,7 @@ crypto_status_t otcrypto_ecdsa_keygen_async_start(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -369,7 +369,7 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -450,7 +450,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -511,7 +511,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -602,7 +602,7 @@ crypto_status_t otcrypto_ecdsa_verify_async_start(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -657,7 +657,7 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -694,7 +694,7 @@ crypto_status_t otcrypto_ecdh_keygen_async_start(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -775,7 +775,7 @@ crypto_status_t otcrypto_ecdh_keygen_async_finalize(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -859,7 +859,7 @@ crypto_status_t otcrypto_ecdh_async_start(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 
@@ -932,7 +932,7 @@ crypto_status_t otcrypto_ecdh_async_finalize(
   }
 
   // Should never get here.
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }
 

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -35,7 +35,7 @@ static size_t keyblob_share_num_bytes(const crypto_key_config_t config) {
       // Symmetric key shares are simply the same size as the unmasked key.
       return config.key_length;
   }
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
 }
 
 size_t keyblob_share_num_words(const crypto_key_config_t config) {

--- a/sw/device/lib/crypto/impl/status.c
+++ b/sw/device/lib/crypto/impl/status.c
@@ -60,6 +60,6 @@ crypto_status_t crypto_status_interpret(status_t status) {
       return kCryptoStatusFatalError;
   }
 
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
   return kCryptoStatusFatalError;
 }

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -521,7 +521,7 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
       res ^= kLcStateRma ^ kErrorBootDataNotFound ^ kErrorOk;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   HARDENED_RETURN_IF_ERROR(res);
@@ -551,7 +551,8 @@ rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
       HARDENED_CHECK_EQ(active_page.has_valid_entry, kHardenedBoolFalse);
       return boot_data_default_get(lc_state, boot_data);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -331,7 +331,7 @@ rom_error_t alert_config_check(lifecycle_state_t lc_state) {
           otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA_OFFSET);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   if (launder32(res) != kErrorOk) {
     return kErrorAlertBadCrc32;

--- a/sw/device/silicon_creator/lib/drivers/ast.c
+++ b/sw/device/silicon_creator/lib/drivers/ast.c
@@ -44,7 +44,7 @@ rom_error_t ast_check(lifecycle_state_t lc_state) {
       HARDENED_CHECK_EQ(lc_state, kLcStateProdEnd);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // OTP can be configured to skip AST initialization. In this situation we do

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -101,7 +101,7 @@ static void transaction_start(transaction_params_t params) {
       bank_erase = false;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   uint32_t reg = bitfield_bit32_write(0, FLASH_CTRL_CONTROL_START_BIT, true);
   reg =
@@ -227,7 +227,8 @@ static uint32_t info_page_addr(flash_ctrl_info_page_t info_page) {
   switch (launder32(info_page)) {
     FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_ADDR_CASE_)
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 
 #undef INFO_PAGE_ADDR_CASE_
@@ -272,7 +273,8 @@ static info_cfg_regs_t info_cfg_regs(flash_ctrl_info_page_t info_page) {
   switch (launder32(info_page)) {
     FLASH_CTRL_INFO_PAGES_DEFINE(INFO_CFG_REGS_CASE_)
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 
 #undef INFO_CFG_REGS_CASE_
@@ -441,7 +443,7 @@ rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
       error = kErrorOk ^ (byte_count - 1);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // Truncate to the closest lower bank/page aligned address.
@@ -563,7 +565,7 @@ void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
       reg = 0;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   sec_mmio_write32_shadowed(kBase + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET,
                             reg);

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -60,7 +60,8 @@ lifecycle_state_t lifecycle_state_get(void) {
       HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_RMA);
       return kLcStateRma;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 

--- a/sw/device/silicon_creator/lib/drivers/watchdog.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog.c
@@ -49,7 +49,7 @@ void watchdog_init(lifecycle_state_t lc_state) {
       enable = kHardenedBoolFalse;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   uint32_t threshold = otp_read32(
@@ -99,7 +99,7 @@ void watchdog_configure(watchdog_config_t config) {
       ctrl = kCtrlDisable;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   sec_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, ctrl);
 

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -117,7 +117,7 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       lc_shift_masked = launder32(kLcShiftRma) ^ kLcStateRma;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // Get the enable and escalation settings for all four alert classes.

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -189,7 +189,8 @@ static hardened_bool_t sigverify_use_sw_rsa_verify(lifecycle_state_t lc_state) {
       return otp_read32(
           OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN_OFFSET);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -209,7 +210,7 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
       error = sigverify_mod_exp_otbn(key, signature, &enc_msg);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   if (launder32(error) != kErrorOk) {
     *flash_exec ^= UINT32_MAX;

--- a/sw/device/silicon_creator/lib/sigverify/spx_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/spx_verify.c
@@ -34,7 +34,8 @@ uint32_t sigverify_spx_verify_enabled(lifecycle_state_t lc_state) {
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
       return otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_EN_OFFSET);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 

--- a/sw/device/silicon_creator/rom/bootstrap.c
+++ b/sw/device/silicon_creator/rom/bootstrap.c
@@ -313,7 +313,7 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
     case kSpiDeviceOpcodeReset:
       rstmgr_reset();
 #ifdef OT_PLATFORM_RV32
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
 #else
       // If this is an off-target test, return `kErrorUnknown` to be able to
       // test without requiring EXPECT_DEATH.
@@ -384,5 +384,5 @@ rom_error_t bootstrap(void) {
     }
     HARDENED_RETURN_IF_ERROR(error);
   }
-  HARDENED_UNREACHABLE();
+  HARDENED_TRAP();
 }

--- a/sw/device/silicon_creator/rom/rom_epmp.c
+++ b/sw/device/silicon_creator/rom/rom_epmp.c
@@ -78,7 +78,7 @@ void rom_epmp_state_init(lifecycle_state_t lc_state) {
       debug_rom_access = kEpmpPermLockedReadWriteExecute;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // Initialize in-memory copy of ePMP register state.
@@ -181,7 +181,7 @@ void rom_epmp_config_debug_rom(lifecycle_state_t lc_state) {
       pmpcfg = (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute) << 8;
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
   CSR_SET_BITS(CSR_REG_PMPCFG3, pmpcfg);
 }

--- a/sw/device/silicon_creator/rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys.c
@@ -64,7 +64,8 @@ static rom_error_t key_is_valid_in_lc_state_rma(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -92,7 +93,8 @@ static rom_error_t key_is_valid_in_lc_state_dev(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return key_is_valid_in_otp(otp_offset, key_index);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -120,7 +122,8 @@ static rom_error_t key_is_valid_in_lc_state_prod(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -146,7 +149,8 @@ static rom_error_t key_is_valid_in_lc_state_test(
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -178,7 +182,8 @@ static rom_error_t key_is_valid(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
       return key_is_valid_in_lc_state_rma(key_type, otp_offset, key_index);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -145,7 +145,7 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolFalse);
       break;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
   }
 
   // Unlock execution of owner stage executable code (text) sections.

--- a/sw/device/silicon_creator/rom_ext/sigverify_keys.c
+++ b/sw/device/silicon_creator/rom_ext/sigverify_keys.c
@@ -33,7 +33,8 @@ static rom_error_t key_is_valid_in_lc_state_rma(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -60,7 +61,8 @@ static rom_error_t key_is_valid_in_lc_state_dev(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorOk;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -87,7 +89,8 @@ static rom_error_t key_is_valid_in_lc_state_prod(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -112,7 +115,8 @@ static rom_error_t key_is_valid_in_lc_state_test(
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
       return kErrorSigverifyBadKey;
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 
@@ -143,7 +147,8 @@ static rom_error_t key_is_valid(sigverify_key_type_t key_type,
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
       return key_is_valid_in_lc_state_rma(key_type, key_index);
     default:
-      HARDENED_UNREACHABLE();
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
   }
 }
 


### PR DESCRIPTION
Follow up to #18382, replaces `HARDENED_UNREACHABLE()` with `HARDENED_TRAP()` (along with `OT_UNREACHABLE()` when needed, i.e. in a `default` case).