### PR TITLE
[DONOTMERGE] lc_ctrl jtag cdc instrument issue rep

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -68,7 +68,7 @@
   uvm_test_seq: lc_ctrl_base_vseq
 
   // TODO(lowrisc/opentitan#16689): Enable cdc instrumentation.
-  run_opts: ["+cdc_instrumentation_enabled=0"]
+  run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // List of test specifications.
   tests: [


### PR DESCRIPTION
Michael,
This is one of lc_ctrl failure with cdc_instrument enabled.

cmd: 
./util/dvsim/dvsim.py hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson -i lc_ctrl_jtag_priority -r 1 -s 4095264234 -w fsdb

![image](https://github.com/lowRISC/opentitan/assets/99843637/d593542a-7a8a-421c-90f2-9af35370db51)

Test failed with csr read check because previous csr_write didn't happen.
After tracing dump,
with cdc instrument enable, tms @183686392 is stretched to 2 cycle and it causes mutax lock failure
and jtag csr write to `transition_target` cannot be done.

