### PR TITLE
[otp] fix RAW OTP image

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -291,13 +291,6 @@ otp_json(
     name = "otp_json_raw",
     partitions = [
         otp_partition(
-            name = "SECRET1",
-            items = {
-                "FLASH_DATA_KEY_SEED": "<random>",
-            },
-            lock = False,
-        ),
-        otp_partition(
             name = "LIFE_CYCLE",
             count = 0,
             state = "RAW",


### PR DESCRIPTION
No fields should be set in the RAW OTP image as pointed out in #18550.