### PR TITLE
[sw/silicon_creator] Add empty boot services message

### DIFF
--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -43,6 +43,18 @@
 #define CHIP_BOOT_SVC_MSG_HEADER_SIZE 44
 
 /**
+ * Maximum payload size for a boot services message.
+ */
+#define CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX 256
+
+/**
+ * Maximum size of a boot services message.
+ */
+// TODO: Has to be a literal because of OT_ASSERT_SIZE. Add an assertion that
+// checks if this is equal to header + max_payload.
+#define CHIP_BOOT_SVC_MSG_SIZE_MAX 300
+
+/**
  * First owner boot stage, e.g. BL0, manifest identifier (ASCII "OTB0").
  */
 #define CHIP_BL0_IDENTIFIER 0x3042544f

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -39,3 +39,25 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "boot_svc_empty",
+    srcs = ["boot_svc_empty.c"],
+    hdrs = ["boot_svc_empty.h"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/drivers:rnd",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_empty_unittest",
+    srcs = ["boot_svc_empty_unittest.cc"],
+    deps = [
+        ":boot_svc_empty",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -2,23 +2,38 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
+
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+dual_cc_library(
     name = "boot_svc_header",
-    srcs = ["boot_svc_header.c"],
-    hdrs = ["boot_svc_header.h"],
-    deps = [
-        "//sw/device/silicon_creator/lib/base:chip",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-    ],
+    srcs = dual_inputs(
+        device = ["boot_svc_header.c"],
+        host = ["mock_boot_svc_header.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_boot_svc_header.h"],
+        shared = ["boot_svc_header.h"],
+    ),
+    deps = dual_inputs(
+        host = [
+            "//sw/device/lib/base:global_mock",
+            "//sw/device/silicon_creator/testing:rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            "//sw/device/silicon_creator/lib/base:chip",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+        ],
+    ),
 )
 
 cc_test(
     name = "boot_svc_header_unittest",
     srcs = ["boot_svc_header_unittest.cc"],
     deps = [
-        ":boot_svc_header",
+        dual_cc_device_library_of(":boot_svc_header"),
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
+
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+
+void boot_svc_empty_init(boot_svc_empty_t *msg) {
+  // We use `uint32_t` instead of `size_t` so that end-of-loop check passes both
+  // on- and off-target tests.
+  uint32_t i = 0, j = kBootSvcEmptyPayloadWordCount - 1;
+  for (; launder32(i) < kBootSvcEmptyPayloadWordCount &&
+         launder32(j) < kBootSvcEmptyPayloadWordCount;
+       ++i, --j) {
+    msg->rand_data[i] = rnd_uint32();
+  }
+  HARDENED_CHECK_EQ(i, kBootSvcEmptyPayloadWordCount);
+  HARDENED_CHECK_EQ(j, UINT32_MAX);
+  boot_svc_header_finalize(kBootSvcEmptyType, sizeof(boot_svc_empty_t),
+                           &msg->header);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_EMPTY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_EMPTY_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  kBootSvcEmptyType = 0xb4594546,
+  kBootSvcEmptyPayloadWordCount =
+      CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX / sizeof(uint32_t),
+};
+
+/**
+ * An empty boot services message.
+ *
+ * This message type consists of a random payload that is as large as the
+ * largest boot services message. ROM_EXT should use an object of this type to
+ * initialize the boot services area in the retention SRAM or to clear a boot
+ * services request before writing the response. Silicon owner code should use
+ * an object of this type to clear a boot services response.
+ */
+typedef struct boot_svc_empty {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Random data.
+   */
+  uint32_t rand_data[kBootSvcEmptyPayloadWordCount];
+} boot_svc_empty_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, rand_data,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_empty_t, CHIP_BOOT_SVC_MSG_SIZE_MAX);
+
+/**
+ * Initialize an empty boot services message.
+ *
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_empty_init(boot_svc_empty_t *msg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_EMPTY_H_

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
+
+#include <array>
+#include <cstring>
+#include <numeric>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+bool operator==(boot_svc_empty_t lhs, boot_svc_empty_t rhs) {
+  return std::memcmp(&lhs, &rhs, sizeof(boot_svc_empty_t)) == 0;
+}
+
+namespace boot_svc_empty_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+using ::testing::Return;
+
+class BootSvcEmptyTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockRnd rnd_;
+  rom_test::MockBootSvcHeader boot_svc_header_;
+};
+
+TEST_F(BootSvcEmptyTest, Init) {
+  std::array<uint32_t, kBootSvcEmptyPayloadWordCount> rand_data;
+  std::iota(rand_data.begin(), rand_data.end(), 0xcafe0000);
+  for (auto v : rand_data) {
+    EXPECT_CALL(rnd_, Uint32).WillOnce(Return(v));
+  }
+  boot_svc_empty_t msg{};
+  EXPECT_CALL(boot_svc_header_,
+              Finalize(kBootSvcEmptyType, sizeof(msg), &msg.header));
+
+  boot_svc_empty_init(&msg);
+
+  EXPECT_THAT(msg.rand_data, ElementsAreArray(rand_data));
+}
+
+}  // namespace
+}  // namespace boot_svc_empty_unittest

--- a/sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.cc
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+
+namespace rom_test {
+extern "C" {
+void boot_svc_header_finalize(uint32_t type, uint32_t length,
+                              boot_svc_header_t *header) {
+  MockBootSvcHeader::Instance().Finalize(type, length, header);
+}
+}
+}  // namespace rom_test

--- a/sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h
+++ b/sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_MOCK_BOOT_SVC_HEADER_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_MOCK_BOOT_SVC_HEADER_H_
+
+#include "sw/device/lib/base/global_mock.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace rom_test {
+namespace internal {
+
+/**
+ * Mock class for boot_svc_header.c.
+ */
+class MockBootSvcHeader : public global_mock::GlobalMock<MockBootSvcHeader> {
+ public:
+  MOCK_METHOD(void, Finalize, (uint32_t, uint32_t, boot_svc_header_t *));
+};
+
+}  // namespace internal
+
+using MockBootSvcHeader = testing::StrictMock<internal::MockBootSvcHeader>;
+
+}  // namespace rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_MOCK_BOOT_SVC_HEADER_H_


### PR DESCRIPTION
This PR adds the empty boot services message that can be used to clear the boot services area in the retention SRAM.

This message type can also be considered a template for the remaining message types.

See #19130 for details.