### PR TITLE
[spi_device] Add TPM mode constraints and clean up a related TODO

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -203,7 +203,7 @@ module spi_cmdparse
   end
 
   // cmd_info latch
-  // TODO(#18354): This can be further optimized as follows:
+  // ICEBOX(#18354): This can be further optimized as follows:
   // At 7th beat, check the opcode[7:1] with cmd_info[NumCmdInfo-1:0].opcode[7:1].
   // Unless SW configures more than one cmd_info slots with same opcode,
   // at most two slots match with the opcode[7:1].

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -250,8 +250,9 @@ module spi_device
   // SPI S2P signals
   // io_mode: Determine s2p/p2s behavior.
   // io_mode is changed at the negedge of SPI_CLK (based on the SPI protocol).
-  // sub_iomode is changed based on the input of SPI, and latched by clk_spi_out.
-  // TODO(#18359): Add this path (sub_iomode) to CDC constraint
+  // sub_iomode originates from the clk_spi_in domain, with flop values that
+  // may have changed based on the input of SPI. The sub_iomode is selected
+  // and sampled on the clk_spi_out domain.
   io_mode_e           io_mode, io_mode_outclk;
   io_mode_e           sub_iomode[IoModeEnd];
   logic               s2p_data_valid;

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -1120,7 +1120,7 @@ module spi_tpm
       end // StInvalid
 
       StEnd: begin // TERMINAL_STATE
-        // TODO(##18355): Check if open pull-up cancel the transaction?
+        // TODO(#18355): Check if open pull-up cancel the transaction?
         // If yes, then drive 0x00 for the read command
         if (cmd_type == Read) begin
           sck_p2s_valid = 1'b 1;

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -507,7 +507,7 @@ module spid_upload
   // Instance //
   //////////////
 
-  // TODO(#18354): Merge two FIFOs into one.
+  // ICEBOX(#18354): Merge two FIFOs into one.
   // Design a module that has one SRAM Read port / one SRAM write port
   // and compile-time configurable # of FIFO ports + N of SramBase Address
   // (Preferrably variable width)

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -106,6 +106,9 @@ set spi_dev_out_setup     [expr  5.0 + 2 * ${spi_dev_board_delay}]
 create_clock -add -name clk_spi  -period ${spi_dev_period} \
     -waveform "0 ${spi_dev_half_period}" [get_ports SPI_DEV_CLK]
 # CSB must act as a clock, in addition to data and a reset.
+# The waveform is semi-arbitrary: This choice shows that both edges happen near
+# the falling edge of clk_spi. The source clock latency constraints then
+# function like set_input_delay where SPI_DEV_CS_L acts as data.
 create_clock -name clk_spid_csb -period ${spi_dev_period} \
     -waveform "${spi_dev_half_period} [expr ${spi_dev_half_period} + 1]" \
     [get_ports SPI_DEV_CS_L]


### PR DESCRIPTION
Add a separate set of clocks overlaid on top of the signals used by the passthrough ones, and use half-cycle sampling for TPM mode.

CC @hcallahan-lowrisc 