### PR TITLE
[otp, bazel] Add unittests for OTP bazel macros 

### DIFF
--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -401,7 +401,7 @@ def otp_alert_classification(alert_list, default = None, **kwargs):
     Example usage:
         otp_alert_classification(
             alert_list = EARLGREY_ALERTS,
-            # The ordering is alert("prod, prod_end, dev, rma)
+            # The ordering is "prod, prod_end, dev, rma"
             default = "                   X, X, X, X",
             gpio_fatal_fault = "          X, X, X, X",
             i2c0_fatal_fault = "          X, X, X, X",
@@ -433,8 +433,10 @@ def otp_alert_classification(alert_list, default = None, **kwargs):
         extra_alerts = sets.difference(alert_set, provided_alert_set)
         if sets.length(extra_alerts) > 0:
             fail("Some alerts were not specified and no default was provided: {}".format(extra_alerts))
+    else:
+        default = _parse_alert_class_string(default)
 
-    return [provided_alerts.get(alert, default = _parse_alert_class_string(default)) for alert in alert_list]
+    return [provided_alerts.get(alert, default = default) for alert in alert_list]
 
 def otp_per_class_bytes(A, B, C, D):
     """Create a bytestring of per-alert-class byte values."""

--- a/rules/tests/BUILD
+++ b/rules/tests/BUILD
@@ -3,5 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/tests:const_unittest.bzl", "const_test_suite")
+load("//rules/tests:otp_unittest.bzl", "otp_test_suite")
 
 const_test_suite()
+
+otp_test_suite()

--- a/rules/tests/const_unittest.bzl
+++ b/rules/tests/const_unittest.bzl
@@ -70,6 +70,22 @@ lcv_hw_to_sw_test = unittest.make(_lcv_hw_to_sw_test)
 def _hex_digits_test(ctx):
     env = unittest.begin(ctx)
 
+    # 4-bit tests
+    asserts.equals(env, "0", hex_digits(0x0, width = 4))
+    asserts.equals(env, "2", hex_digits(0x2, width = 4))
+    asserts.equals(env, "f", hex_digits(0xf, width = 4))
+
+    # 8-bit tests
+    asserts.equals(env, "00", hex_digits(0x0, width = 8))
+    asserts.equals(env, "c4", hex_digits(0xc4, width = 8))
+    asserts.equals(env, "ff", hex_digits(0xff, width = 8))
+
+    # 32-bit tests
+    asserts.equals(env, "00000123", hex_digits(0x123, width = 32))
+    asserts.equals(env, "00000000", hex_digits(0x0, width = 32))
+    asserts.equals(env, "ffffffff", hex_digits(0xffffffff, width = 32))
+
+    # default width tests
     asserts.equals(env, "00000123", hex_digits(0x123))
     asserts.equals(env, "00000000", hex_digits(0x0))
     asserts.equals(env, "ffffffff", hex_digits(0xffffffff))

--- a/rules/tests/otp_unittest.bzl
+++ b/rules/tests/otp_unittest.bzl
@@ -6,6 +6,7 @@
 
 load(
     "//rules:otp.bzl",
+    "otp_alert_classification",
     "otp_bytestring",
     "otp_hex",
     "otp_per_class_bytes",
@@ -50,6 +51,82 @@ def _otp_bytestring_test(ctx):
     return unittest.end(env)
 
 otp_bytestring_test = unittest.make(_otp_bytestring_test)
+
+def _otp_alert_classification_test(ctx):
+    env = unittest.begin(ctx)
+
+    TEST_ALERT_LIST = [
+        "alert0",
+        "alert1",
+        "alert2",
+        "alert3",
+        "alert4",
+    ]
+
+    # All default test
+    asserts.equals(
+        env,
+        ["0x3294ee94"] * 5,
+        otp_alert_classification(
+            alert_list = TEST_ALERT_LIST,
+            default = "X, A, X, D",
+        ),
+    )
+
+    # String spacing test
+    asserts.equals(
+        env,
+        ["0x3294ee94"] * 5,
+        otp_alert_classification(
+            alert_list = TEST_ALERT_LIST,
+            default = "  X   , A,X, D   ",
+        ),
+    )
+
+    # Some alerts specified test
+    asserts.equals(
+        env,
+        ["0x3294ee94", "0x64646464", "0x94a794a7", "0x32a764ee", "0x3294ee94"],
+        otp_alert_classification(
+            alert_list = TEST_ALERT_LIST,
+            default = "X, A, X, D",
+            alert3 = " A, B, C, D",
+            alert1 = " B, B, B, B",
+            alert2 = " C, X, C, X",
+        ),
+    )
+
+    # All alerts specified (with and without defaults) tests
+    asserts.equals(
+        env,
+        ["0x94949494", "0x64646464", "0x94a794a7", "0x32a764ee", "0xee64a732"],
+        otp_alert_classification(
+            alert_list = TEST_ALERT_LIST,
+            default = "X, A, X, D",
+            alert0 = " X, X, X, X",
+            alert3 = " A, B, C, D",
+            alert1 = " B, B, B, B",
+            alert2 = " C, X, C, X",
+            alert4 = " D, C, B, A",
+        ),
+    )
+
+    asserts.equals(
+        env,
+        ["0x94949494", "0x64646464", "0x94a794a7", "0x32a764ee", "0xee64a732"],
+        otp_alert_classification(
+            alert_list = TEST_ALERT_LIST,
+            alert0 = "X, X, X, X",
+            alert3 = "A, B, C, D",
+            alert1 = "B, B, B, B",
+            alert2 = "C, X, C, X",
+            alert4 = "D, C, B, A",
+        ),
+    )
+
+    return unittest.end(env)
+
+otp_alert_classification_test = unittest.make(_otp_alert_classification_test)
 
 def _otp_per_class_bytes_test(ctx):
     env = unittest.begin(ctx)
@@ -158,6 +235,7 @@ def otp_test_suite():
         "otp_tests",
         otp_hex_test,
         otp_bytestring_test,
+        otp_alert_classification_test,
         otp_per_class_bytes_test,
         otp_per_class_ints_test,
         otp_per_class_lists_test,

--- a/rules/tests/otp_unittest.bzl
+++ b/rules/tests/otp_unittest.bzl
@@ -1,0 +1,164 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for otp.bzl"""
+
+load(
+    "//rules:otp.bzl",
+    "otp_bytestring",
+    "otp_hex",
+    "otp_per_class_bytes",
+    "otp_per_class_ints",
+    "otp_per_class_lists",
+)
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _otp_hex_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "0x00000000", otp_hex(0x0))
+    asserts.equals(env, "0x00000a03", otp_hex(0xa03))
+    asserts.equals(env, "0xffffffff", otp_hex(0xffffffff))
+
+    return unittest.end(env)
+
+otp_hex_test = unittest.make(_otp_hex_test)
+
+def _otp_bytestring_test(ctx):
+    env = unittest.begin(ctx)
+
+    # 1-byte tests
+    asserts.equals(env, "0x00", otp_bytestring([0x00]))
+    asserts.equals(env, "0x10", otp_bytestring([0x10]))
+    asserts.equals(env, "0xff", otp_bytestring([0xff]))
+
+    # 4-byte tests
+    asserts.equals(env, "0x00000000", otp_bytestring([0x00] * 4))
+    asserts.equals(env, "0xbbaa0201", otp_bytestring([0x01, 0x02, 0xaa, 0xbb]))
+    asserts.equals(env, "0xffffffff", otp_bytestring([0xff] * 4))
+
+    # 8-byte tests
+    asserts.equals(env, "0x0000000000000000", otp_bytestring([0x00] * 8))
+    asserts.equals(
+        env,
+        "0xffeebbaa11100201",
+        otp_bytestring([0x01, 0x02, 0x10, 0x11, 0xaa, 0xbb, 0xee, 0xff]),
+    )
+    asserts.equals(env, "0xffffffffffffffff", otp_bytestring([0xff] * 8))
+
+    return unittest.end(env)
+
+otp_bytestring_test = unittest.make(_otp_bytestring_test)
+
+def _otp_per_class_bytes_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Kwarg tests
+    asserts.equals(env, "0xb4a30201", otp_per_class_bytes(A = 0x01, B = 0x02, C = 0xa3, D = 0xb4))
+    asserts.equals(env, "0xffffffff", otp_per_class_bytes(A = 0xff, B = 0xff, C = 0xff, D = 0xff))
+
+    # Positional arg tests
+    asserts.equals(env, "0xb4a30201", otp_per_class_bytes(0x01, 0x02, 0xa3, 0xb4))
+    asserts.equals(env, "0xffffffff", otp_per_class_bytes(0xff, 0xff, 0xff, 0xff))
+
+    return unittest.end(env)
+
+otp_per_class_bytes_test = unittest.make(_otp_per_class_bytes_test)
+
+def _otp_per_class_ints_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Kwarg tests
+    asserts.equals(
+        env,
+        ["0x00000123", "0x00000000", "0x0000ffff", "0xffffffff"],
+        otp_per_class_ints(A = 0x123, B = 0x0, C = 0xffff, D = 0xffffffff),
+    )
+
+    # Positonal arg tests
+    asserts.equals(
+        env,
+        ["0x00000123", "0x00000000", "0x0000ffff", "0xffffffff"],
+        otp_per_class_ints(0x123, 0x0, 0xffff, 0xffffffff),
+    )
+
+    return unittest.end(env)
+
+otp_per_class_ints_test = unittest.make(_otp_per_class_ints_test)
+
+def _otp_per_class_lists_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic integer test
+    asserts.equals(
+        env,
+        [
+            "0x00000001",
+            "0x00000002",
+            "0x00000003",
+            "0x00000004",
+            "0xffffffff",
+            "0xffffffff",
+            "0xffffffff",
+            "0xffffffff",
+            "0x00000001",
+            "0x00000002",
+            "0x00000003",
+            "0x00000004",
+            "0x0000000a",
+            "0x0000000b",
+            "0x0000000c",
+            "0x0000000d",
+        ],
+        otp_per_class_lists(
+            A = "0x1, 0x2, 0x3, 0x4",
+            B = "0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff",
+            C = "1, 2, 3, 4",
+            D = "0xa, 0xb, 0xc, 0xd",
+        ),
+    )
+
+    # Extra spacing test
+    asserts.equals(
+        env,
+        [
+            "0x00000001",
+            "0x00000002",
+            "0x00000003",
+            "0x00000004",
+            "0xffffffff",
+            "0xffffffff",
+            "0xffffffff",
+            "0xffffffff",
+            "0x00000001",
+            "0x00000002",
+            "0x00000003",
+            "0x00000004",
+            "0x0000000a",
+            "0x0000000b",
+            "0x0000000c",
+            "0x0000000d",
+        ],
+        otp_per_class_lists(
+            A = " 0x1,0x2,    0x3,              0x4",
+            B = "0xffffffff,   0xffffffff,     0xffffffff,0xffffffff       ",
+            C = "1,2,3,4",
+            D = "   0xa,   0xb,   0xc,   0xd   ",
+        ),
+    )
+
+    return unittest.end(env)
+
+otp_per_class_lists_test = unittest.make(_otp_per_class_lists_test)
+
+def otp_test_suite():
+    """Create test targets and test suite for const.bzl."""
+    unittest.suite(
+        "otp_tests",
+        otp_hex_test,
+        otp_bytestring_test,
+        otp_per_class_bytes_test,
+        otp_per_class_ints_test,
+        otp_per_class_lists_test,
+    )


### PR DESCRIPTION
This PR adds unittests for the OTP bazel macros added in #18439 