### PR TITLE
[chip,cs,dv] increase timeout for cs tests

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1114,7 +1114,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests:rv_core_ibex_rnd_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=10_000_000", "+rng_srate_value_max=32"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+rng_srate_value_max=32"]
     }
     {
       name: chip_sw_rv_core_ibex_nmi_irq
@@ -1271,7 +1271,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20_000_000", "+rng_srate_value_min=15",
+      run_opts: ["+sw_test_timeout_ns=140_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20"]
       run_timeout_mins: 240
     }
@@ -1301,7 +1301,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:entropy_src_csrng_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000", "+rng_srate_value_min=15",
+      run_opts: ["+sw_test_timeout_ns=50_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=30"]
       run_timeout_mins: 120
     }
@@ -1863,7 +1863,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=30_000_000", "+rng_srate_value_min=15",
+      run_opts: ["+sw_test_timeout_ns=180_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20", "+cal_sys_clk_70mhz=1", "+en_jitter=1"]
       run_timeout_mins: 240
     }


### PR DESCRIPTION
Following tests need more run time to pass in the closed source tb. 

- chip_sw_rv_core_ibex_rnd
- chip_sw_csrng_edn_concurrency
- chip_sw_csrng_edn_concurrency_reduced_freq
- chip_sw_entropy_src_csrng