### PR TITLE
[ci] Use GH CLI tool to determine changed files

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -17,17 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Determine changed files
         run: |
-          pr_ref="refs/pull/${{ github.event.number }}/merge"
-          echo $pr_ref
-          git fetch origin "$pr_ref"
-          git diff --name-only \
-            "origin/${{ github.base_ref }}" \
-            FETCH_HEAD > $HOME/changed_files
+          pr_url="https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
+          echo $pr_url
+          gh pr diff $pr_url --name-only > $HOME/changed_files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show files changed
         run: cat $HOME/changed_files


### PR DESCRIPTION
Previous method was flawed and would produce a list of every file changed on master since the PR commit was branched off it. So in general the older the PR the more unconnected to the PR files would appear on the list.