### PR TITLE
[hw,spi_device,dv] Schedule reg prediction for cfg_addr_4b_en

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -516,6 +516,16 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     csr_update(.csr(ral.cmd_info[idx]));
   endtask : add_cmd_info
 
+  // Task to update mirrored value of addr_4b_en after end of SPI transaction
+  virtual task schedule_en_4b_predict(bit value);
+    fork begin
+      @(posedge cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]);
+      `uvm_info(`gfn, $sformatf("set addr_4b_en = %0b", value), UVM_MEDIUM)
+      cfg.clk_rst_vif.wait_clks(3);
+      void'(ral.cfg.addr_4b_en.predict(.value(value)));
+    end join_none
+  endtask
+
   // transfer in command including opcode, address and payload
   // if byte_addr_q is empty, the host_seq will use a random addr
   virtual task spi_host_xfer_flash_item(bit [7:0] op, uint payload_size,
@@ -546,9 +556,11 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     if (op == `gmv(ral.cmd_info_en4b.opcode) && `gmv(ral.cmd_info_en4b.valid)) begin
       cfg.spi_device_agent_cfg.flash_addr_4b_en = 1;
       cfg.spi_host_agent_cfg.flash_addr_4b_en   = 1;
+      schedule_en_4b_predict(1);
     end else if (op == `gmv(ral.cmd_info_ex4b.opcode) && `gmv(ral.cmd_info_ex4b.valid)) begin
       cfg.spi_device_agent_cfg.flash_addr_4b_en = 0;
       cfg.spi_host_agent_cfg.flash_addr_4b_en   = 0;
+      schedule_en_4b_predict(0);
     end
 
     if (cfg.is_read_buffer_cmd(m_spi_host_seq.rsp)) begin
@@ -747,12 +759,24 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   endtask
 
   virtual task read_and_check_4b_en();
-    cfg.clk_rst_vif.wait_clks(10);
-    // avoid accessing this CSR at the same time as tpm_init
-    cfg.spi_cfg_sema.get();
-    csr_rd_check(.ptr(ral.cfg.addr_4b_en),
-                 .compare_value(cfg.spi_device_agent_cfg.flash_addr_4b_en));
-    cfg.spi_cfg_sema.put();
+      uvm_reg_data_t rdata;
+      // Wait for 10 cycles to allow the reg value to update
+      cfg.clk_rst_vif.wait_clks(10);
+      // avoid accessing this CSR at the same time as tpm_init
+      cfg.spi_cfg_sema.get();
+      // Wait for register to be free
+      `DV_SPINWAIT(
+        while(1) begin
+          if (ral.cfg.is_busy()) begin
+            cfg.clk_rst_vif.wait_clks(1);
+          end else begin
+            break;
+          end
+        end)
+      // Check the contents of addr4b_en
+      csr_rd_check(.ptr(ral.cfg.addr_4b_en),
+             .compare_value(cfg.spi_device_agent_cfg.flash_addr_4b_en));
+      cfg.spi_cfg_sema.put();
   endtask
 
   virtual task random_write_spi_mem(int start_addr, int end_addr, string msg_region = "mem",

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_async_fifo_reset_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_async_fifo_reset_vseq.sv
@@ -26,6 +26,8 @@ class spi_device_rx_async_fifo_reset_vseq extends spi_device_txrx_vseq;
     bit [31:0] host_data_exp_q[$];
 
     spi_device_fw_init();
+    // Disable prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(0);
     `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
     `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
     wait_for_tx_avail_bytes(SRAM_WORD_SIZE, SramSpaceAvail, avail_bytes);
@@ -57,6 +59,8 @@ class spi_device_rx_async_fifo_reset_vseq extends spi_device_txrx_vseq;
     for (int i = 0; i < 6; i++) begin
       spi_host_xfer_word(32'h12345678, device_data_exp);
     end
+    // Restore prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(1);
 
   endtask : body
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tx_async_fifo_reset_vseq.sv
@@ -17,6 +17,8 @@ class spi_device_tx_async_fifo_reset_vseq extends spi_device_base_vseq;
     bit [31:0] host_data_exp_q[$];
 
     spi_device_fw_init();
+    // Disable prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(0);
     `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
     `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
     // Fill TX SRAM FIFO with some data, which will be transfered to TX async FIFO
@@ -38,6 +40,8 @@ class spi_device_tx_async_fifo_reset_vseq extends spi_device_base_vseq;
     cfg.clk_rst_vif.wait_clks(100);
     spi_host_xfer_word(host_data, device_data_exp);
     `DV_CHECK_CASE_EQ(32'h12345678, device_data_exp)
+    // Restore prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(1);
 
   endtask : body
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -104,6 +104,8 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
   virtual task body();
     tx_ptr_sema = new(1);
     rx_ptr_sema = new(1);
+    // Disable prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(0);
     for (int i = 1; i <= num_trans; i++) begin
       bit done_tx_write, done_rx_read, done_xfer;
       `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
@@ -133,6 +135,8 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
       join
       check_for_tx_rx_idle();
     end // for
+    // Restore prim_flip_2sync destination pulse assertions
+    fifo_underflow_overflow_sva_control(1);
   endtask : body
 
   virtual task process_tx_write(uint xfer_bytes);


### PR DESCRIPTION
- Schedule the mirror value update for `addr_4b_en` after next SPI transaction since this field gets updated in SPI clock domain
- Disable destination pulse assertion in prim module similar to https://github.com/lowRISC/opentitan/pull/18829

