### PR TITLE
[topgen] fix broken doc comments

### DIFF
--- a/hw/top_earlgrey/sw/autogen/chip/top_earlgrey_memory.rs
+++ b/hw/top_earlgrey/sw/autogen/chip/top_earlgrey_memory.rs
@@ -9,9 +9,9 @@
 
 #![allow(dead_code)]
 
-///! Rust Top-Specific Definitions.
-///!
-///! This file contains const definitions for use within Rust code.
+//! Rust Top-Specific Definitions.
+//!
+//! This file contains const definitions for use within Rust code.
 
 /// Memory base for sram_ctrl_ret_aon_ram_ret_aon in top earlgrey.
 pub const TOP_EARLGREY_RAM_RET_AON_BASE_ADDR: usize = 0x40600000;

--- a/util/topgen/templates/toplevel_memory.rs.tpl
+++ b/util/topgen/templates/toplevel_memory.rs.tpl
@@ -9,9 +9,9 @@ ${helper.file_header.render()}
 
 #![allow(dead_code)]
 
-///! Rust Top-Specific Definitions.
-///!
-///! This file contains const definitions for use within Rust code.
+//! Rust Top-Specific Definitions.
+//!
+//! This file contains const definitions for use within Rust code.
 
 % for m in top["module"]:
   % if "memory" in m:


### PR DESCRIPTION
A newer version of clippy catches this with clippy::suspicious-doc-comments.