### PR TITLE
[prim_present/dv] Only test relevant configs and improve coverage

### DIFF
--- a/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
+++ b/hw/ip/prim/dv/prim_present/tb/prim_present_tb.sv
@@ -21,18 +21,20 @@ module prim_present_tb;
 // config
 //////////////////////////////////////////////////////
 
-  // Key width can be set with a define, but must be 80 or 128
-`ifdef KEY_WIDTH
-  localparam int unsigned KeyWidth = `KEY_WIDTH;
-`else
-  localparam int unsigned KeyWidth = 128;
+`ifndef KEY_WIDTH
+  `define KEY_WIDTH 128
 `endif
 
-  localparam string MSG_ID = $sformatf("%m");
+  // Key width can be set with a define, but must be 80 or 128
+  localparam int unsigned KeyWidth = `KEY_WIDTH;
 
   // used to index the data arrays
   localparam bit Encrypt = 1'b0;
   localparam bit Decrypt = 1'b1;
+  localparam bit SingleRound = 1'b0;
+  localparam bit FullRound   = 1'b1;
+
+  localparam int NumDuts = 4;
 
   // This bit can be set from the command line to indicate that we are running a smoke regression,
   // and to run just a single iteration of the test.
@@ -45,25 +47,22 @@ module prim_present_tb;
 
   // data_in[0]: encryption, data_in[1]: decryption.
   // Same scheme used for key_in, data_out, key_out.
-  logic [1:0][MaxRounds-1:0][DataWidth-1:0] data_in;
-  logic [1:0][MaxRounds-1:0][KeyWidth-1 :0] key_in;
-  logic [1:0][MaxRounds-1:0][4:0]           idx_in;
-  logic [1:0][MaxRounds-1:0][DataWidth-1:0] data_out;
-  logic [1:0][MaxRounds-1:0][KeyWidth-1 :0] key_out;
-  logic [1:0][MaxRounds-1:0][4:0]           idx_out;
+  logic [1:0][NumDuts-1:0][DataWidth-1:0] data_in;
+  logic [1:0][NumDuts-1:0][KeyWidth-1 :0] key_in;
+  logic [1:0][NumDuts-1:0][4:0]           idx_in;
+  logic [1:0][NumDuts-1:0][DataWidth-1:0] data_out;
+  logic [1:0][NumDuts-1:0][KeyWidth-1 :0] key_out;
+  logic [1:0][NumDuts-1:0][4:0]           idx_out;
 
   for (genvar j = 0; j < 2; j++) begin : gen_encrypt_decrypt
-    for (genvar k = 0; k < MaxRounds; k++) begin : gen_duts
-      if (j == 0) begin : gen_encrypt
-        assign idx_in[j][k] = 5'd1;
-      end else begin : gen_decrypt
-        assign idx_in[j][k] = 5'(k+1);
-      end
+    for (genvar k = 0; k < 2; k++) begin : gen_duts
+      localparam int NumRounds = (k > 0) ? MaxRounds : 1;
       prim_present #(
-        .DataWidth  ( DataWidth ),
-        .KeyWidth   ( KeyWidth  ),
-        .NumRounds  ( k+1       ),
-        .Decrypt    ( j         )
+        .DataWidth     ( DataWidth ),
+        .KeyWidth      ( KeyWidth  ),
+        .NumRounds     ( MaxRounds ),
+        .NumPhysRounds ( NumRounds ),
+        .Decrypt       ( j         )
       ) dut (
         .data_i     ( data_in[j][k]  ),
         .key_i      ( key_in[j][k]   ),
@@ -75,7 +74,6 @@ module prim_present_tb;
     end
   end
 
-
 //////////////////////////////////////////////////////
 // API called by the testbench to drive/check stimulus
 //////////////////////////////////////////////////////
@@ -85,63 +83,80 @@ module prim_present_tb;
   task automatic test_present(bit [DataWidth-1:0] plaintext,
                               bit [KeyWidth-1:0]  key);
 
-    bit [MaxRounds-1:0][DataWidth-1:0] encrypted_text;
-
-    check_encryption(plaintext, key, encrypted_text);
-    check_decryption(encrypted_text, key, key_out[Encrypt]);
+    bit [DataWidth-1:0] ciphertext;
+    check_encryption(plaintext, key, ciphertext);
+    check_decryption(ciphertext, key, key_out[Encrypt]);
   endtask
 
 
   // Helper task to drive plaintext and key into each encryption instance.
   // Calls a subroutine to perform checks on the outputs (once they are available).
-  task automatic check_encryption(input bit [DataWidth-1:0]                 plaintext,
-                                  input bit [KeyWidth-1:0]                  key,
-                                  output bit [MaxRounds-1:0][DataWidth-1:0] expected_ciphertext);
+  task automatic check_encryption(input bit  [DataWidth-1:0] plaintext,
+                                  input bit  [KeyWidth-1:0]  key,
+                                  output bit [DataWidth-1:0] expected_ciphertext);
 
     // Drive input into encryption instances.
-    for (int unsigned i = 0; i < MaxRounds; i++) begin
-      data_in[Encrypt][i] = plaintext;
-      key_in[Encrypt][i]  = key;
+    data_in[Encrypt] <= '{default: plaintext};
+    key_in[Encrypt]  <= '{default: key};
+    idx_in[Encrypt]  <= '{default: 5'd1};
+
+    // Iterate MaxRounds times for the single-round instance.
+    for (int unsigned i = 0; i < MaxRounds-1; i++) begin
+      #10ns;
+      data_in[Encrypt][SingleRound] <= data_out[Encrypt][SingleRound];
+      key_in[Encrypt][SingleRound]  <= key_out[Encrypt][SingleRound];
+      idx_in[Encrypt][SingleRound]  <= idx_out[Encrypt][SingleRound];
     end
 
     // Wait a bit for the DUTs to finish calculations.
-    #100ns;
+    #10ns;
 
-    for (int unsigned i = 0; i < MaxRounds; i++) begin
-      crypto_dpi_present_pkg::sv_dpi_present_encrypt(plaintext, MaxKeyWidth'(key),
-                                                     KeyWidth, i + 1, expected_ciphertext[i]);
-
-      check_output(data_out[Encrypt][i],
-                   expected_ciphertext[i],
-                   $sformatf("Encryption; %0d rounds, key width %0d", i + 1, KeyWidth));
-    end
+    crypto_dpi_present_pkg::sv_dpi_present_encrypt(plaintext, MaxKeyWidth'(key),
+                                                   KeyWidth, MaxRounds, expected_ciphertext);
+    check_output(data_out[Encrypt][SingleRound],
+                 expected_ciphertext,
+                 $sformatf("Single Round Encryption; %0d rounds, key width %0d",
+                           MaxRounds, KeyWidth));
+    check_output(data_out[Encrypt][FullRound],
+                 expected_ciphertext,
+                 $sformatf("Full Round Encryption; %0d rounds, key width %0d",
+                           MaxRounds, KeyWidth));
   endtask
 
 
   // Helper task to drive ciphertext and key into each decryption instance.
   // Calls a subroutine to perform checks on the outputs (once they are available).
-  task automatic check_decryption(input bit [MaxRounds-1:0][DataWidth-1:0]  ciphertext,
-                                  input bit [KeyWidth-1:0]                  key,
-                                  input bit [MaxRounds-1:0][KeyWidth-1:0]   decryption_keys);
+  task automatic check_decryption(input bit [DataWidth-1:0]              ciphertext,
+                                  input bit [KeyWidth-1:0]               key,
+                                  input bit [NumDuts-1:0][KeyWidth-1:0]  decryption_keys);
+    bit [DataWidth-1:0] expected_plaintext;
 
     // Drive input into decryption instances.
-    data_in[Decrypt] = ciphertext;
-    key_in[Decrypt] = decryption_keys;
+    data_in[Decrypt] <= '{default: ciphertext};
+    key_in[Decrypt]  <= decryption_keys;
+    idx_in[Decrypt]  <= '{default: 5'(MaxRounds)};
+
+    // Iterate MaxRounds times for the single-round instance.
+    for (int unsigned i = 0; i < MaxRounds-1; i++) begin
+      #10ns;
+      data_in[Decrypt][SingleRound] <= data_out[Decrypt][SingleRound];
+      key_in[Decrypt][SingleRound]  <= key_out[Decrypt][SingleRound];
+      idx_in[Decrypt][SingleRound]  <= idx_out[Decrypt][SingleRound];
+    end
 
     // Wait a bit for the DUTs to finish calculations.
-    #100ns;
+    #10ns;
 
-    // query DPI model for expected decrypted output.
-    for (int unsigned i = 0; i < MaxRounds; i++) begin
-      bit [DataWidth-1:0] expected_plaintext;
-      crypto_dpi_present_pkg::sv_dpi_present_decrypt(ciphertext[i],
-                                                     key, KeyWidth,
-                                                     i + 1,
-                                                     expected_plaintext);
-      check_output(data_out[Decrypt][i],
-                   expected_plaintext,
-                   $sformatf("Decryption; %0d rounds, key width %0d", i + 1, KeyWidth));
-    end
+    crypto_dpi_present_pkg::sv_dpi_present_decrypt(ciphertext, MaxKeyWidth'(key),
+                                                   KeyWidth, MaxRounds, expected_plaintext);
+    check_output(data_out[Decrypt][SingleRound],
+                 expected_plaintext,
+                 $sformatf("Single Round Decryption; %0d rounds, key width %0d",
+                           MaxRounds, KeyWidth));
+    check_output(data_out[Decrypt][FullRound],
+                 expected_plaintext,
+                 $sformatf("Full Round Decryption; %0d rounds, key width %0d",
+                           MaxRounds, KeyWidth));
   endtask
 
 
@@ -194,8 +209,8 @@ module prim_present_tb;
     void'($value$plusargs("smoke_test=%0b", smoke_test));
     num_trans = smoke_test ? 1 : $urandom_range(5000, 25000);
     for (int i = 0; i < num_trans; i++) begin
-      `DV_CHECK_STD_RANDOMIZE_FATAL(plaintext, "", MSG_ID)
-      `DV_CHECK_STD_RANDOMIZE_FATAL(key, "", MSG_ID)
+      randomize(plaintext);
+      randomize(key);
       test_present(plaintext, key);
     end
 
@@ -205,7 +220,6 @@ module prim_present_tb;
     $finish();
   end
 
-  // TODO: perhaps wrap this in a macro?
   initial begin
     bit poll_for_stop;
     int unsigned poll_for_stop_interval_ns;


### PR DESCRIPTION
This reoarganizes the prim_present testbench so that only the relevant instantiations are tested: 1) full round, 2) iterative single round. In particular, by emulating iterations with 2) in the testbench, the code coverage is increased substantially.