### PR TITLE
[bazel] fix bug in ot_python_wheels repo setup

### DIFF
--- a/third_party/python/gen_requirements.sh
+++ b/third_party/python/gen_requirements.sh
@@ -8,13 +8,13 @@
 
 set -e
 
-WHEEL_DIR="./"
+WHEEL_DIR="."
 OUTPUT_FILE="sanitized_requirements.txt"
 
 for wheel in $(ls -1 ${WHEEL_DIR}/*.whl); do
   wheel_basename=$(echo ${wheel} | tr '\n' '\0' | xargs -0 -n 1 basename)
-  IFS='-' read -ra WHEEL_NAME_ARRAY <<< ${wheel_basename}
+  IFS='-' read -ra WHEEL_NAME_ARRAY <<<"${wheel_basename}"
   PACKAGE_NAME=${WHEEL_NAME_ARRAY[0]}
   PACKAGE_VERSION=${WHEEL_NAME_ARRAY[1]}
-  echo "${PACKAGE_NAME}==${PACKAGE_VERSION}" >> ${OUTPUT_FILE}
+  echo "${PACKAGE_NAME}==${PACKAGE_VERSION}" >>${OUTPUT_FILE}
 done


### PR DESCRIPTION
The bash script that prepares the sanitized package list did not work on different bash versions due to missing quotes.