### PR TITLE
[sw/silicon_creator] Reduce ROM size

### DIFF
--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -542,7 +542,7 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
 #ifdef OT_PLATFORM_RV32
 // This string can be tuned to be longer or shorter as desired, for
 // fault-hardening purposes.
-#define HARDENED_UNIMP_SEQUENCE_() "unimp; unimp; unimp; unimp;"
+#define HARDENED_UNIMP_SEQUENCE_() "unimp; unimp; unimp;"
 
 #define HARDENED_CHECK_OP_EQ_ "beq"
 #define HARDENED_CHECK_OP_NE_ "bne"

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -83,12 +83,15 @@ typedef enum flash_ctrl_partition {
   X(kFlashCtrlInfoPageCreatorSecret,     	0xf56af4bb, 0, 1) \
   X(kFlashCtrlInfoPageOwnerSecret,       	0x10adc6aa, 0, 2) \
   X(kFlashCtrlInfoPageWaferAuthSecret,   	0x118b5dbb, 0, 3) \
+  /**
+   * Unused in ROM, commented out to save space.
   X(kFlashCtrlInfoPageBank0Type0Page4,   	0xad3b5bee, 0, 4) \
   X(kFlashCtrlInfoPageBank0Type0Page5,   	0xa4f6f6c3, 0, 5) \
   X(kFlashCtrlInfoPageOwnerReserved0,    	0xf646f11b, 0, 6) \
   X(kFlashCtrlInfoPageOwnerReserved1,    	0x6c86d980, 0, 7) \
   X(kFlashCtrlInfoPageOwnerReserved2,    	0xdd7f34dc, 0, 8) \
   X(kFlashCtrlInfoPageOwnerReserved3,    	0x5f07277e, 0, 9) \
+  */ \
   /**
    * Bank 1 information partition type 0 pages.
    */ \
@@ -96,12 +99,16 @@ typedef enum flash_ctrl_partition {
   X(kFlashCtrlInfoPageBootData1,          0x389c449e, 1, 1) \
   X(kFlashCtrlInfoPageOwnerSlot0,         0x238cf15c, 1, 2) \
   X(kFlashCtrlInfoPageOwnerSlot1,         0xad886d3b, 1, 3) \
+  /**
   X(kFlashCtrlInfoPageBank1Type0Page4,    0x7dfbdf9b, 1, 4) \
   X(kFlashCtrlInfoPageBank1Type0Page5,    0xad5dd31d, 1, 5) \
+  */ \
   X(kFlashCtrlInfoPageCreatorCertificate, 0xe3ffac86, 1, 6) \
+  /**
   X(kFlashCtrlInfoPageBootServices,       0xf4f48c3d, 1, 7) \
   X(kFlashCtrlInfoPageOwnerCerificate0,   0x9fbb840e, 1, 8) \
   X(kFlashCtrlInfoPageOwnerCerificate1,   0xec309461, 1, 9) \
+  */
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -22,6 +22,7 @@
 namespace flash_ctrl_unittest {
 namespace {
 using ::testing::Each;
+using ::testing::ElementsAre;
 using ::testing::Return;
 using ::testing::SizeIs;
 
@@ -67,7 +68,7 @@ class FlashCtrlTest : public rom_test::RomTest {
 };
 
 class InfoPagesTest : public FlashCtrlTest {};
-TEST_F(InfoPagesTest, NumberOfPages) { EXPECT_THAT(InfoPages(), SizeIs(20)); }
+TEST_F(InfoPagesTest, NumberOfPages) { EXPECT_THAT(InfoPages(), SizeIs(9)); }
 
 TEST_F(InfoPagesTest, PagesPerBank) {
   std::array<uint32_t, 2> pages_per_bank = {0, 0};
@@ -77,7 +78,7 @@ TEST_F(InfoPagesTest, PagesPerBank) {
     ++pages_per_bank[bank];
   }
 
-  EXPECT_THAT(pages_per_bank, Each(10));
+  EXPECT_THAT(pages_per_bank, ElementsAre(4, 5));
 }
 
 TEST_F(InfoPagesTest, PageIndices) {

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -350,24 +350,14 @@ static void shutdown_print(shutdown_log_prefix_t prefix, uint32_t val) {
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix >> 24);
 
   // Print the hex representation of `val`.
-  static_assert(kHexStrLen == 8,
-                "Hex representation must be 8 characters long");
   const char kHexTable[16] = "0123456789abcdef";
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 28 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 24 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 20 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 16 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 12 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 8 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET,
-                   kHexTable[val >> 4 & 0xf]);
-  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, kHexTable[val & 0xf]);
+  // `kHexStrLen` is laundered so that it is loaded to a register at every
+  // iteration.
+  for (size_t i = 0; i < launder32(kHexStrLen); ++i) {
+    uint8_t nibble = (uint8_t)bitfield_field32_read(
+        val, (bitfield_field32_t){.mask = 0xf, .index = (7 - i) * 4});
+    abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, kHexTable[nibble]);
+  }
 
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, '\r');
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, '\n');

--- a/util/py/packages/impl/object_size/report.py
+++ b/util/py/packages/impl/object_size/report.py
@@ -25,7 +25,7 @@ def print_utilization_report(memories) -> None:
         bar = Progress(TextColumn(f"[progress.description]{m.name:20}"),
                        BarColumn(complete_style="bold cyan"),
                        TaskProgressColumn(),
-                       f"{Size(used)} of {Size.__str__(m)}")
+                       f"Available: {Size(m.size - used)}, Used: {Size(used)} of {Size.__str__(m)}")
         task = bar.add_task("")
         bar.advance(task, used * 100 // m.size)
         rprint(Padding(bar.get_renderable(), (0, 0, 0, 4)))


### PR DESCRIPTION
This PR reduces the ROM binary size by:
* Merging two functions and removing unused page definitions from `flash_ctrl` driver (saves 708 + 596 = 1304 bytes),
* Reducing the length of the `unimp` sequence in `HARDENED_*` macros (saves 720 bytes),
* Reverting the loop unrolling in shutdown_print() (saves 196 bytes), and
* ~Removing ALWAYS_INLINE from shutdown_print() (saves 108 bytes).~

In total, the changes in this PR reduces the size of the ROM binary by ~2372~ 2264 bytes.
