### PR TITLE
[usbdev] Added frequency corners testing

### DIFF
--- a/hw/dv/dpi/usbdpi/usb_transfer.c
+++ b/hw/dv/dpi/usbdpi/usb_transfer.c
@@ -213,6 +213,7 @@ void transfer_dump(const usbdpi_transfer_t *transfer, FILE *out) {
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 
+extern bool transfer_data_drop(usbdpi_transfer_t *transfer, size_t n);
 extern uint8_t *transfer_data_field(usbdpi_transfer_t *transfer);
 extern uint8_t transfer_data_pid(usbdpi_transfer_t *transfer);
 extern uint32_t transfer_length(const usbdpi_transfer_t *transfer);

--- a/hw/dv/dpi/usbdpi/usb_transfer.h
+++ b/hw/dv/dpi/usbdpi/usb_transfer.h
@@ -224,6 +224,23 @@ inline uint32_t transfer_length(const usbdpi_transfer_t *transfer) {
 }
 
 /**
+ * Drop the specified number of data bytes from the given transfer.
+ *
+ * @param  transfer  Transfer descriptor
+ * @param  n         The number of bytes to be dropped
+ * @return The success of the operation
+ */
+inline bool transfer_data_drop(usbdpi_transfer_t *transfer, size_t n) {
+  assert(transfer);
+  if ((size_t)transfer->num_bytes - transfer->data_start < n) {
+    return false;
+  }
+  transfer->data_start += n;
+  transfer->num_bytes -= n;
+  return true;
+}
+
+/**
  * Diagnostic utility function to dump out the contents of a transfer descriptor
  *
  * @param  transfer  Transfer descriptor

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -329,6 +329,11 @@ struct usbdpi_ctx {
   uint8_t lastrxpid;
 
   /**
+   * Phase (0-3) within 4 times oversampling at which the signals from the
+   * device shall be sampled.
+   */
+  uint8_t tick_sample;
+  /**
    * Count of clock cycles
    */
   uint32_t tick;

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -212,7 +212,6 @@ module usbdpi #(
                        c_state});
 
   logic [10:0] d2p;
-  logic [10:0] d2p_r;
   logic       unused_dummy;
   logic       unused_clk = clk_i;
   logic       unused_rst = rst_ni;
@@ -245,10 +244,7 @@ module usbdpi #(
         dn_int <= p2d[1];
         sense_p2d <= p2d[0];
         unused_dummy <= |p2d[7:5];
