### PR TITLE
[ci] add rom_e2e_smoketest DV test to private CI

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2019,7 +2019,8 @@
               // "chip_sw_pwrmgr_sleep_power_glitch_reset",
               "chip_sw_pwrmgr_sleep_disabled",
               "chip_sw_csrng_kat_test",
-              "chip_sw_sysrst_ctrl_inputs"]
+              "chip_sw_sysrst_ctrl_inputs",
+              "rom_e2e_smoke"]
     }
   ]
 }


### PR DESCRIPTION
This makes the rom_e2e_smoketest run in DV a blocking test to prevent issues like #18696 caused by #18657.

This was originally avoided due to the test runtime being quite long, but I am giving it test run in CI to see if it is feasible.