### PR TITLE
[rv_dm/pinmux/doc] Add more details regarding NDM reset 

### DIFF
--- a/hw/ip/pinmux/doc/theory_of_operation.md
+++ b/hw/ip/pinmux/doc/theory_of_operation.md
@@ -177,6 +177,21 @@ This is to ensure that any functional attributes like inversion or pull-ups / pu
 
 For more information about the life cycle states, see [Life Cycle Controller Specification](../../lc_ctrl/README.md) and the [Life Cycle Definition Table](../../../../doc/security/specs/device_life_cycle/README.md#manufacturing-states).
 
+### Non-debug Module Reset
+
+The only parts of the system that are not reset as part of a non-debug module (NDM) reset are in this strap sampling and TAP selection module, and in the `rv_dm`, power, reset and clock managers.
+Hence, in order to keep a `rv_dm` JTAG debug session alive during an NDM reset, the `lc_hw_debug_en` state needs to be memorized.
+
+To that end, the TAP isolation logic in the pinmux samples the `lc_hw_debug_en` state when the strap sampling pulse is asserted by the power manager.
+This pulse is asserted once during boot (and not after an NDM reset).
+
+Note that DFT TAP selection is not affected by this since the TAP selection logic always consumes the live value for `lc_dft_en`.
+The TAP selection logic also invalidates the sampled `lc_hw_debug_en` whenever a life cycle transition is initiated or an escalation is triggered via `lc_escalate_en`.
+This ensures that the sampled `lc_hw_debug_en` value does not survive a life cycle transition.
+
+Finally, note that there is secondary gating on the `rv_dm` and DFT TAPs that is always consuming live `lc_hw_debug_en` and `lc_dft_en` signals for added protection.
+
+See also [rv_dm documentation](../../rv_dm/README.md).
 
 ## Generic Pad Wrapper
 

--- a/hw/ip/rv_dm/README.md
+++ b/hw/ip/rv_dm/README.md
@@ -59,10 +59,18 @@ All hardware interfaces of the debug system are documented in the [PULP RISC-V D
 ### Life Cycle Control
 
 Debug system functionality is controlled by the [HW_DEBUG_EN](../lc_ctrl/README.md#hw_debug_en) function of the life cycle controller.
+Note that in order to support the non-debug module (NDM) reset functionality, there are two HW_DEBUG_EN signal inputs in the `rv_dm` module:
 
 ```verilog
-input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i, // Debug module lifecycle enable/disable
-```
+
+  input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
+  input  lc_ctrl_pkg::lc_tx_t pinmux_hw_debug_en_i,
+  ```
+
+The first one comes directly from the life cycle controller and is a "live" value, decoded from the current life cycle state.
+The second one is a latched version coming from the [strap sampling and TAP selection logic inside the pinmux](../pinmux/doc/theory_of_operation.md#strap-sampling-and-tap-isolation).
+In addition to the power, reset and clock managers, the `rv_dm` and the TAP selection logic in the pinmux are the only parts of the system that do not get reset when an NDM reset is triggered (see also [reset manager documentation](../rstmgr/doc/theory_of_operation.md#system-reset-tree)).
+The latched variant of the signal allows to keep the JTAG side of the debug module operational while the rest of the system (including the life cycle controller) undergoes a reset cycle.
 
 ### JTAG
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
@@ -1,4 +1,4 @@
-From 08b109094298ddf9abff0ea522a0b52e868b6a1b Mon Sep 17 00:00:00 2001
+From e0f9a11ece9c212d5d59183cb4263af415e0ea23 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:28:07 -0700
 Subject: [PATCH 1/3] Fix lint errors

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
@@ -1,4 +1,4 @@
-From 67e7bb1c9427779182af52016d2f06c4add2db21 Mon Sep 17 00:00:00 2001
+From 107fe81668549a470caccc46aad1d74c1647042c Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 19:38:49 -0700
 Subject: [PATCH 2/3] Add access error signal to dm_mem

--- a/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,4 +1,4 @@
-From 1d6023dbb9b96929d7503bb8541eae8d12a56b41 Mon Sep 17 00:00:00 2001
+From 51db2dfa1d52ea995f244fba457a101215381382 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:27:27 -0700
 Subject: [PATCH 3/3] Use lowrisc instead of PULP primitives
@@ -6,7 +6,7 @@ Subject: [PATCH 3/3] Use lowrisc instead of PULP primitives
 Signed-off-by: Michael Schaffner <msf@google.com>
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index 56091fa..2a907fa 100644
+index 59d1c90..259f3fc 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
 @@ -79,6 +79,7 @@ module dm_csrs #(
@@ -87,7 +87,7 @@ index 56091fa..2a907fa 100644
  
    always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
 diff --git a/src/dmi_cdc.sv b/src/dmi_cdc.sv
-index f9d66fd..ec7a755 100644
+index f9d66fd..ef9e57c 100644
 --- a/src/dmi_cdc.sv
 +++ b/src/dmi_cdc.sv
 @@ -17,6 +17,10 @@
@@ -101,7 +101,7 @@ index f9d66fd..ec7a755 100644
    // JTAG side (master side)
    input  logic             tck_i,
    input  logic             trst_ni,
-@@ -45,70 +49,76 @@ module dmi_cdc (
+@@ -45,70 +49,75 @@ module dmi_cdc (
    input  logic             core_dmi_valid_i
  );
  
@@ -115,7 +115,6 @@ index f9d66fd..ec7a755 100644
 -    .src_data_i  ( jtag_dmi_req_i       ),
 -    .src_valid_i ( jtag_dmi_valid_i     ),
 -    .src_ready_o ( jtag_dmi_ready_o     ),
-+  // TODO: Make it clean for synthesis.
 +  logic jtag_combined_rstn;
 +  always_ff @(posedge tck_i or negedge trst_ni) begin
 +    if (!trst_ni) begin

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_cdc.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_cdc.sv
@@ -50,7 +50,6 @@ module dmi_cdc (
 );
 
 
-  // TODO: Make it clean for synthesis.
   logic jtag_combined_rstn;
   always_ff @(posedge tck_i or negedge trst_ni) begin
     if (!trst_ni) begin


### PR DESCRIPTION
This removes a TODO in the vendored-in code (part of the patch repository) and adds more details to the docs regarding lifecycle gating during NDM reset.