### PR TITLE
[bazel] Temporarily disable jump guards hardening

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,8 @@ build --features=-pedantic_warnings
 
 # Enable toolchain hardening features.
 # `guards` adds `unimp` guard instructions after unconditional jumps.
-build --features=guards
+# TODO: currently disabled until issue #18680 is fixed.
+# build --features=guards
 
 # Enable toolchain resolution with cc
 build --incompatible_enable_cc_toolchain_resolution


### PR DESCRIPTION
As noted in Issue #18680, there is a compiler bug caused by the jump guards hardening, in its interaction with the branch relaxation pass. Until it is fixed, IMO we should temporarily disable that hardening.