### PR TITLE
[rom_ctrl/dv] Increase TL access timeout 

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -16,6 +16,11 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // Enables/disable all protocol delays.
   rand bit zero_delays;
 
+  // Default is 10ms (see default_spinwait_timeout_ns in csr_utils_pkg.sv)
+  // We have to increase this here since the ROM check may actually take longer than that,
+  // which sometimes causes blocked TL accesses to time out.
+  uint tl_access_timeout_ns = 40_000_000; // 40ms
+
   // Bias randomization in favor of enabling zero delays less often.
   constraint zero_delays_c {
     zero_delays dist { 0 := 8,

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -76,7 +76,8 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
                         .blocking(1'b0),
                         .check_rsp(1'b0),
                         .tl_sequencer_h(p_sequencer.tl_sequencer_hs["rom_ctrl_rom_reg_block"]),
-                        .req_abort_pct(do_rom_error_req ? 50 : 0));
+                        .req_abort_pct(do_rom_error_req ? 50 : 0),
+                        .tl_access_timeout_ns(cfg.tl_access_timeout_ns));
     end
     csr_utils_pkg::wait_no_outstanding_access();
   endtask

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -278,7 +278,7 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
     do begin
       @(negedge cfg.clk_rst_vif.clk);
       uvm_hdl_read("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q", rdata_state);
-    end while (!(rdata_state inside states_to_visit));
+    end while (!(rdata_state inside {states_to_visit}));
     `uvm_info(`gfn, $sformatf("reached FSM state %x", rdata_state), UVM_LOW)
     // Remove previous states from queue, including the one that has been reached.
     while (states_to_visit.pop_front() != rdata_state);

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
@@ -8,7 +8,7 @@ class rom_ctrl_kmac_err_chk_vseq extends rom_ctrl_base_vseq;
   `uvm_object_new
 
   task body();
-    rom_ctrl_pkg::fsm_state_e rdata_state;
+    bit [$bits(rom_ctrl_pkg::fsm_state_e)-1:0] rdata_state;
     uvm_reg_data_t act_val;
 
     cfg.m_kmac_agent_cfg.error_rsp_pct = 100;


### PR DESCRIPTION
This should take care of the remaining smoke test timeout errors in the regression.