### PR TITLE
[sw/device] Trivial fixes courtesy of clang-tidy

### DIFF
--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -24,7 +24,7 @@ enum {
              TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES,
 };
 
-void sram_main() {
+void sram_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     // Configure the pinmux.
     CHECK_DIF_OK(dif_pinmux_init(
@@ -62,4 +62,4 @@ void sram_main() {
 // Reference functions that the debugger may wish to call. This prevents the
 // compiler from dropping them as unused functions and has the side benefit of
 // preventing their includes from appearing unused.
-void debugger_support_functions() { (void)icache_invalidate; }
+void debugger_support_functions(void) { (void)icache_invalidate; }

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -152,7 +152,7 @@ typedef struct otbn_app {
   OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_end);        \
   OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_start); \
   OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_end);   \
-  OTBN_DECLARE_SYMBOL_ADDR(app_name, _dmem_data_start);
+  OTBN_DECLARE_SYMBOL_ADDR(app_name, _dmem_data_start)
 
 /**
  * Initializes the OTBN application information structure.

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -94,7 +94,7 @@ crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
  *
  * @return Result of the DRBG uninstantiate operation.
  */
-crypto_status_t otcrypto_drbg_uninstantiate();
+crypto_status_t otcrypto_drbg_uninstantiate(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -152,6 +152,6 @@ status_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds,
   return OK_STATUS();
 }
 
-uint32_t alert_handler_testutils_cycle_rescaling_factor() {
+uint32_t alert_handler_testutils_cycle_rescaling_factor(void) {
   return kDeviceType == kDeviceSimDV ? 1 : 10;
 }

--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -103,6 +103,6 @@ status_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds,
  *  cycles = udiv64_slow(micros * clockFreqHz, 1000000, NULL) *
  *           cycle_rescaling_factor();
  */
-uint32_t alert_handler_testutils_cycle_rescaling_factor();
+uint32_t alert_handler_testutils_cycle_rescaling_factor(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -50,7 +50,7 @@ static uint32_t cast_safely(uint64_t val) {
   return (uint32_t)val;
 }
 
-void initialize_expected_counts() {
+void initialize_expected_counts(void) {
   // The expected counts depend on the device, per sw/device/lib/arch/device.h.
   // Notice the ratios are small enough to fit a uint32_t, even if the Hz number
   // is in uint64_t.

--- a/sw/device/lib/testing/profile.c
+++ b/sw/device/lib/testing/profile.c
@@ -7,7 +7,7 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-uint64_t profile_start() { return ibex_mcycle_read(); }
+uint64_t profile_start(void) { return ibex_mcycle_read(); }
 
 uint32_t profile_end(uint64_t t_start) {
   uint64_t t_end = ibex_mcycle_read();

--- a/sw/device/lib/testing/profile.h
+++ b/sw/device/lib/testing/profile.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * @return Ibex cycle count at start time.
  */
-uint64_t profile_start();
+uint64_t profile_start(void);
 
 /**
  * End a cycle-count timing profile.

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -96,10 +96,10 @@ status_t rstmgr_testutils_post_reset(
   return OK_STATUS();
 }
 
-dif_rstmgr_reset_info_bitfield_t rstmgr_testutils_reason_get() {
+dif_rstmgr_reset_info_bitfield_t rstmgr_testutils_reason_get(void) {
   return retention_sram_get()->reset_reasons;
 }
 
-void rstmgr_testutils_reason_clear() {
+void rstmgr_testutils_reason_clear(void) {
   retention_sram_get()->reset_reasons = 0;
 }

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -51,7 +51,7 @@ static dif_uart_t ottf_console_uart;
 static volatile ottf_console_flow_control_t flow_control_state;
 static volatile uint32_t flow_control_irqs;
 
-void *ottf_console_get() {
+void *ottf_console_get(void) {
   switch (kOttfTestConfig.console.type) {
     case kOttfConsoleSpiDevice:
       return &ottf_console_spi_device;
@@ -123,7 +123,7 @@ void ottf_console_init(void) {
   }
 }
 
-static uint32_t get_flow_control_watermark_plic_id() {
+static uint32_t get_flow_control_watermark_plic_id(void) {
   switch (kOttfTestConfig.console.base_addr) {
 #if !OT_IS_ENGLISH_BREAKFAST
     case TOP_EARLGREY_UART1_BASE_ADDR:

--- a/sw/device/sca/ecc256_sign_serial.c
+++ b/sw/device/sca/ecc256_sign_serial.c
@@ -231,7 +231,7 @@ static void p256_ecdsa_sign(const uint32_t *msg, const uint32_t *private_key_d,
  * Triggers OTBN_P256_sign operation.
  *
  */
-static void ecc256_ecdsa() {
+static void ecc256_ecdsa(const uint8_t *arg, size_t len) {
   LOG_INFO("SSECDSA starting...");
   SS_CHECK_STATUS_OK(otbn_load_app(kOtbnAppP256Ecdsa));
   LOG_INFO("otbn_status: 0x%08x", abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR +

--- a/sw/device/sca/ecc384_serial.c
+++ b/sw/device/sca/ecc384_serial.c
@@ -152,7 +152,7 @@ static void setup_data_pointer(const otbn_addr_t dptr,
  * This function makes the data pointers refer to the pre-allocated DMEM
  * regions to store the actual values.
  */
-static void setup_data_pointers() {
+static void setup_data_pointers(void) {
   setup_data_pointer(kOtbnVarDptrMsg, kOtbnVarMsg);
   setup_data_pointer(kOtbnVarDptrR, kOtbnVarR);
   setup_data_pointer(kOtbnVarDptrS, kOtbnVarS);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/fors_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/fors_test.c
@@ -50,7 +50,7 @@ static rom_error_t pk_from_sig_test(void) {
   return kErrorOk;
 }
 
-bool test_main() {
+bool test_main(void) {
   status_t result = OK_STATUS();
   LOG_INFO("Starting FORS test...");
 

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/verify_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/verify_test.c
@@ -97,7 +97,7 @@ static rom_error_t spx_verify_negative_test(void) {
   return kErrorOk;
 }
 
-bool test_main() {
+bool test_main(void) {
   status_t result = OK_STATUS();
 
   CHECK(kNumNegativeTests <= kSpxVerifyNumTests,

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/wots_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/wots_test.c
@@ -66,7 +66,7 @@ static const uint32_t kExpectedPk[kSpxWotsPkWords] = {
     0x460bec28, 0x3724f477, 0x46f9003f, 0x6357d6ec, 0x7a39121d, 0x511b498f,
     0x2bca40d1, 0x24b829a1};
 
-static rom_error_t pk_from_sig_test() {
+static rom_error_t pk_from_sig_test(void) {
   // Initialize the KMAC block.
   RETURN_IF_ERROR(spx_hash_initialize(&kTestCtx));
 
@@ -81,7 +81,7 @@ static rom_error_t pk_from_sig_test() {
   return kErrorOk;
 }
 
-bool test_main() {
+bool test_main(void) {
   status_t result = OK_STATUS();
   LOG_INFO("Starting WOTS test...");
 

--- a/sw/device/silicon_creator/manuf/lib/sram_exec_test.c
+++ b/sw/device/silicon_creator/manuf/lib/sram_exec_test.c
@@ -64,7 +64,7 @@ static status_t otp_ctrl_read_hw_cfg_device_id(uint32_t *device_id) {
  *
  * The HW_CFG partition should be unlocked and the device ID should be all zero.
  */
-static status_t check_device_id_is_unprovisioned() {
+static status_t check_device_id_is_unprovisioned(void) {
   // Check HW_CFG is unlocked.
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionHwCfg,
@@ -83,7 +83,7 @@ static status_t check_device_id_is_unprovisioned() {
 /**
  * Check the Device ID has been provisioned in OTP, but not locked.
  */
-static status_t check_device_id_is_provisioned() {
+static status_t check_device_id_is_provisioned(void) {
   // Check HW_CFG is still unlocked.
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionHwCfg,
@@ -100,7 +100,7 @@ static status_t check_device_id_is_provisioned() {
 /**
  * Provisions a Device ID into the HW_CFG OTP partition.
  */
-static status_t provisioning_device_id_start() {
+static status_t provisioning_device_id_start(void) {
   LOG_INFO("Provisioning Device ID in OTP.");
   check_device_id_is_unprovisioned();
   TRY(otp_ctrl_testutils_dai_write32(&otp, kDifOtpCtrlPartitionHwCfg,
@@ -112,13 +112,13 @@ static status_t provisioning_device_id_start() {
 /**
  * Provisions a Device ID into the HW_CFG OTP partition.
  */
-static status_t provisioning_device_id_end() {
+static status_t provisioning_device_id_end(void) {
   LOG_INFO("Provisioning complete.");
   check_device_id_is_provisioned();
   return OK_STATUS();
 }
 
-void sram_main() {
+void sram_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   // Initialize UART console.
   pinmux_testutils_init(&pinmux);

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_c_init_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_c_init_test.c
@@ -77,7 +77,7 @@ static void fault(void) {
  * and then reading back, because the pad attribute registers have
  * write-any-read-legal behavior.
  */
-static uint32_t pad_attr_mask_get() {
+static uint32_t pad_attr_mask_get(void) {
   CHECK_EQ(kDeviceType, kDeviceFpgaCw310,
            "This test is only supported for CW310");
 

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -376,8 +376,7 @@ void set_peripheral_clock(const test_t *peripheral,
           "intended_clk_state = %d, received_clk_state = %d", new_clk_state,
           clk_state);
   }
-};
-
+}
 /**
  * A utility function to wait enough until the alert handler pings a peripheral
  * alert

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -382,7 +382,7 @@ void set_peripheral_clock(const test_t *peripheral,
  * A utility function to wait enough until the alert handler pings a peripheral
  * alert
  */
-void wait_enough_for_alert_ping() {
+void wait_enough_for_alert_ping(void) {
   // wait enough
   if (kDeviceType == kDeviceFpgaCw310) {
     // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)

--- a/sw/device/tests/alert_handler_lpg_reset_toggle.c
+++ b/sw/device/tests/alert_handler_lpg_reset_toggle.c
@@ -293,7 +293,7 @@ static void alert_handler_config_peripherals(uint32_t num_peripherals,
  * A utility function to wait enough until the alert handler pings a peripheral
  * alert
  */
-void wait_enough_for_alert_ping() {
+void wait_enough_for_alert_ping(void) {
   // wait enough
   if (kDeviceType == kDeviceFpgaCw310) {
     // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_alerts.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_alerts.c
@@ -266,7 +266,7 @@ static size_t test_step_cnt;
  * Helper function to keep the test body clean
  * Initializes the flash_ctrl and test counters.
  */
-void init_test_components() {
+void init_test_components(void) {
   // Enable global and external IRQ at Ibex.
   irq_global_ctrl(true);
   irq_external_ctrl(true);

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -79,7 +79,7 @@ static void init_peripherals(void) {
  * A utility function to wait enough until the alert handler pings a peripheral
  * alert
  */
-void wait_enough_for_alert_ping() {
+void wait_enough_for_alert_ping(void) {
   // wait enough
   if (kDeviceType == kDeviceFpgaCw310) {
     // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
@@ -295,7 +295,7 @@ static size_t test_step_cnt;
  * Helper function to keep the test body clean
  * Initializes the flash_ctrl and test counters.
  */
-void init_test_components() {
+void init_test_components(void) {
   // Enable global and external IRQ at Ibex.
   irq_global_ctrl(true);
   irq_external_ctrl(true);

--- a/sw/device/tests/clkmgr_off_kmac_trans_test.c
+++ b/sw/device/tests/clkmgr_off_kmac_trans_test.c
@@ -8,6 +8,6 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-bool test_main() {
+bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainKmac);
 }

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -37,8 +37,8 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 typedef struct peri_context {
-  void (*csr_access)();  // The function causing a timeout.
-  uint32_t address;      // The address causing a timeout.
+  void (*csr_access)(void);  // The function causing a timeout.
+  uint32_t address;          // The address causing a timeout.
 } peri_context_t;
 
 static dif_aon_timer_t aon_timer;
@@ -62,7 +62,7 @@ static void set_hung_address(dif_clkmgr_gateable_clock_t clock,
            value, addr);
 }
 
-static void uart0_csr_access() {
+static void uart0_csr_access(void) {
   dif_toggle_t state;
   CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqTxWatermark,
                                         kDifToggleEnabled));
@@ -71,7 +71,7 @@ static void uart0_csr_access() {
   CHECK(state == kDifToggleEnabled);
 }
 
-static void spi_host0_csr_access() {
+static void spi_host0_csr_access(void) {
   dif_toggle_t state;
   CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host0, kDifSpiHostIrqSpiEvent,
                                             kDifToggleEnabled));
@@ -80,7 +80,7 @@ static void spi_host0_csr_access() {
   CHECK(state == kDifToggleEnabled);
 }
 
-static void spi_host1_csr_access() {
+static void spi_host1_csr_access(void) {
   dif_toggle_t state;
   CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host1, kDifSpiHostIrqSpiEvent,
                                             kDifToggleEnabled));
@@ -89,7 +89,7 @@ static void spi_host1_csr_access() {
   CHECK(state == kDifToggleEnabled);
 }
 
-static void usbdev_csr_access() {
+static void usbdev_csr_access(void) {
   CHECK_DIF_OK(dif_usbdev_irq_set_enabled(&usbdev, kDifUsbdevIrqPowered,
                                           kDifToggleEnabled));
   dif_toggle_t state;

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -28,7 +28,7 @@ static uint32_t read_fifo_depth(dif_entropy_src_t *entropy) {
   return fifo_depth;
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_entropy_src_t entropy_src;
   CHECK_DIF_OK(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -242,7 +242,7 @@ status_t execute_test(void) {
  * TODO: Run the test entropy src end reqs in continuous mode
  * (https://github.com/lowRISC/opentitan/issues/13393)
  */
-bool test_main() {
+bool test_main(void) {
   test_initialize();
 
   alert_handler_configure(&alert_handler);

--- a/sw/device/tests/hmac_enc_idle_test.c
+++ b/sw/device/tests/hmac_enc_idle_test.c
@@ -67,7 +67,7 @@ static status_t handle_end_of_process(dif_clkmgr_hintable_clock_t clock) {
   return OK_STATUS();
 }
 
-static status_t execute_test() {
+static status_t execute_test(void) {
   // With the HMAC unit idle, write the HMAC clk hint to 0 within clkmgr to
   // indicate HMAC clk can be gated and verify that the HMAC clk hint status
   // within clkmgr reads 0 (HMAC is disabled).

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -131,7 +131,7 @@ status_t initialize_clkmgr(void) {
                                            kDifToggleEnabled);
 }
 
-status_t execute_test() {
+status_t execute_test(void) {
   // Write the OTBN clk hint to 0 within clkmgr to indicate OTBN clk can be
   // gated and verify that the OTBN clk hint status within clkmgr reads 0 (OTBN
   // is idle).

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -666,7 +666,7 @@ static node_t test_node[kTopEarlgreyAlertPeripheralLast] = {
         },
 };
 
-static void init_expected_cause() {
+static void init_expected_cause(void) {
   kExpectedInfo[kRound1]
       .alert_info.alert_cause[kTopEarlgreyAlertIdI2c0FatalFault] = 1;
   kExpectedInfo[kRound1]

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -693,8 +693,7 @@ static void init_expected_cause(void) {
       .alert_info.alert_cause[kTopEarlgreyAlertIdI2c0FatalFault] = 1;
   kExpectedInfo[kRound3]
       .alert_info.alert_cause[kTopEarlgreyAlertIdSpiHost0FatalFault] = 1;
-};
-
+}
 bool test_main(void) {
   // Enable global and external IRQ at Ibex.
   irq_global_ctrl(true);

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -20,8 +20,8 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 // Declare two assembly functions defined in `rv_core_ibex_rnd_test.S`.
-extern uint32_t rv_core_ibex_rnd_read_and_immediately_check_status();
-extern uint32_t rv_core_ibex_check_rnd_read_possible_while_status_invalid();
+extern uint32_t rv_core_ibex_rnd_read_and_immediately_check_status(void);
+extern uint32_t rv_core_ibex_check_rnd_read_possible_while_status_invalid(void);
 
 enum {
   kRandomDataReads = 32,

--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -1091,7 +1091,7 @@ static void execute_test(const dif_aon_timer_t *aon_timer) {
   CHECK(false, "This should not be reached");
 }
 
-void check_alert_dump() {
+void check_alert_dump(void) {
   dif_rstmgr_alert_info_dump_segment_t dump[DIF_RSTMGR_ALERT_INFO_MAX_SIZE];
   size_t seg_size;
   alert_handler_testutils_info_t actual_info;

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -165,7 +165,7 @@ static void test_event(uint32_t idx, dif_toggle_t fatal, bool set_event) {
   }
 };
 
-void init_units() {
+void init_units(void) {
   CHECK_DIF_OK(dif_pwrmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
   CHECK_DIF_OK(dif_rstmgr_init(
@@ -410,7 +410,7 @@ void ast_enter_sleep_states_and_check_functionality(
 /**
  *  set edn auto mode
  */
-void set_edn_auto_mode() {
+void set_edn_auto_mode(void) {
   const dif_edn_t edn0 = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
   const dif_edn_t edn1 = {
@@ -510,7 +510,7 @@ void ottf_external_isr(void) {
   interrupt_serviced = true;
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_pwrmgr_domain_config_t pwrmgr_config;
 
   const dif_entropy_src_config_t entropy_src_config = {

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -127,7 +127,7 @@ static void check_alert_state(dif_toggle_t fatal) {
       &alert_handler, kTopEarlgreyAlertIdSensorCtrlRecovAlert));
   CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
       &alert_handler, kTopEarlgreyAlertIdSensorCtrlFatalAlert));
-};
+}
 
 /**
  *  First configure fatality of the desired event.
@@ -163,7 +163,7 @@ static void test_event(uint32_t idx, dif_toggle_t fatal, bool set_event) {
     // check whether alert handler captured the event
     check_alert_state(fatal);
   }
-};
+}
 
 void init_units(void) {
   CHECK_DIF_OK(dif_pwrmgr_init(

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -493,7 +493,7 @@ static void alert_handler_config(void) {
       &alert_handler, kDifAlertHandlerIrqClassd, kDifToggleEnabled));
 }
 
-static void set_aon_timers() {
+static void set_aon_timers(void) {
   uint32_t bark_cycles = 0;
   CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
                                                              &bark_cycles));
@@ -518,7 +518,7 @@ static void set_aon_timers() {
  * The aon timers should never trigger actions because escalation should take
  * precedence.
  */
-static void execute_test() {
+static void execute_test(void) {
   alert_handler_config();
 
   // Make sure we can receive both the watchdog and alert NMIs.

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -106,7 +106,7 @@ static void lock_otp_secret0_partition(void) {
   CHECK_STATUS_OK(otp_ctrl_testutils_wait_for_dai(&otp));
 }
 
-static void lock_otp_secret2_partition() {
+static void lock_otp_secret2_partition(void) {
   // Write LC RMA tokens to OTP secret2 partition.
   uint64_t otp_rma_token_0 = 0;
   uint64_t otp_rma_token_1 = 0;

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -47,7 +47,7 @@ static dif_pinmux_t pinmux;
  * . set sysrst_ctrl.KEY_INTR_CTL.pwrb_in_H2L to 1
  * . use IOR13 as pwrb_in
  */
-static void prgm_push_button_wakeup() {
+static void prgm_push_button_wakeup(void) {
   dif_sysrst_ctrl_input_change_config_t config = {
       .input_changes = kDifSysrstCtrlInputPowerButtonH2L,
       .debounce_time_threshold = 1,  // 5us

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -173,7 +173,7 @@ const test_wakeup_sources_t kTestWakeupSources[PWRMGR_PARAM_NUM_WKUPS] = {
     },
 };
 
-void init_units() {
+void init_units(void) {
   CHECK_DIF_OK(dif_adc_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR), &adc_ctrl));
   CHECK_DIF_OK(dif_aon_timer_init(

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.h
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.h
@@ -56,7 +56,7 @@ extern dif_sensor_ctrl_t sensor_ctrl;
 extern dif_sysrst_ctrl_t sysrst_ctrl;
 extern dif_usbdev_t usbdev;
 
-void init_units();
+void init_units(void);
 
 void check_wakeup_reason(uint32_t wakeup_source);
 

--- a/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
@@ -232,4 +232,4 @@ bool test_main(void) {
   }
 
   return true;
-};
+}

--- a/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
@@ -137,7 +137,7 @@ static void ack_spi_tpm_header_irq(dif_spi_device_handle_t *spi_device) {
 // This routine is needed to make sure that an interrupt does not sneak in
 // and jump excution away between the boolean check and the actual invocation
 // of wait_for_interrupt.
-static void atomic_wait_for_interrupt() {
+static void atomic_wait_for_interrupt(void) {
   irq_global_ctrl(false);
   if (!header_interrupt_received) {
     wait_for_interrupt();

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -229,7 +229,7 @@ static void prepare_sram_for_scrambling(void) {
                   kTestBufferSizeWords);
 }
 
-static void execute_main_sram_test() {
+static void execute_main_sram_test(void) {
   LOG_INFO("ut_backdoor: %x,ut_patternt: %x,ut_ecc_error_counter: %x",
            scrambling_frame->backdoor, scrambling_frame->pattern,
            &scrambling_frame->ecc_error_counter);

--- a/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
@@ -53,7 +53,7 @@ static const dif_pinmux_index_t kInputPads[] = {
     kTopEarlgreyPinmuxInselIoc7, kTopEarlgreyPinmuxInselIoc9,
 };
 
-void test_phase_sync() {
+void test_phase_sync(void) {
   test_status_set(kTestStatusInTest);
   test_status_set(kTestStatusInWfi);
 }

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -152,7 +152,7 @@ status_t test_quad_read(void) {
   return OK_STATUS();
 }
 
-static bool is_4_bytes_address_mode_supported() {
+static bool is_4_bytes_address_mode_supported(void) {
   enum { kSupportOnly3Bytes, kSupport3and4Bytes, kSupportOnly4Bytes };
   uint8_t address_mode =
       bitfield_field32_read(sfdp.bfpt[0], SPI_FLASH_ADDRESS_MODE);

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -138,7 +138,7 @@ void test_ret_sram_in_normal_sleep(void) {
 // test these 2 cases:
 // deep sleep, no scrambling -> data preserved
 // deep sleep, with scrambling -> data preserved
-void enter_deep_sleep() {
+void enter_deep_sleep(void) {
   // Prepare rstmgr for a reset.
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
   // set up wakeup timer


### PR DESCRIPTION
I temporarily enabled strict prototypes and pedantic warnings before running clang tidy:

```bash
./bazelisk.sh query 'kind(cc_, //sw/...)' | xargs ./bazelisk.sh build -k --config=clang_tidy_fix //sw/device/...
./bazelisk.sh query 'kind(cc_, //sw/...)' | xargs ./bazelisk.sh build -k --config=clang_tidy_fix --config=riscv32 //sw/device/...
```

This is how I modified the compiler flags:

```diff
diff --git a/.bazelrc b/.bazelrc
index 497d224b5..1771f93d5 100644
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,10 +11,29 @@ build --conlyopt='-std=gnu11'
 # disassemblies when compilation mode is fastbuild.
 build --strip='never'
 
-# Bazel embedded enables the following feature which along with -std=c11 and
-# our codebase generates a lot of warnings by setting the -Wpedantic flag
-build --features=-all_warnings
-build --features=-pedantic_warnings
+# Override default enablement of flags from @crt//common to control C compiler
+# warnings.
+#
+# TODO(#12553) Remove these explicit feature flags once the features in @crt//
+# are enabled by default.
+build --features=pedantic_warnings
+build --features=strict_prototypes_warnings
+build --features=covered_switch_default_warnings
+build --features=extra_warnings
+build --features=clang_covered_switch_default_warnings
+build --features=implicit_conversion_warnings
+build --features=implicit_fallthrough_warnings
+build --features=invalid_pch_warnings
+build --features=switch_default_warnings
+build --features=no_missing_field_initializers_warning
+build --features=no_sign_compare_warning
+build --features=no_unused_function_warning
+build --features=no_unused_parameter_warning
+# Override default enablement of flags from @crt//embedded to control C compiler
+# warnings.
+build --features=clang_gnu_warnings
+build --features=no_gnu_zero_variadic_macro_arguments_warning
+build --features=no_gnu_statement_expression_from_macro_expansion
```

