### PR TITLE
[sw/silicon_creator] Add boot_svc_header.h

### DIFF
--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -38,6 +38,11 @@
 #define CHIP_ROM_EXT_SIZE_MAX 0x10000
 
 /**
+ * Size of the header of a boot services message.
+ */
+#define CHIP_BOOT_SVC_MSG_HEADER_SIZE 44
+
+/**
  * First owner boot stage, e.g. BL0, manifest identifier (ASCII "OTB0").
  */
 #define CHIP_BL0_IDENTIFIER 0x3042544f

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boot_svc_header",
+    hdrs = ["boot_svc_header.h"],
+    deps = [
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_HEADER_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_HEADER_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Boot services message header.
+ *
+ * All boot services messages start with a common header followed by a message
+ * specific payload.
+ */
+typedef struct boot_svc_header {
+  /**
+   * SHA256 digest of the message.
+   *
+   * Digest region starts at `identifier` and extends until the end of the
+   * message.
+   */
+  hmac_digest_t digest;
+  /**
+   * Identifier.
+   *
+   * This field must be `kBootSvcIdentifier` for boot service messages that use
+   * this header format.
+   */
+  uint32_t identifier;
+  /**
+   * Type of the message.
+   */
+  uint32_t type;
+  /**
+   * Total length of the message in bytes.
+   */
+  uint32_t length;
+} boot_svc_header_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, digest, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, identifier, 32);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, type, 36);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, length, 40);
+OT_ASSERT_SIZE(boot_svc_header_t, CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+
+enum {
+  /**
+   * Common identifier shared by all boot services messages.
+   *
+   * ASCII "BSVC".
+   */
+  kBootSvcIdentifier = 0x43565342,
+};
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_HEADER_H_


### PR DESCRIPTION
This PR adds a definition for the common header that will be used by all boot services messages.

See #19130 for details.