### PR TITLE
[opentitantool] Allow more time for DFU bootloader to initialize

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
@@ -198,7 +198,7 @@ pub fn update_firmware(
     // and disconnected from the USB bus.  Wait a little while, and then attempt to establish
     // connection with the DFU bootloader, which will appear with STM DID:VID (not Google's), but
     // same serial number as before.
-    std::thread::sleep(std::time::Duration::from_millis(1000));
+    std::thread::sleep(std::time::Duration::from_millis(2000));
     log::info!("Connecting to DFU bootloader...");
     let mut dfu_device = UsbBackend::new(
         VID_ST_MICROELECTRONICS,
@@ -214,7 +214,7 @@ pub fn update_firmware(
     // At this point, the new firmware has been completely transferred, and the USB device is
     // resetting and booting the new firmware.  Wait a second, then verify that device can now be
     // found on the USB bus with the original DID:VID.
-    std::thread::sleep(std::time::Duration::from_millis(1000));
+    std::thread::sleep(std::time::Duration::from_millis(2000));
     log::info!("Connecting to newly flashed firmware...");
     let _new_device = UsbBackend::new(
         usb_device.get_vendor_id(),

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -26,6 +26,7 @@ impl UsbBackend {
     ) -> Result<Vec<(rusb::Device<rusb::GlobalContext>, String)>> {
         let mut devices = Vec::new();
         let mut deferred_log_messages = Vec::new();
+        log::info!("USB scan({:04x}:{:04x}, {:?})", usb_vid, usb_pid, usb_serial);
         for device in rusb::devices().context("USB error")?.iter() {
             let descriptor = match device.device_descriptor() {
                 Ok(desc) => desc,
@@ -39,6 +40,7 @@ impl UsbBackend {
                     continue;
                 }
             };
+            log::info!("  Device {:04x}:{:04x}", descriptor.vendor_id(), descriptor.product_id());
             if descriptor.vendor_id() != usb_vid {
                 continue;
             }
@@ -69,11 +71,13 @@ impl UsbBackend {
                     continue;
                 }
             };
+            log::info!("    serial: \"{}\"", serial_number);
             if let Some(sn) = &usb_serial {
                 if &serial_number != sn {
                     continue;
                 }
             }
+            log::info!("    match!");
             devices.push((device, serial_number));
         }
 


### PR DESCRIPTION
Updating HyperDebug firmware involves jumping into and out of the built-in DFU bootloader, which causes USB bus reset and re-enumeration. This change allows 2 second for the "new" USB device to appear on the bus, up from one second.
