### PR TITLE
[chip-test] Fix sleep_sram_ret_contents ecc error

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1449,7 +1449,8 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
+                 "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_sensor_ctrl_alert


### PR DESCRIPTION
Add bypass_alert_ready_to_end_check plusarg to skip ECC error thrown due
to reading rescrambled data after reset from ret sram.

Fixes #18141.