### PR TITLE
[py/scripts/object_size] Add additional reports

### DIFF
--- a/util/py/packages/impl/object_size/report.py
+++ b/util/py/packages/impl/object_size/report.py
@@ -6,12 +6,14 @@ import functools
 from pathlib import Path
 
 from rich.console import Console
-from rich.padding import Padding
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
+from rich.rule import Rule
+from rich.table import Column, Padding, Table
 
 from util.py.packages.impl.object_size.elf import parse_elf_file
 from util.py.packages.impl.object_size.memory import parse_memory_file
-from util.py.packages.impl.object_size.types import Size
+from util.py.packages.impl.object_size.types import (Address, Alignment,
+                                                     Memory, Section, Size)
 
 
 def print_utilization_report(memories) -> None:
@@ -27,15 +29,43 @@ def print_utilization_report(memories) -> None:
         rprint(Padding(bar.get_renderable(), (0, 0, 0, 4)))
 
 
+def my_table(*args, **kwargs):
+    return Table(
+        *args, **{
+            "highlight": True,
+            "row_styles": ["on bright_black", ""],
+            **kwargs
+        })
+
+
+def print_section_report(sections: list[Section]) -> None:
+    table = my_table(
+        Column("Name", justify="right", style="bold yellow", no_wrap=True),
+        Column("Memory", justify="center"),
+        Column("Size", justify="right"),
+        Column("Address", justify="left"),
+        Column("Alignment", justify="right"),
+        Column("Type", justify="center"),
+        Column("Flags", justify="right"),
+        title="[bold]Sections ASCENDING by VMA:[/bold]",
+    )
+
+    for s in sorted(sections.values(), key=lambda s: s.vma):
+        table.add_row(s.name, ', '.join(s.memories), Size.__str__(s),
+                      Address.__str__(s), Alignment.__str__(s), s.type_,
+                      s.flags)
+    rprint(Padding(table, (2, 0, 0, 2)))
 def print_report(path: Path, force_color: bool = False) -> None:
     global rprint
     rprint = Console(force_terminal=force_color).print
+    rprint(Padding(Rule(f"[bold]{path.name}[/bold]"), (1, 0, 0, 2)))
     rprint(Padding("[bold]Full path:[/bold]", (1, 0, 0, 2)))
     rprint(Padding(f"{path}", (0, 0, 0, 4)))
     rprint(Padding("[bold]File size:[/bold]", (1, 0, 0, 2)))
     rprint(Padding(f"{Size(path.stat().st_size)}", (0, 0, 0, 4)))
     if (path.suffixes[-1] == ".elf"):
         memories = parse_memory_file()
-        parse_elf_file(path, memories)
+        sections = parse_elf_file(path, memories)
         print_utilization_report(memories)
+        print_section_report(sections)
     rprint(Padding("", (2, 0, 0, 0)))

--- a/util/py/packages/impl/object_size/report.py
+++ b/util/py/packages/impl/object_size/report.py
@@ -5,7 +5,7 @@
 import functools
 from pathlib import Path
 
-from rich import print as rprint
+from rich.console import Console
 from rich.padding import Padding
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
@@ -27,11 +27,9 @@ def print_utilization_report(memories) -> None:
         rprint(Padding(bar.get_renderable(), (0, 0, 0, 4)))
 
 
-def print_report(path: Path) -> None:
-    rprint(
-        Padding(
-            f"[bold underline white on gray15]{path.name}:[/bold underline white on gray15]",
-            (1, 0, 0, 0)))
+def print_report(path: Path, force_color: bool = False) -> None:
+    global rprint
+    rprint = Console(force_terminal=force_color).print
     rprint(Padding("[bold]Full path:[/bold]", (1, 0, 0, 2)))
     rprint(Padding(f"{path}", (0, 0, 0, 4)))
     rprint(Padding("[bold]File size:[/bold]", (1, 0, 0, 2)))

--- a/util/py/packages/impl/object_size/types.py
+++ b/util/py/packages/impl/object_size/types.py
@@ -59,10 +59,9 @@ class Address(Item):
     def __str__(self) -> str:
         """Returns the string representation of the address of this item.
         """
-        return (
-            f"VMA: {hex(self.vma)}, LMA: "
-            f"{hex(self.lma) if isinstance(self.lma, int) else 'N/A (' + self.lma + ')'}"
-        )
+        lma_str = f"{self.lma:08x}" if isinstance(self.lma,
+                                                  int) else f"N/A ({self.lma})"
+        return f"VMA: {self.vma:08x}, LMA: {lma_str}"
 
 
 @dataclass(frozen=True)

--- a/util/py/scripts/object_size.py
+++ b/util/py/scripts/object_size.py
@@ -27,7 +27,8 @@ log = ot_logging.log
 @app.command()
 def main(target: str,
          configs: list[str] = [],
-         log_level: ot_logging.LogLevel = ot_logging.LogLevel.WARNING) -> None:
+         log_level: ot_logging.LogLevel = ot_logging.LogLevel.WARNING,
+         force_color: bool = False) -> None:
     ot_logging.init(log_level)
 
     # We use a `cc_binary` rule to produce ELF files and a `obj_transform` rule to
@@ -42,7 +43,7 @@ def main(target: str,
         for ext in ["elf", "bin"]:
             paths += bazel.get_target_files_with_ext(dep, configs, ext)
     for path in paths:
-        print_report(path)
+        print_report(path, force_color)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds
* LMA calculation for symbols,
* `--force-color` option to preserve colors when piping to `less -r`,
* A high-level report for sections,
* A detailed symbols report (tables showing symbols of each memory and section, ordered ascending by VMA and decreasing by size), and
* A best-effort alignment overhead report.

Note that the alignment report may include false positives due to missing symbols, e.g. the OTBN binary blob in ROM or intentional padding before sections like `.chip_info`.