### PR TITLE
[edn/dv] Fix `edn_disable_auto_req_mode_vseq` and a few smaller problems in `edn_base_vseq`

### DIFF
--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -25,6 +25,8 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   // Variables
   uint   reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
 
+  bit abort_sw_cmd = 0;
+
   // Knobs & Weights
   uint   enable_pct, boot_req_mode_pct, auto_req_mode_pct, cmd_fifo_rst_pct,
          force_disable_pct,

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -56,6 +56,8 @@ class edn_base_vseq extends cip_base_vseq #(
 
   virtual task edn_init(string reset_kind = "HARD");
 
+    additional_data = 0;
+
     if (cfg.use_invalid_mubi) begin
       // Turn off DUT assertions so that the corresponding alert can fire
       cfg.edn_assert_vif.assert_off_alert();

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -16,7 +16,7 @@ class edn_base_vseq extends cip_base_vseq #(
   bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]   fips;
   mubi4_t                                       flags;
   bit [3:0]                                     clen, additional_data;
-  bit [18:0]                                    glen;
+  bit [11:0]                                    glen;
   bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0]        cmd_data;
 
   rand bit                                      set_regwen;

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -48,6 +48,9 @@ class edn_base_vseq extends cip_base_vseq #(
   virtual task device_init();
     csrng_device_seq   m_dev_seq;
 
+    // Let CSRNG agent know that EDN interface is no longer disabled.
+    cfg.edn_vif.drive_edn_disable(0);
+
     m_dev_seq = csrng_device_seq::type_id::create("m_dev_seq");
     fork
       m_dev_seq.start(p_sequencer.csrng_sequencer_h);

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -40,8 +40,8 @@ class edn_base_vseq extends cip_base_vseq #(
 
     if (do_edn_init) begin
       // Initialize DUT and start device sequence
-      edn_init();
       device_init();
+      edn_init();
     end
   endtask
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -87,11 +87,9 @@ class edn_base_vseq extends cip_base_vseq #(
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
         csr_wr(.ptr(ral.generate_cmd), .value(cmd_data));
       end
-      ral.ctrl.cmd_fifo_rst.set(MuBi4True);
-      csr_update(.csr(ral.ctrl));
+      csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4True));
       // TODO: Verify can't write until reset
-      ral.ctrl.cmd_fifo_rst.set(MuBi4False);
-      csr_update(.csr(ral.ctrl));
+      csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4False));
 
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -81,12 +81,6 @@ class edn_base_vseq extends cip_base_vseq #(
       end
     end
 
-    // Enable edn, set modes
-    ral.ctrl.edn_enable.set(cfg.enable);
-    ral.ctrl.boot_req_mode.set(cfg.boot_req_mode);
-    ral.ctrl.auto_req_mode.set(cfg.auto_req_mode);
-    csr_update(.csr(ral.ctrl));
-
     if (cfg.auto_req_mode == MuBi4True) begin
       // Verify CMD_FIFO_RST bit
       for (int i = 0; i < 13; i++) begin
@@ -118,6 +112,12 @@ class edn_base_vseq extends cip_base_vseq #(
         wr_cmd(.cmd_type("generate"), .cmd_data(cmd_data));
       end
     end
+
+    // Enable edn, set modes
+    ral.ctrl.edn_enable.set(cfg.enable);
+    ral.ctrl.boot_req_mode.set(cfg.boot_req_mode);
+    ral.ctrl.auto_req_mode.set(cfg.auto_req_mode);
+    csr_update(.csr(ral.ctrl));
 
     // If set_regwen is set, write random value to the EDN, and expect the write won't be taken.
     if (set_regwen) begin

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -9,69 +9,128 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
   push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)
       m_endpoint_pull_seq[MAX_NUM_ENDPOINTS];
 
-  uint   num_ep_reqs, num_cs_reqs, wait_disable;
-  bit    csrng_init_done;
+  mailbox mbox_kill_endpoint_reqs, mbox_kill_edn_init;
+  bit edn_reenable_done;
+  bit [MAX_NUM_ENDPOINTS-1:0] endpoint_reqs_done;
 
-  virtual task rand_toggle_edn_enable();
-    bit [TL_DW-1:0] ctrl_val;
-    string main_sm_d_path = "tb.dut.u_edn_core.u_edn_main_sm.state_d";
-    // TODO: modify wr_cmd and add back AutoLoadIns.
-    state_e auto_req_sts[$] = {AutoFirstAckWait, AutoAckWait, AutoDispatch,
-            AutoCaptGenCnt, AutoSendGenCmd, AutoCaptReseedCnt, AutoSendReseedCmd};
+  task await_random_main_sm_auto_state();
+    string state_path;
+    state_e exp_state;
+    state_path = cfg.edn_vif.sm_err_path("edn_main_sm");
 