-        d2p_r <= d2p;
-        if (d2p_r != d2p) begin
-          usbdpi_device_to_host(ctx, d2p);
-        end
+        usbdpi_device_to_host(ctx, d2p);
       end else begin
         d_last <= 0;
         dp_int <= 0;

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -86,6 +86,23 @@
       tests: []
     }
     {
+      name: chip_usb_sof
+      desc: '''Verify that USB can detect SOF and respond with `usb_ref_pulse_o` and
+            `usb_ref_val_o`.
+
+            - Configure to enable `usb_ref_disable`.
+            - Send a frame with the same frame number as the USB device to trigger `frame`
+              interrupt.
+            - Ensure `usb_ref_pulse_o` and `usb_ref_val_o` behave correctly.
+            - Stop sending any frame and check the `host_lost` interrupt. Ensure `use_ref_*` behave
+              correctly.
+            '''
+      stage: V3
+      si_stage: NA
+      tests: ["chip_sw_usbdev_hiclk_stream",
+              "chip_sw_usbdev_loclk_stream"]
+    }
+    {
       name: chip_usb_wake_debug
       desc: '''Verify that `usb_state_debug_i` can be read from the CSR.
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -631,6 +631,26 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_hiclk_stream
+      uvm_test_seq: chip_sw_usbdev_stream_vseq
+      sw_images: ["//sw/device/tests:usbdev_stream_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      // Running usbdev at a higher frequency than the usbdpi model
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1", "+usbdpi_clk_freq_delta=-18_500", "+sw_usbdev_stream_retrying=0", "+sw_usbdev_stream_max_packets=1", "+sw_test_timeout_ns=60_000_000"]
+      run_timeout_mins: 120
+      reseed: 1
+    }
+    {
+      name: chip_sw_usbdev_loclk_stream
+      uvm_test_seq: chip_sw_usbdev_stream_vseq
+      sw_images: ["//sw/device/tests:usbdev_stream_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      // Running usbdev at a lower frequency than the usbdpi model
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1", "+usbdpi_clk_freq_delta=+18_500", "+sw_usbdev_stream_retrying=0", "+sw_usbdev_stream_max_packets=1", "+sw_test_timeout_ns=60_000_000"]
+      run_timeout_mins: 120
+      reseed: 1
+    }
+    {
       name: chip_sw_inject_scramble_seed
       uvm_test_seq: chip_sw_inject_scramble_seed_vseq
       sw_images: ["//sw/device/tests/sim_dv:inject_scramble_seed:1:new_rules"]

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -77,6 +77,13 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get ast_ext_clk_vif from uvm_config_db")
     end
 
+    // get the handle to the usbdpi clk/rst interface.
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "usbdpi_clk_rst_vif", cfg.usbdpi_clk_rst_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get usbdpi clk_rst_vif from uvm_config_db")
+    end
+
     // get the handle to the usb20 interface.
     if (!uvm_config_db#(usb20_vif)::get(
             this, "", "usb20_vif", cfg.usb20_vif

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -82,6 +82,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   ast_supply_vif     ast_supply_vif;
   ast_ext_clk_vif    ast_ext_clk_vif;
   usb20_vif          usb20_vif;
+  virtual clk_rst_if usbdpi_clk_rst_vif;
 
   // Number of RAM tiles for each RAM instance.
   uint num_ram_main_tiles;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
@@ -7,13 +7,68 @@ class chip_sw_usbdev_dpi_vseq extends chip_sw_base_vseq;
 
   `uvm_object_new
 
+  // Clock frequency delta (usbdpi clk freq - usbdev clk freq).
+  int usbdpi_clk_freq_delta;
+
+  // Frequency of the usbdpi clk.
+  int usbdpi_freq;
+
+  // Perform the typical start up of the USB DPI automatically.
+  bit do_usbdpi_start = 1;
+
   // Zero initialize the usbdev packet memory
   function void init_packet_mem();
     cfg.mem_bkdr_util_h[UsbdevBuf].clear_mem();
   endfunction
 
+  // Ensure that the USB DPI model has been configured with the desired clock frequency;
+  // it runs on its own clock for a few reasons:
+  //
+  // - there is no shared clock between USB hosts and devices; USB devices are expected
+  //   to synchronize to the received traffic.
+  // - it must remain operable when the chip enters Deep Sleep, so that it
+  //   may provide the Wakeup stimulus; by constrast the USBDEV clock is stopped.
+  // - operating at the opposite frequency extreme permits us to exercise the
+  //   synchronization and bitstream extraction.
+  virtual task cpu_init();
+    super.cpu_init();
+
+    // Read the frequency delta of the usbdpi model relative to usb_clk
+    if (!$value$plusargs("usbdpi_clk_freq_delta=%d", usbdpi_clk_freq_delta)) begin
+      usbdpi_clk_freq_delta = 0;
+    end
+    usbdpi_freq = 48_000_000 + usbdpi_clk_freq_delta;
+  endtask
+
+  // Start the USB DPI model.
+  virtual task usbdpi_start();
+    int freq_khz = (usbdpi_freq + 500) / 1000;
+    `uvm_info(`gfn, $sformatf("USB DPI model starting with a clock frequency of %dkHz", freq_khz),
+              UVM_MEDIUM)
+    cfg.usbdpi_clk_rst_vif.set_freq_khz(freq_khz);
+    // Drop the reset signal, to ensure that the host-driven USB VBUS is in a defined state when
+    // we subsequently connect.
+    cfg.usbdpi_clk_rst_vif.drive_rst_pin(0);
+    cfg.usbdpi_clk_rst_vif.set_active();
+  endtask
+
+  // Reset the USB DPI model; leave the reset asserted for around 100us because the CPU
+  // has a body of code to run before it will connect to the USB.
+  virtual task usbdpi_apply_reset();
+    `uvm_info(`gfn, "Starting reset of USB DPI model", UVM_MEDIUM)
+    fork
+      cfg.usbdpi_clk_rst_vif.apply_reset(.reset_width_clks(4_800));
+    join_none
+  endtask
+
   virtual task body();
     super.body();
+
+    // Optionally start the USB DPI model in the typical manner.
+    if (do_usbdpi_start) begin
+      usbdpi_start();
+      usbdpi_apply_reset();
+    end
 
     // We need to release the tb weak pull up on DP, otherwise usbdev appears
     // to be connected much too soon

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_stream_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_stream_vseq.sv
@@ -7,10 +7,42 @@ class chip_sw_usbdev_stream_vseq extends chip_sw_usbdev_dpi_vseq;
 
   `uvm_object_new
 
+  virtual task cpu_init();
+    // sw_symbol_backdoor_overwrite takes an array as the input
+    bit [7:0] stream_count[1];
+    bit [7:0] stream_retrying[1];
+    bit [7:0] stream_max_packets[1];
+    super.cpu_init();
+
+    // Number of streams to exercise concurrently; by default exercise all available
+    // endpoints/streams.
+    if (!$value$plusargs("sw_usbdev_stream_count=%0d", stream_count[0])) begin
+      stream_count[0] = 8'h0B;
+    end
+
+    // Retrying exercises the ACK/NAK logic within usbdev, and should normally
+    // be enabled.
+    if (!$value$plusargs("sw_usbdev_stream_retrying=%0d", stream_retrying[0])) begin
+      stream_retrying[0] = 8'h01;
+    end
+
+    // Maximum-length packets are required for testing transmission/reception at
+    // frequency extremes. It should normally be disabled, to randomize packet
+    // sizes.
+    if (!$value$plusargs("sw_usbdev_stream_max_packets=%0d", stream_max_packets[0])) begin
+      stream_max_packets[0] = 8'h00;
+    end
+
+    // Present the configuration to the usbdev_stream_test software
+    sw_symbol_backdoor_overwrite("kNumStreams", stream_count);
+    sw_symbol_backdoor_overwrite("kRetrying", stream_retrying);
+    sw_symbol_backdoor_overwrite("kMaxPackets", stream_max_packets);
+  endtask
+
   // TODO: introduce randomization to make this test more useful; candidates:
   // - number of endpoints
   // - response timing of DPI model
-  // - stream test flags (transfer direction(s), variable/max-length packets...)
+  // - stream test flags (transfer direction(s) ...)
 
   virtual task body();
     super.body();

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -219,11 +219,24 @@ module tb;
     .out_o(gsim_tl_win_d2h_int)
   );
 `endif
+
+  // USB DPI model runs on its own clock for two reasons
+  // - it must remain operable when the chip enters Deep Sleep, so that it
+  //   may provide the Wakeup stimulus.
+  // - operating at the opposite frequency extreme permits us to exercise the
+  //   synchronization and bitstream extraction.
+  wire usbdpi_clk;
+  wire usbdpi_rst_n;
+  clk_rst_if u_usbdpi_clk_rst_if(
+    .clk(usbdpi_clk),
+    .rst_n(usbdpi_rst_n)
+  );
+
   // Interface presently just permits the DPI model to be easily connected and
   // disconnected as required, since SENSE pin is a MIO with other uses.
   usb20_if u_usb20_if (
-    .clk_i            (dut.chip_if.usb_clk),
-    .rst_ni           (dut.chip_if.usb_rst_n),
+    .clk_i            (usbdpi_clk),
+    .rst_ni           (usbdpi_rst_n),
 
     .usb_vbus         (dut.chip_if.mios[top_earlgrey_pkg::MioPadIoc7]),
     .usb_p            (dut.chip_if.dios[top_earlgrey_pkg::DioPadUsbP]),
@@ -232,8 +245,8 @@ module tb;
 
   // Instantiate & connect the USB DPI model for top-level testing.
   usb20_usbdpi u_usb20_usbdpi (
-    .clk_i            (dut.chip_if.usb_clk),
-    .rst_ni           (dut.chip_if.usb_rst_n),
+    .clk_i            (usbdpi_clk),
+    .rst_ni           (usbdpi_rst_n),
 
     .enable           (u_usb20_if.connected),
 
@@ -414,9 +427,11 @@ module tb;
     uvm_config_db#(virtual ast_ext_clk_if)::set(
         null, "*.env", "ast_ext_clk_vif", dut.ast_ext_clk_if);
 
-    // USB DPI interface.
+    // USB DPI clk/rst and USB interfaces.
     uvm_config_db#(virtual usb20_if)::set(
         null, "*.env", "usb20_vif", u_usb20_if);
+    uvm_config_db#(virtual clk_rst_if)::set(
+        null, "*.env", "usbdpi_clk_rst_vif", u_usbdpi_clk_rst_if);
 
     // Generic DPI interface.
     uvm_config_db#(virtual tb_dpi_if)::set(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3831,6 +3831,11 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+            "//hw/top_earlgrey:sim_dv": None,
+        },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
@@ -3855,6 +3860,11 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+            "//hw/top_earlgrey:sim_dv": None,
+        },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
@@ -3879,6 +3889,11 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+            "//hw/top_earlgrey:sim_dv": None,
+        },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -135,7 +135,7 @@ static usb_testutils_streams_ctx_t stream_test;
  *   (Note that this substantially alters the timing of interactions with the
  * DPI model and will increase the simulation time)
  */
-static bool verbose = false;
+static bool kVerbose = false;
 
 /*
  * These switches may be modified manually to experimentally measure the
@@ -143,35 +143,41 @@ static bool verbose = false;
  *
  * Are we sending data?
  */
-static bool sending = true;
+static bool kSending = true;
 
 /**
  * Are we generating a valid byte sequence?
  */
-static bool generating = true;
+static bool kGenerating = true;
 
 /**
  * Do we want the host to retry transmissions? (DPI model only; we cannot
  * instruct a physical host to fake delivery failure/packet corruption etc)
+ *
+ * Note: top level testbench may use backdoor overwriting to alter this symbol.
  */
-static bool retrying = true;
+static const volatile uint8_t kRetrying = 1U;
 
 /**
  * Are we expecting to receive data?
  */
-static bool recving = true;
+static bool kRecving = true;
 
 /**
  * Send only maximal length packets?
  * (important for performance measurements on the USB, but obviously undesirable
  *  for testing reliability/function)
+ *
+ * Note: top level testbench may use backdoor overwriting to alter this symbol.
  */
-static bool max_packets = false;
+static const volatile uint8_t kMaxPackets = 0U;
 
 /**
  * Number of streams to be created
+ *
+ * Note: top level testbench may use backdoor overwriting to alter this symbol.
  */
-static const unsigned nstreams = NUM_STREAMS;
+static const volatile uint8_t kNumStreams = NUM_STREAMS;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -182,7 +188,8 @@ bool test_main(void) {
   LOG_INFO("Running USBDEV Stream Test");
 
   // Check we can support the requested number of streams
-  CHECK(nstreams && nstreams < USBDEV_NUM_ENDPOINTS);
+  CHECK(kNumStreams && kNumStreams <= NUM_STREAMS &&
+        kNumStreams < USBDEV_NUM_ENDPOINTS);  // streams exclude Endpoint Zero
 
   // Decide upon the number of bytes to be transferred for the entire test
   uint32_t transfer_bytes = TRANSFER_BYTES_FPGA;
@@ -201,8 +208,8 @@ bool test_main(void) {
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;
   }
-  transfer_bytes = (transfer_bytes + nstreams - 1) / nstreams;
-  LOG_INFO(" - %u stream(s), 0x%x bytes each", nstreams, transfer_bytes);
+  transfer_bytes = (transfer_bytes + kNumStreams - 1) / kNumStreams;
+  LOG_INFO(" - %u stream(s), 0x%x bytes each", kNumStreams, transfer_bytes);
 
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
@@ -212,12 +219,12 @@ bool test_main(void) {
       kTopEarlgreyPinmuxInselIoc7));
 
   // Construct the test/stream flags to be used
-  test_flags = (sending ? kUsbdevStreamFlagRetrieve : 0U) |
-               (generating ? kUsbdevStreamFlagCheck : 0U) |
-               (retrying ? kUsbdevStreamFlagRetry : 0U) |
-               (recving ? kUsbdevStreamFlagSend : 0U) |
+  test_flags = (kSending ? kUsbdevStreamFlagRetrieve : 0U) |
+               (kGenerating ? kUsbdevStreamFlagCheck : 0U) |
+               (kRetrying ? kUsbdevStreamFlagRetry : 0U) |
+               (kRecving ? kUsbdevStreamFlagSend : 0U) |
                // Note: the 'max_packets' test flag is not required by the DPI
-               (max_packets ? kUsbdevStreamFlagMaxPackets : 0U);
+               (kMaxPackets ? kUsbdevStreamFlagMaxPackets : 0U);
 
   // Initialize the test descriptor
   // Note: the 'max packets' test flag is not required by the DPI model
@@ -246,15 +253,15 @@ bool test_main(void) {
   // Note: for now we support only Bulk Transfer streams but this should change
   // in future, eg. in response to test configuration.
   usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX];
-  for (unsigned s = 0U; s < nstreams; s++) {
+  for (unsigned s = 0U; s < kNumStreams; s++) {
     xfr_types[s] = kUsbTransferTypeBulk;
   }
 
   // Initialise the state of the streams
   CHECK_STATUS_OK(usb_testutils_streams_init(
-      ctx, nstreams, xfr_types, transfer_bytes, test_flags, verbose));
+      ctx, kNumStreams, xfr_types, transfer_bytes, test_flags, kVerbose));
 
-  if (verbose) {
+  if (kVerbose) {
     LOG_INFO("Commencing data transfer...");
   }
 
@@ -271,7 +278,7 @@ bool test_main(void) {
   // Determine the total counts of bytes sent and received
   uint32_t tx_bytes = 0U;
   uint32_t rx_bytes = 0U;
-  for (uint8_t s = 0U; s < nstreams; s++) {
+  for (uint8_t s = 0U; s < kNumStreams; s++) {
     uint32_t tx, rx;
     CHECK_STATUS_OK(usb_testutils_stream_status(ctx, s, NULL, &tx, &rx));
     tx_bytes += tx;
@@ -281,12 +288,12 @@ bool test_main(void) {
   LOG_INFO("USB sent 0x%x byte(s), received and checked 0x%x byte(s)", tx_bytes,
            rx_bytes);
 
-  if (sending) {
-    CHECK(tx_bytes == nstreams * transfer_bytes,
+  if (kSending) {
+    CHECK(tx_bytes == kNumStreams * transfer_bytes,
           "Unexpected count of byte(s) sent to USB host");
   }
-  if (recving) {
-    CHECK(rx_bytes == nstreams * transfer_bytes,
+  if (kRecving) {
+    CHECK(rx_bytes == kNumStreams * transfer_bytes,
           "Unexpected count of byte(s) received from USB host");
   }
 


### PR DESCRIPTION
Introduced an independent, asynchronous clock for USB DPI model. ~~The clock is implemented directly at present, but I think it should be possible to replace it with a clk_rst_if~~.

In order to configure usbdev_stream_test to generate max-length packets - a necessary prerequisite of testing the ability of the receiver to track the transmitter after synchronizing - chip_sw_usbdev_stream_vseq overwrites configuration switches, and then two further regression tests are added:

- chip_sw_usbdev_hiclk_stream operates usbdev at a clock frequency higher than that of the usbdpi model
- chip_sw_usbdev_loclk_stream operates usbdev at a lower clock frequency

The tests are found to pass at a frequency offset of 18.5kHz (of 48MHz), but they are unreliable at 30kHz. The failure frequency depends upon the exact data being sent (because of bit stuffing) and the phase relationship of the two clocks at the start of packet transmission.

Update: initial implementation of clk/rst for usbdpi has been replaced by the common clk_rst_if.
