### PR TITLE
[sw device] C implementation of crc32 for use on the host

### DIFF
--- a/rules/cross_platform.bzl
+++ b/rules/cross_platform.bzl
@@ -27,6 +27,7 @@ def dual_cc_library(
         hdrs = [],
         copts = [],
         deps = [],
+        visibility = ["//visibility:private"],
         target_compatible_with = [],
         **kwargs):
     """
@@ -53,6 +54,7 @@ def dual_cc_library(
       @param hdrs: `cc_library()` headers; may be a list or a `dual_inputs()`.
       @params copts: `cc_library() copts; may be a list or a `dual_inputs()`.
       @param deps: `cc_library()` dependencies; may be a list or a `dual_inputs()`.
+      @param visibility: The visibility to be used for the the targets.
       @param **kwargs: Arguments to forward to each `cc_library()`.
 
     Emits rules:
@@ -74,7 +76,7 @@ def dual_cc_library(
         copts = copts_d,
         deps = deps_d,
         target_compatible_with = tgts_d,
-        visibility = ["//visibility:private"],
+        visibility = visibility,
         **kwargs
     )
 
@@ -86,7 +88,7 @@ def dual_cc_library(
         copts = copts_h,
         deps = deps_h,
         target_compatible_with = tgts_h,
-        visibility = ["//visibility:private"],
+        visibility = visibility,
         **kwargs
     )
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -353,6 +353,16 @@ dual_cc_library(
     ),
 )
 
+cc_test(
+    name = "crc32_unittest",
+    srcs = ["crc32_unittest.cc"],
+    deps = [
+        dual_cc_device_library_of(":crc32"),
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
 opentitan_functest(
     name = "crc32_functest",
     srcs = ["crc32_functest.c"],

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -341,17 +341,6 @@ dual_cc_library(
         host = ["mock_crc32.h"],
         shared = ["crc32.h"],
     ),
-    copts = dual_inputs(
-        device = [
-            "-menable-experimental-extensions",
-            "-march=rv32imc_zbr0p93",
-        ],
-    ),
-    target_compatible_with = dual_inputs(
-        # This target cannot be compiled host-side because it uses RISC-V
-        # instructions.
-        device = [OPENTITAN_CPU],
-    ),
     deps = dual_inputs(
         host = [
             "//sw/device/lib/base:global_mock",

--- a/sw/device/silicon_creator/lib/crc32_unittest.cc
+++ b/sw/device/silicon_creator/lib/crc32_unittest.cc
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/crc32.h"
+
+#include <cstring>
+#include <stdint.h>
+
+#include "gtest/gtest.h"
+
+namespace crc32_unittest {
+namespace {
+
+struct TestParams {
+  std::string input;
+  uint32_t exp_crc;
+};
+
+class CrcTest : public testing::TestWithParam<TestParams> {};
+
+// Expected CRC32 values were generated using the following Python snippet:
+// ```
+// import zlib
+// hex(zlib.crc32(b'<string>'))
+// ```
+INSTANTIATE_TEST_SUITE_P(AllCases, CrcTest,
+                         testing::Values(
+                             TestParams{
+                                 "123456789",
+                                 0xcbf43926,
+                             },
+                             TestParams{
+                                 "The quick brown fox jumps over the lazy dog",
+                                 0x414fa339,
+                             },
+                             TestParams{
+                                 "\xfe\xca\xfe\xca\x02\xb0\xad\x1b",
+                                 0x9508ac14,
+                             }));
+
+TEST_P(CrcTest, Crc32) {
+  EXPECT_EQ(crc32(GetParam().input.data(), GetParam().input.length()),
+            GetParam().exp_crc);
+}
+
+TEST_P(CrcTest, Crc32Add) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  crc32_add(&ctx, GetParam().input.data(), GetParam().input.length());
+
+  EXPECT_EQ(crc32_finish(&ctx), GetParam().exp_crc);
+}
+
+TEST_F(CrcTest, Misaligned) {
+  constexpr uint32_t kExpCrc = 0x414fa339;
+  alignas(uint32_t) char input[] =
+      ">The quick brown fox jumps over the lazy dog";
+
+  EXPECT_EQ(crc32(&input[1], std::strlen(input) - 1), kExpCrc);
+
+  uint32_t ctx;
+  crc32_init(&ctx);
+  crc32_add(&ctx, &input[1], std::strlen(input) - 1);
+
+  EXPECT_EQ(crc32_finish(&ctx), kExpCrc);
+}
+
+TEST_P(CrcTest, Crc32Add8) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  for (auto val : GetParam().input) {
+    crc32_add8(&ctx, val);
+  }
+  EXPECT_EQ(crc32_finish(&ctx), GetParam().exp_crc);
+}
+
+TEST_F(CrcTest, Crc32Add32) {
+  uint32_t ctx;
+  crc32_init(&ctx);
+  constexpr uint32_t kExpCrc = 0x9508ac14;
+
+  crc32_add32(&ctx, 0xcafecafe);
+  crc32_finish(&ctx);
+  crc32_add32(&ctx, 0x1badb002);
+
+  EXPECT_EQ(crc32_finish(&ctx), kExpCrc);
+}
+
+}  // namespace
+}  // namespace crc32_unittest


### PR DESCRIPTION
Make use of the `.option arch` directive, now available in LLVM 16, to re-introduce the pure C implementation of CRC32 for use on the host. This implementation is tested in the unit test.