-    // CSRNG requests will drop if disablement is sent.
-    $assertoff(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
-    $assertoff(0, "tb.csrng_if.cmd_push_if.ValidHighUntilReady_A");
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(exp_state,
+                                       exp_state inside {AutoLoadIns, AutoFirstAckWait, AutoAckWait,
+                                                         AutoDispatch, AutoCaptGenCnt,
+                                                         AutoSendGenCmd, AutoCaptReseedCnt,
+                                                         AutoSendReseedCmd};)
 
-    // Random delay, disable edn
-    if ($urandom_range(0, 1)) begin
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wait_disable,
-                                         wait_disable inside
-                                         { [20:300] };)
-      cfg.clk_rst_vif.wait_clks(wait_disable);
-      `uvm_info(`gfn, $sformatf("Wait %0d clk cycles then issue edn disablement",
-                 wait_disable), UVM_HIGH)
-    end else begin
-      bit [8:0] state_val;
-      int rand_st_idx = $urandom_range(0, auto_req_sts.size()-1);
-      `uvm_info(`gfn, $sformatf("Wait until %0s state then issue edn disablement",
-                auto_req_sts[rand_st_idx].name), UVM_HIGH)
-      `DV_SPINWAIT(
-          while (state_val != auto_req_sts[rand_st_idx]) begin
-            `DV_CHECK(uvm_hdl_read(main_sm_d_path, state_val))
-            cfg.clk_rst_vif.wait_n_clks(1);
-          end)
-    end
-
-    `DV_WAIT(csrng_init_done);
-    wait_no_outstanding_access();
-    ctrl_val = {MuBi4False, MuBi4True, MuBi4False, MuBi4False};
-    csr_wr(.ptr(ral.ctrl), .value(ctrl_val));
-    cfg.edn_vif.drive_edn_disable(1);
-    cfg.clk_rst_vif.wait_clks($urandom_range(10, 50));
-
-    // Reset EDN fifos
-    csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4True));
-    csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4False));
-
-    // Enable edn
-    wait_no_outstanding_access();
-    cfg.edn_vif.drive_edn_disable(0);
-    edn_init();
-
-    // Send instantiate cmd after EDN is re-abled for auto_req_mode.
-    instantiate_csrng();
-    `uvm_info(`gfn, "EDN toggle enable field task done", UVM_HIGH);
+    `uvm_info(`gfn, $sformatf("Waiting for main_sm to reach state %s.", exp_state.name()), UVM_LOW)
+    `DV_SPINWAIT(
+      forever begin
+        uvm_hdl_data_t val;
+        state_e act_state;
+        cfg.clk_rst_vif.wait_n_clks(1);
+        `DV_CHECK(uvm_hdl_read(state_path, val))
+        act_state = state_e'(val);
+        if (act_state == exp_state) break;
+      end
+    )
   endtask
 
-  task body();
-    bit edn_enable_toggle_done;
-    bit [MAX_NUM_ENDPOINTS-1:0] edn_reqs, edn_done;
-    super.body();
+  task disable_edn(bit backdoor);
+    bit [TL_DW-1:0] ctrl_val;
+
+    // Write EDN's control CSR.
+    ctrl_val = {MuBi4False, MuBi4True, MuBi4False, MuBi4False};
+    if (!backdoor) wait_no_outstanding_access();
+    csr_wr(.ptr(ral.ctrl), .value(ctrl_val), .backdoor(backdoor), .predict(backdoor));
+
+    // Let CSRNG agent know that EDN is disabled.
+    cfg.edn_vif.drive_edn_disable(1);
+  endtask
+
+  task randomly_disable_edn();
+    if ($urandom_range(1, 10) > 8) begin
+      uint wait_disable;
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(wait_disable, wait_disable inside { [1:300] };)
+      `uvm_info(`gfn, $sformatf("Waiting %0d clock cycles before disabling EDN.", wait_disable),
+                UVM_LOW)
+      cfg.clk_rst_vif.wait_n_clks(wait_disable);
+    end else begin
+      await_random_main_sm_auto_state();
+    end
+
+    `uvm_info(`gfn, $sformatf("Wait complete, disabling EDN."), UVM_LOW)
+    disable_edn(.backdoor(1));
+  endtask
+
+  virtual task pre_start();
+    // Initialize variables for inter-thread communication.
+    mbox_kill_endpoint_reqs = new();
+    mbox_kill_edn_init = new();
+    edn_reenable_done = 0;
+
+    // Create background thread that randomly disables EDN and later re-enables it.
+    fork
+      begin
+        bit unused;
+        // Wait for EDN to come out of reset.
+        wait(cfg.clk_rst_vif.rst_n);
+        // Disable EDN after a random number of cycles or in a random state.
+        randomly_disable_edn();
+        // Abort any open SW commands and wait for CSR accesses to complete, as simply killing their
+        // thread would create problems later due to unterminated accesses.
+        cfg.abort_sw_cmd = 1;
+        wait_no_outstanding_access();
+        // Kill EDN initialization and endpoint requests if necessary.
+        mbox_kill_edn_init.put(1);
+        mbox_kill_endpoint_reqs.put(1);
+        // Wait before re-enabling EDN.
+        `uvm_info(`gfn, $sformatf("Waiting before re-enabling EDN"), UVM_LOW)
+        cfg.clk_rst_vif.wait_n_clks($urandom_range(1, 1000));
+        `uvm_info(`gfn, $sformatf("Wait complete"), UVM_LOW)
+        // Empty mailbox (necessary in case the previous EDN initialization completed before we
+        // killed it).
+        void'(mbox_kill_edn_init.try_get(unused));
+        cfg.abort_sw_cmd = 0;
+        // Let CSRNG know that we're re-enabling EDN.
+        device_init();
+        // Initialize EDN again -- this time without randomly disabling EDN.
+        `uvm_info(`gfn, $sformatf("Re-enabling EDN"), UVM_LOW)
+        edn_init();
+        endpoint_reqs();
+        edn_reenable_done = 1;
+      end
+    join_none
+
+    super.pre_start();
+  endtask
+
+  virtual task edn_init(string reset_kind = "HARD");
+    `DV_SPINWAIT_EXIT(
+        // Main thread: Initialize EDN, write Instantiate command, and set the maximum number of
+        // requests between reseeds to 1 (to maximize coverage over time).
+        super.edn_init();
+        cfg.clk_rst_vif.wait_clks(1);
+        instantiate_csrng();
+        csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(1));
+      ,
+        // Exit thread: Wait for a signal from the thread that randomly disables EDN.
+        bit unused;
+        mbox_kill_edn_init.get(unused);
+      , "Killed edn_init thread."
+    )
+  endtask
+
+  task endpoint_reqs();
+    bit [MAX_NUM_ENDPOINTS-1:0] edn_reqs;
+    uint num_cs_reqs, num_ep_reqs;
     num_cs_reqs    = cfg.num_endpoints;
     num_ep_reqs    = num_cs_reqs * csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH;
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(edn_reqs, $countones(edn_reqs) == cfg.num_endpoints;)
+
+    endpoint_reqs_done = '0;
 
     for (int i = 0; i < MAX_NUM_ENDPOINTS; i++) begin
       automatic int j = i;
@@ -85,38 +144,40 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
           // Start endpoint_pull sequences
           m_endpoint_pull_seq[j].start
               (p_sequencer.endpoint_sequencer_h[j]);
-          edn_done[j] = 1;
-          `uvm_info(`gfn, $sformatf("EDN requesters %0h, current status %0h", edn_reqs, edn_done),
-                    UVM_HIGH)
+
+          endpoint_reqs_done[j] = 1;
         end join_none;
+      end else begin
+        endpoint_reqs_done[j] = 1;
       end
     end
+  endtask
 
-    // Instantiated CSRNG to enable EDN auto_req_mode.
-    fork begin
-      // Reseed as frequently as possible so we can hit more FSM coverage.
-      csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(1));
-      instantiate_csrng();
-      csrng_init_done = 1;
-    end join_none;
+  task body();
+    super.body();
 
-    fork begin
-      rand_toggle_edn_enable();
-      edn_enable_toggle_done = 1;
-    end join_none;
+    `DV_SPINWAIT_EXIT(
+        // Thread 1: Start EDN endpoint requests, which is non-blocking, and keep the thread running
+        // until it gets killed.
+        endpoint_reqs();
+        wait(0);
+      ,
+        // Thread 2: Wait for signal to kill the other thread.
+        bit unused;
+        mbox_kill_endpoint_reqs.get(unused);
+      , "Killed endpoint_reqs in body"
+    )
 
-    // Wait for EDN disablement/enablement done, and wait for EDN request done,
-    // then disable csrng_device_driver to exit the sequence.
-    // Otherwise the testbench will hanging at waiting for more EDN requests.
-    `DV_WAIT(edn_enable_toggle_done == 1);
-    `DV_WAIT(edn_done == edn_reqs);
-    `uvm_info(`gfn, "The body of the sequence ended", UVM_HIGH);
+    `DV_WAIT(edn_reenable_done)
+    `uvm_info(`gfn, $sformatf("EDN re-enable done"), UVM_LOW)
+    `DV_WAIT(endpoint_reqs_done == '1)
+    `uvm_info(`gfn, $sformatf("endpoint reqs done"), UVM_LOW)
   endtask
 
   virtual task post_start();
     super.post_start();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
-    // Add a EDN disablement to terminate all the pending transactions in auto_req_mode.
+    // Disable EDN to terminate all the pending transactions in auto_req_mode.
     cfg.edn_vif.drive_edn_disable(1);
     csr_wr(.ptr(ral.ctrl.edn_enable), .value(MuBi4False));
   endtask


### PR DESCRIPTION
The first 7 commits fix smaller problems in `edn_base_vseq`; the last commit rewrites `edn_disable_auto_req_mode_vseq` to fix its coverage and functional checking problems. Please see the individual commit messages for details. Reviewing commit by commit is highly recommended.

A full regression run showed an overall FSM coverage of 98.5% (98% in Main FSM, 100% in Ack FSM, though dvsim reported only 94%). This PR thus resolves #18370 (together with the already merged PRs #18960 and #18976). Test pass rates are nominal.

The rewrite of `edn_disable_auto_req_mode_vseq` also addresses the missing disable-and-re-enable testing in Auto mode. Thus, this PR also resolves #16429 (as Boot mode already got tested in `edn_disable_vseq`).