### PR TITLE
Enable CDC for tests of tl_agent

### DIFF
--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -28,6 +28,9 @@
   uvm_test: tl_agent_base_test
   uvm_test_seq: tl_agent_base_vseq
 
+  // Enable cdc instrumentation.
+  run_opts: ["+cdc_instrumentation_enabled=1"]
+
   // List of test specifications.
   tests: [
     {


### PR DESCRIPTION
This is sort of trivial: the `tl_agent` tests don't really do anything with multiple clocks anyway. But I guess it makes sense if `tl_agent` is on a list of blocks where we'd like to see things working with CDC checks enabled.