### PR TITLE
Fix DV model and check it for RND/URND requests from OTBN

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -170,10 +170,10 @@ module otbn_core_model
   end
 
   // EDN URND Seed Request Logic
-  logic start_q, start_d;
+  logic start;
   bit is_idle;
 
-  assign start_d = (cmd == CmdExecute) & is_idle;
+  assign start = (cmd == CmdExecute) & is_idle;
   assign is_idle = otbn_pkg::status_e'(status_o) == StatusIdle;
 
   // URND Reseeding is done twice as part of every secure wipe: once before the secure wipe and once
@@ -228,7 +228,7 @@ module otbn_core_model
       end
 
       OtbnCoreModelUrndStateAwaitStart: begin
-        if (start_q) begin
+        if (start) begin
           urnd_state_d = OtbnCoreModelUrndStateAwaitPostStartAck;
         end
       end
@@ -259,11 +259,9 @@ module otbn_core_model
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      start_q            <= 1'b0;
       urnd_state_q       <= OtbnCoreModelUrndStateReset;
       wipe_cyc_cnt_q     <= '0;
     end else begin
-      start_q        <= start_d;
       urnd_state_q   <= urnd_state_d;
       wipe_cyc_cnt_q <= wipe_cyc_cnt_d;
     end


### PR DESCRIPTION
The first commit fixes a bug in the DV model (a flop causing an extra cycle). The second is because some of the strengthened tests can fail when the RTL hasn't been initialised yet. We don't really care, so we have to tell the test to only check once the RTL looks sensible. The final commit turns on a check for when the RTL and model are doing URND requests. It turns out that they didn't line up before this PR. Since the signals are visible at the top of the test, it's easy enough to assert that they must.