### PR TITLE
[i2c, test] Removed early return in compass test.

### DIFF
--- a/sw/device/tests/i2c_host_compass_test.c
+++ b/sw/device/tests/i2c_host_compass_test.c
@@ -52,7 +52,6 @@ static dif_pinmux_t pinmux;
 static dif_i2c_t i2c;
 
 static status_t read_product_id(void) {
-  return OK_STATUS();
   uint8_t reg = kProductIdReg, data = 0;
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, 1, &reg, true));
   TRY(i2c_testutils_read(&i2c, kDeviceAddr, 1, &data, kDefaultTimeoutMicros));


### PR DESCRIPTION
There's an early return in the compass test. That means the product id is never tested.