### PR TITLE
[bazel] Patch serialport crate to catch USB devices reported as PCI 

### DIFF
--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -43,6 +43,10 @@ crates_vendor(
                 "DEP_PQCRYPTO_INTERNALS_INCLUDEPATH": "../crate_index__pqcrypto-internals-0.2.4/include",
             },
         )],
+        "serialport": [crate.annotation(
+            patch_args = ["-p1"],
+            patches = ["@//third_party/rust/patches:serialport-pci-workaround.patch"],
+        )],
     },
     cargo_lockfile = "//third_party/rust:Cargo.lock",
     manifests = ["//third_party/rust:Cargo.toml"],

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -58,7 +58,7 @@ serde_derive = "1.0"
 
 serde_bytes = "0.11"
 serde_json = "1.0.69"
-serialport = "4.0.1"
+serialport = "4.2.0"
 sha2 = { version = "0.10", features = ["oid"] }
 shellwords = "1.1.0"
 structopt = "0.3"

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -3082,6 +3082,12 @@ def crate_repositories():
     maybe(
         http_archive,
         name = "crate_index__serialport-4.2.0",
+        patch_args = [
+            "-p1",
+        ],
+        patches = [
+            "@//third_party/rust/patches:serialport-pci-workaround.patch",
+        ],
         sha256 = "aab92efb5cf60ad310548bc3f16fa6b0d950019cb7ed8ff41968c3d03721cf12",
         type = "tar.gz",
         urls = ["https://crates.io/api/v1/crates/serialport/4.2.0/download"],

--- a/third_party/rust/patches/serialport-pci-workaround.patch
+++ b/third_party/rust/patches/serialport-pci-workaround.patch
@@ -1,0 +1,44 @@
+diff --git a/src/posix/enumerate.rs b/src/posix/enumerate.rs
+index 65c42bb..ee50f55 100644
+--- a/src/posix/enumerate.rs
++++ b/src/posix/enumerate.rs
+@@ -62,6 +62,30 @@ fn udev_hex_property_as_u16(d: &libudev::Device, key: &str) -> Result<u16> {
+     }
+ }
+ 
++/// Attempts to interpret a PCI device as a USB device. This is a workaround for a bug where USB
++/// devices are incorrectly reported with ID_BUS=pci. Luckily, the USB attributes are available in
++/// "ID_USB_*" properties. See <https://github.com/lowRISC/opentitan/issues/18491>.
++///
++/// The buggy behavior has been observed on Debian 11 Bullseye with udev 247.3-7+deb11u2 and systemd
++/// 247.3-7+deb11u2. It seems likely that this has the same root cause as the following Debian bug:
++/// <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1035094>. That discussion indicates that the
++/// bug is fixed upstream in systemd, but it has not yet been released as a package for Debian 11.
++/// We should delete this workaround once the systemd package is patched.
++#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
++fn try_interpret_pci_as_usb(d: &libudev::Device) -> Result<SerialPortType> {
++    assert_eq!(
++        d.property_value("ID_BUS").and_then(OsStr::to_str),
++        Some("pci")
++    );
++    Ok(SerialPortType::UsbPort(UsbPortInfo {
++        vid: udev_hex_property_as_u16(d, "ID_USB_VENDOR_ID")?,
++        pid: udev_hex_property_as_u16(d, "ID_USB_MODEL_ID")?,
++        serial_number: udev_property_as_string(d, "ID_USB_SERIAL_SHORT"),
++        manufacturer: udev_property_as_string(d, "ID_USB_VENDOR"),
++        product: udev_property_as_string(d, "ID_USB_MODEL"),
++    }))
++}
++
+ #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
+     match d.property_value("ID_BUS").and_then(OsStr::to_str) {
+@@ -77,7 +101,7 @@ fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
+                     .or_else(|| udev_property_as_string(d, "ID_MODEL")),
+             }))
+         }
+-        Some("pci") => Ok(SerialPortType::PciPort),
++        Some("pci") => try_interpret_pci_as_usb(d).or(Ok(SerialPortType::PciPort)),
+         _ => Ok(SerialPortType::Unknown),
+     }
+ }


### PR DESCRIPTION
The new patch is based on the v4.2.0 tag of the serialport-rs repo: <https://github.com/serialport/serialport-rs>.

This patch makes serialport::port_type() robust against a potential udev bug I have observed on my machine where USB devices are sometimes erroneously reported with ID_BUS=pci.

Fixes https://github.com/lowRISC/opentitan/issues/18491
Closes https://github.com/lowRISC/opentitan/pull/18631