### PR TITLE
[opentitantool] Support Google Servo Micro debugging device

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -143,6 +143,7 @@ rust_library(
         "src/transport/hyperdebug/gpio.rs",
         "src/transport/hyperdebug/i2c.rs",
         "src/transport/hyperdebug/mod.rs",
+        "src/transport/hyperdebug/servo_micro.rs",
         "src/transport/hyperdebug/spi.rs",
         "src/transport/hyperdebug/ti50.rs",
         "src/transport/ioexpander/mod.rs",

--- a/sw/host/opentitanlib/src/app/config/servo_micro.json
+++ b/sw/host/opentitanlib/src/app/config/servo_micro.json
@@ -1,0 +1,33 @@
+{
+  "interface": "servo_micro",
+  "pins": [
+    {
+      "name": "RESET",
+      "level": true,
+      "alias_of": "XXX" // Change to actual servo micro pin name (if a command other than `gpioset` is required, then further changes to servo_micro.rs are needed, similarly to how c2d2.rs does.)
+    }
+  ],
+  "strappings": [
+    {
+      "name": "RESET",
+      "pins": [
+	{
+	  "name": "RESET",
+	  "level": false
+	}
+      ]
+    },
+    {
+      "name": "ROM_BOOTSTRAP"
+    }
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "baudrate": 115200,
+      "parity": "None",
+      "stopbits": "Stop1",
+      "alias_of": "CR50" // May need to change to actual USB enpoint name
+    }
+  ]
+}

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::app::config::process_config_file;
 use crate::app::{TransportWrapper, TransportWrapperBuilder};
 use crate::transport::dediprog::Dediprog;
-use crate::transport::hyperdebug::{C2d2Flavor, CW310Flavor, StandardFlavor, Ti50Flavor};
+use crate::transport::hyperdebug::{C2d2Flavor, CW310Flavor, ServoMicroFlavor, StandardFlavor, Ti50Flavor};
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 
@@ -89,6 +89,10 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         "c2d2" => (
             hyperdebug::create::<C2d2Flavor>(args)?,
             Some(Path::new("/__builtin__/h1dx_devboard_c2d2.json")),
+        ),
+        "servo_micro" => (
+            hyperdebug::create::<ServoMicroFlavor>(args)?,
+            Some(Path::new("/__builtin__/servo_micro.json")),
         ),
         "ti50" => (hyperdebug::create::<Ti50Flavor>(args)?, None),
         "cw310" => (

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -31,15 +31,17 @@ use crate::transport::{
 };
 use crate::util::usb::UsbBackend;
 
-pub mod c2d2;
-pub mod dfu;
-pub mod gpio;
-pub mod i2c;
-pub mod spi;
-pub mod ti50;
+mod c2d2;
+mod dfu;
+mod gpio;
+mod i2c;
+mod servo_micro;
+mod spi;
+mod ti50;
 
 pub use c2d2::C2d2Flavor;
 pub use dfu::HyperdebugDfu;
+pub use servo_micro::ServoMicroFlavor;
 pub use ti50::Ti50Flavor;
 
 /// Implementation of the Transport trait for HyperDebug based on the

--- a/sw/host/opentitanlib/src/transport/hyperdebug/servo_micro.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/servo_micro.rs
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::rc::Rc;
+
+use crate::io::gpio::GpioPin;
+use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::{TransportError, TransportInterfaceType};
+
+/// The Servo Micro is used to bring up GSC and EC chips sitting inside a computing device, such
+/// that those GSC chips can provide Case Closed Debugging support to allow bringup of the rest of
+/// the computing device.  Servo devices happen to speak almost exactly the same USB protocol as
+/// HyperDebug.  This `Flavor` implementation defines the few deviations: USB PID value, and the
+/// handling of OT reset signal.
+pub struct ServoMicroFlavor {}
+
+impl ServoMicroFlavor {
+    const PID_SERVO_MICRO: u16 = 0x501A;
+}
+
+impl Flavor for ServoMicroFlavor {
+    fn gpio_pin(inner: &Rc<Inner>, pinname: &str) -> Result<Rc<dyn GpioPin>> {
+        StandardFlavor::gpio_pin(inner, pinname)
+    }
+
+    fn spi_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, u8)> {
+        if instance == "AP" {
+            return Ok((super::spi::USB_SPI_REQ_ENABLE_AP, 0));
+        }
+        if instance == "EC" {
+            return Ok((super::spi::USB_SPI_REQ_ENABLE_EC, 0));
+        }
+        bail!(TransportError::InvalidInstance(
+            TransportInterfaceType::Spi,
+            instance.to_string()
+        ))
+    }
+
+    fn get_default_usb_vid() -> u16 {
+        VID_GOOGLE
+    }
+
+    fn get_default_usb_pid() -> u16 {
+        Self::PID_SERVO_MICRO
+    }
+    fn perform_initial_fw_check() -> bool {
+        // The servo micro firmware and hyperdebug firmware are different, so do not check.
+        false
+    }
+}


### PR DESCRIPTION
Some Chromebooks use a device called "Servo Micro" for gaining access to serial console and GPIO signals of the security chip and other chips inside it.  As HyperDebug uses essentially the same USB protocol as Servo Micro, it requires very little effort to allow opentitantool to control a Servo Micro.  (Opentitantool already has support for another similar Google debugging device, called C2D2.)

As future Chromebooks will have OpenTitan chips, which can be reached through this Servo Micro, and as opentitantool has some support for the bootstrap protocols of proprietary Google security chips, it will be quite useful to be able to use servo micro through opentitantool.

This PR adds this support.