### PR TITLE
[hsmtool] Encaspulate library state in a `Module` struct

### DIFF
--- a/sw/host/hsmtool/src/commands/exec.rs
+++ b/sw/host/hsmtool/src/commands/exec.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::{Annotate, Document};
@@ -12,6 +11,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::commands::{BasicResult, Dispatch};
+use crate::module::Module;
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Exec {
@@ -36,7 +36,7 @@ impl Dispatch for Exec {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let commands = std::fs::read_to_string(&self.file)?;
@@ -47,7 +47,7 @@ impl Dispatch for Exec {
         for command in commands {
             let name = command.typetag_name().to_string();
             log::info!("Executing command {name}");
-            match command.run(context, pkcs11, session) {
+            match command.run(context, hsm, session) {
                 Ok(r) => status.push(ExecResult {
                     command: name,
                     result: r,

--- a/sw/host/hsmtool/src/commands/mod.rs
+++ b/sw/host/hsmtool/src/commands/mod.rs
@@ -4,12 +4,12 @@
 
 use anyhow::Result;
 use atty::Stream;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::{Annotate, ColorProfile};
 use std::any::Any;
 
+use crate::module::Module;
 use crate::util::attribute::AttrData;
 
 mod exec;
@@ -22,7 +22,7 @@ pub trait Dispatch {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>>;
 
@@ -50,14 +50,14 @@ impl Dispatch for Commands {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         match self {
-            Commands::Exec(x) => x.run(context, pkcs11, session),
-            Commands::Object(x) => x.run(context, pkcs11, session),
-            Commands::Rsa(x) => x.run(context, pkcs11, session),
-            Commands::Token(x) => x.run(context, pkcs11, session),
+            Commands::Exec(x) => x.run(context, hsm, session),
+            Commands::Object(x) => x.run(context, hsm, session),
+            Commands::Rsa(x) => x.run(context, hsm, session),
+            Commands::Token(x) => x.run(context, hsm, session),
         }
     }
 

--- a/sw/host/hsmtool/src/commands/object/destroy.rs
+++ b/sw/host/hsmtool/src/commands/object/destroy.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
@@ -11,6 +10,7 @@ use std::any::Any;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::helper;
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
@@ -26,7 +26,7 @@ impl Dispatch for Destroy {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/object/list.rs
+++ b/sw/host/hsmtool/src/commands/object/list.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
@@ -12,6 +11,7 @@ use std::str::FromStr;
 
 use crate::commands::Dispatch;
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::{AttributeMap, AttributeType};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
@@ -31,7 +31,7 @@ impl Dispatch for List {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/object/mod.rs
+++ b/sw/host/hsmtool/src/commands/object/mod.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
+use crate::module::Module;
 
 mod destroy;
 mod list;
@@ -29,14 +29,14 @@ impl Dispatch for Object {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         match self {
-            Object::Destroy(x) => x.run(context, pkcs11, session),
-            Object::List(x) => x.run(context, pkcs11, session),
-            Object::Show(x) => x.run(context, pkcs11, session),
-            Object::Update(x) => x.run(context, pkcs11, session),
+            Object::Destroy(x) => x.run(context, hsm, session),
+            Object::List(x) => x.run(context, hsm, session),
+            Object::Show(x) => x.run(context, hsm, session),
+            Object::Update(x) => x.run(context, hsm, session),
         }
     }
     fn leaf(&self) -> &dyn Dispatch

--- a/sw/host/hsmtool/src/commands/object/show.rs
+++ b/sw/host/hsmtool/src/commands/object/show.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
@@ -11,6 +10,7 @@ use std::any::Any;
 
 use crate::commands::Dispatch;
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::AttributeMap;
 use crate::util::helper;
 
@@ -32,7 +32,7 @@ impl Dispatch for Show {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/object/update.rs
+++ b/sw/host/hsmtool/src/commands/object/update.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
@@ -11,6 +10,7 @@ use std::any::Any;
 
 use crate::commands::Dispatch;
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::AttributeMap;
 use crate::util::helper;
 
@@ -29,7 +29,7 @@ impl Dispatch for Update {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/decrypt.rs
+++ b/sw/host/hsmtool/src/commands/rsa/decrypt.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::mechanism::Mechanism;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
@@ -14,6 +13,7 @@ use std::path::PathBuf;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::KeyType;
 use crate::util::helper;
 
@@ -33,7 +33,7 @@ impl Dispatch for Decrypt {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/encrypt.rs
+++ b/sw/host/hsmtool/src/commands/rsa/encrypt.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::mechanism::Mechanism;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
@@ -14,6 +13,7 @@ use std::path::PathBuf;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::KeyType;
 use crate::util::helper;
 
@@ -33,7 +33,7 @@ impl Dispatch for Encrypt {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/export.rs
+++ b/sw/host/hsmtool/src/commands/rsa/export.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, Context, Result};
-use cryptoki::context::Pkcs11;
 use cryptoki::object::{Attribute, ObjectHandle};
 use cryptoki::session::Session;
 use rsa::{RsaPrivateKey, RsaPublicKey};
@@ -14,6 +13,7 @@ use std::path::PathBuf;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::{AttrData, AttributeMap, AttributeType, KeyType, ObjectClass};
 use crate::util::helper;
 use crate::util::key::rsa::{save_private_key, save_public_key};
@@ -70,7 +70,7 @@ impl Dispatch for Export {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/generate.rs
+++ b/sw/host/hsmtool/src/commands/rsa/generate.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::mechanism::Mechanism;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
@@ -13,6 +12,7 @@ use std::str::FromStr;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::{AttrData, AttributeMap, AttributeType};
 use crate::util::helper;
 
@@ -62,7 +62,7 @@ impl Dispatch for Generate {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/import.rs
+++ b/sw/host/hsmtool/src/commands/rsa/import.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Context, Result};
-use cryptoki::context::Pkcs11;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
@@ -14,6 +13,7 @@ use std::str::FromStr;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::{AttrData, AttributeMap, AttributeType, ObjectClass};
 use crate::util::helper;
 use crate::util::key::rsa::{load_private_key, load_public_key};
@@ -72,7 +72,7 @@ impl Dispatch for Import {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/mod.rs
+++ b/sw/host/hsmtool/src/commands/rsa/mod.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
+use crate::module::Module;
 
 pub mod decrypt;
 pub mod encrypt;
@@ -35,17 +35,17 @@ impl Dispatch for Rsa {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         match self {
-            Rsa::Decrypt(x) => x.run(context, pkcs11, session),
-            Rsa::Encrypt(x) => x.run(context, pkcs11, session),
-            Rsa::Generate(x) => x.run(context, pkcs11, session),
-            Rsa::Export(x) => x.run(context, pkcs11, session),
-            Rsa::Import(x) => x.run(context, pkcs11, session),
-            Rsa::Sign(x) => x.run(context, pkcs11, session),
-            Rsa::Verify(x) => x.run(context, pkcs11, session),
+            Rsa::Decrypt(x) => x.run(context, hsm, session),
+            Rsa::Encrypt(x) => x.run(context, hsm, session),
+            Rsa::Generate(x) => x.run(context, hsm, session),
+            Rsa::Export(x) => x.run(context, hsm, session),
+            Rsa::Import(x) => x.run(context, hsm, session),
+            Rsa::Sign(x) => x.run(context, hsm, session),
+            Rsa::Verify(x) => x.run(context, hsm, session),
         }
     }
     fn leaf(&self) -> &dyn Dispatch

--- a/sw/host/hsmtool/src/commands/rsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/rsa/sign.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
@@ -13,6 +12,7 @@ use std::path::PathBuf;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::KeyType;
 use crate::util::helper;
 use crate::util::signing::SignData;
@@ -41,7 +41,7 @@ impl Dispatch for Sign {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/rsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/rsa/verify.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
@@ -13,6 +12,7 @@ use std::path::PathBuf;
 
 use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
+use crate::module::Module;
 use crate::util::attribute::KeyType;
 use crate::util::helper;
 use crate::util::signing::SignData;
@@ -40,7 +40,7 @@ impl Dispatch for Verify {
     fn run(
         &self,
         _context: &dyn Any,
-        _pkcs11: &Pkcs11,
+        _hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let session = session.ok_or(HsmError::SessionRequired)?;

--- a/sw/host/hsmtool/src/commands/token.rs
+++ b/sw/host/hsmtool/src/commands/token.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use cryptoki::context::Pkcs11;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
+use crate::module::Module;
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct List;
@@ -43,12 +43,12 @@ impl Dispatch for List {
     fn run(
         &self,
         _context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         let mut response = Box::<ListResponse>::default();
-        for slot in pkcs11.get_slots_with_token()? {
-            let info = pkcs11.get_token_info(slot)?;
+        for slot in hsm.pkcs11.get_slots_with_token()? {
+            let info = hsm.pkcs11.get_token_info(slot)?;
             response.tokens.push(TokenInfo::from(info));
         }
         Ok(response)
@@ -65,11 +65,11 @@ impl Dispatch for Token {
     fn run(
         &self,
         context: &dyn Any,
-        pkcs11: &Pkcs11,
+        hsm: &Module,
         session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
         match self {
-            Token::List(x) => x.run(context, pkcs11, session),
+            Token::List(x) => x.run(context, hsm, session),
         }
     }
 }


### PR DESCRIPTION
`hsmtool` normally loads the relevant `pkcs11` module which is then used by some of the various command functions.  In order to add PQ crypto support, `hsmtool` will need to load another vendor library and pass it to the command functions.  In preparation for PQ support, migrate the `Pkcs11` library state into a `Module` struct.