### PR TITLE
[bazel] Add missing base:macros to deps

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -53,7 +53,10 @@ cc_library(
     name = "math",
     srcs = ["math.c"],
     hdrs = ["math.h"],
-    deps = [":math_builtins"],
+    deps = [
+        ":macros",
+        ":math_builtins",
+    ],
 )
 
 cc_test(

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -184,6 +184,7 @@ cc_library(
     hdrs = ["rom_print.h"],
     deps = [
         ":error",
+        "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:uart",
     ],
 )


### PR DESCRIPTION
This PR fixes the fallout from #18770. These missing deps don't break regular builds in the CI but cause issues when targets are built individually during coverage measurement.