### PR TITLE
[usb_testutils] Fix LFSR and stricter typing

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi_stream.c
+++ b/hw/dv/dpi/usbdpi/usbdpi_stream.c
@@ -17,9 +17,10 @@
 #define RETRY_LFSR_SEED(s) (uint8_t)(0x24U + (s)*7U)
 
 // Simple LFSR for 8-bit sequences
-#define LFSR_ADVANCE(lfsr) \
-  (((lfsr) << 1) ^         \
-   ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1u))
+#define LFSR_ADVANCE(lfsr)     \
+  (uint8_t)(                   \
+      (uint8_t)((lfsr) << 1) ^ \
+      ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1U))
 
 // Stream signature words
 #define STREAM_SIGNATURE_HEAD 0x579EA01AU

--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -437,9 +437,11 @@ status_t usb_testutils_fin(usb_testutils_ctx_t *ctx) {
                 "USBDEV_NUM_ENDPOINTS must fit into uint8_t");
   static_assert(USBDEV_NUM_ENDPOINTS > 0,
                 "USBDEV_NUM_ENDPOINTS - 1 must not overflow");
-  for (uint8_t ep = USBDEV_NUM_ENDPOINTS - 1; ep >= 0; ep--) {
+  uint8_t ep = USBDEV_NUM_ENDPOINTS;
+  do {
+    ep--;
     TRY(usb_testutils_endpoint_remove(ctx, ep));
-  }
+  } while (ep > 0U);
 
   // Disconnect from the bus
   TRY(dif_usbdev_interface_enable(ctx->dev, kDifToggleDisabled));

--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -97,9 +97,9 @@ typedef enum usb_status {
 
 static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
                                          usb_testutils_ctx_t *ctx,
-                                         int bmRequestType, int bRequest,
-                                         int wValue, int wIndex,
-                                         size_t wLength) {
+                                         uint8_t bmRequestType,
+                                         uint8_t bRequest, uint16_t wValue,
+                                         uint16_t wIndex, uint16_t wLength) {
   size_t len;
   uint32_t stat;
   int zero, type;
@@ -107,7 +107,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
   // Endpoint for SetFeature/ClearFeature/GetStatus requests
   dif_usbdev_endpoint_id_t endpoint = {
       .number = (uint8_t)wIndex,
-      .direction = ((bmRequestType & 0x80) != 0U),
+      .direction = ((bmRequestType & 0x80U) != 0U),
   };
   dif_usbdev_buffer_t buffer;
   CHECK_DIF_OK(dif_usbdev_buffer_request(ctx->dev, ctx->buffer_pool, &buffer));
@@ -121,7 +121,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
         }
         CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &buffer, dev_dscr, len,
                                              &bytes_written));
-        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
         return kUsbTestutilsCtWaitIn;
       } else if ((wValue & 0xff00) == 0x200) {
         usb_testutils_xfr_flags_t flags = kUsbTestutilsXfrDoubleBuffered;
@@ -147,7 +147,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
         } else {
           CHECK_DIF_OK(dif_usbdev_buffer_write(
               ctx->dev, &buffer, ctctx->cfg_dscr, len, &bytes_written));
-          CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+          CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
         }
         return kUsbTestutilsCtWaitIn;
       }
@@ -155,9 +155,9 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
 
     case kUsbSetupReqSetAddress:
       TRC_S("SA");
-      ctctx->new_dev = wValue & 0x7f;
+      ctctx->new_dev = (uint8_t)(wValue & 0x7fU);
       // send zero length packet for status phase
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtAddrStatIn;
 
     case kUsbSetupReqSetConfiguration:
@@ -165,7 +165,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       // only ever expect this to be 1 since there is one config descriptor
       ctctx->usb_config = (uint8_t)wValue;
       // send zero length packet for status phase
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       if (wValue) {
         ctctx->device_state = kUsbTestutilsDeviceConfigured;
       } else {
@@ -182,7 +182,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       // return the value that was set
       CHECK_DIF_OK(dif_usbdev_buffer_write(
           ctx->dev, &buffer, &ctctx->usb_config, len, &bytes_written));
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtWaitIn;
 
     case kUsbSetupReqSetFeature:
@@ -190,7 +190,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
         CHECK_DIF_OK(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint,
                                                       kDifToggleEnabled));
         // send zero length packet for status phase
-        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
         return kUsbTestutilsCtStatIn;
       }
       return kUsbTestutilsCtError;  // unknown
@@ -200,7 +200,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
         CHECK_DIF_OK(dif_usbdev_endpoint_stall_enable(ctx->dev, endpoint,
                                                       kDifToggleDisabled));
         // send zero length packet for status phase
