### PR TITLE
[bazel] Treat clang-tidy warnings as errors

### DIFF
--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -103,6 +103,8 @@ def clang_format_test(**kwargs):
 #  ./bazelisk.sh run @lowrisc_rv32imcb_files//:bin/clang-tidy -- --checks='*' --list-checks
 _CLANG_TIDY_CHECKS = [
     "clang-analyzer-core.*",
+    # Do not warn about replacing memset with memset_s.
+    "-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling",
 ]
 
 def _clang_tidy_aspect_impl(target, ctx):
@@ -197,10 +199,7 @@ def _clang_tidy_aspect_impl(target, ctx):
         if len(_CLANG_TIDY_CHECKS) > 0:
             checks_pattern = ",".join(_CLANG_TIDY_CHECKS)
             args.add("--checks=" + checks_pattern)
-
-            # TODO(#12553) Once C compiler warnings are generally treated as
-            # errors, start interpreting clang-tidy warnings as errors.
-            #args.add("--warnings-as-errors=" + checks_pattern)
+            args.add("--warnings-as-errors=" + checks_pattern)
 
         if ctx.attr._enable_fix:
             args.add("--fix")

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -68,7 +68,8 @@ inline ptrdiff_t misalignment32_of(uintptr_t addr) {
  *
  * Of course, `ptr` must point to word-aligned memory that is at least one word
  * wide. To do otherwise is Undefined Behavior. It goes without saying that the
- * memory this function intents to read must be initialized.
+ * memory this function intends to read must be initialized and the value of
+ * `ptr` must be non-NULL.
  *
  * This function has reordering properties as weak as a normal, non-atomic,
  * non-volatile load.
@@ -78,6 +79,9 @@ inline ptrdiff_t misalignment32_of(uintptr_t addr) {
  */
 OT_WARN_UNUSED_RESULT
 inline uint32_t read_32(const void *ptr) {
+  if (ptr == NULL) {
+    OT_UNREACHABLE();
+  }
   // Both GCC and Clang optimize the code below into a single word-load on most
   // platforms. It is necessary and sufficient to indicate to the compiler that
   // the pointer points to four bytes of four-byte-aligned memory.

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -98,7 +98,7 @@ static status_t aes_key_construct(const crypto_blinded_key_t *blinded_key,
   if (memcmp(&aes_key->mode, &aes_mode, sizeof(aes_key->mode)) != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(aes_key->mode, aes_mode);
+  HARDENED_CHECK_EQ((int)aes_key->mode, (int)aes_mode);
 
   // Set the AES key length (in words).
   aes_key->key_len = keyblob_share_num_words(blinded_key->config);

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -219,16 +219,16 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   HARDENED_RETURN_IF_ERROR(sigverify_rsa_key_get(
       sigverify_rsa_key_id_get(&manifest->rsa_modulus), lc_state, &rsa_key));
 
-  const sigverify_spx_key_t *spx_key;
-  const sigverify_spx_signature_t *spx_signature;
+  const sigverify_spx_key_t *spx_key = NULL;
+  const sigverify_spx_signature_t *spx_signature = NULL;
   uint32_t sigverify_spx_en = sigverify_spx_verify_enabled(lc_state);
   if (launder32(sigverify_spx_en) != kSigverifySpxDisabledOtp) {
-    const manifest_ext_spx_key_t *ext_spx_key;
+    const manifest_ext_spx_key_t *ext_spx_key = NULL;
     HARDENED_RETURN_IF_ERROR(manifest_ext_get_spx_key(manifest, &ext_spx_key));
     HARDENED_RETURN_IF_ERROR(sigverify_spx_key_get(
         sigverify_spx_key_id_get(&ext_spx_key->key), lc_state, &spx_key));
 
-    const manifest_ext_spx_signature_t *ext_spx_signature;
+    const manifest_ext_spx_signature_t *ext_spx_signature = NULL;
     HARDENED_RETURN_IF_ERROR(
         manifest_ext_get_spx_signature(manifest, &ext_spx_signature));
     spx_signature = &ext_spx_signature->signature;


### PR DESCRIPTION
This PR changes the behavior of `//quality:clang_tidy_check` to treat warnings as errors. To avoid introducing build failures, I've made a few tweaks to convince clang-analyzer that certain branches are unreachable.

Try it out:

```sh
./bazelisk.sh test //quality:clang_tidy_check
```