### PR TITLE
[otbn,dv] Properly notice mismatches in insn_cnt in otbn_top_sim.sv

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -427,7 +427,8 @@ module otbn_top_sim (
   end
 
   bit err_latched;
-  assign err_latched = model_err_latched | done_mismatch_latched | err_bits_mismatch_latched;
+  assign err_latched = |{done_mismatch_latched, err_bits_mismatch_latched, cnt_mismatch_latched,
+                         model_err_latched};
 
   int bad_cycles;
   always_ff @(negedge IO_CLK or negedge IO_RST_N) begin


### PR DESCRIPTION
It seems that I latched the error (in df151f9175), but forgot to use that latched error signal in the calculation of `err_latched`.