### PR TITLE
[opentitantool] Fix rescue for c2d2 interface

### DIFF
--- a/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
+++ b/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
@@ -1,0 +1,27 @@
+{
+  "includes": [
+    "/__builtin__/h1dx_devboard.json"
+  ],
+  "interface": "c2d2",
+  "pins": [
+    {
+      "name": "RESET",
+      "level": true,
+      "alias_of": "SPIVREF_RSVD_H1VREF_H1_RST_ODL"
+    }
+  ],
+  "strappings": [
+    {
+      "name": "RESET"
+    },
+    {
+      "name": "ROM_BOOTSTRAP"
+    }
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "alias_of": "CR50"
+    }
+  ]
+}

--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -61,6 +61,7 @@ lazy_static! {
     static ref BUILTINS: HashMap<&'static str, &'static str> = collection! {
         "/__builtin__/dediprog.json" => include_str!("dediprog.json"),
         "/__builtin__/h1dx_devboard.json" => include_str!("h1dx_devboard.json"),
+        "/__builtin__/h1dx_devboard_c2d2.json" => include_str!("h1dx_devboard_c2d2.json"),
         "/__builtin__/h1dx_devboard_ultradebug.json" => include_str!("h1dx_devboard_ultradebug.json"),
         "/__builtin__/ti50emulator.json" => include_str!("ti50emulator.json"),
         "/__builtin__/opentitan_cw310.json" => include_str!("opentitan_cw310.json"),

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -88,7 +88,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         "hyperdebug_dfu" => (hyperdebug::create_dfu(args)?, None),
         "c2d2" => (
             hyperdebug::create::<C2d2Flavor>(args)?,
-            Some(Path::new("/__builtin__/h1dx_devboard.json")),
+            Some(Path::new("/__builtin__/h1dx_devboard_c2d2.json")),
         ),
         "ti50" => (hyperdebug::create::<Ti50Flavor>(args)?, None),
         "cw310" => (

--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -74,7 +74,7 @@ impl GpioPin for C2d2ResetPin {
     /// Sets the value of the GPIO reset pin by means of the special h1_reset command.
     fn write(&self, value: bool) -> Result<()> {
         self.inner
-            .cmd_no_output(&format!("h1_reset {}", if value { 0 } else { 1 }))?;
+            .cmd_one_line_output(&format!("h1_reset {}", if value { 0 } else { 1 }))?;
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -45,6 +45,10 @@ impl Flavor for C2d2Flavor {
     fn get_default_usb_pid() -> u16 {
         Self::PID_C2D2
     }
+    fn perform_initial_fw_check() -> bool {
+        // The c2d2 firmware and hyperdebug firmware are different, so do not check.
+        false
+    }
 }
 
 pub struct C2d2ResetPin {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -78,6 +78,9 @@ pub trait Flavor {
     fn clear_bitstream(_clear: &ClearBitstream) -> Result<()> {
         Err(TransportError::UnsupportedOperation.into())
     }
+    fn perform_initial_fw_check() -> bool {
+        true
+    }
 }
 
 pub const VID_GOOGLE: u16 = 0x18d1;
@@ -124,7 +127,9 @@ impl<T: Flavor> Hyperdebug<T> {
         let current_firmware_version = if let Some(idx) = config_desc.description_string_index() {
             if let Ok(current_firmware_version) = device.read_string_descriptor_ascii(idx) {
                 if let Some(released_firmware_version) = dfu::official_firmware_version()? {
-                    if current_firmware_version != released_firmware_version {
+                    if T::perform_initial_fw_check()
+                        && current_firmware_version != released_firmware_version
+                    {
                         log::warn!(
                             "Current HyperDebug firmware version is {}, newest release is {}, Consider running `opentitantool transport update-firmware`",
                             current_firmware_version,


### PR DESCRIPTION
This commit does the following:
 - Changes fn write for `C2d2ResetPin` implementation to expect a single line of output on console after `h1_reset [01]` cmd
 - Adds builtin `h1dx_devboard_c2d2.json` configuration that allow end-users to use rescue without specifying any external json

Now the following command works to rescue when C2D2 is connected

./opentitantool --interface=c2d2  bootstrap -p rescue /path/to.bin