### PR TITLE
[i2c, test] Fix i2c test writes to accelerometer skipping STOP

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1805,28 +1805,6 @@ opentitan_functest(
 )
 
 opentitan_functest(
-    name = "i2c_host_power_monitor_test",
-    srcs = ["i2c_host_power_monitor_test.c"],
-    cw310 = cw310_params(
-        tags = ["manual"],  # Requires the Bob in CI.
-    ),
-    targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:i2c",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing:i2c_testutils",
-        "//sw/device/lib/testing:rv_core_ibex_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
-
-opentitan_functest(
     name = "i2c_host_clock_stretching_test",
     srcs = ["i2c_host_clock_stretching_test.c"],
     cw310 = cw310_params(
@@ -1846,6 +1824,28 @@ opentitan_functest(
         "//sw/device/lib/testing:i2c_testutils",
         "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
+    name = "i2c_host_power_monitor_test",
+    srcs = ["i2c_host_power_monitor_test.c"],
+    cw310 = cw310_params(
+        tags = ["manual"],  # Requires the BoB in CI.
+    ),
+    targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:i2c_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/i2c_host_accelerometer_test.c
+++ b/sw/device/tests/i2c_host_accelerometer_test.c
@@ -61,7 +61,7 @@ static status_t read_write_thresh_tap(void) {
   // Write some value to the THRESH_TAP register.
   uint8_t write_data[2] = {reg, 0xAB};
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(write_data), write_data,
-                          true));
+                          false));
 
   // Read the value back to confirm the write.
   uint8_t read_data = 0;
@@ -76,7 +76,7 @@ static status_t take_measurement(void) {
   // Set the power mode to enable measurements.
   uint8_t write_data[2] = {kPowerCtrlReg, kMeasure};
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(write_data), write_data,
-                          true));
+                          false));
 
   // Read all six data measurements starting from DATAX0.
   uint8_t data_x_reg = kDataX0Reg;

--- a/sw/device/tests/i2c_host_power_monitor_test.c
+++ b/sw/device/tests/i2c_host_power_monitor_test.c
@@ -40,10 +40,7 @@ enum {
   kManufacturerId = 0x54,
   kProductId = 0x7b,
 };
-/**
- * Declared volatile because it is referenced in the main program flow as well
- * as the ISR.
- */
+
 static dif_rv_core_ibex_t rv_core_ibex;
 static dif_pinmux_t pinmux;
 static dif_i2c_t i2c;
@@ -68,13 +65,13 @@ static status_t read_write_1byte(void) {
   uint8_t reg = kAccumConfigReg, read_data = 0;
 
   // Write config=1.
-  uint8_t write_data[2] = {kAccumConfigReg, 0x01};
+  uint8_t write_data[2] = {reg, 0x01};
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(write_data), write_data,
                           true));
 
   // Check the write worked.
   read_data = 0;
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(read_data), &reg, true));
+  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(reg), &reg, true));
   TRY(i2c_testutils_read(&i2c, kDeviceAddr, sizeof(read_data), &read_data));
   TRY_CHECK(read_data == 0x01, "Unexpected value %x", read_data);
 
@@ -96,7 +93,7 @@ static status_t read_write_2bytes(void) {
   uint8_t reg = kOcLimitNReg, read_data[2] = {0};
 
   // Write new value.
-  uint8_t write_data[3] = {kOcLimitNReg, 0xCA, 0xFE};
+  uint8_t write_data[3] = {reg, 0xCA, 0xFE};
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(write_data), write_data,
                           true));
 


### PR DESCRIPTION
Some of the writes to the i2c device in the `i2c_host_accelerometer_test` skip the STOP signal when they shouldn't.

We've seen one random failure of this test (though I haven't reproduced), so maybe this will improve its reliability.

This PR also includes cosmetic changes to the i2c_host_power_monitor_test, and marks the i2c tests as "manual" since we don't want these to run in CI yet (break-out-boards are still being tested and haven't been added).