### PR TITLE
[chip,dv] Add short rma mode

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -106,6 +106,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // The JTAG RV debugger model.
   jtag_rv_debugger debugger;
 
+  // Run small page rma
+  bit   en_small_rma = 0;
+
   // NOTE: The clk_freq_mhz variable created in the base class was meant to be used by clk_rst_vif
   // interface that is passed by default by the testbench (retrieved by dv_base_env class). It was
   // meant for a CIP-compliant testbench to drive the clock and reset to the DUT. The chip level

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -1051,4 +1051,40 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.chip_vif.pwrb_in_if.drive(1);
   endtask // push_button
 
+  // This task can be called, when rma is requested by lc_ctrl.
+  // Before rma wipe for data partition started (256 pages),
+  // this task force total page to 9 pages. So rma process is completed faster.
+  virtual task enable_small_rma();
+    string path = "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if";
+    string mypath;
+    logic [2:0] rma_wipe_idx;
+    logic [3:0] rma_ack;
+    // Wait for data partition rma.
+    mypath = {path, ".rma_wipe_idx"};
+
+    `DV_SPINWAIT(
+      do begin
+        @(cfg.clk_rst_vif.cb);
+        uvm_hdl_read(mypath, rma_wipe_idx);
+      end while (rma_wipe_idx != 3'h3);,
+      "waiting for rma index = 3", 50_000_000
+    )
+
+    // Reduce page size to 'd9
+    mypath = {path, ".end_page"};
+    `DV_CHECK(uvm_hdl_force(mypath, 'h9));
+
+    // Wait for rma complete
+    mypath = {path, ".rma_ack_q"};
+    `DV_SPINWAIT(
+      do begin
+        @(cfg.clk_rst_vif.cb);
+        uvm_hdl_read(mypath, rma_ack);
+      end while (rma_ack != lc_ctrl_pkg::On);,
+      "waiting for rma ack == On", 50_000_000
+    )
+    mypath = {path, ".end_page"};
+    `DV_CHECK(uvm_hdl_release(mypath));
+  endtask
+
 endclass : chip_sw_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -77,6 +77,13 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
     // The following states will transfer twice to make sure LC_EXIT and RMA tokens are used.
     if (dest_dec_state inside {DecLcStProd, DecLcStDev}) begin
       `DV_WAIT(cfg.sw_logger_vif.printed_log == "Waiting for LC RMA transition done and reboot.")
+
+      // If small_rma enabled
+      if (cfg.en_small_rma) begin
+        `uvm_info(`gfn, "small_rma mode is enabled", UVM_LOW)
+        enable_small_rma();
+      end
+
       // Wait for a large number of cycles to transit to RMA state.
       wait_lc_status(LcTransitionSuccessful, 50_000);
       apply_reset();

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -63,6 +63,9 @@ class chip_base_test extends cip_base_test #(
     // Knob to perform the AST configuration.
     void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", cfg.do_creator_sw_cfg_ast_cfg));
 
+    // Knob to use small page rma
+    void'($value$plusargs("en_small_rma=%0b", cfg.en_small_rma));
+
     // Override the initial AST configuration data at runtime via plusarg.
     foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
       void'($value$plusargs({$sformatf("creator_sw_cfg_ast_cfg_data[%0d]", i), "=%0h"},


### PR DESCRIPTION
In case vendor flash model doesn't support fast sim mode, add extra hook to shorten rma and simulation time. 
Usage:
 - set `en_small_rma` to 1 at cfg.initialize or
 - add `+en_small_rma=1` in hjson
 - plusarg has priority if the value is set at both locations