### PR TITLE
Sram program linker segments

### DIFF
--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -15,6 +15,10 @@ def _ld_library_impl(ctx):
             "-Wl,--defsym=no_ottf_nv_scratch=1",
             "-Wl,--defsym=no_ottf_nv_counter=1",
         ]
+    if ctx.attr.non_page_aligned_segments:
+        user_link_flags += [
+            "-Wl,-nmagic",
+        ]
 
     if ctx.file.script:
         files += ctx.files.script
@@ -48,6 +52,11 @@ ld_library = rule(
     as the linker script for that binary.
 
     At most one ld_library in a cc_binary's dependencies may have a script.
+
+    If non_page_aligned_segments is used, instruct the linker to turn off page
+    alignment for segments and not to include the headers in the first segment
+    (this is the -nmagic option of GNU ld). See https://reviews.llvm.org/D61201
+    for more details.
     """,
     attrs = {
         "script": attr.label(allow_single_file = True),
@@ -58,6 +67,9 @@ ld_library = rule(
         "deps": attr.label_list(
             default = [],
             providers = [CcInfo],
+        ),
+        "non_page_aligned_segments": attr.bool(
+            default = False,
         ),
     },
 )

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -80,6 +80,10 @@ _MANUF_LC_TRANSITION_TEST_CMDS_WBOOTSTRAP = _MANUF_LC_TRANSITION_TEST_CMDS + [
 ld_library(
     name = "sram_program_linker_script",
     script = "sram_program.ld",
+    # We want to avoid page alignment since the SRAM program is not loaded at the beginning of the
+    # SRAM and we the generated ELF segment should not contain any headers (as this could overwrite
+    # some SRAM content)
+    non_page_aligned_segments = True,
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device:info_sections",

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -28,6 +28,10 @@ _dv_log_offset = 0x10000;
 
 ENTRY(sram_start);
 
+/* NOTE This linker script assumes non-page-aligned segments because we skip
+ * the first _static_critical_size bytes of the SRAM and we do not want the
+ * ELF segments to containt the headers as this would overwrite the content
+ * of static critical data */
 SECTIONS {
   /* The ELF SRAM program loader will automatically read back the data of the section
    * containing the entry point to verify that it is correct. The expectation is that


### PR DESCRIPTION
TODO:

- [ ] switch back opentitanlib sram program loader to load segments instead of sections