### PR TITLE
[opentitanlib] define more GPRs and CSRs

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -267,6 +267,7 @@ rust_library(
         "@crate_index//:sha2",
         "@crate_index//:shellwords",
         "@crate_index//:structopt",
+        "@crate_index//:strum",
         "@crate_index//:thiserror",
         "@crate_index//:typetag",
         "@crate_index//:zerocopy",

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -156,7 +156,7 @@ pub enum RiscvCsr {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum RiscvReg {
     /// General Purpose Register
-    GprByName(RiscvGpr),
+    Gpr(RiscvGpr),
     /// Control and Status Register
-    CsrByName(RiscvCsr),
+    Csr(RiscvCsr),
 }

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -160,3 +160,15 @@ pub enum RiscvReg {
     /// Control and Status Register
     Csr(RiscvCsr),
 }
+
+impl From<RiscvGpr> for RiscvReg {
+    fn from(gpr: RiscvGpr) -> Self {
+        Self::Gpr(gpr)
+    }
+}
+
+impl From<RiscvCsr> for RiscvReg {
+    fn from(csr: RiscvCsr) -> Self {
+        Self::Csr(csr)
+    }
+}

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -131,25 +131,200 @@ pub enum JtagTap {
     LcTap,
 }
 
-/// List of useful RISC-V general purpose registers
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+/// List of RISC-V general purpose registers
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub enum RiscvGpr {
-    A0,
-    GP,
-    SP,
     RA,
+    SP,
+    GP,
+    TP,
+    T0,
+    T1,
+    T2,
+    FP,
+    S1,
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+    S2,
+    S3,
+    S4,
+    S5,
+    S6,
+    S7,
+    S8,
+    S9,
+    S10,
+    S11,
+    T3,
+    T4,
+    T5,
+    T6,
+}
+
+impl RiscvGpr {
+    /// Get the register name as a string.
+    pub fn name(self) -> &'static str {
+        self.into()
+    }
 }
 
 /// List of useful RISC-V control and status registers
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
+#[non_exhaustive]
 pub enum RiscvCsr {
-    DPC,
+    MSTATUS,
+    MISA,
+    MIE,
+    MTVEC,
+    MCOUNTINHIBIT,
+    MHPMEVENT3,
+    MHPMEVENT4,
+    MHPMEVENT5,
+    MHPMEVENT6,
+    MHPMEVENT7,
+    MHPMEVENT8,
+    MHPMEVENT9,
+    MHPMEVENT10,
+    MHPMEVENT11,
+    MHPMEVENT12,
+    MHPMEVENT13,
+    MHPMEVENT14,
+    MHPMEVENT15,
+    MHPMEVENT16,
+    MHPMEVENT17,
+    MHPMEVENT18,
+    MHPMEVENT19,
+    MHPMEVENT20,
+    MHPMEVENT21,
+    MHPMEVENT22,
+    MHPMEVENT23,
+    MHPMEVENT24,
+    MHPMEVENT25,
+    MHPMEVENT26,
+    MHPMEVENT27,
+    MHPMEVENT28,
+    MHPMEVENT29,
+    MHPMEVENT30,
+    MHPMEVENT31,
+    MSCRATCH,
+    MEPC,
+    MCAUSE,
+    MTVAL,
+    MIP,
     PMPCFG0,
     PMPCFG1,
     PMPCFG2,
     PMPCFG3,
     PMPADDR0,
+    PMPADDR1,
+    PMPADDR2,
+    PMPADDR3,
+    PMPADDR4,
+    PMPADDR5,
+    PMPADDR6,
+    PMPADDR7,
+    PMPADDR8,
+    PMPADDR9,
+    PMPADDR10,
+    PMPADDR11,
+    PMPADDR12,
+    PMPADDR13,
+    PMPADDR14,
     PMPADDR15,
+    SCONTEXT,
+    MSECCFG,
+    MSECCFGH,
+    TSELECT,
+    TDATA1,
+    TDATA2,
+    TDATA3,
+    MCONTEXT,
+    MSCONTEXT,
+    DCSR,
+    DPC,
+    DSCRATCH0,
+    DSCRATCH1,
+    MCYCLE,
+    MINSTRET,
+    MHPMCOUNTER3,
+    MHPMCOUNTER4,
+    MHPMCOUNTER5,
+    MHPMCOUNTER6,
+    MHPMCOUNTER7,
+    MHPMCOUNTER8,
+    MHPMCOUNTER9,
+    MHPMCOUNTER10,
+    MHPMCOUNTER11,
+    MHPMCOUNTER12,
+    MHPMCOUNTER13,
+    MHPMCOUNTER14,
+    MHPMCOUNTER15,
+    MHPMCOUNTER16,
+    MHPMCOUNTER17,
+    MHPMCOUNTER18,
+    MHPMCOUNTER19,
+    MHPMCOUNTER20,
+    MHPMCOUNTER21,
+    MHPMCOUNTER22,
+    MHPMCOUNTER23,
+    MHPMCOUNTER24,
+    MHPMCOUNTER25,
+    MHPMCOUNTER26,
+    MHPMCOUNTER27,
+    MHPMCOUNTER28,
+    MHPMCOUNTER29,
+    MHPMCOUNTER30,
+    MHPMCOUNTER31,
+    MCYCLEH,
+    MINSTRETH,
+    MHPMCOUNTER3H,
+    MHPMCOUNTER4H,
+    MHPMCOUNTER5H,
+    MHPMCOUNTER6H,
+    MHPMCOUNTER7H,
+    MHPMCOUNTER8H,
+    MHPMCOUNTER9H,
+    MHPMCOUNTER10H,
+    MHPMCOUNTER11H,
+    MHPMCOUNTER12H,
+    MHPMCOUNTER13H,
+    MHPMCOUNTER14H,
+    MHPMCOUNTER15H,
+    MHPMCOUNTER16H,
+    MHPMCOUNTER17H,
+    MHPMCOUNTER18H,
+    MHPMCOUNTER19H,
+    MHPMCOUNTER20H,
+    MHPMCOUNTER21H,
+    MHPMCOUNTER22H,
+    MHPMCOUNTER23H,
+    MHPMCOUNTER24H,
+    MHPMCOUNTER25H,
+    MHPMCOUNTER26H,
+    MHPMCOUNTER27H,
+    MHPMCOUNTER28H,
+    MHPMCOUNTER29H,
+    MHPMCOUNTER30H,
+    MHPMCOUNTER31H,
+    MVENDORID,
+    MARCHID,
+    MIMPID,
+    MHARTID,
+}
+
+impl RiscvCsr {
+    /// Get the register name as a string.
+    pub fn name(self) -> &'static str {
+        self.into()
+    }
 }
 
 /// Available registers for RISC-V TAP
