### PR TITLE
[chip,dv] increase run limit to failure test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1038,6 +1038,7 @@
       uvm_test_seq: chip_sw_sysrst_ctrl_ec_rst_l_vseq
       sw_images: ["//sw/device/tests/sim_dv:sysrst_ctrl_ec_rst_l_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_timeout_mins: 180
     }
     {
       name: chip_sw_aon_timer_irq


### PR DESCRIPTION
chip_sw_sysrst_ctrl_ec_rst_l runs more than an hour, 
mainly due to large sysrst_ctrl.EC_RST_CTL value. ( > 8 ms)
Increase run_timeout_mins.