### PR TITLE
[dv] Fix extension parsing in memutil

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -101,8 +101,10 @@ static MemImageType GetMemImageTypeByName(const std::string &name) {
 // Return a MemImageType for the file at filepath or throw a std::runtime_error.
 // Never returns kMemImageUnknown.
 static MemImageType DetectMemImageType(const std::string &filepath) {
+  size_t stem_pos = filepath.find_last_of("/");
   size_t ext_pos = filepath.find_last_of(".");
-  if (ext_pos == std::string::npos) {
+  if (ext_pos == std::string::npos ||
+      (stem_pos != std::string::npos && ext_pos < stem_pos)) {
     // Assume ELF files if no file extension is given.
     // TODO: Make this more robust by actually checking the file contents.
     return kMemImageElf;


### PR DESCRIPTION
This causes memutil to mistakenly consider relative path like `./foo` to have extension of `/foo` as opposed to extension-less.

Related: lowRISC/ibex-demo-system#51
@marnovandermaas 