@@ -159,6 +334,16 @@ pub enum RiscvReg {
     Gpr(RiscvGpr),
     /// Control and Status Register
     Csr(RiscvCsr),
+}
+
+impl RiscvReg {
+    /// Get the register name as a string.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Gpr(gpr) => gpr.name(),
+            Self::Csr(csr) => csr.name(),
+        }
+    }
 }
 
 impl From<RiscvGpr> for RiscvReg {

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -345,13 +345,13 @@ impl OpenOcdServer {
     // with read_register32.
     fn riscv_reg_name(&self, reg: &RiscvReg) -> &'static str {
         match reg {
-            RiscvReg::GprByName(gpr) => match gpr {
+            RiscvReg::Gpr(gpr) => match gpr {
                 RiscvGpr::A0 => "a0",
                 RiscvGpr::GP => "gp",
                 RiscvGpr::SP => "sp",
                 RiscvGpr::RA => "ra",
             },
-            RiscvReg::CsrByName(csr) => match csr {
+            RiscvReg::Csr(csr) => match csr {
                 RiscvCsr::DPC => "dpc",
                 RiscvCsr::PMPCFG0 => "pmpcfg0",
                 RiscvCsr::PMPCFG1 => "pmpcfg1",

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 use crate::dif::lc_ctrl::LcCtrlReg;
 use crate::impl_serializable_error;
-use crate::io::jtag::{Jtag, JtagError, JtagParams, JtagTap, RiscvCsr, RiscvGpr, RiscvReg};
+use crate::io::jtag::{Jtag, JtagError, JtagParams, JtagTap, RiscvReg};
 use crate::util::parse_int::ParseInt;
 use crate::util::printer;
 
@@ -341,28 +341,6 @@ impl OpenOcdServer {
         }
     }
 
-    // Convert a RISC-V register name into a name that can be used
-    // with read_register32.
-    fn riscv_reg_name(&self, reg: &RiscvReg) -> &'static str {
-        match reg {
-            RiscvReg::Gpr(gpr) => match gpr {
-                RiscvGpr::A0 => "a0",
-                RiscvGpr::GP => "gp",
-                RiscvGpr::SP => "sp",
-                RiscvGpr::RA => "ra",
-            },
-            RiscvReg::Csr(csr) => match csr {
-                RiscvCsr::DPC => "dpc",
-                RiscvCsr::PMPCFG0 => "pmpcfg0",
-                RiscvCsr::PMPCFG1 => "pmpcfg1",
-                RiscvCsr::PMPCFG2 => "pmpcfg2",
-                RiscvCsr::PMPCFG3 => "pmpcfg3",
-                RiscvCsr::PMPADDR0 => "pmpaddr0",
-                RiscvCsr::PMPADDR15 => "pmpaddr15",
-            },
-        }
-    }
-
     /// Read a register: this function does not attempt to translate the
     /// name or number of the register. If force is set, bypass OpenOCD's
     /// register cache.
@@ -580,7 +558,7 @@ impl Jtag for OpenOcdServer {
             matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
             JtagError::Tap(self.jtag_tap.get().unwrap())
         );
-        self.read_register::<u32>(self.riscv_reg_name(reg), true)
+        self.read_register::<u32>(reg.name(), true)
     }
 
     fn write_riscv_reg(&self, reg: &RiscvReg, val: u32) -> Result<()> {
@@ -588,6 +566,6 @@ impl Jtag for OpenOcdServer {
             matches!(self.jtag_tap.get().unwrap(), JtagTap::RiscvTap),
             JtagError::Tap(self.jtag_tap.get().unwrap())
         );
-        self.write_register(self.riscv_reg_name(reg), val)
+        self.write_register(reg.name(), val)
     }
 }

--- a/sw/host/tests/chip/jtag/src/openocd_test.rs
+++ b/sw/host/tests/chip/jtag/src/openocd_test.rs
@@ -139,47 +139,38 @@ fn test_openocd(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     //
     // Test register read/writes
     //
-    let orig_sp = jtag.read_riscv_reg(&RiscvReg::GprByName(RiscvGpr::SP))?;
+    let orig_sp = jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP))?;
     log::info!("SP: {:x}", orig_sp);
-    let orig_pc = jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC))?;
+    let orig_pc = jtag.read_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC))?;
     log::info!("PC: {:x}", orig_pc);
