### PR TITLE
[opentitantool] Speed up HyperDebug driver

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -13,7 +13,6 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs;
-use std::io::ErrorKind;
 use std::io::Read;
 use std::io::Write;
 use std::marker::PhantomData;
@@ -385,31 +384,11 @@ impl Inner {
             .ok_or(TransportError::UnicodePathError)?;
         let _lock = SerialPortExclusiveLock::lock(port_name)?;
         let mut port = TTYPort::open(
-            &serialport::new(port_name, 115_200).timeout(std::time::Duration::from_millis(10)),
+            &serialport::new(port_name, 115_200).timeout(std::time::Duration::from_millis(100)),
         )
-        .expect("Failed to open port");
+        .context("Failed to open HyperDebug console")?;
         flock_serial(&port, port_name)?;
 
-        // Ideally, we would invoke Linux flock() on the serial
-        // device, to detect minicom or another instance of
-        // opentitantool having the same serial port open.  Incoming
-        // serial data could go silenly missing, in such cases.
-        let mut buf = [0u8; 128];
-        loop {
-            match port.read(&mut buf) {
-                Ok(rc) => {
-                    log::info!(
-                        "Discarded {} characters: {:?}",
-                        rc,
-                        &std::str::from_utf8(&buf[0..rc])
-                    );
-                }
-                Err(error) if error.kind() == ErrorKind::TimedOut => {
-                    break;
-                }
-                Err(error) => return Err(error).context("communication error"),
-            }
-        }
         // Send Ctrl-C, followed by the command, then newline.  This will discard any previous
         // partial input, before executing our command.
         port.write(format!("\x03{}\n", cmd).as_bytes())
@@ -419,14 +398,13 @@ impl Inner {
         // we just "typed". Then zero, one or more lines of useful output, which we want to pass
         // to the callback, and then a prompt characters, indicating that the output is
         // complete.
+        let mut buf = [0u8; 128];
         let mut seen_echo = false;
         let mut len: usize = 0;
-        let mut repeated_timeouts: u8 = 0;
         loop {
             // Read more data, appending to existing buffer.
-            match port.read(&mut buf[len..128]) {
+            match port.read(&mut buf[len..]) {
                 Ok(rc) => {
-                    repeated_timeouts = 0;
                     len += rc;
                     // See if we have one or more lines terminated with endline, if so, process
                     // those and remove from the buffer by shifting the remaning data to the
@@ -443,10 +421,17 @@ impl Inner {
                                 .context("communication error")?;
                             if seen_echo {
                                 callback(line);
+                            } else if line.len() >= 2 && line[line.len() - 2..] == *"^C" {
+                                // Expected output from our sending of control character.
                             } else if line.len() >= cmd.len()
                                 && line[line.len() - cmd.len()..] == *cmd
                             {
+                                // A line ending with the command we sent, assume this is echo,
+                                // and that the actual command output will now follow.
                                 seen_echo = true;
+                            } else if !line.is_empty() {
+                                // Unexpected output before or instead of the echo of our command.
+                                log::info!("Unexpected output: {:?}", line)
                             }
                             line_start = i + 1;
                         }
@@ -456,23 +441,11 @@ impl Inner {
                         buf.rotate_left(line_start);
                         len -= line_start;
                     }
-                }
-                Err(error) if error.kind() == ErrorKind::TimedOut => {
-                    if std::str::from_utf8(&buf[0..len]).context("communication error")? == "> " {
-                        // No data arrived for a while, and the last we got was a command
-                        // prompt, this is what we expect when the command has finished
+                    if seen_echo && buf[0..len] == [b'>', b' '] {
+                        // We have seen echo of the command we sent, and now the last we got was a
+                        // command prompt, this is what we expect when the command has finished
                         // successfully.
                         return Ok(());
-                    } else {
-                        // No data arrived for a while, but the last was no a command prompt,
-                        // this could be the command taking a little time to produce its output,
-                        // wait a longer while for additional data.  (Implemented by repeated
-                        // calls, alternatively could have been done by fiddling with timeout
-                        // setting of the underlying serial port object.)
-                        repeated_timeouts += 1;
-                        if repeated_timeouts == 10 {
-                            return Err(error).context("communication error");
-                        }
                     }
                 }
                 Err(error) => return Err(error).context("communication error"),


### PR DESCRIPTION
Avoid waiting for serial timeout on every HyperDebug console command. This is achieved by stopping the processing immediately, when the command prompt "\n> " is detected at the trailing end of characters received from `read()` (rather than doing another `read()` with 10ms timeout after that, and only stopping if that came back without any characters.)

Also, rather than purging any spurious output before sending the command, it is now done after sending the command, using the echo of the command just sent to recognize when to start processing.  (Betting that the probability of seeing the same command as part of the spurious output will be vanishing, as that would otherwise cause the rest of the spurious output to be incorrectly treated as ligitimate command output.)

This change reduces the time of `transport init` from 4.6s to 1.1s for the Ti50 team, which would significantly speed up automated test runs. (Currently, the actual test logic can sometimes be faster than the setup.)