### PR TITLE
[ci] Better bitstream build cache filtering

### DIFF
--- a/ci/fpga-template.yml
+++ b/ci/fpga-template.yml
@@ -15,14 +15,11 @@ steps:
 - template: ./install-package-dependencies.yml
 - bash: |
     ci/scripts/get-bitstream-strategy.sh "chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}" \
-      ':!/third_party/rust/' \
+      "//hw/bitstream/vivado:fpga_${{ parameters.design_suffix }}" \
       ':!/sw/' \
       ':!/*.hjson' \
       ':!/*.tpl' \
-      ':!/site/' \
       ':!/doc/' \
-      ':!/COMMITTERS' \
-      ':!/CLA' \
       ':!/*.md' \
       ':!/.github/' \
       ':!/hw/**/dv/*' \


### PR DESCRIPTION
We want to avoid rebuilding bitstreams if possible. To do this we look at the list of changed files and determine if a rebuild is warranted.

Currently the filtering is entirely hardcoded rules. This PR uses Bazel to get a list of dependencies required for the bitstream, and filter the changes based on that list.