### PR TITLE
[dv] add plusarg to skip ROM backdoor load

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -931,7 +931,7 @@
     //   // in the hardware, not the ROM that is backdoor loaded.
     //   en_run_modes: ["sw_test_mode_common"]
     //   run_opts: [
-    //     "+en_uart_logger=1",
+    //     "+skip_rom_bkdr_load=1",
     //     "+sw_test_timeout_ns=200_000_000",
     //     "+use_otp_image=OtpTypeCustom",
     //   ]

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -17,6 +17,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // use spi or backdoor to load bootstrap on the next boot
   bit                 use_spi_load_bootstrap = 0;
 
+  // skip ROM backdoor loading (when using ROM macro block)
+  bit                 skip_rom_bkdr_load = 0;
+
   // chip top interfaces
   virtual chip_if       chip_vif;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -101,11 +101,13 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)
     // Backdoor load memories with sw images.
+    if (cfg.skip_rom_bkdr_load == 0) begin
 `ifdef DISABLE_ROM_INTEGRITY_CHECK
-    cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
+      cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".32.vmem"});
 `else
-    cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
+      cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
 `endif
+    end
 
     if (cfg.sw_images.exists(SwTypeTestSlotA)) begin
       if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -193,6 +193,9 @@ module tb;
 
   `define SIM_SRAM_IF u_sim_sram.u_sim_sram_if
 
+  // Knob to skip ROM backdoor logging (for sims that use ROM macro). Set below.
+  logic skip_rom_bkdr_load;
+
   // Instantiate & connect the simulation SRAM inside the CPU (rv_core_ibex) using forces.
   bit en_sim_sram = 1'b1;
   wire sel_sim_sram = !dut.chip_if.stub_cpu & en_sim_sram;
@@ -453,7 +456,12 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
 `endif
           .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_ROM_BASE_ADDR));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
+
+      // Knob to skip ROM backdoor logging (for sims that use ROM macro).
+      if (!$value$plusargs("skip_rom_bkdr_load=%0b", skip_rom_bkdr_load)) skip_rom_bkdr_load = 0;
+      if (!skip_rom_bkdr_load) begin
+        `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
+      end
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN IMEM", UVM_MEDIUM)
       m_mem_bkdr_util[OtbnImem] = new(.name  ("mem_bkdr_util[OtbnImem]"),

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -73,6 +73,9 @@ class chip_base_test extends cip_base_test #(
                     $sformatf({"Unsupported plusarg value: +use_otp_image=%0s. An image associated",
                                "with this LC state needs to be created first."}, cfg.use_otp_image))
 
+    // Knob to skip ROM backdoor logging (for sims that use ROM macro).
+    void'($value$plusargs("skip_rom_bkdr_load=%0b", cfg.skip_rom_bkdr_load));
+
     // Set the test timeout value to be sufficiently large.
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);


### PR DESCRIPTION
Skipping the ROM backdoor loading is needed to test the final ROM macro which is integrated into the design.