### PR TITLE
[crypto] Add streaming HMAC-SHA256.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -151,7 +151,7 @@ cc_library(
         ":integrity",
         ":keyblob",
         "//sw/device/lib/base:hardened",
-        "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/impl/sha2:sha256",
     ],
 )

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -4,16 +4,98 @@
 
 #include "sw/device/lib/crypto/include/mac.h"
 
-#include <stdbool.h>
-
-#include "sw/device/lib/crypto/drivers/hmac.h"
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/sha2/sha256.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('m', 'a', 'c')
+
+/**
+ * Ensure that the hmac context is large enough.
+ *
+ * The HMAC context should hold one SHA-256 message block and a SHA-256 state
+ * object.
+ */
+static_assert(
+    sizeof(hmac_context_t) == kSha256MessageBlockBytes + sizeof(sha256_state_t),
+    "hmac_context_t must be the same size as a key block and a SHA-256 state");
+/**
+ * Ensure that the SHA-256 state struct is suitable for `hardened_memcpy()`.
+ */
+static_assert(sizeof(sha256_state_t) % sizeof(uint32_t) == 0,
+              "Size of sha256_state_t must be a multiple of the word size for "
+              "`hardened_memcpy()`");
+
+enum {
+  /**
+   * Word-offset of the key block within the HMAC context object.
+   */
+  kHmacContextKeyBlockWordOffset = 0,
+  /**
+   * Word-offset of the SHA-256 state within the HMAC context object.
+   */
+  kHmacContextSha256StateWordOffset = kSha256MessageBlockWords,
+};
+
+/**
+ * Save a SHA-256 state to an HMAC context.
+ *
+ * @param[out] ctx HMAC context to copy to.
+ * @param state SHA-256 state object.
+ * @param k0 Key block.
+ */
+static void sha256_state_save(hmac_context_t *restrict ctx,
+                              const sha256_state_t *restrict state) {
+  // As per the `hardened_memcpy()` documentation, it
+  // is OK to cast to `uint32_t *` here as long as `state` is word-aligned,
+  // which it must be because all its fields are.
+  uint32_t *dest = ctx->data + kHmacContextSha256StateWordOffset;
+  hardened_memcpy(dest, (uint32_t *)state,
+                  sizeof(sha256_state_t) / sizeof(uint32_t));
+}
+
+/**
+ * Restore a SHA-256 state from an HMAC context.
+ *
+ * @param ctx HMAC context to restore from.
+ * @param[out] state Destination SHA-256 state object.
+ */
+static void sha256_state_restore(const hmac_context_t *restrict ctx,
+                                 sha256_state_t *restrict state) {
+  // As per the `hardened_memcpy()` documentation, it is OK to cast to
+  // `uint32_t *` here as long as `state` is word-aligned, which it must be
+  // because all its fields are.
+  const uint32_t *src = ctx->data + kHmacContextSha256StateWordOffset;
+  hardened_memcpy((uint32_t *)state, src,
+                  sizeof(sha256_state_t) / sizeof(uint32_t));
+}
+/**
+ * Save the key block to an HMAC context.
+ *
+ * @param[out] ctx HMAC context to copy to.
+ * @param k0 Key block to save.
+ */
+static void key_block_save(hmac_context_t *restrict ctx,
+                           const uint32_t *restrict k0) {
+  uint32_t *dest = ctx->data + kHmacContextKeyBlockWordOffset;
+  hardened_memcpy(dest, k0, kSha256MessageBlockWords);
+}
+
+/**
+ * Restore a key block from an HMAC context.
+ *
+ * @param ctx HMAC context to restore from.
+ * @param[out] k0 Destination key block buffer.
+ */
+static void key_block_restore(const hmac_context_t *restrict ctx,
+                              uint32_t *restrict k0) {
+  const uint32_t *src = ctx->data + kHmacContextKeyBlockWordOffset;
+  hardened_memcpy(k0, src, kSha256MessageBlockWords);
+}
 
 crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
   // TODO: Implement KMAC sideloaded key generation once we have a keymgr
@@ -22,84 +104,23 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
   return kCryptoStatusNotImplemented;
 }
 
