### PR TITLE
Add missing `<array>` and `<utility>` includes to `dif_spi_host_unittest.cc'

### DIFF
--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -4,6 +4,9 @@
 
 #include "sw/device/lib/dif/dif_spi_host.h"
 
+#include <array>
+#include <utility>
+
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/global_mock.h"
 #include "sw/device/lib/base/macros.h"


### PR DESCRIPTION
These includes were missing, and caused build failures on my machine.

`<array>` is needed for `std::array` and `<utility>` is needed for `std::pair`.