### PR TITLE
[hw,top_earlgrey,dv] Fixes for I2C test failures with CDC

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_device_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_device_tx_rx_vseq.sv
@@ -97,6 +97,9 @@ class chip_sw_i2c_device_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupStop = half_period_cycles - 2;
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldStop = half_period_cycles;
 
+    // Wait for 1 cycles before releasing SDA line to account for CDC delays
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
+
     // Wait for i2c_device to fill tx_fifo
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Data written to fifo");
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
@@ -49,7 +49,10 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     // the DUT, but instead is used by the i2c agent to simulate when it should begin
     // driving data.  The i2c agent drives to drive data as late as possible.
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow = half_period_cycles - 2;
-
+    // Drive SDA a cycle early to account for CDC delays
+    if (cfg.en_dv_cdc) begin
+      cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow--;
+    end
     // tClockPulse needs to be "slightly" longer than the clock period.
     cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse = half_period_cycles + 1;
 

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -86,6 +86,9 @@ void ottf_external_isr(void) {
       done_irq_seen = true;
       i2c_irq = kDifI2cIrqCmdComplete;
       break;
+    // TODO: remove after #17811 is fixed
+    case kDifI2cIrqSdaInterference:
+      break;
     default:
       LOG_ERROR("Unexpected interrupt (at I2C): %d", i2c_irq);
       break;


### PR DESCRIPTION
- Update `tClockLow` parameter to account for CDC delays on SDA. If this parameter is set to 0, both SDA and SCL toggle at the same time causing glitches when CDC randomization is enabled.
- Skip processing sda_interference interrupt, as there is a software workaround for this (https://github.com/lowRISC/opentitan/issues/17811)