### PR TITLE
[aes, dv] Resolve tool warnings

### DIFF
--- a/hw/ip/aes/dv/cov/aes_cov_bind.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_bind.sv
@@ -6,8 +6,8 @@
 module aes_cov_bind;
 
   bind aes aes_cov_if u_aes_cov_if (
-    .clk_i           (clk_i),
-    .idle_i          (idle_o)
+    .clk_i  (clk_i),
+    .idle_i (idle_o == prim_mubi_pkg::MuBi4True)
   );
 
   bind aes  cip_lc_tx_cov_if u_lc_escalate_en_cov_if (

--- a/hw/ip/aes/dv/env/seq_lib/aes_readability_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_readability_vseq.sv
@@ -22,6 +22,7 @@ class aes_readability_vseq extends aes_base_vseq;
   aes_seq_item cfg_item;
   aes_message_item my_message;
   string str              ="";
+  int success = 1;
 
   task body();
     aes_seq_item cfg_item       = new();         // the configuration for this message
@@ -107,28 +108,29 @@ class aes_readability_vseq extends aes_base_vseq;
     csr_spinwait(.ptr(ral.status.idle) , .exp_data(1'b1));
 
 
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[0]", check_item.data_in[0]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[1]", check_item.data_in[1]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[2]", check_item.data_in[2]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[3]", check_item.data_in[3]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[0]", check_item.data_in[0]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[1]", check_item.data_in[1]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[2]", check_item.data_in[2]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.data_in[3]", check_item.data_in[3]);
 
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[0]", check_item.key[0][0]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[1]", check_item.key[0][1]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[2]", check_item.key[0][2]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[3]", check_item.key[0][3]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[4]", check_item.key[0][4]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[5]", check_item.key[0][5]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[6]", check_item.key[0][6]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[7]", check_item.key[0][7]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[0]", check_item.key[0][0]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[1]", check_item.key[0][1]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[2]", check_item.key[0][2]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[3]", check_item.key[0][3]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[4]", check_item.key[0][4]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[5]", check_item.key[0][5]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[6]", check_item.key[0][6]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share0[7]", check_item.key[0][7]);
 
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[0]", check_item.key[1][0]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[1]", check_item.key[1][1]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[2]", check_item.key[1][2]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[3]", check_item.key[1][3]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[4]", check_item.key[1][4]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[5]", check_item.key[1][5]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[6]", check_item.key[1][6]);
-    uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[7]", check_item.key[1][7]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[0]", check_item.key[1][0]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[1]", check_item.key[1][1]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[2]", check_item.key[1][2]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[3]", check_item.key[1][3]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[4]", check_item.key[1][4]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[5]", check_item.key[1][5]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[6]", check_item.key[1][6]);
+    success &= uvm_hdl_read("tb.dut.u_reg.hw2reg.key_share1[7]", check_item.key[1][7]);
+    `DV_CHECK_FATAL(success == 1)
 
 
     foreach (data_item.data_in[idx]) begin

--- a/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_reseed_vseq.sv
@@ -105,7 +105,7 @@ class aes_reseed_vseq extends aes_base_vseq;
 
       if (`EN_MASKING) begin
         // Read the block counter.
-        uvm_hdl_read(block_ctr_path, block_ctr);
+        `DV_CHECK_FATAL(uvm_hdl_read(block_ctr_path, block_ctr))
 
         // Force a lower value to get more more action.
         if (block_ctr == 8188 || // Speed up testing of the PER_8K setting.
@@ -114,13 +114,13 @@ class aes_reseed_vseq extends aes_base_vseq;
               block_ctr, block_ctr_set_val), UVM_LOW)
           `DV_CHECK(uvm_hdl_force(block_ctr_path, block_ctr_set_val));
           cfg.clk_rst_vif.wait_clks(1);
