### PR TITLE
[opentitanlib] Add support for manifest extensions specs

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -79,6 +79,7 @@ rust_library(
         "src/image/image.rs",
         "src/image/manifest.rs",
         "src/image/manifest_def.rs",
+        "src/image/manifest_ext.rs",
         "src/image/mod.rs",
         "src/io/console.rs",
         "src/io/eeprom.rs",
@@ -285,6 +286,7 @@ rust_test(
     data = [
         "src/image/testdata/hello.txt",
         "src/image/testdata/manifest.hjson",
+        "src/image/testdata/manifest_ext.hjson",
         "src/image/testdata/manifest_missing.hjson",
         "src/image/testdata/test_image.bin",
         "src/image/testdata/world.txt",

--- a/sw/host/opentitanlib/src/image/manifest_ext.rs
+++ b/sw/host/opentitanlib/src/image/manifest_ext.rs
@@ -1,0 +1,203 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use serde::{self, Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use zerocopy::AsBytes;
+
+use crate::crypto::spx::{self, SpxPublicKeyPart};
+use crate::image::manifest::*;
+use crate::image::manifest_def::le_bytes_to_word_arr;
+use crate::util::file::FromReader;
+use crate::util::num_de::HexEncoded;
+use crate::with_unknown;
+
+with_unknown! {
+    /// Known manifest extension variant IDs.
+    #[derive(Default)]
+    pub enum ManifestExtId: u32 {
+        spx_key = MANIFEST_EXT_ID_SPX_KEY,
+        spx_signature = MANIFEST_EXT_ID_SPX_SIGNATURE,
+    }
+}
+
+/// Top level spec for manifest extension HJSON files.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ManifestExtSpec {
+    pub(crate) signed_region: Vec<ManifestExtEntrySpec>,
+    pub(crate) unsigned_region: Vec<ManifestExtEntrySpec>,
+    #[serde(skip)]
+    relative_path: Option<PathBuf>,
+}
+
+/// Specs for the known extension variants.
+///
+/// This includes a raw variant that can take any id, name, and value.
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum ManifestExtEntrySpec {
+    SpxKey {
+        /// The path to the SPHINCS+ public or private key.
+        ///
+        /// If a relative path is used, this path will typically be resolved relative to the path
+        /// given by `ManifestExtSpc::source_path()` of the `ManifestExtSpec` that contains this
+        /// spec.
+        spx_key: PathBuf,
+    },
+    SpxSignature {
+        /// The path to the SPHINCS+ signature.
+        ///
+        /// If a relative path is used, this path will typically be resolved relative to the path
+        /// given by `ManifestExtSpc::source_path()` of the `ManifestExtSpec` that contains this
+        /// spec.
+        spx_signature: PathBuf,
+    },
+    Raw {
+        name: HexEncoded<u32>,
+        identifier: HexEncoded<u32>,
+        value: Vec<HexEncoded<u8>>,
+    },
+}
+
+#[derive(Debug)]
+pub enum ManifestExtEntry {
+    SpxKey(ManifestExtSpxKey),
+    SpxSignature(Box<ManifestExtSpxSignature>),
+    Raw {
+        header: ManifestExtHeader,
+        data: Vec<u8>,
+    },
+}
+
+impl ManifestExtSpec {
+    /// Reads in a `ManifestExtSpec` from an HJSON file.
+    ///
+    /// The parent of `path` (the directory containing the HJSON file to be loaded) is used when
+    /// resolving relative paths for any extension data that references a file.
+    pub fn read_from_file(path: &Path) -> Result<Self> {
+        let mut spec: Self = deser_hjson::from_str(&std::fs::read_to_string(path)?)?;
+        spec.relative_path = path.parent().map(|v| v.to_owned());
+        Ok(spec)
+    }
+
+    /// The partent of the path that was provided when loading this spec.
+    pub fn source_path(&self) -> Option<&Path> {
+        self.relative_path.as_deref()
+    }
+}
+
+impl ManifestExtEntry {
+    /// Creates a new manifest extension from a given SPHINCS+ `key`.
+    pub fn new_spx_key_entry(key: spx::SpxKey) -> Result<Self> {
+        Ok(ManifestExtEntry::SpxKey(ManifestExtSpxKey {
+            header: ManifestExtHeader {
+                identifier: MANIFEST_EXT_ID_SPX_KEY,
+                name: MANIFEST_EXT_NAME_SPX_KEY,
+            },
+            key: SigverifySpxKey {
+                data: le_bytes_to_word_arr(key.pk_as_bytes())?,
+            },
+        }))
+    }
+
+    /// Creates a new manifest extension from a given SPHINCS+ `signature`.
+    pub fn new_spx_signature_entry(signature: spx::SpxSignature) -> Result<Self> {
+        Ok(ManifestExtEntry::SpxSignature(Box::new(
+            ManifestExtSpxSignature {
+                header: ManifestExtHeader {
+                    identifier: MANIFEST_EXT_ID_SPX_SIGNATURE,
+                    name: MANIFEST_EXT_NAME_SPX_SIGNATURE,
+                },
+                signature: SigverifySpxSignature {
+                    data: le_bytes_to_word_arr(&signature.0.to_le_bytes())?,
+                },
+            },
+        )))
+    }
+
+    /// Creates a new manifest extension from a given `spec`.
+    ///
+    /// For extensions that reference other resources, such as SPHINCS+ keys or signatures, this
+    /// function will attempt to load those resources to create the extension.
+    pub fn from_spec(spec: &ManifestExtEntrySpec, relative_path: Option<&Path>) -> Result<Self> {
+        let relative_path = relative_path.unwrap_or(Path::new(""));
+        Ok(match spec {
+            ManifestExtEntrySpec::SpxKey { spx_key } => ManifestExtEntry::new_spx_key_entry(
+                spx::load_spx_key(&relative_path.join(spx_key))?,
+            )?,
+            ManifestExtEntrySpec::SpxSignature { spx_signature } => {
+                ManifestExtEntry::new_spx_signature_entry(spx::SpxSignature::read_from_file(
+                    &relative_path.join(spx_signature),
+                )?)?
+            }
+            ManifestExtEntrySpec::Raw {
+                name,
+                identifier,
+                value,
+            } => ManifestExtEntry::Raw {
+                header: ManifestExtHeader {
+                    identifier: **identifier,
+                    name: **name,
+                },
+                data: value.iter().map(|v| **v).collect(),
+            },
+        })
+    }
+
+    /// Returns the header portion of this extension.
+    pub fn header(&self) -> &ManifestExtHeader {
+        match self {
+            ManifestExtEntry::SpxKey(key) => &key.header,
+            ManifestExtEntry::SpxSignature(sig) => &sig.header,
+            ManifestExtEntry::Raw { header, data: _ } => header,
+        }
+    }
+
+    /// Allocates a new byte `Vec<u8>` and writes the binary extension data to it.
+    pub fn to_vec(&self) -> Vec<u8> {
+        match self {
+            ManifestExtEntry::SpxKey(key) => key.as_bytes().to_vec(),
+            ManifestExtEntry::SpxSignature(sig) => sig.as_bytes().to_vec(),
+            ManifestExtEntry::Raw { header, data } => {
+                header.as_bytes().iter().chain(data).copied().collect()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testdata;
+    use crate::util::num_de::HexEncoded;
+
+    #[test]
+    fn test_manifest_ext_from_hjson() {
+        let spec = ManifestExtSpec::read_from_file(&testdata!("manifest_ext.hjson")).unwrap();
+        assert_eq!(spec.source_path(), Some(testdata!().as_path()));
+        assert_eq!(spec.signed_region.len(), 2);
+        assert_eq!(
+            spec.signed_region[0],
+            ManifestExtEntrySpec::SpxKey {
+                spx_key: "test_spx.pem".into()
+            }
+        );
+        assert_eq!(
+            spec.signed_region[1],
+            ManifestExtEntrySpec::Raw {
+                name: HexEncoded(0xbeef),
+                identifier: HexEncoded(0xabcd),
+                value: [0x01, 0x23, 0x45, 0x67].map(HexEncoded).to_vec()
+            }
+        );
+        assert_eq!(spec.unsigned_region.len(), 1);
+        assert_eq!(
+            spec.unsigned_region[0],
+            ManifestExtEntrySpec::SpxSignature {
+                spx_signature: "test_signature.bin".into()
+            }
+        );
+    }
+}

--- a/sw/host/opentitanlib/src/image/mod.rs
+++ b/sw/host/opentitanlib/src/image/mod.rs
@@ -7,3 +7,4 @@
 pub mod image;
 pub mod manifest;
 pub mod manifest_def;
+pub mod manifest_ext;

--- a/sw/host/opentitanlib/src/image/testdata/manifest.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest.hjson
@@ -168,13 +168,16 @@
    */
   entry_point: "0x00000000"
   extensions: [
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
-    {identifier: "0x00000000", offset: "0x00000000"},
+    "spx_key",
+    "spx_signature",
+    43981, // Raw extension with ID = 0xabcd.
+    {
+      identifier: 61185, // Raw extension with ID = 0xef01.
+      offset: 1024,
+    },
+    null,
+    null,
+    null,
+    null,
   ]
 }

--- a/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  signed_region: [
+    {
+      spx_key: "test_spx.pem",
+    },
+    {
+      name: "0xbeef",
+      identifier: "0xabcd",
+      value: ["0x01", "0x23", "0x45", "0x67"],
+    }
+  ],
+  unsigned_region: [
+    {
+      spx_signature: "test_signature.bin",
+    },
+  ],
+}

--- a/sw/host/opentitanlib/src/util/num_de.rs
+++ b/sw/host/opentitanlib/src/util/num_de.rs
@@ -147,19 +147,19 @@ impl Deref for DeferredValue {
 }
 
 /// Wrapper type to force deserialization assuming octal encoding.
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct OctEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
 where
     T: ParseInt + fmt::Octal;
 
 /// Wrapper type to force deserialization assuming decimal encoding.
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct DecEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
 where
     T: ParseInt + fmt::Display;
 
 /// Wrapper type to force deserialization assuming hexadecimal encoding.
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct HexEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
 where
     T: ParseInt + fmt::LowerHex;


### PR DESCRIPTION
Adds HJSON deserialization for manifest extensions and adds support for applying extensions to images.

Uploading this as a draft right now, since opentitantool is still using the extension support added in https://github.com/lowRISC/opentitan/pull/18584.