-    jtag.write_riscv_reg(&RiscvReg::GprByName(RiscvGpr::SP), 0xdeadbeef)?;
-    jtag.write_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC), 0xcc00ffee)?;
+    jtag.write_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP), 0xdeadbeef)?;
+    jtag.write_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC), 0xcc00ffee)?;
     log::info!(
         "SP: {:x}",
-        jtag.read_riscv_reg(&RiscvReg::GprByName(RiscvGpr::SP))?
+        jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP))?
     );
     log::info!(
         "PC: {:x}",
-        jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC))?
+        jtag.read_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC))?
     );
     // restore
-    jtag.write_riscv_reg(&RiscvReg::GprByName(RiscvGpr::SP), orig_sp)?;
-    jtag.write_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC), orig_pc)?;
+    jtag.write_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP), orig_sp)?;
+    jtag.write_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC), orig_pc)?;
 
     //
     // Test reset
     //
     jtag.reset(/* run */ false)?;
     // the reset address is 0x8080
-    assert_eq!(
-        jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC))?,
-        0x8080
-    );
+    assert_eq!(jtag.read_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC))?, 0x8080);
     jtag.step()?;
     // the first instruction is a jump to 0x8180
-    assert_eq!(
-        jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC))?,
-        0x8180
-    );
+    assert_eq!(jtag.read_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC))?, 0x8180);
     jtag.reset(/* run */ true)?;
     jtag.halt()?;
     // at this point the target must have execute at least one instruction so it should
     // not be at the reset vector anymore
-    assert_ne!(
-        jtag.read_riscv_reg(&RiscvReg::CsrByName(RiscvCsr::DPC))?,
-        0x8080
-    );
+    assert_ne!(jtag.read_riscv_reg(&RiscvReg::Csr(RiscvCsr::DPC))?, 0x8080);
     jtag.resume()?;
 
     jtag.disconnect()?;


### PR DESCRIPTION
Define all GPRs and more CSRs and use `strum` macro to generate the `name` function.

Split from #18908