### PR TITLE
[rv_timer/dv] Increase timeout for random test

### DIFF
--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -52,6 +52,7 @@
       name: rv_timer_random
       uvm_test_seq: rv_timer_random_vseq
       reseed: 200
+      run_opts: ["+test_timeout_ns=10000000000"]
     }
 
     {


### PR DESCRIPTION
`rv_timer_random` seems to occasionally fail in the nightlies due to a timeout.
This increases the timeout by 10x so that there is plenty of margin.