### PR TITLE
[top_englishbreakfast] Align OTP fake driver with latest test ROM

### DIFF
--- a/sw/device/lib/testing/test_rom/english_breakfast_fake_driver_funcs.c
+++ b/sw/device/lib/testing/test_rom/english_breakfast_fake_driver_funcs.c
@@ -23,7 +23,7 @@ void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
   };
 }
 
-uint32_t otp_read32(uint32_t address) { return kHardenedBoolTrue; }
+uint32_t otp_read32(uint32_t address) { return kHardenedBoolFalse; }
 
 dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr) {
   return kDifOk;


### PR DESCRIPTION
This change is needed to re-enable bootstrapping on the CW305 board.

This is a follow-up of dcec66a0b60ddf26dab2aeb1a069d4fbbe3dc204.