### PR TITLE
[i2c,doc] Documentation changes for V2 sign-off

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -236,7 +236,7 @@
         }
         { bits: "11"
           name: "RCONT"
-          desc: "Do not NAK the last byte read, let the read operation continue"
+          desc: "Do not NACK the last byte read, let the read operation continue"
         }
         { bits: "12"
           name: "NAKOK"

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -396,6 +396,7 @@
       desc: '''
             Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
             All values are expressed in units of the input clock period.
+            These must be greater than 2 in order for the change in SCL to propagate to the input of the FSM so that acknowledgements are detected correctly.
             '''
       swaccess: "rw"
       hwaccess: "hro"

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -403,7 +403,7 @@
       fields: [
         { bits: "15:0"
           name: "THIGH"
-          desc: "The actual time to hold SCL high in a given pulse"
+          desc: "The actual time to hold SCL high in a given pulse: in host mode, when there is no stretching this value is 3 cycles longer as tracked in issue #18962"
         }
         { bits: "31:16"
           name: "TLOW"
@@ -425,7 +425,7 @@
         }
         { bits: "31:16"
           name: "T_F"
-          desc: "The nominal fall time to anticipate for the bus (influences SDA hold times)"
+          desc: "The nominal fall time to anticipate for the bus (influences SDA hold times): this is currently counted twice in host mode as tracked in issue #18958"
         }
       ]
     }

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -236,7 +236,7 @@
             Host mode: disable host mode during host mode sequence
 
             Stimulus:
-              - Host sends an address and data but receives NAK response
+              - Host sends an address and data but receives NACK response
                 since agent is reset before transaction is complete and
                 host mode is disabled
             Checking:
@@ -587,10 +587,10 @@
             * Write address transmission with NAKOK
             * Data transmission with NAKOK
             * Stop data with NAKOK
