### PR TITLE
[toolchain] Allow get-toolchain to continue if directory exists but is empty

### DIFF
--- a/util/get-toolchain.py
+++ b/util/get-toolchain.py
@@ -228,7 +228,7 @@ def main():
             installed_toolchain['kind'], installed_toolchain['version'],
             available_toolchain['kind'], available_toolchain['version'])
     else:
-        if unpack_dir.exists():
+        if unpack_dir.exists() and (not unpack_dir.is_dir() or any(unpack_dir.iterdir())):
             sys.exit('Target directory %s already exists. '
                      'Delete it first, or use --update.' % str(unpack_dir))
 


### PR DESCRIPTION
Do so that the user can setup the directory first (with sudo) before installing to it. Can be handy if user do not have write access to the parent directory.