### PR TITLE
[release] Increase timeout of CI job

### DIFF
--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -49,7 +49,7 @@ jobs:
 
 - job: build_release
   displayName: "Create the OpenTitan release"
-  timeoutInMinutes: 360
+  timeoutInMinutes: 500
   dependsOn: checkout
   pool: ci-public
   steps:


### PR DESCRIPTION
Even with a time limit of 5h (increased in 847f85160bcf396b9a5858cfcbc000a49ce380fa / PR #18952), the *Release* job still times out.  A trial run without timeout took 458min to complete.

This commit increases the timeout of the *Release* job to 500min, which is ca. 10% more than the currently expected run time to account for load variances.