### PR TITLE
[ci] Revert "Update actions/github-script to v6"

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -21,7 +21,7 @@ jobs:
       # a review
       - name: 'Download artifact'
         id: get-artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
This reverts commit 325636b7cc53657e142eed21f7293b8dc49d07a8.

As part of #18900, I updated the "github-script" action to v6, which updates the version of Node.js it uses from 12 (now deprecated) to 16. We were hoping this wouldn't break the script, but it has.

Reverting that update to fix the verible lint.

#18910 provides a proper upgrade of the verible lint that will avoid this issue entirely.