### PR TITLE
[hsmtool] Add `exec` command

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "hsmlib",
     srcs = [
+        "src/commands/exec.rs",
         "src/commands/mod.rs",
         "src/commands/object/destroy.rs",
         "src/commands/object/list.rs",

--- a/sw/host/hsmtool/src/commands/exec.rs
+++ b/sw/host/hsmtool/src/commands/exec.rs
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use cryptoki::context::Pkcs11;
+use cryptoki::session::Session;
+use serde::{Deserialize, Serialize};
+use serde_annotate::{Annotate, Document};
+use std::any::Any;
+use std::path::PathBuf;
+use thiserror::Error;
+
+use crate::commands::{BasicResult, Dispatch};
+
+#[derive(clap::Args, Debug, Serialize, Deserialize)]
+pub struct Exec {
+    file: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecResult {
+    pub command: String,
+    pub result: Box<dyn Annotate>,
+}
+
+#[derive(Debug, Error)]
+#[error("Error executing command list: {error:?}")]
+pub struct ExecError {
+    pub error: anyhow::Error,
+    pub result: Document,
+}
+
+#[typetag::serde(name = "__exec__")]
+impl Dispatch for Exec {
+    fn run(
+        &self,
+        context: &dyn Any,
+        pkcs11: &Pkcs11,
+        session: Option<&Session>,
+    ) -> Result<Box<dyn Annotate>> {
+        let commands = std::fs::read_to_string(&self.file)?;
+        let commands = serde_annotate::from_str::<Vec<Box<dyn Dispatch>>>(&commands)?;
+
+        // Execute all of the commands, stopping if an error is encountered.
+        let mut status = Vec::<ExecResult>::new();
+        for command in commands {
+            let name = command.typetag_name().to_string();
+            log::info!("Executing command {name}");
+            match command.run(context, pkcs11, session) {
+                Ok(r) => status.push(ExecResult {
+                    command: name,
+                    result: r,
+                }),
+                Err(e) => {
+                    status.push(ExecResult {
+                        command: name,
+                        result: BasicResult::from_error(&e),
+                    });
+                    return Err(ExecError {
+                        error: e,
+                        result: serde_annotate::serialize(&status)?,
+                    }
+                    .into());
+                }
+            }
+        }
+        Ok(Box::new(status))
+    }
+}

--- a/sw/host/hsmtool/src/commands/object/mod.rs
+++ b/sw/host/hsmtool/src/commands/object/mod.rs
@@ -39,4 +39,15 @@ impl Dispatch for Object {
             Object::Update(x) => x.run(context, pkcs11, session),
         }
     }
+    fn leaf(&self) -> &dyn Dispatch
+    where
+        Self: Sized,
+    {
+        match self {
+            Object::Destroy(x) => x.leaf(),
+            Object::List(x) => x.leaf(),
+            Object::Show(x) => x.leaf(),
+            Object::Update(x) => x.leaf(),
+        }
+    }
 }

--- a/sw/host/hsmtool/src/commands/rsa/mod.rs
+++ b/sw/host/hsmtool/src/commands/rsa/mod.rs
@@ -48,4 +48,18 @@ impl Dispatch for Rsa {
             Rsa::Verify(x) => x.run(context, pkcs11, session),
         }
     }
+    fn leaf(&self) -> &dyn Dispatch
+    where
+        Self: Sized,
+    {
+        match self {
+            Rsa::Decrypt(x) => x.leaf(),
+            Rsa::Encrypt(x) => x.leaf(),
+            Rsa::Generate(x) => x.leaf(),
+            Rsa::Export(x) => x.leaf(),
+            Rsa::Import(x) => x.leaf(),
+            Rsa::Sign(x) => x.leaf(),
+            Rsa::Verify(x) => x.leaf(),
+        }
+    }
 }

--- a/sw/host/hsmtool/src/hsmtool.rs
+++ b/sw/host/hsmtool/src/hsmtool.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use cryptoki::session::UserType;
 use log::LevelFilter;
 
-use hsmtool::commands::{print_result, Commands, Dispatch, Format};
+use hsmtool::commands::{print_command, print_result, Commands, Dispatch, Format};
 use hsmtool::module;
 use hsmtool::util::attribute::AttributeMap;
 
