### PR TITLE
[hw,spi_device,dv] Enable CDC instrumentation

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -7,7 +7,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                                                           .COV_T (spi_device_env_cov));
   `uvm_component_utils(spi_device_scoreboard)
 
-  localparam int FLASH_STATUS_UPDATE_DLY_AFTER_CSB_DEASSERT = 3;
+  localparam int FLASH_STATUS_UPDATE_DLY_AFTER_CSB_DEASSERT = 4;
   typedef enum int {
     NoInternalProcess,
     InternalProcessStatus,
@@ -939,7 +939,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
   // read with no delay, the 2nd one may also doesn't match.
   // add some cycle delays to make it close to design behavior, so that the 2nd interrupt read
   // must match.
-  virtual function void update_pending_intr_w_delay(spi_device_intr_e intr, int delay_cyc = 3);
+  virtual function void update_pending_intr_w_delay(spi_device_intr_e intr, int delay_cyc = 4);
     fork begin
       `uvm_info(`gfn,
         $sformatf("Wait %0d cycles to enable compare of %s interrupt",delay_cyc, intr.name()),

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -44,6 +44,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // Default UVM test and seq class name.
   uvm_test: spi_device_base_test
   uvm_test_seq: spi_device_base_vseq


### PR DESCRIPTION
- Enable CDC randomisation
- Update FLASH_STATUS register update timing to account for CDC randomisation enabled with this change
This PR partially addresses https://github.com/lowRISC/opentitan/issues/16689