### PR TITLE
[hw,sysrst_ctrl,dv] Address TODO and warnings in DV environment

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -107,8 +107,26 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task dut_shutdown();
-    // check for pending sysrst_ctrl operations and wait for them to complete
-    // TODO
+    uvm_reg_data_t rdata;
+    uvm_reg  interrupt_register_q[$] = '{ral.ulp_status,
+                                         ral.wkup_status,
+                                         ral.combo_intr_status,
+                                         ral.key_intr_status};
+    // Check for any active interrupts
+    csr_rd(ral.intr_state, rdata);
+    if (rdata[0]) begin
+      `uvm_info(`gfn, "Unhandled interrupt detected", UVM_LOW)
+      foreach (interrupt_register_q[i]) begin
+        // Check interrupt status
+        csr_rd(interrupt_register_q[i], rdata);
+        if (rdata[0]) begin
+          `uvm_info(`gfn, $sformatf("%s : 0x%0x", interrupt_register_q[i].get_name(), rdata),
+            UVM_LOW)
+          `uvm_info(`gfn, $sformatf("Clearing %s", interrupt_register_q[i].get_name()), UVM_LOW)
+          csr_wr(interrupt_register_q[i], 'd0);
+        end
+      end
+    end
   endtask
 
   // setup basic sysrst_ctrl features

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_ec_rst_with_pre_cond_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_ec_rst_with_pre_cond_vseq.sv
@@ -22,8 +22,8 @@ class sysrst_ctrl_combo_detect_ec_rst_with_pre_cond_vseq extends
     `uvm_info(`gfn, "Starting to setup pre-conditions", UVM_LOW)
 
     // Enable pwrb_in to trigger pre-condition.
-    // TODO: create an enum for key selections in CSR.
-    csr_wr(ral.com_pre_sel_ctl[0], 'h1 << 3);
+    ral.com_pre_sel_ctl[0].pwrb_in_sel.set(1'b1);
+    csr_update(ral.com_pre_sel_ctl[0]);
 
     // Configure the pre_condition detect timer.
     csr_wr(ral.com_pre_det_ctl[0], pre_cond_detect_timer);

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
@@ -14,7 +14,6 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
    rand uint16_t set_pwrb_timer, set_lid_timer, set_ac_timer;
    rand int pwrb_cycles, ac_cycles, lid_cycles;
    rand bit en_ulp;
-   // TODO: z3_wakeup check logic could move to scb.
    uint16_t get_ac_timer, get_pwrb_timer, get_lid_timer;
    bit enable_ulp, exp_z3_wakeup;
 

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env_cov.sv
@@ -103,8 +103,11 @@ class sysrst_ctrl_combo_detect_action_obj extends uvm_object;
   endgroup  // sysrst_ctrl_combo_detect_action_cg
 
   function new(string name = "sysrst_ctrl_combo_detect_action_obj");
+    string str_idx;
     super.new(name);
-    sysrst_ctrl_combo_detect_action_cg = new(name);
+    // Get index from argument
+    str_idx = name.substr(name.len - 1, name.len - 1);
+    sysrst_ctrl_combo_detect_action_cg = new(str_idx.atoi());
   endfunction : new
 endclass : sysrst_ctrl_combo_detect_action_obj
 
@@ -307,7 +310,7 @@ class sysrst_ctrl_env_cov extends cip_base_env_cov #(
     debounce_timer_cg["ulp_lid_debounce_ctl"] = new("ulp_lid_debounce_ctl");
 
     for (int i = 0; i <= 3; i++) begin
-      combo_detect_action[i] = new(i);
+      combo_detect_action[i] = new($sformatf("sysrst_ctrl_combo_detect_action_obj_%0d",i));
     end
 
     combo_key_combinations = new();

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -132,7 +132,8 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       "com_det_ctl_0","com_det_ctl_1","com_det_ctl_2","com_det_ctl_3": begin
          if (addr_phase_write) begin
            string csr_name = csr.get_name();
-           string str_idx = csr_name.getc(csr_name.len - 1);
+           // get the last character
+           string str_idx = csr_name.substr(csr_name.len - 1, csr_name.len - 1);
            int idx = str_idx.atoi();
            cov_if.cg_combo_detect_det_sample (idx,
              get_field_val(ral.com_det_ctl[idx].detection_timer, item.a_data)
@@ -239,7 +240,8 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       "com_pre_det_ctl_0", "com_pre_det_ctl_1", "com_pre_det_ctl_2", "com_pre_det_ctl_3": begin
          if (addr_phase_write) begin
            string csr_name = csr.get_name();
-           string str_idx = csr_name.getc(csr_name.len - 1);
+           // get the last character
+           string str_idx = csr_name.substr(csr_name.len - 1, csr_name.len - 1);
            int idx = str_idx.atoi();
            cov_if.cg_combo_precondition_det_sample (idx,
              get_field_val(ral.com_pre_det_ctl[idx].precondition_timer, item.a_data)

--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -24,7 +24,6 @@
   ral_spec: "{proj_root}/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists


### PR DESCRIPTION
- Update `dut_shutdown` to handle end of test
- Instead of adding enum write to `pre_cond_sel` register using the name of the field
- `z3_wakeup` check is tightly coupled with the test, so no need to move the check
- all the configs in sim_cfg.json apply, so remove the TODO