### PR TITLE
[e2e tests] Do not usr SRST in OpenOCD reset configuration.

### DIFF
--- a/rules/scripts/gdb_test_coordinator.py
+++ b/rules/scripts/gdb_test_coordinator.py
@@ -156,8 +156,13 @@ def main(rom_kind: str = typer.Option(...),
         "; ".join([
             "adapter speed 200",
             "transport select jtag",
-            "reset_config trst_and_srst",
-            "adapter srst delay 10",
+            # Do not use SRST as this will reset the entire chip on the FPGA,
+            # including the JTAG tap. Also the real chip does not have a SRST line
+            # so we do not want to FPGA tests to differ from the real ones. The
+            # chip does not have TRST line. The default setting of OpenOCD is
+            #   reset_config none
+            # but we still put explicitely here.
+            "reset_config none",
         ]),
         "-f",
         openocd_earlgrey_config,


### PR DESCRIPTION
Andreas has identified that OpenOCD was configured to use SRST when issue a `reset`  command. This is problematic since it resets the entire chip, including the JTAG tap and the pinmux. This then causes the pinmux to disable the connection between the pins and the tap a bit later and most likely causes the JTAG issues identified in #17729.
The real chip will not have a srst_n pin and it should not be needed because on RISC-V, issuing a DMI reset though ndmreset will reset *everything* but the part necessary to keep the jtag tap alive, which is exactly what we want.

Hopefully fixes #17729.