### PR TITLE
[rom] Remove pwrmgr_all_resets_enable from rom

### DIFF
--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -146,10 +146,6 @@ static rom_error_t rom_init(void) {
   // Update epmp config for debug rom according to lifecycle state.
   rom_epmp_config_debug_rom(lc_state);
 
-  // Enable all resets.
-  pwrmgr_all_resets_enable();
-  SEC_MMIO_WRITE_INCREMENT(kPwrmgrSecMmioAllResetsEnable);
-
   // Re-initialize the watchdog timer.
   watchdog_init(lc_state);
   SEC_MMIO_WRITE_INCREMENT(kWatchdogSecMmioInit);


### PR DESCRIPTION
This is applied as a workaround for #18696 until we root cause the issue.