### PR TITLE
[governance] Add `SEC_CM_SCOPED` to D1 Checklist

### DIFF
--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -58,6 +58,11 @@ All the outputs of the IP have `ASSERT_KNOWN` assertions.
 A lint flow is set up which compiles and runs.
 It is acceptable to have lint warnings at this stage.
 
+### SEC_CM_SCOPED
+
+The security countermeasures for the IP have been scoped.
+Taking OpenTitan’s [Secure Hardware Design Guidelines](../../security/implementation_guidelines/hardware/README.md) and the specification of the IP into account, the designers have compiled a list of assets and their security properties as well as a high-level list of proposed countermeasures and reviewed both with the Security WG.
+
 ## D2
 
 ### NEW_FEATURES

--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -25,6 +25,7 @@ RTL           | [PHYSICAL_MACROS_DEFINED_80][] | Not Started |
 RTL           | [FUNC_IMPLEMENTED][]           | Not Started |
 RTL           | [ASSERT_KNOWN_ADDED][]         | Not Started |
 Code Quality  | [LINT_SETUP][]                 | Not Started |
+Security      | [SEC_CM_SCOPED][]              | Not Started |
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}
@@ -35,6 +36,7 @@ Code Quality  | [LINT_SETUP][]                 | Not Started |
 [FUNC_IMPLEMENTED]:           {{<relref "/doc/project/checklist.md#func_implemented" >}}
 [ASSERT_KNOWN_ADDED]:         {{<relref "/doc/project/checklist.md#assert_known_added" >}}
 [LINT_SETUP]:                 {{<relref "/doc/project/checklist.md#lint_setup" >}}
+[SEC_CM_SCOPED]:              {{<relref "/doc/project/checklist.md#sec_cm_scoped" >}}
 
 <%text>### D2</%text>
 


### PR DESCRIPTION
Adding the `SEC_CM_SCOPED` item is part of the *Ingesting, Reviewing, and Signing-Off Externally-Developed Code* RFC, which has been approved by the TC on 2023-05-23.