### PR TITLE
[misc] Move non-security blocks to V2S

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -20,7 +20,7 @@
   version:            "1.0",
   life_stage:         "L1",
   design_stage:       "D3",
-  verification_stage: "V2",
+  verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},

--- a/hw/ip/aon_timer/doc/checklist.md
+++ b/hw/ip/aon_timer/doc/checklist.md
@@ -219,11 +219,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | N/A         |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived the V2S review meeting, since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -28,9 +28,8 @@
       version:            "1.1",
       life_stage:         "L1",
       design_stage:       "D3",
-      verification_stage: "V2",
+      verification_stage: "V2S",
       dif_stage:          "S2",
-      commit_id:          "9a2fd04f5e1f36128c858d6a1a7b06c34681337c"
       notes:              ""
     }
   ]

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -230,11 +230,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | N/A         |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived the V2S review meeting, since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -29,7 +29,7 @@
       version:            "1.0",
       life_stage:         "L1",
       design_stage:       "D3",
-      verification_stage: "V2",
+      verification_stage: "V2S",
       dif_stage:          "S2",
       notes:              "",
     }

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -226,11 +226,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | N/A         |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived the V2S review meeting, since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified

--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -27,9 +27,8 @@
       version:            "1.0",
       life_stage:         "L1",
       design_stage:       "D3",
-      verification_stage: "V2",
+      verification_stage: "V2S",
       dif_stage:          "S2",
-      commit_id:          "a25e162b8f91bd0ca32258c83d1d480f93327204",
       notes:              "D3 Reviewed @ 2022-07-28",
     }
   ]

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -228,11 +228,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | N/A         |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived the V2S review meeting, since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -29,9 +29,8 @@
     version:            "1.1",
     life_stage:         "L1",
     design_stage:       "D3",
-    verification_stage: "V2",
+    verification_stage: "V2S",
     dif_stage:          "S2",
-    commit_id:          "558942bb7869d9a5d8abd4bd0eb46dab820d3564"
     notes:              ""
   }
   ]

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -229,11 +229,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | N/A         |
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Waived the V2S review meeting, since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_VERIFIED]:                ../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_verified


### PR DESCRIPTION
These blocks only have the bus integrity error as a CM, which we already test in all cases (from today's regression dashboard Friday May 12 2023 07:07:04 UTC, GitHub Revision: [80a893651](https://github.com/lowrisc/opentitan/tree/80a893651c6936f2101d3fbc960cfc8da1a359ee)):

V2S | tl_intg_err | aon_timer_sec_cm | 10.750s | 7.395ms | 5 | 5 | 100.00
-- | -- | -- | -- | -- | -- | -- | --
  |   | aon_timer_tl_intg_err | 14.430s | 7.993ms | 20 | 20 | 100.00
V2S | sec_cm_bus_integrity | aon_timer_tl_intg_err | 14.430s | 7.993ms | 20 | 20 | 100.00

V2S | tl_intg_err | gpio_tl_intg_err | 1.630s | 308.898us | 20 | 20 | 100.00
-- | -- | -- | -- | -- | -- | -- | --
  |   | gpio_sec_cm | 0.870s | 117.787us | 5 | 5 | 100.00
V2S | sec_cm_bus_integrity | gpio_tl_intg_err | 1.630s | 308.898us | 20 | 20 | 100.00

V2S | tl_intg_err | hmac_sec_cm | 1.040s | 82.754us | 5 | 5 | 100.00
-- | -- | -- | -- | -- | -- | -- | --
  |   | hmac_tl_intg_err | 2.610s | 253.856us | 20 | 20 | 100.00
V2S | sec_cm_bus_integrity | hmac_tl_intg_err | 2.610s | 253.856us | 20 | 20 | 100.00

V2S | tl_intg_err | rv_timer_sec_cm | 0.900s | 169.402us | 5 | 5 | 100.00
-- | -- | -- | -- | -- | -- | -- | --
  |   | rv_timer_tl_intg_err | 1.430s | 224.152us | 20 | 20 | 100.00
V2S | sec_cm_bus_integrity | rv_timer_tl_intg_err | 1.430s | 224.152us | 20 | 20 | 100.00

V2S | tl_intg_err | uart_sec_cm | 0.890s | 64.831us | 5 | 5 | 100.00
-- | -- | -- | -- | -- | -- | -- | --
  |   | uart_tl_intg_err | 1.390s | 114.740us | 20 | 20 | 100.00
V2S | sec_cm_bus_integrity | uart_tl_intg_err | 1.390s | 114.740us | 20 | 20 | 100.00

We can hence sign this off without review meeting, as we've done for other non-security blocks as well, see e.g. `spi_device`:
https://github.com/lowRISC/opentitan/blob/e29688065756ed1d89641a3c46312357cf84c34e/hw/ip/spi_device/doc/checklist.md?plain=1#L220-L228
