### PR TITLE
[sw/silicon_creator] Add version field to retention SRAM

### DIFF
--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -84,8 +84,9 @@ status_t keymgr_testutils_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac) {
   // type of the ROM.
   bool is_using_test_rom =
       retention_sram_get()
-          ->reserved_creator[ARRAYSIZE((retention_sram_t){0}.reserved_creator) -
-                             1] == TEST_ROM_IDENTIFIER;
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER;
 
   // POR reset.
   if (info == kDifRstmgrResetInfoPor) {

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -97,9 +97,9 @@ status_t rstmgr_testutils_post_reset(
 }
 
 dif_rstmgr_reset_info_bitfield_t rstmgr_testutils_reason_get(void) {
-  return retention_sram_get()->reset_reasons;
+  return retention_sram_get()->creator.reset_reasons;
 }
 
 void rstmgr_testutils_reason_clear(void) {
-  retention_sram_get()->reset_reasons = 0;
+  retention_sram_get()->creator.reset_reasons = 0;
 }

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -166,13 +166,13 @@ bool rom_test_main(void) {
 #if !OT_IS_ENGLISH_BREAKFAST
   // Store the reset reason in retention RAM and clear the register.
   volatile retention_sram_t *ret_ram = retention_sram_get();
-  ret_ram->reset_reasons = reset_reasons;
+  ret_ram->creator.reset_reasons = reset_reasons;
   CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
 
   // Write 0x54534554 (ASCII: TEST) to the end of the retention SRAM creator
   // area to be able to determine the type of ROM in tests.
   volatile uint32_t *creator_last_word =
-      &ret_ram->reserved_creator[ARRAYSIZE(ret_ram->reserved_creator) - 1];
+      &ret_ram->creator.reserved[ARRAYSIZE(ret_ram->creator.reserved) - 1];
   *creator_last_word = TEST_ROM_IDENTIFIER;
 #endif
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -144,8 +144,9 @@ static void check_lock_otp_partition(const dif_otp_ctrl_t *otp) {
 rom_error_t keymgr_rom_test(void) {
   ASSERT_OK(keymgr_state_check(kKeymgrStateReset));
   if (retention_sram_get()
-          ->reserved_creator[ARRAYSIZE((retention_sram_t){0}.reserved_creator) -
-                             1] == TEST_ROM_IDENTIFIER) {
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER) {
     keymgr_sw_binding_set(&kBindingValueRomExt, &kBindingValueRomExt);
     keymgr_creator_max_ver_set(kMaxVerRomExt);
     SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet +

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_functest.c
@@ -34,7 +34,7 @@ bool test_main(void) {
 
   // Use the part of the retention RAM reserved for the silicon owner to store
   // the test phase.
-  uint32_t *phase = &retention_sram_get()->reserved_owner[0];
+  uint32_t *phase = &retention_sram_get()->owner.reserved[0];
 
   if (bitfield_bit32_read(reason, kRstmgrReasonPowerOn)) {
     // Clear retention RAM on power-on reset.

--- a/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
@@ -112,7 +112,7 @@ bool test_main(void) {
 
   // Use the part of the retention SRAM reserved for the silicon owner to
   // store the test phase.
-  uint32_t *phase = &retention_sram_get()->reserved_owner[0];
+  uint32_t *phase = &retention_sram_get()->owner.reserved[0];
 
   if (bitfield_bit32_read(reason, kRstmgrReasonPowerOn)) {
     sec_mmio_init();

--- a/sw/device/silicon_creator/lib/irq_asm_functest.c
+++ b/sw/device/silicon_creator/lib/irq_asm_functest.c
@@ -48,7 +48,7 @@ bool test_main(void) {
 
   // Use the part of the retention SRAM reserved for the silicon owner to
   // store the test phase.
-  uint32_t *phase = &retention_sram_get()->reserved_owner[0];
+  uint32_t *phase = &retention_sram_get()->owner.reserved[0];
 
   if (bitfield_bit32_read(reason, kRstmgrReasonPowerOn)) {
     // First execution after bootstrap: Zero out the retention RAM.

--- a/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/provisioning_functest.c
@@ -72,7 +72,7 @@ bool test_main(void) {
   // storing it in flash, and still persists across a SW initiated reset.
   retention_sram_t *ret_sram_data = retention_sram_get();
   manuf_provisioning_t *export_data =
-      (manuf_provisioning_t *)&ret_sram_data->reserved_creator;
+      (manuf_provisioning_t *)&ret_sram_data->creator.reserved;
 
   dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
   if (info & kDifRstmgrResetInfoPor) {

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_rma_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_rma_test.c
@@ -11,7 +11,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  uint32_t bitfield = retention_sram_get()->reset_reasons;
+  uint32_t bitfield = retention_sram_get()->creator.reset_reasons;
   LOG_INFO("reset_info_bitfield: 0x%x", bitfield);
   return true;
 }

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_ret_ram_init_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_ret_ram_init_test.c
@@ -26,7 +26,7 @@ rom_error_t retention_ram_init_test(void) {
   memset(&pattern64, kPattern, sizeof(pattern64));
 
   retention_sram_t *ret = retention_sram_get();
-  uint32_t reset_reasons = ret->reset_reasons;
+  uint32_t reset_reasons = ret->creator.reset_reasons;
 
   // Verify that reset_reasons reports POR.
   if (bitfield_bit32_read(reset_reasons, kRstmgrReasonPowerOn)) {

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_ret_ram_keep_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_ret_ram_keep_test.c
@@ -35,14 +35,14 @@ bool check_ram_unchanged(retention_sram_t *ret) {
 
   // Ensure that all written sections were saved
   bool unchanged = true;
-  // Skip checking word 0 since that is used to store the
-  // reset reason and will be changed.
-  for (size_t i = sizeof(uint32_t); i < sizeof(retention_sram_t);
+  // Skip checking the first two words since that is used to store the
+  // version and reset reason.
+  for (size_t i = 2 * sizeof(uint32_t); i < sizeof(retention_sram_t);
        i += sizeof(uint32_t)) {
     uint32_t val = read_32((char *)ret + i);
     if (val != pattern32) {
-      LOG_ERROR("Retention SRAM changed at word %u (%x --> %x).", i, pattern32,
-                val);
+      LOG_ERROR("Retention SRAM changed at word %u (%x --> %x).",
+                i / sizeof(uint32_t), pattern32, val);
       unchanged = false;
     }
   }
@@ -52,7 +52,7 @@ bool check_ram_unchanged(retention_sram_t *ret) {
 rom_error_t retention_ram_keep_test(void) {
   // Variables of type `retention_sram_t` are static to reduce stack usage.
   retention_sram_t *ret = retention_sram_get();
-  uint32_t reset_reasons = ret->reset_reasons;
+  uint32_t reset_reasons = ret->creator.reset_reasons;
 
   // Verify that reset_reasons reports POR.
   if (bitfield_bit32_read(reset_reasons, kRstmgrReasonPowerOn)) {

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_alert_config_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_shutdown_alert_config_test.c
@@ -28,7 +28,7 @@ static void uart_alert_trigger(void) {
 
 bool test_main(void) {
   LOG_INFO("Starting test...");
-  uint32_t reset_reasons = retention_sram_get()->reset_reasons;
+  uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;
   switch (reset_reasons) {
     case 1 << kRstmgrReasonPowerOn:
       LOG_INFO("No alert escalation, going to trigger alert...");

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -172,9 +172,10 @@ static rom_error_t rom_init(void) {
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
   if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
+    retention_sram_get()->version = kRetentionSramVersion1;
   }
   // Store the reset reason in retention RAM and clear the register.
-  retention_sram_get()->reset_reasons = reset_reasons;
+  retention_sram_get()->creator.reset_reasons = reset_reasons;
   rstmgr_reason_clear(reset_reasons);
 
   // This function is a NOP unless ROM is built for an fpga.
@@ -350,7 +351,8 @@ static void rom_pre_boot_check(void) {
   }
   HARDENED_CHECK_EQ(cpuctrl_csr, cpuctrl_otp);
   // Check rstmgr alert and cpu info collection configuration.
-  SHUTDOWN_IF_ERROR(rstmgr_info_en_check(retention_sram_get()->reset_reasons));
+  SHUTDOWN_IF_ERROR(
+      rstmgr_info_en_check(retention_sram_get()->creator.reset_reasons));
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomPreBootCheck, 6);
 
   sec_mmio_check_counters(/*expected_check_count=*/3);

--- a/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
@@ -190,8 +190,9 @@ static void keymgr_advance_to_creator_root_key(void) {
   // type of the ROM.
   bool is_using_test_rom =
       retention_sram_get()
-          ->reserved_creator[ARRAYSIZE((retention_sram_t){0}.reserved_creator) -
-                             1] == TEST_ROM_IDENTIFIER;
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER;
   CHECK_STATUS_OK(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateReset));
   CHECK_STATUS_OK(keymgr_testutils_advance_state(&keymgr, NULL));
   CHECK_STATUS_OK(

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -28,8 +28,7 @@ enum {
    */
   kRetSramBaseAddr = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
 
-  kRetSramOwnerAddr =
-      kRetSramBaseAddr + offsetof(retention_sram_t, reserved_owner),
+  kRetSramOwnerAddr = kRetSramBaseAddr + offsetof(retention_sram_t, owner),
   kRetRamLastAddr =
       kRetSramBaseAddr + TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES - 1,
 


### PR DESCRIPTION
This PR adds a version field to the `retention_sram_t` so that `rom_ext` can detect the current format and migrate to a different format if needed.