### PR TITLE
[chip,dv] add define for close source env

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -152,6 +152,13 @@
       name: en_ibex_tracer
       build_opts: ["+define+RVFI=1"]
     }
+    // Build mode that configures a testbench in a manner suitable for pad
+    // testing. For example, the testbench may need to have different agents
+    // or interfaces connected to the pads for marked tests.
+    {
+      name: pad_ctrl_test_mode
+      build_opts: ["+define+PADTEST"]
+    }
     // Sim mode that enables build randomization. See the `build_seed` mode
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
     {
@@ -1780,6 +1787,7 @@
     }
     {
       name: chip_padctrl_attributes
+      build_mode: "pad_ctrl_test_mode"
       uvm_test_seq: chip_padctrl_attributes_vseq
       en_run_modes: ["stub_cpu_mode"]
       // Starting the chip in prod LC state frees up all MIOs for this test.


### PR DESCRIPTION
chip_if.cc_if are connected by analog source in closed source env. 
For pad_ctrl test, these should be disconnected otherwise cc_if are driven by '0' and test will fail.
To mitigate this, add ifdef to close source and add define to open source