### PR TITLE
[i2c, test] Appended a reset and test run to the compass device test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1915,6 +1915,7 @@ opentitan_functest(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",

--- a/sw/device/tests/i2c_host_compass_test.c
+++ b/sw/device/tests/i2c_host_compass_test.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
@@ -114,6 +115,22 @@ static status_t test_init(void) {
   return OK_STATUS();
 }
 
+static status_t reset_i2c_and_check(void) {
+  dif_rstmgr_t rstmgr;
+  TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR),
+                      &rstmgr));
+
+  TRY(dif_rstmgr_software_reset(&rstmgr, kTopEarlgreyResetManagerSwResetsI2c2,
+                                kDifRstmgrSoftwareReset));
+
+  dif_i2c_status_t i2c_status;
+  TRY(dif_i2c_get_status(&i2c, &i2c_status));
+  TRY_CHECK(!i2c_status.enable_host, "I2C doesn't appear to have been reset.");
+
+  TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t test_result;
   CHECK_STATUS_OK(test_init());
@@ -126,6 +143,12 @@ bool test_main(void) {
     EXECUTE_TEST(test_result, read_product_id);
     EXECUTE_TEST(test_result, take_measurement);
   }
+
+  // Reset the i2c peripheral and re-run a test
+  // to check the peripheral works after reset.
+  CHECK_STATUS_OK(reset_i2c_and_check());
+  CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFast));
+  EXECUTE_TEST(test_result, read_product_id);
 
   return status_ok(test_result);
 }


### PR DESCRIPTION
Appended a reset and re-test to the compass test to check the i2c peripheral functions after a reset.

This should tick "Reset via Reset manager" in https://github.com/lowRISC/opentitan/issues/18711.