### PR TITLE
[dv, chip-test]: Update some chip tests to use AST ADC output port

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv
@@ -7,9 +7,10 @@ class chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.u_adc.adc_d_o[9:0]";
-  localparam string ADC_DATA_VALID = "tb.dut.u_ast.u_adc.adc_d_val_o";
-  localparam string ADC_POWERDOWN = "tb.dut.u_ast.u_adc.adc_pd_i";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
+  localparam string ADC_DATA_VALID = "tb.dut.u_ast.adc_d_val_o";
+  localparam string ADC_POWERDOWN = "tb.dut.u_ast.adc_pd_i";
+
   localparam string ADC_CTRL_WAKEUP_REQ = "tb.dut.top_earlgrey.u_pwrmgr_aon.wakeups_i[1]";
 
   localparam uint NUM_ADC_CHANNELS = 2;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
@@ -7,11 +7,11 @@ class chip_sw_ast_clk_rst_inputs_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.u_adc.adc_d_o[9:0]";
-  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.u_adc.adc_chnsel_i[1:0]";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
+  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.adc_chnsel_i[1:0]";
 
-  localparam string ADC_DATA_VALID = "tb.dut.u_ast.u_adc.adc_d_val_o";
-  localparam string ADC_POWERDOWN = "tb.dut.u_ast.u_adc.adc_pd_i";
+  localparam string ADC_DATA_VALID = "tb.dut.u_ast.adc_d_val_o";
+  localparam string ADC_POWERDOWN = "tb.dut.u_ast.adc_pd_i";
   localparam string ADC_CTRL_WAKEUP_REQ = "tb.dut.top_earlgrey.u_pwrmgr_aon.wakeups_i[1]";
   localparam uint NUM_ADC_CHANNELS = 2;
   localparam uint NUM_LOW_POWER_SAMPLES = 3;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -6,8 +6,8 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq)
   `uvm_object_new
 
-  localparam string ADC_CHANNEL_OUT_HDL_PATH    = "tb.dut.u_ast.u_adc.adc_d_o[9:0]";
-  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.u_adc.adc_chnsel_i[1:0]";
+  localparam string ADC_CHANNEL_OUT_HDL_PATH = "tb.dut.u_ast.adc_d_o[9:0]";
+  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.adc_chnsel_i[1:0]";
 
   event adc_valid_rising_edge_event;
   event adc_channel1_event;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -4,20 +4,79 @@
 
 class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq)
-
   `uvm_object_new
+
+  localparam string ADC_CHANNEL_OUT_HDL_PATH    = "tb.dut.u_ast.u_adc.adc_d_o[9:0]";
+  localparam string ADC_CHANNEL_IN_SEL_HDL_PATH = "tb.dut.u_ast.u_adc.adc_chnsel_i[1:0]";
+
+  event adc_valid_rising_edge_event;
+  event adc_channel1_event;
+  event release_adc_force;
+
+  virtual task wait_for_adc_channel();
+    bit [1:0] adc_channel;
+    bit [1:0] adc_channel_valid_last_value;
+    forever begin
+      adc_channel_valid_last_value = adc_channel;
+      `DV_CHECK(uvm_hdl_read(ADC_CHANNEL_IN_SEL_HDL_PATH, adc_channel));
+      if ( adc_channel_valid_last_value != 1 && adc_channel == 1) begin
+        ->adc_channel1_event;
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task wait_for_adc_valid_falling_edge();
+    bit adc_data_valid;
+    bit adc_data_valid_last_value;
+    forever begin
+      adc_data_valid_last_value = adc_data_valid;
+      adc_data_valid=cfg.chip_vif.adc_data_valid;
+      if (adc_data_valid_last_value == 0 && adc_data_valid == 1) begin
+        ->adc_valid_rising_edge_event;
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task force_adc_channels(input bit [9:0] channel0_value,
+                                  input bit [9:0] channel1_value);
+    // sync with ADC channel1
+    @(adc_channel1_event);
+    fork : force_adc_channels
+      begin
+        forever begin
+          // force ADC channel0,1
+          @(adc_valid_rising_edge_event);
+          `DV_CHECK(uvm_hdl_force(ADC_CHANNEL_OUT_HDL_PATH, (channel0_value)));
+          @(adc_valid_rising_edge_event);
+          `DV_CHECK(uvm_hdl_force(ADC_CHANNEL_OUT_HDL_PATH, (channel1_value)));
+        end
+      end
+      begin
+        // wait for release the adc force
+        @(release_adc_force);
+        disable force_adc_channels;
+      end
+    join_none;
+  endtask
 
   virtual task pre_start();
     super.pre_start();
-    cfg.chip_vif.pwrb_in_if.drive(1'b1);    // off
+    cfg.chip_vif.pwrb_in_if.drive(1'b1); // off
   endtask
 
   virtual task body();
-    uint                timeout_long = 10_000_000;
-    uint                timeout_short = 1_000_000;
-    bit twice_each = 0;
+    uint timeout_long  = 10_000_000;
+    uint timeout_short = 1_000_000;
+    bit twice_each   = 0;
     int repeat_count = 1;
     super.body();
+
+    fork
+      wait_for_adc_valid_falling_edge();
+      wait_for_adc_channel();
+    join_none
 
     // Give the pin a default value.
     cfg.chip_vif.pinmux_wkup_if.set_pulldown_en(1'b1);
@@ -70,7 +129,6 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
   // Round 1 : input for adc ctrl (force)
   // Round 2 : input for pinmux wakeup detector
   task wakeup_action(int round);
-    string path1 ,path2;
      repeat(20) @(posedge cfg.ast_supply_vif.clk);
     case(round)
       0: begin
@@ -80,10 +138,7 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
       1: begin
         `uvm_info(`gfn, "Force adc out ", UVM_MEDIUM)
         // Force to random positive value
-        path1 = "tb.dut.u_ast.u_adc.u_adc_ana.adc_d_ch0_o";
-        path2 = "tb.dut.u_ast.u_adc.u_adc_ana.adc_d_ch1_o";
-        `DV_CHECK(uvm_hdl_force(path1, 5))
-        `DV_CHECK(uvm_hdl_force(path2, 115))
+        force_adc_channels(5,115);
       end
       2: begin
         `uvm_info(`gfn, "Send pattern to pinmux wakeup detector ", UVM_MEDIUM)
@@ -95,14 +150,11 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
 
   // Release wakeup signals
   task release_action(int round);
-    string path1 ,path2;
     case(round)
       0: cfg.chip_vif.pwrb_in_if.drive(1'b1);
       1: begin
-        path1 = "tb.dut.u_ast.u_adc.u_adc_ana.adc_d_ch0_o";
-        path2 = "tb.dut.u_ast.u_adc.u_adc_ana.adc_d_ch1_o";
-        `DV_CHECK(uvm_hdl_release(path1))
-        `DV_CHECK(uvm_hdl_release(path2))
+        `DV_CHECK(uvm_hdl_release(ADC_CHANNEL_OUT_HDL_PATH))
+        ->release_adc_force;
       end
       2:     cfg.chip_vif.pinmux_wkup_if.drive(1'b0);
       default: `uvm_fatal(`gfn, $sformatf("round %d is not allowed", round))


### PR DESCRIPTION
Update chip_sw_ast_clk_rst_inputs_vseq and chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq tests to use the AST ADC output port.