### PR TITLE
[test] Fix bounds for printing cycle count.

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -123,7 +123,7 @@ char *ottf_task_get_self_name(void);
     if (status_ok(local_status)) {                                       \
       LOG_INFO("Successfully finished test " #test_function_             \
                " in %u cycles or %u us @ %u MHz.",                       \
-               cycles_, micros, clock_mhz);                              \
+               (uint32_t)cycles_, micros, clock_mhz);                    \
     } else {                                                             \
       result_ = local_status;                                            \
       LOG_ERROR("Finished test " #test_function_ ": %r.", local_status); \


### PR DESCRIPTION
Cast cycle count to 32 bits so it prints correctly. I think this broke in f96cd289, which fixed a bug in the cycle count computation by changing `cycles_` to 64 bits but confused the printing as a side effect.

Before this change:
```
I00000 ottf_main.c:143] Running sw/device/tests/crypto/sha256_functest.c
I00001 sha256_functest.c:166] Starting test simple_test...
I00002 sha256_functest.c:166] Successfully finished test simple_test in 536899220 cycles or 1343 us @ 0 MHz.
I00003 sha256_functest.c:167] Starting test empty_test...
I00004 sha256_functest.c:167] Successfully finished test empty_test in 536899320 cycles or 1185 us @ 0 MHz.
I00005 sha256_functest.c:168] Starting test one_update_streaming_test...
I00006 sha256_functest.c:168] Successfully finished test one_update_streaming_test in 536899420 cycles or 49959 us @ 0 MHz.
I00007 sha256_functest.c:169] Starting test multiple_update_streaming_test...
I00008 sha256_functest.c:169] Successfully finished test multiple_update_streaming_test in 536899520 cycles or 247888 us @ 0 MHz.
I00009 ottf_main.c:113] Finished sw/device/tests/crypto/sha256_functest.c
```

After this change:
```
I00000 ottf_main.c:143] Running sw/device/tests/crypto/sha256_functest.c
I00001 sha256_functest.c:166] Starting test simple_test...
I00002 sha256_functest.c:166] Successfully finished test simple_test in 1354 cycles or 135 us @ 10 MHz.
I00003 sha256_functest.c:167] Starting test empty_test...
I00004 sha256_functest.c:167] Successfully finished test empty_test in 1187 cycles or 118 us @ 10 MHz.
I00005 sha256_functest.c:168] Starting test one_update_streaming_test...
I00006 sha256_functest.c:168] Successfully finished test one_update_streaming_test in 49905 cycles or 4990 us @ 10 MHz.
I00007 sha256_functest.c:169] Starting test multiple_update_streaming_test...
I00008 sha256_functest.c:169] Successfully finished test multiple_update_streaming_test in 247865 cycles or 24786 us @ 10 MHz.
I00009 ottf_main.c:113] Finished sw/device/tests/crypto/sha256_functest.c
```
