### PR TITLE
[formal/conn] added ability to run external TCL file for CS implementation

### DIFF
--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -54,6 +54,12 @@ if {$env(DUT_TOP) == "chip_earlgrey_asic"} {
   assume -env {top_earlgrey.u_pinmux_aon.reg2hw.mio_pad_sleep_status == '1}
   # Add this assumption to avoid signal inversion in the pad wrappers.
   assume -env {top_earlgrey.u_pinmux_aon.dio_pad_attr_q == '0}
+
+  # run additional assume commands for foundry implementation if needed
+  if {[info exists ::env(PARTNER_TCL)]} {
+    source $env(PARTNER_TCL)
+  }
+
 }
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
CS implementation requires some additional `assume` commands to be executed in connectivity tests.

In order to not expose internal CS design paths, a separate TCL file with those `assume` commands has to be ran from [`conn.tcl`](https://github.com/lowRISC/opentitan/blob/ec30f955f9e332af38ff4d353bf14f789e52408a/hw/formal/tools/jaspergold/conn.tcl#L47).

