### PR TITLE
[manuf] Read back and verify device that performs the CRC check

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -29,14 +29,22 @@ _dv_log_offset = 0x10000;
 ENTRY(sram_start);
 
 SECTIONS {
-  .text ORIGIN(ram_main) + _static_critical_size : ALIGN(4) {
+  /* The ELF SRAM program loader will automatically read back the data of the section
+   * containing the entry point to verify that it is correct. The expectation is that
+   * this section is very small and only contains the code that computes the CRC of
+   * everything else. For this reason, we separate the sram start+crt code from the
+   * rest. */
+  .sram_start ORIGIN(ram_main) + _static_critical_size : ALIGN(4) {
     _crc_start = .;
     /* Place the entry point of the SRAM program to the start of the main SRAM
      * so that we don't have to maintain a separate offset from the start of
      * the RAM to the entry point for VMEM files. */
     KEEP(*(.sram_start))
-    KEEP(*(.crt))
     . = ALIGN(4);
+  } > ram_main
+
+  .text : ALIGN(4) {
+    KEEP(*(.crt))
     KEEP(*(.text))
     KEEP(*(.text.*))
     . = ALIGN(4);


### PR DESCRIPTION
At the moment we rely on the device code to verify the CRC of the entire program at runtime. This catches most errors but in the unlikely case where the corruption happens in the CRC code itself, the test could pass even though the program is corrupted. This commit adds a feature to the ELF loader to read back the data from the section that contains the entry point of the program. The linker script is modified accordingly so that a tiny section is created that contains the entry point and the only the code to verify the CRC. Since this section is tiny, reading it back has a negligible impact on loading time.

This should close #18635