### PR TITLE
[sw/silicon_creator] Add boot_svc_header_init()

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -68,10 +68,8 @@ static void boot_data_digest_compute(const void *boot_data,
   static_assert(offsetof(boot_data_t, digest) == 0,
                 "`digest` must be the first field of `boot_data_t`.");
 
-  hmac_sha256_init();
-  hmac_sha256_update((const char *)boot_data + kDigestRegionOffset,
-                     kDigestRegionSize);
-  hmac_sha256_final(digest);
+  hmac_sha256((const char *)boot_data + kDigestRegionOffset, kDigestRegionSize,
+              digest);
 }
 
 /**

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -176,12 +176,10 @@ static rom_error_t check_boot_data(const boot_data_t *boot_data,
     return kErrorUnknown;
   }
 
-  hmac_digest_t act_digest;
-  hmac_sha256_init();
-  hmac_sha256_update((const char *)boot_data + kDigestRegionOffset,
-                     kDigestRegionSize);
-  hmac_sha256_final(&act_digest);
-  if (memcmp(&act_digest, &boot_data->digest, sizeof(act_digest)) != 0) {
+  hmac_digest_t exp_digest;
+  hmac_sha256((const char *)boot_data + kDigestRegionOffset, kDigestRegionSize,
+              &exp_digest);
+  if (memcmp(&exp_digest, &boot_data->digest, sizeof(exp_digest)) != 0) {
     return kErrorUnknown;
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -6,9 +6,21 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "boot_svc_header",
+    srcs = ["boot_svc_header.c"],
     hdrs = ["boot_svc_header.h"],
     deps = [
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_header_unittest",
+    srcs = ["boot_svc_header_unittest.cc"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+
+#include <stddef.h>
+
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+
+void boot_svc_header_finalize(uint32_t type, uint32_t length,
+                              boot_svc_header_t *header) {
+  enum {
+    kDigestRegionOffset = sizeof(header->digest),
+  };
+  static_assert(offsetof(boot_svc_header_t, digest) == 0,
+                "`digest` must be the first field of `boot_svc_header_t`.");
+  header->identifier = kBootSvcIdentifier;
+  header->type = type;
+  header->length = length;
+  hmac_sha256((const char *)header + kDigestRegionOffset,
+              length - kDigestRegionOffset, &header->digest);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h
@@ -15,6 +15,15 @@
 extern "C" {
 #endif  // __cplusplus
 
+enum {
+  /**
+   * Common identifier shared by all boot services messages.
+   *
+   * ASCII "BSVC".
+   */
+  kBootSvcIdentifier = 0x43565342,
+};
+
 /**
  * Boot services message header.
  *
@@ -52,14 +61,21 @@ OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, type, 36);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_header_t, length, 40);
 OT_ASSERT_SIZE(boot_svc_header_t, CHIP_BOOT_SVC_MSG_HEADER_SIZE);
 
-enum {
-  /**
-   * Common identifier shared by all boot services messages.
-   *
-   * ASCII "BSVC".
-   */
-  kBootSvcIdentifier = 0x43565342,
-};
+/**
+ * Initialize the header of a boot services message.
+ *
+ * This function assumes that message payload starts immediately after the
+ * header and is exactly `length - sizeof(boot_svc_header_t)` bytes for digest
+ * computation. Since this function also intializes the message digest as part
+ * of header initialization, it must be called after the message payload is
+ * initialized.
+ *
+ * @param type Message type.
+ * @param length Total length of the message in bytes.
+ * @param[out] header Output buffer for the message.
+ */
+void boot_svc_header_finalize(uint32_t type, uint32_t length,
+                              boot_svc_header_t *header);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+
+#include <cstring>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_hmac.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+bool operator==(boot_svc_header_t lhs, boot_svc_header_t rhs) {
+  return std::memcmp(&lhs, &rhs, sizeof(boot_svc_header_t)) == 0;
+}
+
+namespace boot_svc_header_unittest {
+namespace {
+using ::testing::_;
+using ::testing::ElementsAreArray;
+using ::testing::SetArgPointee;
+
+class BootSvcHeaderTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockHmac hmac_;
+};
+
+TEST_F(BootSvcHeaderTest, Init) {
+  struct BootSvcFakeMsg {
+    boot_svc_header_t header{};
+    uint32_t payload{0xbeefbeef};
+  };
+  BootSvcFakeMsg fake_msg;
+  constexpr uint32_t kType = 0xcafecafe;
+  constexpr uint32_t kDigestAreaByteCount =
+      sizeof(fake_msg) - sizeof(fake_msg.header.digest);
+  constexpr hmac_digest_t kFakeDigest = {
+      0x0b00000e, 0x0b01010e, 0x0b02020e, 0x0b03030e,
+      0x0b04040e, 0x0b05050e, 0x0b06060e, 0x0b07070e,
+  };
+
+  EXPECT_CALL(hmac_,
+              sha256(&fake_msg.header.identifier, kDigestAreaByteCount, _))
+      .WillOnce(SetArgPointee<2>(kFakeDigest));
+
+  boot_svc_header_finalize(kType, sizeof(fake_msg), &fake_msg.header);
+
+  EXPECT_THAT(fake_msg.header.digest.digest,
+              ElementsAreArray(kFakeDigest.digest));
+  EXPECT_EQ(fake_msg.header.identifier, kBootSvcIdentifier);
+  EXPECT_EQ(fake_msg.header.type, kType);
+  EXPECT_EQ(fake_msg.header.length, sizeof(fake_msg));
+}
+
+}  // namespace
+}  // namespace boot_svc_header_unittest

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -78,3 +78,9 @@ void hmac_sha256_final(hmac_digest_t *digest) {
                         (i * sizeof(uint32_t)));
   }
 }
