### PR TITLE
Aon timer todos

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_testplan.hjson
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "aon_timer"
-  // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",

--- a/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
+++ b/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
@@ -61,7 +61,6 @@
       name: aon_timer_jump
       uvm_test_seq: aon_timer_jump_vseq
     }
-    // TODO: add more tests here
   ]
 
   // List of regressions.

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -13,7 +13,11 @@ class aon_timer_base_vseq extends cip_base_vseq #(
   // If this is set, the AON clock starts first and then the fast clock starts sometime later. If
   // not, they start in parallel. Since the fast clock is *much* quicker, the practical result is
   // that it starts first.
-  // TODO: Issue #6821: temp set to 1 to avoid assertion error.
+  // Currently set to 1 always so AON clock always start first. The testbench doesn't correctly
+  // support AON and fast clock starting together. Within OpenTitan earlgrey the aon clock is always
+  // active before the fast path so the reset_aon_first == 0 mode isn't required. Leaving the
+  // functionality in for now whilst we decide if we want to support reset_aon_first == 0 in the
+  // testbench or remove this functionality entirely.
   // rand bit reset_aon_first;
   bit reset_aon_first = 1;
 


### PR DESCRIPTION
Opened an issue here: https://github.com/lowRISC/opentitan/issues/19059)  to track resolution of the use of reset_aon_first (Note this is not a concern for M2.5.2)