### PR TITLE
[site] Fixup pagetoc nav issues

### DIFF
--- a/site/book-theme/pagetoc.js
+++ b/site/book-theme/pagetoc.js
@@ -73,6 +73,9 @@ var set_target_highlight = function(event) {
             document.documentElement.style.setProperty(
                 '--target-height', (el.getBoundingClientRect().height + targetMarginTopBottom) + "px"
             );
+            // scroll-margin-top does not seem to work for the first header on a page, so manually
+            // force into view if we nav to it.
+            if (el === document.getElementsByClassName("header")[0]) { el.scrollIntoView(false); }
         }
     });
 };
@@ -218,7 +221,7 @@ var create_pagetoc_structure = function(el_pagetoc) {
     {
         console.assert(startIdx <= stopIdx, "Strictly, 'stopIdx <= startIdx' is required.");
         let wrap = document.createElement("div");
-        wrap.classList.add(`wrap-W${wLevel-1}`);
+        wrap.classList.add(`wrap-W${wLevel}`);
 
         // Loop over the range given, descending recursively where needed.
         let i = startIdx;
@@ -239,8 +242,7 @@ var create_pagetoc_structure = function(el_pagetoc) {
     }
 
     // Invoke the above helper-functions to create the tree
-    // - Start-at-1 so we don't add the title H1 element.
-    let tree = wrapAllDescendingElems(getHnum(1), 1, headerElements.length - 1);
+    let tree = wrapAllDescendingElems(0, 0, headerElements.length - 1);
     el_pagetoc.appendChild(tree);
 };
 


### PR DESCRIPTION
- The initial PR https://github.com/lowRISC/opentitan/pull/18411 assumed a single H1 element on the page (the first heading), and if another H1 was encountered within the page, no further elements would be added to the ToC. This is fixed by including the first H1 element within the ToC, and starting with a first wrap-element "wrap-W0".
      - For example, this stops the Registers from being added to the ToC.
      - Locally testing I saw no issue, but did not rebase and test before merging, and the assumption was then broken in the meantime by https://github.com/lowRISC/opentitan/pull/18694.

- Adding the first H1 element to the pagetoc then caused a minor issue where the scroll-margin-top failed to apply correctly when nav'ing to it, causing it to be placed behind the mdbook header. Add some js to force-scroll into view if this element is selected.