### PR TITLE
[device] OTTF status report queue improvements

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_main.h
+++ b/sw/device/lib/testing/test_framework/ottf_main.h
@@ -130,4 +130,13 @@ char *ottf_task_get_self_name(void);
     }                                                                    \
   } while (0)
 
+/**
+ * Override the default status report list size. This list is used to store
+ * error statuses in case of failed TRY() and are reported when the test
+ * fails. This must be used at the global scope.
+ */
+#define OTTF_OVERRIDE_STATUS_REPORT_LIST(list_size) \
+  const size_t kStatusReportListSize = list_size;   \
+  status_t status_report_list[list_size];
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MAIN_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2702,3 +2702,28 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+_STATUS_REPORT_OVERFLOW_TEST_MSG = "\r\n".join([
+    ".*ottf_main.c:.* Status reported by the test:",
+    ".*ottf_main.c:.* - Aborted.*",
+    ".*ottf_main.c:.* - Unavailable.*",
+    ".*ottf_main.c:.* - Cancelled.*",
+    ".*ottf_main.c:.* Some statuses have been lost.*",
+    ".*status.c:.* FAIL!",
+])
+
+opentitan_functest(
+    name = "status_report_overflow_test",
+    srcs = ["status_report_overflow_test.c"],
+    cw310 = cw310_params(
+        exit_failure = "PASS!",
+        exit_success = _STATUS_REPORT_OVERFLOW_TEST_MSG,
+    ),
+    targets = [
+        "cw310_test_rom",
+    ],
+    deps = [
+        "//sw/device/lib/base:status_report_unittest_c",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2679,10 +2679,11 @@ opentitan_functest(
 )
 
 _STATUS_REPORT_TEST_MSG = "\r\n".join([
-    ".*ottf_main.c:.* - Ok:654321",
-    ".*ottf_main.c:.* - PermissionDenied:\\[\\\"PSY\\\",2.\\]",
-    ".*ottf_main.c:.* - Aborted:\\[\\\"UNT\\\",4.\\]",
+    ".*ottf_main.c:.* Status reported by the test:",
     ".*ottf_main.c:.* - Aborted:\\[\\\"THK\\\",2.\\]",
+    ".*ottf_main.c:.* - Aborted:\\[\\\"UNT\\\",4.\\]",
+    ".*ottf_main.c:.* - PermissionDenied:\\[\\\"PSY\\\",2.\\]",
+    ".*ottf_main.c:.* - Ok:654321",
     ".*status.c:.* FAIL!",
 ])
 

--- a/sw/device/tests/status_report_overflow_test.c
+++ b/sw/device/tests/status_report_overflow_test.c
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/status_report_unittest_c.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+OTTF_OVERRIDE_STATUS_REPORT_LIST(3)
+
+bool test_main(void) {
+  // Manually push items on the stack to overflow the list.
+  for (size_t i = 0; i < 100; i++)
+    status_report(UNKNOWN());
+  status_report(DEADLINE_EXCEEDED());
+  status_report(CANCELLED());
+  status_report(UNAVAILABLE());
+  status_report(ABORTED());
+  // Make the test fails so it prints the status.
+  return false;
+}


### PR DESCRIPTION
See #17703

- add mecanism to override the list size
- add unittest to exercise the behavior in case of overflow

This PR changes the behaviour on overflow: it now records the last N reports (N=size of the list) and prints it backwards.