### PR TITLE
[release] Increase timeout of CI job

### DIFF
--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -49,7 +49,7 @@ jobs:
 
 - job: build_release
   displayName: "Create the OpenTitan release"
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
   dependsOn: checkout
   pool: ci-public
   steps:


### PR DESCRIPTION
In a5024346531f4285f90c32827f3eb8ce7ba31d3d (PR #17216), we increased the timeout of the CI check that builds the CW310 bitstream from 3 h to 4 h due to timeouts (see #17187).  As part of the nightly Release job, we also build a CW310 bitstream, but we have not increased its timeout yet.  This is likely the reason that Release jobs have been timing out for the last month (or so -- as far as traceable with the logs that have been retained).

This commit increases the timeout of the Release job by 60 min, which should fix its timeout issues.