### PR TITLE
[edn/dv] Rework `edn_err` test to substantially increase coverage

### DIFF
--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -98,7 +98,7 @@
 
     {
       name: edn_err
-      uvm_test: edn_intr_test
+      uvm_test: edn_err_test
       uvm_test_seq: edn_err_vseq
     }
 

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -100,6 +100,7 @@
       name: edn_err
       uvm_test: edn_err_test
       uvm_test_seq: edn_err_vseq
+      reseed: 100
     }
 
     {

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -67,6 +67,14 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
     num_boot_reqs inside { [min_num_boot_reqs:max_num_boot_reqs] };}
 
+  constraint which_err_code_c {which_err_code dist {
+    // Certain error codes are more interesting for coverage, so give each of them a higher weight.
+    edn_ack_sm_err  :/ 5,
+    edn_main_sm_err :/ 5,
+    edn_cntr_err    :/ 5
+    // All other error codes will implicitly get a weight of 1.
+  };}
+
   // Functions
   function void post_randomize();
     if (use_invalid_mubi) begin

--- a/hw/ip/edn/dv/env/edn_if.sv
+++ b/hw/ip/edn/dv/env/edn_if.sv
@@ -17,9 +17,12 @@ interface edn_if(input clk, input rst_n);
     return {core_path, ".", fifo_name, "_", which_path};
   endfunction // fifo_err_path
 
-  function automatic string sm_err_path(string which_sm);
+  function automatic string sm_err_path(string which_sm, int ep_idx = 0);
     case (which_sm)
-      "edn_ack_sm": return {core_path, ".gen_ep_blk[0].u_edn_ack_sm_ep.state_q"};
+      "edn_ack_sm": begin
+        string ep_blk_path = $sformatf(".gen_ep_blk[%0d]", ep_idx);
+        return {core_path, ep_blk_path, ".u_edn_ack_sm_ep.state_q"};
+      end
       "edn_main_sm": return {core_path, ".u_edn_main_sm.state_q"};
       default: `uvm_fatal("edn_if", "Invalid sm name!")
     endcase // case (which_sm)

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -60,10 +60,12 @@ class edn_err_vseq extends edn_base_vseq;
     `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
     cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
 
-    // Request data
+    // Create background thread that does endpoint requests.
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
                                        endpoint_port inside { [0:cfg.num_endpoints - 1] };)
-    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+    fork
+      m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+    join_none
 
     reg_name = "err_code";
     csr = ral.get_reg_by_name(reg_name);

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -47,11 +47,17 @@ class edn_err_vseq extends edn_base_vseq;
     $assertoff(0, "tb.dut.u_edn_core.u_prim_fifo_sync_gencmd.DataKnown_A");
     cfg.edn_assert_vif.assert_off();
 
-    // Send INS cmd
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False), .glen(0));
+    // Create background thread that writes the Instantiate and Generate commands to the SW command
+    // register.
+    fork
+      begin
+        // Send INS cmd
+        wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False), .glen(0));
 
-    // Send GEN cmd w/ GLEN 1 (request single genbits)
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False), .glen(1));
+        // Send GEN cmd w/ GLEN 1 (request single genbits)
+        wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False), .glen(1));
+      end
+    join_none
 
     // Load genbits data
     m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::

--- a/hw/ip/edn/dv/tests/edn_err_test.sv
+++ b/hw/ip/edn/dv/tests/edn_err_test.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class edn_err_test extends edn_intr_test;
+
+  `uvm_component_utils(edn_err_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    cfg.boot_req_mode_pct = 40;
+    cfg.auto_req_mode_pct = 40;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
+  endfunction
+endclass : edn_err_test

--- a/hw/ip/edn/dv/tests/edn_intr_test.sv
+++ b/hw/ip/edn/dv/tests/edn_intr_test.sv
@@ -13,6 +13,13 @@ class edn_intr_test extends edn_base_test;
     cfg.en_scb            = 0;
     cfg.use_invalid_mubi  = 0;
 
+    // TODO(#18971): This test is currently not run when EDN is in Auto mode or in Boot mode (i.e.,
+    // only in SW mode), because `auto_req_mode_pct` and `boot_req_mode_pct` have a value of `0` by
+    // inheritance.  The fatal error interrupt should also be triggered and verified in Auto mode
+    // and in Boot mode, though; but this is currently not supported by `edn_intr_vseq`.  When this
+    // is resolved, `edn_intr_test` can potentially be merged with `edn_err_test`, because their
+    // only difference currently is the value of `auto_req_mode_pct` and `boot_req_mode_pct`.
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction

--- a/hw/ip/edn/dv/tests/edn_test.core
+++ b/hw/ip/edn/dv/tests/edn_test.core
@@ -15,6 +15,7 @@ filesets:
       - edn_genbits_test.sv: {is_include_file: true}
       - edn_stress_all_test.sv: {is_include_file: true}
       - edn_intr_test.sv: {is_include_file: true}
+      - edn_err_test.sv: {is_include_file: true}
       - edn_alert_test.sv: {is_include_file: true}
       - edn_disable_test.sv: {is_include_file: true}
       - edn_disable_auto_req_mode_test.sv: {is_include_file: true}

--- a/hw/ip/edn/dv/tests/edn_test_pkg.sv
+++ b/hw/ip/edn/dv/tests/edn_test_pkg.sv
@@ -22,6 +22,7 @@ package edn_test_pkg;
   `include "edn_genbits_test.sv"
   `include "edn_stress_all_test.sv"
   `include "edn_intr_test.sv"
+  `include "edn_err_test.sv"
   `include "edn_alert_test.sv"
   `include "edn_disable_test.sv"
   `include "edn_disable_auto_req_mode_test.sv"


### PR DESCRIPTION
This PR reworks the `edn_err` test so that it achieves full coverage of transitions from *each* FSM state to the Error state. This was one of the main coverage gaps left for M2.5.

Please see the commit messages for details. Reviewing this commit by commit is highly recommended to understand the motivation for each change.