### PR TITLE
[hw,i2c,dv] Remove redundant host_nak test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -231,20 +231,6 @@
       tests: ["i2c_host_rx_oversample"]
     }
     {
-      name: host_nak
-      desc: '''
-            Host mode: test response to not receiving an ack
-
-            Stimulus:
-              - Host sends an address or a data write but receives no ack
-
-            Checking:
-              - Interrupt nak is raised
-            '''
-      stage: V2
-      tests: [""]
-    }
-    {
       name: i2c_host_mode_toggle
       desc: '''
             Host mode: disable host mode during host mode sequence
@@ -256,6 +242,7 @@
             Checking:
               - Check if DUT goes to Idle state after Host mode is disabled
               - Check that transactions process normally after recovery by running a smoketest vseq.
+              - Interrupt nak is raised
             '''
       stage: V2
       tests: ["i2c_host_mode_toggle"]

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -62,7 +62,7 @@
     {
       name: i2c_host_rx_oversample
       uvm_test_seq: i2c_host_rx_oversample_vseq
-      run_opts: ["+test_timeout_ns=15_000_000"]
+      run_opts: ["+test_timeout_ns=80_000_000"]
     }
 
     {
@@ -188,7 +188,7 @@
     {
       name: i2c_target_stress_all
       uvm_test_seq: i2c_target_stress_all_vseq
-      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=200_000_000",
+      run_opts: ["+i2c_agent_mode=Host", "+test_timeout_ns=300_000_000",
                  "+use_intr_handler=1"]
     }
     {
@@ -220,7 +220,7 @@
     {
       name: "i2c_host_mode_toggle"
       uvm_test_seq: "i2c_host_mode_toggle_vseq"
-      run_timeout_mins: 2
+      run_timeout_mins: 10
     }
   ]
 


### PR DESCRIPTION
- As the NAK interrupt scenario is executed in host_mode_toggle test, `i2c_host_nak` test is redundant.
- Update testplan of `host_mode_toggle` to include `nak` interrupt check and remove `i2c_host_nak` from testplan
- Increase timeout for `i2c_host_mode_toggle`, `i2c_host_rx_oversample` and `i2c_target_stress_all` tests to fix nightly failures