@@ -46,6 +46,13 @@ struct Args {
     #[arg(short, long, env = "HSMTOOL_PIN", help = "Pin")]
     pin: Option<String>,
 
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Show JSON encode of the command"
+    )]
+    show_json: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -64,6 +71,10 @@ fn main() -> Result<()> {
     log::set_max_level(LevelFilter::Off);
     let _ = AttributeMap::all();
     log::set_max_level(args.logging);
+
+    if args.show_json {
+        return print_command(args.format, args.color, args.command.leaf());
+    }
 
     let session = if let Some(token) = &args.token {
         Some(module::connect(

--- a/sw/host/hsmtool/src/util/attribute/attr.rs
+++ b/sw/host/hsmtool/src/util/attribute/attr.rs
@@ -8,13 +8,11 @@ use cryptoki::session::Session;
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-use super::AttributeError;
-
 use super::AttrData;
+use super::AttributeError;
 use super::AttributeType;
 use super::CertificateType;
 use super::Date;
@@ -314,11 +312,10 @@ impl FromStr for AttributeMap {
     /// Parses an `AttributeMap` from a string or file.
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if let Some(path) = s.strip_prefix('@') {
-            Ok(serde_json::from_reader::<_, AttributeMap>(File::open(
-                path,
-            )?)?)
+            let data = std::fs::read_to_string(path)?;
+            Ok(serde_annotate::from_str(&data)?)
         } else {
-            Ok(serde_json::from_str::<AttributeMap>(s)?)
+            Ok(serde_annotate::from_str(s)?)
         }
     }
 }

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -17,7 +17,10 @@ crates_vendor(
         )],
         "cryptoki": [crate.annotation(
             patch_args = ["-p2"],
-            patches = ["@//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch"],
+            patches = [
+                "@//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
+                "@//third_party/rust/patches:cryptoki-pr-116.patch",
+            ],
         )],
         "cryptoki-sys": [crate.annotation(
             additive_build_file_content = """

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -1038,6 +1038,7 @@ def crate_repositories():
             "-p2",
         ],
         patches = [
+            "@//third_party/rust/patches:cryptoki-pr-116.patch",
             "@//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
         ],
         sha256 = "7da58729f419780655e9b82f5c5e0c3eba3aab46ea48f610cc615b10d5baad53",

--- a/third_party/rust/patches/cryptoki-pr-116.patch
+++ b/third_party/rust/patches/cryptoki-pr-116.patch
@@ -1,0 +1,13 @@
+diff --git a/cryptoki/src/object.rs b/cryptoki/src/object.rs
+index 17f6c6d..7c7b94d 100644
+--- a/cryptoki/src/object.rs
++++ b/cryptoki/src/object.rs
+@@ -343,7 +343,7 @@ impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
+             CKA_APPLICATION => Ok(AttributeType::Application),
+             CKA_ATTR_TYPES => Ok(AttributeType::AttrTypes),
+             CKA_BASE => Ok(AttributeType::Base),
+-            CKA_CERTIFICATE_CATEGORY => Ok(AttributeType::CertificateType),
++            CKA_CERTIFICATE_TYPE => Ok(AttributeType::CertificateType),
+             CKA_CHECK_VALUE => Ok(AttributeType::CheckValue),
+             CKA_CLASS => Ok(AttributeType::Class),
+             CKA_COEFFICIENT => Ok(AttributeType::Coefficient),

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -27,7 +27,7 @@ def rust_repos(rules_rust = None, safe_ftdi = None, serde_annotate = None):
     http_archive_or_local(
         name = "lowrisc_serde_annotate",
         local = serde_annotate,
-        sha256 = "8772091928c47bf8c22e8ecdec049e1558993c9855ff9fd4a05daad77596ce9e",
-        strip_prefix = "serde-annotate-0.0.7",
-        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.7.tar.gz",
+        sha256 = "ea8bbf4f5cedf7024d7f873798299cf6bf14f98bf8cb50eb00893f68f7f681bb",
+        strip_prefix = "serde-annotate-0.0.8",
+        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.8.tar.gz",
     )


### PR DESCRIPTION
1. Add an `exec` command for executing batches of commands in a single session.
2. Add a `--show-json` option to print the json representation of a command.