### PR TITLE
[chip/conn] run additional TCL for loading CS design files outside core files

### DIFF
--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -34,6 +34,12 @@ if {$env(BBOX_CMD) eq "" } {
     -f [glob *.scr]
 }
 
+# analyze additional/overwrite design modules in CS
+if {[info exists ::env(EXT_CS_DES_FILES_TCL)]} {
+  source $env(EXT_CS_DES_FILES_TCL)
+}
+
+
 # Black-box assistant will blackbox the modules which are not needed by looking at
 # the connectivity csv.
 blackbox_assistant -config -connectivity_map $conn_csvs


### PR DESCRIPTION
This PR allows CS to run additional TCL script after the first `analyze` command, which gives the flexibility to add some additional design files/overwrite existing modules.

