### PR TITLE
[crypto] Fix SHA-256 padding bug and add a regression test.

### DIFF
--- a/sw/device/lib/crypto/impl/sha2/sha256.c
+++ b/sw/device/lib/crypto/impl/sha2/sha256.c
@@ -239,7 +239,7 @@ static status_t process_message(sha256_state_t *state, const uint8_t *msg,
     // We always fill `block`; process it.
     HARDENED_TRY(process_block(&ctx, &block));
     // Check if `additional_block` was used, and process it if so.
-    if (padding_len >= kSha256MessageBlockBytes) {
+    if (padding_len > kSha256MessageBlockBytes) {
       HARDENED_TRY(process_block(&ctx, &additional_block));
     }
   }


### PR DESCRIPTION
Found this while using the new SHA-256 API for HMAC. Because of a `>=` that should have been a `>`, the padding result was wrong when the message size was an exact multiple of the block size. This fixes the bug and adds a regression test that failed on the old code.