### PR TITLE
[chip,dv] add short iteration option to xbar test

### DIFF
--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_random_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_random_vseq.sv
@@ -13,6 +13,7 @@ class xbar_random_vseq extends xbar_base_vseq;
   endfunction
 
   virtual task body();
+    if (cfg.short_xbar_test) num_trans = $urandom_range(1, 3);
     run_all_device_seq_nonblocking();
     for (int i = 1; i <= num_trans; i++) begin
       update_host_seq();

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -31,6 +31,8 @@ class xbar_env_cfg extends dv_base_env_cfg;
   uint               min_device_rsp_delay = 0;
   uint               max_device_rsp_delay = 20;
 
+  // option to run short iteration
+  bit short_xbar_test = 0;
   `uvm_object_utils_begin(xbar_env_cfg)
     `uvm_field_array_object(host_agent_cfg,    UVM_DEFAULT)
     `uvm_field_array_object(device_agent_cfg,  UVM_DEFAULT)

--- a/hw/ip/tlul/generic_dv/tests/xbar_base_test.sv
+++ b/hw/ip/tlul/generic_dv/tests/xbar_base_test.sv
@@ -39,6 +39,7 @@ class xbar_base_test extends dv_base_test #(.ENV_T(xbar_env), .CFG_T(xbar_env_cf
     void'($value$plusargs("min_device_rsp_delay=%d", cfg.min_device_rsp_delay));
     void'($value$plusargs("max_device_rsp_delay=%d", cfg.max_device_rsp_delay));
     void'($value$plusargs("num_enabled_hosts=%d",    cfg.num_enabled_hosts));
+    void'($value$plusargs("short_xbar_test=%b",      cfg.short_xbar_test));
     cfg.update_agent_cfg();
   endfunction : build_phase
 


### PR DESCRIPTION
In closed source env, xbar test run too long(+20hrs). 
Add short run option for fast regression.