### PR TITLE
[ci] New nightly job for the BoB

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -68,3 +68,22 @@ jobs:
         --test_output=errors \
         //sw/device/silicon_creator/rom/e2e/...
     displayName: "Run all ROM E2E tests"
+
+- job: bob_spi_i2c
+  displayName: "BoB: SPI and I2C Tests"
+  timeoutInMinutes: 30
+  dependsOn: checkout
+  pool: FPGA
+  steps:
+  - template: ../ci/checkout-template.yml
+  - template: ../ci/install-package-dependencies.yml
+  - bash: |
+      set -x
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/bazelisk.sh test \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --define bitstream=gcp_splice \
+        --build_tests_only \
+        --test_output=errors \
+        $(bazel query 'attr("tags", "[\[ ]bob[,\]]", attr("tags", "[\[ ]cw310[,\]]", tests(//...)))')
+    displayName: "Run all the SPI and I2C Tests with BoB"

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -274,8 +274,8 @@ status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
   return i2c_testutils_target_check_end(i2c, cont_byte);
 }
 
-status_t i2c_testutils_connect_i2c_to_pinmux_pins(const dif_pinmux_t *pinmux,
-                                                  uint8_t i2c_id) {
+status_t i2c_testutils_select_pinmux(const dif_pinmux_t *pinmux,
+                                     uint8_t i2c_id) {
   // Configure sda pin.
   TRY(dif_pinmux_input_select(pinmux, pinmux_conf[i2c_id].sda.peripheral_in,
                               pinmux_conf[i2c_id].sda.insel));

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -31,41 +31,65 @@ static const dif_i2c_fmt_flags_t kDefaultFlags = {.start = false,
                                                   .read_cont = false,
                                                   .suppress_nak_irq = false};
 
-typedef struct i2c_connect_conf {
-  const top_earlgrey_pinmux_mio_out_t pins_mio_out[2];
-  const top_earlgrey_pinmux_insel_t pins_insel[2];
-  const top_earlgrey_pinmux_peripheral_in_t pins_peripheral_in[2];
-  const top_earlgrey_pinmux_outsel_t pins_outsel[2];
-} i2c_connect_conf_t;
+typedef struct i2c_pinmux_map {
+  const top_earlgrey_pinmux_mio_out_t mio_out;
+  const top_earlgrey_pinmux_insel_t insel;
+  const top_earlgrey_pinmux_peripheral_in_t peripheral_in;
+  const top_earlgrey_pinmux_outsel_t outsel;
+} i2c_pinmux_map_t;
 
-const i2c_connect_conf_t i2c_conf[] = {
-    {.pins_mio_out = {kTopEarlgreyPinmuxMioOutIoa7,
-                      kTopEarlgreyPinmuxMioOutIoa8},
-     .pins_insel = {kTopEarlgreyPinmuxInselIoa7, kTopEarlgreyPinmuxInselIoa8},
-     .pins_peripheral_in =
+typedef struct i2c_pinmux_conf {
+  i2c_pinmux_map_t sda;
+  i2c_pinmux_map_t scl;
+} i2c_pinmux_conf_t;
+
+static const i2c_pinmux_conf_t pinmux_conf[] = {
+    // I2C0.
+    {.sda =
          {
-             kTopEarlgreyPinmuxPeripheralInI2c0Sda,
-             kTopEarlgreyPinmuxPeripheralInI2c0Scl,
+             .mio_out = kTopEarlgreyPinmuxMioOutIoa7,
+             .insel = kTopEarlgreyPinmuxInselIoa7,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c0Sda,
+             .outsel = kTopEarlgreyPinmuxOutselI2c0Sda,
          },
-     .pins_outsel =
+     .scl =
          {
-             kTopEarlgreyPinmuxOutselI2c0Sda,
-             kTopEarlgreyPinmuxOutselI2c0Scl,
+             .mio_out = kTopEarlgreyPinmuxMioOutIoa8,
+             .insel = kTopEarlgreyPinmuxInselIoa8,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c0Scl,
+             .outsel = kTopEarlgreyPinmuxOutselI2c0Scl,
          }},
-    {.pins_mio_out = {kTopEarlgreyPinmuxMioOutIob9,
-                      kTopEarlgreyPinmuxMioOutIob10},
-     .pins_insel = {kTopEarlgreyPinmuxInselIob9, kTopEarlgreyPinmuxInselIob10},
-     .pins_peripheral_in = {kTopEarlgreyPinmuxPeripheralInI2c1Scl,
-                            kTopEarlgreyPinmuxPeripheralInI2c1Sda},
-     .pins_outsel = {kTopEarlgreyPinmuxOutselI2c1Scl,
-                     kTopEarlgreyPinmuxOutselI2c1Sda}},
-    {.pins_mio_out = {kTopEarlgreyPinmuxMioOutIob11,
-                      kTopEarlgreyPinmuxMioOutIob12},
-     .pins_insel = {kTopEarlgreyPinmuxInselIob11, kTopEarlgreyPinmuxInselIob12},
-     .pins_peripheral_in = {kTopEarlgreyPinmuxPeripheralInI2c2Scl,
-                            kTopEarlgreyPinmuxPeripheralInI2c2Sda},
-     .pins_outsel = {kTopEarlgreyPinmuxOutselI2c2Scl,
-                     kTopEarlgreyPinmuxOutselI2c2Sda}}};
+    // I2C1.
+    {.sda =
+         {
+             .mio_out = kTopEarlgreyPinmuxMioOutIob10,
+             .insel = kTopEarlgreyPinmuxInselIob10,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c1Sda,
+             .outsel = kTopEarlgreyPinmuxOutselI2c1Sda,
+         },
+     .scl =
+         {
+             .mio_out = kTopEarlgreyPinmuxMioOutIob9,
+             .insel = kTopEarlgreyPinmuxInselIob9,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c1Scl,
+             .outsel = kTopEarlgreyPinmuxOutselI2c1Scl,
+         }},
+    // I2C2.
+    {.sda =
+         {
+             .mio_out = kTopEarlgreyPinmuxMioOutIob12,
+             .insel = kTopEarlgreyPinmuxInselIob12,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c2Sda,
+             .outsel = kTopEarlgreyPinmuxOutselI2c2Sda,
+         },
+     .scl =
+         {
+             .mio_out = kTopEarlgreyPinmuxMioOutIob11,
+             .insel = kTopEarlgreyPinmuxInselIob11,
+             .peripheral_in = kTopEarlgreyPinmuxPeripheralInI2c2Scl,
+             .outsel = kTopEarlgreyPinmuxOutselI2c2Scl,
+         }},
+};
 
 status_t i2c_testutils_write(const dif_i2c_t *i2c, uint8_t addr,
                              uint8_t byte_count, const uint8_t *data,
@@ -251,15 +275,18 @@ status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
 }
 
 status_t i2c_testutils_connect_i2c_to_pinmux_pins(const dif_pinmux_t *pinmux,
-                                                  uint8_t kI2cIdx) {
-  TRY(dif_pinmux_input_select(pinmux, i2c_conf[kI2cIdx].pins_peripheral_in[0],
-                              i2c_conf[kI2cIdx].pins_insel[0]));
-  TRY(dif_pinmux_input_select(pinmux, i2c_conf[kI2cIdx].pins_peripheral_in[1],
-                              i2c_conf[kI2cIdx].pins_insel[1]));
-  TRY(dif_pinmux_output_select(pinmux, i2c_conf[kI2cIdx].pins_mio_out[0],
-                               i2c_conf[kI2cIdx].pins_outsel[0]));
-  TRY(dif_pinmux_output_select(pinmux, i2c_conf[kI2cIdx].pins_mio_out[1],
-                               i2c_conf[kI2cIdx].pins_outsel[1]));
+                                                  uint8_t i2c_id) {
+  // Configure sda pin.
+  TRY(dif_pinmux_input_select(pinmux, pinmux_conf[i2c_id].sda.peripheral_in,
+                              pinmux_conf[i2c_id].sda.insel));
+  TRY(dif_pinmux_output_select(pinmux, pinmux_conf[i2c_id].sda.mio_out,
+                               pinmux_conf[i2c_id].sda.outsel));
+
+  // Configure scl pin.
+  TRY(dif_pinmux_input_select(pinmux, pinmux_conf[i2c_id].scl.peripheral_in,
+                              pinmux_conf[i2c_id].scl.insel));
+  TRY(dif_pinmux_output_select(pinmux, pinmux_conf[i2c_id].scl.mio_out,
+                               pinmux_conf[i2c_id].scl.outsel));
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -127,8 +127,8 @@ status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t i2c_testutils_connect_i2c_to_pinmux_pins(const dif_pinmux_t *pinmux,
-                                                  uint8_t kI2cIdx);
+status_t i2c_testutils_select_pinmux(const dif_pinmux_t *pinmux,
+                                     uint8_t kI2cIdx);
 
 /**
  * Return whether the fifo is empty.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1805,7 +1805,10 @@ opentitan_functest(
     name = "i2c_host_accelerometer_test",
     srcs = ["i2c_host_accelerometer_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1827,7 +1830,10 @@ opentitan_functest(
     name = "i2c_host_ambient_light_detector_test",
     srcs = ["i2c_host_ambient_light_detector_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1849,7 +1855,10 @@ opentitan_functest(
     name = "i2c_host_hdc1080_humidity_temp_test",
     srcs = ["i2c_host_hdc1080_humidity_temp_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1871,7 +1880,10 @@ opentitan_functest(
     name = "i2c_host_clock_stretching_test",
     srcs = ["i2c_host_clock_stretching_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1895,7 +1907,10 @@ opentitan_functest(
     name = "i2c_host_compass_test",
     srcs = ["i2c_host_compass_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1917,7 +1932,10 @@ opentitan_functest(
     name = "i2c_host_eeprom_test",
     srcs = ["i2c_host_eeprom_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1939,7 +1957,10 @@ opentitan_functest(
     name = "i2c_host_fram_test",
     srcs = ["i2c_host_fram_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1961,7 +1982,10 @@ opentitan_functest(
     name = "i2c_host_gas_sensor_test",
     srcs = ["i2c_host_gas_sensor_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [
@@ -1983,7 +2007,10 @@ opentitan_functest(
     name = "i2c_host_power_monitor_test",
     srcs = ["i2c_host_power_monitor_test.c"],
     cw310 = cw310_params(
-        tags = ["manual"],  # Requires the BoB in CI.
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
     ),
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
     deps = [

--- a/sw/device/tests/i2c_host_accelerometer_test.c
+++ b/sw/device/tests/i2c_host_accelerometer_test.c
@@ -112,7 +112,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_accelerometer_test.c
+++ b/sw/device/tests/i2c_host_accelerometer_test.c
@@ -106,13 +106,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_ambient_light_detector_test.c
+++ b/sw/device/tests/i2c_host_ambient_light_detector_test.c
@@ -138,7 +138,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_ambient_light_detector_test.c
+++ b/sw/device/tests/i2c_host_ambient_light_detector_test.c
@@ -132,13 +132,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/i2c_host_clock_stretching_test.c
@@ -223,7 +223,7 @@ static status_t test_init(void) {
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);

--- a/sw/device/tests/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/i2c_host_clock_stretching_test.c
@@ -78,13 +78,13 @@ static status_t external_isr(void) {
 
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
       top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
-  TRY_CHECK(peripheral == kTopEarlgreyPlicPeripheralI2c0,
-            "IRQ from incorrect peripheral: exp = %d(i2c0), found = %d",
-            kTopEarlgreyPlicPeripheralI2c0, peripheral);
+  TRY_CHECK(peripheral == kTopEarlgreyPlicPeripheralI2c2,
+            "IRQ from incorrect peripheral: exp = %d(i2c2), found = %d",
+            kTopEarlgreyPlicPeripheralI2c2, peripheral);
 
   irq_fired =
       (dif_i2c_irq_t)(plic_irq_id - (dif_rv_plic_irq_id_t)
-                                        kTopEarlgreyPlicIrqIdI2c0FmtThreshold);
+                                        kTopEarlgreyPlicIrqIdI2c2FmtThreshold);
 
   LOG_INFO("%s: plic:%d, i2c:%d", __func__, plic_irq_id, irq_fired);
   TRY(dif_i2c_irq_acknowledge(&i2c, irq_fired));
@@ -218,20 +218,20 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
   TRY(dif_rv_plic_init(base_addr, &plic));
 
   rv_plic_testutils_irq_range_enable(&plic, kHart,
-                                     kTopEarlgreyPlicIrqIdI2c0FmtThreshold,
-                                     kTopEarlgreyPlicIrqIdI2c0HostTimeout);
+                                     kTopEarlgreyPlicIrqIdI2c2FmtThreshold,
+                                     kTopEarlgreyPlicIrqIdI2c2HostTimeout);
 
   // Enable the external IRQ at Ibex.
   irq_global_ctrl(true);

--- a/sw/device/tests/i2c_host_compass_test.c
+++ b/sw/device/tests/i2c_host_compass_test.c
@@ -105,7 +105,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_compass_test.c
+++ b/sw/device/tests/i2c_host_compass_test.c
@@ -99,13 +99,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_eeprom_test.c
+++ b/sw/device/tests/i2c_host_eeprom_test.c
@@ -130,7 +130,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_fram_test.c
+++ b/sw/device/tests/i2c_host_fram_test.c
@@ -137,13 +137,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_fram_test.c
+++ b/sw/device/tests/i2c_host_fram_test.c
@@ -143,7 +143,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_gas_sensor_test.c
+++ b/sw/device/tests/i2c_host_gas_sensor_test.c
@@ -123,13 +123,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_gas_sensor_test.c
+++ b/sw/device/tests/i2c_host_gas_sensor_test.c
@@ -129,7 +129,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_hdc1080_humidity_temp_test.c
+++ b/sw/device/tests/i2c_host_hdc1080_humidity_temp_test.c
@@ -111,7 +111,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_hdc1080_humidity_temp_test.c
+++ b/sw/device/tests/i2c_host_hdc1080_humidity_temp_test.c
@@ -105,13 +105,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/i2c_host_power_monitor_test.c
+++ b/sw/device/tests/i2c_host_power_monitor_test.c
@@ -146,13 +146,13 @@ static status_t test_init(void) {
 
   TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C0_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
   TRY(dif_i2c_init(base_addr, &i2c));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   // Enable the external IRQ at Ibex.

--- a/sw/device/tests/i2c_host_power_monitor_test.c
+++ b/sw/device/tests/i2c_host_power_monitor_test.c
@@ -152,7 +152,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   // Enable the external IRQ at Ibex.

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -272,7 +272,7 @@ static status_t test_init(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  TRY(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
 
   TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard));
   TRY(dif_i2c_device_set_enabled(&i2c, kDifToggleEnabled));

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -168,7 +168,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
 
-  CHECK_STATUS_OK(i2c_testutils_connect_i2c_to_pinmux_pins(&pinmux, kI2cIdx));
+  CHECK_STATUS_OK(i2c_testutils_select_pinmux(&pinmux, kI2cIdx));
 
   // Enable functional interrupts as well as error interrupts to make sure
   // everything is behaving as expected.


### PR DESCRIPTION
This PR:
 - Refactor the i2c testutils function that configures the pinmux to improve readability.
 - Change the i2c tests that requirers the BoB from i2c0 to i2c2.
 - Create a CI nightly job to run the tests.