### PR TITLE
[rom_e2e] add ROM self hash test

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -120,7 +120,8 @@ ifneq (${sw_images},)
 				--ui_event_filters=-info \
 				--noshow_progress \
 				--output=starlark); do \
-				if [[ $$dep != //hw* ]] && [[ $$dep != //util* ]] && [[ $$dep != //sw/host* ]]; then \
+				if [[ $$dep == //hw/ip/otp_ctrl/data* ]] || \
+				  ([[ $$dep != //hw* ]] && [[ $$dep != //util* ]] && [[ $$dep != //sw/host* ]]); then \
 					for artifact in $$($${bazel_cmd} cquery $${dep} \
 						--ui_event_filters=-info \
 						--noshow_progress \

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -881,6 +881,22 @@
       run_timeout_mins: 480
     }
 
+    // ROM self hash test.
+    {
+      name: rom_e2e_self_hash
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:rom_e2e_self_hash:1:signed"
+        "//hw/ip/otp_ctrl/data:img_test_unlocked0:4",
+      ]
+      en_run_modes: ["sw_test_mode_rom_with_real_keys"]
+      run_opts: [
+        "+sw_test_timeout_ns=200_000_000",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      run_timeout_mins: 480
+    }
+
     // Signed chip-level tests to be run with ROM, instead of test ROM.
     {
       name: chip_sw_uart_smoketest_signed

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -1274,7 +1274,7 @@
       '''
       tags: ["rom", "fpga", "dv", "silicon"]
       stage: V3
-      tests: []
+      tests: ["rom_e2e_self_hash"]
     }
   ]
 }

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -1262,5 +1262,19 @@
       stage: V3
       tests: []
     }
+
+    {
+      name: rom_e2e_self_hash
+      desc: '''Verify that the expected ROM has been properly baked into the nelist.
+
+      - Hash the contents of the ROM using SHA256.
+      - Verify the hash against golden hash baked into the test.
+      - Print out hash over console.
+      - Run in TEST_UNLOCKED0 LC state.
+      '''
+      tags: ["rom", "fpga", "dv", "silicon"]
+      stage: V3
+      tests: []
+    }
   ]
 }

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3930,3 +3930,30 @@ opentitan_functest(
     signed = False,
     targets = ["cw310_rom_with_real_keys"],
 )
+
+# TODO(#18686): update to be pres-signed
+opentitan_functest(
+    name = "rom_e2e_self_hash",
+    srcs = ["rom_e2e_self_hash_test.c"],
+    cw310 = cw310_params(
+        timeout = "long",
+        bitstream = "//hw/bitstream:rom_with_real_keys_otp_test_unlocked0",
+    ),
+    dv = dv_params(
+        rom = "//sw/device/silicon_creator/rom:rom_with_real_keys",
+    ),
+    key_struct = RSA_ONLY_KEY_STRUCTS[0],
+    signed = True,
+    targets = [
+        "cw310_rom_with_real_keys",
+        "dv",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  // Hash size.
+  kSha256HashSizeInBits = 256,
+  kSha256HashSizeInBytes = kSha256HashSizeInBits / 8,
+  kSha256HashSizeIn32BitWords = kSha256HashSizeInBytes / 4,
+};
+
+// TODO(#18686): replace with real golden hashes (when real keys are generated).
+/**
+ * The golden ROM size and hashes expected below are generated using the
+ * following instructions. If the ROM is updated, these values must also be
+ * updated to prevent CI failures.
+ *
+ * 1. Build the ROM with Bazel using:
+ *    `bazel build //sw/device/silicon_creator/rom:rom_with_real_keys`
+ *    Note, this will build a separate ROM binary for each device, that can both
+ *    be located with `./bazelisk.sh outquery-all
+ *    //sw/device/silicon_creator/rom:rom_with_real_keys`, including:
+ *    a. one for DV simulations: "rom_with_real_keys_sim_dv.bin", and
+ *    b. one for CW310 FPGA: "rom_with_real_keys_fpga_cw310.bin".
+ *
+ * 2. Query and update the ROM size below (`kGoldenRomSizeBytes`) with:
+ *    `stat -c %s <path to *.bin>`
+ *
+ * 3. Compute and update the golden ROM hashes below (`k*GoldenRomHash`) with:
+ *    `sha256sum <path to *.bin>`
+ *    Note, make sure to reverse the byte order so order is little endian.
+ */
+const size_t kGoldenRomSizeBytes = 32648;
+const uint32_t kSimDvGoldenRomHash[kSha256HashSizeIn32BitWords] = {
+    0xa89b5d02, 0x45ac9691, 0x37ecafa7, 0x3feb8e85,
+    0x8856d902, 0x36012a3e, 0x11ca064b, 0xa5358f02,
+};
+const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
+    0x40e52a49, 0x81729b5d, 0x05f8221f, 0xab685ed2,
+    0xec153ccc, 0xf372b97f, 0x8f9136bc, 0x0ce5576f,
+};
+
+// We hash the ROM using the SHA256 algorithm and print the hash to the console.
+status_t hash_rom(void) {
+  uint32_t rom_hash[kSha256HashSizeIn32BitWords];
+  crypto_const_uint8_buf_t input = {
+      .data = (uint8_t *)TOP_EARLGREY_ROM_BASE_ADDR,
+      .len = kGoldenRomSizeBytes,
+  };
+  crypto_uint8_buf_t output = {
+      .data = (uint8_t *)rom_hash,
+      .len = kSha256HashSizeInBytes,
+  };
+
+  TRY_CHECK(otcrypto_hash(input, kHashModeSha256, &output) == kCryptoStatusOK);
+  LOG_INFO("ROM Hash: 0x%!x", kSha256HashSizeInBytes, rom_hash);
+  if (kDeviceType == kDeviceSimDV) {
+    TRY_CHECK_ARRAYS_EQ((uint8_t *)output.data, (uint8_t *)kSimDvGoldenRomHash,
+                        sizeof(kSimDvGoldenRomHash));
+  } else if (kDeviceType == kDeviceFpgaCw310) {
+    TRY_CHECK_ARRAYS_EQ((uint8_t *)output.data,
+                        (uint8_t *)kFpgaCw310GoldenRomHash,
+                        sizeof(kFpgaCw310GoldenRomHash));
+  } else {
+    LOG_WARNING("ROM hash not self-checked for this device type: 0x%x",
+                kDeviceType);
+  }
+
+  return OK_STATUS();
+};
+
+bool test_main(void) {
+  status_t test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, hash_rom);
+  return status_ok(test_result);
+}


### PR DESCRIPTION
This implements the ROM self hash test (see #18686), and runs it in DV and on the FPGA.

An open TODO is to update the test to use the ROM with real keys (once they are generated) and check-in the golden hashes accordingly.