### PR TITLE
[governance] Minor consistency alignments in V2 checklist

### DIFF
--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -507,7 +507,7 @@ The DV document and testplan are complete and have been reviewed by key stakehol
 - Security architect
 
 This review will focus on the design deltas captured in the testplan since the last review.
-In addition, the fully implemented functional coverage plan, the observed coverage and the coverage exclusions are expected to be scrutinized to ensure there are no verification holes or any gaps in achieving the required stimulus quality, before the work towards progressing to V3 can commence.
+In addition, the fully implemented functional coverage plan, the observed coverage and the coverage exclusions are expected to be scrutinized to ensure there are no verification holes or any gaps in achieving the required verification quality, before the work towards progressing to V3 can commence.
 
 ### V3_CHECKLIST_SCOPED
 
@@ -546,7 +546,7 @@ Security countermeasure blocks may have been excluded in order to satisfy the V2
 If so, these exclusions should be removed.
 
 If UNR exclusion has been generated, it needs to be re-generated and reviewed after all security countermeasure tests have been implemented, as fault injection can exercise countermeasures which are deemed as unreachable code.
-The V2S coverage requirement is the same as V2 (90% code coverage and 70% functional coverage).
+The V2S coverage requirement is the same as V2.
 
 ### SEC_CM_DV_REVIEWED
 


### PR DESCRIPTION
The V2S checklist refers to the V2 coverage requirements, but unfortunately the cited thresholds were not in sync with what the current V2 checklist says. Therefore, we remove the redundant thresholds in the V2S checklist so that V2 becomes the sole source of truth.

The word `stimulus` in DV_DOC_TESTPLAN_REVIEWED is replaced with `verification` to make the statement more generic.

@GregAC @jonmichelson @jdonjdon do we need to get more alignment on these changes?