### PR TITLE
[chip,dv] add external clock to rom_volatile_raw_unlock

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -877,6 +877,7 @@
       run_opts: [
         "+sw_test_timeout_ns=200_000_000",
         "+use_otp_image=OtpTypeLcStRaw",
+        "+chip_clock_source=ChipClockSourceExternal48Mhz",
         "+rom_prod_mode=1",
       ]
       run_timeout_mins: 480


### PR DESCRIPTION
Same reason as described in #18735, 
need to add external clock to access otp from raw lc state