### PR TITLE
[dv, key_sideload_agent] Fix DV environment hanging issue under reset

### DIFF
--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -41,9 +41,13 @@ class key_sideload_driver#(
         cfg.vif.sideload_key.key[0] = 'x;
         cfg.vif.sideload_key.key[1] = 'x;
       end
+      // Always wait for one clock cycle. Otherwise, this task may consume zero time while the
+      // reset is active. This would be problematic as it would cause the key sideload interface
+      // to be updated endlessly and the DV environment to hang.
+      cfg.vif.wait_clks(1);
       // send rsp back to seq
       `uvm_info(`gfn, "item sent", UVM_HIGH)
-      cfg.vif.wait_clks(req.rsp_delay);
+      cfg.vif.wait_clks_or_rst(req.rsp_delay);
       seq_item_port.item_done(req);
     end
   endtask

--- a/hw/dv/sv/key_sideload_agent/key_sideload_if.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_if.sv
@@ -20,10 +20,25 @@ interface key_sideload_if #(
     wait (sideload_key.valid === is_valid);
   endtask
 
-  task automatic wait_clks(int rsp_delay);
-    for (int i = 0; i < rsp_delay; i++) begin
-      if (!rst_ni) break;
-      @(posedge clk_i or negedge rst_ni);
-    end
+  // The following functions are basically copied over from clk_rst_if.sv as we don't have access
+  // to the clock and reset interface.
+
+  // Wait for 'num_clks' clocks based on the positive clock edge.
+  task automatic wait_clks(int num_clks);
+    repeat (num_clks) @(posedge clk_i);
+  endtask
+
+  // Wait for rst_ni to assert and then deassert or just either of the two.
+  task automatic wait_for_reset(bit wait_negedge = 1'b1, bit wait_posedge = 1'b1);
+    if (wait_negedge && ($isunknown(rst_ni) || rst_ni === 1'b1)) @(negedge rst_ni);
+    if (wait_posedge && (rst_ni === 1'b0)) @(posedge rst_ni);
+  endtask
+
+  // Wait for 'num_clks' clocks based on the positive clock edge or reset, whichever comes first.
+  task automatic wait_clks_or_rst(int num_clks);
+    fork
+      wait_clks(num_clks);
+      wait_for_reset(.wait_negedge(1'b1), .wait_posedge(1'b0));
+    join_any
   endtask
 endinterface

--- a/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
@@ -11,9 +11,9 @@ class key_sideload_item #(
   rand bit                valid;
   rand bit [KeyWidth-1:0] key0;
   rand bit [KeyWidth-1:0] key1;
-  rand int unsigned       rsp_delay = 1;
+  rand int unsigned       rsp_delay = 0;
 
-  constraint rsp_delay_constraint_c {rsp_delay inside {[1:10]};}
+  constraint rsp_delay_constraint_c {rsp_delay inside {[0:9]};}
 
   `uvm_object_utils_begin(key_sideload_item#(KEY_T))
     `uvm_field_int(valid, UVM_DEFAULT)


### PR DESCRIPTION
Previously, the `get_and_drive()` task was consuming zero time when the reset was active. This resulted in the key sideload interface endlessly updating the sideload key and the whole DV environment to completely hang. The root cause of this issue was the custom `wait_clks()` implementation of the agent which 1) immediately returned when the reset was active, and 2) was itself called in a forever loop consuming zero time.

To fix this, this commit makes sure every iteration of forever loop inside `get_and_drive()` takes at least one clock cycle. In line with this change, the constraint for the response delay is adjusted to allow for a minimum response delay of zero clock cycles (previously one). The functions for waiting for clocks cycles and/or resets are copied over from the clock and reset interface (`clk_rst_if.sv`) used in other places of the project.

This is related to lowRISC/OpenTitan#19025.