### PR TITLE
[chip,dv] use flash to preserve non-volatile variable

### DIFF
--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -746,11 +746,13 @@ opentitan_functest(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",


### PR DESCRIPTION
Test `sleep_pin_wake_test.c` relies on rand_utils_gen to generate random number. 
This utils happen to generate the same random number over the multiple reset events 
in open source while in closed source, it creates different random number for every reset event.
Since the intention of this test is to generate random number once 
and use the number after another reset event,
preserve the generated random number to flash and read back after the 2nd boot event.