### PR TITLE
[coverage] Fix fallout from LLVM 16.0.2 migration + minor updates

### DIFF
--- a/sw/device/lib/testing/test_framework/coverage_llvm.c
+++ b/sw/device/lib/testing/test_framework/coverage_llvm.c
@@ -37,6 +37,7 @@ void coverage_send_buffer(void) {
   if (buf_size_u64 > sizeof(buf)) {
     LOG_ERROR("ERROR: LLVM profile buffer is too large: %u bytes.",
               (uint32_t)buf_size_u64);
+    OT_UNREACHABLE();
   } else {
     size_t buf_size = (size_t)buf_size_u64;
     __llvm_profile_write_buffer(buf);

--- a/third_party/llvm_compiler_rt/0001-Headers.patch
+++ b/third_party/llvm_compiler_rt/0001-Headers.patch
@@ -29,10 +29,10 @@ index 237acb33f..9e37253b3 100644
  #define INSTR_PROF_VISIBILITY COMPILER_RT_VISIBILITY
  #include "profile/InstrProfData.inc"
 @@ -219,7 +218,6 @@ void __llvm_profile_set_filename(const char *Name);
-  * program initialization time. Support for transferring the mmap'd profile
-  * counts to a new file has not been implemented.
+  * copying the old profile file to new profile file and this function is usually
+  * used when the proess doesn't have permission to open file.
   */
--void __llvm_profile_set_file_object(FILE *File, int EnableMerge);
+-int __llvm_profile_set_file_object(FILE *File, int EnableMerge);
  
  /*! \brief Register to write instrumentation data to file at exit. */
  int __llvm_profile_register_write_file_atexit(void);
@@ -53,8 +53,8 @@ index 0e59148e2..4fd2a5170 100644
 --- a/lib/profile/InstrProfilingPlatformOther.c
 +++ b/lib/profile/InstrProfilingPlatformOther.c
 @@ -10,8 +10,7 @@
-     !(defined(__sun__) && defined(__svr4__)) && !defined(__NetBSD__) &&        \
-     !defined(_WIN32)
+     !defined(__Fuchsia__) && !(defined(__sun__) && defined(__svr4__)) &&       \
+     !defined(__NetBSD__) && !defined(_WIN32) && !defined(_AIX)
  
 -#include <stdlib.h>
 -#include <stdio.h>

--- a/third_party/llvm_compiler_rt/0002-invalid-data.patch
+++ b/third_party/llvm_compiler_rt/0002-invalid-data.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/profile/InstrProfilingPlatformOther.c b/lib/profile/InstrProfilingPlatformOther.c
+index c7b6e842c9fa..38a3551de715 100644
+--- a/lib/profile/InstrProfilingPlatformOther.c
++++ b/lib/profile/InstrProfilingPlatformOther.c
+@@ -42,6 +42,11 @@ static const void *getMaxAddr(const void *A1, const void *A2) {
+ COMPILER_RT_VISIBILITY
+ void __llvm_profile_register_function(void *Data_) {
+   /* TODO: Only emit this function if we can't use linker magic. */
++
++  if ((uintptr_t)Data_ == (uintptr_t)&__llvm_profile_runtime) {
++    return;
++  }
++
+   const __llvm_profile_data *Data = (__llvm_profile_data *)Data_;
+   if (!DataFirst) {
+     DataFirst = Data;

--- a/third_party/llvm_compiler_rt/repos.bzl
+++ b/third_party/llvm_compiler_rt/repos.bzl
@@ -8,10 +8,10 @@ def llvm_compiler_rt_repos():
     http_archive(
         name = "llvm_compiler_rt",
         build_file = Label("//third_party/llvm_compiler_rt:BUILD.llvm_compiler_rt.bazel"),
-        sha256 = "7b33955031f9a9c5d63077dedb0f99d77e4e7c996266952c1cec55626dca5dfc",
-        strip_prefix = "compiler-rt-13.0.1.src",
+        sha256 = "46abe68f006646c15f6d551a2be0ac27e681c5fcc646d712389a5e50ddf69c60",
+        strip_prefix = "compiler-rt-16.0.2.src",
         urls = [
-            "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/compiler-rt-13.0.1.src.tar.xz",
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.2/compiler-rt-16.0.2.src.tar.xz",
         ],
         patches = [
             Label("//third_party/llvm_compiler_rt:0001-Headers.patch"),

--- a/third_party/llvm_compiler_rt/repos.bzl
+++ b/third_party/llvm_compiler_rt/repos.bzl
@@ -15,6 +15,7 @@ def llvm_compiler_rt_repos():
         ],
         patches = [
             Label("//third_party/llvm_compiler_rt:0001-Headers.patch"),
+            Label("//third_party/llvm_compiler_rt:0002-invalid-data.patch"),
         ],
         patch_args = ["-p1"],
     )

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -16,7 +16,7 @@ ARG BAZELISK_VERSION=v1.11.0
 # This should match the version in ci/install-package-dependencies.sh
 ARG GCC_VERSION=9
 # This should match the version of the lowRISC RISC-V toolchain.
-ARG CLANG_VERSION=13
+ARG CLANG_VERSION=16
 
 # Main container image.
 FROM ubuntu:20.04 AS opentitan

--- a/util/coverage/common.py
+++ b/util/coverage/common.py
@@ -34,7 +34,6 @@ DEVICE_LIBS_EXC: List[str] = [
     "//sw/device/lib/crypto/...",
     "//sw/device/lib/arch/...",
     "//sw/device/lib/ujson/...",
-    "//sw/device/lib/base:hardened_status",
     "//sw/device/lib/base:status",
     "//sw/device/lib/base:mmio_on_device_do_not_use_directly",
     "//sw/device/lib/base:mmio_on_host_do_not_use_directly",

--- a/util/coverage/functest_coverage.py
+++ b/util/coverage/functest_coverage.py
@@ -56,8 +56,11 @@ def handle_objs(merged_library: Path, obj_files: List[str]) -> None:
     # used only for generating a coverage report and we link only and all instrumented
     # object files.
     # TODO(#16761): Try to remove these flags.
-    run(LLD_TARGET, "--warn-unresolved-symbols", "-zmuldefs", "-o",
-        str(merged_library), *obj_files)
+    fake_entry_point = "0x0"
+    run(LLD_TARGET, "--unresolved-symbols=ignore-all", "-e", fake_entry_point,
+        "--defsym", "__llvm_profile_register_names_function=0", "--defsym",
+        "__llvm_profile_register_function=0", "--defsym",
+        "__llvm_profile_runtime=0", "-o", str(merged_library), *obj_files)
 
 
 def handle_test_targets(test_targets: List[str]) -> List[str]:

--- a/util/coverage/functest_coverage.py
+++ b/util/coverage/functest_coverage.py
@@ -47,6 +47,11 @@ def handle_objs(merged_library: Path, obj_files: List[str]) -> None:
         merged_library: Path where to save the merged library.
         obj_files: A list of object files.
     """
+    # Remove `pic.o` files.
+    # Note: Bazel started generating these since
+    # 4ff2301bf37230f75ac6fb2e288f111489e383e4.
+    obj_files = [o for o in obj_files if not o.endswith(".pic.o")]
+
     # Note: We allow unresolved symbols and multiple definitions because this library is
     # used only for generating a coverage report and we link only and all instrumented
     # object files.

--- a/util/coverage/functest_coverage_test.py
+++ b/util/coverage/functest_coverage_test.py
@@ -40,10 +40,11 @@ class TestFunc(unittest.TestCase):
 
         functest_coverage.handle_objs(merged_library, obj_files)
 
-        mock_run.assert_called_once_with("<lld_target>",
-                                         AnyStringWith("unresolved"),
-                                         "-zmuldefs", "-o",
-                                         str(merged_library), *obj_files)
+        mock_run.assert_called_once_with(
+            "<lld_target>", AnyStringWith("unresolved"), "-e", "0x0",
+            "--defsym", '__llvm_profile_register_names_function=0', '--defsym',
+            '__llvm_profile_register_function=0', '--defsym',
+            '__llvm_profile_runtime=0', '-o', str(merged_library), *obj_files)
 
     @patch("functest_coverage.run")
     def test_handle_test_targets(self, mock_run):

--- a/util/coverage/unittest_coverage.py
+++ b/util/coverage/unittest_coverage.py
@@ -76,7 +76,6 @@ def handle_test_targets(test_targets: List[str]) -> List[str]:
     res = test_targets + [
         "//sw/device/lib/base:hardened_memory_unittest",
         "//sw/device/lib/base:math_unittest",
-        "//sw/device/lib/base:math_builtins_unittest",
         "//sw/device/lib/base:memory_unittest",
     ]
     logging.info(f"test targets: {pformat(res)}")


### PR DESCRIPTION
https://storage.googleapis.com/sw-coverage/index.html

![image](https://github.com/lowRISC/opentitan/assets/57949550/3eb8d5ef-319e-4305-ac4f-ab5abdf2a589)
