### PR TITLE
Spi host flash tests

### DIFF
--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -301,9 +301,9 @@ static void issue_opcode(const dif_spi_host_t *spi_host,
                          dif_spi_host_segment_t *segment, bool last_segment) {
   wait_tx_fifo(spi_host);
   mmio_region_write8(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET,
-                     segment->opcode);
-  write_command_reg(spi_host, 1, kDifSpiHostWidthStandard,
-                    kDifSpiHostDirectionTx, last_segment);
+                     segment->opcode.opcode);
+  write_command_reg(spi_host, 1, segment->opcode.width, kDifSpiHostDirectionTx,
+                    last_segment);
 }
 
 static void issue_address(const dif_spi_host_t *spi_host,

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -116,7 +116,10 @@ typedef struct dif_spi_host_segment {
   /** The segment type for this segment. */
   dif_spi_host_segment_type_t type;
   union {
-    uint8_t opcode;
+    struct {
+      dif_spi_host_width_t width;
+      uint8_t opcode;
+    } opcode;
     struct {
       dif_spi_host_width_t width;
       dif_spi_host_addr_mode_t mode;

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -287,7 +287,8 @@ class TransactionTest : public SpiHostTest {
 TEST_F(TransactionTest, IssueOpcode) {
   dif_spi_host_segment segment;
   segment.type = kDifSpiHostSegmentTypeOpcode;
-  segment.opcode = 0x5a;
+  segment.opcode.opcode = 0x5a;
+  segment.opcode.width = kDifSpiHostWidthStandard;
 
   EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
   EXPECT_READY(true);

--- a/sw/device/lib/testing/spi_flash_emulator.c
+++ b/sw/device/lib/testing/spi_flash_emulator.c
@@ -167,8 +167,7 @@ status_t spi_flash_emulator(dif_spi_host_t *spih,
         TRY(spi_flash_testutils_program_op(
             spih, kSpiDeviceFlashOpPageProgram4b, info.data, info.data_len,
             info.address,
-            /*addr_is_4b=*/true, kDifSpiHostWidthStandard,
-            kDifSpiHostWidthStandard));
+            /*addr_is_4b=*/true, kTransactionWidthMode111));
         break;
       case kSpiDeviceFlashOpReset:
         running = false;

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1831,6 +1831,34 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "spi_host_gigadevice1Gb_flash_test",
+    srcs = ["spi_host_gigadevice1Gb_flash_test.c"],
+    cw310 = cw310_params(
+        tags = [
+            "bob",
+            "manual",
+        ],  # Requires the BoB in CI.
+    ),
+    targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.
+    deps = [
+        ":spi_host_flash_test_impl",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "spi_host_irq_test",
     srcs = ["spi_host_irq_test.c"],
     targets = ["cw310_test_rom"],  # Can only run on CW310 board right now.

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -186,10 +186,8 @@ void handle_write_status(uint32_t status, uint8_t offset, uint8_t opcode) {
   CHECK_STATUS_OK(spi_flash_testutils_issue_write_enable(&spi_host0));
 
   dif_spi_host_segment_t transaction[] = {
-      {
-          .type = kDifSpiHostSegmentTypeOpcode,
-          .opcode = opcode,
-      },
+      {.type = kDifSpiHostSegmentTypeOpcode,
+       .opcode = {.opcode = opcode, .width = kDifSpiHostWidthStandard}},
       {
           .type = kDifSpiHostSegmentTypeTx,
           .tx =

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
 
 /**
  * Send the sw_reset command.
@@ -105,11 +106,13 @@ status_t test_4bytes_address(dif_spi_host_t *spi);
  *
  * @param spi A spi host handler.
  * @param opcode The opcode used by the part-number for quad page program.
- * @param addr_width The width of the transaction addressing section.
+ * @param page_program_mode The width of the transaction sections (opcode,
+ * address and data).
  * @return status_t containing either OK or an error.
  */
-status_t test_page_program_quad(dif_spi_host_t *spi, uint8_t opcode,
-                                uint8_t address_width);
+status_t test_page_program_quad(
+    dif_spi_host_t *spi, uint8_t opcode,
+    spi_flash_testutils_transaction_width_mode_t page_program_mode);
 
 /**
  * Erase a 32kB block and read it back to check if was erased.

--- a/sw/device/tests/spi_host_gigadevice1Gb_flash_test.c
+++ b/sw/device/tests/spi_host_gigadevice1Gb_flash_test.c
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <assert.h>
+
+#include "spi_host_flash_test_impl.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
+#include "sw/device/lib/testing/spi_host_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "This test assumes the target platform is little endian.");
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static void init_test(dif_spi_host_t *spi_host) {
+  dif_pinmux_t pinmux;
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
+  CHECK_STATUS_OK(
+      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc6));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
+  CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));
+
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+
+  CHECK_DIF_OK(dif_spi_host_configure(spi_host,
+                                      (dif_spi_host_config_t){
+                                          .spi_clock = 1000000,
+                                          .peripheral_clock_freq_hz =
+                                              (uint32_t)kClockFreqPeripheralHz,
+                                      }),
+               "SPI_HOST config failed!");
+
+  CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));
+}
+
+bool test_main(void) {
+  dif_spi_host_t spi_host;
+
+  init_test(&spi_host);
+
+  /**
+   * This flash device does not support dual mode read, so we don't test it.
+   * It also does not require a command to enable the quad mode. Unless we want
+   * to use the QPI (Quad Peripheral Interface) mode. QPI differs from Quad SPI
+   * mode on the opcode section that use four lanes as opposed to one lane in
+   * the Quad SPI.
+   */
+  enum GigadeviceVendorSpecific {
+    kDeviceId = 0x1b47,
+    kManufactureId = 0xC8,
+    kPageQuadProgramOpcode = 0xC2,
+  };
+
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, test_software_reset, &spi_host);
+  EXECUTE_TEST(result, test_read_sfdp, &spi_host);
+  EXECUTE_TEST(result, test_sector_erase, &spi_host);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
+  EXECUTE_TEST(result, test_page_program, &spi_host);
+  if (is_4_bytes_address_mode_supported()) {
+    EXECUTE_TEST(result, test_4bytes_address, &spi_host);
+  }
+  EXECUTE_TEST(result, test_fast_read, &spi_host);
+  EXECUTE_TEST(result, test_quad_read, &spi_host);
+
+  // The Gigadevice flash `4PP` opcode operates in 1-4-4 mode.
+  EXECUTE_TEST(result, test_page_program_quad, &spi_host,
+               kPageQuadProgramOpcode, kTransactionWidthMode144);
+  EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
+  EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
+
+  return status_ok(result);
+}

--- a/sw/device/tests/spi_host_gigadevice256Mb_flash_test.c
+++ b/sw/device/tests/spi_host_gigadevice256Mb_flash_test.c
@@ -59,9 +59,6 @@ bool test_main(void) {
     kDeviceId = 0x1940,
     kManufactureId = 0xC8,
     kPageQuadProgramOpcode = 0x32,
-    // The Gigabyte flash requires that the addr in sent using 1 lane as the
-    // data when issuing the `kPageQuadProgramOpcode` operation.
-    kPageQuadProgramAddrWidth = 1,
   };
 
   status_t result = OK_STATUS();
@@ -77,8 +74,10 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_fast_read, &spi_host);
   EXECUTE_TEST(result, test_dual_read, &spi_host);
   EXECUTE_TEST(result, test_quad_read, &spi_host);
+
+  // The Gigadevice flash `4PP` opcode operates in 1-1-4 mode.
   EXECUTE_TEST(result, test_page_program_quad, &spi_host,
-               kPageQuadProgramOpcode, kPageQuadProgramAddrWidth);
+               kPageQuadProgramOpcode, kTransactionWidthMode114);
   EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
   EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
 

--- a/sw/device/tests/spi_host_gigadevice256Mb_flash_test.c
+++ b/sw/device/tests/spi_host_gigadevice256Mb_flash_test.c
@@ -15,6 +15,7 @@
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/spi_flash_testutils.h"
+#include "sw/device/lib/testing/spi_host_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
@@ -25,44 +26,13 @@ static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static status_t spi_host1_pinmux_connect_to_bob(const dif_pinmux_t *pinmux,
-                                                dif_pinmux_index_t csb_outsel) {
-  // CSB.
-  TRY(dif_pinmux_output_select(pinmux, csb_outsel,
-                               kTopEarlgreyPinmuxOutselSpiHost1Csb));
-  // SCLK.
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa3,
-                               kTopEarlgreyPinmuxOutselSpiHost1Sck));
-  // SD0.
-  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd0,
-                              kTopEarlgreyPinmuxInselIoa5));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa5,
-                               kTopEarlgreyPinmuxOutselSpiHost1Sd0));
-
-  // SD1.
-  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd1,
-                              kTopEarlgreyPinmuxInselIoa4));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa4,
-                               kTopEarlgreyPinmuxOutselSpiHost1Sd1));
-  // SD2.
-  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd2,
-                              kTopEarlgreyPinmuxInselIoa8));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa8,
-                               kTopEarlgreyPinmuxOutselSpiHost1Sd2));
-  // SD3.
-  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd3,
-                              kTopEarlgreyPinmuxInselIoa7));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa7,
-                               kTopEarlgreyPinmuxOutselSpiHost1Sd3));
-  return OK_STATUS();
-}
-
 static void init_test(dif_spi_host_t *spi_host) {
   dif_pinmux_t pinmux;
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
-  spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc11);
+  CHECK_STATUS_OK(
+      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc11));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));

