### PR TITLE
[gpio, verilator] Fix hello world GPIO input in verilator test

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -239,8 +239,7 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
             int idx = parse_dec(&gpio_text);
             if (idx < NUM_GPIO) {
               if (!GET_BIT(gpio_oe[0], idx)) {
-                fprintf(stderr,
-                        "GPIO: Host tried to pull disabled pin low: pin %2d\n",
+                fprintf(stderr, "GPIO: Host tried to pull pin low: pin %2d\n",
                         idx);
               }
               CLR_BIT(ctx->driven_pin_values, idx);
@@ -259,8 +258,7 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
             int idx = parse_dec(&gpio_text);
             if (idx < NUM_GPIO) {
               if (!GET_BIT(gpio_oe[0], idx)) {
-                fprintf(stderr,
-                        "GPIO: Host tried to pull disabled pin high: pin %2d\n",
+                fprintf(stderr, "GPIO: Host tried to pull pin high: pin %2d\n",
                         idx);
               }
               SET_BIT(ctx->driven_pin_values, idx);

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -43,7 +43,7 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
-  for (int bit_idx = 0; bit_idx < 8; ++bit_idx) {
+  for (int bit_idx = 8; bit_idx < 12; ++bit_idx) {
     bool changed = ((state_delta >> bit_idx) & 0x1) != 0;
     bool is_currently_set = ((gpio_state >> bit_idx) & 0x1) != 0;
     if (changed) {

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -108,7 +108,12 @@ void _ottf_main(void) {
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
   CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000));
-  LOG_INFO("Try out USERDIP switches 0-thru-3 on the board");
+  if (kDeviceType == kDeviceFpgaCw310) {
+    LOG_INFO("Try out USERDIP switches 0-thru-3 on the board");
+  }
+  if (kDeviceType == kDeviceSimVerilator) {
+    LOG_INFO("Try out GPIO switches 0, 3, 4, 7");
+  }
   LOG_INFO("or type anything into the console window.");
   LOG_INFO(
       "The LEDs show the lower nibble of the ASCII code of the last "


### PR DESCRIPTION
* Correct the gpiodpi print out message
* Update demo.c GPIO input pin assignment to match hello_world behavior
* Update the hello_world message for verilator test to make the switch location more obvious.