### PR TITLE
[rom_e2e] update ROM self hash test configuration

### DIFF
--- a/ci/scripts/check-ascii.sh
+++ b/ci/scripts/check-ascii.sh
@@ -64,6 +64,7 @@ excl_paths=(
     hw/ip/usbdev/pmod/tusb1106pmod-kicad/fp-info-cache
     'signing/softhsm/tokens/.*'
     site/landing/data/partner_quotes.json
+    'sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.*'
 )
 excl_re=""
 for excl in "${excl_paths[@]}"; do

--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -155,8 +155,9 @@ interface sw_logger_if #(
       fd = $fopen(sw_log_db_files[sw], "r");
       if (!fd) begin
         `dv_info($sformatf("Failed to open sw log db file %s.", sw_log_db_files[sw]))
-        return 1'b0;
+        continue;
       end
+      `dv_info($sformatf("Loading sw log db file %s ...", sw_log_db_files[sw]))
 
       while (!$feof(fd)) begin
         string        field;

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -906,7 +906,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:1:signed:ot_flash_binary"
-        "//hw/ip/otp_ctrl/data:img_test_unlocked0:4",
+        "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_otbn:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_real_keys"]
       run_opts: [
@@ -923,7 +923,7 @@
     //   uvm_test_seq: chip_sw_base_vseq
     //   sw_images: [
     //     "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:1:signed:ot_flash_binary"
-    //     "//hw/ip/otp_ctrl/data:img_rma:4",
+    //     "//sw/device/silicon_creator/rom/e2e:otp_img_sigverify_mod_exp_rma_otbn:4",
     //   ]
     //   // We purposely use the `sw_test_mode_common` run mode here instead of the
     //   // run modes that add either ROM image to the list of sw_images to

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3965,10 +3965,19 @@ opentitan_flash_binary(
     ],
 )
 
+bitstream_splice(
+    name = "bitstream_rom_self_hash_test_rma_otbn_mod_exp",
+    src = "//hw/bitstream:rom_with_real_keys",
+    data = ":otp_img_sigverify_mod_exp_rma_otbn",
+    meminfo = "//hw/bitstream:otp_mmi",
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+
 opentitan_functest(
     name = "rom_e2e_self_hash_test",
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_with_real_keys_otp_test_unlocked0",
+        bitstream = ":bitstream_rom_self_hash_test_rma_otbn_mod_exp",
     ),
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:rom_with_real_keys",

--- a/sw/device/silicon_creator/rom/e2e/presigned_images/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/presigned_images/BUILD
@@ -10,7 +10,7 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-# Pre-signed empty test binaries and aliases.
+# Empty test binaries and aliases.
 _EMPTY_TEST_DEVICES = [
     "sim_dv",
     "sim_verilator",
@@ -52,8 +52,10 @@ scramble_flash_vmem(
         srcs = [
             "rom_e2e_self_hash_{}.signed.bin".format(dev),
         ] + [] if dev == "fpga_cw310" else [
-            ":rom_e2e_self_hash_{}_scr_vmem64".format(dev),
-            ":rom_e2e_self_hash_{}_vmem64".format(dev),
+            ":rom_e2e_self_hash_sim_dv.logs.txt",
+            ":rom_e2e_self_hash_sim_dv.rodata.txt",
+            ":rom_e2e_self_hash_sim_dv_scr_vmem64",
+            ":rom_e2e_self_hash_sim_dv_vmem64",
         ],
     )
     for dev in [

--- a/sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.logs.txt
+++ b/sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.logs.txt
@@ -1,0 +1,364 @@
+addr: 10000
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 65
+nargs: 2
+format: ROM Hash: 0x%0h[%0d]
+str_arg_idx: 
+addr: 10014
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 67
+nargs: 1
+format: rom_chip_info @ %0h:
+str_arg_idx: 
+addr: 10028
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 70
+nargs: 2
+format: scm_revision = %08h%08h
+str_arg_idx: 
+addr: 1003c
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 71
+nargs: 1
+format: version = %08h
+str_arg_idx: 
+addr: 10050
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 78
+nargs: 1
+format: CHECK-fail: (uint8_t *)output.data%0smatches (uint8_t *)kSimDvGoldenRomHash
+str_arg_idx: 0
+addr: 10064
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 78
+nargs: 3
+format: CHECK-fail: [%0d] got: 0x%02h; want: 0x%02h
+str_arg_idx: 
+addr: 10078
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 82
+nargs: 1
+format: CHECK-fail: (uint8_t *)output.data%0smatches (uint8_t *)kFpgaCw310GoldenRomHash
+str_arg_idx: 0
+addr: 1008c
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 82
+nargs: 3
+format: CHECK-fail: [%0d] got: 0x%02h; want: 0x%02h
+str_arg_idx: 
+addr: 100a0
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 85
+nargs: 1
+format: ROM hash not self-checked for this device type: 0x%0h
+str_arg_idx: 
+addr: 100b4
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 94
+nargs: 0
+format: Starting test hash_rom...
+str_arg_idx: 
+addr: 100c8
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 94
+nargs: 0
+format: CHECK-fail: cycles_ <= 4294967295U
+str_arg_idx: 
+addr: 100dc
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 94
+nargs: 0
+format: CHECK-fail:
+str_arg_idx: 
+addr: 100f0
+severity: 0
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 94
+nargs: 3
+format: Successfully finished test hash_rom in %0d cycles or %0d us @ %0d MHz.
+str_arg_idx: 
+addr: 10104
+severity: 2
+file: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+line: 94
+nargs: 1
+format: Finished test hash_rom: %r.
+str_arg_idx: 
+addr: 10118
+severity: 2
+file: in.c
+line: 58
+nargs: 0
+format: OTTF currently only supports use of machine-mode ecall for FreeRTOS context switching.
+str_arg_idx: 
+addr: 1012c
+severity: 0
+file: in.c
+line: 129
+nargs: 1
+format: Running %0s
+str_arg_idx: 0
+addr: 10140
+severity: 2
+file: in.c
+line: 137
+nargs: 1
+format: DIF-fail: dif_rv_core_ibex_init( mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR), &rv_core_ibex) returns %0d
+str_arg_idx: 
+addr: 10154
+severity: 2
+file: in.c
+line: 153
+nargs: 0
+format: CHECK-fail: 0
+str_arg_idx: 
+addr: 10168
+severity: 0
+file: in.c
+line: 99
+nargs: 1
+format: Finished %0s
+str_arg_idx: 0
+addr: 1017c
+severity: 0
+file: in.c
+line: 103
+nargs: 0
+format: Status reported by the test:
+str_arg_idx: 
+addr: 10190
+severity: 0
+file: in.c
+line: 105
+nargs: 1
+format: - %r
+str_arg_idx: 
+addr: 101a4
+severity: 0
+file: w/device/lib/testing/test_framework/freertos_hooks.c
+line: 20
+nargs: 1
+format: %0s
+str_arg_idx: 0
+addr: 101b8
+severity: 0
+file: w/device/lib/testing/test_framework/freertos_hooks.c
+line: 31
+nargs: 1
+format: FreeRTOS stack overflow. Increase stack size of task: %0s
+str_arg_idx: 0
+addr: 101cc
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 71
+nargs: 0
+format: CHECK-fail: kOttfTestConfig.console.type == kOttfConsoleUart
+str_arg_idx: 
+addr: 101e0
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 75
+nargs: 1
+format: DIF-fail: dif_uart_init(mmio_region_from_addr(base_addr), &ottf_console_uart) returns %0d
+str_arg_idx: 
+addr: 101f4
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 76
+nargs: 0
+format: CHECK-fail: kUartBaudrate must fit in uint32_t
+str_arg_idx: 
+addr: 10208
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 78
+nargs: 0
+format: CHECK-fail: kClockFreqPeripheralHz must fit in uint32_t
+str_arg_idx: 
+addr: 1021c
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 88
+nargs: 1
+format: DIF-fail: dif_uart_configure( &ottf_console_uart, (dif_uart_config_t){ .baudrate = (uint32_t)kUartBaudrate, .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz, .parity_enable = kDifToggleDisabled, .parity = kDifUartParityEven, .tx_enable = kDifToggleEnabled, .rx_enable = kDifToggleEnabled, }) returns %0d
+str_arg_idx: 
+addr: 10230
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 99
+nargs: 1
+format: DIF-fail: dif_spi_device_init_handle( mmio_region_from_addr(kOttfTestConfig.console.base_addr), &ottf_console_spi_device) returns %0d
+str_arg_idx: 
+addr: 10244
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 117
+nargs: 1
+format: DIF-fail: dif_spi_device_configure( &ottf_console_spi_device, (dif_spi_device_config_t){ .clock_polarity = kDifSpiDeviceEdgePositive, .data_phase = kDifSpiDeviceEdgeNegative, .tx_order = kDifSpiDeviceBitOrderMsbToLsb, .rx_order = kDifSpiDeviceBitOrderMsbToLsb, .device_mode = kDifSpiDeviceModeGeneric, .mode_cfg = { .generic = { .rx_fifo_commit_wait = kSpiDeviceRxCommitWait, .rx_fifo_len = kDifSpiDeviceBufferLen / 2, .tx_fifo_len = kDifSpiDeviceBufferLen / 2, }, }, }) returns %0d
+str_arg_idx: 
+addr: 10258
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 121
+nargs: 0
+format: CHECK-fail: unsupported OTTF console interface.
+str_arg_idx: 
+addr: 1026c
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 144
+nargs: 1
+format: DIF-fail: dif_rv_plic_init( mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic) returns %0d
+str_arg_idx: 
+addr: 10280
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 147
+nargs: 1
+format: DIF-fail: dif_uart_watermark_rx_set(uart, kFlowControlRxWatermark) returns %0d
+str_arg_idx: 
+addr: 10294
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 149
+nargs: 1
+format: DIF-fail: dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark, kDifToggleEnabled) returns %0d
+str_arg_idx: 
+addr: 102a8
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 153
+nargs: 1
+format: DIF-fail: dif_rv_plic_irq_set_priority( &ottf_plic, get_flow_control_watermark_plic_id(), kDifRvPlicMaxPriority) returns %0d
+str_arg_idx: 
+addr: 102bc
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 156
+nargs: 1
+format: DIF-fail: dif_rv_plic_target_set_threshold(&ottf_plic, kPlicTarget, kDifRvPlicMinPriority) returns %0d
+str_arg_idx: 
+addr: 102d0
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 160
+nargs: 1
+format: DIF-fail: dif_rv_plic_irq_set_enabled(&ottf_plic, get_flow_control_watermark_plic_id(), kPlicTarget, kDifToggleEnabled) returns %0d
+str_arg_idx: 
+addr: 102e4
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 199
+nargs: 1
+format: DIF-fail: dif_uart_irq_is_pending(uart, kDifUartIrqRxWatermark, &rx) returns %0d
+str_arg_idx: 
+addr: 102f8
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 202
+nargs: 1
+format: DIF-fail: dif_uart_irq_acknowledge(uart, kDifUartIrqRxWatermark) returns %0d
+str_arg_idx: 
+addr: 1030c
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 213
+nargs: 1
+format: DIF-fail: dif_uart_irq_disable_all(uart, &snapshot) returns %0d
+str_arg_idx: 
+addr: 10320
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 215
+nargs: 1
+format: DIF-fail: dif_uart_irq_restore_all(uart, &snapshot) returns %0d
+str_arg_idx: 
+addr: 10334
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_console.c
+line: 190
+nargs: 1
+format: DIF-fail: dif_uart_bytes_send(uart, &byte, 1, NULL) returns %0d
+str_arg_idx: 
+addr: 10348
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_isrs.c
+line: 60
+nargs: 4
+format: FAULT: %0s. MCAUSE=%08h MEPC=%08h MTVAL=%08h
+str_arg_idx: 0
+addr: 1035c
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_isrs.c
+line: 159
+nargs: 1
+format: DIF-fail: dif_rv_plic_irq_claim(&ottf_plic, kPlicTarget, &plic_irq_id) returns %0d
+str_arg_idx: 
+addr: 10370
+severity: 2
+file: w/device/lib/testing/test_framework/ottf_isrs.c
+line: 168
+nargs: 1
+format: DIF-fail: dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id) returns %0d
+str_arg_idx: 
+addr: 10384
+severity: 2
+file: sw/device/lib/testing/rand_testutils.c
+line: 32
+nargs: 0
+format: CHECK-fail: rv_core_ibex != ((void*)0)
+str_arg_idx: 
+addr: 10398
+severity: 2
+file: sw/device/lib/testing/rand_testutils.c
+line: 82
+nargs: 0
+format: CHECK-fail: max >= min
+str_arg_idx: 
+addr: 103ac
+severity: 2
+file: sw/device/lib/testing/rand_testutils.c
+line: 88
+nargs: 0
+format: CHECK-fail: result >= min && result <= max
+str_arg_idx: 
+addr: 103c0
+severity: 2
+file: sw/device/lib/testing/rand_testutils.c
+line: 55
+nargs: 5
+format: CHECK-STATUS-fail: %0c%0c%0c:%0d = %0s
+str_arg_idx: 4
+addr: 103d4
+severity: 2
+file: sw/device/lib/testing/rand_testutils.c
+line: 55
+nargs: 1
+format: CHECK-STATUS-fail: 0x%08h
+str_arg_idx: 
+addr: 103e8
+severity: 0
+file: sw/device/lib/testing/test_framework/status.c
+line: 28
+nargs: 0
+format: PASS!
+str_arg_idx: 
+addr: 103fc
+severity: 0
+file: sw/device/lib/testing/test_framework/status.c
+line: 34
+nargs: 0
+format: FAIL!
+str_arg_idx:

