### PR TITLE
[hw,spi_device,dv] Fix issues with  spi_device_flash_and_tpm

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -630,6 +630,10 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     if (intr_cmdfifo) intr_state_val[CmdFifoNotEmpty] = 1;
     if (intr_payload) intr_state_val[PayloadNotEmpty] = 1;
     if (intr_overflow) intr_state_val[PayloadOverflow] = 1;
+    // Wait for register access to complete
+    while(ral.intr_state.is_busy()) begin
+      cfg.clk_rst_vif.wait_clks(1);
+    end
     csr_wr(ral.intr_state, intr_state_val);
 
     if (intr_cmdfifo) `DV_CHECK_GT(cmdfifo_depth_val, 0)
@@ -747,6 +751,10 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
           if (is_watermark) intr_state_val[ReadbufWatermark] = 1;
 
           if (!is_flip && !is_watermark) continue;
+          // Wait for register access to complete
+          while(ral.intr_state.is_busy()) begin
+            cfg.clk_rst_vif.wait_clks(1);
+          end
           csr_wr(ral.intr_state, intr_state_val);
 
           if (is_flip) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -111,6 +111,10 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
     // only clear TPM interrupt, don't clear flash related interrupt,
     // as the other thread processes that one
     intr_state_val[TpmHeaderNotEmpty] = 1;
+    // Wait for register access to complete
+    while(ral.intr_state.is_busy()) begin
+      cfg.clk_rst_vif.wait_clks(1);
+    end
     csr_wr(ral.intr_state, intr_state_val);
   endtask : clear_tpm_interrupt
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -719,7 +719,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     bit [31:0] payload_start_addr = get_converted_addr(PAYLOAD_FIFO_START_ADDR);
     int payload_depth_exp;
     upload_cmd_q.push_back(item.opcode);
-    update_pending_intr_w_delay(CmdFifoNotEmpty);
+    update_pending_intr_w_delay(.intr(CmdFifoNotEmpty), .delay_cyc(4));
 
     if (item.address_q.size > 0) begin
       bit[31:0] addr = convert_addr_from_byte_queue(item.address_q);
@@ -941,7 +941,11 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
   // must match.
   virtual function void update_pending_intr_w_delay(spi_device_intr_e intr, int delay_cyc = 3);
     fork begin
+      `uvm_info(`gfn,
+        $sformatf("Wait %0d cycles to enable compare of %s interrupt",delay_cyc, intr.name()),
+        UVM_MEDIUM)
       cfg.clk_rst_vif.wait_n_clks(delay_cyc);
+      `uvm_info(`gfn,$sformatf("Wait done; Enable compare of %s", intr.name()), UVM_MEDIUM)
       intr_trigger_pending[intr] = 1;
     end join_none
   endfunction


### PR DESCRIPTION
- `spi_device` internally takes up to four cycles to update the `INTR_STATUS`.`upload_cmdfifo_not_empty` bit from the last cycles on which upload command is detected.
- Increase the timeout set using `update_pending_intr_w_delay` so that the `INTR_STATUS` check wont lead to unexpected failures
- Add debug messages in `update_pending_intr_w_delay` to aid debug in case of  failures like these
- Since `spi_device_tpm_all_vseq` and `spi_device_flash_all_vseq` are launched parallelly in `spi_device_flash_and_tpm_vseq`, there are instances where register read to `INTR_STATE` happens while an update to the register is in progress.
- Add a check and wait block to make sure `INTR_STATE` is updated only  if there is no ongoing access

This PR addresses ` spi_device_flash_and_tpm` failures tracked in https://github.com/lowRISC/opentitan/issues/18364