### PR TITLE
[dvsim] add custom wavefile option

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -178,6 +178,10 @@ class FlowCfg():
         # manage to expand everything.
         partial = self.is_primary_cfg
 
+        # If custom dump script is exist, replace with run_script attribute.
+        if self.args.dump_script is not None:
+            self.run_script = '{proj_root}/' + self.args.dump_script
+
         self.__dict__ = find_and_substitute_wildcards(self.__dict__,
                                                       self.__dict__,
                                                       self.ignored_wildcards,

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -576,6 +576,12 @@ def parse_args():
                              'includes both tests scheduled for run and those '
                              'that are automatically rerun.'))
 
+    waveg.add_argument("--dump-script",
+                       "-ds",
+                       help=('Use user define custom dump script file'
+                             'The custom file should be located in {proj_root}'
+                             'Default file is {proj_root}/hw/dv/tools/sim.tcl'))
+
     covg = parser.add_argument_group('Generating simulation coverage')
 
     covg.add_argument("--cov",


### PR DESCRIPTION
In order to reduce chip test bench debug overhead,
create option to use custom wave file.
usage example :      <regular dvsim command>  -ds "mywave.tcl" or --dump-script "mywave.tcl"
mywave.tcl can be any file name.
If this option is specified, mywave.tcl replace hw/dv/tool/sim.tcl

Sample `mywave.tcl` file for `verdi` user:
This tcl will create dump only on `tb.u_sim_sram.u_sim_sram_if` after 2.7 msec
```
run 2.7ms

fsdbDumpfile "waves.fsdb"
fsdbDumpvars 0 tb.u_sim_sram.u_sim_sram_if +all
fsdbDumpSVA 0 tb.u_sim_sram.u_sim_sram_if

run
quit

```