### PR TITLE
[chip,dv] move cfg init under chip_env_cfg

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -248,6 +248,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     // there can also be a pending response in the peripheral.
     // However, the actual ibex data port can only support 1 outstanding item.
     m_tl_agent_cfg.max_outstanding_req = 3;
+
+    // Set the number of RAM tiles (1 each).
+    num_ram_main_tiles = 1;
+    num_ram_ret_tiles = 1;
+    num_otbn_dmem_tiles = 1;
   endfunction
 
   // Disable functional coverage of comportable IP-specific specialized registers.

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -22,11 +22,6 @@ class chip_base_test extends cip_base_test #(
 
     super.build_phase(phase);
 
-    // Set the number of RAM tiles (1 each).
-    cfg.num_ram_main_tiles = 1;
-    cfg.num_ram_ret_tiles = 1;
-    cfg.num_otbn_dmem_tiles = 1;
-
     // Knob to select the chip clock source.
     `DV_GET_ENUM_PLUSARG(chip_clock_source_e, cfg.chip_clock_source, chip_clock_source)
     if (cfg.chip_clock_source != ChipClockSourceInternal) begin


### PR DESCRIPTION
Set init value out of chip_env_cfg causes
test failure in closed source from wrong init cfg value. 
Move these to proper place for future test arragement