+
+void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
+  hmac_sha256_init();
+  hmac_sha256_update(data, len);
+  hmac_sha256_final(digest);
+}

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -44,7 +44,7 @@ void hmac_sha256_init(void);
  * polling for FIFO status is equivalent to stalling on FIFO write.
  *
  * @param data Buffer to copy data from.
- * @param len size of the `data` buffer.
+ * @param len Size of the `data` buffer in bytes.
  */
 void hmac_sha256_update(const void *data, size_t len);
 
@@ -54,6 +54,15 @@ void hmac_sha256_update(const void *data, size_t len);
  * @param[out] digest Buffer to copy digest to.
  */
 void hmac_sha256_final(hmac_digest_t *digest);
+
+/**
+ * Convenience function for computing the SHA-256 digest of a contiguous buffer.
+ *
+ * @param data Buffer to copy data from.
+ * @param len Size of the `data` buffer in bytes.
+ * @param[out] digest Buffer to copy digest to.
+ */
+void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -37,11 +37,8 @@ static const uint32_t kGettysburgDigest[] = {
 };
 
 rom_error_t hmac_test(void) {
-  hmac_sha256_init();
-  hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
-
   hmac_digest_t digest;
-  hmac_sha256_final(&digest);
+  hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1, &digest);
 
   const size_t len = ARRAYSIZE(digest.digest);
   for (int i = 0; i < len; ++i) {

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
@@ -15,5 +15,9 @@ void hmac_sha256_update(const void *data, size_t len) {
 void hmac_sha256_final(hmac_digest_t *digest) {
   MockHmac::Instance().sha256_final(digest);
 }
+
+void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
+  MockHmac::Instance().sha256(data, len, digest);
+}
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.h
@@ -18,8 +18,9 @@ namespace internal {
 class MockHmac : public global_mock::GlobalMock<MockHmac> {
  public:
   MOCK_METHOD(void, sha256_init, ());
-  MOCK_METHOD(rom_error_t, sha256_update, (const void *, size_t));
-  MOCK_METHOD(rom_error_t, sha256_final, (hmac_digest_t *));
+  MOCK_METHOD(void, sha256_update, (const void *, size_t));
+  MOCK_METHOD(void, sha256_final, (hmac_digest_t *));
+  MOCK_METHOD(void, sha256, (const void *, size_t, hmac_digest_t *));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify_functest.c
@@ -119,12 +119,6 @@ static const sigverify_rsa_key_t kKeyExp3 = {
         },
 };
 
-void compute_digest(void) {
-  hmac_sha256_init();
-  hmac_sha256_update(&kMessage, sizeof(kMessage) - 1);
-  hmac_sha256_final(&act_digest);
-}
-
 rom_error_t rsa_verify_test_exp_3(void) {
   uint32_t flash_exec = 0;
   // Signature verification should fail when using exponent 3.
@@ -161,7 +155,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
-  compute_digest();
+  hmac_sha256(&kMessage, sizeof(kMessage) - 1, &act_digest);
 
   EXECUTE_TEST(result, rsa_verify_test_exp_3);
   EXECUTE_TEST(result, rsa_verify_test_exp_65537);


### PR DESCRIPTION
This PR adds `boot_svc_header_init()` for initializing the header of a boot services message.

See #19130 for details.