### PR TITLE
[rtl/rv_core_ibex] Fix RTL assertion for CDC

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -956,7 +956,7 @@ module rv_core_ibex
         u_core.u_ibex_core.id_stage_i.instr_valid_i
         && u_core.u_ibex_core.id_stage_i.decoder_i.opcode == ibex_pkg::OPCODE_MISC_MEM
         && u_core.u_ibex_core.id_stage_i.decoder_i.instr[14:12] == 3'b001 // FENCE.I
-        |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
+        |-> ##[0:14] // upper bound is not exact, but it should not take more than a few cycles
         icache_otp_key_o.req
     )
 


### PR DESCRIPTION
Increase upper bound for cycles to wait in IbexIcacheScrambleKeyRequestAfterFenceI_A.

Partially addresses #16689
