### PR TITLE
[util] Enable toplevel tests when entropy file is used

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -6,6 +6,7 @@ r"""Top Module Generator
 """
 import argparse
 import logging as log
+import os
 import random
 import shutil
 import sys
@@ -1174,9 +1175,12 @@ def main():
             if topcfg.setdefault("rnd_cnst_seed", new_seed) == new_seed:
                 log.warning(
                     "No rnd_cnst_seed specified, setting to {}.".format(new_seed))
-        strong_random.unsecure_generate_from_seed(
-            ENTROPY_BUFFER_SIZE_BYTES,
-            topcfg["rnd_cnst_seed"])
+        if (os.getenv('USE_BUFFER')):
+            strong_random.load(SRCTREE_TOP / './util/topgen_entropy_buffer.txt')
+        else:
+            strong_random.unsecure_generate_from_seed(
+                ENTROPY_BUFFER_SIZE_BYTES,
+                topcfg["rnd_cnst_seed"])
 
     # TODO, long term, the levels of dependency should be automatically determined instead
     # of hardcoded.  The following are a few examples:


### PR DESCRIPTION
As discussed in #15144 Netlist constants, lifecycle and OTP images can be genetared using entropy provided in a buffer file, instead of a PRNG. 
This is enabled in #18412 

To use entropy from files run:
`export USE_BUFFER=1`
`cd hw/ && make all`

Precondition:
Files with entropy need to be present in the following locations:
`-./util/topgen_entropy_buffer.txt`
`-./util/design/lc_entropy_buffer.txt`
`-./util/design/otp_mmap_entropy_buffer.txt`

For testing purposes, these buffers can be generated using ./util/entropy_buffer_generator.py, e.g. by running

`./util/topgen/entropy_buffer_generator.py --sec -n 20000 -o ./util/topgen_entropy_buffer.txt`
`./util/topgen/entropy_buffer_generator.py --sec -n 20000 -o ./util/design/lc_entropy_buffer.txt`
`./util/topgen/entropy_buffer_generator.py --sec -n 20000 -o ./util/design/otp_mmap_entropy_buffer.txt`

This commit enables running toplevel tests when the buffer method is used, as long as the environment variable `USE_BUFFER` is set to `1`.