### PR TITLE
[doc] Fix-up minor Hugo-isms left over in docs

### DIFF
--- a/doc/contributing/hw/comportability/README.md
+++ b/doc/contributing/hw/comportability/README.md
@@ -163,7 +163,7 @@ By "care" an example would be to reset their value synchronously at a time after
 
 Based upon this and the fact that much of the team history was with asynchronous active low reset, we chose that methodology with added requirements that special care be applied for security state, the details of which will come at a later date.
 
-### Bus Interfaces {#bus-interfaces}
+### Bus Interfaces
 
 Peripherals can connect to the chip bus.
 All peripherals are assumed to have registers, and are thus required to expose at least one device interface on the chip bus.
@@ -245,7 +245,7 @@ The connection between the modules are defined in the top-level configuration fi
 
 See the section on [Inter Signal Handling](#inter-signal-handling) below for detailed data structure in the configuration file.
 
-### Security countermeasures {#countermeasures}
+### Security countermeasures
 
 If this IP block is considered security-critical, it will probably have design features that try to mitigate against attacks like fault injection or side channel analysis.
 These features can be loosely categorised and named with identifiers of the following form:
@@ -444,7 +444,7 @@ This is done with a list with key `countermeasures`.
 Each item is a dictionary with keys `name` and `desc`.
 The `desc` field is a human-readable description of the countermeasure.
 The `name` field should be either of the form `ASSET.CM_TYPE` or `INSTANCE.ASSET.CM_TYPE`.
-Here, `ASSET` and `CM_TYPE` should be one of the values given in the tables in the [Security countermeasures](#countermeasures) section.
+Here, `ASSET` and `CM_TYPE` should be one of the values given in the tables in the [Security countermeasures](#security-countermeasures) section.
 If specified, `INSTANCE` should name a submodule of the IP block holding the asset.
 It can be used to disambiguate in situations such as where there are two different keys that are protected with different countermeasures.
 

--- a/doc/contributing/style_guides/c_cpp_coding_style.md
+++ b/doc/contributing/style_guides/c_cpp_coding_style.md
@@ -262,9 +262,9 @@ X macros that are not part of a header's API should be `#undef`ed after they are
 Similarly, the arguments to an X macro, if they are defined in a header, should be `#undef`ed too.
 This is not necessary in a `.c` or `.cc` file, where this cannot cause downstream namespace pollution.
 
-## C++ Style Guide {#cxx-style-guide}
+## C++ Style Guide
 
-### C++ Version {#cxx-version}
+### C++ Version
 
 C++ code should target C++14.
 

--- a/doc/guides/getting_started/src/build_sw.md
+++ b/doc/guides/getting_started/src/build_sw.md
@@ -300,15 +300,15 @@ riscv32-unknown-elf-objdump --disassemble-all --headers --line-numbers --source 
 
 Refer to the output of `riscv32-unknown-elf-objdump --help` for a full list of options.
 
-## Troubleshooting {#troubleshooting}
+## Troubleshooting
 
-### Check CI {#troubleshooting-check-ci}
+### Check CI
 
 First, [check the GitHub repository](https://github.com/lowRISC/opentitan/commits/master) to make sure the CI check is succeeding for the commit you cloned.
 If there's an issue with that commit (it would have a red "X" next to it), check out the most recent commit that passed CI (indicated by a green check mark).
 We try to always keep the main branch healthy, but the project is in active development and we're not immune to temporary breaks.
 
-### Debugging a failed verilator test {#troubleshooting-verilator-test-failure}
+### Debugging a failed verilator test
 
 If your `bazelisk.sh` build failed trying to run a test on Verilator, the first step is to see if you can build the chip simulation on its own:
 

--- a/doc/guides/getting_started/src/setup_fpga.md
+++ b/doc/guides/getting_started/src/setup_fpga.md
@@ -148,7 +148,7 @@ You will then need to run this command to configure the board. You only need to 
 bazel run //sw/host/opentitantool -- --interface=cw310 fpga set-pll
 ```
 
-Check that it's working by [running the demo](#hello-world-demo) or a test, such as the `uart_smoketest` below.
+Check that it's working by [running the demo](#bootstrapping-the-demo-software) or a test, such as the `uart_smoketest` below.
 ```console
 cd $REPO_TOP
 bazel test --test_output=streamed //sw/device/tests:uart_smoketest_fpga_cw310_test_rom
@@ -245,7 +245,7 @@ I00001 test_rom.c:87] TestROM:6b2ca9a1
 I00002 test_rom.c:118] Test ROM complete, jumping to flash!
 ```
 
-#### Bootstrapping the demo software {#hello-world-demo}
+#### Bootstrapping the demo software
 
 The `hello_world` demo software shows off some capabilities of the OpenTitan hardware.
 To load `hello_world` into the FPGA on the ChipWhisperer CW310 board follow the steps shown below.

--- a/doc/rust_for_c_devs.md
+++ b/doc/rust_for_c_devs.md
@@ -25,7 +25,7 @@ C++ users are cautioned: Rust shares a lot of terminology and concepts (ownershi
 Experience in C++ should not be expected to translate cleanly.
 
 
-## What is Rust? {#what-is-rust}
+## What is Rust?
 
 Rust is a general-purpose programming language with a focus on maximum programmer control and zero runtime overhead, while eliminating the sharp edges traditionally associated with such languages.
 It is also sometimes called a "systems language".
@@ -42,7 +42,7 @@ Rust also contains a special dialect called Unsafe Rust, which disables some sta
 We will make reference to this dialect throughout the document.
 
 
-## The Rust Toolchain {#the-rust-toolchain}
+## The Rust Toolchain
 
 A complete Rust toolchain consists of a few major parts:
 
@@ -107,18 +107,18 @@ rustc has a number of flags. The most salient of these are:
 Other interesting flags can be found under `rustc -C help` and, on nightly, under `rustc -Z help`.
 
 
-## Part I: Rewriting your C in Rust {#part-i-rewriting-your-c-in-rust}
+## Part I: Rewriting your C in Rust
 
 Before diving into Rust's specific features, we will begin by exploring how C concepts map onto Rust, as well as Unsafe Rust, a dialect of Rust that is free of many of Rust's restrictions, but also most of its safety guarantees.
 
 
-### Types {#types}
+### Types
 
 Rust and C have roughly the same approach to types, though Rust has few implicit conversions (for example, it lacks integer promotion like C).
 In this section, we will discuss how to translate C types into Rust types.
 
 
-#### Integers {#integers}
+#### Integers
 
 Rust lacks C's `int`, `long`, `unsigned`, and other types with an implementation-defined size.
 Instead, Rust's primitive integer types are exact-size types: `i8`, `i16`, `i32`, `i64`, and `i128` are signed integers of 8, 16, 32, 64, and 128 bits, respectively, while `u8`, `u16`, `u32`, `u64`, and `u128` are their unsigned variants.
@@ -141,7 +141,7 @@ It is also the only type that can be used in `if` and `while` conditions.
 Integers have an extensive set of built-in operations for bit-twiddling, exposed as methods, such as `x.count_zeros()` and `x.next_power_of_two()`[^18].
 See [https://doc.rust-lang.org/std/primitive.u32.html](https://doc.rust-lang.org/std/primitive.u32.html) for examples.
 
-#### Structs and Tuples {#structs-and-tuples}
+#### Structs and Tuples
 
 Structs are declared almost like in C:
 ```rust
@@ -262,7 +262,7 @@ We'll see these enums again when we discuss patterns.
 
 Just like with structs, `#[derive]` can be used on enums to define comparison operators, which are defined analogously to the struct case.
 
-#### Arrays {#arrays}
+#### Arrays
 
 Rust arrays are just C arrays: inline storage of a compile-time-known number of values.
 `T[N]` in C is spelled `[T; N]` in Rust.
@@ -276,7 +276,7 @@ Unsafe Rust can be used to cheat the bounds check when it is known (to the progr
 Rust arrays are "real" types, unlike in C. They can be passed by value into functions, and returned by value from functions.
 They also don't decay into pointers when passed into functions.
 
-#### Pointers {#pointers}
+#### Pointers
 
 Like every other embedded language, Rust has pointers.
 These are usually referred to as _raw pointers_, to distinguish them from the myriad of smart pointer types.
@@ -310,7 +310,7 @@ For that, we use _references_, which are discussed much later.
 We will touch on function pointers when we encounter functions.
 
 
-### Items {#items}
+### Items
 
 Like C, Rust has globals and functions.
 These, along with the type definitions above, are called _items_ in the grammar, to avoid confusion with C's declaration/definition distinction.
@@ -318,7 +318,7 @@ Unlike C, Rust does not have forward declaration or declaration-order semantics;
 Items are imported through dedicated import statements, rather than textual inclusion; more on this later.
 
 
-#### Constants and Globals {#constants-and-globals}
+#### Constants and Globals
 
 Rust has dedicated syntax for compile-time constants, which serve the same purpose as `#define`d constants do in C.
 Their syntax is
@@ -344,7 +344,7 @@ Mutable globals can also be a source other racy behavior due to IRQ control flow
 As such, reading or writing to a mutable global, or creating a reference to one, requires Unsafe Rust.
 
 
-#### Functions {#functions}
+#### Functions
 
 In C and Rust, functions are the most important syntactic construct. Rust declares functions like so:
 ```rust
@@ -385,7 +385,7 @@ The syntax available in `const` functions increases in every release, though.
 Most standard library functions that can be `const` are already `const`.
 
 
-#### Macros {#macros}
+#### Macros
 
 Rust, like C, has macros.
 Rust macros are much more powerful than C macros, and operate on Rust syntax trees, rather than by string replacement.
@@ -394,7 +394,7 @@ For example, `file!()` expands to a string literal with the file name.
 To learn more about macros, see [https://danielkeep.github.io/tlborm/book/index.html](https://danielkeep.github.io/tlborm/book/index.html).
 
 
-#### Aliases {#aliases}
+#### Aliases
 
 Rust has `type`, which works exactly like `typedef` in `C`.
 Its syntax is
@@ -402,7 +402,7 @@ Its syntax is
 type MyAlias = u32;
 ```
 
-### Expressions and Statements {#expressions-and-statements}
+### Expressions and Statements
 
 Very much unlike C, Rust has virtually no statements in its grammar: almost everything is an expression of some kind, and can be used in expression context.
 Roughly speaking, the only statement in the language is creating a binding:
@@ -423,7 +423,7 @@ Like in almost all other languages, literals, operators, function calls, variabl
 Let's dive into some of Rust's other expressions.
 
 
-#### Blocks {#blocks}
+#### Blocks
 
 Blocks in Rust are like better versions of C's blocks; in Rust, every block is an expression.
 A block is delimited by `{ }`, consists of a set of a list of statements and items, and potentially an ending expression, much like a function.
@@ -439,7 +439,7 @@ Blocks are like local functions that execute immediately, and can be useful for 
 If a block does not end in an expression (that is, every statement within ends in a semicolon), it will implicitly return `()`, just like a function does.
 This automatic `()` is important when dealing with constructs like `if` and `match` expressions that need to unify the types of multiple branches of execution into one.
 
-#### Conditionals: `if` and `match` {#conditionals-if-and-match}
+#### Conditionals: `if` and `match`
 
 Rust's `if` expression is, syntactically, similar to C's. The full syntax is
 ```rust
@@ -514,7 +514,7 @@ If this behavior is not desired in an enum (because more variants will be added 
 We will see later that pattern matching makes `match` far more powerful than C's `switch`.
 
 
-#### Loops: `loop` and `while` {#loops-loop-and-while}
+#### Loops: `loop` and `while`
 
 Rust has three kinds of loops: `loop`, `while`, and `for`.
 `for` is not a C-style `for`, so we'll discuss it later.
@@ -533,7 +533,7 @@ Having an unconditional infinite loop allows Rust to perform better type and lif
 Under the hood, all of Rust's control flow is implemented in terms of `loop`, `match`, and `break`.
 
 
-#### Control Flow {#control-flow}
+#### Control Flow
 
 Rust has `return`, `break`, and `continue`, which have their usual meanings from C.
 They are also expressions, and, much like `loop {}`, have type `!` because all code that follows them is never executed (since they yank control flow).
@@ -562,7 +562,7 @@ let value = loop {
 ```
 
 
-### Talking to C {#talking-to-c}
+### Talking to C
 
 One of Rust's great benefits is mostly-seamless interop with existing C libraries.
 Because Rust essentially has no runtime, Rust types that correspond to C types can be trivially shared, and Rust can call C functions with almost no overhead[^54].
@@ -580,9 +580,9 @@ Also, some care must be taken with what types are sent over the boundary.
 See [https://doc.rust-lang.org/reference/items/external-blocks.html](https://doc.rust-lang.org/reference/items/external-blocks.html) for more details.
 
 
-### Analogues of other functionality {#analogues-of-other-functionality}
+### Analogues of other functionality
 
-#### Volatile {#volatile}
+#### Volatile
 
 Rust does not have a `volatile` qualifier.
 Instead, volatile reads can be performed using the `read_volatile()`[^55] and `write_volatile()`[^56] methods on pointers, which behave exactly like volatile pointer dereference in C.
@@ -591,7 +591,7 @@ Note that these methods work on types wider than the architecture's volatile loa
 The same caveat applies in C: `volatile uint64_t` will emit multiple accesses on a 32-bit machine.
 
 
-#### Inline Assembly {#inline-assembly}
+#### Inline Assembly
 
 Rust does not quite support inline assembly yet.
 Clang's inline assembly syntax is available behind the unstable macro `llvm_asm!()`, which will eventually be replaced with a Rust-specific syntax that better integrates with the language.
@@ -600,7 +600,7 @@ Naked functions can be created using `#[naked]`. See [https://doc.rust-lang.org/
 
 [Note that this syntax is currently in the process of being redesigned and stabilized.](https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.html)
 
-#### Bit Casting {#bit-casting}
+#### Bit Casting
 
 Rust provides a type system trap-door for bitcasting any type to any other type of the same size:
 ```rust
@@ -613,7 +613,7 @@ The primary embedded-relevant use-case is for summoning function pointers from t
 [https://doc.rust-lang.org/std/mem/fn.transmute.html](https://doc.rust-lang.org/std/mem/fn.transmute.html) has a list of uses, many of which do not actually require transmute.
 
 
-#### Linker Shenanigans and Other Attributes {#linker-shenanigans-and-other-attributes}
+#### Linker Shenanigans and Other Attributes
 
 Below are miscellaneous attributes relevant to embedded programming.
 Many of these subtly affect linker/optimizer behavior, and are very much in the "you probably don't need to worry about it" category.
@@ -624,14 +624,14 @@ Many of these subtly affect linker/optimizer behavior, and are very much in the 
 *   `#[cold]` can also be used to pessimize inlining for functions that are unlikely to ever be called.
 
 
-## Part II: Rust-Specific Features {#part-ii-rust-specific-features}
+## Part II: Rust-Specific Features
 
 The previous part established enough vocabulary to take roughly any embedded C program and manually translate it into Rust.
 However, those Rust programs are probably about as safe and ergonomic as the C they came from.
 This section will focus on introducing features that make Rust safer and easier to write.
 
 
-### Ownership {#ownership}
+### Ownership
 
 Double-free or, generally, double-use, are a large class of insidious bugs in C, which don't look obviously wrong at a glance:
 ```c
@@ -692,7 +692,7 @@ Of course, the copy/move distinction is something of a misnomer: reassignment du
 The distinction is purely for static analysis.
 
 
-### References and Lifetimes {#references-and-lifetimes}
+### References and Lifetimes
 
 Another class of use-after-free involves stack variables after the stack is destroyed.
 Consider the following C:
@@ -808,7 +808,7 @@ Finally, it should go without saying that references are only useful for main me
 [https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html) elaborates further on the various lifetime rules.
 
 
-#### Operations on References {#operations-on-references}
+#### Operations on References
 
 Rust references behave much more like scalar values than like pointers (borrow-checking aside).
 Because it is statically known that every reference, at all times, points to a valid, initialized value of type `T`, explicit dereferencing is elided most of the time (though, when necessary, they can be dereferenced: `*x` is an lvalue that can be assigned to).
@@ -823,7 +823,7 @@ Pointer equality is still possible with `std::ptr::eq(x, y)`.
 References can be coerced into raw pointers: `x as *const T`, and compared directly.
 
 
-### Methods {#methods}
+### Methods
 
 While Rust is not an object-oriented language, it does provide a mechanism for namespacing functions under types: `impl` (for implementation) blocks.
 These also allow you to make use of Rust's visibility annotations, to make implementation details and helpers inaccessible to outside users.
@@ -885,7 +885,7 @@ impl MyStruct<'_> { /* ... */ }
 As we've already seen, many primitive types have methods, too; these are defined in special `impl` blocks in the standard library.
 
 
-### Slices and `for` {#slices-and-for}
+### Slices and `for`
 
 References also do not allow for pointer arithmetic, so a `&u32` cannot be used to point to a buffer of words.
 Static buffers can be passed around as arrays, like `&[u32; 1024]`, but often we want to pass a pointer to contiguous memory of a runtime-known value.
@@ -962,7 +962,7 @@ This operation is unsafe, but useful for bridging C and Rust, or Rust and Rust a
 More slice operations can be found at [https://doc.rust-lang.org/std/slice/index.html](https://doc.rust-lang.org/std/slice/index.html) and [https://doc.rust-lang.org/std/primitive.slice.html](https://doc.rust-lang.org/std/primitive.slice.html).
 
 
-#### String Literals {#string-literals}
+#### String Literals
 
 Rust string literals are much like C string literals: `"abcd..."`.
 Arbitrary ASCII-range bytes can be inserted with `\xNN`, and supports most of the usual escape sequences.
@@ -992,7 +992,7 @@ Raw strings can also be byte strings: `br#"..."#`.
 Rust also has character literals in the form of `'z'`[^75], though their type is `char`, a 32-bit Unicode code-point.
 To get an ASCII byte of type `u8`, instead, use `b'z'`.
 
-### Destructors and RAII {#destructors-and-raii}
+### Destructors and RAII
 
 Destructors are special functions that perform cleanup logic when a value has become unreachable (i.e., both the `let` that originally declared it can no longer be named, and the last reference to it expired).
 After the destructor is run, each of the value's fields, if it's a struct or enum, are also destroyed (or "dropped").
@@ -1028,7 +1028,7 @@ The function `std::mem::needs_drop()`[^82] can be used to discover if a type nee
 `std::ptr::drop_in_place()`[^83] can be used to run the destructor in the value behind a raw pointer, without technically giving up access to it.
 
 
-### Pattern Matching {#pattern-matching}
+### Pattern Matching
 
 References cannot be null, but it turns out that a null value is sometimes useful.
 `Option<T>` is a standard library type representing a "possibly absent `T`"[^84].
@@ -1203,7 +1203,7 @@ for (k, v) in my_key_values {
 }
 ```
 
-### Traits {#traits}
+### Traits
 
 Traits are Rust's core code-reuse abstraction.
 Rust traits are like interfaces in other languages: a list of methods that a type must implement.
@@ -1264,7 +1264,7 @@ This last syntax is also useful in generic contexts, or for being precise about 
 Traits are also the vehicle for operator overloading: these traits are found in the std::ops[^94] module of the standard library.
 
 
-#### Trait Objects {#trait-objects}
+#### Trait Objects
 
 Traits can be used for dynamic dispatch (also known as virtual polymorphism) through a mechanism called _trait objects_.
 Given a trait `Trait`, and a type `T` that implements it, we can `as`-cast a reference `&T` into a dynamic trait object: `&dyn Trait`.
@@ -1309,7 +1309,7 @@ In other words, all of the functions must treat `Self` as if it were not sized a
 The type `dyn Trait` always behaves as if it implemented `Trait`, which is relevant for generics, discussed below.
 
 
-#### Unsafe Traits {#unsafe-traits}
+#### Unsafe Traits
 
 It is possible to mark a trait as `unsafe` by writing `unsafe trait MyTrait { /* ... */ }`; the only difference with normal traits is that it requires `unsafe impl` to be implemented.
 Unsafe traits typically enforce some kind of additional constraint in addition to their methods; in fact, unsafe traits frequently don't have methods at all.
@@ -1331,7 +1331,7 @@ Auto traits are always markers that you don't really want to opt out of.
 They're like the opposite of `derive()` traits, which you need to opt into, since they meaningfully affect the API of your type in a way that it is important to be able to control.
 
 
-### Generics {#generics}
+### Generics
 
 _Generic programming_ is writing source code that can be compiled for many types.
 Generics are one of Rust's core features, which enable polymorphic[^99] static dispatch.
@@ -1392,7 +1392,7 @@ impl<T> MyWrapper<T> {
 ```
 
 
-#### Generic Bounds {#generic-bounds}
+#### Generic Bounds
 
 However, generics alone have one limitation: the function is only type and borrow checked once, in its generic form, rather than per instantiation; this means that generic code can't just call inherent methods of `T` and expect the lookup to succeed[^104].
 For example, this code won't compile:
@@ -1504,7 +1504,7 @@ This is not always ideal, since it's sometimes useful to expose a `T` in your ty
 For more information on how to use it, refer to the type documentation[^109] or the relevant Rustonomicon entry[^110].
 
 
-### Smart Pointers {#smart-pointers}
+### Smart Pointers
 
 In Rust, a "smart pointer"[^1112] is any type that implements `std::ops::Deref`[^112], the dereference operator[^113].
 `Deref` is defined like this:
@@ -1549,7 +1549,7 @@ For example, `<[u8] as Index<usize>>::Output` is `u8`, while `<[u8] as Index<Ran
 Indexing with a single index produces a single byte, while indexing with a range produces another slice.
 
 
-### Closures {#closures}
+### Closures
 
 Closures (sometimes called "lambda expressions" in other languages) are function literals that capture some portion of their environment, which can be passed into other functions to customize behavior.
 
@@ -1621,7 +1621,7 @@ For example, `Fn(i32) -> i32` represents taking an `i32` argument and returning 
 Closures also implement `Copy` and `Clone` if all of their captures do, too.
 
 
-#### Closures as Function Arguments {#closures-as-function-arguments}
+#### Closures as Function Arguments
 
 There are roughly two ways of writing a function that accepts a closure argument: through dynamic dispatch, or through static dispatch, which have a performance and a size penalty, respectively.
 
@@ -1658,7 +1658,7 @@ The pseudotype `impl Trait` can be used in function argument position to say "th
 Note that `Trait` can technically be any generic bound involving at least one trait: `impl Clone + Default` and `impl Clone + 'a` are valid.
 
 
-#### Closures as Function Returns {#closures-as-function-returns}
+#### Closures as Function Returns
 
 Closure types are generally unnameable. The canonical way to return closures is with `impl Trait` in return position:
 ```rust
@@ -1702,7 +1702,7 @@ fn new_fn(flag: bool) -> fn(i32) -> i32 {
   }
 }
 ```
-#### Closures as Struct Fields {#closures-as-struct-fields}
+#### Closures as Struct Fields
 
 Using closures as struct fields is fairly limited without being able to easily allocate.
 The two options are to either make the trait generic on the closure type (which needs to be propagated through everything that uses the struct), or to require that closures not capture, and use function pointers instead:
@@ -1730,7 +1730,7 @@ struct MyStruct<'a> {
 ```
 
 
-### `Option` and `Result`: Error Handling in Rust {#option-and-result-error-handling-in-rust}
+### `Option` and `Result`: Error Handling in Rust
 
 As we saw above, `Option` is a type that lets us specify a "potentially uninitialized" value.
 While it is common to work with `Option` using `match` expressions, it also has a number of convenience functions that shorten common sequences of code.
@@ -1812,7 +1812,7 @@ let x = my_thing.foo()?.bar()?.baz()?;
 See [https://doc.rust-lang.org/std/result/index.html](https://doc.rust-lang.org/std/result/index.html) for more `Result` operations.
 
 
-### `for` Revisited: Iterators {#for-revisited-iterators}
+### `for` Revisited: Iterators
 
 An _iterator_ is any type that implements the `Iterator` trait, which looks like this:
 ```rust
@@ -1891,7 +1891,7 @@ In general, iterators can produce very efficient code similar to that emitted by
 See [https://doc.rust-lang.org/std/iter/trait.Iterator.html](https://doc.rust-lang.org/std/iter/trait.Iterator.html) and [https://doc.rust-lang.org/std/iter](https://doc.rust-lang.org/std/iter/) for full details on available operations.
 
 
-### Modules and Crate Layout {#modules-and-crate-layout}
+### Modules and Crate Layout
 
 Each Rust crate is (from the compiler's perspective) given a unique, single-identifier name.
 This name is used to namespace a crate's symbols[^121].
@@ -1975,7 +1975,7 @@ Rust does not have headers, or declaration order constraints; modules within a c
 Rust crate namespaces are closed: after a crate is fully compiled, no other symbols can be added to it.
 
 
-### Interior Mutability {#interior-mutability}
+### Interior Mutability
 
 _Interior mutability_ is a borrow check escape hatch for working around Rust's aliasing rules.
 
@@ -2014,7 +2014,7 @@ This illustrates another property of `UnsafeCell`: it causes data that is otherw
 See [https://doc.rust-lang.org/std/cell/index.html](https://doc.rust-lang.org/std/cell/index.html) for more details; as with all aliasing-related topics, it requires careful attention t detail, and this section is far from exhaustive.
 
 
-### Unsafe Rust {#unsafe-rust}
+### Unsafe Rust
 
 Unsafe Rust is a dialect of Rust that is denoted by the keyword `unsafe`: `unsafe` blocks, unsafe functions, unsafe traits.
 Importantly, all of these actions require uttering the keyword `unsafe`, so that they can be easily detected in code review.

--- a/doc/security/implementation_guidelines/README.md
+++ b/doc/security/implementation_guidelines/README.md
@@ -1,3 +1,1 @@
 # Implementation Guidelines
-
-{{% sectionContent %}}

--- a/doc/security/specs/attestation/README.md
+++ b/doc/security/specs/attestation/README.md
@@ -56,7 +56,7 @@ Identity is used to attest the owner and BL0 configuration, as well as an
 attestation key used by the Kernel. This key is endorsed by the Creator Identity,
 but can also be endorsed by the Silicon Owner PKI. Endorsement of the Owner
 Identity with the Owner's PKI, is covered in detail in the
-[Owner Personalization](../device_provisioning/README.md#owner_personalization) process
+[Owner Personalization](../device_provisioning/README.md#owner-personalization) process
 described in the provisioning specification.
 
 When using a Silicon Owner PKI, the Owner is expected to maintain a device
@@ -366,13 +366,13 @@ source with a security strength equivalent to the one supported by the key
 manager. The triggering mechanism for updating the value is covered in the
 [Attestation Updates](#attestation-updates) section.
 
-## Asymmetric Keys {#asymmetric-keys}
+## Asymmetric Keys
 
 OpenTitan uses ECDSA attestation keys conformant to
 [FIPS 186-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf). Future
 revisions of this specification may add support for other signature schemes.
 
-### Key Identifiers {#key-identifiers}
+### Key Identifiers
 
 Key identifiers are defined as follows, where `SALT_CKI`and `SALT_OKI` are 256b
 values defined in `ROM_EXT` and `BL0` respectively.
@@ -629,7 +629,7 @@ OpenTitan Creator Identity custom extension:
   </tr>
 </table>
 
-#### Creator custom Extension {#creator-custom-extension}
+#### Creator custom extension
 
 This extension is formatted as an ASN.1 SEQUENCE containing device identifiable
 information. See [Privacy Considerations](#privacy-considerations) for
@@ -829,7 +829,7 @@ custom extensions.
 The binary manifest format must be standardized at the OpenTitan project level
 to ensure interoperability between silicon and software layers.
 
-## Privacy Considerations {#privacy-considerations}
+## Privacy Considerations
 
 The Silicon Owner software must address any privacy concerns associated with the
 use of device identifiable information.
@@ -870,4 +870,4 @@ DICE terminology.
 [diversification-key]:../identities_and_root_keys/README.md#diversification-key
 
 [device-provisioning]: ../device_provisioning/README.md
-[owner-personalization]: ../device_provisioning/README.md#owner_personalization
+[owner-personalization]: ../device_provisioning/README.md#owner-personalization

--- a/doc/security/specs/device_provisioning/README.md
+++ b/doc/security/specs/device_provisioning/README.md
@@ -15,7 +15,7 @@ two stages:
     [Creator Identity][creator_identity], its endorsement certificate, as well
     as additional secrets required to configure defensive mechanisms. This
     occurs only at manufacturing time.
-*   [Owner Personalization](#owner_personalization): Covers provisioning of
+*   [Owner Personalization](#owner-personalization): Covers provisioning of
     owner secrets and endorsement of the Owner Identity by the Silicon Owner.
     This may occur either at manufacturing time or as part of a later in-field
     ownership transfer.
@@ -48,7 +48,7 @@ requirements:
 
 ## Device Lifecycle and Personalization Stages
 
-### Unlock Tokens {#unlock_tokens}
+### Unlock Tokens
 
 OpenTitan provides a set of lock/unlock tokens to control the state of the
 device in early manufacturing stages. See
@@ -104,7 +104,7 @@ personalization.
 *   `PERSONALIZATION`: See [Personalization](#personalization) section for more
 *   `LOAD FW IMAGE`: Load factory image payload.
 
-## Personalization {#personalization}
+## Personalization
 
 ### Test Setup
 
@@ -185,7 +185,7 @@ flow with emphasis on the personalization process.
 Steps:
 
 1.  [Device identifiers][device_id] (`device_id`) and
-    [unlock tokens](#unlock_tokens) are programmed into the device's One Time
+    [unlock tokens](#unlock-tokens) are programmed into the device's One Time
     Programmable (OTP) memory. The unlock tokens are delivered in cleartext form
     to each OpenTitan die.
 2.  (Optional) A provisioning appliance collects all device identifiers and
@@ -203,7 +203,7 @@ Steps:
             generates `device_secrets` (in the injection case) and endorsement
             certificates. `appliance_secrets` are used to enable signing on
             endorsement certificates with Silicon Creator intermediate CA keys.
-        2.  [Self-Generated Process](#self_generated_process): The device
+        2.  [Self-Generated Process](#self-generated-process): The device
             generates its own `device_secrets` and the provisioning appliance is
             used to sign the endorsement certificate.
 6.  At the end of a successful provisioning flow, the provisioning appliance
@@ -211,7 +211,7 @@ Steps:
     the registry as part of identity ingestion flows.
 7.  The devices are shipped with a factory image and a Silicon Creator
     endorsement certificate. The Silicon Creator may also provide
-    [Owner Personalization](#owner_personalization) services. All shipped
+    [Owner Personalization](#owner-personalization) services. All shipped
     devices have secure boot enabled, which provides a logical locking mechanism
     to restrict the use of open samples.
 8.  The Silicon Creator may issue a Certificate Revocation List (CRL) to the
@@ -402,7 +402,7 @@ more details.
 The public portion of the Creator Identity is tested against the Creator
 Certificate. The result is reported to the TESTER via SPI.
 
-### Self-Generated Process {#self_generated_process}
+### Self-Generated Process
 
 This section describes the personalization self-generate mode in detail. In this
 mode, The device generates its own device secrets and the provisioning appliance
@@ -523,7 +523,7 @@ more details.
 The public portion of the Creator Identity is tested against the Creator
 Certificate. The result is reported to the TESTER via SPI.
 
-## Owner Personalization {#owner_personalization}
+## Owner Personalization
 
 OpenTitan provides a mechanism to enable provisioning of Silicon Owner secrets
 and endorsement certificates in manufacturing and post-manufacturing stages.

--- a/doc/security/specs/identities_and_root_keys/README.md
+++ b/doc/security/specs/identities_and_root_keys/README.md
@@ -93,7 +93,7 @@ the
 [UICC EID Specification](https://www.gsma.com/newsroom/wp-content/uploads/SGP.02-v4.0.pdf)
 as an example.
 
-## Creator Root Key (`CreatorRootKey`) {#creator-root-key}
+## Creator Root Key (`CreatorRootKey`)
 
 The following sequence describes the creation of the `CreatorRootKey`. All
 inputs into the key manager can be locked down during ROM execution.
@@ -247,7 +247,7 @@ The `CreatorIdentitySeed` and the private portion of the Creator Identity shall
 be cleared before the ROM Extension hands over execution to the Silicon Owner
 first boot stage.
 
-## OwnerIntermediateKey {#owner-intermediate-key}
+## OwnerIntermediateKey
 
 The `OwnerIntermediateKey` is used as a root component of the Silicon Owner key
 hierarchy. It is used to establish a cryptographic link to the root secrets
@@ -338,7 +338,7 @@ Visibility: Hidden from software.
 The `OwnerIdentitySeed` and the private portion of the Owner Identity shall be
 cleared before the bootloader (BL0) hands over execution to the kernel.
 
-## Owner Root Key and Versioned Keys {#owner-root-key}
+## Owner Root Key and Versioned Keys
 
 The key manager supports the generation of versioned keys with lineage to the
 `OwnerRootKey` for software consumption and sideload operations.
@@ -439,7 +439,7 @@ charge of enforcing isolation.
   </tr>
 </table>
 
-### Software Binding {#software-binding}
+### Software Binding
 
 Software binding is used to ensure that the key derivation scheme is only
 reproducible for a trusted software configuration. This is achieved by having
@@ -453,7 +453,7 @@ implement binding with the application layer exclusively in software.
 
 Each key manager binding stage shall provide at least 128b of data.
 
-### Key Versioning {#key-versioning}
+### Key Versioning
 
 Key versioning is the mechanism by which software implements key rotation
 triggered by security updates. Since there may be more than one updateable code
@@ -514,15 +514,15 @@ hardening.
 
 ## Recommendations for Programming Model Abstraction
 
-### High Level Key Manager States {#high-level-key-manager-states}
+### High Level Key Manager States
 
 The hardware may opt to implement a software interface with higher level one-way
 step functions to advance the internal state of the key manager. The following
 are the minimum set of steps required:
 
-1   [CreatorRootKey](#creator-root-key)
-2   [OwnerIntermediateKey](#owner-intermediate-key)
-3   [OwnerRootKey](#owner-root-key)
+1   [CreatorRootKey](#creator-root-key-creatorrootkey)
+2   [OwnerIntermediateKey](#ownerintermediatekey)
+3   [OwnerRootKey](#owner-root-key-and-versioned-keys)
 
 <table>
   <tr>

--- a/doc/security/specs/ownership_transfer/README.md
+++ b/doc/security/specs/ownership_transfer/README.md
@@ -54,7 +54,7 @@ They send it back in an `UNLOCKED_OWNERSHIP` state.
 (This unlocking step is vital, although the Silicon Creator can endorse a new owner, they cannot unlock ownership for a device that is in a `LOCKED_OWNERSHIP` state.)
 The Silicon Creator can later endorse the ownership transfer payload of whoever buys the device, without further involvement from the previous owner.
 
-## Owner Keys {#owner-keys}
+## Owner Keys
 
 The following keys are provisioned as part of this flow.
 
@@ -104,7 +104,7 @@ Boot stages:
     *   `BL0`: Bootloader. Signed by the Silicon Owner.
     *   `KERNEL`: Signed by the Silicon Owner.
 
-## Key Provisioning {#key-provisioning}
+## Key Provisioning
 
 As part of the Ownership Transfer flow, the Silicon Owner keys are endorsed
 either by the Silicon Creator or by the Current Owner of the device. This is
@@ -290,7 +290,7 @@ However, there must be at least one mechanism available to perform ownership
 transfer at manufacturing time using an implementation compatible with ATE[^2]
 infrastructure.
 
-### Unlock Ownership {#unlock-ownership}
+### Unlock Ownership
 
 This flow implements transition from `LOCKED_OWNERSHIP` to `UNLOCKED_OWNERSHIP` states. It
 is used by the Silicon Owner to relinquish ownership of the device and enable
@@ -374,7 +374,7 @@ before propagating the result to the Host. The Host propagates the unlock result
 to the Device Registry. The Device Registry may opt to remove the device from
 its allow-list.
 
-### Ownership Transfer {#ownership-transfer-device}
+### Ownership Transfer
 
 An ownership transfer command sent by a host to OpenTitan, is serviced by the
 ROM extension (`ROM_EXT`) allowing the Silicon Owner to take ownership of the
@@ -525,7 +525,7 @@ Detailed steps:
     shared memory region and triggers a reset to perform ownership transfer on
     the next boot cycle.
 7.  The `ROM_EXT` executes the ownership transfer flow described in the
-    [Ownership Transfer](#ownership-transfer-device) section with the following
+    [Ownership Transfer](#ownership-transfer) section with the following
     differences:
     1.  Flash erase and flash image stages are not executed.
     2.  The activate owner stage may be delayed and executed later depending on
@@ -545,7 +545,7 @@ implemented by storing the Silicon Owner BL0 verification keys in the `ROM_EXT`.
 The `ROM_EXT` is thus not required to implement ownership transfer in this
 configuration.
 
-## Flash Layout {#flash-layout}
+## Flash Layout
 
 To simplify the implementation, the flash layout implements fixed offset and
 size allocations for the `ROM_EXT` and the certificate storage regions. This

--- a/doc/security/specs/secure_boot/README.md
+++ b/doc/security/specs/secure_boot/README.md
@@ -15,7 +15,7 @@ The diagram below summarizes the specific steps involved in the secure boot proc
 
 <img src="secure_boot_flow.svg" style="width: 800px;">
 
-## ROM {#rom}
+## ROM
 
 The first stage of secure boot is called "ROM".
 ROM is a region of read-only memory that cannot be updated at all after an OpenTitan device is manufactured.
@@ -40,7 +40,7 @@ On boot, the ROM code does the following:
 5. Check the signature from the manifest against the digest and the selected Silicon Creator public key.
     * Unlock flash execution, configure ePMP so that the `ROM_EXT` region is executable, and jump to the start of `ROM_EXT`.
 
-## `ROM_EXT` {#rom-ext}
+## `ROM_EXT`
 
 The `ROM_EXT` ("ROM extension") stage is another region of read-only memory that is controlled by the Silicon Creator.
 However, unlike the ROM, it *can* be updated after the device is manufactured, as long as the new version is signed by the Silicon Creator.
@@ -69,7 +69,7 @@ Once the code has jumped into the Silicon Owner code at BL0, secure boot in its 
 The Silicon Owner may choose to extend the secure boot process with multiple boot stages of their own; this will differ between device owners, while the stages described here are guaranteed by the Silicon Creator and will be shared by all OpenTitan implementations.
 If any signature verification in the above process fails, or there is any kind of unexpected error, the device will fail to boot.
 
-# Silicon Creator Keys {#silicon-creator-keys}
+# Silicon Creator Keys
 
 The Silicon Creator has multiple public keys.
 This redundancy partially protects against the scenario in which one of the keys is compromised; any OpenTitan devices produced after the key is known to be compromised can mark the compromised key invalid, without requiring a full new ROM implementation.
@@ -129,7 +129,7 @@ The Silicon Owner can change during the lifetime of the device, but the Silicon 
 *   `BL0`: Bootloader. Signed by the Silicon Owner.
 *   `Kernel`: Post-bootloader code. Signed by the Silicon Owner.
 
-# Boot Policy {#boot-policy}
+# Boot Policy
 
 In order to provide a flexible boot mechanism the Boot Info page will store a
 structure called the Boot Policy. The boot policy dictates the boot flow,
@@ -138,7 +138,7 @@ the ROM code to decide when to mark a `ROM_EXT` good or bad. The boot policy
 also contains directions to `ROM_EXT` about which slot it loads silicon owner
 code from. TODO(gdk): Expand on policy.
 
-# Memory Layout {#memory-layout}
+# Memory Layout
 
 <img src="flash_layout.svg" style="width: 800px;">
 
@@ -151,7 +151,7 @@ beginning of each physical flash bank. It is expected that a Silicon Owner might
 arbitrarily reserve space at the end of each flash bank to use as additional
 storage.
 
-# Boot Services {#boot-services}
+# Boot Services
 
 Boot Services refers to the functionality stored inside of `ROM`/`ROM_EXT` that
 can be controlled via specific messages passed between from Silicon Owner code

--- a/hw/README.md
+++ b/hw/README.md
@@ -51,7 +51,3 @@ Finally, we provide the same set of information for all available [top level des
 ### Earl Grey-specific comportable IPs
 
 {{#dashboard top_earlgrey }}
-
-## Hardware documentation overview
-
-{{% sectionContent %}}

--- a/hw/dv/README.md
+++ b/hw/dv/README.md
@@ -1,4 +1,3 @@
 # Common Design Verification Collateral
-The documentation is split into SystemVerilog reference and tools.
 
-{{% sectionContent type="section" depth="1" %}}
+The documentation is split into SystemVerilog reference and tools.

--- a/hw/dv/sv/README.md
+++ b/hw/dv/sv/README.md
@@ -1,4 +1,1 @@
 # Common SystemVerilog and UVM Components
-
-## Content
-{{% sectionContent %}}

--- a/hw/dv/tools/README.md
+++ b/hw/dv/tools/README.md
@@ -1,3 +1,1 @@
 # Tools
-
-{{% sectionContent %}}

--- a/hw/ip/edn/doc/programmers_guide.md
+++ b/hw/ip/edn/doc/programmers_guide.md
@@ -15,7 +15,7 @@ void edn_init(unsigned int enable) {
 }
 ```
 
-## Module enable and disable {#enable-disable}
+## Module enable and disable
 
 EDN may only be enabled if CSRNG is enabled.
 Once disabled, EDN may only be re-enabled after CSRNG has been disabled and re-enabled.

--- a/hw/ip/edn/doc/theory_of_operation.md
+++ b/hw/ip/edn/doc/theory_of_operation.md
@@ -122,7 +122,7 @@ CSRNG application commands will be sent immediately.
 Once these commands have completed, a status bit will be set.
 At this point, firmware can later come and reconfigure the EDN block for a different mode of operation.
 
-The recommended write sequence for the entire entropy system is one configuration write to ENTROPY_SRC, then CSRNG, and finally to EDN (also see [Module enable and disable](#enable-disable)).
+The recommended write sequence for the entire entropy system is one configuration write to ENTROPY_SRC, then CSRNG, and finally to EDN (also see [Module enable and disable](./programmers_guide.md#module-enable-and-disable)).
 
 ### Interrupts
 

--- a/hw/ip/flash_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/flash_ctrl/doc/theory_of_operation.md
@@ -81,7 +81,7 @@ Instead, whether bank erase is allowed is controlled by [`MP_BANK_CFG_SHADOWED`]
 When the corresponding bit is set, that particular bank is permitted to have bank level operations.
 
 The specific behavior of what is erased when bank erase is issued is flash memory dependent and thus can vary by vendor and technology.
-[This section](#flash-bank-erase) describes the general behavior and how open source modeling is done.
+[This section](#flash-bank-erase-behavior) describes the general behavior and how open source modeling is done.
 
 #### Memory Protection for Key Manager and Life Cycle
 
@@ -163,26 +163,26 @@ See (#flash-escalation) for further differentiation between standard and custom 
 Since the flash controller has multiple interfaces for access, transmission integrity failures can manifest in different ways.
 
 There are 4 interfaces:
-- host direct access to flash controller [register files](#host-direct-reg).
-- host direct access to [flash macro](#host-direct-macro)
-- host / software initiated flash controller access to [flash macro (read / program / erase)](#host-controller-op)
-- life cycle management interface / hardware initiated flash controller access to [flash macro (read / program / erase)](#hw-controller-op)
+- host direct access to flash controller [register files](#host-direct-access-to-flash-controller-register-files).
+- host direct access to [flash macro](#host-direct-access-to-flash-macro)
+- host / software initiated flash controller access to [flash macro (read / program / erase)](#host-software-initiated-access-to-flash-macro)
+- life cycle management interface / hardware initiated flash controller access to [flash macro (read / program / erase)](#life-cycle-management-interface-hardware-initiated-access-to-flash-macro)
 
 The impact of transmission integrity of each interface is described below.
 
-##### Host Direct Access to Flash Controller Register Files {#host-direct-reg}
+##### Host Direct Access to Flash Controller Register Files
 This category of transmission integrity behaves identically to other modules.
 A bus transaction, when received, is checked for command and data payload integrity.
 If an integrity error is seen, the issuing bus host receives an in-band error response and a fault is registered in [`STD_FAULT_STATUS.REG_INTG_ERR`](../data/flash_ctrl.hjson#std_fault_status).
 
-##### Host Direct Access to Flash Macro {#host-direct-macro}
+##### Host Direct Access to Flash Macro
 Flash can only be read by the host.
 The transmission integrity scheme used is end-to-end, so integrity generated inside the flash is fed directly to the host.
 It is the host's responsibility to check for integrity correctness and react accordingly.
 
-##### Host / Software Initiated Access to Flash Macro {#host-controller-op}
-Since controller operations are initiated through writes to the register file, the command check is identical to host direct access to [regfiles](#host-direct-reg).
-Controller reads behave similarly to [host direct access to macro](#host-direct-macro), the read data and its associated integrity are returned through the controller read FIFO for the initiating host to handle.
+##### Host / Software Initiated Access to Flash Macro
+Since controller operations are initiated through writes to the register file, the command check is identical to host direct access to [regfiles](#host-direct-access-to-flash-controller-register-files).
+Controller reads behave similarly to [host direct access to macro](#host-direct-access-to-flash-macro), the read data and its associated integrity are returned through the controller read FIFO for the initiating host to handle.
 
 For program operations, the write data and its associated integrity are stored and propagated through the flash protocol and physical controllers.
 Prior to packing the data for final flash program, the data is then checked for integrity correctness.
@@ -193,7 +193,7 @@ The reasons a program error is registered in two locations are two-fold:
 - It is registered in [`ERR_CODE`](../data/flash_ctrl.hjson#err_code) so software can discover during operation status that a program has failed.
 - It is registered in [`STD_FAULT_STATUS`](../data/flash_ctrl.hjson#std_fault_status) because transmission integrity failures represent a fatal failure in the standard structure of the design, something that should never happen.
 
-##### Life Cycle Management Interface / Hardware Initiated Access to Flash Macro {#hw-controller-op}
+##### Life Cycle Management Interface / Hardware Initiated Access to Flash Macro
 The life cycle management interface issues transactions directly to the flash controller and does not perform a command payload integrity check.
 
 For read operations, the read data and its associated integrity are directly checked by the life cycle management interface.
@@ -258,7 +258,7 @@ Every time the protocol controller loses such an arbitration, it increases an ar
 Once this lost count reaches 5, the protocol controller is favored.
 This ensures a stream of host activity cannot deny protocol controller access (for example a tight polling loop).
 
-#### Flash Bank Erase Behavior {#flash-bank-erase}
+#### Flash Bank Erase Behavior
 
 This section describes the open source modeling of flash memory.
 The actual flash memory behavior may differ, and should consult the specific vendor or technology specification.

--- a/hw/ip/keymgr/doc/theory_of_operation.md
+++ b/hw/ip/keymgr/doc/theory_of_operation.md
@@ -134,7 +134,7 @@ If after entering `Disabled` life cycle is deactivated or a fault is encountered
 If ever multiple conditions collide (a fault is detected at the same time software issues disable command), the `Invalid` entry path always takes precedence.
 
 ## Life Cycle Connection
-The function of the key manager is directly managed by the [life cycle controller](../../lc_ctrl/README.md#key-manager-en).
+The function of the key manager is directly managed by the [life cycle controller](../../lc_ctrl/README.md#key_manager_en).
 
 Until the life cycle controller activates the key manager, the key manager does not accept any software commands.
 Once the key manager is activated by the life cycle controller, it is then allowed to transition to the various states previously [described](#key-manager-states).

--- a/hw/ip/lc_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/lc_ctrl/doc/theory_of_operation.md
@@ -155,7 +155,7 @@ This ensures that during specific states (RAW, TEST_LOCKED, SCRAP, INVALID) it i
 
 In conjunction with DFT_EN / HW_DEBUG_EN, this acts as the final layer in life cycle defense in depth.
 
-#### KEY_MANAGER_EN {#key-manager-en}
+#### KEY_MANAGER_EN
 
 The KEY_MANAGER_EN signal allows the key manager to function normally.
 When this signal is logically disabled, any existing key manager collateral is uninstantiated and wiped; further instantiation and generation calls for the key manager are also made unavailable.

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -97,7 +97,7 @@ A single instruction can both read and write to the stack.
 In this case, the read is ordered before the write.
 Providing the stack has at least one element, this is allowed, even if the stack is full.
 
-### Control and Status Registers (CSRs) {#csrs}
+### Control and Status Registers (CSRs)
 
 Control and Status Registers (CSRs) are 32b wide registers used for "special" purposes, as detailed in their description;
 they are not related to the GPRs.
@@ -310,7 +310,7 @@ GPRs are accessible from the base instruction subset, and WDRs are accessible fr
 | ...      |
 | w31      |
 
-### Wide Special Purpose Registers (WSRs) {#wsrs}
+### Wide Special Purpose Registers (WSRs)
 
 OTBN has 256b Wide Special purpose Registers (WSRs).
 These are analogous to the 32b CSRs, but are used by big number instructions.
@@ -462,25 +462,26 @@ Data in OTBN travels along a data path which includes the data memory (DMEM), th
 Whenever possible, data transmitted or stored within OTBN is protected with an integrity protection code which guarantees the detection of at least three modified bits per 32 bit word.
 Additionally, instructions and data stored in the instruction and data memory, respectively, are scrambled with a lightweight, non-cryptographically-secure cipher.
 
-Refer to the [Data Integrity Protection](#design-details-data-integrity-protection) section for details of how the data integrity protections are implemented.
+Refer to the [Data Integrity Protection](./doc/theory_of_operation.md#data-integrity-protection) section for details of how the data integrity protections are implemented.
 
 ## Secure Wipe
 
 OTBN provides a mechanism to securely wipe all state it stores, including the instruction memory.
 
 The full secure wipe mechanism is split into three parts:
-- [Data memory secure wipe](#design-details-secure-wipe-dmem)
-- [Instruction memory secure wipe](#design-details-secure-wipe-imem)
-- [Internal state secure wipe](#design-details-secure-wipe-internal)
+- [Data memory secure wipe](./doc/theory_of_operation.md#data-memory-dmem-secure-wipe)
+- [Instruction memory secure wipe](./doc/theory_of_operation.md#instruction-memory-imem-secure-wipe)
+- [Internal state secure wipe](./doc/theory_of_operation.md#internal-state-secure-wipe)
 
 A secure wipe is performed automatically in certain situations, or can be requested manually by the host software.
 The full secure wipe is automatically initiated as a local reaction to a fatal error.
 In addition, it can be triggered by the [Life Cycle Controller](../lc_ctrl/README.md) before RMA entry using the `lc_rma_req/ack` interface.
 In both cases OTBN enters the locked state afterwards and needs to be reset.
 A secure wipe of only the internal state is performed after reset, whenever an OTBN operation is complete, and after a recoverable error.
-Finally, host software can manually trigger the data memory and instruction memory secure wipe operations by issuing an appropriate [command](#design-details-commands).
+Finally, host software can manually trigger the data memory and instruction memory secure wipe operations by issuing an appropriate
+[command](./doc/theory_of_operation.md#operations-and-commands).
 
-Refer to the [Secure Wipe](#design-details-secure-wipe) section for implementation details.
+Refer to the [Secure Wipe](./doc/theory_of_operation.md#secure-wipe) section for implementation details.
 
 ## Instruction Counter
 
@@ -498,7 +499,7 @@ Software can access the first share of the key through the [`KEY_S0_L`](#key-s0-
 It is up to host software to configure the Key Manager so that it provides the right key to OTBN at the start of the operation, and to remove the key again once the operation on OTBN has completed.
 A `KEY_INVALID` software error is raised if OTBN software accesses any of the `KEY_*` WSRs when the Key Manager has not presented a key.
 
-## Blanking {#blanking}
+## Blanking
 
 To reduce side channel leakage OTBN employs a blanking technique on certain control and data paths.
 When a path is blanked it is forced to 0 (by ANDing the path with a blanking signal) preventing sensitive data bits producing a power signature via that path where that path isn't needed for the current instruction.

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -24,7 +24,7 @@ To maintain its security properties, OTBN requires the following configuration f
 * `edn_rnd` must provide AIS31-compliant class PTG.3 random numbers.
   The randomness from this interface is made available through the `RND` WSR and intended to be used for key generation.
 
-## Design Details {#design-details}
+## Design Details
 
 ### Memories
 
@@ -47,11 +47,11 @@ These access 256b-aligned 256b words.
 Both memories can be accessed through OTBN's register interface ([`DMEM`](../data/otbn.hjson#dmem) and [`IMEM`](../data/otbn.hjson#imem)).
 All memory accesses through the register interface must be word-aligned 32b word accesses.
 
-When OTBN is in any state other than [idle](#design-details-operational-states), reads return zero and writes have no effect.
+When OTBN is in any state other than [idle](#operational-states), reads return zero and writes have no effect.
 Furthermore, a memory access when OTBN is neither idle nor locked will cause OTBN to generate a fatal error with code `ILLEGAL_BUS_ACCESS`.
 A host processor can check whether OTBN is busy by reading the [`STATUS`](../data/otbn.hjson#status) register.
 
-The underlying memories used to implement the IMEM and DMEM may not grant all access requests (see [Memory Scrambling](#design-details-memory-scrambling) for details).
+The underlying memories used to implement the IMEM and DMEM may not grant all access requests (see [Memory Scrambling](#memory-scrambling) for details).
 A request won't be granted if new scrambling keys have been requested for the memory that aren't yet available.
 Functionally it should be impossible for either OTBN or a host processor to make a memory request whilst new scrambling keys are unavailable.
 OTBN is in the busy state whilst keys are requested so OTBN will not execute any programs and a host processor access will generated an `ILLEGAL_BUS_ACCESS` fatal error.
@@ -61,15 +61,15 @@ While DMEM is 4kiB, only the first 3kiB (at addresses `0x0` to `0xbff`) is visib
 This is to allow OTBN applications to store sensitive information in the other 1kiB, making it harder for that information to leak back to Ibex.
 
 Each memory write through the register interface updates a checksum.
-See the [Memory Load Integrity](#mem-load-integrity) section for more details.
+See the [Memory Load Integrity](#memory-load-integrity) section for more details.
 
-### Instruction Prefetch {#instruction-prefetch}
+### Instruction Prefetch
 
 OTBN employs an instruction prefetch stage to enable pre-decoding of instructions to enable the [blanking SCA hardening measure](#blanking).
 Its operation is entirely transparent to software.
 It does not speculate and will only prefetch where the next instruction address can be known.
 This results in a stall cycle for all conditional branches and jumps as the result is neither predicted nor known ahead of time.
-Instruction bits held in the prefetch buffer are unscrambled but use the integrity protection described in [Data Integrity Protection](#design-details-data-integrity-protection).
+Instruction bits held in the prefetch buffer are unscrambled but use the integrity protection described in [Data Integrity Protection](#data-integrity-protection).
 
 ### Random Numbers
 
@@ -105,7 +105,7 @@ The PRNG has a long cycle length but has a fixed point: the sequence of numbers 
 This will never happen in normal operation.
 If a fault causes the state to become zero, OTBN raises a `BAD_INTERNAL_STATE` fatal error.
 
-### Operational States {#design-details-operational-states}
+### Operational States
 
 <!--
 Source: https://docs.google.com/drawings/d/1C0D4UriRk5pKGFoFtAXYLcJ1oBG1BCDd2omCLPYHtr0/edit
@@ -125,7 +125,7 @@ The current operational state is reflected in the [`STATUS`](../data/otbn.hjson#
 - If OTBN is busy, the [`STATUS`](../data/otbn.hjson#status) register is set to one of the values starting with `BUSY_`.
 - If OTBN is locked, the [`STATUS`](../data/otbn.hjson#status) register is set to `LOCKED`.
 
-OTBN transitions into the busy state as result of host software [issuing a command](#design-details-commands); OTBN is then said to perform an operation.
+OTBN transitions into the busy state as result of host software [issuing a command](#operations-and-commands); OTBN is then said to perform an operation.
 OTBN transitions out of the busy state whenever the operation has completed.
 In the [`STATUS`](../data/otbn.hjson#status) register the different `BUSY_*` values represent the operation that is currently being performed.
 
@@ -133,58 +133,58 @@ A transition out of the busy state is signaled by the `done` interrupt ([`INTR_S
 
 The locked state is a terminal state; transitioning out of it requires an OTBN reset.
 
-### Operations and Commands {#design-details-commands}
+### Operations and Commands
 
 OTBN understands a set of commands to perform certain operations.
 Commands are issued by writing to the [`CMD`](../data/otbn.hjson#cmd) register.
 
-The `EXECUTE` command starts the [execution of the application](#design-details-software-execution) contained in OTBN's instruction memory.
+The `EXECUTE` command starts the [execution of the application](#software-execution) contained in OTBN's instruction memory.
 
-The `SEC_WIPE_DMEM` command [securely wipes the data memory](#design-details-secure-wipe).
+The `SEC_WIPE_DMEM` command [securely wipes the data memory](#secure-wipe).
 
-The `SEC_WIPE_IMEM` command [securely wipes the instruction memory](#design-details-secure-wipe).
+The `SEC_WIPE_IMEM` command [securely wipes the instruction memory](#secure-wipe).
 
-### Software Execution {#design-details-software-execution}
+### Software Execution
 
-Software execution on OTBN is triggered by host software by [issuing the `EXECUTE` command](#design-details-commands).
+Software execution on OTBN is triggered by host software by [issuing the `EXECUTE` command](#operations-and-commands).
 The software then runs to completion, without the ability for host software to interrupt or inspect the execution.
 
 - OTBN transitions into the busy state, and reflects this by setting [`STATUS`](../data/otbn.hjson#status) to `BUSY_EXECUTE`.
 - The internal randomness source, which provides random numbers to the `URND` CSR and WSR, is re-seeded from the EDN.
 - The instruction at address zero is fetched and executed.
 - From this point on, all subsequent instructions are executed according to their semantics until either an {{#otbn-insn-ref ECALL}} instruction is executed, or an error is detected.
-- A [secure wipe of internal state](#design-details-secure-wipe-internal) is performed.
+- A [secure wipe of internal state](#internal-state-secure-wipe) is performed.
 - The [`ERR_BITS`](../data/otbn.hjson#err_bits) register is set to indicate either a successful execution (value `0`), or to indicate the error that was observed (a non-zero value).
-- OTBN transitions into the [idle state](#design-details-operational-states) (in case of a successful execution, or a recoverable error) or the locked state (in case of a fatal error).
+- OTBN transitions into the [idle state](#operational-states) (in case of a successful execution, or a recoverable error) or the locked state (in case of a fatal error).
   This transition is signaled by raising the `done` interrupt ([`INTR_STATE.done`](../data/otbn.hjson#intr_state)), and reflected in the [`STATUS`](../data/otbn.hjson#status) register.
 
-### Errors {#design-details-errors}
+### Errors
 
 OTBN is able to detect a range of errors, which are classified as *software errors* or *fatal errors*.
 A software error is an error in the code that OTBN executes.
 In the absence of an attacker, these errors are due to a programmer's mistake.
 A fatal error is typically the violation of a security property.
-All errors and their classification are listed in the [List of Errors](#design-details-list-of-errors).
+All errors and their classification are listed in the [List of Errors](#list-of-errors).
 
 Whenever an error is detected, OTBN reacts locally, and informs the OpenTitan system about it by raising an alert.
 OTBN generally does not try to recover from errors itself, and provides no error handling support to code that runs on it.
 
 OTBN gives host software the option to recover from some errors by restarting the operation.
-All software errors are treated as recoverable, unless [`CTRL.software_errs_fatal`](../data/otbn.hjson#ctrl) is set, and are handled as described in the section [Reaction to Recoverable Errors](#design-details-recoverable-errors).
+All software errors are treated as recoverable, unless [`CTRL.software_errs_fatal`](../data/otbn.hjson#ctrl) is set, and are handled as described in the section [Reaction to Recoverable Errors](#reaction-to-recoverable-errors).
 When [`CTRL.software_errs_fatal`](../data/otbn.hjson#ctrl) is set, software errors become fatal errors.
 
-Fatal errors are treated as described in the section [Reaction to Fatal Errors](#design-details-fatal-errors).
+Fatal errors are treated as described in the section [Reaction to Fatal Errors](#reaction-to-fatal-errors).
 
-### Reaction to Recoverable Errors {#design-details-recoverable-errors}
+### Reaction to Recoverable Errors
 
 Recoverable errors can be the result of a programming error in OTBN software.
 Recoverable errors can only occur during the execution of software on OTBN, and not in other situations in which OTBN might be busy.
 
 The following actions are taken when OTBN detects a recoverable error:
 
-1. The currently running operation is terminated, similar to the way an {{#otbn-insn-ref ECALL}} instruction [is executed](#writing-otbn-applications-ecall):
+1. The currently running operation is terminated, similar to the way an {{#otbn-insn-ref ECALL}} instruction [is executed](#returning-from-an-application):
    - No more instructions are fetched or executed.
-   - A [secure wipe of internal state](#design-details-secure-wipe-internal) is performed.
+   - A [secure wipe of internal state](#internal-state-secure-wipe) is performed.
    - The [`ERR_BITS`](../data/otbn.hjson#err_bits) register is set to a non-zero value that describes the error.
    - The current operation is marked as complete by setting [`INTR_STATE.done`](../data/otbn.hjson#intr_state).
    - The [`STATUS`](../data/otbn.hjson#status) register is set to `IDLE`.
@@ -192,17 +192,17 @@ The following actions are taken when OTBN detects a recoverable error:
 
 The host software can start another operation on OTBN after a recoverable error was detected.
 
-### Reaction to Fatal Errors {#design-details-fatal-errors}
+### Reaction to Fatal Errors
 
 Fatal errors are generally seen as a sign of an intrusion, resulting in more drastic measures to protect the secrets stored within OTBN.
 Fatal errors can occur at any time, even when an OTBN operation isn't in progress.
 
 The following actions are taken when OTBN detects a fatal error:
 
-1. A [secure wipe of the data memory](#design-details-secure-wipe-dmem) and a [secure wipe of the instruction memory](#design-details-secure-wipe-imem) is initiated.
-2. If OTBN [is not idle](#design-details-operational-states), then the currently running operation is terminated, similarly to how an operation ends after an {{#otbn-insn-ref ECALL}} instruction [is executed](#writing-otbn-applications-ecall):
+1. A [secure wipe of the data memory](#data-memory-dmem-secure-wipe) and a [secure wipe of the instruction memory](#instruction-memory-imem-secure-wipe) is initiated.
+2. If OTBN [is not idle](#operational-states), then the currently running operation is terminated, similarly to how an operation ends after an {{#otbn-insn-ref ECALL}} instruction [is executed](#returning-from-an-application):
    - No more instructions are fetched or executed.
-   - A [secure wipe of internal state](#design-details-secure-wipe-internal) is performed.
+   - A [secure wipe of internal state](#internal-state-secure-wipe) is performed.
    - The [`ERR_BITS`](../data/otbn.hjson#err_bits) register is set to a non-zero value that describes the error.
    - The current operation is marked as complete by setting [`INTR_STATE.done`](../data/otbn.hjson#intr_state).
 3. The [`STATUS`](../data/otbn.hjson#status) register is set to `LOCKED`.
@@ -216,7 +216,7 @@ However, every error that OTBN detects when it isn't running is fatal.
 This means that the cause will be reflected in [`FATAL_ALERT_CAUSE`](../data/otbn.hjson#fatal_alert_cause), as described below in [Alerts](#alerts).
 This way, no alert is generated without setting an error code somewhere.
 
-### List of Errors {#design-details-list-of-errors}
+### List of Errors
 
 <table>
   <thead>
@@ -325,10 +325,10 @@ This way, no alert is generated without setting an error code somewhere.
 An alert is a reaction to an error that OTBN detected.
 OTBN has two alerts, one recoverable and one fatal.
 
-A **recoverable alert** is a one-time triggered alert caused by [recoverable errors](#design-details-recoverable-errors).
+A **recoverable alert** is a one-time triggered alert caused by [recoverable errors](#reaction-to-recoverable-errors).
 The error that caused the alert can be determined by reading the [`ERR_BITS`](../data/otbn.hjson#err_bits) register.
 
-A **fatal alert** is a continuously triggered alert caused by [fatal errors](#design-details-fatal-errors).
+A **fatal alert** is a continuously triggered alert caused by [fatal errors](#reaction-to-fatal-errors).
 The error that caused the alert can be determined by reading the [`FATAL_ALERT_CAUSE`](../data/otbn.hjson#fatal_alert_cause) register.
 If OTBN was running, this value will also be reflected in the [`ERR_BITS`](../data/otbn.hjson#err_bits) register.
 A fatal alert can only be cleared by resetting OTBN through the `rst_ni` line.
@@ -337,23 +337,23 @@ The host CPU can clear the [`ERR_BITS`](../data/otbn.hjson#err_bits) when OTBN i
 Writing any value to [`ERR_BITS`](../data/otbn.hjson#err_bits) clears this register to zero.
 Write attempts while OTBN is running are ignored.
 
-### Reaction to Life Cycle Escalation Requests {#design-details-lifecycle-escalation}
+### Reaction to Life Cycle Escalation Requests
 
 OTBN receives and reacts to escalation signals from the [life cycle controller](../../lc_ctrl/README.md#security-escalation).
-An incoming life cycle escalation is a fatal error of type `lifecycle_escalation` and treated as described in the section [Fatal Errors](#design-details-fatal-errors).
+An incoming life cycle escalation is a fatal error of type `lifecycle_escalation` and treated as described in the section [Fatal Errors](#reaction-to-fatal-errors).
 
 ### Idle
 
 OTBN exposes a single-bit `idle_o` signal, intended to be used by the clock manager to clock-gate the block when it is not in use.
 This signal is in the same clock domain as `clk_i`.
-The `idle_o` signal is high when OTBN [is idle](#design-details-operational-states), and low otherwise.
+The `idle_o` signal is high when OTBN [is idle](#operational-states), and low otherwise.
 
 OTBN also exposes another version of the idle signal as `idle_otp_o`.
 This works analogously, but is in the same clock domain as `clk_otp_i`.
 
 TODO: Specify interactions between `idle_o`, `idle_otp_o` and the clock manager fully.
 
-### Data Integrity Protection {#design-details-data-integrity-protection}
+### Data Integrity Protection
 
 OTBN stores and operates on data (state) in its dedicated memories, register files, and internal registers.
 OTBN's data integrity protection is designed to protect all data stored and transmitted within OTBN from modifications through physical attacks.
@@ -363,7 +363,7 @@ Data at rest in the instruction and data memories is additionally scrambled.
 
 In the following, the Integrity Protection Code and the scrambling algorithm are discussed, followed by their application to individual storage elements.
 
-#### Integrity Protection Code {#design-details-integrity-protection-code}
+#### Integrity Protection Code
 
 OTBN uses the same integrity protection code everywhere to provide overarching data protection without regular re-encoding.
 The code is applied to 32b data words, and produces 39b of encoded data.
@@ -372,7 +372,7 @@ The code used is an (39,32) Hsiao "single error correction, double error detecti
 It has a minimum Hamming distance of four, resulting in the ability to detect at least three errors in a 32 bit word.
 The code is used for error detection only; no error correction is performed.
 
-#### Memory Scrambling {#design-details-memory-scrambling}
+#### Memory Scrambling
 
 Contents of OTBN's instruction and data memories are scrambled while at rest.
 The data is bound to the address and scrambled before being stored in memory.
@@ -386,7 +386,7 @@ Obfuscation makes passive probing more difficult, while diffusion makes active f
 The scrambling mechanism is described in detail in the [section "Scrambling Primitive" of the SRAM Controller Technical Specification](../../sram_ctrl/README.md#scrambling-primitive).
 
 When OTBN comes out of reset, its memories have default scrambling keys.
-The host processor can request new keys for each memory by issuing a [secure wipe of DMEM](#design-details-secure-wipe-dmem) and a [secure wipe of IMEM](#design-details-secure-wipe-imem).
+The host processor can request new keys for each memory by issuing a [secure wipe of DMEM](#data-memory-dmem-secure-wipe) and a [secure wipe of IMEM](#instruction-memory-imem-secure-wipe).
 
 #### Actions on Integrity Errors
 
@@ -396,7 +396,7 @@ The section [Error Handling and Reporting](#design-details-error-handling-and-re
 #### Register File Integrity Protection
 
 OTBN contains two register files: the 32b GPRs and the 256b WDRs.
-The data stored in both register files is protected with the [Integrity Protection Code](#design-details-integrity-protection-code).
+The data stored in both register files is protected with the [Integrity Protection Code](#integrity-protection-code).
 Neither the register file contents nor register addresses are scrambled.
 
 The GPRs `x2` to `x31` store a 32b data word together with the Integrity Protection Code, resulting in 39b of stored data.
@@ -426,14 +426,14 @@ Detected integrity violations in a register file raise a fatal `reg_error`.
 OTBN's data memory is 256b wide, but allows for 32b word accesses.
 To facilitate such accesses, all integrity protection in the data memory is done on a 32b word granularity.
 
-All data entering or leaving the data memory block is protected with the [Integrity Protection Code](#design-details-integrity-protection-code);
+All data entering or leaving the data memory block is protected with the [Integrity Protection Code](#integrity-protection-code);
 this code is not re-computed within the memory block.
 
-Before being stored in SRAM, the data word with the attached Integrity Protection Code, as well as the address are scrambled according to the [memory scrambling algorithm](#design-details-memory-scrambling).
+Before being stored in SRAM, the data word with the attached Integrity Protection Code, as well as the address are scrambled according to the [memory scrambling algorithm](#memory-scrambling).
 The scrambling is reversed on a read.
 
 The ephemeral memory scrambling key and the nonce are provided by the [OTP block](../../otp_ctrl/README.md).
-They are set once when OTBN block is reset, and changed whenever a [secure wipe](#design-details-secure-wipe-dmem) of the data memory is performed.
+They are set once when OTBN block is reset, and changed whenever a [secure wipe](#data-memory-dmem-secure-wipe) of the data memory is performed.
 
 
 The Integrity Protection Code is checked on every memory read, even though the code remains attached to the data.
@@ -442,20 +442,20 @@ Detected integrity violations in the data memory raise a fatal `dmem_error`.
 
 #### Instruction Memory (IMEM) Integrity Protection
 
-All data entering or leaving the instruction memory block is protected with the [Integrity Protection Code](#design-details-integrity-protection-code);
+All data entering or leaving the instruction memory block is protected with the [Integrity Protection Code](#integrity-protection-code);
 this code is not re-computed within the memory block.
 
-Before being stored in SRAM, the instruction word with the attached Integrity Protection Code, as well as the address are scrambled according to the [memory scrambling algorithm](#design-details-memory-scrambling).
+Before being stored in SRAM, the instruction word with the attached Integrity Protection Code, as well as the address are scrambled according to the [memory scrambling algorithm](#memory-scrambling).
 The scrambling is reversed on a read.
 
 The ephemeral memory scrambling key and the nonce are provided by the [OTP block](../../otp_ctrl/README.md).
-They are set once when OTBN block is reset, and changed whenever a [secure wipe](#design-details-secure-wipe-imem) of the instruction memory is performed.
+They are set once when OTBN block is reset, and changed whenever a [secure wipe](#instruction-memory-imem-secure-wipe) of the instruction memory is performed.
 
 The Integrity Protection Code is checked on every memory read, even though the code remains attached to the data.
 A further check must be performed when the data is consumed.
 Detected integrity violations in the data memory raise a fatal `imem_error`.
 
-### Memory Load Integrity {#mem-load-integrity}
+### Memory Load Integrity
 
 As well as the integrity protection discussed above for the memories and bus interface, OTBN has a second layer of integrity checking to allow a host processor to ensure that a program has been loaded correctly.
 This is visible through the [`LOAD_CHECKSUM`](../data/otbn.hjson#load_checksum) register.
@@ -483,30 +483,30 @@ To use this functionality, the host processor should set [`LOAD_CHECKSUM`](../da
 Next, it should write the program to be loaded to OTBN's IMEM and DMEM over the bus.
 Finally, it should read back the value of [`LOAD_CHECKSUM`](../data/otbn.hjson#load_checksum) and compare it with an expected value.
 
-### Secure Wipe {#design-details-secure-wipe}
+### Secure Wipe
 
 Applications running on OTBN may store sensitive data in the internal registers or the memory.
 In order to prevent an untrusted application from reading any leftover data, OTBN provides the secure wipe operation.
 This operation can be applied to:
-- [Data memory](#design-details-secure-wipe-dmem)
-- [Instruction memory](#design-details-secure-wipe-imem)
-- [Internal state](#design-details-secure-wipe-internal)
+- [Data memory](#data-memory-dmem-secure-wipe)
+- [Instruction memory](#instruction-memory-imem-secure-wipe)
+- [Internal state](#internal-state-secure-wipe)
 
 The three forms of secure wipe can be triggered in different ways.
 
 A secure wipe of either the instruction or the data memory can be triggered from host software by issuing a `SEC_WIPE_DMEM` or `SEC_WIPE_IMEM` [command](#design-details-command).
 
-A secure wipe of instruction memory, data memory, and all internal state is performed automatically when handling a [fatal error](#design-details-fatal-errors).
+A secure wipe of instruction memory, data memory, and all internal state is performed automatically when handling a [fatal error](#reaction-to-fatal-errors).
 In addition, it can be triggered by the [Life Cycle Controller](../../lc_ctrl/README.md) before RMA entry using the `lc_rma_req/ack` interface.
 In both cases OTBN enters the locked state afterwards and needs to be reset.
 
-A secure wipe of the internal state only is triggered automatically after reset and when OTBN [ends the software execution](#design-details-software-execution), either successfully, or unsuccessfully due to a [recoverable error](#design-details-recoverable-errors).
+A secure wipe of the internal state only is triggered automatically after reset and when OTBN [ends the software execution](#software-execution), either successfully, or unsuccessfully due to a [recoverable error](#reaction-to-recoverable-errors).
 
 If OTBN cannot complete a secure wipe of the internal state (e.g., due to failing to obtain the required randomness), it immediately becomes locked.
 In this case, OTBN must be reset and will then retry the secure wipe.
 The secure wipe after reset must succeed before OTBN can be used.
 
-#### Data Memory (DMEM) Secure Wipe {#design-details-secure-wipe-dmem}
+#### Data Memory (DMEM) Secure Wipe
 
 The wiping is performed by securely replacing the memory scrambling key, making all data stored in the memory unusable.
 The key replacement is a two-step process:
@@ -516,9 +516,9 @@ The key replacement is a two-step process:
 * Request new scrambling parameters from OTP.
   The request takes multiple cycles to complete.
 
-Host software can initiate a data memory secure wipe by [issuing the `SEC_WIPE_DMEM` command](#design-details-commands).
+Host software can initiate a data memory secure wipe by [issuing the `SEC_WIPE_DMEM` command](#operations-and-commands).
 
-#### Instruction Memory (IMEM) Secure Wipe {#design-details-secure-wipe-imem}
+#### Instruction Memory (IMEM) Secure Wipe
 
 The wiping is performed by securely replacing the memory scrambling key, making all instructions stored in the memory unusable.
 The key replacement is a two-step process:
@@ -528,9 +528,9 @@ The key replacement is a two-step process:
 * Request new scrambling parameters from OTP.
   The request takes multiple cycles to complete.
 
-Host software can initiate a data memory secure wipe by [issuing the `SEC_WIPE_IMEM` command](#design-details-commands).
+Host software can initiate a data memory secure wipe by [issuing the `SEC_WIPE_IMEM` command](#operations-and-commands).
 
-#### Internal State Secure Wipe {#design-details-secure-wipe-internal}
+#### Internal State Secure Wipe
 
 OTBN provides a mechanism to securely wipe all internal state, excluding the instruction and data memories.
 

--- a/hw/ip/otbn/dv/doc/fcov.md
+++ b/hw/ip/otbn/dv/doc/fcov.md
@@ -126,7 +126,8 @@ We expect to see each software error triggered and upgraded to a fatal alert.
 
 This is tracked in the `promoted_err_cg` covergroup.
 
-Note that we already track seeing each software error triggered (but not upgraded) with the coverage for `ERR_BITS` in the [external CSRs](#ext-csrs) section below.
+Note that we already track seeing each software error triggered (but not upgraded) with the coverage for `ERR_BITS` in the [external
+CSRs](#external-bus-accessible-csrs) section below.
 
 ## Scratchpad memory
 
@@ -137,10 +138,10 @@ These are tracked in the `addr_cp` coverpoint in `scratchpad_writes_cg`.
 We also want to see a successful write to the top word of accessible DMEM.
 We don't track that explicitly, since it is covered by the `otbn_mem_walk` test.
 
-## External (bus-accessible) CSRs {#ext-csrs}
+## External (bus-accessible) CSRs
 
 The OTBN block exposes functionality to a bus host through bus-accessible CSRs.
-Behavior of some CSRs depends on [OTBN's operational state](../../README.md#design-details-operational-states).
+Behavior of some CSRs depends on [OTBN's operational state](../../doc/theory_of_operation.md#operational-states).
 
 For every CSR (no matter its access restrictions), we want to see an attempt to read it and an attempt to write it.
 The CSRs are tracked in covergroups based on the CSR name, with the format: `ext_csr_<name>_cg`.

--- a/hw/ip/sysrst_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/sysrst_ctrl/doc/theory_of_operation.md
@@ -108,7 +108,7 @@ In particular, the transitions that can be detected are fixed to the following:
 - A H -> L transition on the `pwrb_in_i` signal
 - A L -> H transition on the `lid_open_i` signal
 
-Note that the signals may be potentially inverted due to the [input inversion feature]({{< relref "#inversion" >}}).
+Note that the signals may be potentially inverted due to the [input inversion feature](#pin-output-and-keyboard-inversion-control).
 
 In order to activate this feature, software should do the following:
 
@@ -132,7 +132,7 @@ This is needed because this register has to be synchronized over to the AON cloc
 `sysrst_ctrl` allows the software to read the raw input pin values via the [`PIN_IN_VALUE`](../data/sysrst_ctrl.hjson#pin_in_value) register like GPIOs.
 To this end, the hardware samples the raw input values of `pwrb_in_i`, `key[0,1,2]_in_i`, `ac_present_i`, `ec_rst_l_i`, `flash_wp_l_i` before they are being inverted, and synchronizes them onto the bus clock domain.
 
-## Pin output and keyboard inversion control {#inversion}
+## Pin output and keyboard inversion control
 
 Software can optionally override all output signals, and change the signal polarity of some of the input and output signals.
 The output signal override feature always has higher priority than any of the combo pattern detection mechanisms described above.

--- a/sw/README.md
+++ b/sw/README.md
@@ -44,7 +44,7 @@ Host software must be written in C++ or Rust.
 
 # Other Documentation
 
-## OpenTitan Software API Documentation {#sw-api-docs}
+## OpenTitan Software API Documentation
 
 The [OpenTitan Software API Documentation](https://opentitan.org/gen/doxy/) contains automatically generated documentation for the public software APIs.
 This includes the Device Interface Functions (DIFs).

--- a/sw/device/README.md
+++ b/sw/device/README.md
@@ -26,7 +26,3 @@ There are also prototype versions of some of the boot stages, now only used for 
 
 - [`sw/device/lib/testing/test_rom`](https://github.com/lowRISC/opentitan/tree/master/sw/device/lib/testing/test_rom) is a previous, testing-only version of the ROM.
 - `sw/device/exts` contains software for our prototype second boot stage images.
-
-## Documentation Index
-
-{{% sectionContent %}}

--- a/sw/device/lib/README.md
+++ b/sw/device/lib/README.md
@@ -25,7 +25,3 @@ These are organised into the `sw/device/lib` directory.
     that is a layer of above the DIFs. In other words, this code may make use
     of the DIFs to actuate the hardware, and chip-level test code may make use
     of this code to actuate the DIFs.
-
-## Documentation Index
-
-{{% sectionContent %}}

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -35,7 +35,7 @@ enum {
    * Although some parts of the ERR_BITS register are marked reserved, the OTBN
    * documentation explicitly guarantees that ERR_BITS is zero for a successful
    * execution:
-   *   https://docs.opentitan.org/hw/ip/otbn/doc/#design-details-software-execution
+   *   https://opentitan.org/book/hw/ip/otbn/doc/theory_of_operation.html#software-execution-design-details
    */
   kOtbnErrBitsNoError = 0,
 };

--- a/sw/device/lib/testing/README.md
+++ b/sw/device/lib/testing/README.md
@@ -29,5 +29,3 @@ code will live in: `sw/device/lib/testing/test\_framework`.
   This allows testutils functions to easily mix with DIFs within chip-level tests.
 - Avoid defining testutils that call a single DIF, and use the DIF directly.
   If a DIF does not exist for your needs, create one by following the [DIF development guide](../dif/README.md).
-
-{{% sectionContent %}}

--- a/sw/device/silicon_creator/README.md
+++ b/sw/device/silicon_creator/README.md
@@ -1,5 +1,1 @@
 # Silicon Creator Software
-
-## Documentation Index
-
-{{% sectionContent %}}

--- a/sw/device/silicon_creator/rom/README.md
+++ b/sw/device/silicon_creator/rom/README.md
@@ -26,10 +26,10 @@ The ROM needs to prepare the OpenTitan chip for executing a ROM_EXT, including e
         *   Disable Interrupts and set well-defined exception handler.
             This should keep initial execution deterministic.
 
-        *   [Clean Device State Part 1](#clean-device-state-p1).
+        *   [Clean Device State Part 1](#cleaning-device-state).
             This includes enabling SRAM Scrambling.
 
-        *   Setup structures for C execution ([CRT](#crt-init): `.data`, `.bss` sections, stack).
+        *   Setup structures for C execution ([CRT](#crt-initialization): `.data`, `.bss` sections, stack).
 
         *   Jump into C code
 
@@ -136,7 +136,7 @@ Dependencies:
 *   OTP
 *   ROM Integrity Measurement
 
-### Cleaning Device State {#clean-device-state-p1}
+### Cleaning Device State
 
 Part of this process is done before we can execute any C code. In particular, we
 have to clear all registers and all of the main RAM before we setup the CRT
@@ -160,7 +160,7 @@ until we have setup the CRT.
 
 Dependencies: None
 
-### CRT Initialization {#crt-init}
+### CRT Initialization
 
 Setting up the CRT involves: loading the `.data` and `.bss` sections, and
 setting up the stack and `gp` (`gp` may be used for referencing some data).

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Sequence, Tuple
 from reggen.lib import check_keys, check_str, check_list
 
 # The documentation of assets and cm_types can be found here
-# https://docs.opentitan.org/doc/rm/comportability_specification/#countermeasures
+# https://opentitan.org/book/doc/contributing/hw/comportability/#security-countermeasures
 CM_ASSETS = [
     'KEY',
     'ADDR',


### PR DESCRIPTION
This PR:

* Removes the `{{% sectionContent %}}` Hugo macros which I believe generated an index of the chapter in the old Hugo docs. If we want this later, we can fill these pages in.
* Removes the `{#anchor}` tags from Markdown headers.

Mdbook generates anchors for headings automatically (by making the header lower-case, stripping punctuation, and using dashes for spaces).

Some of the `{#anchor}` tags match what Mdbook gives, which is great. For the others, I've grepped for links to those anchors and updated them. The link checker can't check anchors, so we can't easily see if they're correct, but they're better than they used to be.

I've also updated some doc links in a `.py` and `.c` file that came up in greps.