### PR TITLE
[chip,dv] move cpu_init to pre_start for some tests

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -14,17 +14,15 @@ class chip_base_vseq #(
 
   jtag_dmi_reg_block jtag_dmi_ral;
 
-  // knobs to enable pre_start routines
-
-  // knobs to enable post_start routines
-
-  // various knobs to enable certain routines
-
   // Local queue for holding received UART TX data.
   byte uart_tx_data_q[$];
 
   // Indicates the first power up of the chip.
   bit is_first_pwrup = 1'b1;
+
+  // Knob to start cpu_init in pre_start phase
+  // You have to set this knob before or within dut_init task
+  bit early_cpu_init = 0;
 
   `uvm_object_new
 
@@ -160,7 +158,8 @@ class chip_base_vseq #(
     for (int ram_idx = 0; ram_idx < cfg.num_otbn_dmem_tiles; ram_idx++) begin
       cfg.mem_bkdr_util_h[chip_mem_e'(OtbnDmem0 + ram_idx)].clear_mem();
     end
-
+    // Early cpu init
+    if (early_cpu_init) cpu_init();
     // Bring the chip out of reset.
     super.dut_init(reset_kind);
     alert_ping_en_shorten();
@@ -169,6 +168,10 @@ class chip_base_vseq #(
     // Clear once upon the chip exiting the first reset.
     is_first_pwrup = 0;
   endtask
+
+  // Place holder for cpu_init task
+  // initial implementation is in chip_sw_base_vseq.sv
+  virtual task cpu_init();endtask
 
   virtual task dut_shutdown();
     // check for pending chip operations and wait for them to complete

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
@@ -29,6 +29,7 @@ class chip_sw_lc_base_vseq extends chip_sw_base_vseq;
   endfunction : backdoor_override_otp
 
   virtual task dut_init(string reset_kind = "HARD");
+    early_cpu_init = 1;
     super.dut_init(reset_kind);
 
     // If init state is not reset state (DecLcStInvalid),
@@ -36,4 +37,7 @@ class chip_sw_lc_base_vseq extends chip_sw_base_vseq;
     backdoor_override_otp();
   endtask
 
+  virtual task body();
+    cfg.sw_test_status_vif.set_num_iterations(num_trans);
+  endtask
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_scrap_vseq.sv
@@ -87,16 +87,11 @@ class chip_sw_lc_ctrl_scrap_vseq extends chip_sw_lc_base_vseq;
     apply_reset();
   endtask : perform_transition_to_scrap
 
-  task cpu_init();
-    super.cpu_init();
-
-    // tell SW whether the transition is done by JTAG or SW
-    sw_symbol_backdoor_overwrite("kPerformTransitionBySW", {perform_transition_via_sw});
-  endtask : cpu_init
-
   virtual task body();
     bit [BUS_DW-1:0] state;
     super.body();
+    // tell SW whether the transition is done by JTAG or SW
+    sw_symbol_backdoor_overwrite("kPerformTransitionBySW", {perform_transition_via_sw});
 
     // perform the transition to SCRAP state
     perform_transition_to_scrap();


### PR DESCRIPTION
cpu_init has some disruptive backdoor writes.
So if there is timedelay between post_reset and body, cpu_init can causes spurious data corruptions.
Try this new option for some selected tests to address the issue