### PR TITLE
[earlgrey_es,chip,dv] closed source regression fix ver_118

### DIFF
--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_random_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_random_vseq.sv
@@ -12,8 +12,15 @@ class xbar_random_vseq extends xbar_base_vseq;
   virtual function void update_host_seq();
   endfunction
 
+  virtual task pre_start();
+    super.pre_start();
+    if (cfg.short_xbar_test) begin
+      num_trans_c.constraint_mode(0);
+      num_trans = $urandom_range(1, 3);
+    end
+  endtask
+
   virtual task body();
-    if (cfg.short_xbar_test) num_trans = $urandom_range(1, 3);
     run_all_device_seq_nonblocking();
     for (int i = 1; i <= num_trans; i++) begin
       update_host_seq();

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -115,6 +115,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Add otp_ctrl test status value
   logic [TL_DW-1:0] otp_test_status = 0;
 
+  // Add flash write latency
+  // to compensate vendor flash model
+  // use run_opts: "+flash_write_latency_in_us=<value>"
+  // it will be updated in chip_base_test::build
+  uint flash_write_latency_in_us = 0;
+
   // NOTE: The clk_freq_mhz variable created in the base class was meant to be used by clk_rst_vif
   // interface that is passed by default by the testbench (retrieved by dv_base_env class). It was
   // meant for a CIP-compliant testbench to drive the clock and reset to the DUT. The chip level

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -118,7 +118,8 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
         retval = uvm_hdl_read(RET_KEY_PATH, sram_ret_key);
         `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", RET_KEY_PATH))
       end
-      cfg.clk_rst_vif.wait_clks(1);
+      // The sampling cycle should be faster then otp clock.
+      #1ns;
     end
   endtask
 
@@ -137,7 +138,8 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
         retval = uvm_hdl_read(MAIN_KEY_PATH, sram_main_key);
         `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", MAIN_KEY_PATH))
       end
-      cfg.clk_rst_vif.wait_clks(1);
+      // The sampling cycle should be fater then otp clock.
+      #1ns;
     end
   endtask
 
@@ -164,7 +166,7 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
         end
         break;
       end
-      cfg.clk_rst_vif.wait_clks(1);
+      #1ns;
     end
   endtask
 
@@ -191,7 +193,7 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
         end
         break;
       end
-      cfg.clk_rst_vif.wait_clks(1);
+      #1ns;
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
@@ -82,8 +82,8 @@ class chip_sw_sysrst_ctrl_ec_rst_l_vseq extends chip_sw_base_vseq;
       end else begin
         break;
       end
-      // Some amount of delay between samples of ec_rst.
-      #(AON_CYCLE_PERIOD);
+      // Use 1 cycle delay (AON CLK) between samples of ec_rst.
+      cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
     end
     `DV_CHECK(timeout_count > min_exp_cycles) // check ec_rst length
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -2,6 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Test hand shake sequence between sv and c
+// 1. sv: `write_test_phase`(PHASE)
+//    and waiting for test status change from c
+// 2. c: check kTestPhase in switch
+// 3. c: `wait_next_test_phase`
+//    set test status and write all 1 to flash and wait for
+//    backdoor update from sv
+// 4. sv: Move to next routine and repeat #1 with the next PHASE
 class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq)
   `uvm_object_new
@@ -79,6 +87,7 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual task sync_with_sw();
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    #(cfg.flash_write_latency_in_us * 1us);
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -76,6 +76,9 @@ class chip_base_test extends cip_base_test #(
     // Knob to skip ROM backdoor logging (for sims that use ROM macro).
     void'($value$plusargs("skip_rom_bkdr_load=%0b", cfg.skip_rom_bkdr_load));
 
+    // Knob to add vendor flash write latency
+    void'($value$plusargs("flash_write_latency_in_us=%d", cfg.flash_write_latency_in_us));
+
     // Set the test timeout value to be sufficiently large.
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -255,6 +255,15 @@ status_t flash_ctrl_testutils_backdoor_init(
  * a workaround to invalidate the cache and force it to update. Before using
  * this function `flash_ctrl_testutils_backdoor_init` should be called.
  *
+ * Note:
+ * Given typical flash write latency (a few 10s of us),
+ * this api can causes following misbehavior with real flash model.
+ *
+ * While flash write with all 1's in progress, backdoor write from
+ * sv finished. When that happens, this function can complete without
+ * detecting proper backdoor update value. So it is highly discouraged to use
+ * this api without opensource flash model.
+ *
  * @param flash_state A flash_ctrl handle.
  * @param addr The address to a `const uint32_t` variable where the testbench
  * will write to.

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -940,6 +940,7 @@ opentitan_functest(
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -224,16 +224,16 @@ static void prepare_sram_for_scrambling(void) {
       (uint32_t)reference_frame->pattern,
       (sram_ctrl_testutils_data_t){.words = kRamTestPattern2,
                                    .len = kTestBufferSizeWords});
-  LOG_INFO("Checking addr 0x%x", reference_frame);
+  LOG_INFO("Checking addr 0x%x", reference_frame->pattern);
   CHECK_ARRAYS_EQ(reference_frame->pattern, kRamTestPattern2,
                   kTestBufferSizeWords);
 }
 
 static void execute_main_sram_test(void) {
-  LOG_INFO("ut_backdoor: %x,ut_patternt: %x,ut_ecc_error_counter: %x",
+  LOG_INFO("ut_backdoor: %x,ut_pattern: %x,ut_ecc_error_counter: %x",
            scrambling_frame->backdoor, scrambling_frame->pattern,
            &scrambling_frame->ecc_error_counter);
-  LOG_INFO("ref_backdoor: %x,ref_patternt: %x,ref_ecc_error_counter: %x",
+  LOG_INFO("ref_backdoor: %x,ref_pattern: %x,ref_ecc_error_counter: %x",
            reference_frame->backdoor, reference_frame->pattern,
            &reference_frame->ecc_error_counter);
   // Reset the Ecc error count.


### PR DESCRIPTION
Following closed source test failures are fixed

- chip_sw_sram_ctrl_scrambled_access_*
- xbar_stress_all*
- chip_sw_sysrst_ctrl_ulp_z3_wakeup
- chip_sw_sysrst_ctrl_ec_rst_l