### PR TITLE
[dv] Increase timeout of top level tests

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -36,6 +36,7 @@
         "+sw_test_timeout_ns=20000000",
         "+use_otp_image=OtpTypeCustom",
       ]
+      run_timeout_mins: 120
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_test_unlocked0

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -563,7 +563,7 @@
       sw_images: ["//sw/device/tests/sim_dv:exit_test_unlocked_bootstrap:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
-      run_timeout_mins: 180
+      run_timeout_mins: 220
     }
     {
       name: chip_sw_uart_rand_baudrate


### PR DESCRIPTION
The tests `rom_e2e_shutdown_output` and `chip_sw_exit_test_unlocked_bootstrap` are flaky due to timeout.
This PR increase the timeout of these two tests.