### PR TITLE
[englishbreakfast] Disable riscv32 bitmanip

### DIFF
--- a/ci/scripts/run-english-breakfast-verilator-tests.sh
+++ b/ci/scripts/run-english-breakfast-verilator-tests.sh
@@ -20,6 +20,7 @@ ci/bazelisk.sh clean
 # Build some other dependencies.
 ci/bazelisk.sh build  \
     --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_ \
+    --features=-rv32_bitmanip \
     //sw/host/opentitantool //hw/ip/otp_ctrl/data:img_rma
 
 # Run the one test.

--- a/hw/top_englishbreakfast/util/prepare_sw.py
+++ b/hw/top_englishbreakfast/util/prepare_sw.py
@@ -180,6 +180,7 @@ def main():
     shell_out([
         REPO_TOP / 'bazelisk.sh',
         'build',
+        '--features=-rv32_bitmanip',
         '--copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_',
     ] + BAZEL_BINARIES)
 


### PR DESCRIPTION
To save gates, the Ibex on English Breakfast does not have bitmanip enabled. In https://github.com/lowRISC/crt/pull/24 we introduce a toolchain feature to control the bitmanip feature which will be enabled by default.