### PR TITLE
[dv/pwmgr] Fix PwrmgrSecCmEscToSlowResetReq_A

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -151,12 +151,11 @@ module pwrmgr
   // In simulation mode, the prim_cdc_rand_delay module inserts a random one cycle delay to the
   // two flop synchronizers. There are two CDCs in the path from escalation reset to the fast fsm
   // receiving it, one to the slow clock, and one back to the fast one. And there are additional
-  // cycles in the fast fsm to generate outputs.
+  // cycles in the fast fsm to generate outputs. However, esc_rst_req_q can be dropped due to
+  // rst_lc_n.
   `ASSERT(PwrmgrSecCmEscToSlowResetReq_A,
-          esc_rst_req_d |-> ##[2:5] (
-              (!esc_rst_req_d && (fetch_en_o != lc_ctrl_pkg::On)) ||
-              slow_peri_reqs_masked.rstreqs[ResetEscIdx]
-          ), clk_slow_i, !rst_slow_ni)
+          esc_rst_req_q |-> ##[1:5] !esc_rst_req_q || slow_peri_reqs_masked.rstreqs[ResetEscIdx],
+          clk_slow_i, !rst_slow_ni)
   `ASSERT(PwrmgrSecCmFsmEscToResetReq_A,
           slow_peri_reqs_masked.rstreqs[ResetEscIdx] |-> ##[1:4] u_fsm.reset_reqs_i[ResetEscIdx],
           clk_i, !rst_ni)


### PR DESCRIPTION
Use esc_rst_req_q for clarity. Clarify it can be dropped due to rst_lc_n.
Using the flopped version of esc_rst_req_d means the assertion is extended by a cycle,
which was needed since it uses overlapped implication.