### PR TITLE
[otbn,dv] Fix indentation in `otbn_escalate_if.sv`

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
@@ -23,9 +23,9 @@ interface otbn_escalate_if (
     // Send Req
     `DV_SPINWAIT_EXIT(begin
         repeat (n) @(posedge clk_i);
-          req <= cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
-                                                  .f_weight(f_weight),
-                                                  .other_weight(other_weight));
+        req <= cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
+                                                .f_weight(f_weight),
+                                                .other_weight(other_weight));
       end, @(negedge rst_ni);, "Not setting req signal because we've gone into reset",
                       "otbn_escalate_if")
   endtask


### PR DESCRIPTION
No functional change, but it's a bit easier to read because the previous version looked like we were repeating the call to `get_rand_lc_tx_val`.