### PR TITLE
[chip,dv] adjust verbosity for full chip debug

### DIFF
--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -59,7 +59,7 @@ interface prim_count_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 
 endinterface

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -64,6 +64,6 @@ interface prim_double_lfsr_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -55,12 +55,10 @@ interface prim_onehot_check_if #(
       }
       cp_onehot_enable_fault: coverpoint onehot_fault_type {
         option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = EnableCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotEnableFault};
       }
       cp_onehot_addr_fault: coverpoint onehot_fault_type {
         option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = AddrCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotAddrFault};
       }
     endgroup
@@ -161,6 +159,6 @@ interface prim_onehot_check_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -90,6 +90,6 @@ interface prim_sparse_fsm_flop_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/top_earlgrey/dv/env/flash_ctrl_host_gnt_fault_if.sv
+++ b/hw/top_earlgrey/dv/env/flash_ctrl_host_gnt_fault_if.sv
@@ -43,6 +43,6 @@ interface flash_ctrl_host_gnt_fault_if (
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/top_earlgrey/dv/env/rstmgr_cnsty_fault_if.sv
+++ b/hw/top_earlgrey/dv/env/rstmgr_cnsty_fault_if.sv
@@ -46,6 +46,6 @@ interface rstmgr_cnsty_fault_if (
     if_proxy.path = {path, ".leaf_rst_path"};
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface


### PR DESCRIPTION
These interfaces create too much unnecessary info in the `initial` block. 
Adjust verbosity to HIGH to reduce log