### PR TITLE
[i2c,dv] Various timing fixes for the agent and CDC

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -11,6 +11,9 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   timing_cfg_t    timing_cfg;
   bit host_stretch_test_mode = 0;
+  // If 1, perform clock stretching after an ACK, just before the next data
+  // bit. If 0, perform stretching during the ACK / NACK bit.
+  bit stretch_after_ack = 0;
 
   virtual i2c_if  vif;
 

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -135,6 +135,9 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
       end
       HostStop: begin
         cfg.vif.drv_phase = DrvStop;
+        // If SCL is paused high, wait for it to fall.
+        `DV_WAIT(cfg.vif.scl_i === 1'b0,, scl_spinwait_timeout_ns, "drive_host_item HostStop")
+        // Now disable the SCL drive thread.
         cfg.host_scl_stop = 1;
         cfg.vif.host_stop(cfg.timing_cfg);
         if (cfg.allow_bad_addr & !cfg.valid_addr) begin
@@ -226,6 +229,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
             cfg.vif.scl_o <= 1'b0;
             cfg.vif.wait_for_dly(cfg.timing_cfg.tClockLow);
             cfg.vif.wait_for_dly(cfg.timing_cfg.tSetupBit);
+            if (cfg.host_scl_stop) break;
             cfg.vif.scl_o <= 1'b1;
             `DV_WAIT(cfg.vif.scl_i === 1'b1,, scl_spinwait_timeout_ns, "i2c_drv_scl")
             cfg.vif.wait_for_dly(cfg.timing_cfg.tClockPulse);

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -169,7 +169,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
       RdData: begin
         `uvm_info(`gfn, $sformatf("Send readback data %0x", req.rdata), UVM_MEDIUM)
         for (int i = 7; i >= 0; i--) begin
