### PR TITLE
[spi_host,dv] Extend sw_reset test to trigger mid-transaction

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -262,8 +262,8 @@ class spi_host_base_vseq extends cip_base_vseq #(
 
 
   // wait dut ready for new command
-  virtual task wait_ready_for_command();
-    csr_spinwait(.ptr(ral.status.ready), .exp_data(1'b1));
+  virtual task wait_ready_for_command(bit backdoor = 1'b0);
+    csr_spinwait(.ptr(ral.status.ready), .exp_data(1'b1), .backdoor(backdoor));
   endtask : wait_ready_for_command
 
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_sw_reset_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_sw_reset_vseq.sv
@@ -2,15 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// sw_reset test vseq
-// sequence does a software reset while ongoing host transactions
-// checks for rx and tx queue empty post reset application
+// Trigger a software reset (CONTROL.SW_RST) randomly during an ongoing transaction
+
+// - Check rx and tx queues are empty post SW_RST application
+// From Documentation (hw/ip/spi_host/data/spi_host.hjson):
+// >  In the current implementation, the CDC FIFOs are drained (not reset).
+// >  Therefore, software must confirm that both FIFO's are empty before releasing the IP from reset
+//
 class spi_host_sw_reset_vseq extends spi_host_tx_rx_vseq;
   `uvm_object_utils(spi_host_sw_reset_vseq)
   `uvm_object_new
-
-  bit rxempty;
-  bit txempty;
 
   function void pre_randomize();
     super.pre_randomize();
@@ -21,36 +22,67 @@ class spi_host_sw_reset_vseq extends spi_host_tx_rx_vseq;
   endfunction
 
   virtual task body();
-    for (int i = 0; i < num_runs; i++) begin
-      fork
-        begin : isolation_fork
-          fork
-            start_reactive_seq();
-          join_none
-
-          begin
-            wait_ready_for_command();
-            start_spi_host_trans(num_trans);
-            csr_spinwait(.ptr(ral.status.active), .exp_data(1'b0));
-            csr_spinwait(.ptr(ral.status.rxqd), .exp_data(8'h0));
-            cfg.clk_rst_vif.wait_clks(100);
-          end
-
-          disable fork;
-        end
+    int edges_until_sw_rst;
+    for (int i = 0; i < num_runs; i++) begin : for_num_runs
+      `uvm_info(`gfn, $sformatf("Starting run %0d/%0d now!", i, num_runs), UVM_LOW)
+      fork begin : isolation_fork
+        fork
+          start_reactive_seq();
+        join_none
 
         begin
-          read_rx_fifo();
+          wait_ready_for_command();
+          start_spi_host_trans(num_trans);
+          fork
+            begin
+              // Read data out of RXFIFO once the DUT becomes active
+              read_rx_fifo(); // Returns when status.active == 0 + rxdata is cleared out.
+            end
+
+            // Happy-path : Start transaction(s), wait for DUT to become idle again.
+            // Then trigger a sw_reset event.
+            begin
+              csr_spinwait(.ptr(ral.status.active), .exp_data(1'b0), .backdoor(1));
+              if (edges_until_sw_rst > 0) begin
+                // Look at the edge-counter to check if the other thread is triggering the sw_reset.
+                // (The other thread will only trigger when the counter reaches 0)
+                // This stops both threads from trying to write to the register.
+                csr_utils_pkg::wait_no_outstanding_access();
+                `uvm_info(`gfn, "Triggering CONTROL.SW_RST now!", UVM_LOW)
+                spi_host_init();
+              end
+            end
+
+            // Sad-path : Wait for a random-number of SCK-edges into the transaction, then
+            // trigger CONTROL.SW_RESET.
+            // > If we randomize to a larger number of SCK edges than the transaction, the above
+            //   block will end, causing this block to get disabled.
+            begin
+              `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(edges_until_sw_rst,
+                edges_until_sw_rst inside { [40 : 120] };) // TODO(#18886) Examine txn len for range
+              while (edges_until_sw_rst > 0) begin
+                // TODO(#18886) The below statement assumes CSB[0], future work may break this.
+                cfg.m_spi_agent_cfg.wait_sck_edge(DrivingEdge, 2'b00);
+                edges_until_sw_rst--;
+              end
+              csr_utils_pkg::wait_no_outstanding_access();
+              `uvm_info(`gfn, "Triggering CONTROL.SW_RST now!", UVM_LOW)
+              spi_host_init();
+            end
+          join_any;
         end
-      join
 
-      txfifo_fill();
+        // Wait for no outstanding accesses before using 'disable fork' to kill the path
+        // which did not join.
+        csr_utils_pkg::wait_no_outstanding_access();
+        disable fork;
+      end : isolation_fork join
 
-      cfg.clk_rst_vif.wait_clks($urandom_range(100,200));
-      spi_host_init();
-      cfg.clk_rst_vif.wait_clks($urandom_range(100,200));
+      cfg.clk_rst_vif.wait_clks($urandom_range(100, 200));
+      // Confirm that both FIFO's are empty before releasing the IP from reset.
       csr_rd_check(.ptr(ral.status.rxempty), .compare_value(1'b1));
       csr_rd_check(.ptr(ral.status.txempty), .compare_value(1'b1));
-    end  // end for loop
+
+    end : for_num_runs
   endtask : body
 endclass : spi_host_sw_reset_vseq

--- a/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cov.sv
@@ -45,8 +45,7 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
     duplex_cp : coverpoint direction{ ignore_bins unsupported_dir = {None}; }
   endgroup
 
-  covergroup control_cg with function sample(spi_host_ctrl_t spi_ctrl_reg, bit spien,
-                                             bit output_en, bit sw_rst);
+  covergroup control_cg with function sample(spi_host_ctrl_t spi_ctrl_reg, bit active);
     tx_watermark_cp : coverpoint spi_ctrl_reg.tx_watermark{
       bins lower[10] = {[1:30]};
       bins upper[20] = {[31:SPI_HOST_TX_DEPTH]};
@@ -55,9 +54,10 @@ class spi_host_env_cov extends cip_base_env_cov #(.CFG_T(spi_host_env_cfg));
       bins lower[10] = {[1:30]};
       bins upper[20] = {[31:SPI_HOST_RX_DEPTH]};
     }
-    spien_cp : coverpoint spien{ bins spien = {1}; }
-    output_en_cp : coverpoint output_en{ bins output_en = {1}; }
-    sw_rst_cp : coverpoint sw_rst{ bins sw_rst = {1}; }
+    spien_cp : coverpoint spi_ctrl_reg.spien { bins spien = {1}; }
+    output_en_cp : coverpoint spi_ctrl_reg.output_en { bins output_en = {1}; }
+    sw_rst_cp : coverpoint spi_ctrl_reg.sw_rst { bins sw_rst = {1}; }
+    sw_rst_active_cross : cross sw_rst_cp, active;
   endgroup
 
   covergroup status_cg with function sample(spi_host_status_t spi_status_reg);

--- a/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
@@ -67,6 +67,9 @@ package spi_host_env_pkg;
   } spi_host_configopts_t;
 
   typedef struct {
+    rand bit spien;
+    rand bit output_en;
+    rand bit sw_rst;
     // csid register
     rand bit [31:0] csid;
     // control register fields


### PR DESCRIPTION
This required a bit of refactoring to the scoreboard and some base_vseq routines to handle what is effectively an on-the-fly reset condition. (e.g. spinwaiting tasks prevent us from accessing the bus to trigger the reset!)

The testcase now triggers a SW_RESET both during and between transactions, and an extra cross-coverage point (`sw_rst_active_cross`) has been added for this.

closes #16510 