### PR TITLE
Remove stale comment in pwrmgr.hjson

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -52,7 +52,6 @@
     { name: "wakeup", desc: "Wake from low power state. See wake info for more details" },
   ],
 
-  // Define flash_ctrl <-> flash_phy struct package
   inter_signal_list: [
     { struct:  "pwr_ast",
       type:    "req_rsp",


### PR DESCRIPTION
This file is supposed to be autogenerated from pwrmgr.hjson.tpl, but it appears we don't always do that! Indeed, the comment went away from the template file two years ago, in
d7f00ea49fe2eea5bebf6d1e579f9f5b582d3438.

There's clearly some scope for clean-ups (enforce autogeneration, or do away with it altogether!), but let's just get this line in sync for now.

Fixes #18834.