### PR TITLE
[chip,dv] apply exclusion to chip_prim_tl_access_vseq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_prim_tl_access_vseq.sv
@@ -46,6 +46,17 @@ class chip_prim_tl_access_vseq extends chip_stub_cpu_base_vseq;
     bit [TL_AW-1:0] addr = csr.get_address();
     bit [TL_DW-1:0] data = $urandom();
     bit [TL_DW-1:0] exp_data;
+
+    csr_excl_item csr_excl = get_excl_item(csr);
+
+    // Apply CsrExclWrite
+    if (!csr_excl.is_excl(csr, CsrExclWrite, CsrAllTests)) begin
+      tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
+      if (!gated) begin
+        void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
+      end
+    end
+
     tl_access(.addr(addr), .write(1), .data(data), .exp_err_rsp(gated));
     if (!gated) begin
       void'(csr.predict(.value(data), .kind(UVM_PREDICT_WRITE)));


### PR DESCRIPTION
tag - excl is set in some closed source prim csrs. 
Apply those settings to the relevant test.