### PR TITLE
[hw,spi_device,dv] Use register offset and lock offset in TL access

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_mem_parity_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_mem_parity_vseq.sv
@@ -33,10 +33,14 @@ class spi_device_mem_parity_vseq extends spi_device_common_vseq;
       `DV_CHECK(uvm_hdl_read(path, mem_data));
       `DV_CHECK(uvm_hdl_deposit(path, mem_data ^ flip_bits));
       // frontdoor read to check it returns d_error
-      tl_access(.addr(offset << 2), .write(0), .data(data), .mask(get_rand_contiguous_mask()),
+      tl_access(.addr(ral.buffer.get_offset() + (offset << 2)),
+                .write(0),
+                .data(data),
+                .mask(get_rand_contiguous_mask()),
                 .exp_err_rsp(1),
                 // returned data is all 1s when it detects an error
-                .check_exp_data(1), .exp_data('1));
+                .check_exp_data(1),
+                .exp_data({TL_DW{1'b1}}));
     end
   endtask
 endclass : spi_device_mem_parity_vseq

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -112,7 +112,7 @@
     {
       name: "spi_device_mem_parity"
       uvm_test_seq: "spi_device_mem_parity_vseq"
-      run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0"]
+      run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0", "+en_scb_mem_chk=0"]
       reseed: 20
     }
 


### PR DESCRIPTION
- Use buffer block offset and word offset in the TL access check after injecting parity error
- Disable scoreboard mem_model checks as these are enabled even if `en_scb` is set to 0

This PR fixes  `spi_device_mem_parity` failures in https://github.com/lowRISC/opentitan/issues/18364 and is based on https://github.com/lowRISC/opentitan/pull/18678