### PR TITLE
[top_englishbreakfast] Remove retention SRAM to save FPGA resources

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1004,11 +1004,11 @@ module chip_earlgrey_cw310 #(
     .SecOtbnSkipUrndReseedAtStart(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .RvCoreIbexPipeLine(1),
+    .SramCtrlRetAonInstrExec(0),
     .UsbdevRcvrWakeTimeUs(10000),
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
     .RvCoreIbexSecureIbex(0),
-    .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -346,28 +346,6 @@
       base_addr: "0x40480000",
       attr: "reggen_only",
     },
-    { name: "sram_ctrl_ret_aon",
-      type: "sram_ctrl",
-      clock_srcs: {clk_i: "io_div4", clk_otp_i: "io_div4"},
-      clock_group: "infra",
-      reset_connections: {rst_ni: "sys_io_div4", rst_otp_ni: "lc_io_div4"},
-      domain: ["Aon"],
-      param_decl: {
-        InstrExec: "0",
-      }
-      base_addrs: {regs: "0x40500000", ram: "0x40600000"},
-      // Memory regions must be associated with a dedicated
-      // TL-UL device interface.
-      memory: {
-        ram: {
-          label:    "ram_ret_aon",
-          swaccess:   "rw",
-          exec:       "True",
-          byte_write: "True",
-          size:     "0x1000"
-        }
-      }
-    },
     { name: "flash_ctrl",
       type: "flash_ctrl",
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
@@ -636,8 +614,7 @@
         // OTP HW_CFG Broadcast signals.
         // TODO(#6713): The actual struct breakout and mapping currently needs to
         // be performed by hand in the toplevel template.
-        'sram_ctrl_main.otp_en_sram_ifetch',
-        'sram_ctrl_ret_aon.otp_en_sram_ifetch'
+        'sram_ctrl_main.otp_en_sram_ifetch'
     ],
 
     // ext is to create port in the top.

--- a/hw/top_englishbreakfast/data/xbar_peri.hjson
+++ b/hw/top_englishbreakfast/data/xbar_peri.hjson
@@ -77,18 +77,6 @@
       reset:     "rst_peri_ni",
       pipeline:  false
     },
-    { name:      "sram_ctrl_ret_aon.regs",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  false
-    },
-    { name:      "sram_ctrl_ret_aon.ram",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  false
-    },
     { name:      "ast",
       type:      "device",
       clock:     "clk_peri_i",
@@ -101,7 +89,7 @@
       "uart0",
       "gpio", "spi_device", "spi_host0", "rv_timer", "usbdev",
       "pwrmgr_aon", "rstmgr_aon", "clkmgr_aon", "pinmux_aon",
-      "sram_ctrl_ret_aon.ram", "sram_ctrl_ret_aon.regs", "ast"
+      "ast"
     ],
   },
 }

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -165,7 +165,6 @@ module chip_englishbreakfast_verilator (
     .SecAesSkipPRNGReseeding(1'b1),
     .UsbdevStub(1'b1),
     .RvCoreIbexICache(0),
-    .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_englishbreakfast (

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -58,6 +58,7 @@ cc_library(
     deps = [
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/rom:bootstrap",
     ],
 )
@@ -152,7 +153,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:static_critical_boot_measurements",
         "//sw/device/silicon_creator/lib/base:static_critical_epmp_state",
         "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
-        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
 

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -25,7 +25,9 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/chip_info.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#endif
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
 
@@ -158,6 +160,7 @@ bool rom_test_main(void) {
   dif_rstmgr_reset_info_bitfield_t reset_reasons;
   CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &reset_reasons));
 
+#if !OT_IS_ENGLISH_BREAKFAST
   // Store the reset reason in retention RAM and clear the register.
   volatile retention_sram_t *ret_ram = retention_sram_get();
   ret_ram->reset_reasons = reset_reasons;
@@ -168,6 +171,7 @@ bool rom_test_main(void) {
   volatile uint32_t *creator_last_word =
       &ret_ram->reserved_creator[ARRAYSIZE(ret_ram->reserved_creator) - 1];
   *creator_last_word = TEST_ROM_IDENTIFIER;
+#endif
 
   // Print the FPGA version-id.
   // This is guaranteed to be zero on all non-FPGA implementations.

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1085,6 +1085,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecOtbnSkipUrndReseedAtStart(1'b1),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
     .RvCoreIbexPipeLine(1),
+    .SramCtrlRetAonInstrExec(0),
     .UsbdevRcvrWakeTimeUs(10000),
 % elif target["name"] == "cw305":
     .RvCoreIbexPipeLine(0),
@@ -1102,6 +1103,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .SecAesSkipPRNGReseeding(1'b0),
+    .SramCtrlRetAonInstrExec(0),
     .EntropySrcStub(1'b1),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
@@ -1112,7 +1114,6 @@ module chip_${top["name"]}_${target["name"]} #(
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
     .RvCoreIbexSecureIbex(0),
-    .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (


### PR DESCRIPTION
The retention SRAM is not used on the English Breakfast top level but consumes costly logic and BRAM resources. Removing it frees up these resources as well as additional logic in the peripheral crossbar.  