### PR TITLE
[chip,dv] update lc state for otp vendor csr test

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -472,4 +472,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     return 0;
   endfunction
 
+  virtual function void update_otp_test_status();
+    otp_test_status = 0;
+  endfunction
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv
@@ -19,9 +19,6 @@ class chip_sw_otp_ctrl_vendor_test_csr_access_vseq extends chip_sw_base_vseq;
     lc_state dist {
         LcStRaw :/ 1,
         [LcStTestUnlocked0 : LcStTestUnlocked7] :/ 4,
-        LcStDev :/ 1,
-        LcStProd :/ 1,
-        LcStProdEnd :/ 1,
         LcStRma :/ 1
     };
   }
@@ -70,7 +67,8 @@ class chip_sw_otp_ctrl_vendor_test_csr_access_vseq extends chip_sw_base_vseq;
 
     // In open source prim_otp module, the vendor_test_status output is tied to 0.
     // For closed source module, cfg.otp_test_stastatus needs to be updated
-    // at cfg::initialize()
+    // by cfg::update_otp_test_status() before checking.
+    cfg.update_otp_test_status();
     `DV_CHECK_EQ(otp_vendor_test_status, cfg.otp_test_status)
 
     // Probe vendor_test_ctrl from OTP_CTRL port to ensure that in certain lc states, the


### PR DESCRIPTION
otp_vendor_test requires lc_raw_test_rma = on.
Therefore, exclude LcStProd,LcStProdEnd,LcStDev from vendor_csr access test.