### PR TITLE
[Sram, dv] Improve synchronization of scrambled access test.

### DIFF
--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -940,6 +940,7 @@ opentitan_functest(
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -224,16 +224,16 @@ static void prepare_sram_for_scrambling(void) {
       (uint32_t)reference_frame->pattern,
       (sram_ctrl_testutils_data_t){.words = kRamTestPattern2,
                                    .len = kTestBufferSizeWords});
-  LOG_INFO("Checking addr 0x%x", reference_frame);
+  LOG_INFO("Checking addr 0x%x", reference_frame->pattern);
   CHECK_ARRAYS_EQ(reference_frame->pattern, kRamTestPattern2,
                   kTestBufferSizeWords);
 }
 
 static void execute_main_sram_test(void) {
-  LOG_INFO("ut_backdoor: %x,ut_patternt: %x,ut_ecc_error_counter: %x",
+  LOG_INFO("ut_backdoor: %x,ut_pattern: %x,ut_ecc_error_counter: %x",
            scrambling_frame->backdoor, scrambling_frame->pattern,
            &scrambling_frame->ecc_error_counter);
-  LOG_INFO("ref_backdoor: %x,ref_patternt: %x,ref_ecc_error_counter: %x",
+  LOG_INFO("ref_backdoor: %x,ref_pattern: %x,ref_ecc_error_counter: %x",
            reference_frame->backdoor, reference_frame->pattern,
            &reference_frame->ecc_error_counter);
   // Reset the Ecc error count.


### PR DESCRIPTION
This PR makes the following changes to `chip_sw_sram_ctrl_scrambled_access` test:
 -  Fix-up typos ;
 - Improve synchronization of the SW with the testbench.
