### PR TITLE
[site,doc] Fixup some formatting of lc_ctrl tables

### DIFF
--- a/hw/ip/lc_ctrl/doc/lc_ctrl_access_signals_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_access_signals_table.md
@@ -1,6 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
-
 <table style="text-align:center;font-size:small">
   <tr>
     <td style="text-align:left"><strong>State \ Function</strong></td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_counter_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_counter_table.md
@@ -1,6 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
-
 <table style="text-align:center;font-size:small">
   <tr>
     <td style="text-align:left"><strong>Strokes \ Halfword</strong></td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_encoding_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_encoding_table.md
@@ -1,6 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
-
 <table style="text-align:center;font-size:small">
   <tr>
     <td style="text-align:left"><strong>State \ Halfword</strong></td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_flash_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_flash_accessibility.md
@@ -1,5 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
 <table>
 <thead>
 <tr>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_flash_collateral.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_flash_collateral.md
@@ -1,5 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
 <table>
 <thead>
 <tr>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_flash_partitions.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_flash_partitions.md
@@ -1,5 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
 <table>
 <thead>
 <tr>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_function_signals_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_function_signals_table.md
@@ -1,6 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
-
 <table style="text-align:center;font-size:small">
   <tr>
     <td style="text-align:left"><strong>State \ Function</strong></td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
@@ -1,5 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
 <table>
 <thead>
 <tr>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_otp_collateral.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_otp_collateral.md
@@ -1,5 +1,3 @@
-###
-<!-- this is a workaround to get around Hugo Issue #7296 (https://github.com/gohugoio/hugo/issues/7296) -->
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
The ### characters were being interpreted as an empty heading which appeared in the ToC. The workaround mentioned is no longer relevant now we have moved to mdBook for documentation.