### PR TITLE
[test] Retarget gpio_smoketest to the LEDs on CW310

### DIFF
--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -141,8 +141,8 @@ const dif_pinmux_index_t kPinmuxTestutilsGpioMioOutPins[kDifGpioNumPins] = {
 
 uint32_t pinmux_testutils_get_testable_gpios_mask(void) {
   if (kDeviceType == kDeviceFpgaCw310) {
-    // Only IOA2 to IOA8 are available for use as GPIOs.
-    return 0x1fc;
+    // Only IOR6, IOR7, and IOR10 to IOR13 are available for use as GPIOs.
+    return 0xfc000000;
   } else {
     return 0xffffffff;
   }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1084,10 +1084,6 @@ opentitan_functest(
 opentitan_functest(
     name = "gpio_smoketest",
     srcs = ["gpio_smoketest.c"],
-    cw310 = cw310_params(
-        # FIXME #18623 Flaky test gpio_smoketest_fpga_cw310_test_rom
-        tags = ["broken"],
-    ),
     targets = [
         #not compatible with the verilated top level
         "cw310_test_rom",


### PR DESCRIPTION
This would only be for the SAM3X variant. Also, we might want to check whether the switching speed is reasonable for the LEDs--Other than the time it takes to execute the DIF instructions, there is no wait between write and read in the test.

Fixes #18623 