### PR TITLE
[hw,uart,dv] Enable CDC instrumentation

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
@@ -100,7 +100,9 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
     if (en_noise_filter) cfg.clk_rst_vif.wait_clks(3);
 
     ral.ctrl.llpbk.set(0);
+    ral.fifo_ctrl.rxrst.set(1);
     csr_update(ral.ctrl);
+    csr_update(ral.fifo_ctrl);
   endtask
 
 endclass : uart_loopback_vseq

--- a/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
@@ -8,6 +8,24 @@ class uart_noise_filter_vseq extends uart_tx_rx_vseq;
 
   `uvm_object_new
 
+  string cdc_sel_path = "tb.dut.uart_core.sync_rx.u_prim_cdc_rand_delay.gen_enable.data_sel";
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    // Disable CDC randomization for rx_sync by forcing internal select signal
+    if (cfg.en_dv_cdc && uvm_hdl_check_path(cdc_sel_path)) begin
+      `DV_CHECK(uvm_hdl_force(cdc_sel_path, 0));
+    end
+  endtask
+
+  virtual task dut_shutdown();
+    super.dut_init();
+    // Enable CDC randomization for rx_sync by releasing internal select signal
+    if (cfg.en_dv_cdc && uvm_hdl_check_path(cdc_sel_path)) begin
+      `DV_CHECK(uvm_hdl_release(cdc_sel_path));
+    end
+  endtask
+
   // add noise before sending rx byte
   // check rxidle should be high after adding noise
   virtual task send_rx_byte(byte data);

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -40,6 +40,9 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // Default UVM test and seq class name.
   uvm_test: uart_base_test
   uvm_test_seq: uart_base_vseq


### PR DESCRIPTION
- Enable CDC randomization in uart block level TB
- Add delays to account for CDC randomization
- Clear `RDATA FIFO` at the end of the line loopback sequence to make sure data captured in this mode won't affect the sys_loopback sequence
- Disable CDC randomization for noise_filter test https://github.com/lowRISC/opentitan/issues/18912

This PR resolves https://github.com/lowRISC/opentitan/issues/18895