### PR TITLE
[rom] update sigverify mode behavior

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1389,10 +1389,7 @@ SIGVERIFY_MOD_EXP_CASES = [
     {
         "name": "invalid",
         "use_sw_rsa_verify": 0,
-        "exit_success": {
-            lc_state: MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else "use_sw_rsa_verify=0x00000000"
-            for lc_state, lc_state_val in get_lc_items()
-        },
+        "exit_success": {lc_state: "use_sw_rsa_verify=0x00000000" for lc_state, lc_state_val in get_lc_items()},
     },
 ]
 


### PR DESCRIPTION
We update the ROM to always read the OTP setting for what sigverify mode to use (SW vs OTBN), regardless of the LC state (previously, the mode setting was only read from OTP when the LC state was NOT TEST_UNLOCKED*).

Additionally, we default the sigverify mode to SW, if the `CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN` field OTP is uninitialized (i.e., all 0s).

We make these changes because we want to run GLS tests in the TEST_UNLOCKED* LC state using the real ROM, and not enabling the use of OTBN signature verification causes GLS runtimes to explode.