### PR TITLE
[ci] make JTAG tests blocking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -566,33 +566,8 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
-
-- job: execute_rom_fpga_jtag_tests_cw310
-  displayName: Experimental CW310 ROM JTAG Tests
-  pool: FPGA
-  timeoutInMinutes: 60
-  dependsOn:
-    - chip_earlgrey_cw310
-    - sw_build
-  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - template: ci/download-artifacts-template.yml
-    parameters:
-      downloadPartialBuildBinFrom:
-        - chip_earlgrey_cw310
-        - sw_build
-  - bash: |
-      set -e
-      . util/build_consts.sh
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
-    displayName: Execute tests
-    # TODO(lowRISC/opentitan#16067) Fail CI when JTAG tests fail.
-    continueOnError: True
 
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
@@ -614,8 +589,32 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_rom,-jtag || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-cw310-tests.sh cw310_rom,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
+
+- job: execute_fpga_manuf_tests_cw310
+  displayName: CW310 Manufacturing Tests
+  pool: FPGA
+  timeoutInMinutes: 60
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-cw310-tests.sh manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://docs.opentitan.org/doc/getting_started/setup_fpga/#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+
 
 - job: deploy_release_artifacts
   displayName: Package & deploy release

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -57,5 +57,4 @@ for tag in "${cw310_tags[@]}"; do
         --build_tests_only \
         --define cw310=lowrisc \
         --flaky_test_attempts=2
-
 done

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -114,6 +114,7 @@ opentitan_functest(
     srcs = ["individualize_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev_initial",
+        tags = ["manuf"],
     ),
     key_struct = RSA_ONLY_KEY_STRUCTS[1],
     targets = [
@@ -156,6 +157,7 @@ opentitan_functest(
     srcs = ["individualize_preop_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
+        tags = ["manuf"],
     ),
     targets = [
         "cw310_rom",
@@ -201,6 +203,7 @@ opentitan_functest(
     srcs = ["provisioning_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev_individualized",
+        tags = ["manuf"],
         test_cmds = [
             "--clear-bitstream",
             "--rom-kind=rom",
@@ -250,6 +253,7 @@ lc_raw_unlock_token(
         srcs = ["empty_functest.c"],
         cw310 = cw310_params(
             bitstream = "//hw/bitstream:rom_otp_{}".format(lc_state.lower()),
+            tags = ["manuf"],
             test_cmds = (
                 _MANUF_LC_TRANSITION_TEST_CMDS if (
                     (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS
@@ -284,6 +288,7 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_raw",
+        tags = ["manuf"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
@@ -352,6 +357,7 @@ otp_json(
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            tags = ["manuf"],
             test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS + [
                 "--initial-lc-state=\"{}\"".format(lc_state),
             ],
@@ -435,6 +441,7 @@ opentitan_ram_binary(
         srcs = ["flash_device_info_flash_wr_functest.c"],
         cw310 = cw310_params(
             bitstream = "bitstream_rom_exec_disabled_{}".format(init_lc_state.lower()),
+            tags = ["manuf"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",
@@ -515,6 +522,7 @@ opentitan_ram_binary(
         srcs = ["idle_functest.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
+            tags = ["manuf"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",
@@ -571,6 +579,7 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/manuf/lib:empty_functest.c"],
     cw310 = cw310_params(
         bitstream = ":bitstream_otp_ctrl_functest",
+        tags = ["manuf"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
@@ -590,6 +599,7 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = ":bitstream_otp_ctrl_functest",
+        tags = ["manuf"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -201,7 +201,6 @@ opentitan_functest(
     srcs = ["provisioning_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_dev_individualized",
-        tags = ["jtag"],
         test_cmds = [
             "--clear-bitstream",
             "--rom-kind=rom",
@@ -251,7 +250,6 @@ lc_raw_unlock_token(
         srcs = ["empty_functest.c"],
         cw310 = cw310_params(
             bitstream = "//hw/bitstream:rom_otp_{}".format(lc_state.lower()),
-            tags = ["jtag"],
             test_cmds = (
                 _MANUF_LC_TRANSITION_TEST_CMDS if (
                     (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS
@@ -286,7 +284,6 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_raw",
-        tags = ["jtag"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
@@ -355,7 +352,6 @@ otp_json(
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
-            tags = ["jtag"],
             test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS + [
                 "--initial-lc-state=\"{}\"".format(lc_state),
             ],
@@ -439,7 +435,6 @@ opentitan_ram_binary(
         srcs = ["flash_device_info_flash_wr_functest.c"],
         cw310 = cw310_params(
             bitstream = "bitstream_rom_exec_disabled_{}".format(init_lc_state.lower()),
-            tags = ["jtag"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",
@@ -520,7 +515,6 @@ opentitan_ram_binary(
         srcs = ["idle_functest.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
-            tags = ["jtag"],
             test_cmds = [
                 "--clear-bitstream",
                 "--rom-kind=rom",
@@ -577,7 +571,6 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/manuf/lib:empty_functest.c"],
     cw310 = cw310_params(
         bitstream = ":bitstream_otp_ctrl_functest",
-        tags = ["jtag"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
@@ -597,7 +590,6 @@ opentitan_functest(
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_params(
         bitstream = ":bitstream_otp_ctrl_functest",
-        tags = ["jtag"],
         test_cmds = _MANUF_LC_TRANSITION_TEST_CMDS,
     ),
     data = OPENTITANTOOL_OPENOCD_DATA_DEPS,

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -499,10 +499,10 @@ opentitan_functest(
     srcs = ["rom_e2e_bootstrap_rma_test.c"],
     cw310 = cw310_params(
         bitstream = ":bitstream_bootstrap_rma",
-        tags = [
-            "jtag",
-        ],
         test_cmds = [
+            # We need to clear the bitstream between consecutive runs of this
+            # test since it modifies OTP state (i.e., the LC state).
+            "--clear-bitstream",
             "--rom-kind=rom",
             "--bitstream=\"$(rootpath {bitstream})\"",
             "--bootstrap=\"$(rootpath {flash})\"",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2343,7 +2343,6 @@ opentitan_functest(
     srcs = ["example_test_from_flash.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_otp_test_unlocked0",
-        tags = ["jtag"],
         test_cmds = [
             "--rom-kind=rom",
             "--bitstream=\"$(rootpath {bitstream})\"",


### PR DESCRIPTION
This PR:

1. removes the `jtag` tag from `opentitan_functest`s that was used to run a separate non-blocking CI job for tests that used the OpenOCD/JTAG infra (this was hard to maintain as it was manually maintained), and
2. removes the separate non-blocking JTAG test job from CI as the JTAG tests are now run in either the test ROM tests or ROM tests stages and are blocking.