### PR TITLE
[hw,spi_device,dv] Fix failures related to DstPulseCheck_A assertion in spi_device nightly regression

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -455,10 +455,16 @@ class spi_device_base_vseq extends cip_base_vseq #(
       $asserton(0, "tb.dut.u_txf_underflow.SrcPulseCheck_M");
       $asserton(0, "tb.dut.u_txf_underflow.DstPulseCheck_A");
       $asserton(0, "tb.dut.u_rxf_overflow.SrcPulseCheck_M");
+      if (cfg.en_dv_cdc) begin
+        $asserton(0, "tb.dut.u_rxf_overflow.DstPulseCheck_A");
+      end
     end else begin
       $assertoff(0, "tb.dut.u_txf_underflow.SrcPulseCheck_M");
       $assertoff(0, "tb.dut.u_txf_underflow.DstPulseCheck_A");
       $assertoff(0, "tb.dut.u_rxf_overflow.SrcPulseCheck_M");
+      if (cfg.en_dv_cdc) begin
+        $assertoff(0, "tb.dut.u_rxf_overflow.DstPulseCheck_A");
+      end
     end
   endfunction
 endclass : spi_device_base_vseq


### PR DESCRIPTION
- Disable `DstPulseCheck_A` assertion of `prim_pulse_sync.sv` in case of CDC randomization.
- Even though `src_pulse` to the module is separated by a minimum number of cycles, CDC randomization can cause two output pulses to overlap resulting in assertion errors.
This PR partially addresses https://github.com/lowRISC/opentitan/issues/18364