### PR TITLE
[sw] Fix UB downcast in GlobalMock

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -16,6 +16,27 @@ cc_library(
     hdrs = ["global_mock.h"],
 )
 
+cc_test(
+    name = "global_mock_unittest",
+    srcs = ["global_mock_unittest.cc"],
+    # Enable UBSan by setting copts and linkopts. This is roughly what
+    # `--config=ubsan` does, as defined in `.bazelrc`.
+    copts = [
+        "-fsanitize=undefined",
+        "-g",
+        "-fno-omit-frame-pointer",
+        # Make detected UB fatal. Without this flag, the test would always pass.
+        "-fno-sanitize-recover",
+    ],
+    linkopts = [
+        "-fsanitize=undefined",
+    ],
+    deps = [
+        ":global_mock",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "stdasm",
     hdrs = ["stdasm.h"],

--- a/sw/device/lib/base/global_mock.h
+++ b/sw/device/lib/base/global_mock.h
@@ -54,7 +54,7 @@ class GlobalMock {
          << "` is already instantiated.";
       throw std::runtime_error(std::move(ss).str());
     }
-    instance_ = static_cast<Mock *>(this);
+    instance_ = this;
   }
 
   // Note: Destructors of mock classes must be virtual for `testing::StrictMock`
@@ -67,7 +67,7 @@ class GlobalMock {
       ss << "Mock `" << typeid(GlobalMock).name() << "` not instantiated yet.";
       throw std::runtime_error(std::move(ss).str());
     }
-    return *instance_;
+    return *static_cast<Mock *>(instance_);
   }
 
   GlobalMock(const GlobalMock &) = delete;
@@ -76,10 +76,10 @@ class GlobalMock {
   GlobalMock &operator=(GlobalMock &&) = delete;
 
  private:
-  static Mock *instance_;
+  static GlobalMock<Mock> *instance_;
 };
 template <typename Mock>
-Mock *GlobalMock<Mock>::instance_ = nullptr;
+GlobalMock<Mock> *GlobalMock<Mock>::instance_ = nullptr;
 
 }  // namespace global_mock
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_GLOBAL_MOCK_H_

--- a/sw/device/lib/base/global_mock_unittest.cc
+++ b/sw/device/lib/base/global_mock_unittest.cc
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/global_mock.h"
+
+#include "gtest/gtest.h"
+
+namespace global_mock_test {
+
+// This is a regression test for a casting bug in `GlobalMock<T>`. The
+// `GlobalMock()` constructor erroneously cast `this` to `T*` before the `T`
+// object was constructed.
+//
+// This is what UBSan has to say when `GlobalMock`'s constructor casts `this` to
+// `MockFoo*`:
+//     runtime error: downcast of address 0x7ffdb2a52900 which does not point to
+//     an object of type 'MockFoo'
+TEST(GlobalMockTest, DowncastHygieneRegressionTest) {
+  class MockFoo : public global_mock::GlobalMock<MockFoo> {
+   public:
+    int value() { return value_; }
+
+   private:
+    int value_ = 42;
+  };
+
+  MockFoo foo;
+  MockFoo &foo_ref = global_mock::GlobalMock<MockFoo>::Instance();
+  ASSERT_EQ(foo_ref.value(), 42);
+}
+
+}  // namespace global_mock_test


### PR DESCRIPTION
This commit changes the implementation of GlobalMock, deferring downcasting `this` to the derived class until the derived class's constructor has returned.

It also adds a regression test that compiles with UBSan.