### PR TITLE
[util,site] Serve elasticlunr search index files compressed with brotli

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -8,13 +8,10 @@
 # RHEL/CentOS 7 in sync. These were derived from the Ubuntu requirements
 # and are maintained in yum-requirements.txt.
 #
-# This list of packages is also included in the documentation at
-# doc/ug/install_instructions/index.md. When updating this file also check if
-# doc/ug/install_instructions/index.md needs to be updated as well.
-#
 # Keep it sorted.
 autoconf
 bison
+brotli
 build-essential
 clang-format
 cmake

--- a/util/site/post-build.sh
+++ b/util/site/post-build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+##########################################################
+#
+# Utility tasks that may be run after building the site (build-docs.sh)
+# but before deploying (cloudbuild-deploy-docs.yaml/deploy.sh)
+#
+##########################################################
+
+set -e
+
+# Get the project directory from the location of this script
+this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+proj_root=$( realpath "${this_dir}/../.." )
+build_dir="${proj_root}/build-site"
+
+# Check for brotli
+if ! command -v brotli >/dev/null; then
+    echo "E: brotli not found." >&2
+    exit 1
+fi
+
+############
+# BUILDING #
+############
+
+compress_br_inplace () {
+    # Compress the searchindex.json files (which are large, hence worth compressing here.)
+    search_indexes=$(find "${build_dir}" -type f -name '*searchindex.json')
+    for f in $search_indexes; do
+        echo "Compressing ${f}"
+        # When serving from gcloud buckets, file should be uploaded with an identical name as the
+        # original, but compressed and with the matching 'content-encoding' tag applied.
+        cp "${f}" "${f}.orig"
+        brotli "${f}"
+        mv "${f}.br" "${f}"
+        # Log the resulting improvement
+        du -h "${f}.orig"
+        du -h "${f}"
+    done
+}
+
+#######
+# CLI #
+#######
+case "$1" in
+    "compress_br") compress_br_inplace ;;
+    "help"|*)
+        echo "USAGE: $0 <command>"
+        echo ""
+        echo "commands:"
+        echo "  help             prints this message."
+        echo "  compress_br      compresses using brotli in-place, replacing the existing files"
+        exit 0
+        ;;
+esac

--- a/util/site/site-builder/cloudbuild-deploy-docs.yaml
+++ b/util/site/site-builder/cloudbuild-deploy-docs.yaml
@@ -13,14 +13,44 @@ steps:
       - |
         chown -R dev:dev /workspace
         exec gosu dev:dev /bin/bash -c "./util/site/build-docs.sh build"
-# Copy the build artifacts to the bucket where the site is hosted
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: 'gcr.io/cloud-builders/gcloud'
+    env:
+    - 'PROJECT=gold-hybrid-255313'
+    script: |
+      #!/usr/bin/env bash
+      build_dir="/workspace/build-site"
+
+      # First, upload all (uncompressed) files
+      gcloud storage cp -R --gzip-in-flight=js,css,html "${build_dir}/*" gs://${PROJECT}-prod
+  - name: 'gcr.io/gold-hybrid-255313/builder'
+    entrypoint: bash
     args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - '-d'
-      - '/workspace/build-site/'
-      - 'gs://gold-hybrid-255313-prod'
+      - '-c'
+      - |
+        # This script compresses the searchindex files, replacing the originals in-place.
+        # (This is how 'content-encoding'-tagged files should be uploaded to gcloud buckets)
+        exec gosu dev:dev /bin/bash -c "./util/site/post-build.sh compress_br"
+  - name: 'gcr.io/cloud-builders/gcloud'
+    env:
+    - 'PROJECT=gold-hybrid-255313'
+    script: |
+      #!/usr/bin/env bash
+      build_dir="/workspace/build-site"
+
+      # Next, upload the brotli-compressed files.
+      search_indexes=$(find ${build_dir}/ -type f -name '*searchindex.json')
+      for f in $search_indexes; do
+          echo "Uploading compressed file ${f}"
+          # Get directory of file, relative to the build directory.
+          # - var=${var#*//} # removes stuff from the begining up to //
+          dir=$(dirname "${f#*"${build_dir}"/}")
+          # When serving from gcloud buckets, file should be uploaded with an identical name as the
+          # original, but compressed and with the matching 'content-encoding' and 'content-type' tags applied.
+          gcloud storage cp \
+                 --content-encoding=br \
+                 --content-type=application/json \
+                 -R \
+                 "$f" "gs://${PROJECT}-prod/${dir}/"
+      done
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -4,14 +4,11 @@
 
 # List of packages installed with yum on RHEL/CentOS 7 platforms.
 #
-# This list of packages is also included in the documentation at
-# doc/ug/install_instructions/index.md. When updating this file also check if
-# doc/ug/install_instructions/index.md needs to be updated as well.
-#
 # Keep it sorted.
 "Development Tools"
 autoconf
 bison
+brotli
 cmake
 curl
 doxygen


### PR DESCRIPTION
This reduces the payload size of these files to approximately 7% of the uncompressed size, which increases the usability of the site on low-bandwidth connections.

I've tested this on [staging.opentitan.org](staging.opentitan.org) and works well. (currently serves the indexes compressed without issue).