### PR TITLE
[hw,pwm,dv] Enable CDC instrumentation

### DIFF
--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -54,7 +54,8 @@
     }
   ]
 
-    run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}"]
+    run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}",
+               "+cdc_instrumentation_enabled=1"]
 
 
   // Default UVM test and seq class name.


### PR DESCRIPTION
Enable CDC instrumentation in `pwm` block level TB as part of https://github.com/lowRISC/opentitan/issues/16689

There are no new errors with this change