### PR TITLE
[ci] Increase spi_host_smoketest timeout

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1714,6 +1714,9 @@ opentitan_functest(
 opentitan_functest(
     name = "spi_host_smoketest",
     srcs = ["spi_host_smoketest.c"],
+    cw310 = cw310_params(
+        timeout = "moderate",
+    ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This is needed because test_chip_erase takes more than a minute on the larger flash chip now installed in CI. See #18500 for more details.