### PR TITLE
Sram program integrity

### DIFF
--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -436,5 +436,22 @@
       stage: V3
       tests: []
     }
+
+    {
+      name: manuf_sram_program_crc_functest
+      desc: '''Verifies SRAM CRC mechanism.
+
+            SRAM programs are loaded via JTAG which has no data integrity mechanism. To make sure that
+            the program is not corrupted, the SRAM CRT computes the CRC of the entire program at runtime
+            and compares it to the host provided data. This test verifies the CRC check is correctly done
+            by running two tests:
+            - load a SRAM program and make sure that it works as expected (print a message),
+            - corrupt a byte in memory (where the program was loaded), try to re-run it and confirm that
+              the CRT now reports a CRC mismatch error.
+            '''
+      tags: ["fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
   ]
 }

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -433,6 +433,31 @@ cc_library(
 )
 
 opentitan_ram_binary(
+    name = "sram_empty_functest",
+    srcs = ["sram_empty_functest.c"],
+    hdrs = ["sram_empty_functest.h"],
+    archive_symbol_prefix = "sram_empty_functest",
+    deps = [
+        ":sram_program_linker_script",
+        ":sram_start",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:status",
+    ],
+)
+
+platform_target(
+    name = "sram_empty_functest_fpga_cw310_elf",
+    platform = OPENTITAN_PLATFORM,
+    target = ":sram_empty_functest_fpga_cw310.elf",
+)
+
+opentitan_ram_binary(
     name = "sram_device_info_flash_wr_functest",
     srcs = ["sram_device_info_flash_wr_functest.c"],
     hdrs = ["sram_device_info_flash_wr_functest.h"],
@@ -587,6 +612,45 @@ test_suite(
     tags = ["manual"],
     tests = [
         ":manuf_cp_ast_test_execution_{}_functest".format(lc_state.lower())
+        for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+    ],
+)
+
+# We are using a bitstream with disabled execution so the content of the flash
+# does not matter but opentitan_functest() is unhappy if we don't provide one.
+# Additionally, ROM execution is disabled in the OTP image we use so we do not
+# attempt to bootstrap.
+[
+    opentitan_functest(
+        name = "manuf_sram_program_crc_{}_functest".format(lc_state.lower()),
+        srcs = ["idle_functest.c"],
+        cw310 = cw310_params(
+            bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
+            tags = ["manuf"],
+            test_cmds = [
+                "--clear-bitstream",
+                "--bitstream=\"$(rootpath {bitstream})\"",
+                "--elf=\"$(rootpath :sram_empty_functest_fpga_cw310_elf)\"",
+            ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        ),
+        data = [":sram_empty_functest_fpga_cw310_elf"] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
+        targets = ["cw310_rom_with_fake_keys"],
+        test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
+        deps = [
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:otp_ctrl_testutils",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
+]
+
+test_suite(
+    name = "manuf_sram_program_crc_functest",
+    tags = ["manual"],
+    tests = [
+        ":manuf_sram_program_crc_{}_functest".format(lc_state.lower())
         for lc_state, _ in _TEST_UNLOCKED_LC_ITEMS
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/sram_empty_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/sram_empty_functest.c
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_uart_t uart;
+static dif_pinmux_t pinmux;
+
+void sram_main(void) {
+  // Initialize UART console.
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
+  pinmux_testutils_init(&pinmux);
+  CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK_DIF_OK(dif_uart_configure(
+      &uart, (dif_uart_config_t){
+                 .baudrate = (uint32_t)kUartBaudrate,
+                 .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                 .parity_enable = kDifToggleDisabled,
+                 .parity = kDifUartParityEven,
+                 .tx_enable = kDifToggleEnabled,
+                 .rx_enable = kDifToggleEnabled,
+             }));
+  base_uart_stdout(&uart);
+
+  LOG_INFO("hello");
+
+  // Make sure that the function returns so that the CRT can notify the host.
+}

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -30,6 +30,7 @@ ENTRY(sram_start);
 
 SECTIONS {
   .text ORIGIN(ram_main) + _static_critical_size : ALIGN(4) {
+    _crc_start = .;
     /* Place the entry point of the SRAM program to the start of the main SRAM
      * so that we don't have to maintain a separate offset from the start of
      * the RAM to the entry point for VMEM files. */
@@ -67,6 +68,7 @@ SECTIONS {
     KEEP(*(.sdata))
     KEEP(*(.sdata.*))
     . = ALIGN(4);
+    _crc_end = .;
   } > ram_main
 
   /**

--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -8,11 +8,13 @@
  * CRT library for SRAM programs.
  *
  * The purpose of this small library is to setup the stack pointer, global
- * pointer and verify the integrity
+ * pointer and clear the BSS. It will also verify the integrity with CRC32
+ * and compare it with the host provided CRC32 data.
+ *
+ * @param a0 expected CRC32 value of the data between _crc_start and _crc_end.
  */
 
   .section .sram_start, "ax"
-
   .balign 4
   .global sram_start
   .type sram_start, @function
@@ -25,6 +27,17 @@ sram_start:
   la  gp, __global_pointer$
   .option pop
 
+  // Save CRC32
+  mv   sp, a0
+  // Verify CRC
+  la   a0, _crc_start
+  la   a1, _crc_end
+  call compute_crc32
+  beq  a0, sp, .L_crc_match
+  li   sp, SRAM_MAGIC_SP_CRC_ERROR
+  ebreak
+
+.L_crc_match:
   // Set up the stack.
   la  sp, _stack_end
 
@@ -39,6 +52,62 @@ sram_start:
   // Notify the host that we are done.
   li  sp, SRAM_MAGIC_SP_EXECUTION_DONE
   ebreak
+
+  // Set function size to allow disassembly.
+  .size sram_start, .-sram_start
+
+  /**
+   * Compute the CRC32 of the section bounded by the start and end pointers.
+   * The section must be word (4 byte) aligned.
+   *
+   * This function follows the standard ILP32 calling convention for arguments
+   * but does not require a valid stack pointer, thread pointer or global
+   * pointer.
+   *
+   * Clobbers a0, t0 and t1.
+   *
+   * @param a0 pointer to start of section to clear (inclusive).
+   * @param a1 pointer to end of section to clear (exclusive).
+   */
+  .balign 4
+  .global compute_crc32
+  .type compute_crc32, @function
+compute_crc32:
+  // Check that start is before end.
+  bgeu a0, a1, .L_crc_nothing
+
+  // Check that start and end are word aligned.
+  or   t0, a0, a1
+  andi t0, t0, 0x3
+  bnez t0, .L_crc_error
+  // Initialize CRC digest.
+  li   t0, 0xffffffff
+
+.L_crc_loop:
+  // Compute the CRC word-by-word.
+  lw      t1, 0(a0)
+  xor     t0, t0, t1
+  .option push
+  .option arch, +zbr0p93
+  crc32.w t0, t0
+  .option pop
+  addi    a0, a0, 4
+  bltu    a0, a1, .L_crc_loop
+
+  // Finalize and return CRC
+  li  t1, 0xffffffff
+  xor a0, t0, t1
+  ret
+
+.L_crc_nothing:
+  // If section length is 0 just return. Otherwise end is before start
+  // which is invalid so trigger an error.
+  bne a0, a1, .L_crc_error
+  li  a0, 0
+  ret
+
+.L_crc_error:
+  unimp
 
   // Set function size to allow disassembly.
   .size sram_start, .-sram_start

--- a/sw/device/silicon_creator/manuf/lib/sram_start.h
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.h
@@ -10,5 +10,6 @@
  * ebreak.
  */
 #define SRAM_MAGIC_SP_EXECUTION_DONE 0xcafebabe
+#define SRAM_MAGIC_SP_CRC_ERROR 0xbaddcafe
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_SRAM_START_H_

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -134,6 +134,7 @@ pub enum JtagTap {
 /// List of useful RISC-V general purpose registers
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum RiscvGpr {
+    A0,
     GP,
     SP,
     RA,

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -346,6 +346,7 @@ impl OpenOcdServer {
     fn riscv_reg_name(&self, reg: &RiscvReg) -> &'static str {
         match reg {
             RiscvReg::GprByName(gpr) => match gpr {
+                RiscvGpr::A0 => "a0",
                 RiscvGpr::GP => "gp",
                 RiscvGpr::SP => "sp",
                 RiscvGpr::RA => "ra",

--- a/sw/host/tests/manuf/manuf_sram_program_crc_check/BUILD
+++ b/sw/host/tests/manuf/manuf_sram_program_crc_check/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "manuf_sram_program_crc_check",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+        "@crate_index//:structopt",
+    ],
+)

--- a/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
+++ b/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
@@ -1,0 +1,114 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use structopt::StructOpt;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::JtagTap;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::load_sram_program::{
+    execute_sram_program, ExecutionError, ExecutionMode, ExecutionResult, SramProgramParams,
+};
+use opentitanlib::uart::console::UartConsole;
+
+// use top_earlgrey::top_earlgrey_memory;
+
+#[derive(Debug, StructOpt)]
+struct Opts {
+    #[structopt(flatten)]
+    init: InitializeTest,
+
+    #[structopt(flatten)]
+    sram_program: SramProgramParams,
+}
+
+fn test_sram_load(opts: &Opts, transport: &TransportWrapper, corrupt: bool) -> Result<()> {
+    let uart = transport.uart("console")?;
+    //
+    // Connect to the RISC-V TAP
+    //
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    let jtag = opts.init.jtag_params.create(transport)?;
+    log::info!("Connecting to RISC-V TAP");
+    jtag.connect(JtagTap::RiscvTap)?;
+    log::info!("Halting core");
+    jtag.halt()?;
+
+    // Load program on the device.
+    let sram_prog_info = opts.sram_program.load(&jtag)?;
+
+    // Corrupt program if asked to: mModify a random word in the code, not too close to the
+    // starting point so that the CRT can still verify the CRC.
+    if corrupt {
+        let mut sram_content = [0u8];
+        let tweak_addr = sram_prog_info.entry_point + 1000;
+        log::info!("Corrupt SRAM program at address {:x}", tweak_addr);
+        jtag.read_memory(tweak_addr, &mut sram_content)?;
+        sram_content[0] ^= 0xff;
+        jtag.write_memory(tweak_addr, &sram_content)?;
+    }
+
+    // Execute and check execution status.
+    let exec_res = execute_sram_program(
+        &jtag,
+        &sram_prog_info,
+        ExecutionMode::JumpAndWait(Duration::from_secs(5)),
+    )?;
+    match exec_res {
+        ExecutionResult::ExecutionDone => {
+            if corrupt {
+                bail!("SRAM program finished successfully but expected a CRC failure")
+            } else {
+                log::info!("SRAM program finished successfully")
+            }
+        }
+        ExecutionResult::ExecutionError(err) => match err {
+            ExecutionError::CrcMismatch if corrupt => {
+                log::info!("SRAM program correctly reported a CRC mismatch")
+            }
+            _ => bail!("SRAM program execution failed with {:?}", err),
+        },
+        _ => {
+            bail!(
+                "SRAM program execution failed with unexpected result {:?}",
+                exec_res
+            )
+        }
+    }
+
+    // If the program was not corrupted, make sure that it printed the expected message.
+    if !corrupt {
+        const CONSOLE_TIMEOUT: Duration = Duration::from_secs(1);
+        let _ = UartConsole::wait_for(
+            &*uart,
+            r"sram_empty_functest\.c:\d+\] hello.",
+            CONSOLE_TIMEOUT,
+        )
+        .context("SRAM program did not print 'hello' in time")?;
+    }
+
+    jtag.halt()?;
+    jtag.disconnect()?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::from_args();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    // First test is normal.
+    execute_test!(test_sram_load, &opts, &transport, false);
+    // Second test we try to corrupt the data.
+    execute_test!(test_sram_load, &opts, &transport, true);
+
+    Ok(())
+}


### PR DESCRIPTION
WIP see #18635
Tasks:

- [x] create crt to setup stack pointer and global pointer
- [x] add support for loading ELF files directly
- [x] check integrity in crt
- [x] modify opentitanlib to compute crt

Left to another PR:
- have the loader read back a tiny bit of the program (the sram start) to make sure that the code CRC'ing the everything else is not corrupted.