-/**
- * Call the hardware HMAC-SHA256 driver.
- *
- * Note: the hardware implementation is unhardened against side-channel and
- * fault attacks.
- *
- * @param key HMAC key.
- * @param message Input message.
- * @param[out] tag Output tag.
- */
-OT_WARN_UNUSED_RESULT
-static status_t hmac_sha256(const crypto_blinded_key_t *key,
-                            crypto_const_uint8_buf_t message,
-                            crypto_uint8_buf_t *tag) {
-  // Should never be called if the following checks fail; this indicates a
-  // possible fault attack.
-  HARDENED_CHECK_EQ(key->config.key_mode, kKeyModeHmacSha256);
-  HARDENED_CHECK_EQ(tag->len, kHmacDigestNumBytes);
-
-  // Get the individual key shares.
-  uint32_t *share0;
-  uint32_t *share1;
-  HARDENED_TRY(keyblob_to_shares(key, &share0, &share1));
-
-  // Convert the key to the HMAC-specific struct.
-  // NOTE: this unmasks the key, because the HMAC hardware is unhardened.
-  // TODO: randomize the iteration order of this loop.
-  hmac_key_t hmac_key;
-  for (size_t i = 0; i < kHmacKeyNumWords; i++) {
-    hmac_key.key[i] = share0[i] ^ share1[i];
-  }
-
-  // Initialize the hardware.
-  hmac_hmac_init(&hmac_key);
-
-  // Pass the message.
-  hmac_update(message.data, message.len);
-
-  // Retrieve the digest and copy it to the destination buffer.
-  hmac_digest_t hmac_digest;
-  hmac_final(&hmac_digest);
-  memcpy(tag->data, hmac_digest.digest, kHmacDigestNumBytes);
-
-  return OTCRYPTO_OK;
-}
-
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_uint8_buf_t input_message,
                               crypto_uint8_buf_t *tag) {
-  // Check for null pointers.
-  if (key == NULL || key->keyblob == NULL || tag == NULL || tag->data == NULL) {
-    return kCryptoStatusBadArgs;
+  // Compute HMAC using the streaming API.
+  // TODO(#17803): Make this more ergonomic once `crypto_status_t` and
+  // `status_t` are compatible.
+  hmac_context_t ctx;
+  crypto_status_t err = otcrypto_hmac_init(&ctx, key);
+  if (err != kCryptoStatusOK) {
+    return err;
   }
-
-  // Check for null input message with nonzero length.
-  if (input_message.data == NULL && input_message.len != 0) {
-    return kCryptoStatusBadArgs;
+  err = otcrypto_hmac_update(&ctx, input_message);
+  if (err != kCryptoStatusOK) {
+    return err;
   }
-
-  // Check the integrity of the blinded key.
-  if (integrity_blinded_key_check(key) != kHardenedBoolTrue) {
-    return kCryptoStatusBadArgs;
-  }
-
-  // TODO (#16410, #15590): Add sideload support.
-  if (key->config.hw_backed == kHardenedBoolTrue) {
-    return kCryptoStatusNotImplemented;
-  }
-
-  // Check tag length.
-  if (tag->len != kHmacDigestNumBytes) {
-    return kCryptoStatusBadArgs;
-  }
-
-  // Call hardware HMAC driver.
-  OTCRYPTO_TRY_INTERPRET(hmac_sha256(key, input_message, tag));
-  return kCryptoStatusOK;
+  return otcrypto_hmac_final(&ctx, tag);
 }
 
 OT_WARN_UNUSED_RESULT
@@ -173,18 +194,119 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
 
 crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
                                    const crypto_blinded_key_t *key) {
-  // TODO: Implement streaming HMAC API once we have streaming SHA256.
-  return kCryptoStatusNotImplemented;
+  if (ctx == NULL || key == NULL || key->keyblob == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  if (key->config.hw_backed != kHardenedBoolFalse) {
+    // TODO(#15590): Add support for sideloaded keys.
+    return kCryptoStatusBadArgs;
+  }
+
+  // Key mode must be HMAC-SHA256.
+  if (key->config.key_mode != kKeyModeHmacSha256) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Check the integrity of the key.
+  if (integrity_blinded_key_check(key) != kHardenedBoolTrue) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Get pointers to key shares.
+  uint32_t *share0;
+  uint32_t *share1;
+  OTCRYPTO_TRY_INTERPRET(keyblob_to_shares(key, &share0, &share1));
+
+  // TODO: Once we have hardened SHA-256, do not unmask the key here.
+  uint32_t unmasked_key[keyblob_share_num_words(key->config)];
+  for (size_t i = 0; i < keyblob_share_num_words(key->config); i++) {
+    unmasked_key[i] = share0[i] ^ share1[i];
+  }
+
+  // Initialize the key block, K0. See FIPS 198-1, section 4.
+  uint32_t k0[kSha256MessageBlockWords] = {0};
+  if (key->config.key_length <= kSha256MessageBlockBytes) {
+    // If the key fits into the SHA-256 block size, we just need to copy it
+    // into the first part of K0.
+    hardened_memcpy(k0, unmasked_key, ARRAYSIZE(unmasked_key));
+  } else {
+    // If the key is longer than the SHA-256 block size, we need to hash it
+    // and write the digest into the start of K0.
+    OTCRYPTO_TRY_INTERPRET(sha256((unsigned char *)unmasked_key,
+                                  key->config.key_length, (unsigned char *)k0));
+  }
+
+  // Compute SHA256(K0 ^ ipad).
+  uint32_t inner_block[kSha256MessageBlockWords];
+  for (size_t i = 0; i < kSha256MessageBlockWords; i++) {
+    inner_block[i] = k0[i] ^ 0x36363636;
+  }
+
+  // Start computing SHA256(K0 ^ ipad) || message).
+  sha256_state_t sha256_ctx;
+  sha256_init(&sha256_ctx);
+  OTCRYPTO_TRY_INTERPRET(sha256_update(
+      &sha256_ctx, (unsigned char *)inner_block, sizeof(inner_block)));
+
+  // Save the key block and SHA-256 state.
+  key_block_save(ctx, k0);
+  sha256_state_save(ctx, &sha256_ctx);
+
+  return kCryptoStatusOK;
 }
 
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
                                      crypto_const_uint8_buf_t input_message) {
-  // TODO: Implement streaming HMAC API once we have streaming SHA256.
-  return kCryptoStatusNotImplemented;
+  if (ctx == NULL || (input_message.data == NULL && input_message.len != 0)) {
+    return kCryptoStatusBadArgs;
+  }
+
+  sha256_state_t sha256_ctx;
+  sha256_state_restore(ctx, &sha256_ctx);
+  OTCRYPTO_TRY_INTERPRET(
+      sha256_update(&sha256_ctx, input_message.data, input_message.len));
+  sha256_state_save(ctx, &sha256_ctx);
+  return kCryptoStatusOK;
 }
 
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
                                     crypto_uint8_buf_t *tag) {
-  // TODO: Implement streaming HMAC API once we have streaming SHA256.
-  return kCryptoStatusNotImplemented;
+  if (ctx == NULL || tag == NULL || tag->data == NULL) {
+    return kCryptoStatusBadArgs;
+  }
+
+  if (tag->len != kSha256DigestBytes) {
+    return kCryptoStatusBadArgs;
+  }
+
+  // Restore the SHA-256 state from the context.
+  sha256_state_t sha256_ctx;
+  sha256_state_restore(ctx, &sha256_ctx);
+
+  // Finalize the computation of SHA256(K0 ^ ipad || message).
+  uint32_t inner_digest[kSha256DigestWords];
+  OTCRYPTO_TRY_INTERPRET(
+      sha256_final(&sha256_ctx, (unsigned char *)inner_digest));
+
+  // Restore the key block K0 from the context.
+  uint32_t k0[kSha256MessageBlockWords];
+  key_block_restore(ctx, k0);
+
+  // Compute K0 ^ opad.
+  uint32_t outer_block[kSha256MessageBlockWords];
+  for (size_t i = 0; i < kSha256MessageBlockWords; i++) {
+    outer_block[i] = k0[i] ^ 0x5c5c5c5c;
+  }
+
+  // Start a new hash computation to get the final tag: SHA256(K0 ^ opad ||
+  // SHA256(K0 ^ ipad || message))
+  sha256_init(&sha256_ctx);
+  OTCRYPTO_TRY_INTERPRET(sha256_update(
+      &sha256_ctx, (unsigned char *)outer_block, sizeof(outer_block)));
+  OTCRYPTO_TRY_INTERPRET(sha256_update(
+      &sha256_ctx, (unsigned char *)inner_digest, sizeof(inner_digest)));
+  OTCRYPTO_TRY_INTERPRET(sha256_final(&sha256_ctx, tag->data));
+
+  return kCryptoStatusOK;
 }

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -36,7 +36,9 @@ typedef enum kmac_mode {
  * Representation is internal to the hmac implementation; initialize
  * with #otcrypto_hmac_init.
  */
-typedef struct hmac_context hmac_context_t;
+typedef struct hmac_context {
+  uint32_t data[42];
+} hmac_context_t;
 
 /**
  * Generates a new HMAC or KMAC key.

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -11,40 +10,58 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-// Test key (big endian) =
-// 0x1bff10eaa5b9b204d6f3232a573e8e51a27b68c319366deaf26b91b0712f7a34
-static const hmac_key_t kTestKey = {
-    .key =
-        {
-            0x1bff10ea,
-            0xa5b9b204,
-            0xd6f3232a,
-            0x573e8e51,
-            0xa27b68c3,
-            0x19366dea,
-            0xf26b91b0,
-            0x712f7a34,
-        },
+enum {
+  /**
+   * HMAC-SHA256 tag length (256 bits) in words.
+   */
+  kTagLenWords = 256 / 32,
 };
 
