### PR TITLE
[lib] Always return an error code when `HARDENED_TRY` fails.

### DIFF
--- a/sw/device/lib/base/hardened_status_unittest.cc
+++ b/sw/device/lib/base/hardened_status_unittest.cc
@@ -36,5 +36,32 @@ TEST(HardenedStatus, NormalOkIsNotHardenedOk) {
   EXPECT_EQ(hardened_status_ok(OK_STATUS()), kHardenedBoolFalse);
 }
 
+/**
+ * Run `HARDENED_TRY` and return a non-hardened `OK` if it passes.
+ *
+ * @param status status code to try.
+ */
+__attribute__((noinline)) status_t do_hardened_try(status_t status) {
+  HARDENED_TRY(status);
+  return OK_STATUS();
+}
+
+TEST(HardenedStatus, HardenedTryOfNonHardenedOkIsError) {
+  EXPECT_EQ(status_err(do_hardened_try(OK_STATUS())), kInternal);
+}
+
+TEST(HardenedStatus, HardenedTryOfHardenedOkIsOk) {
+  EXPECT_EQ(status_ok(do_hardened_try(HARDENED_OK_STATUS)), true);
+}
+
+TEST(HardenedStatus, HardenedTryOfErrorIsError) {
+  EXPECT_EQ(status_ok(do_hardened_try(INVALID_ARGUMENT())), false);
+}
+
+TEST(HardenedStatus, HardenedTryOfErrorWithTruthyArgIsError) {
+  EXPECT_EQ(status_ok(do_hardened_try(INVALID_ARGUMENT(kHardenedBoolTrue))),
+            false);
+}
+
 }  // namespace
 }  // namespace hardened_status_unittest


### PR DESCRIPTION
This prevents the failure clause of `HARDENED_TRY` from passing a subsequent `TRY`. Also adds some unit tests for the expected behavior.

@cfrantz and I already started discussing a previous version of this change on a draft PR here (the rest of that PR is  pretty much orthogonal to this change): https://github.com/lowRISC/opentitan/pull/18523

As @cfrantz pointed out in that comment, my original approach of forcing the error bit to 1 has some disadvantages. For example, if the status is `0x738` instead of the expected hardened-OK `0x739`, then we would return `0x80000738`. If `TRY` catches this in a test, it will get the nonsensical Abseil code `24`, the "line number" `0x738 >> 5 = 57` and an all-zero module ID and print an unhelpful error message something like `Undefined24: [@@@, 57]`.

I updated the change to instead run `status_ok` first and return the error unmodified if the error bit is already set, and then separately check the hardened value. If this second check fails, we return a newly-created `INTERNAL()` error with a line/module number that matches the location of the failed `HARDENED_TRY`.

Here's a dissassembly snippet for the new `HARDENED_TRY`. The `bltz` is the `status_ok()` check, and then the `bne` is the check against `kHardenedBoolTrue`. After that there's a `beq` and `unimp` sequence from `HARDENED_CHECK_EQ`. I clipped the next section, which is just the normal execution of the program if the `HARDENED_TRY` passes. Finally, at the end, there is the jump site for the `bne`, which constructs the `INTERNAL()` error.
```
/proc/self/cwd/sw/device/lib/crypto/drivers/kmac.c:687
  HARDENED_TRY(kmac_init(kKmacOperationSHA3, kKmacSecurityStrength224));
20003698:                 4585                  li      a1,1
2000369a:                 4501                  li      a0,0
2000369c:                 2895                  jal     20003710 <kmac_init>
2000369e:          /----- 02054b63              bltz    a0,200036d4 <kmac_sha3_224+0x4c>
launder32():
/proc/self/cwd/./sw/device/lib/base/hardened.h:245
200036a2:          |      862a                  mv      a2,a0
200036a4:          |      73900593              li      a1,1849
kmac_sha3_224():
/proc/self/cwd/sw/device/lib/crypto/drivers/kmac.c:687
200036a8:       /--|----- 04b61063              bne     a2,a1,200036e8 <kmac_sha3_224+0x60>
200036ac:       |  |  /-- 00b50663              beq     a0,a1,200036b8 <kmac_sha3_224+0x30>
200036b0:       |  |  |   0000                  unimp
200036b2:       |  |  |   0000                  unimp
200036b4:       |  |  |   0000                  unimp
200036b6:       |  |  |   0000                  unimp
/proc/self/cwd/sw/device/lib/crypto/drivers/kmac.c:689

... < some more code from kmac.c> ...

200036e8:       \-------> 00006517              auipc   a0,0x6
200036ec:                 92550613              addi    a2,a0,-1755 # 2000900d <kTwoBlockExpDigest+0x40>
200036f0:                 4535                  li      a0,13
200036f2:                 356405b7              lui     a1,0x35640
200036f6:                 2af00693              li      a3,687
200036fa:                 40b2                  lw      ra,12(sp)
200036fc:                 4422                  lw      s0,8(sp)
200036fe:                 4492                  lw      s1,4(sp)
20003700:                 4902                  lw      s2,0(sp)
20003702:                 0141                  addi    sp,sp,16
20003704:                 6a50306f              j       200075a8 <status_create>
```

For cryptolib, we probably don't want to end up calling `status_create` on failure for fault-attack reasons. That leaves me with a few options:
1. Create a new variant of `HARDENED_TRY` that uses a cryptolib error code instead of `INTERNAL()`, bypassing `status_create`, and use that variant in the cryptolib instead of `HARDENED_TRY` (or better, with the new cryptolib status changes, uses `INTERNAL()` when debugging is turned on and a hardcoded value otherwise).
  - This would give me the behavior I want but seems a bit silly given I think cryptolib is the only thing that currently uses `hardened_status.h` anyway, so `HARDENED_TRY` would be unused.
3. Move `hardened_status.h` entirely into the cryptolib, so cryptolib error codes are in scope, and code only one version which matches the description above.

I'm kind of leaning to option 2, although I think that can be a follow-up PR. Are there any thoughts/objections about me formally specializing `hardened_status.h` to be cryptolib-only?