### PR TITLE
[doc,reggen] Fixup window register header level

### DIFF
--- a/util/reggen/gen_md.py
+++ b/util/reggen/gen_md.py
@@ -97,7 +97,7 @@ def gen_md_window(output: TextIO, win: Window, comp: str, regwidth: int) -> None
     end_addr = start_addr + 4 * win.items - 4
 
     output.write(
-        title(wname, 3) +
+        title(wname, 2) +
         win.desc +
         "\n\n" +
         list_item(


### PR DESCRIPTION
Should be one level higher, can be seen easily by looking at the ToC. e.g. https://opentitan.org/book/hw/ip/spi_host/data/spi_host.html#rxdata

@HU90m 