### PR TITLE
[hw,i2c,dv] Improve I2C Functional coverage

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -520,14 +520,8 @@
     {
       name: i2c_rd_wr_cg
       desc: '''
-            Cover the number of bytes read from Target
-            Cover the number of bytes written to Target
-            * Cross the number of bytes read in Target and Host mode of DUT
-            * Cross the number of bytes written in Target and Host mode of DUT
             Cover the address match feature of IP
-            * Cross the address sent or received with Host and Target mode of DUT
-            * Cross write address with address match
-            * Cross read address with address match
+            * Cross the address match with Host and Target mode of DUT
             Cover values in Read bytes
             * Cross with operating mode of I2C
             Cover values in Write bytes
@@ -617,10 +611,12 @@
             Cover protocol transitions supported by I2C with single host
             * Cross protocol transitions with mode of operation of DUT (Host or Target)
             Cover host mode and target mode enable bits
-            Cover number of bytes transferred in write and read operation
-            * Cover number of bytes as buckets instead of covering every value of number of bytes
-            Cross number of bytes transferred and mode of operation
             Cover mistimed Start or Stop glitches in target mode
+            Cover the number of bytes read from Target
+            Cover the number of bytes written to Target
+            * Cover number of bytes as buckets instead of covering every value of number of bytes
+            * Cross the number of bytes read in Target and Host mode of DUT
+            * Cross the number of bytes written in Target and Host mode of DUT
             '''
     }
     {

--- a/hw/ip/i2c/dv/env/i2c_env_cov.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cov.sv
@@ -178,23 +178,6 @@ covergroup i2c_scl_sda_override_cg
   cp_txorvden_x_sdaval : cross cp_txorvden, cp_sdaval;
 endgroup : i2c_scl_sda_override_cg
 
-covergroup i2c_cmd_complete_cg
-  with function sample(
-    bit cmd_complete,
-    bit host_mode_read,
-    bit host_mode_write,
-    bit target_mode_read,
-    bit target_mode_write
-  );
-  option.per_instance = 1;
-
-  cp_cmd_complete : coverpoint cmd_complete;
-  cp_host_mode_read_complete    : cross cp_cmd_complete, host_mode_read;
-  cp_host_mode_write_complete   : cross cp_cmd_complete, host_mode_write;
-  cp_target_mode_read_complete  : cross cp_cmd_complete, target_mode_read;
-  cp_target_mode_write_complete : cross cp_cmd_complete, target_mode_write;
-endgroup : i2c_cmd_complete_cg
-
 // The 'format FIFO' controls the HWIP state-machine in HOST-mode, where the
 // transaction to be enacted is specified by a series of 1-byte+5-bit
 // packets in the FIFO. Each entry in the 'format FIFO' may part of a larger
@@ -319,6 +302,19 @@ covergroup i2c_b2b_txn_cg with function sample(bit[7:0] past_addr, bit[7:0] addr
      }
 endgroup
 
+// Cover timing parameters of I2C transactions
+covergroup i2c_timing_param_cg(string name="i2c_timing_param_cg") with
+  function sample(bit[15:0] param);
+  option.per_instance = 1;
+  option.name = name;
+  cp_timing_param : coverpoint param {
+    bins zero = {0};
+    bins low = {[1: 100]};
+    bins med = {[101: 1000]};
+    bins high = {[1001: 65535]};
+  }
+endgroup : i2c_timing_param_cg
+
 class i2c_env_cov extends cip_base_env_cov #(.CFG_T(i2c_env_cfg));
   `uvm_component_utils(i2c_env_cov)
 
@@ -333,6 +329,17 @@ class i2c_env_cov extends cip_base_env_cov #(.CFG_T(i2c_env_cfg));
   i2c_acq_fifo_cg acq_fifo_cg;
   i2c_b2b_txn_cg    b2b_txn_host_cg;
   i2c_b2b_txn_cg    b2b_txn_target_cg;
+
+  i2c_timing_param_cg     tlow_cg;
+  i2c_timing_param_cg     thigh_cg;
+  i2c_timing_param_cg     t_r_cg;
+  i2c_timing_param_cg     t_f_cg;
+  i2c_timing_param_cg     thd_sta_cg;
+  i2c_timing_param_cg     tsu_sta_cg;
+  i2c_timing_param_cg     tsu_dat_cg;
+  i2c_timing_param_cg     thd_dat_cg;
+  i2c_timing_param_cg     t_buf_cg;
+  i2c_timing_param_cg     tsu_sto_cg;
   bit got_first_addr;
   bit [7:0] past_addr;
 
@@ -349,6 +356,16 @@ class i2c_env_cov extends cip_base_env_cov #(.CFG_T(i2c_env_cfg));
     acq_fifo_cg = new();
     b2b_txn_host_cg = new();
     b2b_txn_target_cg = new();
+    tlow_cg = new("tlow_cg");
+    thigh_cg = new("thigh_cg");
+    t_r_cg = new("t_r_cg");
+    t_f_cg = new("t_f_cg");
+    thd_sta_cg = new("thd_sta_cg");
+    tsu_sta_cg = new("tsu_sta_cg");
+    tsu_dat_cg = new("tsu_dat_cg");
+    thd_dat_cg = new("thd_dat_cg");
+    t_buf_cg = new("t_buf_cg");
+    tsu_sto_cg = new("tsu_sto_cg");
     got_first_addr = 0;
   endfunction : new
 

--- a/hw/ip/i2c/dv/env/i2c_env_cov.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cov.sv
@@ -222,17 +222,16 @@ with function sample(bit[7:0] fbyte, bit start, bit stop, bit read, bit rcont, b
     bins stop_byte = binsof(stop) intersect {1};
     bins stop_after_start = binsof(stop) intersect {1} &&
                             binsof(start) intersect {1};
-    //TODO(#18033) add these back in once it is possible to sample the ack in the scoreboard.
-    // bins write_address_byte_nak = binsof(start) intersect {1} &&
-    //                               binsof(cp_ack) intersect {0};
-    // bins data_byte_nack = binsof(cp_ack) intersect {0};
-    // bins stop_byte_nack = binsof(stop) intersect {1} &&
-    //                       binsof(cp_ack) intersect {0};
-    // bins nakok_byte_nack = binsof(nakok) intersect {1} &&
-    //                        binsof(cp_ack) intersect {0};
-    // bins nakok_addr_byte_nack = binsof(start) intersect {1} &&
-    //                             binsof(nakok) intersect {1} &&
-    //                             binsof(cp_ack) intersect {0};
+    bins write_address_byte_nak = binsof(start) intersect {1} &&
+                                  binsof(cp_ack) intersect {0};
+    bins data_byte_nack = binsof(cp_ack) intersect {0};
+    bins stop_byte_nack = binsof(stop) intersect {1} &&
+                          binsof(cp_ack) intersect {0};
+    bins nakok_byte_nack = binsof(nakok) intersect {1} &&
+                           binsof(cp_ack) intersect {0};
+    bins nakok_addr_byte_nack = binsof(start) intersect {1} &&
+                                binsof(nakok) intersect {1} &&
+                                binsof(cp_ack) intersect {0};
   }
 
 endgroup : i2c_fmt_fifo_cg

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -404,6 +404,36 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             mirrored_txdata.push_back(item.a_data[7:0]);
           end
         end
+        "timing0": begin
+          if (cfg.en_cov) begin
+            cov.thigh_cg.sample(`gmv(ral.timing0.thigh));
+            cov.tlow_cg.sample(`gmv(ral.timing0.thigh));
+          end
+        end
+        "timing1": begin
+          if (cfg.en_cov) begin
+            cov.t_r_cg.sample(`gmv(ral.timing1.t_r));
+            cov.t_f_cg.sample(`gmv(ral.timing1.t_f));
+          end
+        end
+        "timing2": begin
+          if (cfg.en_cov) begin
+            cov.tsu_sta_cg.sample(`gmv(ral.timing2.tsu_sta));
+            cov.thd_sta_cg.sample(`gmv(ral.timing2.thd_sta));
+          end
+        end
+        "timing3": begin
+          if (cfg.en_cov) begin
+            cov.tsu_dat_cg.sample(`gmv(ral.timing3.tsu_dat));
+            cov.thd_dat_cg.sample(`gmv(ral.timing3.thd_dat));
+          end
+        end
+        "timing4": begin
+          if (cfg.en_cov) begin
+            cov.t_buf_cg.sample(`gmv(ral.timing4.t_buf));
+            cov.tsu_sto_cg.sample(`gmv(ral.timing4.tsu_sto));
+          end
+        end
       endcase
 
       if (cfg.under_reset || !host_init) return;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_vseq.sv
@@ -28,11 +28,11 @@ class i2c_host_perf_vseq extends i2c_rx_tx_vseq;
   constraint scl_frequency_c {
     solve speed_mode before scl_frequency;
     if(speed_mode == Standard){
-      scl_frequency == 100;
+      scl_frequency inside {100, 50};
     }else if(speed_mode == Fast) {
-      scl_frequency == 400;
+      scl_frequency inside {400, 200};
     }else if(speed_mode == FastPlus) {
-      scl_frequency == 1000;
+      scl_frequency inside {1000, 500};
     }
   }
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -56,7 +56,6 @@
     {
       name: i2c_host_override
       uvm_test_seq: i2c_host_override_vseq
-      run_opts: ["+en_scb=0"]
     }
 
     {

--- a/hw/ip/i2c/dv/sva/i2c_bind.sv
+++ b/hw/ip/i2c/dv/sva/i2c_bind.sv
@@ -24,7 +24,9 @@ module i2c_bind;
     .clk (clk_i),
     .rst_n (rst_ni),
     .scl (cio_scl_i),
-    .sda (cio_sda_i)
+    .sda (cio_sda_i),
+    .intr_cmd_complete (intr_cmd_complete_o),
+    .intr_tx_stretch   (intr_tx_stretch_o)
   );
 
 endmodule

--- a/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
+++ b/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
@@ -355,9 +355,6 @@ module i2c_protocol_cov(
     RStart_during_read_data_cp : coverpoint bus_state_q iff (!host_mode_en) {
       bins Start_during_read_data = (ReadData => RStart);
     }
-    RStart_before_Write_data_ACK_cp : coverpoint bus_state_q iff (!host_mode_en) {
-      bins Start_before_Write_data_ACK_Nack = (WriteDataACK, WriteDataNACK => RStart);
-    }
     RStart_before_read_data_ACK_cp : coverpoint bus_state_q iff (!host_mode_en) {
       bins Start_before_read_data_ACK_Nack = (ReadDataACK, ReadDataNACK => RStart);
     }


### PR DESCRIPTION
#### Changes to cover and improve functional coverage of I2C

- Enable scoreboard for override test sequence to sample register values in scoreboard
- update constraint for `scl_frequency` in `i2c_host_perf` test to cover frequencies less than maximum supported by each operating mode (Standard, Fast and Fast Plus)
- Remove coverpoint `RStart_before_Write_data_ACK_cp` since
  - In Target mode, there is no option to NACK for write data
  - In Host mode, `RStart` is not applicable since multi-host mode is not supported

#### Implement covergroups `i2c_rd_wr_cg` and `i2c_timing_param_cg` specified in testplan
- Move `i2c_cmd_complete_cg` to `i2c_protocol_cov.sv` as it is easier to sample the  variables related to this covergroup
- Update covergroup description for `i2c_rd_wr_cg` and `i2c_protocol_cov_cg` as some of the coverage points mentioned in `i2c_rd_wr_cg` are covered in `i2c_protocol_cov_cg`
