### PR TITLE
[chip,dv] fix test out of sync

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -84,6 +84,11 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
+    // Add status sync at the beginning of the test
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest,
+             "wait for initial test state",
+             5_000_000)
+
     // TODO(lowRISC/opentitan:#13373): Revisit pad assignments.
     // pinmux_wkup_vif (at Iob7) is re-used for PinZ3WakeupOut
     // due to lack of unused pins. Disable the default drive


### PR DESCRIPTION
chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq uses
very delicate sync between c and sv test.
Add test sync at the beginning of the sv test to avoid out of sync when boot process takes longer than usual.