-            Cross bytes with NAK from Target
-            * Cross data byte with NAKOK and NAK from Target
-            * Cross address byte with NAKOK and NAK from Target
-            * Cross data byte with NAKOK and NAK from Target
+            Cross bytes with NACK from Target
+            * Cross data byte with NAKOK and NACK from Target
+            * Cross address byte with NAKOK and NACK from Target
+            * Cross data byte with NAKOK and NACK from Target
             '''
     }
     {
@@ -601,9 +601,9 @@
             * Read address byte
             * Data byte
             * ACK before STOP
-            * NAK before STOP
+            * NACK before STOP
             * RSTART with previous ACK for READ
-            * RSTART with previous NAK for READ
+            * RSTART with previous NACK for READ
             '''
     }
     {

--- a/hw/ip/i2c/doc/programmers_guide.md
+++ b/hw/ip/i2c/doc/programmers_guide.md
@@ -72,6 +72,7 @@ $$ \textrm{TIMING0.THIGH}=\max(\textrm{PERIOD}-\textrm{T_R} - \textrm{TIMING0.TL
 We are aware of two issues with timing calculations.
 First, the fall time (T_F) is counted twice in host mode as is tracked in [issue #18958](https://github.com/lowRISC/opentitan/issues/18958).
 Second, the high time (THIGH) is 3 cycles longer when no clock stretching is detected as tracked in [issue #18962](https://github.com/lowRISC/opentitan/issues/18962).
+Due to these two discrepancies and the tendency of the above equations to create an underestimate of the eventual clock frequency, we recommend that the internal clock is driven at least 50x higher than the line speed.
 
 #### Timing parameter examples
 

--- a/hw/ip/i2c/doc/programmers_guide.md
+++ b/hw/ip/i2c/doc/programmers_guide.md
@@ -69,6 +69,9 @@ $$ \textrm{TIMING0.TLOW}=\textrm{TLOW_MIN} $$
 1. THIGH is then set to satisfy both constraints in the desired SCL period and in the minimum permissible values for t<sub>HIGH</sub>:
 $$ \textrm{TIMING0.THIGH}=\max(\textrm{PERIOD}-\textrm{T_R} - \textrm{TIMING0.TLOW} -\textrm{T_F}, \textrm{THIGH_MIN}) $$
 
+We are aware of two issues with timing calculations.
+First, the fall time (T_F) is counted twice in host mode as is tracked in [issue #18958](https://github.com/lowRISC/opentitan/issues/18958).
+Second, the high time (THIGH) is 3 cycles longer when no clock stretching is detected as tracked in [issue #18962](https://github.com/lowRISC/opentitan/issues/18962).
 
 #### Timing parameter examples
 

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -52,7 +52,7 @@ However if the line speeds and the module clock speeds become very close (2x), t
 
 Therefore, it is recommended that the internal module clock frequency is much higher than the line speeds.
 Another reason to have this higher internal clock frequency is that the timing parameters can be more accurately defined, which helps attain the desired I2C clock rate.
-Since there are currently also a few cycles discrepancy between the specified timings and the actual ones (as described in the Programmer's Guide), it is recommended that the internal module clock frequency is at leat 50x higher than the I2C line speeds.
+Since there are currently also a few cycles discrepancy between the specified timings and the actual ones (as described in the [Programmer's Guide](./programmers_guide.md#timing-parameter-tuning-algorithm)), it is recommended that the internal module clock frequency is at leat 50x higher than the I2C line speeds.
 
 ### Byte-Formatted Programming Mode
 
@@ -167,7 +167,7 @@ Note in order to ensure compliance with the I2C spec, firmware must program thes
 These values can be directly computed using DIFs given the desired speed standard, the desired operating frequency, and the actual line capacitance.
 These timing parameters are then fed directly to the I2C state machine to control the bus timing.
 
-A detailed description of the algorithm for determining these parameters--as well as a couple of concrete examples--are given in the [Programmers Guide section of this document.](#timing-parameter-tuning-algorithm)
+A detailed description of the algorithm for determining these parameters--as well as a couple of concrete examples--are given in the [Programmer's Guide](./programmers_guide.md#timing-parameter-tuning-algorithm).
 
 ### Timeout Control
 A malfunctioning (or otherwise very slow) target device can hold SCL low indefinitely, stalling the bus.

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -50,7 +50,9 @@ This adds a one cycle module clock delay to both signals.
 If the module clock is sufficiently faster than I2C line speeds (for example 20MHz), this is not an issue.
 However if the line speeds and the module clock speeds become very close (2x), the 1 cycle delay may have an impact, as the internal state machine may mistakenly think it has sampled an SDA that has not yet been updated.
 
-Therefore, it is recommended that the internal module clock frequency is at least 5-10x the line speeds.
+Therefore, it is recommended that the internal module clock frequency is much higher than the line speeds.
+Another reason to have this higher internal clock frequency is that the timing parameters can be more accurately defined, which helps attain the desired I2C clock rate.
+Since there are currently also a few cycles discrepancy between the specified timings and the actual ones (as described in the Programmer's Guide), it is recommended that the internal module clock frequency is at leat 50x higher than the I2C line speeds.
 
 ### Byte-Formatted Programming Mode
 
@@ -159,7 +161,8 @@ Moreover, since the pin driver fall time is likely to be less then one clock cyc
 - t<sub>SU,STO</sub>: set in register [`TIMING4.TSU_STO`](../data/i2c.hjson#timing4).
 - t<sub>BUF</sub>: set in register [`TIMING4.T_BUF`](../data/i2c.hjson#timing4)
 
-The values programmed into the registers [`TIMING0`](../data/i2c.hjson#timing0) through [`TIMING4`](../data/i2c.hjson#timing4) are to be expressed in units of the bus clock period.
+The values programmed into the registers [`TIMING0`](../data/i2c.hjson#timing0) through [`TIMING4`](../data/i2c.hjson#timing4) are to be expressed in units of the input clock period.
+It is important that the internal clock is at least 50x the bus clock so that the proportions of the timings can be accurately captured.
 Note in order to ensure compliance with the I2C spec, firmware must program these registers with values within the ranges laid out in Table 10 of the specification.
 These values can be directly computed using DIFs given the desired speed standard, the desired operating frequency, and the actual line capacitance.
 These timing parameters are then fed directly to the I2C state machine to control the bus timing.


### PR DESCRIPTION
This PR is meant to check off the remaining checklist items for I2C V2: https://github.com/lowRISC/opentitan/issues/18741 Please refer to that issue for the relevant issue links, etc.

There are a couple of RTL fixes necessary in a future release, but this PR explains these in the documentation to pass V2: https://github.com/lowRISC/opentitan/issues/18962 and https://github.com/lowRISC/opentitan/issues/18962