### PR TITLE
[Spi host, flash] Add new tests

### DIFF
--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -35,7 +35,6 @@ typedef enum spi_device_flash_opcode {
   kSpiDeviceFlashOpBlockErase32k = 0x52,
   kSpiDeviceFlashOpBlockErase64k = 0xd8,
   kSpiDeviceFlashOpPageProgram = 0x02,
-  kSpiDeviceFlashOpPageQuadProgram = 0x32,
   kSpiDeviceFlashOpEnter4bAddr = 0xb7,
   kSpiDeviceFlashOpExit4bAddr = 0xe9,
   kSpiDeviceFlashOpResetEnable = 0x66,

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -35,6 +35,7 @@ typedef enum spi_device_flash_opcode {
   kSpiDeviceFlashOpBlockErase32k = 0x52,
   kSpiDeviceFlashOpBlockErase64k = 0xd8,
   kSpiDeviceFlashOpPageProgram = 0x02,
+  kSpiDeviceFlashOpPageQuadProgram = 0x32,
   kSpiDeviceFlashOpEnter4bAddr = 0xb7,
   kSpiDeviceFlashOpExit4bAddr = 0xe9,
   kSpiDeviceFlashOpResetEnable = 0x66,

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -164,10 +164,10 @@ status_t spi_flash_emulator(dif_spi_host_t *spih,
                                          info.address, /*addr_is_4b=*/true));
         break;
       case kSpiDeviceFlashOpPageProgram4b:
-        TRY(spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageProgram4b,
-                                           info.data, info.data_len,
-                                           info.address,
-                                           /*addr_is_4b=*/true, kDifSpiHostWidthStandard));
+        TRY(spi_flash_testutils_program_op(
+            spih, kSpiDeviceFlashOpPageProgram4b, info.data, info.data_len,
+            info.address,
+            /*addr_is_4b=*/true, kDifSpiHostWidthStandard));
         break;
       case kSpiDeviceFlashOpReset:
         running = false;

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -167,7 +167,7 @@ status_t spi_flash_emulator(dif_spi_host_t *spih,
         TRY(spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageProgram4b,
                                            info.data, info.data_len,
                                            info.address,
-                                           /*addr_is_4b=*/true));
+                                           /*addr_is_4b=*/true, kDifSpiHostWidthStandard));
         break;
       case kSpiDeviceFlashOpReset:
         running = false;

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -93,7 +93,7 @@ status_t spi_flash_testutils_read_status(dif_spi_host_t *spih, uint8_t opcode,
                                          size_t length) {
   TRY_CHECK(spih != NULL);
   TRY_CHECK(length <= 3);
-  uint32_t status;
+  uint32_t status = 0;
   dif_spi_host_segment_t transaction[] = {
       {
           .type = kDifSpiHostSegmentTypeOpcode,
@@ -141,7 +141,7 @@ status_t spi_flash_testutils_write_status(dif_spi_host_t *spih, uint8_t opcode,
 
 status_t spi_flash_testutils_wait_until_not_busy(dif_spi_host_t *spih) {
   TRY_CHECK(spih != NULL);
-  int32_t status;
+  int32_t status = 0;
 
   do {
     status = TRY(
@@ -314,7 +314,7 @@ status_t spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,
 
 status_t spi_flash_testutils_quad_enable(dif_spi_host_t *spih, uint8_t method,
                                          bool enabled) {
-  uint32_t status;
+  uint32_t status = 0;
   switch (method) {
     case 0:
       // Device does not have a QE bit.

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -214,7 +214,8 @@ status_t spi_flash_testutils_erase_sector(dif_spi_host_t *spih,
 
 status_t spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
                                         const void *payload, size_t length,
-                                        uint32_t address, bool addr_is_4b) {
+                                        uint32_t address, bool addr_is_4b,
+                                        dif_spi_host_width_t write_width) {
   TRY_CHECK(spih != NULL);
   TRY_CHECK(payload != NULL);
   TRY_CHECK(length <= 256);  // Length must be less than a page size.
@@ -241,7 +242,7 @@ status_t spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
           .type = kDifSpiHostSegmentTypeTx,
           .tx =
               {
-                  .width = kDifSpiHostWidthStandard,
+                  .width = write_width,
                   .buf = payload,
                   .length = length,
               },
@@ -257,7 +258,17 @@ status_t spi_flash_testutils_program_page(dif_spi_host_t *spih,
                                           const void *payload, size_t length,
                                           uint32_t address, bool addr_is_4b) {
   return spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageProgram,
-                                        payload, length, address, addr_is_4b);
+                                        payload, length, address, addr_is_4b,
+                                        kDifSpiHostWidthStandard);
+}
+
+status_t spi_flash_testutils_program_page_quad(dif_spi_host_t *spih,
+                                               const void *payload,
+                                               size_t length, uint32_t address,
+                                               bool addr_is_4b) {
+  return spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageQuadProgram,
+                                        payload, length, address, addr_is_4b,
+                                        kDifSpiHostWidthQuad);
 }
 
 status_t spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -212,6 +212,18 @@ status_t spi_flash_testutils_erase_sector(dif_spi_host_t *spih,
                                       address, addr_is_4b);
 }
 
+status_t spi_flash_testutils_erase_block32k(dif_spi_host_t *spih,
+                                            uint32_t address, bool addr_is_4b) {
+  return spi_flash_testutils_erase_op(spih, kSpiDeviceFlashOpBlockErase32k,
+                                      address, addr_is_4b);
+}
+
+status_t spi_flash_testutils_erase_block64k(dif_spi_host_t *spih,
+                                            uint32_t address, bool addr_is_4b) {
+  return spi_flash_testutils_erase_op(spih, kSpiDeviceFlashOpBlockErase64k,
+                                      address, addr_is_4b);
+}
+
 status_t spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
                                         const void *payload, size_t length,
                                         uint32_t address, bool addr_is_4b,

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -263,12 +263,12 @@ status_t spi_flash_testutils_program_page(dif_spi_host_t *spih,
 }
 
 status_t spi_flash_testutils_program_page_quad(dif_spi_host_t *spih,
+                                               uint8_t opcode,
                                                const void *payload,
                                                size_t length, uint32_t address,
                                                bool addr_is_4b) {
-  return spi_flash_testutils_program_op(spih, kSpiDeviceFlashOpPageQuadProgram,
-                                        payload, length, address, addr_is_4b,
-                                        kDifSpiHostWidthQuad);
+  return spi_flash_testutils_program_op(spih, opcode, payload, length, address,
+                                        addr_is_4b, kDifSpiHostWidthQuad);
 }
 
 status_t spi_flash_testutils_read_op(dif_spi_host_t *spih, uint8_t opcode,

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -228,6 +228,7 @@ status_t spi_flash_testutils_program_page(dif_spi_host_t *spih,
  * Does not return until the programming operation completes.
  *
  * @param spih A SPI host handle.
+ * @param opcode The program page quad opcode as it varies across parts.
  * @param payload A pointer to the payload to be written to the page.
  * @param length Number of bytes in the payload. Must be less than or equal to
  *               256 bytes.
@@ -239,6 +240,7 @@ status_t spi_flash_testutils_program_page(dif_spi_host_t *spih,
  */
 OT_WARN_UNUSED_RESULT
 status_t spi_flash_testutils_program_page_quad(dif_spi_host_t *spih,
+                                               uint8_t opcode,
                                                const void *payload,
                                                size_t length, uint32_t address,
                                                bool addr_is_4b);

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -188,12 +188,14 @@ status_t spi_flash_testutils_erase_sector(dif_spi_host_t *spih,
  *                Note that an address + length that crosses a page boundary may
  *                wrap around to the start of the page.
  * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ * @param write_width The width of the write transaction.
  * @return status_t containing either OK or an error.
  */
 OT_WARN_UNUSED_RESULT
 status_t spi_flash_testutils_program_op(dif_spi_host_t *spih, uint8_t opcode,
                                         const void *payload, size_t length,
-                                        uint32_t address, bool addr_is_4b);
+                                        uint32_t address, bool addr_is_4b,
+                                        dif_spi_host_width_t write_width);
 
 /**
  * Perform full Page Program sequence via the standard page program opcode.
@@ -217,6 +219,29 @@ OT_WARN_UNUSED_RESULT
 status_t spi_flash_testutils_program_page(dif_spi_host_t *spih,
                                           const void *payload, size_t length,
                                           uint32_t address, bool addr_is_4b);
+/**
+ * Perform full Page Program sequence via the quad page program opcode.
+ * The sequence includes the Write Enable and Page Program commands,
+ * and then polls the status registers in a loop until the WIP bit
+ * clears.
+ *
+ * Does not return until the programming operation completes.
+ *
+ * @param spih A SPI host handle.
+ * @param payload A pointer to the payload to be written to the page.
+ * @param length Number of bytes in the payload. Must be less than or equal to
+ *               256 bytes.
+ * @param address The start address where the payload programming should begin.
+ *                Note that an address + length that crosses a page boundary may
+ *                wrap around to the start of the page.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ * @return status_t containing either OK or an error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t spi_flash_testutils_program_page_quad(dif_spi_host_t *spih,
+                                               const void *payload,
+                                               size_t length, uint32_t address,
+                                               bool addr_is_4b);
 
 /**
  * Perform a read via the requested opcode.

--- a/sw/device/lib/testing/spi_flash_testutils.h
+++ b/sw/device/lib/testing/spi_flash_testutils.h
@@ -172,6 +172,35 @@ status_t spi_flash_testutils_erase_sector(dif_spi_host_t *spih,
                                           uint32_t address, bool addr_is_4b);
 
 /**
+ * Perform full 32 kB block erase.
+ * The sequence includes the Write Enable and Block Erase commands,
+ * and then polls the status registers in a loop until the WIP
+ * bit clears.
+ * Does not return until the erase completes.
+ *
+ * @param spih A SPI host handle.
+ * @param address An address contained within the desired block.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ * @return status_t containing either OK or an error.
+ */
+status_t spi_flash_testutils_erase_block32k(dif_spi_host_t *spih,
+                                            uint32_t address, bool addr_is_4b);
+
+/**
+ * Perform full 64 kB block erase.
+ * The sequence includes the Write Enable and Block Erase commands,
+ * and then polls the status registers in a loop until the WIP
+ * bit clears.
+ * Does not return until the erase completes.
+ *
+ * @param spih A SPI host handle.
+ * @param address An address contained within the desired block.
+ * @param addr_is_4b True if `address` is 4 bytes long, else 3 bytes.
+ * @return status_t containing either OK or an error.
+ */
+status_t spi_flash_testutils_erase_block64k(dif_spi_host_t *spih,
+                                            uint32_t address, bool addr_is_4b);
+/**
  * Perform full Page Program sequence via the requested opcode.
  * The sequence includes the Write Enable and Page Program commands,
  * and then polls the status registers in a loop until the WIP bit

--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -110,11 +110,11 @@ char *ottf_task_get_self_name(void);
  * Execute a test function, profile the execution and log the test result.
  * Update the result value if there is a failure code.
  */
-#define EXECUTE_TEST(result_, test_function_)                            \
+#define EXECUTE_TEST(result_, test_function_, ...)                       \
   do {                                                                   \
     LOG_INFO("Starting test " #test_function_ "...");                    \
     uint64_t t_start_ = ibex_mcycle_read();                              \
-    status_t local_status = INTO_STATUS(test_function_());               \
+    status_t local_status = INTO_STATUS(test_function_(__VA_ARGS__));    \
     uint64_t cycles_ = ibex_mcycle_read() - t_start_;                    \
     CHECK(cycles_ <= UINT32_MAX);                                        \
     CHECK(kClockFreqCpuHz <= UINT32_MAX, "");                            \

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1714,6 +1714,26 @@ opentitan_functest(
     ],
 )
 
+cc_library(
+    name = "spi_host_flash_test_impl",
+    srcs = ["spi_host_flash_test_impl.c"],
+    hdrs = ["spi_host_flash_test_impl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
+    ],
+)
+
 opentitan_functest(
     name = "spi_host_smoketest",
     srcs = ["spi_host_smoketest.c"],
@@ -1722,6 +1742,7 @@ opentitan_functest(
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
+        ":spi_host_flash_test_impl",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1759,6 +1759,27 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "spi_host_winbond_flash_test",
+    srcs = ["spi_host_winbond_flash_test.c"],
+    targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
+    deps = [
+        ":spi_host_flash_test_impl",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "spi_host_irq_test",
     srcs = ["spi_host_irq_test.c"],
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -119,6 +119,28 @@ status_t test_page_program(dif_spi_host_t *spi) {
   return OK_STATUS();
 }
 
+status_t test_page_program_quad(dif_spi_host_t *spi, uint8_t opcode) {
+  enum {
+
+    kPageSize = 256,
+    kAddress = kPageSize * 10
+  };
+  TRY(spi_flash_testutils_erase_sector(spi, kAddress, false));
+
+  TRY(spi_flash_testutils_program_page_quad(
+      spi, opcode, kGettysburgPrelude, sizeof(kGettysburgPrelude),
+      /*address=*/kAddress, /*addr_is_4b=*/false));
+
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
+                                  sizeof(buf), kAddress,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/1,
+                                  /*dummy=*/0));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
 // Read the flash device using the "fast read" opcode.
 status_t test_fast_read(dif_spi_host_t *spi) {
   uint8_t buf[256];

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -64,6 +64,17 @@ status_t test_read_sfdp(dif_spi_host_t *spi) {
   return OK_STATUS();
 }
 
+status_t test_read_jedec(dif_spi_host_t *spi, uint16_t device_id,
+                         uint8_t manufacture_id) {
+  spi_flash_testutils_jedec_id_t jdec;
+  TRY(spi_flash_testutils_read_id(spi, &jdec));
+  TRY_CHECK(jdec.device_id == device_id, "Expected %x, got %x!", device_id,
+            jdec.device_id);
+  TRY_CHECK(jdec.manufacturer_id == manufacture_id, "Expected %x, got %x!",
+            manufacture_id, jdec.manufacturer_id);
+  return OK_STATUS();
+}
+
 status_t test_sector_erase(dif_spi_host_t *spi) {
   TRY(spi_flash_testutils_erase_sector(spi, 0, false));
 

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -237,3 +237,34 @@ status_t test_erase_32k_block(dif_spi_host_t *spi) {
 
   return OK_STATUS();
 }
+
+status_t test_erase_64k_block(dif_spi_host_t *spi) {
+  enum { kPageSize = 256, kBlockSize = 64 * 1024, kAddress = kBlockSize * 5 };
+  TRY(spi_flash_testutils_erase_block64k(spi, kAddress, false));
+
+  uint8_t expected[256];
+  memset(expected, 0xFF, sizeof(expected));
+  uint8_t dummy[256];
+  memset(dummy, 0x5A, sizeof(dummy));
+
+  for (size_t addr = kAddress; addr < kAddress + kBlockSize;
+       addr += kPageSize) {
+    uint8_t buf[256] = {0};
+    // Check that all the pages in the block actually got erased.
+    TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
+                                    sizeof(buf),
+                                    /*address=*/addr,
+                                    /*addr_is_4b=*/false,
+                                    /*width=*/1,
+                                    /*dummy=*/0));
+    TRY_CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
+
+    // Write dummy data to make sure that the next time the block will really be
+    // erased.
+    TRY(spi_flash_testutils_program_page(spi, dummy, sizeof(dummy),
+                                         /*address=*/addr,
+                                         /*addr_is_4b=*/false));
+  }
+
+  return OK_STATUS();
+}

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <assert.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// A data pattern to program into the chip:
+// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
+static const char kGettysburgPrelude[256] =
+    "Four score and seven years ago our fathers brought forth on this "
+    "continent, a new nation, conceived in Liberty, and dedicated to the "
+    "proposition that all men are created equal.";
+
+// The SFDP structure we'll read out of the chip.
+typedef struct sfdp {
+  union {
+    struct {
+      spi_flash_testutils_sfdp_header_t header;
+      spi_flash_testutils_parameter_header_t param;
+    };
+    uint8_t data[256];
+  };
+  uint32_t *bfpt;
+} sfdp_t;
+
+sfdp_t sfdp;
+
+status_t test_software_reset(dif_spi_host_t *spi) {
+  // The software reset sequence is two transactions: RSTEN followed by RST.
+  dif_spi_host_segment_t op = {
+      .type = kDifSpiHostSegmentTypeOpcode,
+      .opcode = kSpiDeviceFlashOpResetEnable,
+  };
+  TRY(dif_spi_host_transaction(spi, /*cs_id=*/0, &op, 1));
+
+  op.opcode = kSpiDeviceFlashOpResetEnable;
+  TRY(dif_spi_host_transaction(spi, /*cs_id=*/0, &op, 1));
+  return OK_STATUS();
+}
+
+status_t test_read_sfdp(dif_spi_host_t *spi) {
+  TRY(spi_flash_testutils_read_sfdp(spi, 0, sfdp.data, sizeof(sfdp.data)));
+  LOG_INFO("SFDP signature is 0x%08x", sfdp.header.signature);
+  CHECK(sfdp.header.signature == kSfdpSignature,
+        "Expected to find the SFDP signature!");
+
+  uint32_t bfpt_offset = (uint32_t)sfdp.param.table_pointer[0] |
+                         (uint32_t)(sfdp.param.table_pointer[1] << 8) |
+                         (uint32_t)(sfdp.param.table_pointer[2] << 16);
+  sfdp.bfpt = (uint32_t *)(sfdp.data + bfpt_offset);
+  return OK_STATUS();
+}
+
+status_t test_sector_erase(dif_spi_host_t *spi) {
+  TRY(spi_flash_testutils_erase_sector(spi, 0, false));
+
+  // Check that the first page of flash actually got erased.
+  uint8_t buf[256] = {0};
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
+                                  sizeof(buf),
+                                  /*address=*/0,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/1,
+                                  /*dummy=*/0));
+  uint8_t expected[256];
+  memset(expected, 0xFF, sizeof(expected));
+  TRY_CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
+  return OK_STATUS();
+}
+
+status_t test_enable_quad_mode(dif_spi_host_t *spi) {
+  if (sfdp.param.length < 14) {
+    return INVALID_ARGUMENT();
+  }
+  uint8_t mech =
+      (uint8_t)bitfield_field32_read(sfdp.bfpt[14], SPI_FLASH_QUAD_ENABLE);
+  LOG_INFO("Setting the EEPROM's QE bit via mechanism %d", mech);
+  TRY(spi_flash_testutils_quad_enable(spi, mech, /*enabled=*/true));
+  return OK_STATUS();
+}
+
+// Program a pattern into the flash part and read it back.
+status_t test_page_program(dif_spi_host_t *spi) {
+  TRY(spi_flash_testutils_program_page(spi, kGettysburgPrelude,
+                                       sizeof(kGettysburgPrelude),
+                                       /*address=*/0, /*addr_is_4b=*/0));
+
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
+                                  sizeof(buf), 0,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/1,
+                                  /*dummy=*/0));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast read" opcode.
+status_t test_fast_read(dif_spi_host_t *spi) {
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadFast, buf,
+                                  sizeof(buf), 0,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/1,
+                                  /*dummy=*/8));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast dual read" opcode.
+status_t test_dual_read(dif_spi_host_t *spi) {
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadDual, buf,
+                                  sizeof(buf), 0,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/2,
+                                  /*dummy=*/8));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+// Read the flash device using the "fast quad read" opcode.
+status_t test_quad_read(dif_spi_host_t *spi) {
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadQuad, buf,
+                                  sizeof(buf), 0,
+                                  /*addr_is_4b=*/false,
+                                  /*width=*/4,
+                                  /*dummy=*/8));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return OK_STATUS();
+}
+
+bool is_4_bytes_address_mode_supported(void) {
+  enum { kSupportOnly3Bytes, kSupport3and4Bytes, kSupportOnly4Bytes };
+  uint32_t address_mode =
+      bitfield_field32_read(sfdp.bfpt[0], SPI_FLASH_ADDRESS_MODE);
+  return (address_mode == kSupport3and4Bytes ||
+          address_mode == kSupportOnly4Bytes);
+}
+
+status_t test_4bytes_address(dif_spi_host_t *spi) {
+  enum { kAddress = 0x01000100, kSectorSize = 4096 };
+  static_assert(kAddress % kSectorSize,
+                "Should be at the beginning of the sector.");
+
+  TRY(spi_flash_testutils_enter_4byte_address_mode(spi));
+  TRY(spi_flash_testutils_erase_sector(spi, kAddress, true));
+
+  TRY(spi_flash_testutils_program_page(spi, kGettysburgPrelude,
+                                       sizeof(kGettysburgPrelude), kAddress,
+                                       /*addr_is_4b=*/true));
+
+  uint8_t buf[256];
+  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
+                                  sizeof(buf), kAddress,
+                                  /*addr_is_4b=*/true,
+                                  /*width=*/1,
+                                  /*dummy=*/0));
+  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
+  return spi_flash_testutils_exit_4byte_address_mode(spi);
+}

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -117,4 +117,12 @@ status_t test_page_program_quad(dif_spi_host_t *spi, uint8_t opcode);
  */
 status_t test_erase_32k_block(dif_spi_host_t *spi);
 
+/**
+ * Erase a 64kB block and read it back to check if was erased.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_erase_64k_block(dif_spi_host_t *spi);
+
 #endif  // OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -109,4 +109,12 @@ status_t test_4bytes_address(dif_spi_host_t *spi);
  */
 status_t test_page_program_quad(dif_spi_host_t *spi, uint8_t opcode);
 
+/**
+ * Erase a 32kB block and read it back to check if was erased.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_erase_32k_block(dif_spi_host_t *spi);
+
 #endif  // OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_
+#define OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+
+/**
+ * Send the sw_reset command.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_software_reset(dif_spi_host_t *spi);
+
+/**
+ * Read the sfdp header and check the signature.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_read_sfdp(dif_spi_host_t *spi);
+
+/**
+ * Send the sector erase command, read a page that it was erased.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_sector_erase(dif_spi_host_t *spi);
+
+/**
+ * Send the enable quad mode command.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_enable_quad_mode(dif_spi_host_t *spi);
+
+/**
+ * Program a complete page and read it back to verify.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_page_program(dif_spi_host_t *spi);
+
+/**
+ * Perform a fast read operation.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_fast_read(dif_spi_host_t *spi);
+
+/**
+ * Perform a dual read operation.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_dual_read(dif_spi_host_t *spi);
+
+/**
+ * Perform a quad read operation.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_quad_read(dif_spi_host_t *spi);
+
+/**
+ * Check if the flash supports 4-byte addressing.
+ *
+ * @param spi A spi host handler.
+ * @return True if 4-byte addressing mode is supported.
+ */
+bool is_4_bytes_address_mode_supported(void);
+
+/**
+ * Enable 4-byte addressing mode, write and read to a page that needs 4 byes to
+ * be addressed and disables the the 4-bytes addressing mode.
+ *
+ * @param spi A spi host handler.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_4bytes_address(dif_spi_host_t *spi);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -33,6 +33,17 @@ status_t test_read_sfdp(dif_spi_host_t *spi);
 status_t test_sector_erase(dif_spi_host_t *spi);
 
 /**
+ * Read jedec and check the device_id and manufacturer_id.
+ *
+ * @param spi A spi host handler.
+ * @param device_id The expected device_id.
+ * @param manufacture_id The expected manufacture_id.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_read_jedec(dif_spi_host_t *spi, uint16_t device_id,
+                         uint16_t manufacture_id);
+
+/**
  * Send the enable quad mode command.
  *
  * @param spi A spi host handler.

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -100,4 +100,13 @@ bool is_4_bytes_address_mode_supported(void);
  */
 status_t test_4bytes_address(dif_spi_host_t *spi);
 
+/**
+ * Write and read in order to compare a page using quad mode.
+ *
+ * @param spi A spi host handler.
+ * @param opcode The opcode used by the part-number for quad page program.
+ * @return status_t containing either OK or an error.
+ */
+status_t test_page_program_quad(dif_spi_host_t *spi, uint8_t opcode);
+
 #endif  // OPENTITAN_SW_DEVICE_TESTS_SPI_HOST_FLASH_TEST_IMPL_H_

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <assert.h>
 
+#include "spi_host_flash_test_impl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
@@ -22,163 +23,6 @@ static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
               "This test assumes the target platform is little endian.");
 
 OTTF_DEFINE_TEST_CONFIG();
-
-// A data pattern to program into the chip:
-// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
-static const char kGettysburgPrelude[256] =
-    "Four score and seven years ago our fathers brought forth on this "
-    "continent, a new nation, conceived in Liberty, and dedicated to the "
-    "proposition that all men are created equal.";
-
-// The SFDP structure we'll read out of the chip.
-typedef struct sfdp {
-  union {
-    struct {
-      spi_flash_testutils_sfdp_header_t header;
-      spi_flash_testutils_parameter_header_t param;
-    };
-    uint8_t data[256];
-  };
-  uint32_t *bfpt;
-} sfdp_t;
-
-sfdp_t sfdp;
-
-status_t test_software_reset(dif_spi_host_t *spi) {
-  // The software reset sequence is two transactions: RSTEN followed by RST.
-  dif_spi_host_segment_t op = {
-      .type = kDifSpiHostSegmentTypeOpcode,
-      .opcode = kSpiDeviceFlashOpResetEnable,
-  };
-  TRY(dif_spi_host_transaction(spi, /*cs_id=*/0, &op, 1));
-
-  op.opcode = kSpiDeviceFlashOpResetEnable;
-  TRY(dif_spi_host_transaction(spi, /*cs_id=*/0, &op, 1));
-  return OK_STATUS();
-}
-
-status_t test_read_sfdp(dif_spi_host_t *spi) {
-  TRY(spi_flash_testutils_read_sfdp(spi, 0, sfdp.data, sizeof(sfdp.data)));
-  LOG_INFO("SFDP signature is 0x%08x", sfdp.header.signature);
-  CHECK(sfdp.header.signature == kSfdpSignature,
-        "Expected to find the SFDP signature!");
-
-  uint32_t bfpt_offset = (uint32_t)sfdp.param.table_pointer[0] |
-                         (uint32_t)(sfdp.param.table_pointer[1] << 8) |
-                         (uint32_t)(sfdp.param.table_pointer[2] << 16);
-  sfdp.bfpt = (uint32_t *)(sfdp.data + bfpt_offset);
-  return OK_STATUS();
-}
-
-status_t test_erase(dif_spi_host_t *spi) {
-  TRY(spi_flash_testutils_erase_sector(spi, 0, false));
-
-  // Check that the first page of flash actually got erased.
-  uint8_t buf[256] = {0};
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
-                                  sizeof(buf),
-                                  /*address=*/0,
-                                  /*addr_is_4b=*/false,
-                                  /*width=*/1,
-                                  /*dummy=*/0));
-  uint8_t expected[256];
-  memset(expected, 0xFF, sizeof(expected));
-  TRY_CHECK_ARRAYS_EQ(buf, expected, ARRAYSIZE(expected));
-  return OK_STATUS();
-}
-
-status_t test_enable_quad_mode(dif_spi_host_t *spi) {
-  if (sfdp.param.length < 14) {
-    return INVALID_ARGUMENT();
-  }
-  uint8_t mech =
-      (uint8_t)bitfield_field32_read(sfdp.bfpt[14], SPI_FLASH_QUAD_ENABLE);
-  LOG_INFO("Setting the EEPROM's QE bit via mechanism %d", mech);
-  TRY(spi_flash_testutils_quad_enable(spi, mech, /*enabled=*/true));
-  return OK_STATUS();
-}
-
-// Program a pattern into the flash part and read it back.
-status_t test_page_program(dif_spi_host_t *spi) {
-  TRY(spi_flash_testutils_program_page(spi, kGettysburgPrelude,
-                                       sizeof(kGettysburgPrelude),
-                                       /*address=*/0, /*addr_is_4b=*/0));
-
-  uint8_t buf[256];
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
-                                  sizeof(buf), 0,
-                                  /*addr_is_4b=*/false,
-                                  /*width=*/1,
-                                  /*dummy=*/0));
-  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
-  return OK_STATUS();
-}
-
-// Read the flash device using the "fast read" opcode.
-status_t test_fast_read(dif_spi_host_t *spi) {
-  uint8_t buf[256];
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadFast, buf,
-                                  sizeof(buf), 0,
-                                  /*addr_is_4b=*/false,
-                                  /*width=*/1,
-                                  /*dummy=*/8));
-  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
-  return OK_STATUS();
-}
-
-// Read the flash device using the "fast dual read" opcode.
-status_t test_dual_read(dif_spi_host_t *spi) {
-  uint8_t buf[256];
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadDual, buf,
-                                  sizeof(buf), 0,
-                                  /*addr_is_4b=*/false,
-                                  /*width=*/2,
-                                  /*dummy=*/8));
-  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
-  return OK_STATUS();
-}
-
-// Read the flash device using the "fast quad read" opcode.
-status_t test_quad_read(dif_spi_host_t *spi) {
-  uint8_t buf[256];
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadQuad, buf,
-                                  sizeof(buf), 0,
-                                  /*addr_is_4b=*/false,
-                                  /*width=*/4,
-                                  /*dummy=*/8));
-  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
-  return OK_STATUS();
-}
-
-static bool is_4_bytes_address_mode_supported(void) {
-  enum { kSupportOnly3Bytes, kSupport3and4Bytes, kSupportOnly4Bytes };
-  uint32_t address_mode =
-      bitfield_field32_read(sfdp.bfpt[0], SPI_FLASH_ADDRESS_MODE);
-  return (address_mode == kSupport3and4Bytes ||
-          address_mode == kSupportOnly4Bytes);
-}
-
-status_t test_4bytes_address(dif_spi_host_t *spi) {
-  enum { kAddress = 0x01000100, kSectorSize = 4096 };
-  static_assert(kAddress % kSectorSize,
-                "Should be at the beginning of the sector.");
-
-  TRY(spi_flash_testutils_enter_4byte_address_mode(spi));
-  TRY(spi_flash_testutils_erase_sector(spi, kAddress, true));
-
-  TRY(spi_flash_testutils_program_page(spi, kGettysburgPrelude,
-                                       sizeof(kGettysburgPrelude), kAddress,
-                                       /*addr_is_4b=*/true));
-
-  uint8_t buf[256];
-  TRY(spi_flash_testutils_read_op(spi, kSpiDeviceFlashOpReadNormal, buf,
-                                  sizeof(buf), kAddress,
-                                  /*addr_is_4b=*/true,
-                                  /*width=*/1,
-                                  /*dummy=*/0));
-  TRY_CHECK_ARRAYS_EQ(buf, kGettysburgPrelude, ARRAYSIZE(kGettysburgPrelude));
-  return spi_flash_testutils_exit_4byte_address_mode(spi);
-}
 
 bool test_main(void) {
   dif_spi_host_t spi_host;
@@ -200,7 +44,7 @@ bool test_main(void) {
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
-  EXECUTE_TEST(result, test_erase, &spi_host);
+  EXECUTE_TEST(result, test_sector_erase, &spi_host);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -62,5 +62,6 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_quad_read, &spi_host);
   EXECUTE_TEST(result, test_page_program_quad, &spi_host,
                kWinbondPageQuadProgramOpcode);
+  EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
   return status_ok(result);
 }

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -41,7 +41,11 @@ bool test_main(void) {
                "SPI_HOST config failed!");
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(&spi_host, true));
 
