### PR TITLE
[chip,dv] coremark test fix

### DIFF
--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -59,7 +59,7 @@ interface prim_count_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 
 endinterface

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -64,6 +64,6 @@ interface prim_double_lfsr_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -55,12 +55,10 @@ interface prim_onehot_check_if #(
       }
       cp_onehot_enable_fault: coverpoint onehot_fault_type {
         option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = EnableCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotEnableFault};
       }
       cp_onehot_addr_fault: coverpoint onehot_fault_type {
         option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = AddrCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotAddrFault};
       }
     endgroup
@@ -161,6 +159,6 @@ interface prim_onehot_check_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -90,6 +90,6 @@ interface prim_sparse_fsm_flop_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/uart_agent/uart_logger.sv
+++ b/hw/dv/sv/uart_agent/uart_logger.sv
@@ -22,13 +22,13 @@ class uart_logger extends uvm_component;
     string fname = {`gfn, ".log"};
     if (cfg.write_logs_to_file) begin
       logs_output_fd = $fopen(fname, "w");
-      `DV_CHECK_FATAL(!logs_output_fd, $sformatf("Failed to open %s for writing", fname))
+      `DV_CHECK_FATAL((logs_output_fd !=0), $sformatf("Failed to open %s for writing", fname))
     end
     capture_logs();
   endtask
 
   virtual function void final_phase(uvm_phase phase);
-    if (logs_output_fd) $fclose(logs_output_fd);
+    if (logs_output_fd != 0) $fclose(logs_output_fd);
   endfunction
 
   // Captures bytes received from UART TX port and constructs the logs for printing.
@@ -36,8 +36,8 @@ class uart_logger extends uvm_component;
     uart_item item;
     string    char;
     string    log;
-    byte      lf = 8'ha;
-    byte      cr = 8'hd;
+    byte      lf = 8'ha;   // \n
+    byte      cr = 8'hd;   // \r
 
     fork
       forever begin
@@ -90,7 +90,7 @@ class uart_logger extends uvm_component;
         `uvm_info(`gfn, log, UVM_LOW)
       end
     endcase
-    if (logs_output_fd) begin
+    if (logs_output_fd != 0) begin
       $fwrite(logs_output_fd, "[%15t]: %0s\n", $time, log);
     end
   endfunction

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1481,7 +1481,7 @@
     }
     {
       name: chip_sw_coremark
-      uvm_test_seq: chip_sw_base_vseq
+      uvm_test_seq: chip_sw_uart_tx_vseq
       sw_images: ["//third_party/coremark/top_earlgrey:coremark_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -54,6 +54,7 @@ filesets:
       - seq_lib/chip_prim_tl_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_tap_straps_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_uart_tx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_jtag_base_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/flash_ctrl_host_gnt_fault_if.sv
+++ b/hw/top_earlgrey/dv/env/flash_ctrl_host_gnt_fault_if.sv
@@ -43,6 +43,6 @@ interface flash_ctrl_host_gnt_fault_if (
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/top_earlgrey/dv/env/rstmgr_cnsty_fault_if.sv
+++ b/hw/top_earlgrey/dv/env/rstmgr_cnsty_fault_if.sv
@@ -46,6 +46,6 @@ interface rstmgr_cnsty_fault_if (
     if_proxy.path = {path, ".leaf_rst_path"};
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_vseq.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_uart_tx_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_uart_tx_vseq)
+  `uvm_object_new
+
+  virtual task connect_uart_agent(uint uart_idx = 0);
+      `uvm_info(`gfn, $sformatf("Configuring and connecting UART agent to UART %0d ...", uart_idx),
+        UVM_LOW)
+      cfg.m_uart_agent_cfgs[uart_idx].set_parity(1'b0, 1'b0);
+      cfg.m_uart_agent_cfgs[uart_idx].set_baud_rate(cfg.uart_baud_rate);
+      cfg.m_uart_agent_cfgs[uart_idx].en_tx_monitor = 1;
+      cfg.chip_vif.enable_uart(uart_idx, 1);
+  endtask
+
+  virtual task disconnect_uart_agent(uint uart_idx = 0);
+      `uvm_info(`gfn, $sformatf("Disconnecting UART agent from UART %0d ...", uart_idx),
+        UVM_LOW)
+      cfg.chip_vif.enable_uart(uart_idx, 0);
+      cfg.m_uart_agent_cfgs[uart_idx].en_tx_monitor = 0;
+  endtask
+
+  virtual task body();
+    super.body();
+
+    fork
+      get_uart_tx_items();
+    join_none
+
+    `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    connect_uart_agent();
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+    disconnect_uart_agent();
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -10,6 +10,7 @@
 `include "chip_jtag_mem_vseq.sv"
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
+`include "chip_sw_uart_tx_vseq.sv"
 `include "chip_sw_lc_base_vseq.sv"
 `include "chip_sw_uart_smoke_vseq.sv"
 `include "chip_jtag_base_vseq.sv"


### PR DESCRIPTION
This test uses uart logger which has been outdated.
Add a sequence to enable uart agent and enable uart connection.