### PR TITLE
[chip,dv,jtag] Add skip por_n reset support

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -20,6 +20,9 @@ class chip_base_vseq #(
   // Indicates the first power up of the chip.
   bit is_first_pwrup = 1'b1;
 
+  // Skip POR_N : required for closed source test
+  bit skip_por_n_during_first_pwrup = 0;
+
   // Knob to start cpu_init in pre_start phase
   // You have to set this knob before or within dut_init task
   bit early_cpu_init = 0;
@@ -37,7 +40,6 @@ class chip_base_vseq #(
   endtask
 
   virtual task apply_reset(string kind = "HARD");
-    bit skip_por_n_during_first_pwrup;
     callback_vseq.pre_apply_reset();
     // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
     // These IOs have pad attributes that are driven from registers, and as long as

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_mem_vseq.sv
@@ -15,7 +15,20 @@ class chip_jtag_mem_vseq extends chip_common_vseq;
   virtual task pre_start();
     cfg.select_jtag = JtagTapRvDm;
     cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
-    super.pre_start();
+    void'($value$plusargs("skip_por_n_during_first_pwrup=%0b", skip_por_n_during_first_pwrup));
+    // If we want to skip POR_N,
+    // make sure jtag agent under reset until jtag target selection is
+    // confirmed by the pinmux
+    if (skip_por_n_during_first_pwrup && is_first_pwrup) begin
+       cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
+       super.pre_start();
+       `DV_WAIT(cfg.chip_vif.pinmux_lc_hw_debug_en);
+       cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
+       cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
+    end else begin
+       super.pre_start();
+    end
+
   endtask
 
   virtual task body();


### PR DESCRIPTION
Closed source has requirement to skip por_n at the beginning of the power up.
Adjust test sequence accordingly to support this feature.