### PR TITLE
[bazel] Disable pedantic warnings in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,7 @@ build --strip='never'
 # Bazel embedded enables the following feature which along with -std=c11 and
 # our codebase generates a lot of warnings by setting the -Wpedantic flag
 build --features=-all_warnings
+build --features=-pedantic_warnings
 
 # Enable toolchain hardening features.
 # `guards` adds `unimp` guard instructions after unconditional jumps.


### PR DESCRIPTION
Currently, the all_warnings feature controls both `-Wall` and `-Wpedantic` and is enabled by default. These flags are both disabled in .bazelrc by way of `--features=-all_warnings`.

As of lowRISC/crt#19, `-Wpedantic` has been split out of all_warnings into its own feature: pedantic_warnings.

This commit preemptively disables pedantic_warnings to prevent build errors when we bump the crt version.