### PR TITLE
[ujson] Added crc checks to the roundtrip test

### DIFF
--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -39,11 +39,8 @@ status_t roundtrip(const char *name) {
     TRY(ujson_serialize_direction(&uj, &x));
   } else if (!strcmp(name, "fuzzy_bool")) {
     fuzzy_bool x = {0};
-    fprintf(stderr, "-- fuzzy_bool\n");
     TRY(ujson_deserialize_fuzzy_bool(&uj, &x));
-    fprintf(stderr, "-- %d\n", (int)x);
     TRY(ujson_serialize_fuzzy_bool(&uj, &x));
-    fprintf(stderr, "-- done\n");
   } else if (!strcmp(name, "misc")) {
     misc_t x = {0};
     TRY(ujson_deserialize_misc_t(&uj, &x));

--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -8,6 +8,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/example.h"
+#include "sw/device/silicon_creator/lib/crc32.h"
 
 status_t stdio_getc(void *context) {
   int ch = fgetc(stdin);
@@ -19,32 +20,67 @@ status_t stdio_putbuf(void *context, const char *buf, size_t len) {
   return OK_STATUS();
 }
 
+status_t check_crc32(ujson_t *uj) {
+  uint32_t expected = ujson_crc32_finish(uj);
+  uint32_t actual;
+  scanf("%x", &actual);
+
+  if (expected != actual) {
+    fprintf(stderr, "CRC32 Error: expected = %x, actual = %x\n", expected,
+            actual);
+    return DATA_LOSS();
+  };
+  return OK_STATUS();
+}
+
 status_t roundtrip(const char *name) {
   ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf);
   if (!strcmp(name, "foo")) {
     foo x = {0};
     TRY(ujson_deserialize_foo(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
     TRY(ujson_serialize_foo(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
   } else if (!strcmp(name, "rect")) {
     rect x = {0};
     TRY(ujson_deserialize_rect(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
     TRY(ujson_serialize_rect(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
   } else if (!strcmp(name, "matrix")) {
     matrix x = {0};
     TRY(ujson_deserialize_matrix(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
     TRY(ujson_serialize_matrix(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
   } else if (!strcmp(name, "direction")) {
     direction x = {0};
     TRY(ujson_deserialize_direction(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
     TRY(ujson_serialize_direction(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
   } else if (!strcmp(name, "fuzzy_bool")) {
+    fuzzy_bool x = {0};
+    TRY(ujson_deserialize_fuzzy_bool(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
+    TRY(ujson_serialize_fuzzy_bool(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
+  } else if (!strcmp(name, "fuzzy_bool_no_crc")) {
     fuzzy_bool x = {0};
     TRY(ujson_deserialize_fuzzy_bool(&uj, &x));
     TRY(ujson_serialize_fuzzy_bool(&uj, &x));
   } else if (!strcmp(name, "misc")) {
     misc_t x = {0};
     TRY(ujson_deserialize_misc_t(&uj, &x));
+    TRY(check_crc32(&uj));
+    ujson_crc32_reset(&uj);
     TRY(ujson_serialize_misc_t(&uj, &x));
+    printf("\n%x", ujson_crc32_finish(&uj));
   } else {
     return INVALID_ARGUMENT();
   }

--- a/sw/device/lib/ujson/rust/BUILD
+++ b/sw/device/lib/ujson/rust/BUILD
@@ -32,6 +32,7 @@ rust_test(
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
+        "@crate_index//:crc",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
     ],

--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -397,8 +397,8 @@ status_t ujson_deserialize_status_t(ujson_t *uj, status_t *value) {
 
 status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value) {
   buffer_sink_t out = {
-      .data = uj->io_context,
-      .sink = (size_t(*)(void *, const char *, size_t))uj->putbuf,
+      .data = uj,
+      .sink = (size_t(*)(void *, const char *, size_t))ujson_putbuf,
   };
   base_fprintf(out, "%!r", *value);
   return OK_STATUS();


### PR DESCRIPTION
Added CRC checks to the roundtrip test. Part of https://github.com/lowRISC/opentitan/issues/17496

Note:
1. There was a bug due to the `status_t` serialisation being handled by `uj->putbuf` directly. The current solution works but it may be nicer to use a dedicated ujson serialisation function:

    ```c
    status_t ujson_serialize_status_t(ujson_t *uj, const status_t *value) {
      // The module id is defined to be 3 chars long.
      char mod[] = {'"', '\0', '\0', '\0', '"', ','};
      int32_t arg;
      const char *start;
      bool err = status_extract(*value, &start, &arg, &mod[1]);
    
      // strlen of the status code.
      const char *end = start;
      while (*end)
        end++;
    
      TRY(ujson_putbuf(uj, "{\"", 2));
      TRY(ujson_putbuf(uj, start, (size_t)(end - start)));
      TRY(ujson_putbuf(uj, "\"", 1));
    
      TRY(ujson_putbuf(uj, ":", 1));
    
      if (err) {
        // All error codes include the module identifier.
        TRY(ujson_putbuf(uj, "[", 1));
        TRY(ujson_putbuf(uj, mod, sizeof(mod)));
        TRY(ujson_serialize_uint32_t(uj, &arg));
        TRY(ujson_putbuf(uj, "]", 1));
      } else {
        // Ok codes include only the arg
        TRY(ujson_serialize_uint32_t(uj, &arg));
      }
      TRY(ujson_putbuf(uj, "}", 1));
      return OK_STATUS();
    }
    ```

2. The unknown variant of the `FuzzyBool` isn't being checked. This is explained in `test_fuzzy_maybe`.