### PR TITLE
[site] Animate opacity of nav-chapter chevrons

### DIFF
--- a/site/book-theme/css/chrome.css
+++ b/site/book-theme/css/chrome.css
@@ -122,13 +122,17 @@ a > .hljs {
 
 .menu-bar,
 .menu-bar:visited,
-.nav-chapters,
 .nav-chapters:visited,
 .mobile-nav-chapters,
 .mobile-nav-chapters:visited,
 .menu-bar .icon-button,
 .menu-bar a i {
     color: var(--icons);
+}
+
+.nav-chapters .fa{
+    opacity: 0;
+    transition: opacity 0.15s;
 }
 
 .menu-bar i:hover,
@@ -164,6 +168,11 @@ a > .hljs {
     text-decoration: none;
     background-color: var(--theme-hover);
     transition: background-color 0.15s, color 0.15s;
+}
+
+.nav-chapters:hover .fa{
+    opacity: 1;
+    transition: opacity 0.15s;
 }
 
 .nav-wrapper {


### PR DESCRIPTION
Previously on hover, the animation transitioned from a background to a foreground color. However, the background colour of white in this case would show up on-top-of page content under circumstances with a narrow page width.

Change to animate the opacity instead, so chevrons are entirely transparent when not-hovered.

Closes #18891 