### PR TITLE
[spi_host, dif] Fix build failure with some compilers

### DIFF
--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/dif/dif_spi_host.h"
 
+#include <array>
+
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/global_mock.h"
 #include "sw/device/lib/base/macros.h"


### PR DESCRIPTION
Add missing <array> include that causes build failure on some compilers.

For example, using latest Debian GCC compiler (Debian 12.2.0-14):
```
ERROR: /home/loic/Src/rv/opentitan/sw/device/lib/dif/BUILD:988:8: Compiling sw/device/lib/dif/dif_spi_host_unittest.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=gnu++14' -MD -MF ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox
sw/device/lib/dif/dif_spi_host_unittest.cc:532:59: error: 'constexpr const std::array<std::array<unsigned int, 2>, 6> dif_spi_host_unittest::{anonymous}::EventEnableRegTest::kEventsMap' has incomplete type
  532 |   static constexpr std::array<std::array<uint32_t, 2>, 6> kEventsMap{{
      |                                                           ^~~~~~~~~~
sw/device/lib/dif/dif_spi_host_unittest.cc: In member function 'virtual void dif_spi_host_unittest::{anonymous}::StatusTest_Read_Test::TestBody()':
sw/device/lib/dif/dif_spi_host_unittest.cc:646:7: error: variable 'constexpr const std::array<std::pair<unsigned int, dif_spi_host_status>, 14> kMap' has initializer but incomplete type
  646 |       kMap = {{
      |       ^~~~
sw/device/lib/dif/dif_spi_host_unittest.cc: At global scope:
sw/device/lib/dif/dif_spi_host_unittest.cc:713:59: error: 'constexpr const std::array<std::array<unsigned int, 2>, 5> dif_spi_host_unittest::{anonymous}::ErrorEnableRegTest::kErrorsMap' has incomplete type
  713 |   static constexpr std::array<std::array<uint32_t, 2>, 5> kErrorsMap{{
      |                                                           ^~~~~~~~~~
sw/device/lib/dif/dif_spi_host_unittest.cc: In member function 'virtual void dif_spi_host_unittest::{anonymous}::ErrorStatusTest_Read_Test::TestBody()':
sw/device/lib/dif/dif_spi_host_unittest.cc:806:7: error: variable 'constexpr const std::array<std::pair<unsigned int, unsigned int>, 6> kMap' has initializer but incomplete type
  806 |       kMap = {{
      |       ^~~~
Aspect @rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //sw/device/lib/dif:spi_host_unittest up-to-date (nothing to build)
INFO: Elapsed time: 27.561s, Critical Path: 2.33s
INFO: 22 processes: 9 internal, 13 linux-sandbox.
FAILED: Build did NOT complete successfully
```