### PR TITLE
[pinmux/fpv] Fix FPV testbench

### DIFF
--- a/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
@@ -88,7 +88,6 @@ module pinmux_tb
     tap_strap1_idx:    Tap1PadIdx,
     dft_strap0_idx:    Dft0PadIdx,
     dft_strap1_idx:    Dft1PadIdx,
-    // TODO: check whether there is a better way to pass these USB-specific params
     usb_dp_idx:        DioUsbdevDp,
     usb_dn_idx:        DioUsbdevDn,
     usb_sense_idx:     MioInUsbdevSense,

--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -434,12 +434,12 @@ module pinmux_strap_sampling
   `ASSERT_INIT(dft_strap1_idxRange_A, TargetCfg.dft_strap1_idx >= 0 &&
                                       TargetCfg.dft_strap1_idx < NumIOs)
 
-  `ASSERT(RvTapOff0_A, lc_hw_debug_en_i == Off ##2 strap_en_i |=> rv_jtag_o == '0)
+  `ASSERT(RvTapOff0_A, lc_hw_debug_en_i == Off ##3 strap_en_i |=> rv_jtag_o == '0)
   `ASSERT(RvTapOff1_A, pinmux_hw_debug_en[0] == Off |-> rv_jtag_o == '0)
   `ASSERT(DftTapOff0_A, lc_dft_en_i == Off |-> ##2 dft_jtag_o == '0)
 
   // These assumptions are only used in FPV. They will cause failures in simulations.
-  `ASSUME_FPV(RvTapOff2_A, lc_hw_debug_en_i == Off ##2 strap_en_i |=> rv_jtag_i == '0)
+  `ASSUME_FPV(RvTapOff2_A, lc_hw_debug_en_i == Off ##3 strap_en_i |=> rv_jtag_i == '0)
   `ASSUME_FPV(RvTapOff3_A, pinmux_hw_debug_en[0] == Off |-> rv_jtag_i == '0)
   `ASSUME_FPV(DftTapOff1_A, lc_dft_en_i == Off |-> ##2 dft_jtag_i == '0)
 

--- a/hw/top_earlgrey/ip/pinmux/fpv/tb/pinmux_tb.sv
+++ b/hw/top_earlgrey/ip/pinmux/fpv/tb/pinmux_tb.sv
@@ -11,7 +11,8 @@ module pinmux_tb
   import prim_pad_wrapper_pkg::*;
   import top_earlgrey_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter bit SecVolatileRawUnlockEn = 1
 ) (
   input  clk_i,
   input  rst_ni,
@@ -23,6 +24,7 @@ module pinmux_tb
   output logic usb_wkup_req_o,
   input  sleep_en_i,
   input  strap_en_i,
+  input  strap_en_override_i,
   input lc_ctrl_pkg::lc_tx_t lc_dft_en_i,
   input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
   input lc_ctrl_pkg::lc_tx_t lc_check_byp_en_i,
@@ -78,7 +80,6 @@ module pinmux_tb
   localparam int TrstNPadIdx = 39;
   localparam int TdiPadIdx = 37;
   localparam int TdoPadIdx = 36;
-
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
     tck_idx:           TckPadIdx,
@@ -166,7 +167,8 @@ module pinmux_tb
 
   pinmux #(
     .TargetCfg(PinmuxTargetCfg),
-    .AlertAsyncOn(AlertAsyncOn)
+    .AlertAsyncOn(AlertAsyncOn),
+    .SecVolatileRawUnlockEn(SecVolatileRawUnlockEn)
   ) dut_asic (.*);
 
 endmodule : pinmux_tb


### PR DESCRIPTION
Fixes a syntax error in the pinmux_chip_fpv testbench and aligns several SVAs with the newest design state.

Fix #18397.`