--- a/sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.rodata.txt
+++ b/sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.rodata.txt
@@ -1,0 +1,5320 @@
+addr: 20000338
+string: Gl�q
+addr: 2000037d
+string: 
+addr: 20000380
+string: �W
+addr: 20000384
+string: �
+addr: 20000400
+string: o
+addr: 20000402
+string: � s
+addr: 20000407
+string: �s
+addr: 2000040b
+string: �o
+addr: 2000040e
+string: �$s
+addr: 20000413
+string: �s
+addr: 20000417
+string: �s
+addr: 2000041b
+string: �o
+addr: 2000041f
+string: )s
+addr: 20000423
+string: �s
+addr: 20000427
+string: �s
+addr: 2000042b
+string: �o
+addr: 2000042e
+string: @-s
+addr: 20000433
+string: �s
+addr: 20000437
+string: �s
+addr: 2000043b
+string: �s
+addr: 2000043f
+string: �s
+addr: 20000443
+string: �s
+addr: 20000447
+string: �s
+addr: 2000044b
+string: �s
+addr: 2000044f
+string: �s
+addr: 20000453
+string: �s
+addr: 20000457
+string: �s
+addr: 2000045b
+string: �s
+addr: 2000045f
+string: �s
+addr: 20000463
+string: �s
+addr: 20000467
+string: �s
+addr: 2000046b
+string: �s
+addr: 2000046f
+string: �s
+addr: 20000473
+string: �s
+addr: 20000477
+string: �s
+addr: 2000047b
+string: �o
+addr: 20000480
+string: �!
+addr: 20000483
+string: 𓁁4����
+addr: 20000494
+string: ���s�R0%
+addr: 2000049f
+string: �Ų��A��
+addr: 200004ac
+string: ���(%
+addr: 200004b5
+string: ����%
+addr: 200004bd
+string: �e� 
+addr: 200004c8
+string: D�
+addr: 200004d0
+string: ���cx�
+addr: 200004d8
+string: �"
+addr: 200004dc
+string: ���l��o `c~�
+addr: 200004ec
+string: �b�
+addr: 200004f0
+string: ��2
+addr: 200004f4
+string: c�
+addr: 200004f8
+string: # 
+addr: 200004fc
+string: �m����c�
+addr: 20000508
+string: ��
+addr: 2000050c
+string: cy��b�
+addr: 20000514
+string: ���
+addr: 20000518
+string: ��2
+addr: 2000051c
+string: c���@3��@c�b
+addr: 2000052c
+string: �"
+addr: 20000530
+string: # U
+addr: 20000536
+string: �j����c�
+addr: 20000542
+string: ��
+addr: 20000548
+string: !
+addr: 2000054b
+string: �!��A�@2C�CRD�DrE�UV�V2W�WRX�XrY�IJ�J6K�KVL�LvM�]^�^6_�_�R��
+addr: 2000058e
+string: s�0�B���
+addr: 2000059c
+string: �"
+addr: 2000059f
+string: 0��r�	c���b
+addr: 200005ae
+string: ��#*UP�#"
+addr: 200005bc
+string: ����"4s# 4�Ccs
+addr: 200005ce
+string: ����
+addr: 200005d4
+string: C3�c
+addr: 200005da
+string: cn
+addr: 200005de
+string: ������
+addr: 200005e8
+string: �R
+addr: 200005ec
+string: ���D�
+addr: 200005f4
+string: c
+addr: 200005f8
+string: �#
+addr: 200005fb
+string: ���ç#�#
+addr: 20000604
+string: ��
+addr: 20000608
+string: ������"�&�*�.�2�6�:�>�B�F�J����������������������������"
+addr: 20000647
+string: 0�ڝ?�i?� so
+addr: 20000656
+string: @������"�&�*�.�2�6�:�>�B�F�J����������������������������"
+addr: 20000697
+string: 0���"4��7� �wo
+addr: 200006a8
+string: 
+addr: 200006ac
+string: ������"�&�*�.�2�6�:�>�B�F�J����������������������������"
+addr: 200006eb
+string: 0���"4��=� �so
+addr: 200006fc
+string: �
+addr: 20000700
+string: ������"�&�*�.�2�6�:�>�B�F�J����������������������������"
+addr: 2000073f
+string: 0���"4�E5� �oo
+addr: 20000750
+string: �
+addr: 20000754
+string: ������"�&�*�.�2�6�:�>�B�F�J����������������������������"
+addr: 20000793
+string: 0���"4��5� pzo
+addr: 200007a4
+string: `
+addr: 200007a6
+string: 
+addr: 200007a8
+string: �R
+addr: 200007ac
+string: ���(�
+addr: 200007b4
+string: c
+addr: 200007b8
+string: �#
+addr: 200007bb
+string: ���Ë�
+addr: 200007c4
+string: �Bs�4�Rs�0�@�B2C�CRD�DrE�UV�V2W�WRX�XrY�IJ�J6K�KVL�LvM�]^�^6_�_�s
+addr: 2000080e
+string: 0Yq�֢Ԧ���������������(*�
+addr: 2000082d
+string: *�!e��e%�!e�-cDu
+addr: 2000084a
+string: �+eSc��
+addr: 20000855
+string: ��z�E
+addr: 2000085f
+string: 4�0�/�
+addr: 20000869
+string: ��z��
+addr: 20000871
+string: ��%q�E"��0@.P@@�
+addr: 20000885
+string: �ez�E�0 -D�
+addr: 20000895
+string: ��z�E�0 ,U�s
+addr: 200008a5
+string: �s
+addr: 200008a9
+string: ���u
+addr: 200008b0
+string: �%�0��V
+addr: 200008bc
+string: ���
+addr: 200008c3
+string: ��s
+addr: 200008c9
+string: �s
+addr: 200008cd
+string: �U
+addr: 200008d2
+string: ��(
+addr: 200008d8
+string: QF�@�A(
+addr: 200008e0
+string: �
+addr: 200008e3
+string: 0�0@U
+addr: 200008ee
+string: �%(
+addr: 200008f4
+string: QF�@�?�
+addr: 200008fd
+string: �eh(
+addr: 20000904
+string: ���0@D@)
+addr: 20000910
+string: U
+addr: 20000914
+string: �(
+addr: 2000091a
+string: QF�@�=(
+addr: 20000922
+string: ��J��0@
+addr: 2000092b
+string: DU
+addr: 20000930
+string: ��(
+addr: 20000936
+string: QF�@�;(
+addr: 2000093e
+string: ���0�u
+addr: 20000948
+string: $�A	Ec�Y�u
+addr: 20000958
+string: )E&U
+addr: 20000960
+string: E�Eʅ�F�0p0�U��U
+addr: 20000976
+string: e
+addr: 2000097d
+string: .�҅�@ F5
+addr: 2000098a
+string: ��
+addr: 2000098e
+string: Eq
+addr: 20000992
+string: 5�c�$q�s
+addr: 2000099d
+string: �s
+addr: 200009a1
+string: �u
+addr: 200009a6
+string: )e!U
+addr: 200009ae
+string: e�Eʅ�F�0�+�U��U
+addr: 200009c4
+string: �
+addr: 200009cb
+string: .�҅�@@A5
+addr: 200009d8
+string: ��
+addr: 200009dc
+string: Eq
+addr: 200009e0
+string: )�c�1�s
+addr: 200009eb
+string: �s
+addr: 200009ef
+string: �c��
+addr: 200009f7
+string: ��j�E"��0���s
+addr: 20000a09
+string: �s
+addr: 20000a0d
+string: �c��
+addr: 20000a15
+string: ��c�U
+addr: 20000a1e
+string: �u�E�0�Q�s
+addr: 20000a2d
+string: �s
+addr: 20000a31
+string: �c��
+addr: 20000a39
+string: �%d�U
+addr: 20000a42
+string: �5�E�0`�s
+addr: 20000a51
+string: �s
+addr: 20000a55
+string: �U
+addr: 20000a5a
+string: �%(
+addr: 20000a60
+string: QF�@ )(
+addr: 20000a68
+string: ���0
+addr: 20000a6d
+string: u
+addr: 20000a72
+string: �%�U
+addr: 20000a7a
+string: ��5E�`��s
+addr: 20000a89
+string: �s
+addr: 20000a8d
+string: �U
+addr: 20000a92
+string: ��(
+addr: 20000a98
+string: QF�@�%U
+addr: 20000aa2
+string: �5�(
+addr: 20000aa8
+string: �0
+addr: 20000aac
+string: �DU
+addr: 20000ab2
+string: �	�
+addr: 20000ab9
+string: �
+addr: 20000abd
+string: ���ZU&�D
+addr: 20000aca
+string: 3�
+addr: 20000ace
+string: K
+addr: 20000ad2
+string: c�
+addr: 20000ad6
+string: �EV�&���Z��0��s
+addr: 20000ae9
+string: �s
+addr: 20000aed
+string: �(
+addr: 20000af0
+string: QF΅�@
+addr: 20000af7
+string: (
+addr: 20000afa
+string: ��"�چ� �z�㞄�U
+addr: 20000b0e
+string: e�5E��ʅ�0p��c����U
+addr: 20000b2c
+string: ��͓���s
+addr: 20000b39
+string: �s
+addr: 20000b3d
+string: �U
+addr: 20000b42
+string: �%�(
+addr: 20000b48
+string: QF�@�U
+addr: 20000b52
+string: �5�(
+addr: 20000b58
+string: � 0u�DU
+addr: 20000b62
+string: �	e�
+addr: 20000b69
+string: �
+addr: 20000b6d
+string: ��%RU&�D
+addr: 20000b7a
+string: 3�
+addr: 20000b7e
+string: K
+addr: 20000b82
+string: c�
+addr: 20000b86
+string: �EV�&���Z�� �|�s
+addr: 20000b99
+string: �s
+addr: 20000b9d
+string: �(
+addr: 20000ba0
+string: QF΅�@
+addr: 20000ba7
+string: (
+addr: 20000baa
+string: ��"�چ� �o�㞄�U
+addr: 20000bbe
+string: e�5E� ʅ�0p��c�U
+addr: 20000bd8
+string: ��Eʅ�F�0����s
+addr: 20000bed
+string: �s
+addr: 20000bf1
+string: ����U
+addr: 20000bfa
+string: ���� ʅ�0��P"&��P&T�TY�IfJ�JFK�K&Lea��s
+addr: 20000c29
+string: �s
+addr: 20000c2d
+string: �9q�"�&�J�N�R�V�Z�u
+addr: 20000c44
+string: +��U
+addr: 20000c4c
+string: ��Eڅ�F�0��u
+addr: 20000c5e
+string: ��%*�c�
+addr: 20000c68
+string: �
+addr: 20000c6b
+string: ��D�E� �n�s
+addr: 20000c7b
+string: �s
+addr: 20000c7f
+string: �U
+addr: 20000c84
+string: ���(
+addr: 20000c8a
+string: QF�@�(
+addr: 20000c92
+string: � �as$
+addr: 20000c99
+string: ��$
+addr: 20000c9d
+string: �s%
+addr: 20000ca1
+string: �����6��s%
+addr: 20000cad
+string: ��%
+addr: 20000cb1
+string: �s&
+addr: 20000cb5
+string: ����36�
+addr: 20000cbe
+string: "���@3��@�5�
+addr: 20000ccc
+string: ��3��
+addr: 20000cd2
+string: U
+addr: 20000cd6
+string: �Eڅ�F�0
+addr: 20000ce3
+string: y�5
+addr: 20000ce8
+string: ��
+addr: 20000cec
+string: �Eq
+addr: 20000cf0
+string: ��c�
+addr: 20000cf6
+string: �
+addr: 20000cf9
+string: �%=�E� �e�s
+addr: 20000d09
+string: �s
+addr: 20000d0d
+string: �U
+addr: 20000d12
+string: �%�(
+addr: 20000d18
+string: QF�0�}(
+addr: 20000d20
+string: � �XU
+addr: 20000d28
+string: ŭ5E��څ�0�s�%
+addr: 20000d3c
+string: }�35�
+addr: 20000d42
+string: m��1eժ� 0FU
+addr: 20000d54
+string: �Eڅ�F�0 q�u
+addr: 20000d66
+string: ���L@��
+addr: 20000d70
+string: ��
+addr: 20000d74
+string: �Eq
+addr: 20000d78
+string: ��c�
+addr: 20000d7e
+string: �
+addr: 20000d81
+string: ��5�E� p]�s
+addr: 20000d91
+string: �s
+addr: 20000d95
+string: �U
+addr: 20000d9a
+string: ���(
+addr: 20000da0
+string: QF�00u(
+addr: 20000da8
+string: � 0PU
+addr: 20000db0
+string: E�5E��څ�0@k�%
+addr: 20000dc4
+string: }�35�
+addr: 20000dca
+string: m��1eժ� �=c�	@��C��5�4�ɀ3T�c��
+addr: 20000df7
+string: ��/�ER���&�� �U��s
+addr: 20000e0d
+string: �s
+addr: 20000e11
+string: �c��
+addr: 20000e19
+string: ��.�EN�� �S��s
+addr: 20000e2b
+string: �s
+addr: 20000e2f
+string: �U
+addr: 20000e34
+string: ���(
+addr: 20000e3a
+string: QF�0�k(
+addr: 20000e42
+string: ҅"���� 0F�s
+addr: 20000e51
+string: �s
+addr: 20000e55
+string: �U
+addr: 20000e5a
+string: �e�(
+addr: 20000e60
+string: QF�00i(
+addr: 20000e68
+string: ΅� DN�E��}��PbT�TBY�Y"Z�Z[!a��s
+addr: 20000e8d
+string: �s
+addr: 20000e91
+string: ��"�&�J�N�.���5
+addr: 20000ea6
+string: �5�
+addr: 20000eaa
+string: m���
+addr: 20000eb0
+string: ɍ7�5�c�6��Bc���,
+addr: 20000eca
+string: 2��*cL*���sc�c�
+addr: 20000ee6
+string: �EP@7�5�c���e���c�5�e���cG6	�e��%�c���e��ebc��@&�ʅ�
+addr: 20000f26
+string: PUcO*���sc�c�
+addr: 20000f40
+string: �s
+addr: 20000f45
+string: �s
+addr: 20000f49
+string: ��e��UOc���e���c���e���,c��&�ʅ"��
+addr: 20000f70
+string: �cJ*���sc�c�
+addr: 20000f8a
+string: ݠs
+addr: 20000f8f
+string: �s
+addr: 20000f93
+string: �����c���e���Qc��&�ʅ"�&cL*���sc�c�
+addr: 20000fc6
+string: m�s
+addr: 20000fcb
+string: �s
+addr: 20000fcf
+string: �&�ʅ"��*�s��sc��c�
+addr: 20000fee
+string: a�s
+addr: 20000ff3
+string: �s
+addr: 20000ff7
+string: �&�ʅ"��
+addr: 20001000
+string: |cB*���sc�c�
+addr: 2000101a
+string: ��s
+addr: 2000101f
+string: �s
+addr: 20001023
+string: �&�ʅ"�/cM*���sc�c�
+addr: 20001044
+string: 5�s
+addr: 20001049
+string: �s
+addr: 2000104d
+string: �@&�ʅ�
+addr: 20001056
+string: NcG*���sc�
+addr: 20001066
+string: c�
+addr: 20001070
+string: �s	�s
+addr: 20001079
+string: �s
+addr: 2000107d
+string: �7u
+addr: 20001081
+string: ����@bD�DBI�Ia��s
+addr: 20001097
+string: �s
+addr: 2000109b
+string: �*�7�5��ɝf���c���f���cG��f��&�c��f��fbc���s
+addr: 200010d5
+string: �s
+addr: 200010d9
+string: ��f��VOc	��f���c��f���,c��
+addr: 200010fb
+string: -�s
+addr: 20001101
+string: �s
+addr: 20001105
+string: �����c��f��Q�Fc
+addr: 20001118
+string: ��s
+addr: 2000111f
+string: �s
+addr: 20001123
+string: ��
+addr: 20001127
+string: 9�s
+addr: 2000112d
+string: �s
+addr: 20001131
+string: ��
+addr: 20001135
+string: ���s��s
+addr: 20001141
+string: �s
+addr: 20001145
+string: �yq�"�&�J�2�PB.���
+addr: 2000115b
+string: c�
+addr: 20001166
+string: 5 &�ʅ�(��(@��
+addr: 20001179
+string: �0�7�P"T�TYEa��s
+addr: 2000118d
+string: �s
+addr: 20001191
+string: �7A#(
+addr: 2000119a
+string: �U�#"
+addr: 200011a2
+string: �@��s@c�
+addr: 200011b4
+string: c�
+addr: 200011be
+string: E�s
+addr: 200011c5
+string: �s
+addr: 200011c9
+string: �c�
+addr: 200011d4
+string: E�A��E�ɂ�s
+addr: 200011e5
+string: �s
+addr: 200011e9
+string: ��
+addr: 200011ee
+string: �v5
+addr: 200011f2
+string: ��
+addr: 200011f6
+string: U��
+addr: 200011fe
+string: 7A�
+addr: 20001206
+string: 
+addr: 2000120a
+string: #
+addr: 2000120c
+string: ���35�
+addr: 20001214
+string: ��6
+addr: 20001218
+string: �7�
+addr: 2000121c
+string: 鏅2���1�s
+addr: 20001229
+string: �s
+addr: 2000122d
+string: �*�Ec�
+addr: 20001236
+string: 7A�FB# �������7A�
+addr: 20001254
+string: �#
+addr: 2000125a
+string: Հ����s
+addr: 20001263
+string: �s
+addr: 20001267
+string: ��A	F�ɐA�v
+addr: 20001276
+string: �޷A�¡E�B��q��7A#(
+addr: 20001298
+string: �U�#"
+addr: 200012a0
+string: ���s
+addr: 200012a7
+string: �s
+addr: 200012ab
+string: �A�"�&�J�2���*��EE�(cN*���sc�c�
+addr: 200012da
+string: E��&�ʆ�@"D�DIA]�s
+addr: 200012f1
+string: �s
+addr: 200012f5
+string: �7u
+addr: 200012f9
+string: ��ز@"D�DIA��s
+addr: 2000130d
+string: �s
+addr: 20001311
+string: �*��A7u
+addr: 2000131b
+string: ���7W
+addr: 20001323
+string: ��4�N��
+addr: 2000132e
+string: c���
+addr: 20001336
+string: c��u��s�sc�c�
+addr: 20001354
+string: 7ATJ������Hw
+addr: 20001366
+string: �w���]�ٍՍL�Lʂ�s
+addr: 2000137f
+string: �s
+addr: 20001383
+string: �:���s
+addr: 2000138b
+string: �s
+addr: 2000138f
+string: �7u
+addr: 20001393
+string: ��؂�s
+addr: 2000139d
+string: �s
+addr: 200013a1
+string: �-q#.#,�#*�#(!#&1#$A#"Q6���*����A7u
+addr: 200013cf
+string: ���7W
+addr: 200013d7
+string: ��4�N��
+addr: 200013e2
+string: c���
+addr: 200013ea
+string: c��uԓ�s�s7u
+addr: 200013fd
+string: ���c�c��
+addr: 20001410
+string: �AuG��7W
+addr: 2000141b
+string: ��4�N��
+addr: 20001426
+string: c���
+addr: 2000142e
+string: c�	�u��s��sc��,�Fc�
+addr: 2000144e
+string: c���Ic�Y�A7u
+addr: 2000145f
+string: ���7W
+addr: 20001467
+string: ���4�s7A���N�
+addr: 2000147e
+string: cE�
+addr: 20001486
+string: cO(B�F��scc
+addr: 200014a2
+string: 3�5
+addr: 200014aa
+string: �9
+addr: 200014ae
+string: ]��	#
+addr: 200014b4
+string: �
+addr: 200014b6
+string: �Y�։a�s
+addr: 200014c1
+string: �s
+addr: 200014c5
+string: �:�� �$��$A)�)�*��*Aa��s
+addr: 200014eb
+string: �s
+addr: 200014ef
+string: ��F�$
+addr: 200014f6
+string: �A7u
+addr: 200014fd
+string: ���7W
+addr: 20001505
+string: ��4��s�A�O�
+addr: 20001518
+string: �H��
+addr: 20001520
+string: cLB�F��s��c�
+addr: 2000153c
+string: 3Ƕ C�#����������Y�Ec�*I
+addr: 2000155e
+string: U�cH
+addr: 2000156a
+string: 
+addr: 2000156d
+string: �E�0�
+addr: 20001574
+string: E�1
+addr: 2000157a
+string: �҆��E�Z�
+addr: 2000158a
+string: }�i���s�sc�3�@�A���c�
+addr: 200015b2
+string: ��
+addr: 200015b8
+string: ��:
+addr: 200015bc
+string: Տ#��
+addr: 200015c2
+string: ��u�Δ��Ŏ#��
+addr: 200015d4
+string: �A���7u
+addr: 200015e1
+string: ���7V
+addr: 200015e9
+string: ��4�M��
+addr: 200015f4
+string: �J���
+addr: 200015fc
+string: cC�����s��sc��c�
+addr: 2000161a
+string: 7AHIru��Ec���s�sc�c��
+addr: 20001640
+string: �%I
+addr: 20001644
+string: �ŁEF
+addr: 2000164c
+string: �U3E� A7A��A�7u
+addr: 20001669
+string: ��طW
+addr: 20001671
+string: ����4�s���3���7�
+addr: 2000168a
+string: �
+addr: 2000168e
+string: ����#��N��
+addr: 2000169c
+string: ����
+addr: 200016a4
+string: c��uԓ�s��c
+addr: 200016be
+string: �gg
+addr: 200016c2
+string: ��
+addr: 200016c6
+string: $
+addr: 200016ca
+string: .�#
+addr: 200016ce
+string: �
+addr: 200016d0
+string: E�
+addr: 200016d6
+string: �'
+addr: 200016da
+string: ���
+addr: 200016e0
+string: !�#��
+addr: 200016e6
+string: 'I
+addr: 200016ea
+string: �����7A�E��s�s
+addr: 20001701
+string: �s
+addr: 20001705
+string: �7u
+addr: 20001709
+string: ���m�s
+addr: 20001713
+string: �s
+addr: 20001717
+string: ��}�s
+addr: 2000171f
+string: �s
+addr: 20001723
+string: �F�M�s
+addr: 2000172b
+string: �s
+addr: 2000172f
+string: �7�5�A�s
+addr: 2000173d
+string: �s
+addr: 20001741
+string: �2�Q�s
+addr: 20001749
+string: �s
+addr: 2000174d
+string: ����s
+addr: 20001755
+string: �s
+addr: 20001759
+string: �A�"�&�J�2���*��EEU6cN*���sc�c�
+addr: 20001788
+string: E��&�ʆ�@"D�DIA!�s
+addr: 2000179f
+string: �s
+addr: 200017a3
+string: �7u
+addr: 200017a7
+string: ��ز@"D�DIA��s
+addr: 200017bb
+string: �s
+addr: 200017bf
+string: �A�"�&�J�2���*��EE=>cN*���sc�c�
+addr: 200017ee
+string: E��&�ʆ�@"D�DIAM�s
+addr: 20001805
+string: �s
+addr: 20001809
+string: �7u
+addr: 2000180d
+string: ��ز@"D�DIA��s
+addr: 20001821
+string: �s
+addr: 20001825
+string: �A�"�&�J�2���*��EE�<cN*���sc�c�
+addr: 20001854
+string: E��&�ʆ�@"D�DIA5�s
+addr: 2000186b
+string: �s
+addr: 2000186f
+string: �7u
+addr: 20001873
+string: ��ز@"D�DIA��s
+addr: 20001887
+string: �s
+addr: 2000188b
+string: ��#. #,� #*� #(!!#&1!#$A!#"Q!# a!#.q#,�#*�#(�#&���2���*�E
+addr: 200018d0
+string: ��6(QF�0�A(�
+addr: 200018e0
+string: �7��cL2ޅ�sc��2c��
+addr: 200018fc
+string: &�%J3l� 35�
+addr: 2000190c
+string: ���
+addr: 20001910
+string: ct�
+addr: 20001914
+string: 3��
+addr: 20001918
+string: #.�#,�&��%�# �#"��
+addr: 20001936
+string: 35�
+addr: 2000193a
+string: 3��
+addr: 2000193e
+string: ct�
+addr: 20001942
+string: 35�
+addr: 20001946
+string: # �#"��7��5�Ѥs
+addr: 2000195d
+string: �s
+addr: 20001961
+string: �2�.�	�s�s�u
+addr: 20001971
+string: �����c%+:�6�c)
+addr: 20001988
+string: �
+addr: 2000198c
+string: �M�LR��D
+addr: 20001996
+string: E&��
+addr: 2000199c
+string: �vcJ��c�%'c%
+addr: 200019b2
+string: �E��&��
+addr: 200019bc
+string: �tcJ��c�%%c%
+addr: 200019d2
+string: !�����%ZY��(	
+addr: 200019ef
+string: ��	.­+
+addr: 200019fb
+string: 3%A�c~�
+addr: 20001a06
+string: J���s
+addr: 20001a0d
+string: �s
+addr: 20001a11
+string: ���!�s
+addr: 20001a19
+string: �s
+addr: 20001a1d
+string: �7u
+addr: 20001a21
+string: ���*���s��3�,օ"��0�+	,	E.��cL^�c� IE��3�@c��
+addr: 20001a62
+string: 
+addr: 20001a65
+string: ��m�f�օZ��0@(�sc��le�$	��
+addr: 20001a89
+string: 3	�@&��EJ��0�.�
+addr: 20001a9b
+string: F&��0�-
+addr: 20001aa7
+string: ,pXc`�
+addr: 20001ab9
+string: �E�0 ,
+addr: 20001ac3
+string: 3	�@x4PU�i�2EU�i��U�i�"EU�i��	,	&��cDޅ�sc���
+addr: 20001b05
+string: c��
+addr: 20001b10
+string: cb�	�,��c@ޅ�sc��c��
+addr: 20001b34
+string: JE�	}&��cOޅ�sc��c��
+addr: 20001b56
+string: �
+addr: 20001b5a
+string: �D7u
+addr: 20001b61
+string: �	�ؓ�sAKD
+addr: 20001b70
+string: E΅�-��cB^�cUc�[
+addr: 20001b8c
+string: �	E΅"�%-��cB^�cUc�[
+addr: 20001bac
+string: !��	��d��
+addr: 20001bb8
+string: ���c@ޅ�sc��c��
+addr: 20001bd4
+string: ,AFR�Y.,	
+addr: 20001be1
+string: Eq&%��%�#"�# �%�%A#$�#&���s	�s
+addr: 20001c0f
+string: �s
+addr: 20001c13
+string: �7u
+addr: 20001c17
+string: ����^�� �!$�!�$A!)!�)� *� �*A + �+�,��,A-�-�"��s
+addr: 20001c5b
+string: �s
+addr: 20001c5f
+string: ��Km�s
+addr: 20001c67
+string: �s
+addr: 20001c6b
+string: �ʋ}�s
+addr: 20001c73
+string: �s
+addr: 20001c77
+string: �Qq�עզ������Ͳ���*�E
+addr: 20001c90
+string: ���(
+addr: 20001c96
+string: AF�,	�
+addr: 20001ca1
+string: J��E�0��ǂł˂�(
+addr: 20001cb4
+string: ��s�s��&��6cM��c�E��sc�
+addr: 20001cda
+string: AE,
+addr: 20001cde
+string: �AV�i��}�u�,
+addr: 20001cee
+string: 
+addr: 20001cf1
+string: N��0
+addr: 20001cf8
+string: (
+addr: 20001cfa
+string: �E�&�
+addr: 20001d01
+string: J��&�s	�s
+addr: 20001d0f
+string: �s
+addr: 20001d13
+string: �7u
+addr: 20001d17
+string: ��ؾP.T�TY�InJma��s
+addr: 20001d2f
+string: �s
+addr: 20001d33
+string: �Qq�עզ������Ͳ���*�E
+addr: 20001d4c
+string: ���(
+addr: 20001d52
+string: AF1,	�
+addr: 20001d5d
+string: J��E�0��ǂł˂�(
+addr: 20001d70
+string: ��s�s��&�>cM��c�E��sc�
+addr: 20001d96
+string: AE,
+addr: 20001d9a
+string: �AV�i��}�u�,
+addr: 20001daa
+string: 
+addr: 20001dad
+string: N�� Pt(
+addr: 20001db6
+string: �EA,�
+addr: 20001dbd
+string: J�a$�s	�s
+addr: 20001dcb
+string: �s
+addr: 20001dcf
+string: �7u
+addr: 20001dd3
+string: ��ؾP.T�TY�InJma��s
+addr: 20001deb
+string: �s
+addr: 20001def
+string: �yq�"�&�J�N�R�V�Z�*�A�
+addr: 20001e0b
+string: :���E
+addr: 20001e12
+string: �I7u
+addr: 20001e17
+string: ��ؓ�s}K@U�i*�%��U�i*�El
+addr: 20001e38
+string: &��$cO��c�UcU
+addr: 20001e50
+string: �E,
+addr: 20001e56
+string: &�E,c@��c�UcU
+addr: 20001e6e
+string: !�	��w;�%
+addr: 20001e7c
+string: �
+addr: 20001e80
+string: # �
+addr: 20001e84
+string: AF�sc��J��(cD*���sc�c�
+addr: 20001eaa
+string: �s1�s
+addr: 20001eb3
+string: �s
+addr: 20001eb7
+string: �R��P"T�TY�IbJ�JBKEa��s
+addr: 20001ed1
+string: �s
+addr: 20001ed5
+string: �7u
+addr: 20001ed9
+string: ����s
+addr: 20001ee3
+string: �s
+addr: 20001ee7
+string: �A�"�*�
+addr: 20001ef3
+string: 8E��,cC*���sc�c�
+addr: 20001f12
+string: �&cF*���sc�c�
+addr: 20001f2c
+string: �&cI*���sc�c�
+addr: 20001f46
+string: # 
+addr: 20001f4a
+string: �s	�s
+addr: 20001f53
+string: �s
+addr: 20001f57
+string: �7u
+addr: 20001f5b
+string: ��ز@"DA��s
+addr: 20001f6b
+string: �s
+addr: 20001f6f
+string: �]q�ƢĦ���N�R�V�Z�^ֲ�.�*����"�*�E���Dc���D�	������"�%
+addr: 20001fb0
+string: 3F%!3HE!���ږ�q�Z���3�w3�w��7A}�A�}��G��q���U�3�u��u��5A��э�������y�эA���&��oU�c�T
+addr: 20002018
+string: �@&D�DI�YbZ�ZB[�[aa��s
+addr: 20002031
+string: �s
+addr: 20002035
+string: �7������s
+addr: 20002043
+string: �s
+addr: 20002047
+string: �]q�ƢĦ���N�R�V�Z�.���(�((Q *�D9�	K����
+addr: 20002076
+string: (�(�%
+addr: 2000207e
+string: 3E5!��V���e3�e��%A��Ս������m�u��d�
+addr: 200020a6
+string: A?���eD�cD
+addr: 200020ba
+string: �@&D�DI�YbZ�ZB[aa��s
+addr: 200020d1
+string: �s
+addr: 200020d5
+string: �# 
+addr: 200020da
+string: �L���s
+addr: 200020e3
+string: �s
+addr: 200020e7
+string: �HA��s
+addr: 200020ef
+string: �s
+addr: 200020f3
+string: �A�
+addr: 200020fa
+string: �.���s
+addr: 20002103
+string: �s
+addr: 20002107
+string: �A�"Ī�y�7�7�!��&
+addr: 20002120
+string: E��35�
+addr: 20002128
+string: 3�� �G�3��
+addr: 20002134
+string: Y���s�sc�c�
+addr: 2000214e
+string: 7�A2�6� 	�s
+addr: 2000215d
+string: �s
+addr: 20002161
+string: �7u
+addr: 20002165
+string: ���"��@"DA��s
+addr: 20002177
+string: �s
+addr: 2000217b
+string: �G�Fc|��FG�G� �
+addr: 20002190
+string: �G� #������
+addr: 200021a0
+string: ����ce�
+addr: 200021b2
+string: ������c��
+addr: 200021c2
+string: ��s
+addr: 200021c7
+string: �s
+addr: 200021cb
+string: �W�����6�=�%
+addr: 200021de
+string: G��38�
+addr: 200021e6
+string: �G� G*37�
+addr: 200021f2
+string: 3g�
+addr: 200021f6
+string: !��s�sc�Gc��
+addr: 20002210
+string: �Fc~�
+addr: 20002216
+string: �F7�A���A��6���j��c��
+addr: 20002238
+string: ��s	�s
+addr: 20002241
+string: �s
+addr: 20002245
+string: �7u
+addr: 20002249
+string: ����6���s
+addr: 20002255
+string: �s
+addr: 20002259
+string: �Aơ cL*���sc�c�
+addr: 20002278
+string: 7A����s	�s
+addr: 2000228b
+string: �s
+addr: 2000228f
+string: �7u
+addr: 20002293
+string: ��ز@A��s
+addr: 200022a1
+string: �s
+addr: 200022a5
+string: �}UE�s�A�M3E�@���sc��c�
+addr: 200022ca
+string: �M��
+addr: 200022d4
+string: ��s
+addr: 200022d9
+string: �s
+addr: 200022dd
+string: �7�
+addr: 200022e1
+string: �夂�s
+addr: 200022eb
+string: �s
+addr: 200022ef
+string: �}UE�s7A��N.��.����3E�@7APN���sc��
+addr: 2000231e
+string: !�.���c��
+addr: 20002332
+string: 7u
+addr: 20002335
+string: ��؂�s
+addr: 2000233f
+string: �s
+addr: 20002343
+string: ���
+addr: 2000234c
+string: 7U
+addr: 2000234f
+string: ��4��s
+addr: 20002359
+string: �s
+addr: 2000235d
+string: ���sc�
+addr: 2000236c
+string: �A�M�
+addr: 2000237a
+string: �M��
+addr: 20002384
+string: ��s
+addr: 20002389
+string: �s
+addr: 2000238d
+string: �A�?cH*���sc�c�
+addr: 200023ac
+string: 7A�E�5?cG*���sc�
+addr: 200023c4
+string: c�
+addr: 200023ce
+string: �s	�s
+addr: 200023d7
+string: �s
+addr: 200023db
+string: �7u
+addr: 200023df
+string: ��ز@A��s
+addr: 200023ed
+string: �s
+addr: 200023f1
+string: �A�E=cI*���sc�c�
+addr: 20002410
+string: 7A�0��=cG*���sc�
+addr: 2000242a
+string: c�
+addr: 20002434
+string: �s	�s
+addr: 2000243d
+string: �s
+addr: 20002441
+string: �7u
+addr: 20002445
+string: ��ز@A��s
+addr: 20002453
+string: �s
+addr: 20002457
+string: ��"�&�J�N�R�Vª�HA�@7�6�c��c�
+addr: 20002484
+string: �D�Dca�cu�
+addr: 20002496
+string: �s��sc��c�
+addr: 200024ac
+string: �;*�cM���sc��c�
+addr: 200024c8
+string: �D
+addr: 200024cc
+string: ��
+addr: 200024d0
+string: ��
+addr: 200024d4
+string: ���
+addr: 200024d8
+string: ]=*�cG���sc��c�
+addr: 200024f4
+string: �=*�cI���sc��3ZA�ec�
+addr: 20002516
+string: c��
+addr: 2000251a
+string: 7�5�a�s
+addr: 20002527
+string: �s
+addr: 2000252b
+string: ��s�s�u
+addr: 20002537
+string: ����cE�@	�cJ
+addr: 2000254e
+string: 7EA-1�scE�sc�
+addr: 2000256a
+string: c
+addr: 2000256c
+string: 9�D�H39A	�A>*�cG���sc��
+addr: 2000258a
+string: c�
+addr: 20002594
+string: �s	�s
+addr: 2000259d
+string: �s
+addr: 200025a1
+string: �7u
+addr: 200025a5
+string: ���"��@bD�DBI�I"J�Ja��s
+addr: 200025c1
+string: �s
+addr: 200025c5
+string: ��
+addr: 200025cd
+string: �%��	��@ao pNs
+addr: 200025df
+string: �s
+addr: 200025e3
+string: �U
+addr: 200025e8
+string: %�y��
+addr: 200025f1
+string: ����E�@ao Vs
+addr: 20002603
+string: �s
+addr: 20002607
+string: �E
+addr: 2000260c
+string: ��(
+addr: 20002612
+string: QF�
+addr: 20002617
+string: n(
+addr: 2000261a
+string: �
+addr: 2000261d
+string: I�@a��s
+addr: 20002627
+string: �s
+addr: 2000262b
+string: �
+addr: 2000262f
+string: ��%��Fc��
+addr: 2000263a
+string: ��
+addr: 2000263e
+string: # ֢
+addr: 20002645
+string: �f���� ����s
+addr: 20002655
+string: �s
+addr: 20002659
+string: �9q�"�&�J�eE5�@4U
+addr: 20002672
+string: %�nY
+addr: 2000267a
+string: �5
+addr: 2000267e
+string: ��e;�Y.%ip�H��
+addr: 20002691
+string: �婅E"��@L�s
+addr: 200026a3
+string: �s
+addr: 200026a7
+string: �E
+addr: 200026ac
+string: �QF�
+addr: 200026b7
+string: d����>7A,��,9�*�%ip��
+addr: 200026d7
+string: �Ŧ�E"���G�s
+addr: 200026e9
+string: �s
+addr: 200026ed
+string: �E
+addr: 200026f2
+string: ��QF� �_����:1eժ� *,��
+addr: 2000271b
+string: ���aF�
+addr: 20002727
+string: ]�
+addr: 2000272c
+string: �
+addr: 20002732
+string: e�E
+addr: 2000273a
+string: ����
+addr: 20002741
+string: @G�F�G� �� �@1�s
+addr: 20002755
+string: �s
+addr: 20002759
+string: �i(U
+addr: 20002760
+string: $�EE
+addr: 20002768
+string: ��E���F��O�
+addr: 2000277a
+string: �E�
+addr: 2000277e
+string: ��%ip	��
+addr: 20002789
+string: �圁E��<�s
+addr: 20002799
+string: �s
+addr: 2000279d
+string: �E
+addr: 200027a2
+string: �%QF� �T��/E
+addr: 200027b8
+string: ��5E��	����J�%
+addr: 200027cc
+string: }�35�
+addr: 200027d2
+string: m��1eժ� �PbT�TBY!a��s
+addr: 200027ef
+string: �s
+addr: 200027f3
+string: �9q�"�&�J�N�R�V�Z�� p}���/�	�� p}*�1�s
+addr: 2000281d
+string: �s
+addr: 20002821
+string: �IU
+addr: 20002828
+string: %�ST
+addr: 20002830
+string: �5
+addr: 20002836
+string: ����
+addr: 2000283e
+string: ��*%U�H��
+addr: 2000284d
+string: �呅E&���0c	%i5	u�s
+addr: 20002867
+string: �s
+addr: 2000286b
+string: �E
+addr: 20002870
+string: ���(
+addr: 20002876
+string: QF� �G(
+addr: 2000287e
+string: ����"�	�*Uc
+addr: 20002890
+string: �
+addr: 20002893
+string: �Ŏ�E�@,�s
+addr: 200028a3
+string: �s
+addr: 200028a7
+string: �E
+addr: 200028ac
+string: ��(
+addr: 200028b2
+string: QF�
+addr: 200028b7
+string: D(
+addr: 200028ba
+string: �
+addr: 200028bd
+string: ���%�x�e�ժ)�D����~E
+addr: 200028dc
+string: �	E��
+addr: 200028e3
+string: ���c
+addr: 200028ec
+string: �@�EV���&1�s
+addr: 200028fb
+string: �s
+addr: 200028ff
+string: �(
+addr: 20002902
+string: QF΅� �>�@(
+addr: 2000290e
+string: ��%�x��g�� J����PbT�TBY�Y"Z�Z[!a��s
+addr: 2000293d
+string: �s
+addr: 20002941
+string: ���s
+addr: 20002947
+string: �s
+addr: 2000294b
+string: ��U
+addr: 20002954
+string: %�B�E
+addr: 2000295e
+string: �e�(
+addr: 20002964
+string: QF� �8E
+addr: 2000296e
+string: ���(
+addr: 20002974
+string: �`�s
+addr: 2000297d
+string: �s
+addr: 20002981
+string: ��
+addr: 20002985
+string: �%��E
+addr: 2000298e
+string: ���E��E�
+addr: 2000299c
+string: �-�@�"�U
+addr: 200029ac
+string: %E=.��E
+addr: 200029b8
+string: ���QF� @3���� )�s
+addr: 200029d1
+string: �s
+addr: 200029d5
+string: ��
+addr: 200029d9
+string: �%~�E"���E�
+addr: 200029ea
+string: �(�`A�E�
+addr: 200029f8
+string: p,E�
+addr: 200029fe
+string: �)E�
+addr: 20002a04
+string: .��?�E�@A��s
+addr: 20002a15
+string: �s
+addr: 20002a19
+string: �9q�"�&�J�N�R�5
+addr: 20002a2c
+string: �
+addr: 20002a30
+string: %J
+addr: 20002a34
+string: $�
+addr: 20002a38
+string: �Ec�A�c U
+addr: 20002a48
+string: $EE
+addr: 20002a50
+string: ��E���F�p!�E���Eqc�U
+addr: 20002a70
+string: %1c�
+addr: 20002a7b
+string: �Eu�E��M�s
+addr: 20002a8b
+string: �s
+addr: 20002a8f
+string: �����f"��p4I�*�U
+addr: 20002aa6
+string: %�-5��
+addr: 20002aaf
+string: �Ex�E"��`��s
+addr: 20002ac1
+string: �s
+addr: 20002ac5
+string: �U
+addr: 20002aca
+string: $%E
+addr: 20002ad2
+string: ��E���F�P��Eqc�U
+addr: 20002af0
+string: %)a��
+addr: 20002af9
+string: �%v�E��٨s
+addr: 20002b09
+string: �s
+addr: 20002b0d
+string: �E
+addr: 20002b12
+string: ��o(
+addr: 20002b18
+string: QF� �(
+addr: 20002b20
+string: ���
+addr: 20002b24
+string: �x1eժ�
+addr: 20002b2e
+string: 0hU
+addr: 20002b34
+string: U�!�ąE.����#�
+addr: 20002b4a
+string: #�
+addr: 20002b4e
+string: �#
+addr: 20002b54
+string: ����%Z,
+addr: 20002b60
+string: ��))�*�U
+addr: 20002b6c
+string: %E!��
+addr: 20002b75
+string: �%m�E"��
+addr: 20002b80
+string: ~�s
+addr: 20002b87
+string: �s
+addr: 20002b8b
+string: �E
+addr: 20002b90
+string: �i(
+addr: 20002b96
+string: QF� �(
+addr: 20002b9e
+string: ���
+addr: 20002ba2
+string: �p1eժ�
+addr: 20002bac
+string: P`����T�
+addr: 20002bb8
+string: �~q�s
+addr: 20002bbf
+string: �s
+addr: 20002bc3
+string: �E
+addr: 20002bc8
+string: ��f(
+addr: 20002bce
+string: QF� @(
+addr: 20002bd6
+string: �
+addr: 20002bd8
+string: PmE
+addr: 20002bde
+string: ��5E�����p�%
+addr: 20002bf2
+string: }�35�
+addr: 20002bf8
+string: m�c$1eժ�
+addr: 20002c06
+string: �Z��s
+addr: 20002c0d
+string: �s
+addr: 20002c11
+string: �E
+addr: 20002c16
+string: �%Y(
+addr: 20002c1c
+string: QF� `(
+addr: 20002c24
+string: �
+addr: 20002c26
+string: phE
+addr: 20002c2c
+string: �5E�p�����%
+addr: 20002c40
+string: }�35�
+addr: 20002c46
+string: m�7
+addr: 20002c4b
+string: @�1eժ�
+addr: 20002c56
+string: �U����?"��PE)�*�U
+addr: 20002c6e
+string: %%��
+addr: 20002c77
+string: ��V�E"��
+addr: 20002c82
+string: �m�s
+addr: 20002c89
+string: �s
+addr: 20002c8d
+string: �E
+addr: 20002c92
+string: ��R(
+addr: 20002c98
+string: QF� �(
+addr: 20002ca0
+string: ���
+addr: 20002ca4
+string: �`1eժ�
+addr: 20002cae
+string: 0PU
+addr: 20002cb4
+string: �)��E
+addr: 20002cbc
+string: �E΅�F��z�U
+addr: 20002cce
+string: �e�%I
+addr: 20002cd6
+string: ��
+addr: 20002cda
+string: ���Eq��U
+addr: 20002ce8
+string: %�		��
+addr: 20002cf1
+string: �eP�E�
+addr: 20002cfa
+string: pf�s
+addr: 20002d01
+string: �s
+addr: 20002d05
+string: �E
+addr: 20002d0a
+string: �eL(
+addr: 20002d10
+string: QF�0~(
+addr: 20002d18
+string: �
+addr: 20002d1a
+string: 0YE
+addr: 20002d20
+string: Ż5E��΅�@t�%
+addr: 20002d34
+string: }�35�
+addr: 20002d3a
+string: m��1eժ�
+addr: 20002d46
+string: �FE
+addr: 20002d4c
+string: �E΅�F��q�U
+addr: 20002d5e
+string: ��
+addr: 20002d62
+string: L@��
+addr: 20002d68
+string: ���Eq��U
+addr: 20002d76
+string: %�
+addr: 20002d7a
+string: ��
+addr: 20002d7f
+string: ��H�E�
+addr: 20002d88
+string: �]�s
+addr: 20002d8f
+string: �s
+addr: 20002d93
+string: �E
+addr: 20002d98
+string: ��D(
+addr: 20002d9e
+string: QF�Pu(
+addr: 20002da6
+string: �
+addr: 20002da8
+string: PPE
+addr: 20002dae
+string: �5E��΅�`k�$
+addr: 20002dc3
+string: @�%
+addr: 20002dc8
+string: }�35�
+addr: 20002dce
+string: m��1eժ�
+addr: 20002dda
+string: p=&�"��E*�*�*����e&,
+addr: 20002df4
+string: �0;)�*�U
+addr: 20002e00
+string: %���
+addr: 20002e09
+string: �eA�E"��
+addr: 20002e14
+string: �T�s
+addr: 20002e1b
+string: �s
+addr: 20002e1f
+string: �E
+addr: 20002e24
+string: �E=(
+addr: 20002e2a
+string: QF��l(
+addr: 20002e32
+string: ���
+addr: 20002e36
+string: pG1eժ�
+addr: 20002e40
+string: 7���� �
+addr: 20002e4c
+string: �fE�)(�PbT�TBY�Y"Z!a��s
+addr: 20002e69
+string: �s
+addr: 20002e6d
+string: �yq�"�&�J�N�R����E7
+addr: 20002e87
+string: H�
+addr: 20002e8a
+string: Y
+addr: 20002e90
+string: 9�*�%	���
+addr: 20002e9d
+string: �%=�E"��
+addr: 20002ea8
+string: �K�s
+addr: 20002eaf
+string: �s
+addr: 20002eb3
+string: �E
+addr: 20002eb8
+string: �9�QF�Pc����
+addr: 20002eca
+string: 0>1eժ�
+addr: 20002ed4
+string: �-5
+addr: 20002eda
+string: ��H@�Ec�
+addr: 20002ee6
+string: ���	�	�s
+addr: 20002ef3
+string: �s
+addr: 20002ef7
+string: ����	 �EN���89���%	���
+addr: 20002f15
+string: ��6�E&��
+addr: 20002f20
+string: D�s
+addr: 20002f27
+string: �s
+addr: 20002f2b
+string: �E
+addr: 20002f30
+string: ��2�QF��[����
+addr: 20002f42
+string: �61eժ�
+addr: 20002f4c
+string: P&�EFN��p9���%	���
+addr: 20002f65
+string: �%3�E&��
+addr: 20002f70
+string: ?�s
+addr: 20002f77
+string: �s
+addr: 20002f7b
+string: �E
+addr: 20002f80
+string: �/�QF��V����
+addr: 20002f92
+string: �11eժ�
+addr: 20002f9c
+string: P!D�
+addr: 20002fa3
+string: �����BM���E4
+addr: 20002fb6
+string: ch�
+addr: 20002fba
+string: �E9�s
+addr: 20002fc1
+string: �s
+addr: 20002fc5
+string: ���
+addr: 20002fca
+string: E
+addr: 20002fce
+string: &%h�����
+addr: 20002fdc
+string: �9���%	���
+addr: 20002feb
+string: �,�E&��
+addr: 20002ff6
+string: �6�s
+addr: 20002ffd
+string: �s
+addr: 20003001
+string: �E
+addr: 20003006
+string: ��'�QF�pN����
+addr: 20003018
+string: P)1eժ�
+addr: 20003022
+string: �E
+addr: 20003028
+string: &Eb���E�E�
+addr: 20003038
+string: 9���%	���
+addr: 20003047
+string: ��'�E&��
+addr: 20003052
+string: �0�s
+addr: 20003059
+string: �s
+addr: 2000305d
+string: �E
+addr: 20003062
+string: �e#�QF��H����
+addr: 20003074
+string: �#1eժ�
+addr: 2000307e
+string: 0Ech�
+addr: 20003086
+string: �E9�s
+addr: 2000308d
+string: �s
+addr: 20003091
+string: ���
+addr: 20003096
+string: ������FDF�
+addr: 200030a6
+string: p9���%	���
+addr: 200030b5
+string: ��!�E&��
+addr: 200030c0
+string: *�s
+addr: 200030c7
+string: �s
+addr: 200030cb
+string: �E
+addr: 200030d0
+string: ���QF��A����
+addr: 200030e2
+string: �1eժ�
+addr: 200030ec
+string: P���##��E�.Ei.�EN�)(�P"T�TY�IbJEa��s
+addr: 20003117
+string: �s
+addr: 2000311b
+string: �yq�"�&�J�N�.�*�,���Y
+addr: 20003136
+string: 9��������
+addr: 20003143
+string: ���E&��
+addr: 2000314e
+string: 0!�s
+addr: 20003155
+string: �s
+addr: 20003159
+string: �E
+addr: 2000315e
+string: ���QF��8����
+addr: 20003170
+string: �1eժ�
+addr: 2000317a
+string: p"�ʅ�*��,"���9�*������
+addr: 20003199
+string: ���E"��
+addr: 200031a4
+string: ��s
+addr: 200031ab
+string: �s
+addr: 200031af
+string: �E
+addr: 200031b4
+string: ���QF��3����
+addr: 200031c6
+string: p1eժ�
+addr: 200031d1
+string: ~&��P"T�TY�IEa��s
+addr: 200031e5
+string: �s
+addr: 200031e9
+string: �yq�"�&�J�5
+addr: 200031f8
+string: %��Ec�
+addr: 20003202
+string: �����	�s
+addr: 2000320f
+string: �s
+addr: 20003213
+string: ����E����%��#.��E�"�� jY
+addr: 2000323a
+string: 9���%i���
+addr: 20003247
+string: ��E&��
+addr: 20003252
+string: ��s
+addr: 20003259
+string: �s
+addr: 2000325d
+string: �E
+addr: 20003262
+string: ��(
+addr: 20003268
+string: QF��((
+addr: 20003270
+string: ���
+addr: 20003274
+string: �1eժ�
+addr: 2000327e
+string: s�D��ȅE"�� �E"��`g9�*�%i���
+addr: 200032a1
+string: ���E"��
+addr: 200032ac
+string: P�s
+addr: 200032b3
+string: �s
+addr: 200032b7
+string: �E
+addr: 200032bc
+string: ��(
+addr: 200032c2
+string: QF�#(
+addr: 200032ca
+string: ���
+addr: 200032ce
+string: �}1eժ�
+addr: 200032d8
+string: �m35�
+addr: 200032de
+string: �P"T�TYEa��s
+addr: 200032ed
+string: �s
+addr: 200032f1
+string: �9q�"�&�J�N�R����&D�-®���EZ
+addr: 20003314
+string: c��,
+addr: 2000331a
+string: N���*�LF��U)���5
+addr: 20003336
+string: ���%�5
+addr: 20003340
+string: ��Yʅ��cH"E�Ec�%D��Dc	�a�s
+addr: 20003365
+string: �s
+addr: 20003369
+string: �U
+addr: 2000336e
+string: �%儃&D�5
+addr: 2000337a
+string: %VE�PbT�TBY�Y"Z!ao s
+addr: 20003395
+string: �s
+addr: 20003399
+string: ���}��5
+addr: 200033a2
+string: ��S� ʅ�@��ϧ]�s
+addr: 200033b9
+string: �s
+addr: 200033bd
+string: ��Ecg�
+addr: 200033c4
+string: %D��Dc�
+addr: 200033ce
+string: �&D�5
+addr: 200033d6
+string: ePEʅ��s
+addr: 200033e3
+string: �s
+addr: 200033e7
+string: �#�LFN��F��l9�*�U
+addr: 20003400
+string: %���
+addr: 20003409
+string: ���EJ��
+addr: 20003414
+string: �t�s
+addr: 2000341b
+string: �s
+addr: 2000341f
+string: �E
+addr: 20003424
+string: ���(
+addr: 2000342a
+string: QF��(
+addr: 20003432
+string: ʅ�-1eժ�+#*�ԃ%���&D�5
+addr: 2000344e
+string: �HE����&��PbT�TBY�Y"Z!a��s
+addr: 2000346f
+string: �s
+addr: 20003473
+string: �	�!Es 0��s
+addr: 20003481
+string: �s
+addr: 20003485
+string: �!Es00��s
+addr: 20003491
+string: �s
+addr: 20003495
+string: ���(s E0��s
+addr: 200034a5
+string: �s
+addr: 200034a9
+string: ��(s0E0��s
+addr: 200034b7
+string: �s
+addr: 200034bb
+string: ��
+addr: 200034c1
+string: s E0��s
+addr: 200034cb
+string: �s
+addr: 200034cf
+string: �
+addr: 200034d3
+string: s0E0��s
+addr: 200034dd
+string: �s
+addr: 200034e1
+string: �	�!Es E0��s
+addr: 200034ef
+string: �s
+addr: 200034f3
+string: �!Es0E0��s
+addr: 200034ff
+string: �s
+addr: 20003503
+string: �yq�"�&�J�N�.���a#���+�U
+addr: 2000351e
+string: ��%�*����
+addr: 20003529
+string: �%�EN�ʆ&����P"T�TY�IEa)�s
+addr: 20003549
+string: �s
+addr: 2000354d
+string: �E
+addr: 20003552
+string: ��(
+addr: 20003558
+string: QF��y(
+addr: 20003560
+string: ΅J���"��#�P"T�TY�IEa��s
+addr: 2000357b
+string: �s
+addr: 2000357f
+string: �A��)}��Ec��E
+addr: 20003592
+string: ��%�3E� A��@A��s
+addr: 200035a7
+string: �s
+addr: 200035ab
+string: ��@A��s
+addr: 200035b5
+string: �s
+addr: 200035b9
+string: ��@A��s
+addr: 200035c3
+string: �s
+addr: 200035c7
+string: ��@A%�s
+addr: 200035d1
+string: �s
+addr: 200035d5
+string: ��@A-�s
+addr: 200035df
+string: �s
+addr: 200035e3
+string: ��@A1�s
+addr: 200035ed
+string: �s
+addr: 200035f1
+string: ��@Ao��s
+addr: 200035fd
+string: �s
+addr: 20003601
+string: �	 Aƥ)��}�F
+addr: 20003612
+string: ��3E� A�5�)AƱ)��E
+addr: 2000362c
+string: U��=�!Aơ!��E
+addr: 20003640
+string: ���55!yq�"�&������E�*�D
+addr: 20003662
+string: !�*���q	��
+addr: 2000366f
+string: �υE"��!�s
+addr: 2000367f
+string: �s
+addr: 20003683
+string: �E
+addr: 20003688
+string: ���(
+addr: 2000368e
+string: QF�@f(
+addr: 20003696
+string: ��	)1eժ9&U�E
+addr: 200036a8
+string: ��E3E� A�Ec���?�-�V�����Eu*!�*���q	��
+addr: 200036d9
+string: ��ɅE"��)�s
+addr: 200036e9
+string: �s
+addr: 200036ed
+string: �E
+addr: 200036f2
+string: �e�(
+addr: 200036f8
+string: QF��_(
+addr: 20003700
+string: ��e&1eժU$�P"T�TEa��s
+addr: 20003719
+string: �s
+addr: 2000371d
+string: ��&��E
+addr: 20003726
+string: ���;�&Aƹ&��E
+addr: 2000373a
+string: �����.A�%.�
+addr: 2000374d
+string: ��c�
+addr: 20003754
+string: �Uc��@A��s
+addr: 20003763
+string: �s
+addr: 20003767
+string: ��@Aɷs
+addr: 20003771
+string: �s
+addr: 20003775
+string: �)&��E
+addr: 2000377e
+string: E���?��$��F��1�s
+addr: 20003793
+string: �s
+addr: 20003797
+string: �F2���s
+addr: 200037a1
+string: �s
+addr: 200037a5
+string: �7
+addr: 200037aa
+string: �����
+addr: 200037b2
+string: 36�
+addr: 200037b6
+string: Y�]��&
+addr: 200037be
+string: G
+addr: 200037c2
+string: Q�F�A�5
+addr: 200037ce
+string: �(q�2�AF���3�H���
+addr: 200037e6
+string: ٍ�2���s
+addr: 200037f1
+string: �s
+addr: 200037f5
+string: ��6
+addr: 200037fa
+string: ��G
+addr: 20003802
+string: َ7F
+addr: 20003808
+string: G
+addr: 2000380c
+string: U��F�A�F3ť �6���s
+addr: 20003823
+string: �s
+addr: 20003827
+string: ��6
+addr: 2000382c
+string: �5�
+addr: 20003830
+string: Ս�6F
+addr: 20003836
+string: ��
+addr: 2000383a
+string: ͎�E��A�E�
+addr: 20003848
+string: 6��.���s
+addr: 20003853
+string: �s
+addr: 20003857
+string: ��6
+addr: 2000385c
+string: �5�
+addr: 20003860
+string: Ս�6
+addr: 20003866
+string: ͎�E��A�
+addr: 20003872
+string: .�HA�E�.���s
+addr: 20003881
+string: �s
+addr: 20003885
+string: ��6
+addr: 2000388a
+string: �5�
+addr: 2000388e
+string: ͎�E��A�E�
+addr: 2000389c
+string: 6�P�.���s
+addr: 200038a7
+string: �s
+addr: 200038ab
+string: �yq�"�&�J�F
+addr: 200038ba
+string: �$&0.�*�E
+addr: 200038c6
+string: ��E���F�
+addr: 200038d2
+string: :�5 ��
+addr: 200038dc
+string: �E���E
+addr: 200038e6
+string: %�I��
+addr: 200038ef
+string: ����E�$9�s
+addr: 200038fd
+string: �s
+addr: 20003901
+string: �E
+addr: 20003906
+string: �%�(
+addr: 2000390c
+string: QF�`>(
+addr: 20003914
+string: Y*E
+addr: 2000391a
+string: ��5E�
+addr: 20003923
+string: ���
+addr: 20003928
+string: �4�%
+addr: 2000392e
+string: }�35�
+addr: 20003934
+string: m�	�1eժ�(# $aejH�7ŭ����7
+addr: 20003959
+string: �uH�
+addr: 20003963
+string: �E
+addr: 20003968
+string: ���?�}U	FH�c��
+addr: 20003978
+string: #(
+addr: 2000397c
+string: �P"T�TYEa��s
+addr: 2000398b
+string: �s
+addr: 2000398f
+string: ���F��1�s
+addr: 2000399b
+string: �s
+addr: 2000399f
+string: �F2���s
+addr: 200039a9
+string: �s
+addr: 200039ad
+string: �αe��ժc��e�c��E
+addr: 200039c8
+string: ��E;�����@a��s
+addr: 200039d9
+string: �s
+addr: 200039dd
+string: �E
+addr: 200039e2
+string: %�9!�E
+addr: 200039ec
+string: �E	(
+addr: 200039f2
+string: QF�
+addr: 200039f7
+string: 0(
+addr: 200039fa
+string: E(=�s
+addr: 20003a01
+string: �s
+addr: 20003a05
+string: �E
+addr: 20003a0a
+string: %e79�E
+addr: 20003a14
+string: ��(
+addr: 20003a1a
+string: QF��-(
+addr: 20003a22
+string: a 5�s
+addr: 20003a29
+string: �s
+addr: 20003a2d
+string: ��
+addr: 20003a31
+string: �圁E"E
+addr: 20003a3e
+string: %�3űe��ժ�s
+addr: 20003a4f
+string: �s
+addr: 20003a53
+string: ��
+addr: 20003a57
+string: �E��E"E
+addr: 20003a64
+string: %�1ťe��	 s
+addr: 20003a74
+string: P��s
+addr: 20003a7b
+string: �s
+addr: 20003a7f
+string: �s% 4��s
+addr: 20003a89
+string: �s
+addr: 20003a8d
+string: �s%04��s
+addr: 20003a97
+string: �s
+addr: 20003a9b
+string: �s%4��s
+addr: 20003aa5
+string: �s
+addr: 20003aa9
+string: �yq�"�&�*�F�B�>�:�6�2�.�HA7
+addr: 20003ac7
+string: �}�E� >T@3�@��6��
+addr: 20003adf
+string: Jɓ
+addr: 20003ae6
+string: 1�s
+addr: 20003aeb
+string: �s
+addr: 20003aef
+string: �T@@�Ec�
+addr: 20003afa
+string: �E
+addr: 20003afe
+string: ��%�3E� A	�s
+addr: 20003b0d
+string: �s
+addr: 20003b11
+string: �E
+addr: 20003b16
+string: �e�����֤TDE
+addr: 20003b28
+string: ���*��T#��TH*�HL$E
+addr: 20003b46
+string: ���*�@"D�DEa��s
+addr: 20003b59
+string: �s
+addr: 20003b5d
+string: �F�B�>ʗG
+addr: 20003b6a
+string: ��g!:�6�2Ĉ�(
+addr: 20003b78
+string: *�EE
+addr: 20003b82
+string: 2�A�����a��s
+addr: 20003b93
+string: �s
+addr: 20003b97
+string: �2���s
+addr: 20003b9f
+string: �s
+addr: 20003ba3
+string: �����#�L����K��
+addr: 20003bba
+string: E����s
+addr: 20003bc5
+string: �s
+addr: 20003bc9
+string: ��"�&�J�N�
+addr: 20003bd7
+string: ���x��������3�@B��F��B�#
+addr: 20003bfa
+string: �
+addr: 20003bfc
+string: ������&�FG�H
+addr: 20003c10
+string: �
+addr: 20003c13
+string: ���
+addr: 20003c18
+string: #��
+addr: 20003c1c
+string: !��W��F�
+addr: 20003c2a
+string: �
+addr: 20003c2d
+string: ���
+addr: 20003c32
+string: #
+addr: 20003c34
+string: �
+addr: 20003c36
+string: ������
+addr: 20003c42
+string: �G�#��
+addr: 20003c4c
+string: ����c��G��c�73��
+addr: 20003c68
+string: G
+addr: 20003c6c
+string: ���
+addr: 20003c70
+string: �#��
+addr: 20003c76
+string: ����
+addr: 20003c7e
+string: 04ŁI�s
+addr: 20003c89
+string: �s
+addr: 20003c8d
+string: �%�F#'�FN���@bD�DBI�Ia��s
+addr: 20003caf
+string: �s
+addr: 20003cb3
+string: ����E;��
+addr: 20003cc2
+string: E����s
+addr: 20003ccd
+string: �s
+addr: 20003cd1
+string: ��"�&�J�N�2�Ʈ�*��D3��
+addr: 20003cec
+string: �E
+addr: 20003cf0
+string: "��
+addr: 20003cf4
+string: a����ʄ1�s
+addr: 20003d05
+string: �s
+addr: 20003d09
+string: ��D3�$�@bD�DBI�Ia��s
+addr: 20003d21
+string: �s
+addr: 20003d25
+string: �yq�F�B�>�:�6�2�.ʗ��3�A�A*�H*�T2�:�(�@Ea��s
+addr: 20003d5b
+string: �s
+addr: 20003d5f
+string: �����0�B�B.���2���>���)�s
+addr: 20003d7d
+string: �s
+addr: 20003d81
+string: �q�΢̦�����������^�b�f�j�nֲ�6�6�F
+addr: 20003da8
+string: cP��*���
+addr: 20003db6
+string: �	eށJJ�P�`e%�*�3�DD
+addr: 20003dda
+string: c��c
+addr: 20003de4
+string: J���R�����Ҕ�;�
+addr: 20003df4
+string: c�	�s
+addr: 20003dfd
+string: �s
+addr: 20003e01
+string: �c�i��
+addr: 20003e0e
+string: cJ�
+addr: 20003e16
+string: c���$
+addr: 20003e1e
+string: �K�s
+addr: 20003e27
+string: �s
+addr: 20003e2b
+string: �K�҅c�FDLE��e�v����cd�v��3F� �%� ����
+addr: 20003e64
+string: ���5�s
+addr: 20003e6d
+string: �s
+addr: 20003e71
+string: �
+addr: 20003e75
+string: 
+addr: 20003e79
+string: 
+addr: 20003e7d
+string: ���
+addr: 20003e85
+string: 2��s
+addr: 20003e8d
+string: �s
+addr: 20003e91
+string: ��ck���s
+addr: 20003e9d
+string: �s
+addr: 20003ea1
+string: �u�cB���cm��E
+addr: 20003eb6
+string: ����3E� A�c�3RE�E
+addr: 20003ecc
+string: .�+
+addr: 20003ed2
+string: c\
+addr: 20003ed6
+string: E
+addr: 20003eda
+string: ���FJ�����3`Aw�E
+addr: 20003ef2
+string: �ǩGJ�΅Z�E�s
+addr: 20003f03
+string: �s
+addr: 20003f07
+string: ��c��c��/c�-E
+addr: 20003f1c
+string: ���u�s
+addr: 20003f25
+string: �s
+addr: 20003f29
+string: �c�RE�E
+addr: 20003f34
+string: .�A��
+addr: 20003f3c
+string: .�PA�w�E
+addr: 20003f48
+string: �U��s
+addr: 20003f51
+string: �s
+addr: 20003f55
+string: �RE�E
+addr: 20003f5c
+string: .�Aw�E
+addr: 20003f68
+string: U�5�s
+addr: 20003f71
+string: �s
+addr: 20003f75
+string: �c�'RE�E
+addr: 20003f80
+string: .�A��
+addr: 20003f88
+string: .�PA�w�E
+addr: 20003f94
+string: �����s
+addr: 20003f9d
+string: �s
+addr: 20003fa1
+string: �RE�E
+addr: 20003fa8
+string: .�Ac�'c,E
+addr: 20003fb8
+string: �E�F=�s
+addr: 20003fc3
+string: �s
+addr: 20003fc7
+string: �c�#RE�E
+addr: 20003fd2
+string: .�A#�LF9�s
+addr: 20003fe3
+string: �s
+addr: 20003fe7
+string: �c�!RE�E
+addr: 20003ff2
+string: .�Aw�E
+addr: 20003ffe
+string: %��G]�s
+addr: 20004009
+string: �s
+addr: 2000400d
+string: �c�E
+addr: 20004016
+string: �5�	FJ����E�E
+addr: 20004026
+string: 2ʐA��E
+addr: 20004030
+string: ��F
+addr: 20004039
+string: �GJ�΅E&��}�s
+addr: 20004049
+string: �s
+addr: 2000404d
+string: �RE�E
+addr: 20004054
+string: .�A�E#�� .�l�Q�)�E*�����
+addr: 2000407a
+string: �e���6
+addr: 20004088
+string: E
+addr: 2000408e
+string: ���J����E*�3�@J���*�E
+addr: 200040a8
+string: ��J�Z���*�
+addr: 200040b8
+string: ��zFJ���R�*�2EcE
+addr: 200040d0
+string: ���FJ���*�LFJ���V*�E
+addr: 200040ec
+string: E��GJ�΅�FG�$*�E
+addr: 20004102
+string: ���FJ���"��s
+addr: 20004113
+string: �s
+addr: 20004117
+string: �RE�E
+addr: 2000411e
+string: .�c�A��
+addr: 2000412a
+string: .�LA��s
+addr: 20004133
+string: �s
+addr: 20004137
+string: �c�RE�E
+addr: 20004142
+string: .�Aw�E
+addr: 2000414e
+string: %��G��s
+addr: 20004159
+string: �s
+addr: 2000415d
+string: �c�RE�E
+addr: 20004168
+string: .�A��
+addr: 20004170
+string: .�PA�w�E
+addr: 2000417c
+string: �E�HJ�΅"���s
+addr: 2000418d
+string: �s
+addr: 20004191
+string: �RE�E
+addr: 20004198
+string: .�Aw�E
+addr: 200041a4
+string: Ŝ�GJ�΅��,��s
+addr: 200041b7
+string: �s
+addr: 200041bb
+string: �c�RE�E
+addr: 200041c6
+string: .�A��
+addr: 200041ce
+string: .�PA�w�E
+addr: 200041da
+string: �e�J�΅"�H"!�s
+addr: 200041ed
+string: �s
+addr: 200041f1
+string: �E
+addr: 200041f6
+string: �u�=FJ������
+addr: 20004206
+string: J��U�s
+addr: 20004211
+string: �s
+addr: 20004215
+string: �w�E
+addr: 2000421e
+string: %��GY�s
+addr: 20004229
+string: �s
+addr: 2000422d
+string: �VE
+addr: 20004234
+string: œ�GJ�΅�FGy**�E
+addr: 2000424a
+string: �E�J�Z���V���
+addr: 2000425a
+string: e�s
+addr: 2000425f
+string: �s
+addr: 20004263
+string: �AF3��
+addr: 2000426c
+string: E
+addr: 20004270
+string: }�}Y�s
+addr: 2000427b
+string: �s
+addr: 2000427f
+string: �E
+addr: 20004284
+string: �ՍF��s
+addr: 2000428f
+string: �s
+addr: 20004293
+string: �E
+addr: 20004298
+string: ���EFJ�����1�s
+addr: 200042a9
+string: �s
+addr: 200042ad
+string: ��JV��@fD�DFI�I&J�JK�[b\�\B]�]%a��s
+addr: 200042d3
+string: �s
+addr: 200042d7
+string: �E
+addr: 200042dc
+string: �U�1Fu�s
+addr: 200042e7
+string: �s
+addr: 200042eb
+string: �q�΢̦�����������^�b�f�j�n�ƋB�6���.���c��3gAh
+addr: 2000431e
+string: 
+addr: 20004321
+string: 
+addr: 20004325
+string: ���
+addr: 2000432a
+string: p%��M�T�l
+addr: 20004336
+string: N�&�����e�c
+addr: 20004346
+string: ��s
+addr: 2000434b
+string: �s
+addr: 2000434f
+string: ��Mc�DF}�
+addr: 20004360
+string: �
+addr: 20004363
+string: }]Z�c
+addr: 2000436c
+string: &�V�E
+addr: 20004374
+string: �UE
+addr: 20004378
+string: ޕ��
+addr: 2000437e
+string: ��
+addr: 20004382
+string: #��
+addr: 20004386
+string: =�^�
+addr: 2000438e
+string: ���
+addr: 20004394
+string: c�l
+addr: 2000439a
+string: 
+addr: 2000439d
+string: N��F��}����	�l
+addr: 200043b2
+string: N����n��@fD�DFI�I&J�JK�[b\�\B]�]%a��s
+addr: 200043db
+string: �s
+addr: 200043df
+string: �yq֮�)�N��2�3V����h
+addr: 200043fc
+string: ��u@��
+addr: 20004404
+string: ���#�u
+addr: 2000440c
+string: }�p��3�A��Ecc�-�s
+addr: 20004423
+string: �s
+addr: 20004427
+string: ��
+addr: 2000442c
+string: ��F�ғ
+addr: 20004437
+string: �նc~�
+addr: 20004440
+string: ���@|
+addr: 20004446
+string: 3��@}#
+addr: 2000444e
+string: �
+addr: 20004450
+string: �}��.�l
+addr: 2000445a
+string: �������PEa��s
+addr: 2000446b
+string: �s
+addr: 2000446f
+string: �6�!���2��E
+addr: 2000447c
+string: ��������}cx�
+addr: 20004490
+string: ����c��
+addr: 20004498
+string: ������v
+addr: 200044a7
+string: c���=�s
+addr: 200044b5
+string: �s
+addr: 200044b9
+string: �c^��M�s
+addr: 200044c9
+string: �s
+addr: 200044cd
+string: ���v�mGc��
+addr: 200044dc
+string: }F��
+addr: 200044e2
+string: ��
+addr: 200044e9
+string: Bc�
+addr: 200044f0
+string: ��)�s
+addr: 200044f9
+string: �s
+addr: 200044fd
+string: ����v��Gc��
+addr: 2000450c
+string: }G��
+addr: 20004512
+string: �W��
+addr: 2000451d
+string: эc�
+addr: 20004524
+string: ��)�s
+addr: 2000452d
+string: �s
+addr: 20004531
+string: ����v�mGc��
+addr: 20004540
+string: }Fjэ}�VVM�Q��)B���s
+addr: 2000455d
+string: �s
+addr: 20004561
+string: �'
+addr: 20004566
+string: G
+addr: 2000456a
+string: x��7
+addr: 20004572
+string: �h�
+addr: 20004576
+string: �
+addr: 20004579
+string: c�
+addr: 2000457e
+string: }}����G��G� �C��ϓՁ�
+addr: 200045a2
+string: 큓�#��
+addr: 200045ac
+string: �e
+addr: 200045b0
+string: 큓����
+addr: 200045ba
+string: m�#��
+addr: 200045c6
+string: 1�s
+addr: 200045cb
+string: �s
+addr: 200045cf
+string: ��35�
+addr: 200045d6
+string: ��s
+addr: 200045db
+string: �s
+addr: 200045df
+string: ���]�s
+addr: 200045e7
+string: �s
+addr: 200045eb
+string: �E��s
+addr: 200045f3
+string: �s
+addr: 200045f7
+string: �A�FMŔI	Gcb�6����E�e���>����Y�A�\�A3����A�A�E���
+addr: 20004640
+string: �}6
+addr: 2000464a
+string: ��
+addr: 2000464e
+string: �]�}7
+addr: 20004658
+string: 3c�
+addr: 2000465e
+string: ��
+addr: 20004664
+string: �7
+addr: 20004669
+string: ��A��W
+addr: 20004674
+string: ]�3g�
+addr: 2000467a
+string: X�AJ��I�v���IA��U��A�)��qF�-F2��@A��s
+addr: 200046b3
+string: �s
+addr: 200046b7
+string: �yq�"�&�J�N�R�V�Z�^�b�f�>�:���*��%
+addr: 200046de
+string: ��
+addr: 200046e2
+string: �e
+addr: 200046e6
+string: ��E
+addr: 200046ea
+string: BɎBُ9�>}���3uU6�c
+addr: 20004704
+string: 3��@�Fcc�
+addr: 20004710
+string: *�	I�c�
+addr: 2000471c
+string: .�9�s
+addr: 20004723
+string: �s
+addr: 20004727
+string: ��E
+addr: 2000472c
+string: 3Ź U
+addr: 20004734
+string: �k��J�3F�E���@c��
+addr: 2000474a
+string: ��%
+addr: 20004750
+string: ޕ��b��c�
+addr: 2000475e
+string: �.1�s
+addr: 20004765
+string: �s
+addr: 20004769
+string: ��!U
+addr: 20004770
+string: f�cjU�+
+addr: 2000477a
+string: 3UA��
+addr: 20004782
+string: #�
+addr: 20004786
+string: RQ�#�
+addr: 2000478e
+string: ��f���3E	�P"T�TY�IbJ�JBK�K"L�LEa��s
+addr: 200047b9
+string: �s
+addr: 200047bd
+string: ��"�&�J�N�.���5
+addr: 200047d2
+string: ��
+addr: 200047d6
+string: ɍE��2��֩c��c	��
+addr: 200047ee
+string: f}�B	����3u�
+addr: 20004802
+string: 3��
+addr: 20004806
+string: �G
+addr: 2000480a
+string: �3Ǵ
+addr: 20004810
+string: WI��@}u�>�3G�jW�Af�E��M�*�"�։��N�B�ʇH���EF��E
+addr: 2000484e
+string: g���WF
+addr: 20004856
+string: }�Ս���
+addr: 20004860
+string: 3FY�э��3E%5
+addr: 20004872
+string: }5�1�s
+addr: 2000487b
+string: �s
+addr: 2000487f
+string: �E�@bD�DBI�Ia��s
+addr: 20004893
+string: �s
+addr: 20004897
+string: ���F��1�s
+addr: 200048a3
+string: �s
+addr: 200048a7
+string: �F2���s
+addr: 200048b1
+string: �s
+addr: 200048b5
+string: ���F��1�s
+addr: 200048c1
+string: �s
+addr: 200048c5
+string: �F2���s
+addr: 200048cf
+string: �s
+addr: 200048d3
+string: ��6
+addr: 200048d8
+string: 7
+addr: 200048dc
+string: َ��
+addr: 200048e2
+string: G
+addr: 200048e6
+string: U��F�AA�F3U�H#
+addr: 200048f8
+string: �
+addr: 200048fa
+string: 6���s
+addr: 20004901
+string: �s
+addr: 20004905
+string: �36�
+addr: 2000490a
+string: ���
+addr: 2000490e
+string: �F��AF��(�2���s
+addr: 20004925
+string: �s
+addr: 20004929
+string: ��6�
+addr: 2000492e
+string: ��
+addr: 20004932
+string: u��F	�AXA�F}6
+addr: 20004944
+string: 3�H��
+addr: 2000494c
+string: ٍL�6���s
+addr: 20004957
+string: �s
+addr: 2000495b
+string: �́�APB��AE#�
+addr: 2000496e
+string: ��s
+addr: 20004973
+string: �s
+addr: 20004977
+string: �E��s
+addr: 2000497f
+string: �s
+addr: 20004983
+string: �6
+addr: 20004988
+string: ��
+addr: 2000498c
+string: юF��AAFL�2���s
+addr: 200049a1
+string: �s
+addr: 200049a5
+string: �A�"�&�J�Dq����A���@M�*��HEci��Hcf�7�
+addr: 200049d2
+string: 6-��6n��`��U��Ae}9�s
+addr: 200049ef
+string: �s
+addr: 200049f3
+string: ��E���FG�$Vэ��%
+addr: 20004a0c
+string: #�
+addr: 20004a10
+string: �%
+addr: 20004a14
+string: F�у%
+addr: 20004a1c
+string: #��%
+addr: 20004a24
+string: #��%
+addr: 20004a2c
+string: #�
+addr: 20004a30
+string: �%
+addr: 20004a34
+string: }V���HB��H��
+addr: 20004a44
+string: M��D}6
+addr: 20004a4e
+string: ���
+addr: 20004a56
+string: ��DэM��%
+addr: 20004a62
+string: �
+addr: 20004a66
+string: Q���%
+addr: 20004a70
+string: D#"
+addr: 20004a76
+string: "��@"D�DIA��s
+addr: 20004a87
+string: �s
+addr: 20004a8b
+string: ��*��F5Ec�
+addr: 20004a98
+string: BRE����Ս҂�s
+addr: 20004aad
+string: �s
+addr: 20004ab1
+string: �E��s
+addr: 20004ab9
+string: �s
+addr: 20004abd
+string: �7
+addr: 20004ac2
+string: ��
+addr: 20004ac6
+string: ُG��G�(
+addr: 20004ad4
+string: 'H��3��
+addr: 20004ae0
+string: G
+addr: 20004ae4
+string: �#.�
+addr: 20004aea
+string: �����G��:���s
+addr: 20004afd
+string: �s
+addr: 20004b01
+string: ��ATJ����TJ����L�AHJ!�u�E��s
+addr: 20004b23
+string: �s
+addr: 20004b27
+string: �E��s
+addr: 20004b2f
+string: �s
+addr: 20004b33
+string: �6
+addr: 20004b38
+string: ��
+addr: 20004b3c
+string: юF��AHQF"a���2���s
+addr: 20004b55
+string: �s
+addr: 20004b59
+string: �G)�s
+addr: 20004b61
+string: �s
+addr: 20004b65
+string: �yq�"�&�J�N�R�V�Z���:�����.�*��5
+addr: 20004b88
+string: )�t��R�@F	��Z�.�l
+addr: 20004b9e
+string: ɍc
+addr: 20004ba4
+string: N�V��"�s
+addr: 20004baf
+string: �s
+addr: 20004bb3
+string: �.�΅V�-*2E���TA��V�֙�J�D
+addr: 20004bd0
+string: 3e�
+addr: 20004bd4
+string: ��u��R�A*�3�Tc
+addr: 20004bea
+string: ,
+addr: 20004bec
+string: N�"�"1�s
+addr: 20004bf7
+string: �s
+addr: 20004bfb
+string: �(
+addr: 20004bfe
+string: ΅"��("E�u��ҕ��"��������P"T�TY�IbJ�JBKEa��s
+addr: 20004c2d
+string: �s
+addr: 20004c31
+string: �G�s
+addr: 20004c39
+string: �s
+addr: 20004c3d
+string: �A"ƁHH�CN����
+addr: 20004c52
+string: }S���c�
+addr: 20004c5c
+string: ���)�s
+addr: 20004c65
+string: �s
+addr: 20004c69
+string: ��^��������
+addr: 20004c76
+string: ���
+addr: 20004c7a
+string: ���3n�
+addr: 20004c84
+string: ���
+addr: 20004c8a
+string: ��w
+addr: 20004c8e
+string: c	�
+addr: 20004c92
+string: �7�
+addr: 20004c96
+string: 9�s
+addr: 20004c9b
+string: �s
+addr: 20004c9f
+string: ����
+addr: 20004ca4
+string: �
+addr: 20004ca8
+string: ���3h�
+addr: 20004cb2
+string: ���A3��
+addr: 20004cbc
+string: 񏳃�@���
+addr: 20004cc6
+string: 3�@3�@�����o�	�# w
+addr: 20004cde
+string: #"�F�2DA��s
+addr: 20004cef
+string: �s
+addr: 20004cf3
+string: ��6
+addr: 20004cf8
+string: �
+addr: 20004cfc
+string: َ��F��cl�
+addr: 20004d08
+string: �ƥ
+addr: 20004d0c
+string: ��2������@��6
+addr: 20004d1c
+string: �A�3�c�
+addr: 20004d2a
+string: ��*�Ɔ��
+addr: 20004d34
+string: #
+addr: 20004d36
+string: �
+addr: 20004d38
+string: ����c����B3�����c��
+addr: 20004d5a
+string: 3A3ƕ��
+addr: 20004d68
+string: #
+addr: 20004d6a
+string: �
+addr: 20004d6c
+string: }�m���s
+addr: 20004d79
+string: �s
+addr: 20004d7d
+string: ��F2�ce�
+addr: 20004d86
+string: 3�@���@�3��
+addr: 20004d96
+string: ˪���#��
+addr: 20004da0
+string: ����cp�����������
+addr: 20004dbe
+string: ���l�cz�
+addr: 20004dca
+string: ���
+addr: 20004dd0
+string: #��
+addr: 20004dd4
+string: }�e���s
+addr: 20004ddf
+string: �s
+addr: 20004de3
+string: ��F��ca��6�
+addr: 20004df0
+string: 3ǥ
+addr: 20004df4
+string: �37�
+addr: 20004dfa
+string: ��2������@��6
+addr: 20004e0a
+string: �A�3�c���.�Ɔ��
+addr: 20004e22
+string: G
+addr: 20004e26
+string: c��ck�����%�s
+addr: 20004e3b
+string: �s
+addr: 20004e3f
+string: ���B3�C�ֆiW�ic��cd�����c��3AƕF��F
+addr: 20004e72
+string: �
+addr: 20004e76
+string: c��
+addr: 20004e7a
+string: cc�}�m�E��s
+addr: 20004e8d
+string: �s
+addr: 20004e91
+string: �`���s
+addr: 20004e9b
+string: �s
+addr: 20004e9f
+string: ����s
+addr: 20004ea9
+string: �s
+addr: 20004ead
+string: ��F��cf�
+addr: 20004eb6
+string: 3�@�~7
+addr: 20004ebe
+string: ��c�
+addr: 20004ec6
+string: ������
+addr: 20004ece
+string: c��������A�3��c���������e���7�
+addr: 20004f00
+string: ���A��V
+addr: 20004f0a
+string: 3��@c��V@3�v
+addr: 20004f1a
+string: cw��f
+addr: 20004f22
+string: c�fსǑ���c��
+addr: 20004f34
+string: 3�A���
+addr: 20004f40
+string: c�}�u��E.���s
+addr: 20004f53
+string: �s
+addr: 20004f57
+string: ��Ϳs
+addr: 20004f5f
+string: �s
+addr: 20004f63
+string: ��ݷs
+addr: 20004f6b
+string: �s
+addr: 20004f6f
+string: ���s
+addr: 20004f77
+string: �s
+addr: 20004f7b
+string: ��F��cf�
+addr: 20004f84
+string: ��@��6
+addr: 20004f8c
+string: �V@��V
+addr: 20004f96
+string: ���3�
+addr: 20004f9e
+string: ��c���F�����}.��f�.���s
+addr: 20004fbd
+string: �s
+addr: 20004fc1
+string: ������7�
+addr: 20004fd2
+string: Af��c�r�u
+addr: 20004fe4
+string: ����F�
+addr: 20004fec
+string: Ⴙ�3G�@�vc��v�
+addr: 20005000
+string: c���v�����u
+addr: 20005012
+string: U�s
+addr: 20005017
+string: �s
+addr: 2000501b
+string: ��c�F������.��f�Q�s
+addr: 20005037
+string: �s
+addr: 2000503b
+string: �������s
+addr: 20005045
+string: �s
+addr: 20005049
+string: �������s
+addr: 20005053
+string: �s
+addr: 20005057
+string: �������s
+addr: 20005061
+string: �s
+addr: 20005065
+string: ��E��s
+addr: 2000506d
+string: �s
+addr: 20005071
+string: �yq�"�&�J�N�R�V�Z�^�bľ�:���2���*�&
+addr: 20005098
+string: E%}[c
+addr: 2000509e
+string: *��I-1���
+addr: 200050ad
+string: �3E� q{����K�E�
+addr: 200050c4
+string: #
+addr: 200050c6
+string: �
+addr: 200050c8
+string: �
+addr: 200050cc
+string: 6
+addr: 200050d0
+string: ��
+addr: 200050d4
+string: U���uң�1�s
+addr: 200050e7
+string: �s
+addr: 200050eb
+string: �"��%��s
+addr: 200050f5
+string: �s
+addr: 200050f9
+string: �#�E3T�#���K
+addr: 2000510c
+string: J��+���##�{E�#��
+addr: 20005122
+string: #�{#�#�Z�҅N�ﰏ�#��
+addr: 2000513c
+string: c�
+addr: 20005140
+string: #�zsp0���%�����%L�lA�l�%L����%�# ��%L����&���%�A�%L�HU���c�#"|�s
+addr: 2000519d
+string: �s
+addr: 200051a1
+string: �#"|�%�Ec��DV�"�=#�Q�����	��N�1+���%
+addr: 200051d2
+string: "�+�����#������)���e��)���#,5����#*�����%��#,���������%�3�(#���3E� 3EU!LA#��
+addr: 20005234
+string: �E#��
+addr: 2000523a
+string: �E#"&#�%#��
+addr: 20005248
+string: A��(%�K�%L�Z��P"T�TY�IbJ�JBK�K"LEa��s
+addr: 20005279
+string: �s
+addr: 2000527d
+string: ����%������%���A�Ƀ%���A}��%��hAł�s
+addr: 200052ab
+string: �s
+addr: 200052af
+string: �s`0��s
+addr: 200052b9
+string: �s
+addr: 200052bd
+string: �A�"����%�����E#%�܅�s
+addr: 200052dd
+string: �s
+addr: 200052e1
+string: ����#+����%��A�%�،Yc�
+addr: 200052fe
+string: %�؃%�ؓ�E�Џ����%��`E�3E� ���e߳E� �AHA��
+addr: 20005336
+string: ��c�
+addr: 2000533c
+string: HA���HE#%�ز@"DA��s
+addr: 20005353
+string: �s
+addr: 20005357
+string: �A�
+addr: 20005360
+string: %�5
+addr: 20005368
+string: �������
+addr: 20005377
+string: �FG��υEc�sp0���}V#+�����#*�����#$�����5
+addr: 200053ac
+string: %���@A��s
+addr: 200053b9
+string: �s
+addr: 200053bd
+string: ��"�&�J�N�R�V����������������$�!�sp0%i���j�lA�l��j��)�@ED
+addr: 2000540a
+string: &%��}#%���$�}#�������Xu&"�e&]�s
+addr: 20005431
+string: �s
+addr: 20005435
+string: �s
+addr: 2000543a
+string: e�s
+addr: 2000543f
+string: �s
+addr: 20005443
+string: ����%Ņ#(�Ă�s
+addr: 20005457
+string: �s
+addr: 2000545b
+string: ��"�&�J�N�sp0���%������%��A��%����%���#&��%��e����%��}������A�����͗�������ŗ���HXEXGS@OW�S��@B��c�
+addr: 200054e2
+string: D�#$B��PGGDK��@G\��@�G
+addr: 20005500
+string: c�
+addr: 20005504
+string: ���@}��PW��%����(#����D� ��!�@
+addr: 20005525
+string: �DT�D���D˔@�����"��Vcd�
+addr: 20005542
+string: #�	�AA����%%��A��%%�HEA1�s
+addr: 20005563
+string: �s
+addr: 20005567
+string: �}U����#������$i���- ���#+	������_�E�@bD�DBI�Ia��s
+addr: 200055a1
+string: �s
+addr: 200055a5
+string: ����%�	����%���#,��)�s
+addr: 200055c3
+string: �s
+addr: 200055c7
+string: ����"ŭ�#.U�������c�%c������#+Ӫ#������%e��#+��%c�A�%c�HEA1�s
+addr: 20005619
+string: �s
+addr: 2000561d
+string: �}U##��%h�c�%c�AIɗ�������%c�HEHELAc�LEEXI�LE��PC�E
+addr: 20005660
+string: c�
+addr: 20005664
+string: L�C��U�QPM�Q��PC��c�
+addr: 20005684
+string: L�#$C��LU�C�3�(#�ä�ŵ ��!�A�FX�FT��LɈA��%c�A=�}U##��9�s
+addr: 200056cf
+string: �s
+addr: 200056d3
+string: �##��E��s
+addr: 200056df
+string: �s
+addr: 200056e3
+string: ���
+addr: 200056e8
+string: L�}V�L��# 
+addr: 200056f6
+string: ��s
+addr: 200056fb
+string: �s
+addr: 200056ff
+string: �#(
+addr: 20005704
+string: ��s
+addr: 20005709
+string: �s
+addr: 2000570d
+string: �ETAI��ET��Ac��
+addr: 20005720
+string: ��#(
+addr: 20005726
+string: �A}���A��s
+addr: 20005733
+string: �s
+addr: 20005737
+string: �A�"�&�J�*�=�	�u�A�5�
+addr: 20005752
+string: 3�@i��������$E���챠s
+addr: 2000576d
+string: �s
+addr: 20005771
+string: �������#*������)%�J��UD
+addr: 20005790
+string: ���36�
+addr: 20005798
+string: ��#)�����ˑ�3�$�s
+addr: 200057af
+string: �s
+addr: 200057b3
+string: ������O�E�@"D�DIA��s
+addr: 200057cd
+string: �s
+addr: 200057d1
+string: ���s
+addr: 200057d7
+string: �s
+addr: 200057db
+string: �E��s
+addr: 200057e3
+string: �s
+addr: 200057e7
+string: �E��s
+addr: 200057ef
+string: �s
+addr: 20005800
+string: sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 2000583b
+string: ROM Hash: 0x%!x
+addr: 2000584b
+string: rom_chip_info @ %p:
+addr: 2000585f
+string: scm_revision = %08x%08x
+addr: 20005877
+string: version = %08x
+addr: 20005886
+string: CHECK-fail: (uint8_t *)output.data%smatches (uint8_t *)kSimDvGoldenRomHash
+addr: 200058d1
+string: un
+addr: 200058d5
+string: CHECK-fail: [%d] got: 0x%02x; want: 0x%02x
+addr: 20005900
+string: CHECK-fail: (uint8_t *)output.data%smatches (uint8_t *)kFpgaCw310GoldenRomHash
+addr: 2000594f
+string: ROM hash not self-checked for this device type: 0x%x
+addr: 20005984
+string: Starting test hash_rom...
+addr: 2000599e
+string: CHECK-fail: cycles_ <= 4294967295U
+addr: 200059c1
+string: CHECK-fail:
+addr: 200059ce
+string: Successfully finished test hash_rom in %u cycles or %u us @ %u MHz.
+addr: 20005a12
+string: Finished test hash_rom: %r.
+addr: 20005a45
+string: X
+addr: 20005a47
+string: �jf#�Y�6EBprx�<���o��@	�!�6�!\Ő�v2��~k�A�ǧ��uh����_�
+addr: 20005a8d
+string: X
+addr: 20005a8f
+string: A
+addr: 20005a94
+string: 
+addr: 20005a98
+string: ;X
+addr: 20005a9b
+string: 
+addr: 20005aa1
+string: X
+addr: 20005aa3
+string: C
+addr: 20005aa8
+string: 
+addr: 20005aac
+string: KX
+addr: 20005aaf
+string: 
+addr: 20005ab5
+string: X
+addr: 20005ab7
+string: F
+addr: 20005abc
+string: 
+addr: 20005ac0
+string: _X
+addr: 20005ac3
+string: 
+addr: 20005ac9
+string: X
+addr: 20005acb
+string: G
+addr: 20005ad0
+string: 
+addr: 20005ad4
+string: wX
+addr: 20005ad7
+string: 
+addr: 20005add
+string: X
+addr: 20005adf
+string: N
+addr: 20005ae4
+string: 
+addr: 20005ae8
+string: �X
+addr: 20005aeb
+string: 
+addr: 20005af1
+string: X
+addr: 20005af3
+string: N
+addr: 20005af8
+string: 
+addr: 20005afc
+string: �X
+addr: 20005aff
+string: 
+addr: 20005b05
+string: X
+addr: 20005b07
+string: R
+addr: 20005b0c
+string: 
+addr: 20005b11
+string: Y
+addr: 20005b13
+string: 
+addr: 20005b19
+string: X
+addr: 20005b1b
+string: R
+addr: 20005b20
+string: 
+addr: 20005b24
+string: �X
+addr: 20005b27
+string: 
+addr: 20005b2d
+string: X
+addr: 20005b2f
+string: U
+addr: 20005b34
+string: 
+addr: 20005b38
+string: OY
+addr: 20005b3b
+string: 
+addr: 20005b41
+string: X
+addr: 20005b43
+string: ^
+addr: 20005b4c
+string: �Y
+addr: 20005b4f
+string: 
+addr: 20005b55
+string: X
+addr: 20005b57
+string: ^
+addr: 20005b60
+string: �Y
+addr: 20005b63
+string: 
+addr: 20005b69
+string: X
+addr: 20005b6b
+string: ^
+addr: 20005b74
+string: �Y
+addr: 20005b77
+string: 
+addr: 20005b7d
+string: X
+addr: 20005b7f
+string: ^
+addr: 20005b84
+string: 
+addr: 20005b88
+string: �Y
+addr: 20005b8b
+string: 
+addr: 20005b91
+string: X
+addr: 20005b93
+string: ^
+addr: 20005b98
+string: 
+addr: 20005b9c
+string: Z
+addr: 20005b9f
+string: �
+addr: 20005ba4
+string: �
+addr: 20005ba8
+string: �
+addr: 20005bac
+string: h
+addr: 20005bb0
+string: H
+addr: 20005bb4
+string: g�	jɼ�g�;�ʄr�n<+���:�O��6_RQт歌h�l>+�كk�A���[y!~]���؞�*)�b�|6ZY��p0��/9Y�g&3g1���J��Xh.ۧ��dH�G�O��H\
+addr: 20005c37
+string: �b
+addr: 20005c3b
+string: �b
+addr: 20005c3f
+string: f
+addr: 20005c43
+string: 
+addr: 20005c48
+string: 7
+addr: 20005c4c
+string: 
+addr: 20005c50
+string: �
+addr: 20005c54
+string: ����#�!
+addr: 20005c5c
+string: 7
+addr: 20005c60
+string: :�
+addr: 20005c68
+string: ���#�!
+addr: 20005c70
+string: �
+addr: 20005c72
+string: �
+addr: 20005c74
+string: s
+addr: 20005c78
+string: ���7
+addr: 20005c80
+string: 8*
+addr: 20005c88
+string: �
+addr: 20005c8c
+string: ��Ȼ��
+addr: 20005c94
+string: 7
+addr: 20005c98
+string: �'
+addr: 20005ca0
+string: �
+addr: 20005ca4
+string: ��
+addr: 20005ca8
+string: �	`�
+addr: 20005cb0
+string: ���7
+addr: 20005cb8
+string: {
+addr: 20005cbe
+string: �
+addr: 20005cc4
+string: 0{
+addr: 20005ccc
+string: A'
+addr: 20005cd0
+string: Q&
+addr: 20005cd4
+string: 
+addr: 20005cd8
+string: {�{�����?A��({�(	��{�/�����p��[Q{9����o���({�(=��{�/�����p{�����?���({�(	��{�/��+�?Q+�p+\a��o���h{�h=��{�o��+�p��?���8{�8	��{�?����?a���p��\q{��A��+{�+=��{�/�����p{9�A�w*{8*	��{�/��+�?q+�p+m{9�A�w,{x,=��{�/��+�p�i
+addr: 20005de8
+string: �
+addr: 20005dec
+string: �j
+addr: 20005df0
+string: {�kA{;lA{�lA{;mAQ6
+addr: 20005e08
+string: ��(
+addr: 20005e0c
+string: ��(��(��(��(��(��(��(�
+addr: 20005e2c
+string: �
+addr: 20005e30
+string: {���
+addr: 20005e38
+string: A�
+addr: 20005e3c
+string: {;�A�7`�:`#��W�z`'��W{(
+addr: 20005e58
+string: �*
+addr: 20005e5c
+string: {hX��
+addr: 20005e64
+string: {hX������{;�A{9b�:b{iY�yb){i9�)R
+addr: 20005e8c
+string: �Z@
+addr: 20005e90
+string: ��j
+addr: 20005e94
+string: ��Y{�/�+z
+addr: 20005ea0
+string: +�
+addr: 20005ea4
+string: ��5+Z��A�{��A��c��c#��W��c'��W{�
+addr: 20005ed0
+string: ��
+addr: 20005ed4
+string: {hX�*
+addr: 20005edc
+string: {hX������{��A{�a��a{iY��a){i9��A
+addr: 20005f04
+string: �Z0
+addr: 20005f08
+string: ��Z
+addr: 20005f0c
+string: ��Y{�/�+j
+addr: 20005f18
+string: +�P���@��:+Z+A+{;�A�7c�:c#��W�zc'��W{(s
+addr: 20005f4c
+string: �*
+addr: 20005f50
+string: {hX��
+addr: 20005f58
+string: {hX������{;�A{9a�:a{iY�ya){i9�)1
+addr: 20005f80
+string: �Z
+addr: 20005f84
+string: ��J
+addr: 20005f88
+string: ��Y{�/�+Z
+addr: 20005f94
+string: +�`������:+Z��@�{��A��b��b#��W��b'��W{�b
+addr: 20005fc8
+string: ��r
+addr: 20005fcc
+string: {hX�*s
+addr: 20005fd4
+string: {hX������{��A{�`��`{iY��`){i9��
+addr: 20005ffc
+string: �Z
+addr: 20006000
+string: ��:
+addr: 20006004
+string: ��Y{�/�+J
+addr: 20006010
+string: +�p������:+Z+
+addr: 20006022
+string: @+��
+addr: 2000602c
+string: A�
+addr: 20006030
+string: {;�A�7b�:b#��W�zb'��W{(R
+addr: 2000604c
+string: �*b
+addr: 20006050
+string: {hX��b
+addr: 20006058
+string: {hX������{;�A{9`�:`{iY�y`){i9�)
+addr: 20006080
+string: �Z
+addr: 20006084
+string: ��*
+addr: 20006088
+string: ��Y{�/�+:
+addr: 20006094
+string: +�@���
+addr: 2000609c
+string: ��:+Z��C�{��A��a��a#��W��a'��W{�A
+addr: 200060c8
+string: ��Q
+addr: 200060cc
+string: {hX�*R
+addr: 200060d4
+string: {hX������{��A{�c��c{iY��c){i9��
+addr: 200060fc
+string: �Zp
+addr: 20006100
+string: ��
+addr: 20006104
+string: ��Y{�/�+*
+addr: 20006110
+string: +�P���@��:+Z+C+{;�A�7a�:a#��W�za'��W{(1
+addr: 20006144
+string: �*A
+addr: 20006148
+string: {hX��A
+addr: 20006150
+string: {hX������{;�A{9c�:c{iY�yc){i9�)s
+addr: 20006178
+string: �Z`
+addr: 2000617c
+string: ��
+addr: 20006180
+string: ��Y{�/�+
+addr: 2000618c
+string: +�`������:+Z��B�
+addr: 200061a2
+string: {��A��`��`#��W��`'��W{�
+addr: 200061c0
+string: ��0
+addr: 200061c4
+string: {hX�*1
+addr: 200061cc
+string: {hX������{��A{�b��b{iY��b){i9��b
+addr: 200061f4
+string: �ZP
+addr: 200061f8
+string: ��z
+addr: 200061fc
+string: ��Y{�/�+
+addr: 20006208
+string: +�p������:+Z+B+
+addr: 2000621e
+string: �
+addr: 20006224
+string: �(
+addr: 20006228
+string: ��
+addr: 2000622c
+string: �(
+addr: 20006230
+string: �(���
+addr: 20006238
+string: �(�(��
+addr: 20006244
+string: �(�(���
+addr: 20006250
+string: �(�(��
+addr: 2000625c
+string: �(�(���
+addr: 20006268
+string: �(�(��
+addr: 20006274
+string: �(�(���
+addr: 20006280
+string: �(g�
+addr: 200062a0
+string: ɼ�g�	j
+addr: 200062c0
+string: ;�ʄ��g�
+addr: 200062e0
+string: +���r�n<
+addr: 20006300
+string: �6_:�O�
+addr: 20006320
+string: т�RQ
+addr: 20006340
+string: l>+�h�
+addr: 20006360
+string: k�A��ك
+addr: 20006380
+string: y!~��[
+addr: 200063a0
+string: "�(ט/�B�e�#�D7q/;M������ۉ��۵�8�H�[�V9����Y�O���?��m��^�B���ؾopE[����N��1$����}Uo�{�t]�r��;��ހ5�%�ܛ�&i�t���J��i���%O8�G��Ռ�Ɲ�e��w̡$u+Yo,�-��n��tJ��A�ܩ�\�S�ڈ�v��f�RQ>�2�-m�1�?!���'����Y��=���%��G���o��Qc�png))�/�F��'&�&\8!.�*�Z�m,M߳��8S�c��Tse��w<�jv��G.�;5��,r�d�L�迢0B�Kf�����p�K�0�T�Ql�R�����eU$��* qW�5��ѻ2p�j��Ҹ��S�AQl7���LwH'�H�ᵼ�4cZ�ų9ˊA�J��Ns�cwOʜ[�����o.h���]t`/Coc�xr��xȄ�9dǌ(c#����齂��lP�yƲ����+Sr��xqƜa&��>'���!Ǹ������}��x�n�O}��or�g���Ȣ�}c����?G5q�}#�w�(�$�@{��2�����<L��gC�B>˾��L*~e��)Y���:�o�_XGJ�Dlsw/device/lib/testing/test_framework/ottf_main.c
+addr: 20006651
+string: OTTF currently only supports use of machine-mode ecall for FreeRTOS context switching.
+addr: 200066a8
+string: Running %s
+addr: 200066b3
+string: DIF-fail: dif_rv_core_ibex_init( mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR), &rv_core_ibex) returns %d
+addr: 2000672e
+string: test_main
+addr: 20006738
+string: CHECK-fail: 0
+addr: 20006746
+string: Finished %s
+addr: 20006752
+string: Status reported by the test:
+addr: 2000676f
+string: - %r
+addr: 20006774
+string: 
+addr: 20006778
+string: f
+addr: 2000677b
+string: :
+addr: 20006784
+string: Qf
+addr: 20006787
+string: 
+addr: 2000678c
+string: f
+addr: 2000678f
+string: �
+addr: 20006794
+string: 
+addr: 20006798
+string: �f
+addr: 2000679b
+string: 
+addr: 200067a0
+string: f
+addr: 200067a3
+string: �
+addr: 200067a8
+string: 
+addr: 200067ac
+string: �f
+addr: 200067af
+string: 
+addr: 200067b4
+string: f
+addr: 200067b7
+string: �
+addr: 200067c0
+string: 8g
+addr: 200067c3
+string: 
+addr: 200067c8
+string: f
+addr: 200067cb
+string: c
+addr: 200067d0
+string: 
+addr: 200067d4
+string: Fg
+addr: 200067d7
+string: 
+addr: 200067dc
+string: f
+addr: 200067df
+string: g
+addr: 200067e8
+string: Rg
+addr: 200067eb
+string: 
+addr: 200067f0
+string: f
+addr: 200067f3
+string: i
+addr: 200067f8
+string: 
+addr: 200067fc
+string: og
+addr: 200067ff
+string: sw/device/lib/testing/test_framework/freertos_hooks.c
+addr: 20006836
+string: FreeRTOS malloc failed. Increase heap size in FreeRTOSConfig.h
+addr: 20006875
+string: FreeRTOS stack overflow. Increase stack size of task: %s
+addr: 200068b5
+string: h
+addr: 200068b7
+string: 
+addr: 200068bc
+string: 
+addr: 200068c0
+string: �h
+addr: 200068c3
+string: 
+addr: 200068c9
+string: h
+addr: 200068cb
+string: 
+addr: 200068d0
+string: 
+addr: 200068d4
+string: uh
+addr: 200068d7
+string: sw/device/lib/testing/test_framework/ottf_console.c
+addr: 2000690c
+string: CHECK-fail: kOttfTestConfig.console.type == kOttfConsoleUart
+addr: 20006949
+string: DIF-fail: dif_uart_init(mmio_region_from_addr(base_addr), &ottf_console_uart) returns %d
+addr: 200069a2
+string: CHECK-fail: kUartBaudrate must fit in uint32_t
+addr: 200069d1
+string: CHECK-fail: kClockFreqPeripheralHz must fit in uint32_t
+addr: 20006a09
+string: DIF-fail: dif_uart_configure( &ottf_console_uart, (dif_uart_config_t){ .baudrate = (uint32_t)kUartBaudrate, .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz, .parity_enable = kDifToggleDisabled, .parity = kDifUartParityEven, .tx_enable = kDifToggleEnabled, .rx_enable = kDifToggleEnabled, }) returns %d
+addr: 20006b37
+string: DIF-fail: dif_spi_device_init_handle( mmio_region_from_addr(kOttfTestConfig.console.base_addr), &ottf_console_spi_device) returns %d
+addr: 20006bbc
+string: DIF-fail: dif_spi_device_configure( &ottf_console_spi_device, (dif_spi_device_config_t){ .clock_polarity = kDifSpiDeviceEdgePositive, .data_phase = kDifSpiDeviceEdgeNegative, .tx_order = kDifSpiDeviceBitOrderMsbToLsb, .rx_order = kDifSpiDeviceBitOrderMsbToLsb, .device_mode = kDifSpiDeviceModeGeneric, .mode_cfg = { .generic = { .rx_fifo_commit_wait = kSpiDeviceRxCommitWait, .rx_fifo_len = kDifSpiDeviceBufferLen / 2, .tx_fifo_len = kDifSpiDeviceBufferLen / 2, }, }, }) returns %d
+addr: 20006d9e
+string: CHECK-fail: unsupported OTTF console interface.
+addr: 20006dce
+string: DIF-fail: dif_rv_plic_init( mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &ottf_plic) returns %d
+addr: 20006e38
+string: DIF-fail: dif_uart_watermark_rx_set(uart, kFlowControlRxWatermark) returns %d
+addr: 20006e86
+string: DIF-fail: dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark, kDifToggleEnabled) returns %d
+addr: 20006ee5
+string: DIF-fail: dif_rv_plic_irq_set_priority( &ottf_plic, get_flow_control_watermark_plic_id(), kDifRvPlicMaxPriority) returns %d
+addr: 20006f61
+string: DIF-fail: dif_rv_plic_target_set_threshold(&ottf_plic, kPlicTarget, kDifRvPlicMinPriority) returns %d
+addr: 20006fc7
+string: DIF-fail: dif_rv_plic_irq_set_enabled(&ottf_plic, get_flow_control_watermark_plic_id(), kPlicTarget, kDifToggleEnabled) returns %d
+addr: 2000704a
+string: DIF-fail: dif_uart_irq_is_pending(uart, kDifUartIrqRxWatermark, &rx) returns %d
+addr: 2000709a
+string: DIF-fail: dif_uart_irq_acknowledge(uart, kDifUartIrqRxWatermark) returns %d
+addr: 200070e6
+string: DIF-fail: dif_uart_irq_disable_all(uart, &snapshot) returns %d
+addr: 20007125
+string: DIF-fail: dif_uart_irq_restore_all(uart, &snapshot) returns %d
+addr: 20007164
+string: DIF-fail: dif_uart_bytes_send(uart, &byte, 1, NULL) returns %d
+addr: 200071a4
+string: 
+addr: 200071a8
+string: �h
+addr: 200071ab
+string: G
+addr: 200071b4
+string: i
+addr: 200071b7
+string: 
+addr: 200071bc
+string: �h
+addr: 200071bf
+string: K
+addr: 200071c4
+string: 
+addr: 200071c8
+string: Ii
+addr: 200071cb
+string: 
+addr: 200071d0
+string: �h
+addr: 200071d3
+string: L
+addr: 200071dc
+string: �i
+addr: 200071df
+string: 
+addr: 200071e4
+string: �h
+addr: 200071e7
+string: N
+addr: 200071f0
+string: �i
+addr: 200071f3
+string: 
+addr: 200071f8
+string: �h
+addr: 200071fb
+string: X
+addr: 20007200
+string: 
+addr: 20007204
+string: j
+addr: 20007207
+string: 
+addr: 2000720c
+string: �h
+addr: 2000720f
+string: c
+addr: 20007214
+string: 
+addr: 20007218
+string: 7k
+addr: 2000721b
+string: 
+addr: 20007220
+string: �h
+addr: 20007223
+string: u
+addr: 20007228
+string: 
+addr: 2000722c
+string: �k
+addr: 2000722f
+string: 
+addr: 20007234
+string: �h
+addr: 20007237
+string: y
+addr: 20007240
+string: �m
+addr: 20007243
+string: 
+addr: 20007248
+string: �h
+addr: 2000724b
+string: �
+addr: 20007250
+string: 
+addr: 20007254
+string: �m
+addr: 20007257
+string: 
+addr: 2000725c
+string: �h
+addr: 2000725f
+string: �
+addr: 20007264
+string: 
+addr: 20007268
+string: 8n
+addr: 2000726b
+string: 
+addr: 20007270
+string: �h
+addr: 20007273
+string: �
+addr: 20007278
+string: 
+addr: 2000727c
+string: �n
+addr: 2000727f
+string: 
+addr: 20007284
+string: �h
+addr: 20007287
+string: �
+addr: 2000728c
+string: 
+addr: 20007290
+string: �n
+addr: 20007293
+string: 
+addr: 20007298
+string: �h
+addr: 2000729b
+string: �
+addr: 200072a0
+string: 
+addr: 200072a4
+string: ao
+addr: 200072a7
+string: 
+addr: 200072ac
+string: �h
+addr: 200072af
+string: �
+addr: 200072b4
+string: 
+addr: 200072b8
+string: �o
+addr: 200072bb
+string: 
+addr: 200072c0
+string: �h
+addr: 200072c3
+string: �
+addr: 200072c8
+string: 
+addr: 200072cc
+string: Jp
+addr: 200072cf
+string: 
+addr: 200072d4
+string: �h
+addr: 200072d7
+string: �
+addr: 200072dc
+string: 
+addr: 200072e0
+string: �p
+addr: 200072e3
+string: 
+addr: 200072e8
+string: �h
+addr: 200072eb
+string: �
+addr: 200072f0
+string: 
+addr: 200072f4
+string: �p
+addr: 200072f7
+string: 
+addr: 200072fc
+string: �h
+addr: 200072ff
+string: �
+addr: 20007304
+string: 
+addr: 20007308
+string: %q
+addr: 2000730b
+string: 
+addr: 20007310
+string: �h
+addr: 20007313
+string: �
+addr: 20007318
+string: 
+addr: 2000731c
+string: dq
+addr: 2000731f
+string: �5
+addr: 20007323
+string: �5
+addr: 20007327
+string: �5
+addr: 2000732b
+string: �5
+addr: 2000732f
+string: 6
+addr: 20007333
+string: �5
+addr: 20007337
+string: 6
+addr: 2000733b
+string: �5
+addr: 2000733f
+string: �5
+addr: 20007343
+string: 6
+addr: 20007347
+string: 6
+addr: 2000734b
+string: �5
+addr: 2000734f
+string: sw/device/lib/testing/test_framework/ottf_isrs.c
+addr: 20007381
+string: FAULT: %s. MCAUSE=%08x MEPC=%08x MTVAL=%08x
+addr: 200073ad
+string: Software IRQ
+addr: 200073ba
+string: Timer IRQ
+addr: 200073c4
+string: DIF-fail: dif_rv_plic_irq_claim(&ottf_plic, kPlicTarget, &plic_irq_id) returns %d
+addr: 20007416
+string: DIF-fail: dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id) returns %d
+addr: 2000746a
+string: External IRQ
+addr: 20007477
+string: Instruction Misaligned
+addr: 2000748e
+string: Instruction Access
+addr: 200074a1
+string: Illegal Instruction
+addr: 200074b5
+string: Breakpoint
+addr: 200074c0
+string: Load Address Misaligned
+addr: 200074d8
+string: Load Access Fault
+addr: 200074ea
+string: Store Address Misaligned
+addr: 20007503
+string: Store Access Fault
+addr: 20007516
+string: U-mode Ecall
+addr: 20007523
+string: S-mode Ecall
+addr: 20007530
+string: Reserved
+addr: 20007539
+string: M-mode Ecall
+addr: 20007546
+string: Instruction Page Fault
+addr: 2000755d
+string: Load Page Fault
+addr: 2000756d
+string: Store Page Fault
+addr: 2000757e
+string: Internal IRQ
+addr: 2000758c
+string: 
+addr: 20007590
+string: Ps
+addr: 20007593
+string: <
+addr: 20007598
+string: 
+addr: 2000759c
+string: �s
+addr: 2000759f
+string: 
+addr: 200075a4
+string: Ps
+addr: 200075a7
+string: �
+addr: 200075ac
+string: 
+addr: 200075b0
+string: �s
+addr: 200075b3
+string: 
+addr: 200075b8
+string: Ps
+addr: 200075bb
+string: �
+addr: 200075c0
+string: 
+addr: 200075c4
+string: t
+addr: 200075c7
+string: wt
+addr: 200075cb
+string: �t
+addr: 200075cf
+string: �t
+addr: 200075d3
+string: �t
+addr: 200075d7
+string: �t
+addr: 200075db
+string: �t
+addr: 200075df
+string: �t
+addr: 200075e3
+string: u
+addr: 200075e7
+string: u
+addr: 200075eb
+string: #u
+addr: 200075ef
+string: 0u
+addr: 200075f3
+string: 9u
+addr: 200075f7
+string: Fu
+addr: 200075fb
+string: ]u
+addr: 200075ff
+string: 0u
+addr: 20007603
+string: mu
+addr: 20007607
+string: 0u
+addr: 2000760b
+string: 0u
+addr: 2000760f
+string: 0u
+addr: 20007613
+string: 0u
+addr: 20007617
+string: 0u
+addr: 2000761b
+string: 0u
+addr: 2000761f
+string: 0u
+addr: 20007623
+string: 0u
+addr: 20007627
+string: 0u
+addr: 2000762b
+string: 0u
+addr: 2000762f
+string: 0u
+addr: 20007633
+string: 0u
+addr: 20007637
+string: 0u
+addr: 2000763b
+string: 0u
+addr: 2000763f
+string: 0u
+addr: 20007643
+string: 0u
+addr: 20007647
+string: 
+addr: 2000764c
+string: 
+addr: 20007650
+string: sw/device/lib/testing/rand_testutils.c
+addr: 20007677
+string: CHECK-fail: rv_core_ibex != ((void*)0)
+addr: 2000769e
+string: CHECK-fail: max >= min
+addr: 200076b5
+string: CHECK-fail: result >= min && result <= max
+addr: 200076e0
+string: CHECK-STATUS-fail: %c%c%c:%d = %s
+addr: 20007702
+string: CHECK-STATUS-fail: 0x%08x
+addr: 2000771c
+string: CHECK-STATUS-fail: %r
+addr: 20007734
+string: 
+addr: 20007738
+string: Pv
+addr: 2000773b
+string: 
+addr: 20007744
+string: wv
+addr: 20007747
+string: 
+addr: 2000774c
+string: 
+addr: 20007750
+string: 
+addr: 20007754
+string: 
+addr: 20007758
+string: 
+addr: 2000775c
+string: 
+addr: 20007760
+string: 
+addr: 20007764
+string: 
+addr: 20007768
+string: 
+addr: 2000776c
+string: 
+addr: 20007770
+string: 
+addr: 20007774
+string: 
+addr: 20007778
+string: 
+addr: 2000777c
+string: 
+addr: 20007780
+string: 
+addr: 20007784
+string: 
+addr: 20007788
+string: 
+addr: 2000778c
+string: 
+addr: 20007790
+string: 
+addr: 20007794
+string: 
+addr: 20007798
+string: 
+addr: 2000779c
+string: 
+addr: 200077a0
+string: 
+addr: 200077a4
+string: 
+addr: 200077a8
+string: 
+addr: 200077ac
+string: 
+addr: 200077b0
+string: 
+addr: 200077b4
+string: 
+addr: 200077b8
+string: 
+addr: 200077bc
+string: 
+addr: 200077c0
+string: 
+addr: 200077c4
+string: 
+addr: 200077c8
+string: 
+addr: 200077cc
+string: 
+addr: 200077d0
+string: 
+addr: 200077d4
+string: 
+addr: 200077d8
+string: 
+addr: 200077dc
+string: 
+addr: 200077e0
+string: 
+addr: 200077e4
+string: 
+addr: 200077e8
+string: 
+addr: 200077ec
+string: 
+addr: 200077f0
+string: 
+addr: 200077f4
+string: 
+addr: 200077f8
+string: 
+addr: 200077fc
+string: 
+addr: 20007800
+string: 
+addr: 20007804
+string: 
+addr: 20007808
+string: 
+addr: 2000780c
+string: 
+addr: 20007810
+string: 
+addr: 20007814
+string: 
+addr: 20007818
+string: 
+addr: 2000781c
+string: 
+addr: 20007820
+string: 
+addr: 20007824
+string: 
+addr: 20007828
+string: 
+addr: 2000782c
+string: 
+addr: 20007830
+string: 
+addr: 20007834
+string: 
+addr: 20007838
+string: 
+addr: 2000783c
+string: 
+addr: 20007840
+string: 
+addr: 20007844
+string: 
+addr: 20007848
+string: 
+addr: 2000784c
+string: 
+addr: 20007850
+string: 
+addr: 20007854
+string: 
+addr: 20007858
+string: 
+addr: 2000785c
+string: 
+addr: 20007860
+string: 
+addr: 20007864
+string: 
+addr: 20007868
+string: 
+addr: 2000786c
+string: 
+addr: 20007870
+string: 
+addr: 20007874
+string: 
+addr: 20007878
+string: 
+addr: 2000787c
+string: 
+addr: 20007880
+string: 
+addr: 20007884
+string: 
+addr: 20007888
+string: 
+addr: 2000788c
+string: 
+addr: 20007890
+string: 
+addr: 20007894
+string: 
+addr: 20007898
+string: 
+addr: 2000789c
+string: 
+addr: 200078a0
+string: 
+addr: 200078a4
+string: 
+addr: 200078a8
+string: 
+addr: 200078ac
+string: 
+addr: 200078b0
+string: 
+addr: 200078b4
+string: 
+addr: 200078b8
+string: 
+addr: 200078bc
+string: 
+addr: 200078c0
+string: 
+addr: 200078c4
+string: 
+addr: 200078c8
+string: 
+addr: 200078cc
+string: 
+addr: 200078d0
+string: 
+addr: 200078d4
+string: 
+addr: 200078d8
+string: 
+addr: 200078dc
+string: 
+addr: 200078e0
+string: 
+addr: 200078e4
+string: 
+addr: 200078e8
+string: 
+addr: 200078ec
+string: 
+addr: 200078f0
+string: 
+addr: 200078f4
+string: 
+addr: 200078f8
+string: 
+addr: 200078fc
+string: 
+addr: 20007900
+string: 
+addr: 20007904
+string: 
+addr: 20007908
+string: 
+addr: 2000790c
+string: 
+addr: 20007910
+string: 
+addr: 20007914
+string: 
+addr: 20007918
+string: 
+addr: 2000791c
+string: 
+addr: 20007920
+string: 
+addr: 20007924
+string: 
+addr: 20007928
+string: 
+addr: 2000792c
+string: 
+addr: 20007930
+string: 
+addr: 20007934
+string: 
+addr: 20007938
+string: 
+addr: 2000793c
+string: 
+addr: 20007940
+string: 
+addr: 20007944
+string: 
+addr: 20007948
+string: 
+addr: 2000794c
+string: 
+addr: 20007950
+string: 
+addr: 20007954
+string: 
+addr: 20007958
+string: 
+addr: 2000795c
+string: 
+addr: 20007960
+string: 
+addr: 20007964
+string: 
+addr: 20007968
+string: 
+addr: 2000796c
+string: 
+addr: 20007970
+string: 
+addr: 20007974
+string: 
+addr: 20007978
+string: 
+addr: 2000797c
+string: 
+addr: 20007980
+string: 
+addr: 20007984
+string: 
+addr: 20007988
+string: 
+addr: 2000798c
+string: 
+addr: 20007990
+string: 
+addr: 20007994
+string: 
+addr: 20007998
+string: 
+addr: 2000799c
+string: 
+addr: 200079a0
+string: 
+addr: 200079a4
+string: 
+addr: 200079a8
+string: 
+addr: 200079ac
+string: 
+addr: 200079b0
+string: 
+addr: 200079b4
+string: 
+addr: 200079b8
+string: 
+addr: 200079bc
+string: 
+addr: 200079c0
+string: 
+addr: 200079c4
+string: 
+addr: 200079c8
+string: 
+addr: 200079cc
+string: 
+addr: 200079d0
+string: 
+addr: 200079d4
+string: 
+addr: 200079d8
+string: 
+addr: 200079dc
+string: 
+addr: 200079e0
+string: 
+addr: 200079e4
+string: 
+addr: 200079e8
+string: 
+addr: 200079ec
+string: 
+addr: 200079f0
+string: 
+addr: 200079f4
+string: 
+addr: 200079f8
+string: 
+addr: 200079fc
+string: 
+addr: 20007a00
+string: 
+addr: 20007a04
+string: 
+addr: 20007a08
+string: 
+addr: 20007a0c
+string: 
+addr: 20007a10
+string: 
+addr: 20007a14
+string: 
+addr: 20007a18
+string: 
+addr: 20007a1c
+string: 
+addr: 20007a20
+string: 
+addr: 20007a24
+string: 
+addr: 20007a28
+string: 
+addr: 20007a2c
+string: sw/device/lib/testing/test_framework/status.c
+addr: 20007a5a
+string: PASS!
+addr: 20007a60
+string: FAIL!
+addr: 20007a6c
+string: ,z
+addr: 20007a6f
+string: 
+addr: 20007a78
+string: Zz
+addr: 20007a7b
+string: 
+addr: 20007a80
+string: ,z
+addr: 20007a83
+string: "
+addr: 20007a8c
+string: `z
+addr: 20007a8f
+string: %s%05d %s:%d]
+addr: 20007a9f
+string: 
+addr: 20007aa2
+string: I
+addr: 20007aa4
+string: W
+addr: 20007aa6
+string: F
+addr: 20007aa8
+string: ?
+addr: 20007aac
+string: �z
+addr: 20007aaf
+string: �z
+addr: 20007ab3
+string: W}
+addr: 20007ab7
+string: �z
+addr: 20007abb
+string: *?
+addr: 20007abf
+string: v?
+addr: 20007ac3
+string: �A
+addr: 20007ac7
+string: �A
+addr: 20007acb
+string: �A
+addr: 20007acf
+string: �A
+addr: 20007ad3
+string: �A
+addr: 20007ad7
+string: �A
+addr: 20007adb
+string: �A
+addr: 20007adf
+string: �A
+addr: 20007ae3
+string: �?
+addr: 20007ae7
+string: �?
+addr: 20007aeb
+string: �>
+addr: 20007aef
+string: �A
+addr: 20007af3
+string: �A
+addr: 20007af7
+string: �A
+addr: 20007afb
+string: �A
+addr: 20007aff
+string: �>
+addr: 20007b03
+string: �A
+addr: 20007b07
+string: �A
+addr: 20007b0b
+string: �A
+addr: 20007b0f
+string: �A
+addr: 20007b13
+string: �A
+addr: 20007b17
+string: �?
+addr: 20007b1b
+string: @
+addr: 20007b1f
+string: �A
+addr: 20007b23
+string: N@
+addr: 20007b27
+string: A
+addr: 20007b2b
+string: �A
+addr: 20007b2f
+string: 8A
+addr: 20007b33
+string: �A
+addr: 20007b37
+string: �A
+addr: 20007b3b
+string: ^A
+addr: 20007b3f
+string: �A
+addr: 20007b43
+string: %08x:
+addr: 20007b4a
+string: %!s
+addr: 20007b4e
+string: 
+addr: 20007b51
+string: %
+addr: 20007b53
+string: -
+addr: 20007b55
+string: 0x
+addr: 20007b58
+string: true
+addr: 20007b5d
+string: false
+addr: 20007b63
+string: {"
+addr: 20007b66
+string: [
+addr: 20007b68
+string: ]
+addr: 20007b6a
+string: }
+addr: 20007b6c
+string: 0123456789abcdef%<unexpected nul>%<bad width>0123456789ABCDEF%<unknown spec>
+addr: 20007bbc
+string: Ok
+addr: 20007bbf
+string: Cancelled
+addr: 20007bc9
+string: Unknown
+addr: 20007bd1
+string: InvalidArgument
+addr: 20007be1
+string: DeadlineExceeded
+addr: 20007bf2
+string: NotFound
+addr: 20007bfb
+string: AlreadyExists
+addr: 20007c09
+string: PermissionDenied
+addr: 20007c1a
+string: ResourceExhausted
+addr: 20007c2c
+string: FailedPrecondition
+addr: 20007c3f
+string: Aborted
+addr: 20007c47
+string: OutOfRange
+addr: 20007c52
+string: Unimplemented
+addr: 20007c60
+string: Internal
+addr: 20007c69
+string: Unavailable
+addr: 20007c75
+string: DataLoss
+addr: 20007c7e
+string: Unauthenticated
+addr: 20007c8e
+string: Undefined17
+addr: 20007c9a
+string: Undefined18
+addr: 20007ca6
+string: Undefined19
+addr: 20007cb2
+string: Undefined20
+addr: 20007cbe
+string: Undefined21
+addr: 20007cca
+string: Undefined22
+addr: 20007cd6
+string: Undefined23
+addr: 20007ce2
+string: Undefined24
+addr: 20007cee
+string: Undefined25
+addr: 20007cfa
+string: Undefined26
+addr: 20007d06
+string: Undefined27
+addr: 20007d12
+string: Undefined28
+addr: 20007d1e
+string: Undefined29
+addr: 20007d2a
+string: Undefined30
+addr: 20007d36
+string: Undefined31
+addr: 20007d42
+string: ErrorError
+addr: 20007d4f
+string: 
+addr: 20007d54
+string: IDLE
+addr: 20007d61
+string: ��
+addr: 20007d69
+string: 6n
+addr: 20007d70
+string: @B
+addr: 20007d78
+string: �
+addr: 20007d7a
+string: A�
+addr: 10001fc8
+string: �{
+addr: 10001fcb
+string: �{
+addr: 10001fcf
+string: �{
+addr: 10001fd3
+string: �{
+addr: 10001fd7
+string: �{
+addr: 10001fdb
+string: �{
+addr: 10001fdf
+string: �{
+addr: 10001fe3
+string: |
+addr: 10001fe7
+string: |
+addr: 10001feb
+string: ,|
+addr: 10001fef
+string: ?|
+addr: 10001ff3
+string: G|
+addr: 10001ff7
+string: R|
+addr: 10001ffb
+string: `|
+addr: 10001fff
+string: i|
+addr: 10002003
+string: u|
+addr: 10002007
+string: ~|
+addr: 1000200b
+string: �|
+addr: 1000200f
+string: �|
+addr: 10002013
+string: �|
+addr: 10002017
+string: �|
+addr: 1000201b
+string: �|
+addr: 1000201f
+string: �|
+addr: 10002023
+string: �|
+addr: 10002027
+string: �|
+addr: 1000202b
+string: �|
+addr: 1000202f
+string: �|
+addr: 10002033
+string: }
+addr: 10002037
+string: }
+addr: 1000203b
+string: }
+addr: 1000203f
+string: *}
+addr: 10002043
+string: 6}
+addr: 10002047
+string: B}
+addr: 0
+string: ����sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 80
+string: ����sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 100
+string: ����sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 180
+string: ����sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 200
+string: ����sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+addr: 280
+string: ����sw/device/lib/testing/test_framework/ottf_main.c
+addr: 300
+string: ����sw/device/lib/testing/test_framework/ottf_console.c
+addr: 380
+string: ����sw/device/lib/testing/test_framework/ottf_console.c
+addr: 400
+string: ����sw/device/lib/testing/test_framework/ottf_console.c
+addr: 480
+string: ����sw/device/lib/testing/test_framework/ottf_console.c
+addr: 500
+string: ����sw/device/lib/testing/rand_testutils.c
+addr: 580
+string: ����sw/device/lib/testing/rand_testutils.c
+addr: 600
+string: ����sw/device/lib/testing/rand_testutils.c
+addr: 680
+string: ����sw/device/lib/testing/rv_core_ibex_testutils.c
+addr: 700
+string: ����sw/device/lib/testing/rv_core_ibex_testutils.c
+addr: 780
+string: ����sw/device/lib/testing/rv_core_ibex_testutils.c

--- a/util/fix_trailing_whitespace.py
+++ b/util/fix_trailing_whitespace.py
@@ -19,8 +19,15 @@ from pathlib import Path
 # calls to get back to the top.
 REPO_TOP = Path(__file__).resolve().parent.parent
 
+IGNORED = {
+    Path('sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.logs.txt'),
+    Path('sw/device/silicon_creator/rom/e2e/presigned_images/rom_e2e_self_hash_sim_dv.rodata.txt'),
+}
+
 
 def is_ignored(path):
+    if path in IGNORED:
+        return True
     return subprocess.run(['git', 'check-ignore', path]).returncode == 0
 
 
@@ -68,7 +75,7 @@ def main():
     total_fixable = 0
     for path in files:
         path = Path(path).resolve().relative_to(REPO_TOP)
-        if not path.is_file() or path.is_symlink():
+        if not path.is_file() or path.is_symlink() or is_ignored(path):
             continue
         if 'vendor' in path.parts or path.suffix in ['.patch', '.svg', '.tpl']:
             continue


### PR DESCRIPTION
This updates the ROM self hash test:
1. add missing backdoor logging DB files so the pre-signed test can print the hash in DV environment (via backdoor), and
2. to run with an OTP image that has OTBN signature verification enabled and is in the RMA LC state (for both DV and FPGA test platforms).