### PR TITLE
[sw/silicon_creator] Enable all resets in rom_init()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -763,3 +763,15 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "pwrmgr",
+    srcs = ["pwrmgr.c"],
+    hdrs = ["pwrmgr.h"],
+    deps = [
+        "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/pwrmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/pwrmgr.c
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/pwrmgr.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pwrmgr_regs.h"
+
+enum {
+  kBase = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR,
+  kAllResetsEnable = (1 << kTopEarlgreyPowerManagerResetRequestsLast) - 1,
+  kSyncConfig = (1 << PWRMGR_CFG_CDC_SYNC_SYNC_BIT),
+};
+
+static_assert(kAllResetsEnable == 0x1,
+              "Number of reset requests changed, update expectation if this is "
+              "intentional");
+static_assert(
+    PWRMGR_RESET_EN_EN_FIELD_WIDTH == 1,
+    "RESET_EN field width changed, kAllResetsEnable may need to be updated");
+
+void pwrmgr_all_resets_enable(void) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kPwrmgrSecMmioAllResetsEnable, 1);
+  // Enable all resets.
+  sec_mmio_write32(kBase + PWRMGR_RESET_EN_REG_OFFSET, kAllResetsEnable);
+  // Sync configuration across clock domains.
+  // Note: This synchronization can take several clock cycles. Ideally we should
+  // wait for the `SYNC` bit to clear but we don't do that since this is our
+  // second try and we want to avoid loops as much as possible.
+  abs_mmio_write32(kBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, kSyncConfig);
+}

--- a/sw/device/silicon_creator/lib/drivers/pwrmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/pwrmgr.h
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PWRMGR_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PWRMGR_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions in provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  pwrmgr_all_resets_enable();
+ *  SEC_MMIO_WRITE_INCREMENT(kPwrmgrSecMmioAllResetsEnable);
+ * ```
+ */
+enum {
+  kPwrmgrSecMmioAllResetsEnable = 1,
+};
+
+/**
+ * Enable all resets.
+ */
+void pwrmgr_all_resets_enable(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_PWRMGR_H_

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -145,6 +145,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:pinmux",
+        "//sw/device/silicon_creator/lib/drivers:pwrmgr",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -26,6 +26,7 @@
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/pwrmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
@@ -144,6 +145,10 @@ static rom_error_t rom_init(void) {
 
   // Update epmp config for debug rom according to lifecycle state.
   rom_epmp_config_debug_rom(lc_state);
+
+  // Enable all resets.
+  pwrmgr_all_resets_enable();
+  SEC_MMIO_WRITE_INCREMENT(kPwrmgrSecMmioAllResetsEnable);
 
   // Re-initialize the watchdog timer.
   watchdog_init(lc_state);


### PR DESCRIPTION
We enable all resets already in [`rom_start.S`](https://github.com/lowRISC/opentitan/blob/b162939882e011f17f6a9ace6cd6809240c2e234/sw/device/silicon_creator/rom/rom_start.S#LL166C1-L174C18). This PR adds a minimal silicon_creator driver for the `pwrmgr` and enables all resets again in `rom_init()` using `sec_mmio`.