### PR TITLE
[chip,dv] Add lc_ctrl ready polling before jtag access

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -64,6 +64,10 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       // continuously issue LC JTAG read until it returns valid value.
       // In the meantime, TAP selection could happen in between a transaction and might return an
       // error. This error is permitted and can be ignored.
+
+      // This is for a temporary tb patch.
+      // Before using jtag, wait for lc_ctrl is ready.
+      wait_rom_check_done();
       wait_lc_ready(.allow_err(1));
 
       fork

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
@@ -44,6 +44,9 @@ class chip_sw_otp_ctrl_vendor_test_csr_access_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
+    // Before issuing jtag access (from wait_lc_ready),
+    // make sure lc_ctrl readya by polling csr.
+    wait_rom_check_done();
     wait_lc_ready(.allow_err(1));
 
     // Claim the mux interface via JTAG.


### PR DESCRIPTION
Following tests need lc_ctrl ready before calling 'wait_lc_ready'