### PR TITLE
[release] Increase timeout of CI job

### DIFF
--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -49,7 +49,7 @@ jobs:
 
 - job: build_release
   displayName: "Create the OpenTitan release"
-  timeoutInMinutes: 300
+  timeoutInMinutes: 360
   dependsOn: checkout
   pool: ci-public
   steps:


### PR DESCRIPTION
Even with a time limit of 4h (increased in 6537129b68079d1196de105dae0fb0c0cff352d4 / PR #18906), the *Release* job still times out.  New logs indicate that:
- Building the regular CW310 bitstream takes ca. 3h 20min.
- Bitstream splicing then takes ca. 10min.
- Building the Hyperdebug CW310 bitstream then starts and times out. According to logs from CI checks, that would take ca. 1h 40min.

Thus, the runtime of the *Release* job should be some 10min above 5h.

This commit increases the timeout to 6h, so that there's some margin for when additional work is added or the complexity of existing tasks increases.