### PR TITLE
[usbdev_dpi] Extend timeout to allow for 1ms bus frame

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -541,7 +541,7 @@
       uvm_test_seq: chip_sw_usbdev_dpi_vseq
       sw_images: ["//sw/device/tests:usbdev_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1", "+sw_test_timeout_ns=30_000_000"]
       run_timeout_mins: 120
       reseed: 1
     }


### PR DESCRIPTION
Test has been timing out with the specified 1ms bus frame; extend timeout until such time as the DPI model can perform multiple control transfers per bus frame.