### PR TITLE
[bazel] Bump CRT dependency to v0.4.6, clean up .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,27 +13,7 @@ build --strip='never'
 
 # Override default enablement of flags from @crt//common to control C compiler
 # warnings.
-#
-# TODO(#12553) Remove these explicit feature flags once the features in @crt//
-# are enabled by default.
 build --features=-pedantic_warnings
-build --features=strict_prototypes_warnings
-build --features=covered_switch_default_warnings
-build --features=extra_warnings
-build --features=clang_covered_switch_default_warnings
-build --features=implicit_conversion_warnings
-build --features=implicit_fallthrough_warnings
-build --features=invalid_pch_warnings
-build --features=switch_default_warnings
-build --features=no_missing_field_initializers_warning
-build --features=no_sign_compare_warning
-build --features=no_unused_function_warning
-build --features=no_unused_parameter_warning
-# Override default enablement of flags from @crt//embedded to control C compiler
-# warnings.
-build --features=clang_gnu_warnings
-build --features=no_gnu_zero_variadic_macro_arguments_warning
-build --features=no_gnu_statement_expression_from_macro_expansion
 
 # Enable toolchain hardening features.
 # `guards` adds `unimp` guard instructions after unconditional jumps.

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.5.tar.gz",
-            strip_prefix = "crt-0.4.5",
-            sha256 = "1062cbad466dc1673b7a29a97736e04108525b8d66267c097cc9449231497dcf",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.6.tar.gz",
+            strip_prefix = "crt-0.4.6",
+            sha256 = "b1dee52e96b18a4a2e180be18f2fbb65a918d5e4350c9b664883b79658f711ec",
         )


### PR DESCRIPTION
The major change in v0.4.6 is that features from #12553 are now enabled by default. With that change, we no longer need to force-enable those features in .bazelrc. This commit deletes the relevant --features lines from .bazelrc.

The CRT release:
https://github.com/lowRISC/crt/releases/tag/v0.4.6