### PR TITLE
[chip,dv] remove unecessary eot reset

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1425,14 +1425,15 @@
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0"]
+      run_opts: ["+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0",
+                 "+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_sram_ctrl_scrambled_access_jitter_en
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=12_000_000",
+      run_opts: ["+sw_test_timeout_ns=12_000_000", "+bypass_alert_ready_to_end_check=1",
                  "+en_jitter=1", "+en_scb_tl_err_chk=0"]
     }
     {
@@ -1848,7 +1849,7 @@
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
-                 "+sw_test_timeout_ns=12_000_000",
+                 "+sw_test_timeout_ns=12_000_000", "+bypass_alert_ready_to_end_check=1",
                  "+en_jitter=1", "+en_scb_tl_err_chk=0", "+cal_sys_clk_70mhz=1"]
     }
     {

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -397,7 +397,6 @@ bool test_main(void) {
     reference_frame = (scramble_test_frame *)main_sram_addr;
 
     execute_retention_sram_test();
-    CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
     return true;
   }
 


### PR DESCRIPTION
sram_ctrl_scrambled_access_test.c has unnecessary end of test reset
https://cs.opensource.google/opentitan/opentitan/+/master:sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c;drc=78036ec7cb0ca2a70f88ebc8ca05b31694a05e62;l=399
This issue has been discovered in #16259 and #16597 but closed by #16662 which explains 
sw reset is needed for retention sram test but not exactly at the end of test.
I reviewed the test and find the end of test reset is added to avoid test timeout.
The timeout happens because this test creates several "expected" rv_core_ibex_fatal_hw_err
and chip level test bench only uses alert monitor.
So instead of using rtl reset, add "+bypass_alert_ready_to_end_check=1" to the test and let the test
finish gracefully after run_phase.
