### PR TITLE
[i2c,dv] I2C todo cleanup

### DIFF
--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -319,7 +319,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
               if (exp_wr_item.start && exp_wr_item.bus_op == BusOpWrite) begin
                 // irq is asserted with 2 latency cycles (#3422)
                 cfg.clk_rst_vif.wait_clks(2);
-                // TODO: Gather all irq verification in SCB instead of distribute in vseq
+                // ICEBOX(#18980): Gather all irq verification in SCB instead of distribute in vseq
                 if (cfg.intr_vif.pins[FmtOverflow]) begin
                   exp_wr_item.fmt_ovf_data_q.push_back(fbyte);
                   //wait(!cfg.intr_vif.pins[FmtOverflow]);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
@@ -46,7 +46,7 @@ class i2c_host_fifo_full_vseq extends i2c_rx_tx_vseq;
     `uvm_info(`gfn, "\n--> end of i2c_host_fifo_full_vseq", UVM_DEBUG)
   endtask : body
 
-  // TODO: weicai suggested corner tests: send N + 1 items (N is fifo depth), configure agent
+  // ICEBOX(#18979): weicai suggested corner tests: send N + 1 items (N is fifo depth), configure agent
   // to slow read mode (not able to completely handle one item before N+1 items are written),
   // then check fifo_full bit is
   //   - not asserted when N items are written to fifo (fifo_lvl = N-1)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -60,9 +60,9 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
                    ((trans_type == ReadOnly)  ? 1'b1 : rw_bit);
           // program address for folowing transaction types
           chained_read = fmt_item.read && fmt_item.rcont;
-          if ((cur_tran == 1'b1) ||    // first read transaction
-              (!fmt_item.read)   ||    // write transactions
-              (!chained_read)) begin   // non-chained read transactions
+          if ((cur_tran == 1'b1) ||  // first read transaction
+              (!fmt_item.read)   ||  // write transactions
+              (!chained_read)) begin // non-chained read transactions
             program_address_to_target();
           end
 
@@ -160,7 +160,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
         csr_rd(.ptr(ral.status.rxfull), .value(rx_full));
         rx_threshold |= (cfg.seq_cfg.en_rx_threshold & rx_full);
       end
-      start_read = rx_smoke    | // read rx_fifo if there is valid data
+      start_read = rx_smoke     | // read rx_fifo if there is valid data
                    rx_threshold | // read rx_fifo after full (ensure intr rx_threshold asserted)
                    rx_overflow;   // read rx_fifo after overflow (ensure intr_rx_overflow asserted)
       if (start_read) begin
@@ -200,7 +200,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
         if (stopbyte && (i == num_wr_bytes)) begin
         fmt_item.fbyte = 8'hee;
         end else begin
-        fmt_item.fbyte = wr_data[i-1];
+        fmt_item.fbyte = wr_data[i - 1];
         end
       end while (!fmt_item.nakok && !fmt_item.rcont && !fmt_item.fbyte);
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -157,8 +157,6 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
       rx_smoke    = !cfg.seq_cfg.en_rx_threshold & !cfg.seq_cfg.en_rx_overflow;
       rx_overflow |= (cfg.seq_cfg.en_rx_overflow  & cfg.intr_vif.pins[RxOverflow]);
       if (cfg.seq_cfg.en_rx_threshold) begin
-        // TODO: Weicai's comments in PR #3128: consider constraining
-        // rx_fifo_access_dly to test threshold irq (require revise threshold_vseq)
         csr_rd(.ptr(ral.status.rxfull), .value(rx_full));
         rx_threshold |= (cfg.seq_cfg.en_rx_threshold & rx_full);
       end

--- a/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
+++ b/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
@@ -105,8 +105,7 @@ module i2c_protocol_cov(
   always@(posedge clk or negedge rst_n) begin
     if(!rst_n) begin
       bus_state_q <= Idle;
-    end
-    else begin
+    end else begin
       bus_state_q <= bus_state_d;
     end
   end
@@ -117,7 +116,7 @@ module i2c_protocol_cov(
 // (coverage is sampled on this signal)
 // The values of 'bus_state_d' represent the last event detected on the bus.
 //
-// bus_state_d == Idle -> no active transactions on I2C bus
+// bus_state_d == Idle -> No active transactions on I2C bus
 // bus_state_d == Start -> Detected a Start condition, and are waiting for the next
 //                         bus event. In this case, we are waiting for the next posedge of scl, at
 //                         which point we sample sda as the first bit of the address and move to the
@@ -131,25 +130,25 @@ module i2c_protocol_cov(
 //                        which would represent an ACK or NACK. Upon observing an ACK 'bus_state_d'
 //                        will be updated to ReadAddrACK else Idle.
 // bus_state_d == Write -> Detected a 'Write' event. ('sda' == '0' on posedge_scl() after
-//                        all 7 addr bits). We are now waiting for the next posedge_scl() event,
-//                        which would represent an ACK or NACK. Upon observing an ACK 'bus_state_d'
-//                        will be updated to WriteAddrACK else Idle.
+//                         all 7 addr bits). We are now waiting for the next posedge_scl() event,
+//                         which would represent an ACK or NACK. Upon observing an ACK 'bus_state_d'
+//                         will be updated to WriteAddrACK else Idle.
 // bus_state_d == WriteAddrACK -> Detected a ACK response for Write Address byte and 'bus_state_d'
 //                                will be updated to WriteData.
 // bus_state_d == ReadAddrACK -> Detected a ACK response for Read Address byte and 'bus_state_d' will
 //                               be updated to ReadData.
 // bus_state_d == ReadData -> Sample read data bytes on every posedge_scl() until complete byte is
-//                             captured.
+//                            captured.
 // bus_state_d == WriteData -> Sample write data bytes on every posedge_scl() until complete byte is
 //                             captured.
 // bus_state_d == ReadDataACK -> Detected a ACK response for Read data byte and 'bus_state_d'
-//                                will be updated to ReadData to capture next byte
+//                               will be updated to ReadData to capture next byte
 // bus_state_d == WriteDataACK -> Detected a ACK response for Write data byte and 'bus_state_d'
 //                                will be updated to WriteData to capture next byte
 // bus_state_d == WriteDataNACK -> Detected a NACK response for Write data byte. FSM remains in the
 //                                 state unless Start or Stop condition is detected
 // bus_state_d == ReadDataNACK -> Detected a NACK response for Read data byte. FSM remains in the
-//                                 state unless Start or Stop condition is detected
+//                                state unless Start or Stop condition is detected
 //////////////////////////////////
   always@(scl or sda or scl_q or sda_q) begin
     if(!rst_n) begin

--- a/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
+++ b/hw/ip/i2c/dv/sva/i2c_protocol_cov.sv
@@ -102,7 +102,6 @@ module i2c_protocol_cov(
 
   // Flop the state value that was updated on 'scl' or 'sda' events.
   // This ensures that when we sample for coverage, we don't race against new events.
-  // TODO Consider a cleaner way of achieving this.
   always@(posedge clk or negedge rst_n) begin
     if(!rst_n) begin
       bus_state_q <= Idle;


### PR DESCRIPTION
This PR is, as far as I know, the last task remaining for closing I2C verification for M2.5:
https://github.com/lowRISC/opentitan/issues/17890
Assuming V2 sign-off is merged as well: https://github.com/lowRISC/opentitan/pull/18211

It mainly puts DV TODOs into iceboxes as described in the commit messages.