### PR TITLE
[ci] Enable HyperDebug tests to run in CI

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1106,7 +1106,6 @@ opentitan_functest(
     srcs = ["gpio_pinmux_test.c"],
     cw310 = cw310_params(
         interface = "hyper310",
-        tags = ["manual"],
         test_cmds = [
             "--bitstream=\"$(location {bitstream})\"",
             "--bootstrap=\"$(location {flash})\"",
@@ -2452,7 +2451,6 @@ opentitan_functest(
         # This test will need hyperdebug once we start using multi-lane
         # SPI modes.
         #interface = "hyper310",
-        #tags = ["manual"],
         test_cmds = [
             "--bitstream=\"$(location {bitstream})\"",
             "--bootstrap=\"$(location {flash})\"",
@@ -2533,7 +2531,6 @@ opentitan_functest(
     srcs = ["spi_device_ottf_console_test.c"],
     cw310 = cw310_params(
         interface = "hyper310",
-        tags = ["manual"],
         test_cmds = [
             "--bitstream=\"$(location {bitstream})\"",
             "--bootstrap=\"$(location {flash})\"",
@@ -2560,7 +2557,6 @@ opentitan_functest(
         # This test needs hyperdebug to serve as I2C host to OpenTitan's
         # I2C target device.
         interface = "hyper310",
-        tags = ["manual"],
         test_cmds = [
             "--bitstream=\"$(location {bitstream})\"",
             "--bootstrap=\"$(location {flash})\"",


### PR DESCRIPTION
HyperDebug hardware is required for running these tests, so they were disabled for CI runs. CI now has HyperDebug boards installed for all FPGAs, so these should be capable of running there.

Applying a new `hyperdebug` tag so these can be skipped when working with hardware that doesn't have HyperDebug connected (or when it breaks). **EDIT**: as per https://github.com/lowRISC/opentitan/pull/18866#issuecomment-1585685976, the `cw310_params` function (macro?) automatically applies a tag for the `hyper310` interface.

Resolves https://github.com/lowRISC/opentitan/issues/17782