### PR TITLE
Fix module ids

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy_kat.c
+++ b/sw/device/lib/crypto/drivers/entropy_kat.c
@@ -12,6 +12,8 @@
 #include "csrng_regs.h"  // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('e', 'n', 'k')
+
 enum {
   kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
 };

--- a/sw/device/lib/crypto/drivers/entropy_test.c
+++ b/sw/device/lib/crypto/drivers/entropy_test.c
@@ -14,6 +14,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('e', 'n', 't')
+
 OTTF_DEFINE_TEST_CONFIG();
 
 static void entropy_complex_init_test(void) {

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -12,6 +12,8 @@
 
 #include "alert_handler_regs.h"  // Generated
 
+#define MODULE_ID MAKE_MODULE_ID('a', 'h', 't')
+
 /**
  * This is used to traverse the dump treating it as an array of bits, and
  * extract a number of bits placing them in a uint32_t. The word and bit index

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -15,6 +15,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('a', 'o', 't')
+
 status_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds,
                                                     uint32_t *cycles) {
   uint64_t cycles_ = udiv64_slow(microseconds * kClockFreqAonHz, 1000000,

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -7,6 +7,8 @@
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/dif/dif_clkmgr.h"
 
+#define MODULE_ID MAKE_MODULE_ID('c', 'm', 't')
+
 static const char *measure_clock_names[kDifClkmgrMeasureClockUsb + 1] = {
     "io_clk", "io_div2_clk", "io_div4_clk", "main_clk", "usb_clk"};
 

--- a/sw/device/lib/testing/clkmgr_testutils.h
+++ b/sw/device/lib/testing/clkmgr_testutils.h
@@ -10,6 +10,8 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('c', 'm', 'h')
+
 /**
  * Returns the transactional block's clock status.
  *
@@ -181,5 +183,7 @@ status_t clkmgr_testutils_enable_external_clock_blocking(
               clock_state, expected_state);                                    \
     OK_STATUS();                                                               \
   })
+
+#undef MODULE_ID
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CLKMGR_TESTUTILS_H_

--- a/sw/device/lib/testing/csrng_testutils.c
+++ b/sw/device/lib/testing/csrng_testutils.c
@@ -11,6 +11,8 @@
 
 #include "csrng_regs.h"  // Generated
 
+#define MODULE_ID MAKE_MODULE_ID('r', 'n', 't')
+
 enum {
   kNumOutputWordsMax = 16,
 };

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -12,6 +12,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('e', 'n', 'y')
+
 static status_t setup_entropy_src(const dif_entropy_src_t *entropy_src) {
   CHECK_DIF_OK(dif_entropy_src_configure(
       entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -18,6 +18,8 @@
 #include "flash_ctrl_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('f', 'c', 't')
+
 status_t flash_ctrl_testutils_wait_for_init(
     dif_flash_ctrl_state_t *flash_state) {
   dif_flash_ctrl_status_t status;

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -10,6 +10,8 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('h', 'm', 't')
+
 const char kHmacRefData[34] = "Sample message for keylen=blocklen";
 
 const uint8_t kHmacRefLongKey[100] = {

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -14,6 +14,8 @@
 #include "sw/device/lib/dif/dif_hmac.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('h', 'm', 'h')
+
 /**
  * Timeouts to be used for different HMAC operations.
  *
@@ -155,5 +157,7 @@ status_t hmac_testutils_finish_and_check_polled(
 OT_WARN_UNUSED_RESULT
 status_t hmac_testutils_push_message(const dif_hmac_t *hmac, const char *data,
                                      size_t len);
+
+#undef MODULE_ID
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_HMAC_TESTUTILS_H_

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -19,6 +19,8 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "i2c_regs.h"  // Generated.
 
+#define MODULE_ID MAKE_MODULE_ID('i', 'i', 't')
+
 enum {
   kI2cWrite = 0,
   kI2cRead = 1,

--- a/sw/device/lib/testing/json/chip_specific_startup.h
+++ b/sw/device/lib/testing/json/chip_specific_startup.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 // clang-format off
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'c', 'h')
+
 // OTP words that we care about for low-level init.
 #define STRUCT_ROM_OTP_CONFIG(field, string) \
     field(creator_sw_cfg_ast_init_en, uint32_t) \
@@ -47,6 +49,8 @@ UJSON_SERDE_STRUCT(SramInit, sram_init_t, STRUCT_SRAM_INIT);
     field(ast_init_done, bool) \
     field(sram, sram_init_t)
 UJSON_SERDE_STRUCT(ChipStartup, chip_startup_t, STRUCT_CHIP_STARTUP);
+
+#undef MODULE_ID
 
 // clang-format on
 #ifdef __cplusplus

--- a/sw/device/lib/testing/json/gpio.c
+++ b/sw/device/lib/testing/json/gpio.c
@@ -8,6 +8,8 @@
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'g', 'p')
+
 status_t gpio_set(ujson_t *uj, const dif_gpio_t *gpio) {
   gpio_set_t op;
   TRY(ujson_deserialize_gpio_set_t(uj, &op));

--- a/sw/device/lib/testing/json/gpio.h
+++ b/sw/device/lib/testing/json/gpio.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 // clang-format off
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'g', 'h')
+
 #define ENUM_GPIO_SET_ACTION(_, value) \
     value(_, Write) \
     value(_, WriteAll) \
@@ -36,6 +38,8 @@ UJSON_SERDE_STRUCT(GpioGet, gpio_get_t, STRUCT_GPIO_GET);
 status_t gpio_set(ujson_t *uj, const dif_gpio_t *gpio);
 status_t gpio_get(ujson_t *uj, const dif_gpio_t *gpio);
 #endif
+
+#undef MODULE_ID
 
 // clang-format on
 #ifdef __cplusplus

--- a/sw/device/lib/testing/json/i2c_target.h
+++ b/sw/device/lib/testing/json/i2c_target.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 // clang-format off
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'i', 'i')
+
 #define STRUCT_I2C_TARGET_ADDRESS(field, string) \
     field(id0, uint8_t) \
     field(mask0, uint8_t) \
@@ -28,6 +30,8 @@ UJSON_SERDE_STRUCT(I2cTransaction, i2c_transaction_t, STRUCT_I2C_TRANSACTION);
     field(address, uint8_t) \
     field(continuation, uint8_t)
 UJSON_SERDE_STRUCT(I2cRxResult, i2c_rx_result_t, STRUCT_I2C_RX_RESULT);
+
+#undef MODULE_ID
 
 // clang-format on
 #ifdef __cplusplus

--- a/sw/device/lib/testing/json/pinmux_config.h
+++ b/sw/device/lib/testing/json/pinmux_config.h
@@ -9,6 +9,8 @@
 extern "C" {
 #endif
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'p', 'x')
+
 //  Dependencies between usjon structure definitions can be a little tricky:
 //  - If not generating an implementation, we can just include the dependency.
 //  - If generating an implementation, we instead include the dependency in
@@ -36,6 +38,8 @@ UJSON_SERDE_STRUCT(PinmuxOutputSelection, pinmux_output_selection_t,
     field(input, pinmux_input_selection_t)  \
     field(output, pinmux_output_selection_t)
 UJSON_SERDE_STRUCT(PinmuxConfig, pinmux_config_t, STRUCT_PINMUX_CONFIG);
+
+#undef MODULE_ID
 
 // clang-format on
 #ifndef RUST_PREPROCESSOR_EMIT

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#define MODULE_ID MAKE_MODULE_ID('j', 'p', 'd')
+
 /**
  * Wrapped (encrypted) RMA unlock token.
  *
@@ -44,6 +46,8 @@ UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
 UJSON_SERDE_STRUCT(ManufProvisioning, \
                    manuf_provisioning_t, \
                    STRUCT_MANUF_PROVISIONING);
+
+#undef MODULE_ID
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/device/lib/testing/json/spi_passthru.h
+++ b/sw/device/lib/testing/json/spi_passthru.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 // clang-format off
 
+#define MODULE_ID MAKE_MODULE_ID('j', 's', 'p')
+
 #define STRUCT_CONFIG_JEDEC_ID(field, string) \
     field(device_id, uint16_t) \
     field(manufacturer_id, uint8_t) \
@@ -77,6 +79,8 @@ UJSON_SERDE_STRUCT(SpiFlashWrite, spi_flash_write_t, STRUCT_SPI_FLASH_WRITE);
     field(mask, uint32_t) \
     field(value, uint32_t)
 UJSON_SERDE_STRUCT(SpiPassthruSwapMap, spi_passthru_swap_map_t, STRUCT_SPI_PASSTHRU_SWAP_MAP);
+
+#undef MODULE_ID
 
 // clang-format on
 #ifdef __cplusplus

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -21,6 +21,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('k', 'm', 't')
+
 enum {
   /** Flash Secret partition ID. */
   kFlashInfoPartitionId = 0,

--- a/sw/device/lib/testing/otbn_testutils.c
+++ b/sw/device/lib/testing/otbn_testutils.c
@@ -10,6 +10,8 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('o', 'b', 't')
+
 enum {
   /**
    * Data width of big number subset, in bytes.

--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -9,6 +9,8 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('o', 'c', 't')
+
 /*
  * OTP the Direct Access Interface (DAI) operation time-out in micro seconds.
  *

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -12,6 +12,8 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
+#define MODULE_ID MAKE_MODULE_ID('r', 'm', 'g')
+
 status_t rstmgr_testutils_is_reset_info(const dif_rstmgr_t *rstmgr,
                                         dif_rstmgr_reset_info_bitfield_t info) {
   dif_rstmgr_reset_info_bitfield_t actual_info;

--- a/sw/device/lib/testing/rv_core_ibex_testutils.c
+++ b/sw/device/lib/testing/rv_core_ibex_testutils.c
@@ -9,6 +9,8 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('r', 'v', 'c')
+
 bool rv_core_ibex_testutils_is_rnd_data_valid(
     const dif_rv_core_ibex_t *rv_core_ibex) {
   dif_rv_core_ibex_rnd_status_t rnd_status;

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -7,6 +7,8 @@
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('s', 'd', 't')
+
 status_t spi_device_testutils_configure_passthrough(
     dif_spi_device_handle_t *spi_device, uint32_t filters,
     bool upload_write_commands) {

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -13,6 +13,8 @@
 #include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/spi_flash_testutils.h"
 
+#define MODULE_ID MAKE_MODULE_ID('s', 'f', 'e')
+
 enum {
   // JEDEC standard continuation code.
   kJedecContCode = 0x7f,

--- a/sw/device/lib/testing/spi_flash_testutils.c
+++ b/sw/device/lib/testing/spi_flash_testutils.c
@@ -10,6 +10,8 @@
 #include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('s', 'f', 't')
+
 status_t spi_flash_testutils_read_id(dif_spi_host_t *spih,
                                      spi_flash_testutils_jedec_id_t *id) {
   TRY_CHECK(spih != NULL);

--- a/sw/device/lib/testing/sram_ctrl_testutils.c
+++ b/sw/device/lib/testing/sram_ctrl_testutils.c
@@ -10,6 +10,8 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('s', 'c', 't')
+
 void sram_ctrl_testutils_write(uintptr_t address,
                                const sram_ctrl_testutils_data_t data) {
   mmio_region_t region = mmio_region_from_addr(address);

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -22,6 +22,8 @@
 // TODO: make this toplevel agnostic.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('o', 't', 'c')
+
 /**
  * OTTF console configuration parameters.
  */

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -30,6 +30,8 @@
 // TODO: make this toplevel agnostic.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('o', 't', 'm')
+
 // Check layout of test configuration struct since OTTF ISR asm code requires a
 // specific layout.
 OT_ASSERT_MEMBER_OFFSET(ottf_test_config_t, enable_concurrency, 0);

--- a/sw/device/lib/testing/usb_testutils.c
+++ b/sw/device/lib/testing/usb_testutils.c
@@ -9,6 +9,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('u', 's', 't')
+
 #define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR
 
 static dif_usbdev_t usbdev;

--- a/sw/device/lib/testing/usb_testutils_streams.c
+++ b/sw/device/lib/testing/usb_testutils_streams.c
@@ -18,6 +18,8 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/usb_testutils_diags.h"
 
+#define MODULE_ID MAKE_MODULE_ID('u', 't', 's')
+
 /**
  * Read method to be employed
  */

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -12,6 +12,8 @@
 #include "sw/device/lib/testing/profile.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
+#define MODULE_ID MAKE_MODULE_ID('a', 'g', 't')
+
 /**
  * Static mask to use for testing.
  */

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -17,6 +17,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+#define MODULE_ID MAKE_MODULE_ID('s', 'h', 'f')
+
 // A data pattern to program into the chip:
 // From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
 static const char kGettysburgPrelude[256] =


### PR DESCRIPTION
The first commits are those of #19062

The rational for the rename is as follows is to modify in priority the libraries to use less common names so that they won't interfere with autogenerated functest name.