### PR TITLE
[chip,dv] Add switch to external clock before raw->unlock transition

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -51,7 +51,7 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
     sw_symbol_backdoor_overwrite("kOtpExitToken", otp_exit_token);
     sw_symbol_backdoor_overwrite("kOtpUnlockToken", otp_unlock_token);
 
-    wait_lc_ready(.allow_err(1));
+    switch_to_external_clock();
     jtag_lc_state_transition(DecLcStRaw, DecLcStTestUnlocked0);
     apply_reset();
 


### PR DESCRIPTION
When LC is Raw state, cpu enable is 0. So switch to external clock is required by the same reasoning as
#18147 