-  enum { kDeviceId = 0x2180, kManufactureId = 0xef };
+  enum {
+    kDeviceId = 0x2180,
+    kManufactureId = 0xef,
+    kWinbondPageQuadProgramOpcode = 0x32,
+  };
 
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, test_software_reset, &spi_host);
@@ -56,5 +60,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_fast_read, &spi_host);
   EXECUTE_TEST(result, test_dual_read, &spi_host);
   EXECUTE_TEST(result, test_quad_read, &spi_host);
+  EXECUTE_TEST(result, test_page_program_quad, &spi_host,
+               kWinbondPageQuadProgramOpcode);
   return status_ok(result);
 }

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -41,10 +41,13 @@ bool test_main(void) {
                "SPI_HOST config failed!");
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(&spi_host, true));
 
+  enum { kDeviceId = 0x2180, kManufactureId = 0xef };
+
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -47,5 +47,11 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
+  if (is_4_bytes_address_mode_supported()) {
+    EXECUTE_TEST(result, test_4bytes_address, &spi_host);
+  }
+  EXECUTE_TEST(result, test_fast_read, &spi_host);
+  EXECUTE_TEST(result, test_dual_read, &spi_host);
+  EXECUTE_TEST(result, test_quad_read, &spi_host);
   return status_ok(result);
 }

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -63,5 +63,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_page_program_quad, &spi_host,
                kWinbondPageQuadProgramOpcode);
   EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
+  EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
+
   return status_ok(result);
 }


### PR DESCRIPTION
This PR:
 - Refactor the `EXECUTE_TEST` to accept and forward parameter to the test.
 - Refactor the spi host flash smoke test to pass the spi_host handler as an argument.
 - Refactor the spi host flash smoke test and move the tests implementation to a new file.
 - create a new test called winbond as we communicate to a winbond memory in the FPGA.
 - Add new commands to the winbond test.