### PR TITLE
[csrng/dv] Clean up TODO items for M2.5

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -361,7 +361,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
-    // post test checks - ensure that all local fifos and queues are empty
+    // TODO(#19031): post test checks - ensure that all local fifos and queues are empty
   endfunction
 
   // From NIST.SP.800-90Ar1

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -41,7 +41,7 @@ class csrng_base_vseq extends cip_base_vseq #(
 
   virtual task dut_shutdown();
     // check for pending csrng operations and wait for them to complete
-    // TODO
+    // TODO(#19031): Remove this task once scoreboard checks that its queues are empty.
   endtask
 
   // setup basic csrng features

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -61,7 +61,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
   endtask // test_cs_entropy_req
 
   task test_cs_sw_cmd_sts();
-    // TODO: Instead of forcing ack_sts, find a way to actually generate the csrng_rsp_sts
+    // TODO(#16516): Instead of forcing ack_sts, find a way to actually generate the csrng_rsp_sts
     // response as described in the documentation
     // 1. Failure of the entropy source
     // 2. Attempts to use an instance which has not been properly instantiated, or
@@ -79,7 +79,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
   endtask
 
   task test_cs_hw_inst_exc();
-    // TODO: Instead of forcing ack_sts, find a way to actually generate the csrng_rsp_sts
+    // TODO(#16516): Instead of forcing ack_sts, find a way to actually generate the csrng_rsp_sts
     // response as described in the documentation
     // 1. Failure of the entropy source
     // 2. Attempts to use an instance which has not been properly instantiated, or


### PR DESCRIPTION
The TODOs in CSRNG's DV are not relevant for M2.5. This PR links them to an existing and a new issue to track their resolution post M2.5.