### PR TITLE
[ujson] Added crc32 to ujson lib

### DIFF
--- a/sw/device/lib/ujson/BUILD
+++ b/sw/device/lib/ujson/BUILD
@@ -5,6 +5,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:ujson.bzl", "ujson_rust")
+load("//rules:cross_platform.bzl", "dual_cc_device_library_of")
 
 cc_library(
     name = "ujson",
@@ -20,6 +21,7 @@ cc_library(
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:print",
+        dual_cc_device_library_of("//sw/device/silicon_creator/lib:crc32"),
     ],
 )
 

--- a/sw/device/lib/ujson/example_test.cc
+++ b/sw/device/lib/ujson/example_test.cc
@@ -21,6 +21,7 @@ TEST(Derive, FooSerialize) {
   EXPECT_TRUE(status_ok(ujson_serialize_foo(&uj, &foo)));
   EXPECT_EQ(ss.Sink(),
             R"json({"foo":-5,"bar":150000,"message":"Kilroy was here"})json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x1e31c20e);
 }
 
 TEST(Derive, FooDeserialize) {
@@ -31,6 +32,7 @@ TEST(Derive, FooDeserialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
   EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x1e31c20e);
 }
 
 TEST(Derive, FooDeserializeNoFoo) {
@@ -40,6 +42,7 @@ TEST(Derive, FooDeserializeNoFoo) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
   EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x431acc08);
 }
 
 TEST(Derive, FooDeserializeNoMessage) {
@@ -52,6 +55,7 @@ TEST(Derive, FooDeserializeNoMessage) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
   EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xded4ce6);
 }
 
 TEST(Derive, FooDeserializeMessageToLong) {
@@ -62,6 +66,7 @@ TEST(Derive, FooDeserializeMessageToLong) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_foo(&uj, &foo)));
   EXPECT_EQ(memcmp(&foo, &expected, sizeof(foo)), 0);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xfaebc314);
 }
 
 TEST(Derive, FooDeserializeBogusKey) {
@@ -80,6 +85,7 @@ TEST(Derive, RectSerialize) {
   EXPECT_EQ(
       ss.Sink(),
       R"json({"top_left":{"x":10,"y":10},"bottom_right":{"x":60,"y":40}})json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x4b9a0fb1);
 }
 
 TEST(Derive, RectDeserialize) {
@@ -90,6 +96,7 @@ TEST(Derive, RectDeserialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_rect(&uj, &r)));
   EXPECT_EQ(memcmp(&r, &expected, sizeof(r)), 0);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xb11e9dea);
 }
 
 TEST(Derive, MatrixSerialize) {
@@ -101,6 +108,7 @@ TEST(Derive, MatrixSerialize) {
   EXPECT_TRUE(status_ok(ujson_serialize_matrix(&uj, &m)));
   EXPECT_EQ(ss.Sink(),
             R"json({"k":[[0,1,2,3,4],[5,6,7,8,9],[-1,-2,-3,-4,-5]]})json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x927a936);
 }
 
 TEST(Derive, MatrixDeserialize) {
@@ -111,6 +119,7 @@ TEST(Derive, MatrixDeserialize) {
   SourceSink ss(R"json({"k":[[0,1],[2, 3, 4, 5],[-1]]})json");
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_matrix(&uj, &m)));
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xca69b105);
   ujson_serialize_matrix(&uj, &m);
   std::cout << ss.Sink() << "\n\n";
   EXPECT_EQ(memcmp(&m, &expected, sizeof(m)), 0);
@@ -122,16 +131,21 @@ TEST(Derive, DirectionSerialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json("East")json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x20ab69de);
 
   ss.Reset();
+  ujson_crc32_reset(&uj);
   d = kDirectionSouth;
   EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json("South")json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x236b5d67);
 
   ss.Reset();
