### PR TITLE
[chip,dv] update test with multiple test phases

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -115,6 +115,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Add otp_ctrl test status value
   logic [TL_DW-1:0] otp_test_status = 0;
 
+  // Add flash write latency
+  // to compensate vendor flash model
+  // use run_opts: "+flash_write_latency_in_us=<value>"
+  // it will be updated in chip_base_test::build
+  uint flash_write_latency_in_us = 0;
+
   // NOTE: The clk_freq_mhz variable created in the base class was meant to be used by clk_rst_vif
   // interface that is passed by default by the testbench (retrieved by dv_base_env class). It was
   // meant for a CIP-compliant testbench to drive the clock and reset to the DUT. The chip level

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -2,6 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Test hand shake sequence between sv and c
+// 1. sv: `write_test_phase`(PHASE)
+//    and waiting for test status change from c
+// 2. c: check kTestPhase in switch
+// 3. c: `wait_next_test_phase`
+//    set test status and write all 1 to flash and wait for
+//    backdoor update from sv
+// 4. sv: Move to next routine and repeat #1 with the next PHASE
 class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq)
   `uvm_object_new
@@ -79,6 +87,7 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual task sync_with_sw();
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    #(cfg.flash_write_latency_in_us * 1us);
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -76,6 +76,9 @@ class chip_base_test extends cip_base_test #(
     // Knob to skip ROM backdoor logging (for sims that use ROM macro).
     void'($value$plusargs("skip_rom_bkdr_load=%0b", cfg.skip_rom_bkdr_load));
 
+    // Knob to add vendor flash write latency
+    void'($value$plusargs("flash_write_latency_in_us=%d", cfg.flash_write_latency_in_us));
+
     // Set the test timeout value to be sufficiently large.
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -255,6 +255,15 @@ status_t flash_ctrl_testutils_backdoor_init(
  * a workaround to invalidate the cache and force it to update. Before using
  * this function `flash_ctrl_testutils_backdoor_init` should be called.
  *
+ * Note:
+ * Given typical flash write latency (a few 10s of us),
+ * this api can causes following misbehavior with real flash model.
+ *
+ * While flash write with all 1's in progress, backdoor write from
+ * sv finished. When that happens, this function can complete without
+ * detecting proper backdoor update value. So it is highly discouraged to use
+ * this api without opensource flash model.
+ *
  * @param flash_state A flash_ctrl handle.
  * @param addr The address to a `const uint32_t` variable where the testbench
  * will write to.


### PR DESCRIPTION
sync up between c and sv using flash device can causes misbehavior with real flash model.
Add temporary fix to `chip_sw_sysrst_ctrl_ulp_z3_wakeup` and create a note to flash_ctrl_testutils.h