### PR TITLE
[opentitantool] New HyperDebug firmware, support fourth I2C port

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230509_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "d25cffd7d5a1e6666855f4226064af644a43cc7372017cbb27787e0ae9306f6e",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230517_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "df79a383c826dab275281e90a4473e16275b41c5cd346e1fea33137a169a0656",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Allow controlling all four I2C ports of the STM32L5 chip through opentitantool.  This means that signals CN10_8 and CN10_12 now default to "alternate" mode, rather than "input".  Any code that uses them as GPIO inputs without explicitly declaring them as such may stop working.