### PR TITLE
[ci] Update EOL GitHub Actions

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -21,7 +21,7 @@ jobs:
       # a review
       - name: 'Download artifact'
         id: get-artifacts
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -13,7 +13,7 @@ jobs:
   review_triggered:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # this workflow does not run in a PR context
       # download 'event.json' and concatenated verible config files

--- a/.github/workflows/pr_trigger.yml
+++ b/.github/workflows/pr_trigger.yml
@@ -10,7 +10,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: concatenate verible configs
         run: |
           find . -type f -name '*.rules.verible_lint' -exec cat {} \; > verible_config
@@ -29,7 +29,7 @@ jobs:
       # so we just save the file needed to do the review
       # in a context with proper access rights
       - name: Upload event file and config as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: verible_input
           path: |


### PR DESCRIPTION
actions/checkout@v2 and actions/upload-artifact@v2 use Node.js 12, which will be deprecated from GitHub's Ubuntu runner in the summer of 2023.

Update: also updated actions/github-script@3.1.0 to v6 to use Node.js 16. This is used in the `pr-lint-review` pipeline which isn't run on this pull request's context, so isn't checked here.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/