### PR TITLE
[gpio/dv] Add second build mode for CDC prims

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -100,7 +100,7 @@
   //     }
   //   ]
   //
-  // To use a build mode for a specific test, set the 'use_build_mode' key.
+  // To use a build mode for a specific test, set the 'build_mode' key.
   //
   build_modes: []
 

--- a/hw/ip/gpio/data/gpio_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_testplan.hjson
@@ -18,10 +18,15 @@
             - Configures all gpio pins as inputs, drives random value on cio_gpio_i signal and
               reads data_in register after random delay
             - Configures all gpio pins as outputs, programs direct_out and direct_oe registers to
-              random values and reads data_in register after random delay'''
+              random values and reads data_in register after random delay
+            The test is also run in a second build mode that enables the input synchronizers in
+            order to cover the input paths through these primitives.
+            '''
       stage: V1
       tests: ["gpio_smoke",
-              "gpio_smoke_no_pullup_pulldown"]
+              "gpio_smoke_no_pullup_pulldown",
+              "gpio_smoke_en_cdc_prim",
+              "gpio_smoke_no_pullup_pulldown_en_cdc_prim"]
     }
     {
       name: direct_and_masked_out

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -50,6 +50,22 @@
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
+  // Add a second build mode to test the input synchronizers.
+  // Note that since the scoreboard has a cycle accurate model
+  // for GPIO without the synchronizers, the majority of the tests
+  // is run in the default build mode without the CDC prims. The en_cdc_prims
+  // build mode is used to run some additional smoke checks to ensure
+  // that the input paths through the CDC prims are connected correctly.
+  build_modes: [
+    {
+      name: en_cdc_prims
+      build_opts: ["+define+GPIO_ASYNC_ON"]
+    }
+  ]
+
+  en_cdc_prims_vcs_cov_cfg_file: "{default_vcs_cov_cfg_file}"
+  en_cdc_prims_xcelium_cov_cfg_file: "{default_xcelium_cov_cfg_file}"
+
   // List of test specifications.
   tests: [
     {
@@ -151,13 +167,26 @@
       run_opts: ["+do_clear_all_interrupts=0"]
     }
 
+    // Additional smoke checks for second build mode
+    {
+      name: gpio_smoke_en_cdc_prim
+      uvm_test_seq: gpio_smoke_vseq
+      build_mode: en_cdc_prims
+    }
+
+    {
+      name: gpio_smoke_no_pullup_pulldown_en_cdc_prim
+      uvm_test_seq: gpio_smoke_vseq
+      build_mode: en_cdc_prims
+      run_opts: ["+no_pullup_pulldown=1"]
+    }
   ]
 
   // List of regressions.
   regressions: [
     {
       name: smoke
-      tests: ["gpio_smoke"]
+      tests: ["gpio_smoke", "gpio_smoke_en_cdc_prim"]
     }
   ]
 }

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -42,10 +42,13 @@ module tb;
 
   // dut
   gpio #(
-    // TODO: The scoreboard does not handle the 2 cycle delay yet, hence we disable the 2-flop
-    // synchronizers in the block level TB (they are enabled at the top). This should be aligned,
-    // so that synchronizers are always enabled.
+    // We have two build modes in this testbench: one with CDC synchronizers enabled, and one
+    // where they are disabled.
+`ifdef GPIO_ASYNC_ON
+    .GpioAsyncOn(1)
+`else
     .GpioAsyncOn(0)
+`endif
   ) dut (
     .clk_i (clk),
     .rst_ni(rst_n),


### PR DESCRIPTION
This covers the input path through CDC prims.
Other tests unfortunately don't run with CDC prims since the scoreboard is cycle accurate and currently can't account for additional delay on the input path.

Fixes #9941