-        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+        CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       }
       return kUsbTestutilsCtStatIn;
 
@@ -223,13 +223,13 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       // return the value that was set
       CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &buffer, (uint8_t *)&stat,
                                            len, &bytes_written));
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtWaitIn;
 
     case kUsbSetupReqSetInterface:
       // Don't support alternate interfaces, so just ignore
       // send zero length packet for status phase
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtStatIn;
 
     case kUsbSetupReqGetInterface:
@@ -241,7 +241,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       // Don't support interface, so return zero
       CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &buffer, (uint8_t *)&zero,
                                            len, &bytes_written));
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtWaitIn;
 
     case kUsbSetupReqSynchFrame:
@@ -253,7 +253,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
       // Don't support synch_frame so return zero
       CHECK_DIF_OK(dif_usbdev_buffer_write(ctx->dev, &buffer, (uint8_t *)&zero,
                                            len, &bytes_written));
-      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+      CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
       return kUsbTestutilsCtWaitIn;
 
     default:
@@ -272,8 +272,7 @@ static usb_testutils_ctstate_t setup_req(usb_testutils_controlep_ctx_t *ctctx,
             }
             CHECK_DIF_OK(dif_usbdev_buffer_write(
                 ctx->dev, &buffer, ctctx->test_dscr, len, &bytes_written));
