### PR TITLE
[chip,dv] Adjust eos status for chip_sw_otp_ctrl_vendor_test_csr_access

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -676,6 +676,27 @@ class chip_sw_base_vseq extends chip_base_vseq;
     return (digest_bits[TokenWidthBit-1:0]);
   endfunction
 
+  virtual function bit is_test_locked_lc_state(lc_state_e state);
+    return (state inside {LcStTestLocked0, LcStTestLocked1,
+                          LcStTestLocked2, LcStTestLocked3,
+                          LcStTestLocked4, LcStTestLocked5,
+                          LcStTestLocked6});
+  endfunction // is_locked_lc_state
+  virtual function bit is_test_unlocked_lc_state(lc_state_e state);
+    return (state inside {LcStTestUnlocked0, LcStTestUnlocked1,
+                          LcStTestUnlocked2, LcStTestUnlocked3,
+                          LcStTestUnlocked4, LcStTestUnlocked5,
+                          LcStTestUnlocked6, LcStTestUnlocked7
+                          });
+  endfunction
+  // Indicate LC state where cpu_en == 1
+  // This has to follow Manufacturing State description
+  // https://opentitan.org/book/doc/security/specs/device_life_cycle/#manufacturing-states
+  virtual function bit is_cpu_enabled_lc_state(lc_state_e state);
+    return ((state inside {LcStDev, LcStProd, LcStProdEnd, LcStRma}) ||
+            (is_test_unlocked_lc_state(state) == 1));
+  endfunction
+
 
   // LC_CTRL JTAG tasks
   virtual task wait_lc_status(lc_ctrl_status_e expect_status, int max_attempt = 5000);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
@@ -81,8 +81,11 @@ class chip_sw_otp_ctrl_vendor_test_csr_access_vseq extends chip_sw_base_vseq;
   endtask
 
   task post_start();
+    // If cpu is enabled, sw_test_status continues transitioning to the end.
+    // SwTestStatusBooted->SwTestStatusInBootRom->SwTestStatusInTest->SwTestStatusPassed
     // Some LC state does not enable CPU so sw cannot return a pass status.
-    override_test_status_and_finish(.passed(1));
+    // Therefore, we need to force status to passed state.
+    if (!is_cpu_enabled_lc_state(lc_state)) override_test_status_and_finish(.passed(1));
 
     super.post_start();
   endtask : post_start


### PR DESCRIPTION
Fix issue #18597.
This test runs at 'Booted' state while most runs at 'InTest' state. At the end of the test, sometimes test state keep transitioning as normal flow. So restict force 'pass' state at the end of the test only to cpu disabled state.