### PR TITLE
[otbn,dv] Don't apply loop warps in Verilator when no longer running

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -249,6 +249,15 @@ extern "C" void OtbnTopApplyLoopWarp() {
     loop_count_stack.push_back(loop_controller->loop_iterations_i);
   }
 
+  // We only have work to do if the RTL actually thinks that it's
+  // currently in a loop. This normally matches the model, but they
+  // disagree if we finish an execution while still running loop
+  // iterations. In that case, we don't need to do any fixing up:
+  // we've stopped anyway.
+  if (!loop_controller->current_loop_valid) {
+    return;
+  }
+
   if (!loop_count_stack.empty()) {
     // There is a loop that's currently active. Its iteration count for the
     // next cycle is provided to the prefetcher via `prefetch_loop_iterations_o`


### PR DESCRIPTION
These "warps" are to bodge the internal loop counters in the RTL so that they match the warping in the model.

The translation that they do doesn't work any more once the FSM in the RTL has stopped, because the value of `prefetch_loop_iterations_o` becomes `32'ffffffff`.

Fortunately, we don't really care: we know we're stopping anyway. Avoid bodging the loop counts in the RTL in that case: they'll never have any more effect anyway.