-            CHECK_DIF_OK(
-                dif_usbdev_send(ctx->dev, (uint8_t)ctctx->ep, &buffer));
+            CHECK_DIF_OK(dif_usbdev_send(ctx->dev, ctctx->ep, &buffer));
             return kUsbTestutilsCtWaitIn;
           } break;
           case kVendorSetupReqTestStatus: {
@@ -294,7 +293,7 @@ static status_t ctrl_tx_done(void *ctctx_v, usb_testutils_xfr_result_t result) {
   switch (ctctx->ctrlstate) {
     case kUsbTestutilsCtAddrStatIn:
       // Now the status was sent on device 0 can switch to new device ID
-      TRY(dif_usbdev_address_set(ctx->dev, (uint8_t)ctctx->new_dev));
+      TRY(dif_usbdev_address_set(ctx->dev, ctctx->new_dev));
       TRC_I(ctctx->new_dev, 8);
       ctctx->ctrlstate = kUsbTestutilsCtIdle;
       // We now have a device address on the USB
@@ -334,11 +333,11 @@ static status_t ctrl_rx(void *ctctx_v, dif_usbdev_rx_packet_info_t packet_info,
         alignas(uint32_t) uint8_t bp[8];
         TRY(dif_usbdev_buffer_read(ctx->dev, ctx->buffer_pool, &buffer, bp,
                                    sizeof(bp), &bytes_written));
-        int bmRequestType = bp[0];
-        int bRequest = bp[1];
-        int wValue = (bp[3] << 8) | bp[2];
-        int wIndex = (bp[5] << 8) | bp[4];
-        size_t wLength = (bp[7] << 8) | bp[6];
+        uint8_t bmRequestType = bp[0];
+        uint8_t bRequest = bp[1];
+        uint16_t wValue = (uint16_t)((bp[3] << 8) | bp[2]);
+        uint16_t wIndex = (uint16_t)((bp[5] << 8) | bp[4]);
+        uint16_t wLength = (uint16_t)((bp[7] << 8) | bp[6]);
         TRC_C('0' + bRequest);
 
         ctctx->ctrlstate = setup_req(ctctx, ctx, bmRequestType, bRequest,
@@ -397,7 +396,7 @@ static status_t ctrl_reset(void *ctctx_v) {
 }
 
 status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
-                                      usb_testutils_ctx_t *ctx, int ep,
+                                      usb_testutils_ctx_t *ctx, uint8_t ep,
                                       const uint8_t *cfg_dscr,
                                       size_t cfg_dscr_len,
                                       const uint8_t *test_dscr,

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -32,10 +32,10 @@ typedef enum usb_testutils_device_state {
 
 typedef struct usb_testutils_controlep_ctx {
   usb_testutils_ctx_t *ctx;
-  int ep;
+  uint8_t ep;
   usb_testutils_ctstate_t ctrlstate;
   usb_testutils_device_state_t device_state;
-  uint32_t new_dev;
+  uint8_t new_dev;
   uint8_t usb_config;
   /**
    * USB configuration descriptor
@@ -63,7 +63,7 @@ typedef struct usb_testutils_controlep_ctx {
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
-                                      usb_testutils_ctx_t *ctx, int ep,
+                                      usb_testutils_ctx_t *ctx, uint8_t ep,
                                       const uint8_t *cfg_dscr,
                                       size_t cfg_dscr_len,
                                       const uint8_t *test_dscr,

--- a/sw/device/lib/testing/usb_testutils_simpleserial.c
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.c
@@ -45,7 +45,7 @@ static status_t ss_flush(void *ssctx_v) {
     TRY(dif_usbdev_buffer_write(ctx->dev, &ssctx->cur_buf, ssctx->chold.data_b,
                                 ssctx->cur_cpos & 0x3, &bytes_written));
   }
-  TRY(dif_usbdev_send(ctx->dev, (uint8_t)ssctx->ep, &ssctx->cur_buf));
+  TRY(dif_usbdev_send(ctx->dev, ssctx->ep, &ssctx->cur_buf));
   ssctx->sending = true;
   ssctx->cur_cpos = -1;  // given it to the hardware
   return OK_STATUS();
@@ -67,7 +67,7 @@ status_t usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
     TRY(dif_usbdev_buffer_write(ctx->dev, &ssctx->cur_buf, ssctx->chold.data_b,
                                 /*src_len=*/4, &bytes_written));
     if (ssctx->cur_cpos >= MAX_GATHER && !ssctx->sending) {
-      TRY(dif_usbdev_send(ctx->dev, (uint8_t)ssctx->ep, &ssctx->cur_buf));
+      TRY(dif_usbdev_send(ctx->dev, ssctx->ep, &ssctx->cur_buf));
       ssctx->sending = true;
       ssctx->cur_cpos = -1;  // given it to the hardware
     }
@@ -76,10 +76,10 @@ status_t usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
 }
 
 status_t usb_testutils_simpleserial_init(usb_testutils_ss_ctx_t *ssctx,
-                                         usb_testutils_ctx_t *ctx, int ep,
+                                         usb_testutils_ctx_t *ctx, uint8_t ep,
                                          void (*got_byte)(uint8_t)) {
-  TRY(usb_testutils_endpoint_setup(ctx, (uint8_t)ep, kUsbdevOutStream, ssctx,
-                                   ss_tx_done, ss_rx, ss_flush, NULL));
+  TRY(usb_testutils_endpoint_setup(ctx, ep, kUsbdevOutStream, ssctx, ss_tx_done,
+                                   ss_rx, ss_flush, NULL));
   ssctx->ctx = ctx;
   ssctx->ep = ep;
   ssctx->sending = false;

--- a/sw/device/lib/testing/usb_testutils_simpleserial.h
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.h
@@ -14,7 +14,7 @@
 // This is only here because caller of _init needs it
 typedef struct usb_testutils_ss_ctx {
   usb_testutils_ctx_t *ctx;
-  int ep;
+  uint8_t ep;
   bool sending;
   dif_usbdev_buffer_t cur_buf;
   int cur_cpos;
@@ -48,7 +48,7 @@ status_t usb_testutils_simpleserial_send_byte(usb_testutils_ss_ctx_t *ssctx,
  */
 OT_WARN_UNUSED_RESULT
 status_t usb_testutils_simpleserial_init(usb_testutils_ss_ctx_t *ssctx,
-                                         usb_testutils_ctx_t *ctx, int ep,
+                                         usb_testutils_ctx_t *ctx, uint8_t ep,
                                          void (*got_byte)(uint8_t));
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_SIMPLESERIAL_H_

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -276,7 +276,7 @@ static status_t rx_show(void *stream_v, dif_usbdev_rx_packet_info_t packet_info,
 
 // Returns an indication of whether a stream has completed its data transfer
 bool usb_testutils_stream_completed(const usb_testutils_streams_ctx_t *ctx,
-                                    size_t id) {
+                                    uint8_t id) {
   // Locate the stream context information
   const usbdev_stream_t *s = &ctx->streams[id];
 
@@ -437,14 +437,14 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
   TRY_CHECK(nstreams <= UINT8_MAX);
 
   // Remember the stream count
-  ctx->nstreams = nstreams;
+  ctx->nstreams = (uint8_t)nstreams;
 
   // Initialize the state of each stream
-  for (uint8_t id = 0; id < nstreams; id++) {
+  for (uint8_t id = 0U; id < nstreams; id++) {
     // Which endpoint are we using for the IN transfers to the host?
-    const uint8_t ep_in = id + 1;
+    const uint8_t ep_in = id + 1U;
     // Which endpoint are we using for the OUT transfers from the host?
-    const uint8_t ep_out = id + 1;
+    const uint8_t ep_out = id + 1U;
     TRY(usb_testutils_stream_init(ctx, id, ep_in, ep_out, num_bytes, flags,
                                   verbose));
   }
@@ -452,7 +452,7 @@ status_t usb_testutils_streams_init(usb_testutils_streams_ctx_t *ctx,
   // Decide how many buffers each endpoint may queue up for transmission;
   // we must ensure that there are buffers available for reception, and we
   // do not want any endpoint to starve another
-  for (uint8_t s = 0; s < nstreams; s++) {
+  for (uint8_t s = 0U; s < nstreams; s++) {
     // This is slightly overspending the available buffers, leaving the
     //   endpoints to vie for the final few buffers, so it's important that
     //   we limit the total number of buffers across all endpoints too
@@ -481,7 +481,7 @@ status_t usb_testutils_streams_service(usb_testutils_streams_ctx_t *ctx) {
 
 bool usb_testutils_streams_completed(const usb_testutils_streams_ctx_t *ctx) {
   // See whether any streams still have more work to do
-  for (size_t id = 0; id < ctx->nstreams; id++) {
+  for (uint8_t id = 0; id < ctx->nstreams; id++) {
     if (!usb_testutils_stream_completed(ctx, id)) {
       return false;
     }

--- a/sw/device/lib/testing/usb_testutils_streams.h
+++ b/sw/device/lib/testing/usb_testutils_streams.h
@@ -38,11 +38,11 @@
 #define BUFSZ_LFSR_SEED(s) (uint8_t)(0x17U + (s)*7U)
 
 // Simple LFSR for 8-bit sequences
-// Note: zero is an isolated state that shall be avoided
-#define LFSR_ADVANCE(lfsr)                                    \
-  (uint8_t)((uint8_t)((lfsr) << 1) ^ (uint8_t)((lfsr) >> 1) ^ \
-            (uint8_t)((lfsr) >> 2) ^ (uint8_t)((lfsr) >> 3) ^ \
-            (uint8_t)((lfsr) >> 7) & 1u)
+/// Note: zero is an isolated state that shall be avoided
+#define LFSR_ADVANCE(lfsr)     \
+  (uint8_t)(                   \
+      (uint8_t)((lfsr) << 1) ^ \
+      ((((lfsr) >> 1) ^ ((lfsr) >> 2) ^ ((lfsr) >> 3) ^ ((lfsr) >> 7)) & 1U))
 
 // Test/stream flags
 typedef enum {
@@ -190,7 +190,7 @@ struct usb_testutils_streams_ctx {
   /**
    * Number of streams in use
    */
-  unsigned nstreams;
+  uint8_t nstreams;
   /**
    * State information for each of the test streams
    */
@@ -293,6 +293,6 @@ status_t usb_testutils_stream_service(usb_testutils_streams_ctx_t *ctx,
  */
 OT_WARN_UNUSED_RESULT
 bool usb_testutils_stream_completed(const usb_testutils_streams_ctx_t *ctx,
-                                    size_t id);
+                                    uint8_t id);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_STREAMS_H_

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -449,6 +449,8 @@ rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
       break;
     default:
       HARDENED_TRAP();
+      byte_count = 0U;
+      break;
   }
 
   // Truncate to the closest lower bank/page aligned address.
@@ -569,10 +571,12 @@ void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
       break;
     case kHardenedBoolFalse:
       HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
-      reg = 0;
+      reg = 0U;
       break;
     default:
       HARDENED_TRAP();
+      reg = 0U;
+      break;
   }
   sec_mmio_write32_shadowed(kBase + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET,
                             reg);

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -123,8 +123,8 @@ bool test_main(void) {
     CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
   }
 
-  // Set up two serial ports.
-  CHECK_STATUS_OK(usb_testutils_simpleserial_init(&simple_serial, &usbdev, 1,
+  // Set up a serial port.
+  CHECK_STATUS_OK(usb_testutils_simpleserial_init(&simple_serial, &usbdev, 1U,
                                                   usb_receipt_callback));
 
   // Send a "Hi!Hi!" sign on message.
@@ -146,6 +146,8 @@ bool test_main(void) {
           kExpectedUsbRecved[i], buffer[i]);
   }
   LOG_INFO("USB received %d characters: %s", usb_chars_recved_total, buffer);
+
+  CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
 
   return true;
 }


### PR DESCRIPTION
Stricter types in usb_testutils layer; in many cases the context variables should have been declared as uint8_t but historically were just declared as 'int'. Their values are actually constrained by the USB protocol specification.
Fix LFSR generation expression; suffers a bit from too many parentheses, being a macro definition. LFSR code exists in DPI model at the other end of the USB connection too.
Correct usb_testutils_fin re-expression
Introduce shutdown code in usbdev_test; usb_testutils_fin was in use only within some other top-level tests that have not yet been merged into the repository.
Fixed some uninitialized variable warnings in flash_ctrl