### PR TITLE
[manuf] cleanup RAW unlock test

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -286,14 +286,12 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_raw",
-        tags = [
-            "jtag",
-        ],
-        test_cmds = OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        tags = ["jtag"],
+        test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
     targets = ["cw310_rom"],
-    test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw:manuf_cp_unlock_raw",
+    test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw",
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/testing/test_framework:ottf_main",


### PR DESCRIPTION
The RAW unlock test attempts to transition from RAW to TEST_UNLOCKED0 by connecting to the LC TAP and issuing the proper LC transition sequence with the RAW unlock token. This cleans up the test as it was not compiling.