### PR TITLE
[i2c,rtl] SDA should be driven high in advance of SCL for restarts

### DIFF
--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -1355,4 +1355,7 @@ module i2c_fsm import i2c_pkg::*;
   `ASSERT(AcqDepthRdCheck_A, ((state_q == TransmitSetup) && (acq_fifo_depth_i > '0)) |->
           (acq_fifo_depth_i == 1) && acq_fifo_rdata_i[0])
 
+  // Check that we don't change SCL and SDA in the same clock cycle in host mode.
+  `ASSERT(SclSdaChangeNotSimultaneous_A, !(host_enable_i && (scl_d != scl_q) && (sda_d != sda_q)))
+
 endmodule

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -500,7 +500,11 @@ module i2c_fsm import i2c_pkg::*;
       end
       ClockLow : begin
         host_idle_o = 1'b0;
-        sda_d = fmt_byte_i[bit_index];
+        if (pend_restart) begin
+          sda_d = 1'b1;
+        end else begin
+          sda_d = fmt_byte_i[bit_index];
+        end
         scl_d = 1'b0;
       end
       // ClockPulse: SCL is released, SDA keeps the indexed bit value


### PR DESCRIPTION
Previously when undertaking a restart SDA and SCL went high in the same clock cycle which is believed to be a violation of the I2C specification. With this change SDA will be driven high before SCL after observing the appropriate hold time following the ACK bit.

This fix comes from @a-will see https://github.com/lowRISC/opentitan/issues/18721

This is a trial fix only, in particular isn't meant to represent the behaviour of a final ECO, should one be implemented. It exists to enable further exploration of the issue.