### PR TITLE
Verify module IDs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -192,6 +192,10 @@ jobs:
   - bash: ci/scripts/verible-lint.sh fpv
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Verible FPV (Verilog lint)
+  - bash: ci/scripts/check-module-ids.sh
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Check status_t Module IDs (Experimental)
+    continueOnError: True
 
 - job: sw_build
   displayName: Earl Grey SW Build & Test

--- a/ci/scripts/check-module-ids.sh
+++ b/ci/scripts/check-module-ids.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that all module IDs are unique.
+
+set -e
+
+# List of all targets that need to be checked: we only consider targets that
+# produce a binary file and that depend on the status library. Since every test
+# is usually built for real targets and dv, we only check for one real target to
+# save time.
+query_elfs='
+    filter(
+        ".*prog_fpga_cw310.*",
+        kind(
+            cc_binary,
+            rdeps(
+                //sw/device/...,
+                //sw/device/lib/base:status
+            )
+        )
+    )'
+target_file=$(mktemp)
+./bazelisk.sh query "$query_elfs" >"$target_file"
+# We now ask bazel to build all targets but we also add the module ID checker aspect
+# and we query the corresponding output group to force bazel to run the checks.
+./ci/bazelisk.sh build \
+    --config=riscv32 \
+    --aspects=rules/quality.bzl%modid_check_aspect \
+    --output_groups=modid_check \
+    --target_pattern_file="$target_file"

--- a/ci/scripts/check-module-ids.sh
+++ b/ci/scripts/check-module-ids.sh
@@ -3,17 +3,17 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Checks that all module IDs are unique.
+# Checks that all status_t module IDs are unique.
 
 set -e
 
 # List of all targets that need to be checked: we only consider targets that
 # produce a binary file and that depend on the status library. Since every test
-# is usually built for real targets and dv, we only check for one real target to
+# is usually built for FPGA and simulation targets, we only check for one target to
 # save time.
 query_elfs='
     filter(
-        ".*prog_fpga_cw310.*",
+        ".*fpga_cw310.*",
         kind(
             cc_binary,
             rdeps(

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -93,8 +93,8 @@ impl CommandDispatch for LintCommand {
         let mut mod_id_map: HashMap<String, HashSet<ModuleIdProvenance>> = HashMap::new();
 
         if let Some(filename) = &self.touch {
-            let _ = std::fs::File::create(&filename)
-                .context("could not create empty file for bazel")?;
+            let _ =
+                std::fs::File::create(filename).context("could not create empty file for bazel")?;
         }
 
         for elf in &self.elf_files {

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -79,7 +79,7 @@ pub struct LintCommand {
 
 #[derive(PartialEq, Eq, Hash, Debug, serde::Serialize)]
 struct ModuleIdProvenance {
-    filename: String,
+    filename: PathBuf,
     overriden: bool,
 }
 
@@ -104,7 +104,7 @@ impl CommandDispatch for LintCommand {
                     .entry(record.get_module_id()?)
                     .or_insert_with(HashSet::new)
                     .insert(ModuleIdProvenance {
-                        filename: record.filename,
+                        filename: record.filename.into(),
                         overriden: record.module_id.is_some(),
                     });
             }
@@ -118,7 +118,7 @@ impl CommandDispatch for LintCommand {
                         true => "specified by MAKE_MODULE_ID",
                         false => "computed from filename",
                     };
-                    eprintln!("- {}: {}", prov.filename, explain);
+                    eprintln!("- {}: {}", prov.filename.display(), explain);
                 }
                 contain_collisions = true;
             }


### PR DESCRIPTION
See #17605.

The goal of this PR is to add a check to enforce that module IDs are not conflicting.
The approach is to run the `opentitantool status lint` command on every relevant ELF file (see commits for details).

One downside of this approach is it triggers a build of `opentitantool` and also builds all the test ELF files. The former is quite slow because opentitanlib depends on `pqcrypto-sphincsplus` even though this is not useful for this particular check. This can also be fixed by reorganizing `opentitanlib`.

One possibility would be to run those checks at the same time as we run the device tests on FPGA since everything has to be built anyway, but this could be a bit confusing.

Questions:
- At the moment I am using an aspect with an explicit output group, but apparently bazel supports [validation actions](https://bazel.build/extending/rules#validation_actions), I don't know if it worth using those?
- While going through `quality/BUILD.bazel`, I noticed an hardcoded list `RUST_TARGETS` of targets. Could this use similar mecanism to what is done in this PR to avoid a list?