### PR TITLE
[rv_timer/dv] Remove TODO for interrupt checking

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -216,7 +216,6 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
       // Check all interrupts in DataChannel of every Read/Write except when ctimecmp updated
       // during timer active. This scenario is checked in base sequence by reading the intr_state.
       // Ignored checking here because sticky intr_pin update has one cycle delay.
-      // TODO #1464: temp constraint, if support external reg, this can be removed
       if (!ctimecmp_update_on_fly) check_interrupt_pin();
       ctimecmp_update_on_fly = 0;
 


### PR DESCRIPTION
The TODO suggested checking the interrupt pin could be changed if the interrupt CSRs were implemented as hwext. However, that did not occur on the design side and is not planned. So, remove the TODO.

For the production release, I think we'll want to tackle #18918 on the design side, but that is not relevant for the shuttle. That may have an effect on the scoreboard here, though.