### PR TITLE
[sw/silicon_creator] Finish manifest extensions and SPHINCS+ work

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -11,10 +11,10 @@ CONST = struct(
     # Must match the definitions in chip.h.
     ROM_EXT = 0x4552544f,
     OWNER = 0x3042544f,
-    MANIFEST_SIZE = 8852,
-    ROM_EXT_SIZE_MIN = 8852,
+    MANIFEST_SIZE = 964,
+    ROM_EXT_SIZE_MIN = 964,
     ROM_EXT_SIZE_MAX = 0x10000,
-    BL0_SIZE_MIN = 8852,
+    BL0_SIZE_MIN = 964,
     BL0_SIZE_MAX = 0x70000,
     DEFAULT_USAGE_CONSTRAINTS = 0xa5a5a5a5,
     # Must match the definition in spx_verify.h

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -13,7 +13,7 @@
 /**
  * Manifest size for boot stages stored in flash (in bytes).
  */
-#define CHIP_MANIFEST_SIZE 8852
+#define CHIP_MANIFEST_SIZE 964
 
 /**
  * Number of entries in the manifest extensions table.

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -346,7 +346,7 @@ typedef struct manifest_ext_spx_signature {
   /**
    * SPHINCS+ signature of the image.
    */
-  sigverify_spx_key_t signature;
+  sigverify_spx_signature_t signature;
 } manifest_ext_spx_signature_t;
 
 /**
@@ -449,7 +449,7 @@ inline uintptr_t manifest_entry_point_get(const manifest_t *manifest) {
 }
 
 #define DEFINE_GETTER(index_, type_, name_, id_, _)                            \
-  inline rom_error_t manifest_get_ext_##name_(const manifest_t *manifest,      \
+  inline rom_error_t manifest_ext_get_##name_(const manifest_t *manifest,      \
                                               const type_ **name_) {           \
     enum {                                                                     \
       kMinSize = CHIP_MANIFEST_SIZE,                                           \
@@ -470,6 +470,7 @@ inline uintptr_t manifest_entry_point_get(const manifest_t *manifest) {
         if (launder32(header_id) == id_) {                                     \
           HARDENED_CHECK_EQ(header_id, id_);                                   \
           *name_ = (const type_ *)ext_address;                                 \
+          return kErrorOk;                                                     \
         }                                                                      \
       }                                                                        \
     }                                                                          \

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -149,12 +149,6 @@ typedef struct manifest_ext_table {
  */
 typedef struct manifest {
   /**
-   * SPHINCS+ signature of the image.
-   *
-   * TODO(#17824): Make this optional.
-   */
-  sigverify_spx_signature_t spx_signature;
-  /**
    * RSA signature of the image.
    *
    * RSASSA-PKCS1-v1_5 signature of the image generated using a 3072-bit RSA
@@ -178,10 +172,6 @@ typedef struct manifest {
    * Usage constraints.
    */
   manifest_usage_constraints_t usage_constraints;
-  /**
-   * SPHINCS+ public key of the signer.
-   */
-  sigverify_spx_key_t spx_key;
   /**
    * Modulus of the signer's 3072-bit RSA public key.
    */
@@ -258,25 +248,23 @@ typedef struct manifest {
   manifest_ext_table_t extensions;
 } manifest_t;
 
-OT_ASSERT_MEMBER_OFFSET(manifest_t, spx_signature, 0);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_signature, 7856);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, usage_constraints, 8240);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, spx_key, 8288);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_modulus, 8320);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, address_translation, 8704);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 8708);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, signed_region_end, 8712);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, length, 8716);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, version_major, 8720);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, version_minor, 8724);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, security_version, 8728);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, timestamp, 8732);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, binding_value, 8740);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, max_key_version, 8772);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, code_start, 8776);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, code_end, 8780);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, entry_point, 8784);
-OT_ASSERT_MEMBER_OFFSET(manifest_t, extensions, 8788);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_signature, 0);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, usage_constraints, 384);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_modulus, 432);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, address_translation, 816);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 820);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, signed_region_end, 824);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, length, 828);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, version_major, 832);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, version_minor, 836);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, security_version, 840);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, timestamp, 844);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, binding_value, 852);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, max_key_version, 884);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, code_start, 888);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, code_end, 892);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, entry_point, 896);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, extensions, 900);
 OT_ASSERT_SIZE(manifest_t, CHIP_MANIFEST_SIZE);
 
 /**

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -378,11 +378,11 @@ inline rom_error_t manifest_check(const manifest_t *manifest) {
     return kErrorManifestBadSignedRegion;
   }
 
-  // Executable region must be empty, inside the image, located after the
-  // manifest, and word aligned.
+  // Executable region must be non-empty, inside the signed region, located
+  // after the manifest, and word aligned.
   if (manifest->code_start >= manifest->code_end ||
       manifest->code_start < sizeof(manifest_t) ||
-      manifest->code_end > manifest->length ||
+      manifest->code_end > manifest->signed_region_end ||
       (manifest->code_start & 0x3) != 0 || (manifest->code_end & 0x3) != 0) {
     return kErrorManifestBadCodeRegion;
   }

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -215,9 +215,9 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   HARDENED_RETURN_IF_ERROR(sigverify_rsa_key_get(
       sigverify_rsa_key_id_get(&manifest->rsa_modulus), lc_state, &rsa_key));
 
-  const sigverify_spx_key_t *spx_key;
-  HARDENED_RETURN_IF_ERROR(sigverify_spx_key_get(
-      sigverify_spx_key_id_get(&manifest->spx_key), lc_state, &spx_key));
+  // const sigverify_spx_key_t *spx_key;
+  // HARDENED_RETURN_IF_ERROR(sigverify_spx_key_get(
+  //     sigverify_spx_key_id_get(&manifest->spx_key), lc_state, &spx_key));
 
   uint32_t clobber_value = rnd_uint32();
   for (size_t i = 0; i < ARRAYSIZE(boot_measurements.rom_ext.data); ++i) {
@@ -251,21 +251,24 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomVerify, 2);
   // Swap the order of signature verifications randomly.
   *flash_exec = 0;
-  if (rnd_uint32() < 0x80000000) {
-    HARDENED_RETURN_IF_ERROR(sigverify_rsa_verify(
-        &manifest->rsa_signature, rsa_key, &act_digest, lc_state, flash_exec));
-    return sigverify_spx_verify(
-        &manifest->spx_signature, spx_key, lc_state, &usage_constraints_from_hw,
-        sizeof(usage_constraints_from_hw), anti_rollback, anti_rollback_len,
-        digest_region.start, digest_region.length, flash_exec);
-  } else {
-    HARDENED_RETURN_IF_ERROR(sigverify_spx_verify(
-        &manifest->spx_signature, spx_key, lc_state, &usage_constraints_from_hw,
-        sizeof(usage_constraints_from_hw), anti_rollback, anti_rollback_len,
-        digest_region.start, digest_region.length, flash_exec));
-    return sigverify_rsa_verify(&manifest->rsa_signature, rsa_key, &act_digest,
-                                lc_state, flash_exec);
-  }
+  // if (rnd_uint32() < 0x80000000) {
+  //   HARDENED_RETURN_IF_ERROR(sigverify_rsa_verify(
+  //       &manifest->rsa_signature, rsa_key, &act_digest, lc_state,
+  //       flash_exec));
+  //   return sigverify_spx_verify(
+  //       &manifest->spx_signature, spx_key, lc_state,
+  //       &usage_constraints_from_hw, sizeof(usage_constraints_from_hw),
+  //       anti_rollback, anti_rollback_len, digest_region.start,
+  //       digest_region.length, flash_exec);
+  // } else {
+  //   HARDENED_RETURN_IF_ERROR(sigverify_spx_verify(
+  //       &manifest->spx_signature, spx_key, lc_state,
+  //       &usage_constraints_from_hw, sizeof(usage_constraints_from_hw),
+  //       anti_rollback, anti_rollback_len, digest_region.start,
+  //       digest_region.length, flash_exec));
+  return sigverify_rsa_verify(&manifest->rsa_signature, rsa_key, &act_digest,
+                              lc_state, flash_exec);
+  // }
 }
 
 /* These symbols are defined in

--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -16,12 +16,8 @@ use zerocopy::LayoutVerified;
 use crate::crypto::rsa::Modulus;
 use crate::crypto::rsa::Signature as RsaSignature;
 use crate::crypto::sha256;
-use crate::crypto::spx::Signature as SpxSignature;
-use crate::crypto::spx::SpxPublicKeyPart;
-use crate::image::manifest::Manifest;
-use crate::image::manifest_def::{
-    ManifestRsaBuffer, ManifestSpec, ManifestSpxKey, ManifestSpxSignature,
-};
+use crate::image::manifest::{Manifest, ManifestExtTableEntry};
+use crate::image::manifest_def::{ManifestRsaBuffer, ManifestSpec};
 use crate::util::file::{FromReader, ToWriter};
 use crate::util::parse_int::ParseInt;
 
@@ -116,30 +112,6 @@ impl Image {
         // Convert to a `ManifestSpec` so we can supply the rsa_modulus as a `BigInt`.
         let mut manifest_def: ManifestSpec = (&*manifest).try_into()?;
         manifest_def.update_modulus(ManifestRsaBuffer::from_le_bytes(rsa_modulus.to_le_bytes())?);
-        *manifest = manifest_def.try_into()?;
-        Ok(())
-    }
-
-    /// Updates the spx_signature field in the `Manifest`.
-    pub fn update_spx_signature(&mut self, signature: SpxSignature) -> Result<()> {
-        let manifest = self.borrow_manifest_mut()?;
-
-        let mut manifest_def: ManifestSpec = (&*manifest).try_into()?;
-        manifest_def.update_spx_signature(ManifestSpxSignature::from_le_bytes(
-            signature.to_le_bytes(),
-        )?);
-
-        *manifest = manifest_def.try_into()?;
-        Ok(())
-    }
-
-    /// Updates the spx_key field in the `Manifest`.
-    pub fn update_spx_key(&mut self, key: &impl SpxPublicKeyPart) -> Result<()> {
-        let manifest = self.borrow_manifest_mut()?;
-
-        let mut manifest_def: ManifestSpec = (&*manifest).try_into()?;
-        manifest_def.update_spx_key(ManifestSpxKey::from_le_bytes(key.pk_as_bytes())?);
-
         *manifest = manifest_def.try_into()?;
         Ok(())
     }

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -29,6 +29,10 @@ use zerocopy::FromBytes;
 pub const CHIP_MANIFEST_SIZE: u32 = 964;
 pub const CHIP_MANIFEST_EXT_TABLE_COUNT: u32 = 8;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
+pub const MANIFEST_EXT_ID_SPX_KEY: u32 = 0x94ac01ec;
+pub const MANIFEST_EXT_ID_SPX_SIGNATURE: u32 = 0xad77f84a;
+pub const MANIFEST_EXT_NAME_SPX_KEY: u32 = 0x30545845;
+pub const MANIFEST_EXT_NAME_SPX_SIGNATURE: u32 = 0x31545845;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
 pub const CHIP_BL0_IDENTIFIER: u32 = 0x3042544f;
 pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8788;
@@ -61,7 +65,7 @@ pub struct Manifest {
 
 /// A type that holds 1964 32-bit words for SPHINCS+ signtures.
 #[repr(C)]
-#[derive(FromBytes, AsBytes, Debug)]
+#[derive(FromBytes, AsBytes, Debug, Copy, Clone)]
 pub struct SigverifySpxSignature {
     pub data: [u32; 1964usize],
 }
@@ -92,7 +96,7 @@ pub struct ManifestExtSpxSignature {
 
 /// A type that holds 8 32-bit words for SPHINCS+ public keys.
 #[repr(C)]
-#[derive(FromBytes, AsBytes, Debug, Default)]
+#[derive(FromBytes, AsBytes, Debug, Default, Copy, Clone)]
 pub struct SigverifySpxKey {
     pub data: [u32; 8usize],
 }

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -26,7 +26,7 @@ use zerocopy::FromBytes;
 //      -- -I./ -Isw/device/lib/base/freestanding
 // TODO: Generate some constants as hex if possible, replacing manually for now.
 
-pub const CHIP_MANIFEST_SIZE: u32 = 8852;
+pub const CHIP_MANIFEST_SIZE: u32 = 964;
 pub const CHIP_MANIFEST_EXT_TABLE_COUNT: u32 = 8;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
@@ -40,10 +40,8 @@ pub const CHIP_BL0_SIZE_MAX: u32 = 0x70000;
 #[repr(C)]
 #[derive(FromBytes, AsBytes, Debug, Default)]
 pub struct Manifest {
-    pub spx_signature: SigverifySpxSignature,
     pub rsa_signature: SigverifyRsaBuffer,
     pub usage_constraints: ManifestUsageConstraints,
-    pub spx_key: SigverifySpxKey,
     pub rsa_modulus: SigverifyRsaBuffer,
     pub address_translation: u32,
     pub identifier: u32,
@@ -190,25 +188,23 @@ mod tests {
     /// requires a nightly compiler.
     #[test]
     pub fn test_manifest_layout() {
-        assert_eq!(offset_of!(Manifest, spx_signature), 0);
-        assert_eq!(offset_of!(Manifest, rsa_signature), 7856);
-        assert_eq!(offset_of!(Manifest, usage_constraints), 8240);
-        assert_eq!(offset_of!(Manifest, spx_key), 8288);
-        assert_eq!(offset_of!(Manifest, rsa_modulus), 8320);
-        assert_eq!(offset_of!(Manifest, address_translation), 8704);
-        assert_eq!(offset_of!(Manifest, identifier), 8708);
-        assert_eq!(offset_of!(Manifest, signed_region_end), 8712);
-        assert_eq!(offset_of!(Manifest, length), 8716);
-        assert_eq!(offset_of!(Manifest, version_major), 8720);
-        assert_eq!(offset_of!(Manifest, version_minor), 8724);
-        assert_eq!(offset_of!(Manifest, security_version), 8728);
-        assert_eq!(offset_of!(Manifest, timestamp), 8732);
-        assert_eq!(offset_of!(Manifest, binding_value), 8740);
-        assert_eq!(offset_of!(Manifest, max_key_version), 8772);
-        assert_eq!(offset_of!(Manifest, code_start), 8776);
-        assert_eq!(offset_of!(Manifest, code_end), 8780);
-        assert_eq!(offset_of!(Manifest, entry_point), 8784);
-        assert_eq!(offset_of!(Manifest, extensions), 8788);
+        assert_eq!(offset_of!(Manifest, rsa_signature), 0);
+        assert_eq!(offset_of!(Manifest, usage_constraints), 384);
+        assert_eq!(offset_of!(Manifest, rsa_modulus), 432);
+        assert_eq!(offset_of!(Manifest, address_translation), 816);
+        assert_eq!(offset_of!(Manifest, identifier), 820);
+        assert_eq!(offset_of!(Manifest, signed_region_end), 824);
+        assert_eq!(offset_of!(Manifest, length), 828);
+        assert_eq!(offset_of!(Manifest, version_major), 832);
+        assert_eq!(offset_of!(Manifest, version_minor), 836);
+        assert_eq!(offset_of!(Manifest, security_version), 840);
+        assert_eq!(offset_of!(Manifest, timestamp), 844);
+        assert_eq!(offset_of!(Manifest, binding_value), 852);
+        assert_eq!(offset_of!(Manifest, max_key_version), 884);
+        assert_eq!(offset_of!(Manifest, code_start), 888);
+        assert_eq!(offset_of!(Manifest, code_end), 892);
+        assert_eq!(offset_of!(Manifest, entry_point), 896);
+        assert_eq!(offset_of!(Manifest, extensions), 900);
         assert_eq!(size_of::<Manifest>(), CHIP_MANIFEST_SIZE as usize);
     }
 }

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -24,34 +24,14 @@ pub enum ManifestError {
 }
 
 fixed_size_bigint!(ManifestRsaBuffer, at_most 3072);
-fixed_size_bigint!(ManifestSpxSignature, at_most 62848);
-fixed_size_bigint!(ManifestSpxKey, at_most 256);
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 struct ManifestRsaBigInt(Option<HexEncoded<ManifestRsaBuffer>>);
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
-struct ManifestSpxSignatureBigInt(Option<HexEncoded<ManifestSpxSignature>>);
-
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
-struct ManifestSpxKeyBigInt(Option<HexEncoded<ManifestSpxKey>>);
-
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
 struct ManifestSmallInt<T: ParseInt + fmt::LowerHex>(Option<HexEncoded<T>>);
 
 impl fmt::LowerHex for ManifestRsaBuffer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt::LowerHex::fmt(&self.as_biguint(), f)
-    }
-}
-
-impl fmt::LowerHex for ManifestSpxSignature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt::LowerHex::fmt(&self.as_biguint(), f)
-    }
-}
-
-impl fmt::LowerHex for ManifestSpxKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::LowerHex::fmt(&self.as_biguint(), f)
     }
@@ -122,14 +102,6 @@ impl ManifestSpec {
         self.overwrite(other)
     }
 
-    pub fn update_spx_signature(&mut self, spx_signature: ManifestSpxSignature) {
-        self.spx_signature.0 = Some(HexEncoded(spx_signature))
-    }
-
-    pub fn update_spx_key(&mut self, spx_key: ManifestSpxKey) {
-        self.spx_key.0 = Some(HexEncoded(spx_key))
-    }
-
     pub fn update_rsa_signature(&mut self, rsa_signature: ManifestRsaBuffer) {
         self.rsa_signature.0 = Some(HexEncoded(rsa_signature))
     }
@@ -140,14 +112,6 @@ impl ManifestSpec {
 
     pub fn rsa_signature(&self) -> Option<&ManifestRsaBuffer> {
         self.rsa_signature.0.as_ref().map(|v| &v.0)
-    }
-
-    pub fn spx_signature(&self) -> Option<&ManifestSpxSignature> {
-        self.spx_signature.0.as_ref().map(|v| &v.0)
-    }
-
-    pub fn spx_key(&self) -> Option<&ManifestSpxKey> {
-        self.spx_key.0.as_ref().map(|v| &v.0)
     }
 
     pub fn rsa_modulus(&self) -> Option<&ManifestRsaBuffer> {
@@ -170,36 +134,6 @@ trait ManifestPacked<T> {
 
 impl ManifestPacked<ManifestRsaBuffer> for ManifestRsaBigInt {
     fn unpack(self, name: &'static str) -> Result<ManifestRsaBuffer> {
-        match self.0 {
-            Some(v) => Ok(v.0),
-            None => self.unpack_err(name),
-        }
-    }
-
-    fn overwrite(&mut self, o: Self) {
-        if o.0.is_some() {
-            *self = o;
-        }
-    }
-}
-
-impl ManifestPacked<ManifestSpxSignature> for ManifestSpxSignatureBigInt {
-    fn unpack(self, name: &'static str) -> Result<ManifestSpxSignature> {
-        match self.0 {
-            Some(v) => Ok(v.0),
-            None => self.unpack_err(name),
-        }
-    }
-
-    fn overwrite(&mut self, o: Self) {
-        if o.0.is_some() {
-            *self = o;
-        }
-    }
-}
-
-impl ManifestPacked<ManifestSpxKey> for ManifestSpxKeyBigInt {
-    fn unpack(self, name: &'static str) -> Result<ManifestSpxKey> {
         match self.0 {
             Some(v) => Ok(v.0),
             None => self.unpack_err(name),
@@ -271,10 +205,8 @@ impl<T: ParseInt + fmt::LowerHex, const N: usize> ManifestPacked<[T; N]>
 
 manifest_def! {
     pub struct ManifestSpec {
-        spx_signature: ManifestSpxSignatureBigInt,
         rsa_signature: ManifestRsaBigInt,
         usage_constraints: ManifestUsageConstraintsDef,
-        spx_key: ManifestSpxKeyBigInt,
         rsa_modulus: ManifestRsaBigInt,
         address_translation: ManifestSmallInt<u32>,
         identifier: ManifestSmallInt<u32>,
@@ -307,58 +239,6 @@ manifest_def! {
 pub struct ManifestExtTableEntryDef {
     identifier: ManifestSmallInt<u32>,
     offset: ManifestSmallInt<u32>,
-}
-
-impl TryFrom<ManifestSpxSignature> for SigverifySpxSignature {
-    type Error = anyhow::Error;
-
-    fn try_from(spx_signature: ManifestSpxSignature) -> Result<SigverifySpxSignature> {
-        if spx_signature.eq(&ManifestSpxSignature::from_le_bytes([0])?) {
-            // In the case where the BigInt fields are defined but == 0 we should just keep it 0.
-            // Without this the conversion to [u32; 8] would fail.
-            Ok(SigverifySpxSignature {
-                data: le_slice_to_arr(&[0]),
-            })
-        } else {
-            // Convert between the BigInt byte representation and the manifest word representation.
-            Ok(SigverifySpxSignature {
-                data: le_slice_to_arr(
-                    spx_signature
-                        .to_le_bytes()
-                        .chunks(4)
-                        .map(|v| Ok(u32::from_le_bytes(le_slice_to_arr(v))))
-                        .collect::<Result<Vec<u32>>>()?
-                        .as_slice(),
-                ),
-            })
-        }
-    }
-}
-
-impl TryFrom<ManifestSpxKey> for SigverifySpxKey {
-    type Error = anyhow::Error;
-
-    fn try_from(spx_key: ManifestSpxKey) -> Result<SigverifySpxKey> {
-        if spx_key.eq(&ManifestSpxKey::from_le_bytes([0])?) {
-            // In the case where the BigInt fields are defined but == 0 we should just keep it 0.
-            // Without this the conversion to [u32; 8] would fail.
-            Ok(SigverifySpxKey {
-                data: le_slice_to_arr(&[0]),
-            })
-        } else {
-            // Convert between the BigInt byte representation and the manifest word representation.
-            Ok(SigverifySpxKey {
-                data: le_slice_to_arr(
-                    spx_key
-                        .to_le_bytes()
-                        .chunks(4)
-                        .map(|v| Ok(u32::from_le_bytes(le_slice_to_arr(v))))
-                        .collect::<Result<Vec<u32>>>()?
-                        .as_slice(),
-                ),
-            })
-        }
-    }
 }
 
 impl TryFrom<ManifestRsaBuffer> for SigverifyRsaBuffer {
@@ -425,40 +305,6 @@ impl TryFrom<[u32; 8]> for LifecycleDeviceId {
 
     fn try_from(words: [u32; 8]) -> Result<LifecycleDeviceId> {
         Ok(LifecycleDeviceId { device_id: words })
-    }
-}
-
-impl TryFrom<SigverifySpxSignature> for ManifestSpxSignatureBigInt {
-    type Error = anyhow::Error;
-
-    fn try_from(o: SigverifySpxSignature) -> Result<ManifestSpxSignatureBigInt> {
-        (&o).try_into()
-    }
-}
-
-impl TryFrom<&SigverifySpxSignature> for ManifestSpxSignatureBigInt {
-    type Error = anyhow::Error;
-
-    fn try_from(o: &SigverifySpxSignature) -> Result<ManifestSpxSignatureBigInt> {
-        let spx_signature = ManifestSpxSignature::from_le_bytes(o.data.as_bytes())?;
-        Ok(ManifestSpxSignatureBigInt(Some(HexEncoded(spx_signature))))
-    }
-}
-
-impl TryFrom<SigverifySpxKey> for ManifestSpxKeyBigInt {
-    type Error = anyhow::Error;
-
-    fn try_from(o: SigverifySpxKey) -> Result<ManifestSpxKeyBigInt> {
-        (&o).try_into()
-    }
-}
-
-impl TryFrom<&SigverifySpxKey> for ManifestSpxKeyBigInt {
-    type Error = anyhow::Error;
-
-    fn try_from(o: &SigverifySpxKey) -> Result<ManifestSpxKeyBigInt> {
-        let spx_key = ManifestSpxKey::from_le_bytes(o.data.as_bytes())?;
-        Ok(ManifestSpxKeyBigInt(Some(HexEncoded(spx_key))))
     }
 }
 

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -65,6 +65,7 @@ rust_binary(
         "@crate_index//:shellwords",
         "@crate_index//:structopt",
         "@crate_index//:thiserror",
+        "@crate_index//:zerocopy",
         "@lowrisc_serde_annotate//:serde_annotate",
     ],
 )

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -385,7 +385,7 @@ fn test_bootstrap_phase1_page_program(opts: &Opts, transport: &TransportWrapper)
     SpiFlash::from_spi(&*spi)?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
         // Note: We must start at a flash-word-aligned address.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
@@ -422,7 +422,7 @@ fn test_bootstrap_phase1_erase(
     // Send `erase_cmd` to transition to phase 2.
     erase()?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
 
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
@@ -464,7 +464,7 @@ fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Resu
         // Send CHIP_ERASE to transition to phase 2.
         .chip_erase(&*spi)?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
 
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
@@ -480,7 +480,7 @@ fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Resu
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x00);
     let mut buf: [u8; 8] = [0xa5; 8];
-    SpiFlash::from_spi(&*spi)?.read(&*spi, 0x82200, &mut buf)?;
+    SpiFlash::from_spi(&*spi)?.read(&*spi, 0x80330, &mut buf)?;
     log::info!("Received: {:?}", &buf);
     assert_ne!(u64::from_le_bytes(buf), 0x4552_544f_0000_0000u64);
 
@@ -529,7 +529,7 @@ fn test_bootstrap_phase2_page_program(opts: &Opts, transport: &TransportWrapper)
         // Send CHIP_ERASE to transition to phase 2.
         .chip_erase(&*spi)?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
 
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -559,7 +559,7 @@ fn test_bootstrap_phase2_erase(
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let erase = || match erase_cmd {
         // We should erase the page of the identifier of the second slot.
-        SpiFlash::SECTOR_ERASE => spiflash.erase(&*spi, 0x82200 & (!4096 + 1), 4096),
+        SpiFlash::SECTOR_ERASE => spiflash.erase(&*spi, 0x80330 & (!4096 + 1), 4096),
         SpiFlash::CHIP_ERASE => spiflash.chip_erase(&*spi),
         _ => bail!("Unexpected erase command opcode: {:?}", erase_cmd),
     };
@@ -567,7 +567,7 @@ fn test_bootstrap_phase2_erase(
     // Send `erase_cmd` to transition to phase 2.
     erase()?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?;
     // Erase again.
     erase()?;
 
@@ -598,9 +598,9 @@ fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Resu
         // Send CHIP_ERASE to transition to phase 2.
         .chip_erase(&*spi)?
         // Write "OTRE" to the identifier field of the manifest in the second slot.
-        .program(&*spi, 0x82200, &0x4552_544f_0000_0000_u64.to_le_bytes())?
-        // Read 8 bytes starting from 0x82200.
-        .read(&*spi, 0x82200, &mut read_buf)?;
+        .program(&*spi, 0x80330, &0x4552_544f_0000_0000_u64.to_le_bytes())?
+        // Read 8 bytes starting from 0x80330.
+        .read(&*spi, 0x80330, &mut read_buf)?;
     let received = u64::from_le_bytes(read_buf);
     log::info!("Received: {:#x}", received);
     assert_ne!(received, 0x4552_544f_0000_0000_u64);

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -219,7 +219,7 @@ fn check_epmp(_opts: &Opts, cs: &ChipStartup) -> Result<()> {
         EpmpEntry {
             cfg: EPMP_CFG_LRX,
             kind: EpmpRegionKind::Tor,
-            range: EpmpAddressRange(0x2000_2300, _)
+            range: EpmpAddressRange(0x2000_0400, _)
         }
     ));
     assert!(matches!(


### PR DESCRIPTION
This PR replaces the previously added SPHINCS+ fields with manifest extensions and updates silicon_creator code to use extensions for SPHINCS+ signature verification, completing the SPHINCS+ signature verification & manifest extensions implementation in ROM.

This PR updates `opentitantool` enough to unblock this work, remaining work (planned to be completed by @jon-flatley) is tracked as part of #18496.