### PR TITLE
[test] Fix activity-checking part of the power virus test

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -1140,25 +1140,25 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_spi_host_1_fsm_state,
       spi_host_1_state, 3)
 
-  // Signal probe function for `state_q` of CSRNG main FSM
-  wire [csrng_pkg::MainSmStateWidth-1:0] csrng_main_state;
+  // Signal probe function for `acmd_q` of CSRNG core
+  wire [2:0] csrng_acmd_q;
 `ifdef GATE_LEVEL
-  assign csrng_main_state = 0;
+  assign csrng_acmd_q = 0;
 `else
-  assign csrng_main_state = `CSRNG_HIER.u_csrng_core.u_csrng_main_sm.state_q;
+  assign csrng_acmd_q = `CSRNG_HIER.u_csrng_core.acmd_q;
 `endif
-  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_csrng_main_fsm_state,
-      csrng_main_state, csrng_pkg::MainSmStateWidth)
-  // Signal probe function for `aes_ctrl_cs` of AES_CTRL_FSM
-  wire [5:0] aes_ctrl_fsm_state;
-  assign aes_ctrl_fsm_state =
+  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_csrng_acmd_q,
+      csrng_acmd_q, 3)
+  // Signal probe function for `rnd_ctr` of AES_CIPHER_CTRL
+  wire [3:0] aes_ctrl_rnd_ctr;
+  assign aes_ctrl_rnd_ctr =
 `ifdef GATE_LEVEL
                              0;
 `else
-      `AES_CONTROL_HIER.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.u_aes_control_fsm.aes_ctrl_cs;
+      `AES_HIER.u_aes_core.u_aes_cipher_core.u_aes_cipher_control.rnd_ctr;
 `endif
-  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_aes_ctrl_fsm_state,
-      aes_ctrl_fsm_state, 6)
+  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_aes_ctrl_rnd_ctr,
+      aes_ctrl_rnd_ctr, 4)
 
   // Signal probe function for `st_q` of HMAC
   wire [2:0] hmac_fsm_state;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_virus_vseq.sv
@@ -134,7 +134,7 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
   // A local define to probe the state of an IP and to check if it is IDLE.
   `define _DV_PROBE_AND_CHECK_IDLE(SIGNAL_NAME, IDLE_VAL)          \
       SIGNAL_NAME = cfg.chip_vif.signal_probe_``SIGNAL_NAME``(SignalProbeSample); \
-      `uvm_info(`gfn, $sformatf("adc_ctrl_state = 0x%0x", SIGNAL_NAME), UVM_LOW); \
+      `uvm_info(`gfn, $sformatf("%s = 0x%0x", `"SIGNAL_NAME`", SIGNAL_NAME), UVM_LOW); \
       `DV_CHECK_NE(SIGNAL_NAME, IDLE_VAL);
 
   // A utility function to check the FSM states of the IPs.
@@ -143,8 +143,8 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
     logic spi_device_cio_csb_i;
     logic spi_host_0_cio_csb_o;
     logic [2:0] spi_host_1_fsm_state;
-    logic [csrng_pkg::MainSmStateWidth-1:0] csrng_main_fsm_state;
-    logic [5:0] aes_ctrl_fsm_state;
+    logic [2:0] csrng_acmd_q;
+    logic [3:0] aes_ctrl_rnd_ctr;
     logic [2:0] hmac_fsm_state;
     logic [5:0] kmac_fsm_state;
     logic [6:0] otbn_fsm_state;
@@ -163,8 +163,7 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
     `_DV_PROBE_AND_CHECK_IDLE(spi_device_cio_csb_i, 1'b1)
     `_DV_PROBE_AND_CHECK_IDLE(spi_host_0_cio_csb_o, 1'b1)
     `_DV_PROBE_AND_CHECK_IDLE(spi_host_1_fsm_state, 3'b000)
-    `_DV_PROBE_AND_CHECK_IDLE(csrng_main_fsm_state, csrng_pkg::MainSmIdle)
-    `_DV_PROBE_AND_CHECK_IDLE(aes_ctrl_fsm_state, aes_pkg::CTRL_IDLE)
+    `_DV_PROBE_AND_CHECK_IDLE(aes_ctrl_rnd_ctr, 4'b0000)
     `_DV_PROBE_AND_CHECK_IDLE(hmac_fsm_state, 3'b000)
     `_DV_PROBE_AND_CHECK_IDLE(kmac_fsm_state, 6'b011000)
     `_DV_PROBE_AND_CHECK_IDLE(otbn_fsm_state, otbn_pkg::OtbnStartStopStateInitial)
@@ -173,6 +172,10 @@ class chip_sw_power_virus_vseq extends chip_sw_base_vseq;
     `_DV_PROBE_AND_CHECK_IDLE(entropy_src_fsm_state, entropy_src_main_sm_pkg::Idle)
     `_DV_PROBE_AND_CHECK_IDLE(pattgen_chan_1_0_enable, 2'b00)
     `_DV_PROBE_AND_CHECK_IDLE(pwm_core_cntr_en, 1'b0)
+
+    csrng_acmd_q = cfg.chip_vif.signal_probe_csrng_acmd_q(SignalProbeSample);
+    `uvm_info(`gfn, $sformatf("%s = 0x%0x", "csrng_acmd_q",csrng_acmd_q), UVM_LOW);
+    `DV_CHECK_GE(csrng_acmd_q, 2);
   endtask
 
   task pre_start();


### PR DESCRIPTION
This part of the tests checks if all of the IPs are active during the max-power-epoch.

The CSRNG state machine was toggling between the idle and active states, and it was causing the test fail once in a while.

This commit changes the activity indicator for CSRNG to the "acmd_q" signal, which shows the last executed CSRNG operation. The chip_sw_power_virus_vseq.sv file checks if the last CSRNG command is the reseed (0x2) or generate(0x3).

Tested on the local EDA farm instance.