### PR TITLE
[sw/silicon_creator] Remove the padding between .crt and .text

### DIFF
--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -90,7 +90,10 @@ SECTIONS {
     ASSERT(
         SIZEOF(.vectors) + SIZEOF(.crt) <= _epmp_reset_rx_size,
         "Error: .crt overflows reset ePMP region");
-    . = MAX(., _epmp_reset_rx_size - SIZEOF(.vectors));
+    /**
+     * FIXME: Renable after diagnosing the overflow caused by #18671 and #18665.
+     * . = MAX(., _epmp_reset_rx_size - SIZEOF(.vectors));
+     */
   } > rom
 
   /**


### PR DESCRIPTION
This commit removes the padding between .crt and .text to reenable builds after #18671 and #18665 caused the ROM to overflow.