-          uvm_hdl_release(block_ctr_path);
+          `DV_CHECK_FATAL(uvm_hdl_release(block_ctr_path))
 
         end else if (block_ctr == 0) begin
           // Check whether the DUT is actually busy. Unless it's doing a block operation, no reseed
           // operation is getting triggered.
           csr_rd(.ptr(ral.status), .value(status), .blocking(1));
-          uvm_hdl_read(cipher_crypt_path, cipher_crypt);
+          `DV_CHECK_FATAL(uvm_hdl_read(cipher_crypt_path, cipher_crypt))
           if (!status.idle && cipher_crypt) begin
             // Check entropy_masking_req to verify the reseeding is actually triggered.
             check_masking_prng_reseed();
@@ -129,8 +129,8 @@ class aes_reseed_vseq extends aes_base_vseq;
             block_done = 0;
             `DV_SPINWAIT_EXIT(
                 while (!block_done) begin
-                  uvm_hdl_read(cipher_out_valid_path, cipher_out_valid);
-                  uvm_hdl_read(cipher_out_ready_path, cipher_out_ready);
+                  `DV_CHECK_FATAL(uvm_hdl_read(cipher_out_valid_path, cipher_out_valid))
+                  `DV_CHECK_FATAL(uvm_hdl_read(cipher_out_ready_path, cipher_out_ready))
                   if (cipher_out_valid && cipher_out_ready) begin
                     block_done = 1;
                   end
@@ -197,7 +197,7 @@ class aes_reseed_vseq extends aes_base_vseq;
       `DV_SPINWAIT_EXIT(
         while (!sideload_valid) begin
           cfg.clk_rst_vif.wait_clks(1);
-          uvm_hdl_read(sideload_valid_path, sideload_valid);
+          `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
         end,
         cfg.clk_rst_vif.wait_clks(wait_timeout_cycles);,
         "Timeout waiting for valid sideload key")
@@ -211,7 +211,7 @@ class aes_reseed_vseq extends aes_base_vseq;
         begin
           while (sideload_valid && !sideload_enabled) begin
             cfg.clk_rst_vif.wait_clks(1);
-            uvm_hdl_read(sideload_valid_path, sideload_valid);
+            `DV_CHECK_FATAL(uvm_hdl_read(sideload_valid_path, sideload_valid))
           end
         end
       join

--- a/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_cipher_if.sv
@@ -106,7 +106,9 @@ interface fi_cipher_if
       value = 0;
     end else begin
       // Read the current value.
-      uvm_hdl_read(intf_array[target], read);
+      if (!uvm_hdl_read(intf_array[target], read)) begin
+        `uvm_error("fi_cipher_if", $sformatf("Was not able to read %s", intf_array[target]))
+      end
       value = !read;
     end
     // always announce we are forcing something
@@ -124,7 +126,17 @@ interface fi_cipher_if
 
 
   function automatic void release_single_bit(int target);
-    uvm_hdl_release(intf_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_array[target])) begin
+      `uvm_error("fi_cipher_if", $sformatf("Was not able to release %s", intf_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
   endfunction
 
@@ -151,7 +163,9 @@ interface fi_cipher_if
       value = value & 2'h3;
     end else begin
       // Read the current value.
-      uvm_hdl_read(intf_mul_array[target], read);
+      if (!uvm_hdl_read(intf_mul_array[target], read)) begin
+        `uvm_error("fi_cipher_if", $sformatf("Was not able to read %s", intf_mul_array[target]))
+      end
       if (check_target_name(intf_mul_array[target], "sel_o")) begin
         // The selector signals are OR-combined. Flipping one bit in one rail to zero doesn't have
         // an effect and cannot be detected. Therefore, this test forces a least one additional bit
@@ -177,9 +191,19 @@ interface fi_cipher_if
 
 
   function automatic void release_multi_bit(int target);
-    uvm_hdl_release(intf_mul_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_mul_array[target])) begin
+      `uvm_error("fi_cipher_if", $sformatf("Was not able to release %s", intf_mul_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
-  endfunction // release_single_bit
+  endfunction
 
 
 

--- a/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_control_if.sv
@@ -97,7 +97,9 @@ interface fi_control_if
       value = 0;
     end else begin
       // Read the current value.
-      uvm_hdl_read(intf_array[target], read);
+      if (!uvm_hdl_read(intf_array[target], read)) begin
+        `uvm_error("fi_control_if", $sformatf("Was not able to read %s", intf_array[target]))
+      end
       value = !read;
     end
     // always announce we are forcing something
@@ -115,7 +117,17 @@ interface fi_control_if
 
 
   function automatic void release_single_bit(int target);
-    uvm_hdl_release(intf_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_array[target])) begin
+      `uvm_error("fi_control_if", $sformatf("Was not able to release %s", intf_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
   endfunction
 
@@ -133,7 +145,9 @@ interface fi_control_if
       `uvm_fatal("fi_control_if", $sformatf("PATH NOT EXISTING %m"))
     end
     // read the value currently of bit 0
-    uvm_hdl_read(intf_mul_array[target], read);
+    if (!uvm_hdl_read(intf_mul_array[target], read)) begin
+      `uvm_error("fi_control_if", $sformatf("Was not able to read %s", intf_mul_array[target]))
+    end
     // flip bit to make sure we don't force the value currently on bus
     value[0] = !read;
     if (!uvm_hdl_force(intf_mul_array[target], value)) begin
@@ -147,9 +161,19 @@ interface fi_control_if
 
 
   function automatic void release_multi_bit(int target);
-    uvm_hdl_release(intf_mul_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_mul_array[target])) begin
+      `uvm_error("fi_control_if", $sformatf("Was not able to release %s", intf_mul_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
-  endfunction // release_single_bit
+  endfunction
 
 
 

--- a/hw/ip/aes/dv/err_injection_if/fi_core_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_core_if.sv
@@ -63,9 +63,19 @@ interface fi_core_if
   endfunction
 
   function automatic void release_multi_bit(int target);
-    uvm_hdl_release(intf_mul_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_mul_array[target])) begin
+      `uvm_error("fi_core_if", $sformatf("Was not able to release %s", intf_mul_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
-  endfunction // release_single_bit
+  endfunction
 
   ///////////////////////////////////
   // Fault inject coverage         //

--- a/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/fi_ctr_fsm_if.sv
@@ -49,7 +49,9 @@ interface fi_ctr_fsm_if
       `uvm_fatal("fi_ctr_fsm_if", $sformatf("PATH NOT EXISTING %m"))
     end
     // read the value currently
-    uvm_hdl_read(intf_array[target], read);
+    if (!uvm_hdl_read(intf_array[target], read)) begin
+      `uvm_error("fi_ctr_fsm_if", $sformatf("Was not able to read %s", intf_array[target]))
+    end
     // always announce we are forcing something
     `uvm_info("if_ctr_fsm_if",
        $sformatf(" I am forcing target %d %s, value %b",target, intf_array[target], !read),UVM_LOW);
@@ -64,7 +66,17 @@ interface fi_ctr_fsm_if
 
 
   function automatic void release_single_bit(int target);
-    uvm_hdl_release(intf_array[target]);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(intf_array[target])) begin
+      `uvm_error("fi_ctr_fsm_if", $sformatf("Was not able to release %s", intf_array[target]))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
   endfunction
 

--- a/hw/ip/aes/dv/err_injection_if/force_if.sv
+++ b/hw/ip/aes/dv/err_injection_if/force_if.sv
@@ -24,10 +24,10 @@ interface force_if
     // pragma coverage off
 
     if (!uvm_hdl_check_path(path)) begin
-      `uvm_fatal("Force_if", $sformatf("PATH NOT EXISTING %m"))
+      `uvm_fatal("force_if", $sformatf("PATH NOT EXISTING %m"))
     end
-    if (!uvm_hdl_force(path,state)) begin
-      `uvm_error("Force_if", $sformatf("Was not able to force %s", state))
+    if (!uvm_hdl_force(path, state)) begin
+      `uvm_error("force_if", $sformatf("Was not able to force %s", path))
     end
 
     //VCS coverage on
@@ -36,7 +36,17 @@ interface force_if
   endfunction
 
   function static void release_state();
-    uvm_hdl_release(path);
+
+    //VCS coverage off
+    // pragma coverage off
+
+    if (!uvm_hdl_release(path)) begin
+      `uvm_error("force_if", $sformatf("Was not able to release %s", path))
+    end
+
+    //VCS coverage on
+    // pragma coverage on
+
     $asserton(0,"tb.dut");
   endfunction
 endinterface

--- a/hw/ip/aes/dv/sva/aes_idle_check.sv
+++ b/hw/ip/aes/dv/sva/aes_idle_check.sv
@@ -20,5 +20,5 @@ module aes_idle_check
   assign idle = (reg2hw.status.idle.q == 1'b1);
 
   // make sure idle_i always matched the register idle state
-  `ASSERT(IdleNotIdle_A, prim_mubi_pkg::mubi4_bool_to_mubi(idle) == idle_i);
+  `ASSERT(IdleNotIdle_A, prim_mubi_pkg::mubi4_bool_to_mubi(idle) == idle_i)
 endmodule

--- a/hw/ip/aes/dv/sva/aes_masking_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_masking_reseed_if.sv
@@ -26,15 +26,15 @@ interface aes_masking_reseed_if
   );
 
   // make sure the entropy received from EDN goes into the masking prng_seed signals
-  `ASSERT(EdnInputMatchesMaskingPrngSeed0_A, prng_seed_en[0] |-> ##1 entropy_i == prng_seed[0]);
-  `ASSERT(EdnInputMatchesMaskingPrngSeed1_A, prng_seed_en[1] |-> ##1 entropy_i == prng_seed[1]);
-  `ASSERT(EdnInputMatchesMaskingPrngSeed2_A, prng_seed_en[2] |-> ##1 entropy_i == prng_seed[2]);
-  `ASSERT(EdnInputMatchesMaskingPrngSeed3_A, prng_seed_en[3] |-> ##1 entropy_i == prng_seed[3]);
-  `ASSERT(EdnInputMatchesMaskingPrngSeed4_A, prng_seed_en[4] |-> ##1 entropy_i == prng_seed[4]);
+  `ASSERT(EdnInputMatchesMaskingPrngSeed0_A, prng_seed_en[0] |-> ##1 entropy_i == prng_seed[0])
+  `ASSERT(EdnInputMatchesMaskingPrngSeed1_A, prng_seed_en[1] |-> ##1 entropy_i == prng_seed[1])
+  `ASSERT(EdnInputMatchesMaskingPrngSeed2_A, prng_seed_en[2] |-> ##1 entropy_i == prng_seed[2])
+  `ASSERT(EdnInputMatchesMaskingPrngSeed3_A, prng_seed_en[3] |-> ##1 entropy_i == prng_seed[3])
+  `ASSERT(EdnInputMatchesMaskingPrngSeed4_A, prng_seed_en[4] |-> ##1 entropy_i == prng_seed[4])
   // make sure masking prng_seed signals match the PRNG LSFR inputs
-  `ASSERT(MaskingPrngSeedMatchesLfsrInput0_A, prng_seed_en[0] |-> ##1 prng_seed[0] == lfsr_q_0);
-  `ASSERT(MaskingPrngSeedMatchesLfsrInput1_A, prng_seed_en[1] |-> ##1 prng_seed[1] == lfsr_q_1);
-  `ASSERT(MaskingPrngSeedMatchesLfsrInput2_A, prng_seed_en[2] |-> ##1 prng_seed[2] == lfsr_q_2);
-  `ASSERT(MaskingPrngSeedMatchesLfsrInput3_A, prng_seed_en[3] |-> ##1 prng_seed[3] == lfsr_q_3);
-  `ASSERT(MaskingPrngSeedMatchesLfsrInput4_A, prng_seed_en[4] |-> ##1 prng_seed[4] == lfsr_q_4);
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput0_A, prng_seed_en[0] |-> ##1 prng_seed[0] == lfsr_q_0)
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput1_A, prng_seed_en[1] |-> ##1 prng_seed[1] == lfsr_q_1)
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput2_A, prng_seed_en[2] |-> ##1 prng_seed[2] == lfsr_q_2)
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput3_A, prng_seed_en[3] |-> ##1 prng_seed[3] == lfsr_q_3)
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput4_A, prng_seed_en[4] |-> ##1 prng_seed[4] == lfsr_q_4)
 endinterface // aes_masking_reseed_if

--- a/hw/ip/aes/dv/sva/aes_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_reseed_if.sv
@@ -35,17 +35,19 @@ interface aes_reseed_if
   assign seed = {buffer_q, entropy_i};
 
   // make sure clearing PRNG LSFR input always matches the EDN input
-  `ASSERT(ClearingPrngInputMatchesEdnInput_A, seed_en |-> ##1 seed == lfsr_q);
+  `ASSERT(ClearingPrngInputMatchesEdnInput_A, seed_en |-> ##1 seed == lfsr_q)
 
   // make sure masking PRNG reseeded at the specified rate
   // check the reseed rate for per_1 reseed rate
-  `ASSERT(MaskingPrngReseedRatePer1_A, (SecMasking && prng_reseed_rate == PER_1 &&
-          block_ctr_decr) |-> ##[1:$] entropy_masking_req);
+  `ASSERT(MaskingPrngReseedRatePer1_A,
+      (SecMasking && prng_reseed_rate == PER_1 && block_ctr_decr) |->
+      ##[1:$] entropy_masking_req)
   // check the reseed rate for per_64 or per_8k reseed rate
-  `ASSERT(MaskingPrngReseedRate_A, ( SecMasking && (prng_reseed_rate == PER_64 |
-          prng_reseed_rate == PER_8K) && block_ctr_expr) |-> ##[1:$] entropy_masking_req);
+  `ASSERT(MaskingPrngReseedRate_A, (SecMasking &&
+      (prng_reseed_rate == PER_64 | prng_reseed_rate == PER_8K) && block_ctr_expr) |->
+      ##[1:$] entropy_masking_req)
   // check the reseed happens after the block counter resets (when control register is updated)
-  `ASSERT(MaskingPrngReseedCorrectAfter_A, (SecMasking && ctrl_we_q && !ctrl_phase_i) |->
-          ##[1:$] entropy_masking_req);
+  `ASSERT(MaskingPrngReseedCorrectAfter_A,
+      (SecMasking && ctrl_we_q && !ctrl_phase_i) |-> ##[1:$] entropy_masking_req)
 
 endinterface // aes_reseed_if

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -38,7 +38,7 @@ module tb;
   `DV_EDN_IF_CONNECT
   `DV_ALERT_IF_CONNECT()
 
-  key_sideload_if sideload_if(.clk_i(clk), .rst_ni(rst_n));
+  key_sideload_if sideload_if(.clk_i(clk), .rst_ni(rst_n), .sideload_key());
  //lc_ctrl_pkg::On
   assign lc_escalate_en = lc_escalate[0] ?
                           lc_ctrl_pkg::lc_tx_t'(lc_escalate[$bits(lc_ctrl_pkg::lc_tx_t):1]) :


### PR DESCRIPTION
This PR resolves most of the tool warnings we're currently seeing for AES DV. Most of them are related due to ignoring return values of built in UVM functions. As these functions take string arguments and we use a couple of different ways in AES DV to pass these strings, it's not always possible to simply wrap the function calls using with a call to the `DV_CHECK_FATAL` macro as we do in other places of the project. In some cases, we also need to wrap the resulting `if/else` constructs with pragmas to turn off and on again coverage collection.

This is required for V2.5. This is related to lowRISC/OpenTitan#18428.