### PR TITLE
[i2c] Remove SCL glitch when FMT FIFO empties mid-transaction

### DIFF
--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -473,11 +473,18 @@ module i2c_fsm import i2c_pkg::*;
     stretch_en = 1'b0;
     expect_stop = 1'b0;
     unique case (state_q)
-      // Idle: initial state, SDA and SCL are released (high)
+      // Idle: initial state, SDA is released (high), SCL is released if the
+      // bus is idle. Otherwise, if no STOP condition has been sent yet,
+      // continue pulling SCL low in host mode.
       Idle : begin
-        host_idle_o = 1'b1;
         sda_d = 1'b1;
-        scl_d = 1'b1;
+        if (host_enable_i && trans_started) begin
+          host_idle_o = 1'b0;
+          scl_d = 1'b0;
+        end else begin
+          host_idle_o = 1'b1;
+          scl_d = 1'b1;
+        end
       end
       // SetupStart: SDA and SCL are released
       SetupStart : begin


### PR DESCRIPTION
Prior to this change, if the FMT FIFO doesn't yet have its next entry from software and the transaction is not done (i.e. STOP hasn't been issued), the i2c FSM would cause a glitch on SCL. The FSM would follow the sequence HostHoldBitAck -> PopFmtFifo -> Idle, and the Idle state would unconditionally cause a 0 -> 1 transition on SCL, even if the user intended to follow up with more data. Consequently, the host and device would fall out of alignment for the bit count.

For the purposes of an ECO, change the Idle state to only release SCL if it is not in the middle of a transaction in host mode. A subsequent commit may change the FSM for readability (e.g. going to Active if this IP is still in the middle of a bus transaction and fixing up the Active state to wait for instructions from the FMT FIFO).