-          cfg.vif.device_send_bit(cfg.timing_cfg, req.rdata[i]);
+          cfg.vif.device_send_bit(cfg.timing_cfg, req.rdata[i], 1'b0);
         end
         `uvm_info(`gfn, $sformatf("\n  device_driver, trans %0d, byte %0d  %0x",
             req.tran_id, req.num_data+1, rd_data[rd_data_cnt]), UVM_DEBUG)

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -235,8 +235,8 @@ interface i2c_if(
     sda_o = 1'b1;
   endtask: device_send_bit
 
-  task automatic device_send_ack(ref timing_cfg_t tc);
-    device_send_bit(tc, 1'b0, 1'b1); // special case for ack bit
+  task automatic device_send_ack(ref timing_cfg_t tc, input bit can_stretch);
+    device_send_bit(tc, 1'b0, can_stretch); // special case for ack bit
   endtask: device_send_ack
 
   // when the I2C module is in transmit mode, `scl_interference` interrupt
@@ -334,6 +334,9 @@ interface i2c_if(
     sda_o = 1'b1;
     wait_for_dly(tc.tSetupBit);
     scl_o = 1'b1;
+    // The agent is allowing SCL to go high, but the device might not be. Wait
+    // until the device stops pulling it low.
+    wait(scl_i === 1'b1);
     wait_for_dly(tc.tClockPulse);
     scl_o = 1'b0;
     wait_for_dly(tc.tHoldBit);

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -320,9 +320,11 @@ interface i2c_if(
     // Ensure SDA Is low before SCL positive edge so a low to high transition can be generated. If
     // SCL is high already SDA will be low already due to check above.
     sda_o = 1'b0;
-    wait(scl_i === 1'b1);
     wait_for_dly(tc.tClockStop);
     scl_o = 1'b1;
+    // The agent is allowing SCL to go high, but the device might not be. Wait
+    // until the device stops pulling it low.
+    wait(scl_i === 1'b1);
     wait_for_dly(tc.tSetupStop);
     sda_o = 1'b1;
     wait_for_dly(tc.tHoldStop);

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -261,7 +261,10 @@
       tests: ["i2c_target_smoke", "i2c_target_stress_wr",
               "i2c_target_stress_rd", "i2c_target_stretch",
               "i2c_target_intr_smoke", "i2c_target_intr_stress_wr",
-              "i2c_target_timeout"]
+              "i2c_target_timeout", "i2c_target_unexp_stop",
+              "i2c_target_glitch", "i2c_target_perf", "i2c_target_tx_ovf",
+              "i2c_target_fifo_reset_acq", "i2c_target_fifo_reset_tx",
+              "i2c_target_bad_addr", "i2c_target_hrst"]
     }
   ]
 }

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -229,7 +229,8 @@
     {
       name: "i2c_target_stress_all_with_rand_reset"
       uvm_test_seq: "i2c_common_vseq"
-      run_opts: ["+run_stress_all_with_rand_reset",
+      run_opts: ["+i2c_agent_mode=Host",
+                 "+run_stress_all_with_rand_reset",
                  "+stress_seq=i2c_target_stress_all_vseq"]
       run_timeout_mins: 20
     }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_host_tx_rx_vseq.sv
@@ -17,6 +17,7 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     bit[7:0] rise_fall_nanos_arr[1] = {rise_fall_nanos};
     bit[7:0] i2c_clock_period_nanos_arr[4] = {<<byte{i2c_clock_period_nanos}};
     bit[7:0] i2c_idx_arr[1];
+    bit[7:0] i2c_cdc_enabled_arr[1];
 
     void'($value$plusargs("i2c_idx=%0d", i2c_idx));
     `DV_CHECK(i2c_idx inside {[0:NUM_I2CS-1]})
@@ -28,9 +29,14 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     sw_symbol_backdoor_overwrite("kI2cRiseFallNanos", rise_fall_nanos_arr);
     sw_symbol_backdoor_overwrite("kI2cClockPeriodNanos", i2c_clock_period_nanos_arr);
     sw_symbol_backdoor_overwrite("kI2cIdx", i2c_idx_arr);
+    if (cfg.en_dv_cdc) begin
+      i2c_cdc_enabled_arr = {8'd1};
+      sw_symbol_backdoor_overwrite("kI2cCdcInstrumentationEnabled", i2c_cdc_enabled_arr);
+    end
   endtask
 
   virtual task body();
+    int tSetupBit;
     super.body();
 
     // enable the monitor
@@ -47,12 +53,22 @@ class chip_sw_i2c_host_tx_rx_vseq extends chip_sw_i2c_tx_rx_vseq;
     // After fixing #15003, the clock low needs to be shortened by 1 additional cycle
     // to account for delayed output. The ClockLow value is not used to program
     // the DUT, but instead is used by the i2c agent to simulate when it should begin
-    // driving data.  The i2c agent drives to drive data as late as possible.
-    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow = half_period_cycles - 2;
+    // driving data.  The i2c agent drives data as late as possible.
+    tSetupBit = 2;
+    // Nullify the CDC instrumentation delays on the input synchronizers,
+    // since SDA never truly changes simultaneously with SCL. Their happening
+    // on the same cycle in simulation is due to time/cycle quantization.
+    // Drive SDA a cycle early to account for CDC delays, if CDC is enabled.
+    // Hold SDA a cycle longer to account for CDC delays, if CDC is enabled.
+    if (cfg.en_dv_cdc) begin
+      tSetupBit++;
+      cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit = 1;
+    end
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupBit = tSetupBit;
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow = half_period_cycles - tSetupBit;
+    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse = half_period_cycles;
 
-    // tClockPulse needs to be "slightly" longer than the clock period.
-    cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse = half_period_cycles + 1;
-
+    print_i2c_timing_cfg(i2c_idx);
     i2c_device_autoresponder();
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -15,4 +15,41 @@ class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
   int clock_period_cycles = ((i2c_clock_period_nanos - 1) / clock_period_nanos) + 1;
   int half_period_cycles = ((i2c_clock_period_nanos/2 - 1) / clock_period_nanos) + 1;
 
+  function print_i2c_timing_cfg(uint i2c_idx);
+    string str;
+    str = {str, $sformatf("\n    timing_cfg.tSetupStart       : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupStart)};
+    str = {str, $sformatf("\n    timing_cfg.tHoldStart        : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldStart)};
+    str = {str, $sformatf("\n    timing_cfg.tClockStart       : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockStart)};
+    str = {str, $sformatf("\n    timing_cfg.tClockLow         : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockLow)};
+    str = {str, $sformatf("\n    timing_cfg.tSetupBit         : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupBit)};
+    str = {str, $sformatf("\n    timing_cfg.tClockPulse       : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockPulse)};
+    str = {str, $sformatf("\n    timing_cfg.tHoldBit          : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldBit)};
+    str = {str, $sformatf("\n    timing_cfg.tClockStop        : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tClockStop)};
+    str = {str, $sformatf("\n    timing_cfg.tSetupStop        : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupStop)};
+    str = {str, $sformatf("\n    timing_cfg.tHoldStop         : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tHoldStop)};
+    str = {str, $sformatf("\n    timing_cfg.tTimeOut          : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tTimeOut)};
+    str = {str, $sformatf("\n    timing_cfg.enbTimeOut        : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.enbTimeOut)};
+    str = {str, $sformatf("\n    timing_cfg.tStretchHostClock : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tStretchHostClock)};
+    str = {str, $sformatf("\n    timing_cfg.tSdaUnstable      : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSdaUnstable)};
+    str = {str, $sformatf("\n    timing_cfg.tSdaInterference  : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSdaInterference)};
+    str = {str, $sformatf("\n    timing_cfg.tSclInterference  : %d",
+              cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSclInterference)};
+    `uvm_info(`gfn, $sformatf("%s", str), UVM_MEDIUM);
+  endfunction
+
 endclass : chip_sw_i2c_tx_rx_vseq

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -37,6 +37,7 @@ OTTF_DEFINE_TEST_CONFIG();
 static volatile const uint8_t kClockPeriodNanos = 0;
 static volatile const uint8_t kI2cRiseFallNanos = 0;
 static volatile const uint32_t kI2cClockPeriodNanos = 0;
+static volatile const uint8_t kI2cCdcInstrumentationEnabled = 0;
 
 /**
  * This symbol is meant to be backdoor loaded by the testbench.
@@ -308,6 +309,12 @@ bool test_main(void) {
 
   dif_i2c_config_t config;
   CHECK_DIF_OK(dif_i2c_compute_timing(timing_config, &config));
+  if (kI2cCdcInstrumentationEnabled) {
+    // Increase rise cycles to accommodate CDC incorrectly delaying the data
+    // change. Without this, the SDA interference interrupt will be triggered
+    // when the prim_flop_2sync randomly adds an extra cycle of delay.
+    config.rise_cycles++;
+  }
   CHECK_DIF_OK(dif_i2c_configure(&i2c, config));
   CHECK_DIF_OK(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   CHECK_DIF_OK(


### PR DESCRIPTION
This is kind of a grab bag of timing and other fixes, where each individual commit addresses something different.

There are a couple other changes I haven't yet pushed up, but this set should eliminate errors for target mode tests (except I haven't done the target_stress_all* tests yet).

### Test Results
|  Stage  |         Name         | Tests                     |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:--------------------:|:--------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |     target_smoke     | i2c_target_smoke          |      19.100s      |     9.073ms      |    50     |   50    |  100.00 %   |
|   V1    |                      | **TOTAL**                 |                   |                  |    50     |   50    |  100.00 %   |
|   V2    |  target_fifo_empty   | i2c_target_stress_rd      |      33.710s      |     3.805ms      |    50     |   50    |  100.00 %   |
|         |                      | i2c_target_intr_smoke     |      2.710s       |     2.285ms      |    50     |   50    |  100.00 %   |
|   V2    |   target_fifo_full   | i2c_target_stress_rd      |      33.710s      |     3.805ms      |    50     |   50    |  100.00 %   |
|         |                      | i2c_target_intr_stress_wr |      35.400s      |     64.277ms     |    50     |   50    |  100.00 %   |
|         |                      | i2c_target_stress_wr      |      47.100s      |     66.840ms     |    50     |   50    |  100.00 %   |
|   V2    |    target_timeout    | i2c_target_timeout        |      2.740s       |     11.990ms     |    49     |   50    |   98.00 %   |
|   V2    | target_clock_stretch | i2c_target_stretch        |      9.745m       |     46.677ms     |    50     |   50    |  100.00 %   |
|   V2    |                      | **TOTAL**                 |                   |                  |    299    |   300   |   99.67 %   |
|         |                      | **TOTAL**                 |                   |                  |    349    |   350   |   99.71 %   |

### Test Results
|  Stage  |         Name         | Tests                     |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:--------------------:|:--------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2    |  target_error_intr   | i2c_target_unexp_stop     |      3.070s       |     18.028ms     |    50     |   50    |  100.00 %   |
|   V2    |    target_glitch     | i2c_target_glitch         |      1.460s       |     5.721ms      |     2     |    2    |  100.00 %   |
|   V2    |     target_perf      | i2c_target_perf           |      1.910s       |    914.762us     |    50     |   50    |  100.00 %   |
|   V2    | target_fifo_overflow | i2c_target_tx_ovf         |      13.880s      |     9.357ms      |    50     |   50    |  100.00 %   |
|   V2    |  target_fifo_reset   | i2c_target_fifo_reset_acq |      12.460s      |     10.105ms     |    50     |   50    |  100.00 %   |
|         |                      | i2c_target_fifo_reset_tx  |      12.010s      |     10.069ms     |    50     |   50    |  100.00 %   |
|   V2    |     bad_address      | i2c_target_bad_addr       |      2.200s       |     7.752ms      |    50     |   50    |  100.00 %   |
|   V2    |  target_mode_glitch  | i2c_target_hrst           |      1.070s       |     3.139ms      |    50     |   50    |  100.00 %   |
|   V2    |                      | **TOTAL**                 |                   |                  |    352    |   352   |  100.00 %   |
|         |                      | **TOTAL**                 |                   |                  |    352    |   352   |  100.00 %   |

The commit that fixes up HostStop's relationship with the SCL drive thread finished off i2c_target_timeout, but I haven't done the full run of all tests with that commit in yet.

On the host side, I'm still tweaking the constraints solver for i2c_host_perf. The two failure modes are unsolvable constraints and "DUT not working as expected" because the measured SCL period is significantly longer than expected (likely fixable by including the extra 3 cycles for thigh + double-counted t_f). The current commit is held back, but this is where it stands with that WIP commit:

### Test Results
|  Stage  |        Name         | Tests                    |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:-------------------:|:-------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |     host_smoke      | i2c_host_smoke           |      58.920s      |     12.812ms     |    50     |   50    |  100.00 %   |
|   V1    |                     | **TOTAL**                |                   |                  |    50     |   50    |  100.00 %   |
|   V2    |   host_error_intr   | i2c_host_error_intr      |      0.810s       |     46.466us     |    50     |   50    |  100.00 %   |
|   V2    |      host_perf      | i2c_host_perf            |      15.904m      |    143.365ms     |    32     |   50    |   64.00 %   |
|   V2    |    host_override    | i2c_host_override        |      0.280s       |     14.757us     |    50     |   50    |  100.00 %   |
|   V2    | host_fifo_watermark | i2c_host_fifo_watermark  |      2.056m       |     13.564ms     |    50     |   50    |  100.00 %   |
|   V2    | host_fifo_overflow  | i2c_host_fifo_overflow   |      2.506m       |     6.824ms      |    50     |   50    |  100.00 %   |
|   V2    |   host_fifo_reset   | i2c_host_fifo_fmt_empty  |      14.060s      |    741.621us     |    50     |   50    |  100.00 %   |
|         |                     | i2c_host_fifo_reset_rx   |      5.320s       |    267.579us     |    50     |   50    |  100.00 %   |
|         |                     | i2c_host_fifo_reset_fmt  |      0.430s       |     1.086ms      |    50     |   50    |  100.00 %   |
|   V2    |   host_fifo_full    | i2c_host_fifo_full       |      1.271m       |     47.803ms     |    50     |   50    |  100.00 %   |
|   V2    |    host_timeout     | i2c_host_stretch_timeout |      20.450s      |     3.163ms      |    50     |   50    |  100.00 %   |
|   V2    | host_rx_oversample  | i2c_host_rx_oversample   |      56.250s      |     5.548ms      |    50     |   50    |  100.00 %   |
|   V2    |                     | **TOTAL**                |                   |                  |    532    |   550   |   96.73 %   |
|         |                     | **TOTAL**                |                   |                  |    582    |   600   |   97.00 %   |