### PR TITLE
[edn/dv] Fix type of `target` argument to `find_index`

### DIFF
--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -290,7 +290,7 @@ class edn_base_vseq extends cip_base_vseq #(
   endtask // force_path_err
 
   // Find the first or last index in the original string that the target character appears
-  function automatic int find_index (string target, string original_str, string which_index);
+  function automatic int find_index (byte target, string original_str, string which_index);
     int        index;
     case (which_index)
       "first": begin


### PR DESCRIPTION
The `target` argument is used in the `find_index` function in comparisons against an indexed string, which returns a byte.  Thus, it's type must also be a byte.  This caused warnings in VCS, which are fixed by this commit (and which are relevant for V2.5 sign off).

After this fix, there are no more compile-time or run-time warnings by the simulator tool. The `ALL_TOOL_WARNINGS_ARE_REVIEWED` checklist item for V2.5 sign-off can thus get ticked off.