### PR TITLE
[dif] Fix UB bitshift in autogenerated tests

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -158,8 +158,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -150,8 +150,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 4;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 4;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_alert_handler_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -167,8 +167,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_aon_timer_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -169,8 +169,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 4;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 4;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_csrng_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -167,8 +167,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_edn_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -174,8 +174,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 4;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 4;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_entropy_src_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -173,8 +173,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 6;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 6;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_flash_ctrl_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -154,8 +154,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 32;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 32;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_gpio_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -161,8 +161,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 3;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 3;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_hmac_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -162,8 +162,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 15;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 15;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_i2c_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -161,8 +161,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_keymgr_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -167,8 +167,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 3;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 3;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_kmac_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -152,8 +152,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_otbn_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -172,8 +172,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -165,8 +165,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_pattgen_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -154,8 +154,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -160,8 +160,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_rv_timer_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
@@ -174,8 +174,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_sensor_ctrl_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -168,8 +168,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 12;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 12;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_spi_device_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -166,8 +166,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_spi_host_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
@@ -160,8 +160,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 1;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 1;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_sysrst_ctrl_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -162,8 +162,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 8;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 8;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_uart_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -164,8 +164,8 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 17;
-  const uint32_t irq_mask = (1u << num_irqs) - 1;
+  constexpr uint32_t num_irqs = 17;
+  constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_usbdev_irq_state_snapshot_t irq_snapshot = 1;
 
   // Test a few snapshots.

--- a/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
@@ -325,8 +325,8 @@ namespace {
     for irq in ip.irqs:
       num_irqs += irq.width
   %>
-    const uint32_t num_irqs = ${num_irqs};
-    const uint32_t irq_mask = (1u << num_irqs) - 1;
+    constexpr uint32_t num_irqs = ${num_irqs};
+    constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
     dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 1;
 
     // Test a few snapshots.


### PR DESCRIPTION
I also regenerated the files in sw/device/lib/dif/autogen/:
    util/make_new_dif.py --mode=regen --only=autogen

This commit fixes errors like the following:

```
sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc:158:33: warning: left shift count >= width of type [-Wshift-count-overflow]
158 |   const uint32_t irq_mask = (1u << num_irqs) - 1;
```