### PR TITLE
[chip,dv] add switch to external clock for lc state transition

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_testunlocks_vseq.sv
@@ -51,11 +51,8 @@ class chip_sw_lc_walkthrough_testunlocks_vseq extends chip_sw_base_vseq;
     sw_symbol_backdoor_overwrite("kOtpExitToken", otp_exit_token);
     sw_symbol_backdoor_overwrite("kOtpUnlockToken", otp_unlock_token);
 
-    // Since super.body only does backdoor operatoin,
-    // add wait for clock task before the test uses jtag polling task.
-    wait_rom_check_done();
-    wait_lc_ready(.allow_err(1));
-
+    // Any lc state transition from Raw requires external clock.
+    switch_to_external_clock();
     jtag_lc_state_transition(DecLcStRaw, DecLcStTestUnlocked0);
     apply_reset();
 


### PR DESCRIPTION
Similar issue with #18147 
Test does lc state transition from raw state with uncalibrated clock. Fixed by adding external clock.