### PR TITLE
[chip,dv] add otp_vendor_test_status hook

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -109,6 +109,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Run small page rma
   bit   en_small_rma = 0;
 
+  // Add otp_ctrl test status value
+  logic [TL_DW-1:0] otp_test_status = 0;
+
   // NOTE: The clk_freq_mhz variable created in the base class was meant to be used by clk_rst_vif
   // interface that is passed by default by the testbench (retrieved by dv_base_env class). It was
   // meant for a CIP-compliant testbench to drive the clock and reset to the DUT. The chip level

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
@@ -69,7 +69,9 @@ class chip_sw_otp_ctrl_vendor_test_csr_access_vseq extends chip_sw_base_vseq;
                       cfg.chip_vif.signal_probe_otp_vendor_test_ctrl(SignalProbeSample);
 
     // In open source prim_otp module, the vendor_test_status output is tied to 0.
-    `DV_CHECK_EQ(otp_vendor_test_status, 0)
+    // For closed source module, cfg.otp_test_stastatus needs to be updated
+    // at cfg::initialize()
+    `DV_CHECK_EQ(otp_vendor_test_status, cfg.otp_test_status)
 
     // Probe vendor_test_ctrl from OTP_CTRL port to ensure that in certain lc states, the
     // vendor_test_req is not gated.


### PR DESCRIPTION
otp_vendor_test status hook is tied to zero in open source. 
Add proper place holder to update otp_vendor_test_status in closed source test