### PR TITLE
[chip,dv] exclude ibex_sw_fatal from alert_handler_lpg test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1201,7 +1201,8 @@
       run_opts: ["+en_scb=0",
                  "+sw_test_timeout_ns=3000_000_000",
                  "+bypass_alert_ready_to_end_check=1",
-                 "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl*state_regs,otp_ctrl*u_otp_ctrl_dai"]
+                 "+avoid_inject_fatal_error_for_ips=sram_ctrl_main,flash_ctrl,lc_ctrl*state_regs",
+                 "+avoid_ferr_ips_append=otp_ctrl*u_otp_ctrl_dai,rv_core_ibex*sw_fatal_err"]
       run_timeout_mins: 240
       reseed: 90
     }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -108,9 +108,14 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     if ($value$plusargs("inject_fatal_error_for_ip=%s", actual_ip)) begin
       ip_index = get_ip_index_from_name(actual_ip, sec_cm);
     end else begin
-      string excluded_ips[$];
+      string excluded_ips[$], excluded_ips_append[$];
       int excluded_ip_idxs[$];
       `DV_GET_QUEUE_PLUSARG(excluded_ips, avoid_inject_fatal_error_for_ips)
+      `DV_GET_QUEUE_PLUSARG(excluded_ips_append, avoid_ferr_ips_append)
+      if (excluded_ips_append.size() > 0) begin
+        while(excluded_ips_append.size() > 0)
+          excluded_ips.push_back(excluded_ips_append.pop_front());
+      end
       foreach (excluded_ips[i]) begin
         int sep_idx = find_separator(excluded_ips[i]);
         if (sep_idx >= 0) begin


### PR DESCRIPTION
fix #18527 
- Exclude ibex sw fatal from hw force test.
- Add support to split and append exclude list to avoid lint failure.