### PR TITLE
[sw/silicon_creator] Control SRAM scrambling and init with OTP

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -598,6 +598,18 @@
       default: "4",
       local: "true"
     },
+    { name: "CreatorSwCfgSramKeyRenewEnOffset",
+      desc: "Offset of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN",
+      type: "int",
+      default: "352",
+      local: "true"
+    },
+    { name: "CreatorSwCfgSramKeyRenewEnSize",
+      desc: "Size of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
     { name: "CreatorSwCfgDigestOffset",
       desc: "Offset of CREATOR_SW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -240,6 +240,10 @@
                     name: "CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST",
                     size: "4"
                 }
+                {
+                    name: "CREATOR_SW_CFG_SRAM_KEY_RENEW_EN",
+                    size: "4"
+                }
             ],
             desc: '''Software configuration partition for
             device-specific calibration data (Clock, LDO,

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -39,6 +39,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                |            |      32bit       |        CREATOR_SW_CFG_RNG_EXTHT_LO_THRESHOLDS         |     0x154      |     4      |
 |         |                |            |      32bit       |          CREATOR_SW_CFG_RNG_ALERT_THRESHOLD           |     0x158      |     4      |
 |         |                |            |      32bit       |        CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST        |     0x15C      |     4      |
+|         |                |            |      32bit       |           CREATOR_SW_CFG_SRAM_KEY_RENEW_EN            |     0x160      |     4      |
 |         |                |            |      64bit       | [CREATOR_SW_CFG_DIGEST](#Reg_creator_sw_cfg_digest_0) |     0x358      |     8      |
 |    2    |  OWNER_SW_CFG  |    800     |      32bit       |           OWNER_SW_CFG_ROM_ERROR_REPORTING            |     0x360      |     4      |
 |         |                |            |      32bit       |            OWNER_SW_CFG_ROM_BOOTSTRAP_DIS             |     0x364      |     4      |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -327,7 +327,8 @@ package otp_ctrl_part_pkg;
     }),
     6400'({
       64'h74501C921B4BAE3A,
-      4032'h0, // unallocated space
+      4000'h0, // unallocated space
+      32'h0,
       32'h0,
       32'h0,
       32'h0,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -86,6 +86,8 @@ package otp_ctrl_reg_pkg;
   parameter int CreatorSwCfgRngAlertThresholdSize = 4;
   parameter int CreatorSwCfgRngHealthConfigDigestOffset = 348;
   parameter int CreatorSwCfgRngHealthConfigDigestSize = 4;
+  parameter int CreatorSwCfgSramKeyRenewEnOffset = 352;
+  parameter int CreatorSwCfgSramKeyRenewEnSize = 4;
   parameter int CreatorSwCfgDigestOffset = 856;
   parameter int CreatorSwCfgDigestSize = 8;
   parameter int OwnerSwCfgOffset = 864;

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -391,9 +391,17 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
 
   // Scramble and initialize main memory (main SRAM).
   // Memory accesses will stall until initialization is complete.
+  // Set `SRAM_KEY_RENEW_EN` OTP item to `HARDENED_BOOL_FALSE` to disable and
+  // any other value to enable.
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_OFFSET(a0)
+  li   t1, HARDENED_BOOL_FALSE
+  beq t0, t1, .L_sram_key_renew_skip
   li a0, TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR
   li a1, (1 << SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT) | (1 << SRAM_CTRL_CTRL_INIT_BIT)
   sw a1, SRAM_CTRL_CTRL_REG_OFFSET(a0)
+.L_sram_key_renew_skip:
 
   /**
    * Clean Device State Part 1 (Please refer to `boot.md` section "Cleaning Device


### PR DESCRIPTION
This PR adds an OTP item to control the SRAM scrambling and init performed in `rom_start.S` to derisk the ROM in case the entropy source fails to work correctly at boot. In order not to change the default behavior that we have been testing so far and to favor security, `HARDENED_BOOL_FALSE` disables and any other value enables.

@GregAC @msfschaffner @moidx I think this PR will also require you to allow the changes in OTP.