-// Random value for masking (should not affect result).
-static const uint32_t kTestMask[kHmacKeyNumWords] = {
-    0x8cb847c3, 0xc6d34f36, 0x72edbf7b, 0x9bc0317f,
-    0x8f003c7f, 0x1d7ba049, 0xfd463b63, 0xbb720c44,
+// 256-bit test key (big endian) =
+// 0x1bff10eaa5b9b204d6f3232a573e8e51a27b68c319366deaf26b91b0712f7a34
+static const uint32_t kBasicTestKey[] = {
+    0xea10ff1b, 0x04b2b9a5, 0x2a23f3d6, 0x518e3e57,
+    0xc3687ba2, 0xea6d3619, 0xb0916bf2, 0x347a2f71,
+};
+
+// Short test key, 32 bits (big endian) = 0x1bff10ea
+static const uint32_t kShortTestKey[] = {
+    0xea10ff1b,
+};
+
+// Long test key, 544 bits (big endian) =
+// 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243
+static const uint32_t kLongTestKey[] = {
+    0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514,
+    0x1b1a1918, 0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c,
+    0x33323130, 0x37363534, 0x3b3a3938, 0x3f3e3d3c, 0x43424140,
+};
+
+// Random value for masking, as large as the longest test key. This value
+// should not affect the result.
+static const uint32_t kTestMask[ARRAYSIZE(kLongTestKey)] = {
+    0x8cb847c3, 0xc6d34f36, 0x72edbf7b, 0x9bc0317f, 0x8f003c7f, 0x1d7ba049,
+    0xfd463b63, 0xbb720c44, 0x784c215e, 0xeb101d65, 0x35beb911, 0xab481345,
+    0xa7ebc3e3, 0x04b2a1b9, 0x764a9630, 0x78b8f9c5, 0x3f2a1d8e,
 };
 
 /**
  * Call the `otcrypto_mac` API and check the resulting tag.
  *
+ * @param key Key material.
+ * @param key_num_words Key length in bytes.
  * @param msg Input message.
  * @param exp_tag Expected tag (256 bits).
+ * @return Result (OK or error).
  */
-static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_tag) {
+static status_t run_test(const uint32_t *key, size_t key_len,
+                         crypto_const_uint8_buf_t msg,
+                         const uint32_t *exp_tag) {
   // Construct blinded key.
   crypto_key_config_t config = {
       .version = kCryptoLibVersion1,
       .key_mode = kKeyModeHmacSha256,
-      .key_length = kHmacKeyNumBytes,
+      .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
       .diversification_hw_backed = {.data = NULL, .len = 0},
       .exportable = kHardenedBoolFalse,
@@ -52,8 +69,7 @@ static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_tag) {
   };
 
   uint32_t keyblob[keyblob_num_words(config)];
-  CHECK_STATUS_OK(
-      keyblob_from_key_and_mask(kTestKey.key, kTestMask, config, keyblob));
+  TRY(keyblob_from_key_and_mask(key, kTestMask, config, keyblob));
   crypto_blinded_key_t blinded_key = {
       .config = config,
       .keyblob = keyblob,
@@ -62,60 +78,104 @@ static void run_test(crypto_const_uint8_buf_t msg, const uint32_t *exp_tag) {
   };
   blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
 
-  uint32_t act_tag[kHmacDigestNumWords];
+  uint32_t act_tag[kTagLenWords];
   crypto_uint8_buf_t tag_buf = {
       .data = (unsigned char *)act_tag,
       .len = sizeof(act_tag),
   };
 
   crypto_status_t status = otcrypto_hmac(&blinded_key, msg, &tag_buf);
-  CHECK(status == kCryptoStatusOK, "Error during hmac operation: 0x%08x.",
-        status);
-  CHECK_ARRAYS_EQ(act_tag, exp_tag, kHmacDigestNumWords);
+  TRY_CHECK(status == kCryptoStatusOK, "Error during hmac operation: 0x%08x.",
+            status);
+  TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
+  return OK_STATUS();
 }
 
 /**
  * Simple test with a short message.
  *
- * HMAC-SHA256(kTestKey, 'Test message.')
+ * HMAC-SHA256(kBasicTestKey, 'Test message.')
  *   = 0xb4595b02be2a1638893166366656ece12b749b95a2815e52d687535309f3126f
  */
-static void simple_test(void) {
+static status_t simple_test(void) {
   const char plaintext[] = "Test message.";
   crypto_const_uint8_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };
-  const uint32_t exp_tag[kHmacDigestNumWords] = {
-      0x09f3126f, 0xd6875353, 0xa2815e52, 0x2b749b95,
-      0x6656ece1, 0x89316636, 0xbe2a1638, 0xb4595b02,
+  const uint32_t exp_tag[] = {
+      0x025b59b4, 0x38162abe, 0x36663189, 0xe1ec5666,
+      0x959b742b, 0x525e81a2, 0x535387d6, 0x6f12f309,
   };
-  run_test(msg_buf, exp_tag);
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
 }
 
 /**
  * Test with an empty message.
  *
- * HMAC-SHA256(kTestKey, '')
+ * HMAC-SHA256(kBasicTestKey, '')
  * = 0xa9425cbb40d13a0e07916761c06c4aa37969305361508afae62e8bbca5c099a4
  */
-static void empty_test(void) {
-  const uint32_t exp_tag[kHmacDigestNumWords] = {
-      0xa5c099a4, 0xe62e8bbc, 0x61508afa, 0x79693053,
-      0xc06c4aa3, 0x07916761, 0x40d13a0e, 0xa9425cbb,
+static status_t empty_test(void) {
+  const uint32_t exp_tag[] = {
+      0xbb5c42a9, 0x0e3ad140, 0x61679107, 0xa34a6cc0,
+      0x53306979, 0xfa8a5061, 0xbc8b2ee6, 0xa499c0a5,
   };
   crypto_const_uint8_buf_t msg_buf = {
       .data = NULL,
       .len = 0,
   };
-  run_test(msg_buf, exp_tag);
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test using a short key.
+ *
+ * HMAC-SHA256(kShortTestKey, 'Test message.')
+ *   = 0x3f08885633d7caa1728f798c49110ed8c8020f74ba6de7d0b549935b87eb3ef1
+ */
+static status_t short_key_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0x5688083f, 0xa1cad733, 0x8c798f72, 0xd80e1149,
+      0x740f02c8, 0xd0e76dba, 0x5b9349b5, 0xf13eeb87,
+  };
+  return run_test(kShortTestKey, sizeof(kShortTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test using a long key.
+ *
+ * HMAC-SHA256(kLongTestKey, 'Test message.')
+ *   = 0x6fab77a49de1fa73dfa97f4f36b956d552afd11d77f584cd8c5c8332d32a6836
+ */
+static status_t long_key_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_uint8_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0xa477ab6f, 0x73fae19d, 0x4f7fa9df, 0xd556b936,
+      0x1dd1af52, 0xcd84f577, 0x32835c8c, 0x36682ad3,
+  };
+  return run_test(kLongTestKey, sizeof(kLongTestKey), msg_buf, exp_tag);
 }
 
 OTTF_DEFINE_TEST_CONFIG();
 
-bool test_main(void) {
-  simple_test();
-  empty_test();
+// Holds the test result.
+static volatile status_t test_result;
 
-  return true;
+bool test_main(void) {
+  test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, simple_test);
+  EXECUTE_TEST(test_result, empty_test);
+  EXECUTE_TEST(test_result, short_key_test);
+  EXECUTE_TEST(test_result, long_key_test);
+  return status_ok(test_result);
 }


### PR DESCRIPTION
The cryptolib API calls for streaming HMAC-SHA256, which is possible now that we have a SHA-256 implementation that supports save/restore. This also adds new tests for differently-sized HMAC keys.