### PR TITLE
[governance] Fix formatting of issue prios

### DIFF
--- a/doc/project_governance/priority_definitions.md
+++ b/doc/project_governance/priority_definitions.md
@@ -1,6 +1,4 @@
----
-title: Generalized Priority Definitions
----
+# Generalized Priority Definitions
 
 ## Definitions
 
@@ -13,15 +11,37 @@ The following definitions are used:
 
 ### Priority Definitions Table
 
-
-| Issue Priority | Description
-| ---------------|------------
-| **P0 - Blocking** | An issue that requires immediate resolution. Examples include top-of-tree CI outages or merge skew causing compilation simulation or synthesis breakages.
-| **P1 - High** | An issue requiring quick resolution since it significantly impacts a large percentage of functionality or maintainers; existing workarounds are only partial or exceedingly painful. The issue impacts a core function, and/or fundamentally impedes progress towards target milestones on any of the work streams.
-| **P2 - Default** | An issue that needs to be resolved within a reasonable amount of time. This could be:
-| | (a) an issue that would have a higher priority, but has a reasonable workaround,
-| | (b) an issue that impacts a large percentage of maintainers and is linked with a core function,
-| | (c) an issue that needs to be addressed to reach the next milestone on a given work stream.
-| | This is the default priority level.
-| **P3 - Best effort** | An issue that should be resolved on a best effort basis. Such an issue is relevant to core functions of OpenTitan, but does not impede progress towards target milestones on a given work stream or else has a reasonable workaround
-| **P4 - Deferrable** | An issue that should be resolved eventually. Such an issue is not relevant to core functions or upcoming milestones on any of the work streams; or it only addresses cosmetic aspects of the underlying subject.
+<table>
+  <thead>
+    <tr>
+      <th>Issue Priority</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>P0 - Blocking</b></td>
+      <td>An issue that requires immediate resolution. Examples include top-of-tree CI outages or merge skew causing compilation simulation or synthesis breakages.</td>
+    </tr>
+    <tr>
+      <td><b>P1 - High</b></td>
+      <td>An issue requiring quick resolution since it significantly impacts a large percentage of functionality or maintainers; existing workarounds are only partial or exceedingly painful. The issue impacts a core function, and/or fundamentally impedes progress towards target milestones on any of the work streams.</td>
+    </tr>
+    <tr>
+      <td><b>P2 - Default</b></td>
+      <td>An issue that needs to be resolved within a reasonable amount of time. This could be:
+          <br>(a) an issue that would have a higher priority, but has a reasonable workaround,
+          <br>(b) an issue that impacts a large percentage of maintainers and is linked with a core function,
+          <br>(c) an issue that needs to be addressed to reach the next milestone on a given work stream.
+          <br>This is the default priority level.</td>
+    </tr>
+    <tr>
+      <td><b>P3 - Best effort</b></td>
+      <td>An issue that should be resolved on a best effort basis. Such an issue is relevant to core functions of OpenTitan, but does not impede progress towards target milestones on a given work stream or else has a reasonable workaround.</td>
+    </tr>
+    <tr>
+      <td><b>P4 - Deferrable</b></td>
+      <td>An issue that should be resolved eventually. Such an issue is not relevant to core functions or upcoming milestones on any of the work streams; or it only addresses cosmetic aspects of the underlying subject.</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
This fixes the title and reformats the table so that the enumerated items for the P2 priority are not spread accross multiple table rows.