### PR TITLE
[adc_ctrl] Ensure minimum power-up time is adhered

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -118,7 +118,7 @@
             ADC power up time, measured in always on clock cycles.
             After power up time is reached, the ADC controller needs one additional cycle before an ADC channel is selected for access.
           '''
-          resval: "6",
+          resval: "7",
         }
         { bits: "31:8",
           name: "wakeup_time",

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -269,7 +269,7 @@ module adc_ctrl_reg_top (
   logic unused_aon_adc_pd_ctl_wdata;
 
   always_comb begin
-    aon_adc_pd_ctl_qs = 32'h64060;
+    aon_adc_pd_ctl_qs = 32'h64070;
     aon_adc_pd_ctl_qs[0] = aon_adc_pd_ctl_lp_mode_qs_int;
     aon_adc_pd_ctl_qs[7:4] = aon_adc_pd_ctl_pwrup_time_qs_int;
     aon_adc_pd_ctl_qs[31:8] = aon_adc_pd_ctl_wakeup_time_qs_int;
@@ -277,7 +277,7 @@ module adc_ctrl_reg_top (
 
   prim_reg_cdc #(
     .DataWidth(32),
-    .ResetVal(32'h64060),
+    .ResetVal(32'h64070),
     .BitMask(32'hfffffff1),
     .DstWrReq(0)
   ) u_adc_pd_ctl_cdc (
@@ -1481,7 +1481,7 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h6)
+    .RESVAL  (4'h7)
   ) u_adc_pd_ctl_pwrup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/sw/device/tests/chip_power_sleep_load.c
+++ b/sw/device/tests/chip_power_sleep_load.c
@@ -396,7 +396,7 @@ bool test_main(void) {
                      .mode = kDifAdcCtrlLowPowerScanMode,
                      .num_low_power_samples = kNumLowPowerSamples,
                      .num_normal_power_samples = kNumNormalPowerSamples,
-                     .power_up_time_aon_cycles = power_up_time_aon_cycles,
+                     .power_up_time_aon_cycles = power_up_time_aon_cycles + 1,
                      .wake_up_time_aon_cycles = wake_up_time_aon_cycles}));
   CHECK_DIF_OK(dif_adc_ctrl_set_enabled(&adc_ctrl, kDifToggleEnabled));
 

--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -21,7 +21,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 enum {
-  kPowerUpTimeAonCycles = 6,
+  kPowerUpTimeAonCycles = 7,
 };
 
 // These constants will be setup from the testbench

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -219,7 +219,7 @@ static void configure_adc_ctrl(const dif_adc_ctrl_t *adc_ctrl) {
                     .mode = kDifAdcCtrlLowPowerScanMode,
                     .num_low_power_samples = kNumLowPowerSamples,
                     .num_normal_power_samples = kNumNormalPowerSamples,
-                    .power_up_time_aon_cycles = power_up_time_aon_cycles,
+                    .power_up_time_aon_cycles = power_up_time_aon_cycles + 1,
                     .wake_up_time_aon_cycles = wake_up_time_aon_cycles}));
 }
 

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -55,7 +55,7 @@ static void prgm_sysrst_ctrl_wakeup(void *dif) {
 static void prgm_adc_ctrl_wakeup(void *dif) {
   dif_adc_ctrl_config_t cfg = {
       .mode = kDifAdcCtrlLowPowerScanMode,
-      .power_up_time_aon_cycles = 6,
+      .power_up_time_aon_cycles = 7,
       .wake_up_time_aon_cycles = 100,
       .num_low_power_samples = 2,
       .num_normal_power_samples = 8,


### PR DESCRIPTION
This supersedes #18178.

It basically makes sure we are on the safe side by checking that the power down signal stays low long enough, and that the channel select signal remains stable throughout the entire period. The SVA is updated so that it only samples input signals in order to make the check explicit.

The RTL is adapted accordingly to fulfill this requirement.

CC @meisnere