### PR TITLE
[opentitanlib] move jtag_params into `InitializeTest` struct

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
@@ -23,11 +23,6 @@
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
-static_assert(
-    (sizeof(wrapped_rma_unlock_token_t) % sizeof(uint32_t)) == 0,
-    "Size of the wrapped_rma_unlock_token_t struct must the an even multiple "
-    "of 32-bit words since it is written to the non-volatile flash region.");
-
 /**
  * DIF Handles.
  *

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -17,6 +17,7 @@ use super::bootstrap::Bootstrap;
 use super::load_bitstream::LoadBitstream;
 use crate::app::TransportWrapper;
 use crate::backend;
+use crate::io::jtag::JtagParams;
 // use opentitanlib::io::uart::UartParams;
 
 #[derive(Debug, StructOpt)]
@@ -43,6 +44,9 @@ pub struct InitializeTest {
 
     #[structopt(flatten)]
     pub bootstrap: Bootstrap,
+
+    #[structopt(flatten)]
+    pub jtag_params: JtagParams,
 }
 
 impl InitializeTest {

--- a/sw/host/tests/chip/jtag/src/openocd_test.rs
+++ b/sw/host/tests/chip/jtag/src/openocd_test.rs
@@ -12,7 +12,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boolean::MultiBitBool8;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap, RiscvCsr, RiscvGpr, RiscvReg};
+use opentitanlib::io::jtag::{JtagTap, RiscvCsr, RiscvGpr, RiscvReg};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -22,8 +22,6 @@ use top_earlgrey::top_earlgrey_memory;
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
 }
 
 fn reset(transport: &TransportWrapper, strappings: &[&str], reset_delay: Duration) -> Result<()> {
@@ -61,7 +59,7 @@ fn test_openocd(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         opts.init.bootstrap.options.reset_delay,
     )?;
 
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::RiscvTap)?;
     jtag.halt()?;
     // Definitions for hardware registers
@@ -195,7 +193,7 @@ fn test_openocd(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         opts.init.bootstrap.options.reset_delay,
     )?;
 
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::LcTap)?;
 
     // Test reads by checking the LC_STATE register

--- a/sw/host/tests/chip/jtag/src/sram_load.rs
+++ b/sw/host/tests/chip/jtag/src/sram_load.rs
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::load_sram_program::{ExecutionMode, SramProgramParams};
 use opentitanlib::uart::console::UartConsole;
@@ -21,8 +21,7 @@ use opentitanlib::uart::console::UartConsole;
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
+
     #[structopt(flatten)]
     sram_program: SramProgramParams,
 }
@@ -35,7 +34,7 @@ fn test_sram_load(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
 
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     log::info!("Connecting to RISC-V TAP");
     jtag.connect(JtagTap::RiscvTap)?;
     log::info!("Halting core");

--- a/sw/host/tests/manuf/manuf_cp_ast_test_execution/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_ast_test_execution/src/main.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::otp_ctrl::DaiParam;
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{Jtag, JtagParams, JtagTap};
+use opentitanlib::io::jtag::{Jtag, JtagTap};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
@@ -24,10 +24,10 @@ use opentitanlib::uart::console::{ExitStatus, UartConsole};
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
+
     #[structopt(flatten)]
     sram_program: SramProgramParams,
+
     #[structopt(
         long, parse(try_from_str=humantime::parse_duration),
         default_value = "600s",
@@ -51,7 +51,7 @@ fn connect_riscv_jtag(opts: &Opts, transport: &TransportWrapper) -> Result<Rc<dy
         .reset_target(opts.init.bootstrap.options.reset_delay, true)
         .context("failed to reset")?;
 
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     log::info!("Connecting to RISC-V TAP");
     jtag.connect(JtagTap::RiscvTap)?;
 

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -12,7 +12,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::backend;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::{trigger_lc_transition, wait_for_status};
 use opentitanlib::test_utils::load_sram_program::{
@@ -24,9 +24,6 @@ use opentitanlib::uart::console::{ExitStatus, UartConsole};
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-
-    #[structopt(flatten)]
-    jtag: JtagParams,
 
     #[structopt(flatten)]
     sram_program: SramProgramParams,
@@ -50,7 +47,7 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
     // Set CPU TAP straps, reset, and connect to the JTAG interface.
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::RiscvTap)?;
 
     // Reset and halt the CPU to ensure we are in a known state, and clear out any ROM messages

--- a/sw/host/tests/manuf/manuf_cp_test_lock/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_test_lock/src/main.rs
@@ -16,7 +16,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::dif::otp_ctrl::{DaiParam, Partition};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{Jtag, JtagParams, JtagTap};
+use opentitanlib::io::jtag::{Jtag, JtagTap};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition;
 use opentitanlib::test_utils::otp_ctrl::{OtpParam, OtpPartition};
@@ -25,8 +25,6 @@ use opentitanlib::test_utils::otp_ctrl::{OtpParam, OtpPartition};
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
 }
 
 /// Pre-image of the TEST_UNLOCK token that will be written to OTP.
@@ -164,7 +162,7 @@ fn reset_to_tap(
         .reset_target(opts.init.bootstrap.options.reset_delay, true)
         .context("failed to reset")?;
 
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(tap)
         .with_context(|| format!("failed to connect to {tap:?} over JTAG"))?;
 

--- a/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, DifLcCtrlToken, LcCtrlReg};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition;
 
@@ -21,8 +21,6 @@ mod lc_raw_unlock_token;
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
 }
 
 fn manuf_cp_unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
@@ -36,7 +34,7 @@ fn manuf_cp_unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
         .context("failed to reset")?;
 
     // Connect to the LC TAP via JTAG.
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::LcTap)
         .context("failed to connect to LC TAP over JTAG")?;
 

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::extclk::{ClockSpeed, ExternalClock};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::wait_for_status;
@@ -26,9 +26,6 @@ use top_earlgrey::top_earlgrey_memory;
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-
-    #[structopt(flatten)]
-    jtag: JtagParams,
 
     #[structopt(
         long, parse(try_from_str = DifLcCtrlState::parse_lc_state_str),
@@ -45,7 +42,7 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
         .apply()
         .context("failed to apply RISCV TAP strapping")?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::RiscvTap)
         .context("failed to connect to RISCV TAP over JTAG")?;
 

--- a/sw/host/tests/manuf/manuf_scrap/src/main.rs
+++ b/sw/host/tests/manuf/manuf_scrap/src/main.rs
@@ -8,7 +8,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 
@@ -16,9 +16,6 @@ use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-
-    #[structopt(flatten)]
-    jtag_params: JtagParams,
 
     #[structopt(
         long, parse(try_from_str = DifLcCtrlState::parse_lc_state_str),
@@ -32,7 +29,7 @@ fn manuf_scrap(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // Reset the chip, select the LC TAP, and connect to it.
     transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    let jtag = transport.jtag(&opts.jtag_params)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::LcTap)?;
 
     // Check the initial LC state.

--- a/sw/host/tests/manuf/otp_ctrl/src/main.rs
+++ b/sw/host/tests/manuf/otp_ctrl/src/main.rs
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::otp_ctrl::{DaiParam, Partition};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::otp_ctrl::{OtpParam, OtpPartition};
 
@@ -18,8 +18,6 @@ use opentitanlib::test_utils::otp_ctrl::{OtpParam, OtpPartition};
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-    #[structopt(flatten)]
-    jtag: JtagParams,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -46,7 +44,7 @@ fn program_readback(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result
         .context("failed to reset")?;
 
     // Connect to the RISCV TAP via JTAG.
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::RiscvTap)
         .context("failed to connect to RISCV TAP over JTAG")?;
 
@@ -78,7 +76,7 @@ fn lock_partition(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<(
         .context("failed to reset")?;
 
     // Connect to the RISCV TAP via JTAG.
-    let jtag = transport.jtag(&opts.jtag)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::RiscvTap)
         .context("failed to connect to RISCV TAP over JTAG")?;
 

--- a/sw/host/tests/manuf/provisioning/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/src/main.rs
@@ -18,7 +18,7 @@ use structopt::StructOpt;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::{trigger_lc_transition, wait_for_status};
 use opentitanlib::test_utils::rpc::UartRecv;
@@ -38,9 +38,6 @@ struct Opts {
         help = "Console receive timeout",
     )]
     timeout: Duration,
-
-    #[structopt(flatten)]
-    jtag_params: JtagParams,
 
     #[structopt(long, help = "HSM generated ECDH private key DER file.")]
     hsm_ecdh_sk: PathBuf,
@@ -97,7 +94,7 @@ fn provisioning(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     }
 
     // Connect to JTAG LC TAP.
-    let jtag = transport.jtag(&opts.jtag_params)?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::LcTap)?;
 
     // Check the current LC state is Dev or Prod.

--- a/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Bootstrap RMA e2e test.
-//!
 //! This test harness:
 //!
 //! 1. Checks that the ROM times out and resets under the `RMA_BOOTSTRAP` strapping.
@@ -25,7 +24,7 @@ use opentitanlib::dif::lc_ctrl::{
 };
 use opentitanlib::dif::rstmgr::DifRstmgrResetInfo;
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition;
 use opentitanlib::uart::console::{ExitStatus, UartConsole};
@@ -38,9 +37,6 @@ const CONSOLE_TIMEOUT: Duration = Duration::from_secs(5);
 struct Opts {
     #[structopt(flatten)]
     init: InitializeTest,
-
-    #[structopt(flatten)]
-    jtag: JtagParams,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -135,7 +131,7 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result
 
     log::info!("Connecting to JTAG interface");
 
-    let jtag = transport.jtag(&opts.jtag).context("failed to get JTAG")?;
+    let jtag = opts.init.jtag_params.create(transport)?;
     jtag.connect(JtagTap::LcTap)
         .context("failed to connect to JTAG")?;
 


### PR DESCRIPTION
This updates the `InitializeTest` struct to contain the JtagParams in response to this review comment: https://github.com/lowRISC/opentitan/pull/18404#discussion_r1188699371

Additionally, an unneeded static_assert in a test was removed, in response to this review comment: https://github.com/lowRISC/opentitan/pull/18404#discussion_r1188692669