--- a/sw/device/tests/spi_host_macronix_flash_test.c
+++ b/sw/device/tests/spi_host_macronix_flash_test.c
@@ -58,8 +58,6 @@ bool test_main(void) {
     kDeviceId = 0x1B20,
     kManufactureId = 0xC2,
     kPageQuadProgramOpcode = 0x38,
-    // The Macronix flash `4PP` opcode operates in 1-4-4 mode.
-    kPageQuadProgramAddrWidth = 4,
   };
 
   status_t result = OK_STATUS();
@@ -75,8 +73,9 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_fast_read, &spi_host);
   EXECUTE_TEST(result, test_dual_read, &spi_host);
   EXECUTE_TEST(result, test_quad_read, &spi_host);
+  // The Macronix flash `4PP` opcode operates in 1-4-4 mode.
   EXECUTE_TEST(result, test_page_program_quad, &spi_host,
-               kPageQuadProgramOpcode, kPageQuadProgramAddrWidth);
+               kPageQuadProgramOpcode, kTransactionWidthMode144);
   EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
   EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
 

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -45,8 +45,6 @@ bool test_main(void) {
     kDeviceId = 0x2180,
     kManufactureId = 0xef,
     kPageQuadProgramOpcode = 0x32,
-    // The Winbond flash `4PP` opcode operates in 1-1-4 mode.
-    kPageQuadProgramAddrWidth = 1,
   };
 
   status_t result = OK_STATUS();
@@ -62,8 +60,9 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_fast_read, &spi_host);
   EXECUTE_TEST(result, test_dual_read, &spi_host);
   EXECUTE_TEST(result, test_quad_read, &spi_host);
+  // The Winbond flash `4PP` opcode operates in 1-1-4 mode.
   EXECUTE_TEST(result, test_page_program_quad, &spi_host,
-               kPageQuadProgramOpcode, kPageQuadProgramAddrWidth);
+               kPageQuadProgramOpcode, kTransactionWidthMode114);
   EXECUTE_TEST(result, test_erase_32k_block, &spi_host);
   EXECUTE_TEST(result, test_erase_64k_block, &spi_host);
 


### PR DESCRIPTION
This PR:
 - Refactor the DIF spi_host to allow the use of 4 lanes for the opcode section.
 - Add a new spi flash test for a gigadevice flash of 1Gb.