### PR TITLE
[hw,spi_device,dv] Simplify the check for flash_status

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -599,59 +599,35 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     uvm_reg_data_t rdata;
     csr_rd(ral.flash_status, rdata);
     busy = get_field_val(ral.flash_status.busy, rdata);
+    `uvm_info(`gfn, $sformatf("read complete, flash_status: %x", rdata), UVM_HIGH)
   endtask
 
   virtual task clear_flash_busy_bit();
-    bit spi_txn_started = 0;
-    bit tpm_txn_started = 0;
     bit busy;
+    uint wait_txn_count = 1;
     `uvm_info(`gfn, "Clearing flash busy bit", UVM_MEDIUM)
-    csr_wr(ral.flash_status.busy, 0);
-    // Loop to detect SPI transaction and delay read check after end of SPI transaction
-    // The intent here is to check the flash_status until busy is cleared and add a delay if there
-    // is an end of SPI transaction(since flash_status gets update after CSB is deasserted)
-    // CHECK_PHASE1 of the loop is used to detect a start of transaction
-    // CHECK_PHASE2 of the loop is used to detect a end of transaction and also
-    //              check the flash_status
-    // If we do not yet detect the start or end of a transaction,
-    // we fall-through the checking each time to the final `get_flash_status_busy(busy)`,
-    // effectively reading the register in a spinwait loop.
-    `DV_SPINWAIT(
-      while(1) begin
-        // CHECK_PHASE1: Check for start of SPI transaction
-        if (!tpm_txn_started && !cfg.spi_host_agent_cfg.vif.csb[TPM_CSB_ID]) begin
-          `uvm_info(`gfn, "Detected active TPM SPI transaction during spinwait for flash_status",
-            UVM_HIGH)
-          tpm_txn_started = 1;
-        end else if (!spi_txn_started && !cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]) begin
-          `uvm_info(`gfn, "Detected active SPI transaction during spinwait for flash_status",
-            UVM_HIGH)
-          spi_txn_started = 1;
-        end
-        // CHECK_PHASE2:
-        // Check for end of SPI transaction and wait for status to update
-        if (tpm_txn_started && cfg.spi_host_agent_cfg.vif.csb[TPM_CSB_ID]) begin
-          `uvm_info(`gfn, "Detected end of TPM SPI transaction during spinwait for flash_status",
-            UVM_HIGH)
-          cfg.clk_rst_vif.wait_clks(5);
-          `uvm_info(`gfn, "Wait done after end of TPM SPI transaction", UVM_HIGH)
-          get_flash_status_busy(busy);
-          if (!busy) break;
-        end else if (spi_txn_started && cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]) begin
-          `uvm_info(`gfn, "Detected end of SPI transaction during spinwait for flash_status",
-            UVM_HIGH)
-          cfg.clk_rst_vif.wait_clks(5);
-          `uvm_info(`gfn, "Wait done after end of SPI transaction", UVM_HIGH)
-          get_flash_status_busy(busy);
-          if (!busy) break;
-        end else begin
-          // FLASH_STATUS gets updated in SPI clock domain so the register should hold the
-          // previous busy status value, read the register, scoreboard checks the value
-          get_flash_status_busy(busy);
-          if (!busy) break;
-        end
-      end
-    )
+    // Check if there is any ongoing SPI transaction
+    if (!cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]) begin
+      wait_txn_count++;
+    end
+    // clear busy bit
+    ral.flash_status.busy.set(0);
+    csr_update(ral.flash_status);
+    // The intent here is to check the flash_status after csr_wr and then read the register
+    // after end of SPI transaction (since flash_status gets update after CSB is deasserted)
+    // Wait for end of SPI transaction
+    repeat (wait_txn_count) begin
+      @(posedge cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]);
+      `uvm_info(`gfn, "Detected end of SPI transaction", UVM_HIGH)
+    end
+    // Wait for 5 cycles after deassertion of CSB to allow for flash_status to get updated
+    cfg.clk_rst_vif.wait_clks(5);
+    get_flash_status_busy(busy);
+    // If busy bit is not cleared, check once more else raise an error
+    if (busy) begin
+      get_flash_status_busy(busy);
+      `DV_CHECK_EQ(busy, 0, "flash_status.busy == 1 expected to be 0")
+    end
     `uvm_info(`gfn, "Cleared flash busy bit", UVM_MEDIUM)
   endtask
 


### PR DESCRIPTION
Read `flash_status` register after the register write and after the end of the SPI transaction, to avoid using a thread for register read.

This PR fixes corner case failures of https://github.com/lowRISC/opentitan/issues/18854 bucket 1 (partially fixed with PR https://github.com/lowRISC/opentitan/pull/18888)