### PR TITLE
[util/sh] Add coverage_test.sh

### DIFF
--- a/util/sh/lib/called_from.sh
+++ b/util/sh/lib/called_from.sh
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+source util/sh/lib/log.sh
+
+function called_from() {
+    local file=${BASH_SOURCE[2]##*/}
+    local line=${BASH_LINENO[1]}
+    log "Called from: ${file}:${line}" 1
+}

--- a/util/sh/lib/debug.sh
+++ b/util/sh/lib/debug.sh
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+set -x

--- a/util/sh/lib/error.sh
+++ b/util/sh/lib/error.sh
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+error() {
+    log "ERROR: $1" 1 >&2
+    exit 1
+}

--- a/util/sh/lib/log.sh
+++ b/util/sh/lib/log.sh
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+function log() {
+    local msg="$1"
+    local stack_offset=${2:-0}
+    local timestamp
+    timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    local file=${BASH_SOURCE[$((stack_offset + 1))]##*/}
+    local line=${BASH_LINENO[${stack_offset}]}
+    echo "${timestamp} ${file}:${line}: ${msg}"
+}

--- a/util/sh/lib/strict.sh
+++ b/util/sh/lib/strict.sh
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+set -euo pipefail

--- a/util/sh/lib/traps.sh
+++ b/util/sh/lib/traps.sh
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+source util/sh/lib/error.sh
+source util/sh/lib/called_from.sh
+
+last_command=""
+preexec() {
+    last_command="${BASH_COMMAND}"
+}
+
+handle_error() {
+    local status_code=$?
+    if [ $status_code -ne 0 ]; then
+        called_from >&2
+        error "Command '${last_command}' exited with non-zero status code: ${status_code}"
+    fi
+}
+
+trap 'preexec' DEBUG
+trap 'handle_error' ERR

--- a/util/sh/scripts/coverage_test.sh
+++ b/util/sh/scripts/coverage_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+source util/sh/lib/strict.sh
+source util/sh/lib/log.sh
+source util/sh/lib/error.sh
+source util/sh/lib/traps.sh
+
+readonly BAZEL="./bazelisk.sh"
+readonly BITSTREAM_TARGET="//hw/bitstream:gcp_spliced_test_rom"
+readonly WORKSPACE_PATH
+WORKSPACE_PATH=$(${BAZEL} info workspace)
+readonly BITSTREAM_PATH
+BITSTREAM_PATH=${WORKSPACE_PATH}/$(${BAZEL} cquery --output=starlark --starlark:expr "target.files.to_list()[0].path" "${BITSTREAM_TARGET}")
+readonly COVERAGE_TEST_TARGET="//sw/device/tests:coverage_test_fpga_cw310_test_rom"
+readonly COVERAGE_TEST_LOG
+COVERAGE_TEST_LOG="$(${BAZEL} info bazel-testlogs)/sw/device/tests/coverage_test_fpga_cw310_test_rom/test.log"
+
+# Build and program bitstream with uninstrumented ROM
+log "Bitstream target: ${BITSTREAM_TARGET}"
+log "Bitstream path: ${BITSTREAM_PATH}"
+log "Building bitstream..."
+${BAZEL} build "${BITSTREAM_TARGET}"
+log "Programming the FPGA..."
+${BAZEL} run //sw/host/opentitantool -- --cw310-uarts=/dev/opentitan/cw_310_uart_0,/dev/opentitan/cw_310_uart_1 fpga load-bitstream "${BITSTREAM_PATH}"
+# Measure coverage
+log "Measuring coverage..."
+${BAZEL} coverage --define bitstream=skip --test_output=streamed --config=ot_coverage_on_target "${COVERAGE_TEST_TARGET}"
+# Check log
+log "Test log: ${COVERAGE_TEST_LOG}"
+raw_profile_buffer_size=$(grep length "${COVERAGE_TEST_LOG}" | sed "s/.*length: \([0-9]*\) bytes.*/\1/" || echo "UNKNOWN")
+log "Raw profile buffer is ${raw_profile_buffer_size} bytes"
+# Process raw profile data
+util/coverage/device_profile_data.py --input_file "${COVERAGE_TEST_LOG}" prof.raw
+# Check the contents
+/tools/riscv/bin/llvm-cov --version
+/tools/riscv/bin/llvm-profdata show prof.raw || true


### PR DESCRIPTION
This PR adds a minimal bash library and a script for verifying that our on-target coverage measurement infrastructure works as expected.

The directory layout is inspired by #17212