+  ujson_crc32_reset(&uj);
   d = static_cast<direction>(120);
   EXPECT_TRUE(status_ok(ujson_serialize_direction(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json({"IntValue":120})json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x63cb5f57);
 }
 
 TEST(Derive, DirectionDeserialize) {
@@ -140,14 +154,19 @@ TEST(Derive, DirectionDeserialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
   EXPECT_EQ(d, kDirectionWest);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xb5e93a6b);
 
   ss.Reset(R"json("North")json");
+  ujson_crc32_reset(&uj);
   EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
   EXPECT_EQ(d, kDirectionNorth);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x1f4749b);
 
   ss.Reset(R"json({"IntValue":35})json");
+  ujson_crc32_reset(&uj);
   EXPECT_TRUE(status_ok(ujson_deserialize_direction(&uj, &d)));
   EXPECT_EQ(d, static_cast<direction>(35));
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x86f181c2);
 }
 
 TEST(Derive, FuzzyBoolSerialize) {
@@ -156,16 +175,21 @@ TEST(Derive, FuzzyBoolSerialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json("True")json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x68d3703f);
 
   ss.Reset();
+  ujson_crc32_reset(&uj);
   d = kFuzzyBoolFalse;
   EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json("False")json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x52b000f3);
 
   ss.Reset();
+  ujson_crc32_reset(&uj);
   d = static_cast<fuzzy_bool>(75);
   EXPECT_TRUE(status_ok(ujson_serialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(ss.Sink(), R"json(75)json");
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x876d76e8);
 }
 
 TEST(Derive, FuzzyBoolDeserialize) {
@@ -174,14 +198,19 @@ TEST(Derive, FuzzyBoolDeserialize) {
   ujson_t uj = ss.UJson();
   EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(d, kFuzzyBoolFalse);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x52b000f3);
 
+  ujson_crc32_reset(&uj);
   ss.Reset(R"json("True")json");
   EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(d, kFuzzyBoolTrue);
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0x68d3703f);
 
+  ujson_crc32_reset(&uj);
   ss.Reset(R"json(35)json");
   EXPECT_TRUE(status_ok(ujson_deserialize_fuzzy_bool(&uj, &d)));
   EXPECT_EQ(d, static_cast<fuzzy_bool>(35));
+  EXPECT_EQ(ujson_crc32_finish(&uj), 0xe301b3ec);
 }
 
 }  // namespace

--- a/sw/device/lib/ujson/ujson.h
+++ b/sw/device/lib/ujson/ujson.h
@@ -23,6 +23,8 @@ typedef struct ujson {
   status_t (*getc)(void *);
   /** An internal single character buffer for ungetting a character. */
   int16_t buffer;
+  /** Holds the rolling CRC32 of characters that are sent and received.*/
+  uint32_t crc32;
 } ujson_t;
 
 // clang-format off
@@ -32,6 +34,7 @@ typedef struct ujson {
     .putbuf_ = (putbuf_),                    \
     .getc = (getc_),                         \
     .buffer = -1,                            \
+    .crc32 = UINT32_MAX,                     \
   }
 // clang-format on
 
@@ -72,6 +75,24 @@ status_t ujson_ungetc(ujson_t *uj, char ch);
  * @return OK or an error.
  */
 status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len);
+
+/**
+ * Resets the CRC32 calculation to an initial state.
+ *
+ * @param uj A ujson IO context.
+ */
+void ujson_crc32_reset(ujson_t *uj);
+
+/**
+ * Returns the finished value of a CRC32 calculation.
+ *
+ * Note the state is un-altered by this function.
+ * One must reset before starting a new calculation.
+ *
+ * @param uj A ujson IO context.
+ * @return The final value for the CRC32 calculation.
+ */
+uint32_t ujson_crc32_finish(ujson_t *uj);
 
 /**
  * Compares two strings for equality.

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -341,6 +341,8 @@ dual_cc_library(
         host = ["mock_crc32.h"],
         shared = ["crc32.h"],
     ),
+    # This library is a dependancy of the ujson library.
+    visibility = ["//sw/device/lib/ujson:__pkg__"],
     deps = dual_inputs(
         host = [
             "//sw/device/lib/base:global_mock",


### PR DESCRIPTION
- crc32 calculations to ujson serialisers and deserialisers.
- crc32_t created so these calculations can be serialised and deserialised.

Yet to do:
- Add crc checks to the roundtrip test
- Add crc checks to `RESP_OK/_ERR` macros and the opentitantool.

Part of https://github.com/lowRISC/opentitan/issues/17496