### PR TITLE
[site] Seperate chip and block level regressions on the DV Dashboard

### DIFF
--- a/site/landing/layouts/shortcodes/all-blocks-dashboard.html
+++ b/site/landing/layouts/shortcodes/all-blocks-dashboard.html
@@ -1,15 +1,26 @@
-<div id="blocks-dashboard" class="dashboard-table"></div>
+<div id="chips-dashboard" class="dashboard-table">
+    <h2>Chip-Level</h2>
+</div>
+<div id="blocks-dashboard" class="dashboard-table">
+    <h2>Block-Level</h2>
+</div>
 <script src="/js/dashboard.js"></script>
 <script src="/js/ot-nightly-results.js"></script>
 <script>
-  function produce_results_table(results) {
+  function produce_results_table(results, table_id) {
     let block_result_collection = new BlockLevelResultsCollection();
     results.map((result) => block_result_collection.add_results(result));
 
-    var dashboard_table_toplevel = document.querySelector("#blocks-dashboard");
+    var dashboard_table_toplevel = document.querySelector(table_id);
     var results_table = block_result_collection.make_results_table();
     results_table.render(dashboard_table_toplevel);
   }
 
-  fetch_all_results().then(produce_results_table);
+  fetch_results(chip_level_urls, true).then(function(results) {
+    produce_results_table(results, "#chips-dashboard")
+  });
+
+  fetch_results(block_level_urls).then(function(results) {
+    produce_results_table(results, "#blocks-dashboard")
+  });
 </script>

--- a/site/landing/static/css/dv-dashboard.css
+++ b/site/landing/static/css/dv-dashboard.css
@@ -7,8 +7,7 @@
 }
 
 .dashboard-table table {
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
 }
 
 .dashboard-table tr:nth-child(1) {

--- a/util/site-dashboard/dashboard.js
+++ b/util/site-dashboard/dashboard.js
@@ -78,7 +78,7 @@ class DashboardSingleEntry {
 class DashboardSingleEntryCollection {
   constructor(entries, title = null, report_url = null) {
     this.entries = entries;
-    this.report_url = report_url
+    this.report_url = report_url;
     this.title = title;
   }
 
@@ -146,18 +146,23 @@ class DashboardTable {
 }
 
 class BlockLevelResults {
-  constructor(json, report_url) {
+  constructor(name, json, report_url) {
+    this.name = name;
     this.process_report(json);
     this.report_url = report_url;
   }
 
   process_report(report) {
-    this.block_name = report.block_name;
+    if (!this.name) {
+      this.block_name = report.block_name;
+    } else {
+      this.block_name = this.name;
+    }
     if ("block_variant" in report && report.block_variant != null) {
       this.block_name += '/' + report.block_variant;
     }
 
-    this.coverage = report.results.coverage
+    this.coverage = report.results.coverage;
     this.calculate_summary_coverage(report.tool);
 
     this.tests = 0;
@@ -267,7 +272,7 @@ class BlockLevelResultsCollection {
       "Toggle Coverage",
       "Assert Coverage",
       "Functional Coverage"
-    ]
+    ];
 
     let kinds = [
       DashValueKindLink,

--- a/util/site-dashboard/ot-nightly-results.js
+++ b/util/site-dashboard/ot-nightly-results.js
@@ -2,67 +2,87 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-const all_report_urls = [
-  ["adc_ctrl", ["https://reports.opentitan.org/hw/ip/adc_ctrl/dv/latest/"]],
-  ["aes", ["https://reports.opentitan.org/hw/ip/aes_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/aes_unmasked/dv/latest/"]],
-  ["alert_handler", ["https://reports.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/dv/latest/"]],
-  ["aon_timer", ["https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/"]],
-  ["clkmgr", ["https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/"]],
-  ["csrng", ["https://reports.opentitan.org/hw/ip/csrng/dv/latest/"]],
-  ["edn", ["https://reports.opentitan.org/hw/ip/edn/dv/latest/"]],
-  ["entropy_src", ["https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/"]],
-  ["flash_ctrl", ["https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/"]],
-  ["gpio", ["https://reports.opentitan.org/hw/ip/gpio/dv/latest/"]],
-  ["hmac", ["https://reports.opentitan.org/hw/ip/hmac/dv/latest/"]],
-  ["i2c", ["https://reports.opentitan.org/hw/ip/i2c/dv/latest/"]],
-  ["keymgr", ["https://reports.opentitan.org/hw/ip/keymgr/dv/latest/"]],
-  ["kmac", ["https://reports.opentitan.org/hw/ip/kmac_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/kmac_unmasked/dv/latest/"]],
-  ["lc_ctrl", ["https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/"]],
-  ["otbn", ["https://reports.opentitan.org/hw/ip/otbn/dv/uvm/latest/"]],
-  ["otp_ctrl", ["https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/"]],
-  ["pattgen", ["https://reports.opentitan.org/hw/ip/pattgen/dv/latest/"]],
-  ["prim_alert", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/"]],
-  ["prim_esc", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/"]],
-  ["prim_lfsr", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/"]],
-  ["prim_present", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/"]],
-  ["prim_prince", ["https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/"]],
-  ["pwm", ["https://reports.opentitan.org/hw/ip/pwm/dv/latest/"]],
-  ["pwrmgr", ["https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/"]],
-  ["rom_ctrl", ["https://reports.opentitan.org/hw/ip/rom_ctrl/dv/latest/"]],
-  ["rstmgr", ["https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/"]],
-  ["rstmgr_cnsty_chk", ["https://reports.opentitan.org/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/latest/"]],
-  ["rv_dm", ["https://reports.opentitan.org/hw/ip/rv_dm/dv/latest/"]],
-  ["rv_timer", ["https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/"]],
-  ["spi_device", ["https://reports.opentitan.org/hw/ip/spi_device/dv/latest/"]],
-  ["spi_host", ["https://reports.opentitan.org/hw/ip/spi_host/dv/latest/"]],
-  ["sram_ctrl", ["https://reports.opentitan.org/hw/ip/sram_ctrl_main/dv/latest/", "https://reports.opentitan.org/hw/ip/sram_ctrl_ret/dv/latest/"]],
-  ["sysrst_ctrl", ["https://reports.opentitan.org/hw/ip/sysrst_ctrl/dv/latest/"]],
-  ["tl_agent", ["https://reports.opentitan.org/hw/dv/sv/tl_agent/dv/latest/"]],
-  ["uart", ["https://reports.opentitan.org/hw/ip/uart/dv/latest/"]],
-  ["usbdev", ["https://reports.opentitan.org/hw/ip/usbdev/dv/latest/"]],
-  ["xbar", ["https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_main/dv/autogen/latest/", "https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_peri/dv/autogen/latest/"]],
-  ["chip", ["https://reports.opentitan.org/hw/top_earlgrey/dv/latest/"]],
-  ["rv_core_ibex", ["https://ibex.reports.lowrisc.org/opentitan/latest/"]]
-];
+const block_level_urls = {
+  "adc_ctrl": ["https://reports.opentitan.org/hw/ip/adc_ctrl/dv/latest/"],
+  "aes": ["https://reports.opentitan.org/hw/ip/aes_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/aes_unmasked/dv/latest/"],
+  "alert_handler": ["https://reports.opentitan.org/hw/top_earlgrey/ip_autogen/alert_handler/dv/latest/"],
+  "aon_timer": ["https://reports.opentitan.org/hw/ip/aon_timer/dv/latest/"],
+  "clkmgr": ["https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/"],
+  "csrng": ["https://reports.opentitan.org/hw/ip/csrng/dv/latest/"],
+  "edn": ["https://reports.opentitan.org/hw/ip/edn/dv/latest/"],
+  "entropy_src": ["https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/"],
+  "flash_ctrl": ["https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/"],
+  "gpio": ["https://reports.opentitan.org/hw/ip/gpio/dv/latest/"],
+  "hmac": ["https://reports.opentitan.org/hw/ip/hmac/dv/latest/"],
+  "i2c": ["https://reports.opentitan.org/hw/ip/i2c/dv/latest/"],
+  "keymgr": ["https://reports.opentitan.org/hw/ip/keymgr/dv/latest/"],
+  "kmac": ["https://reports.opentitan.org/hw/ip/kmac_masked/dv/latest/", "https://reports.opentitan.org/hw/ip/kmac_unmasked/dv/latest/"],
+  "lc_ctrl": ["https://reports.opentitan.org/hw/ip/lc_ctrl/dv/latest/"],
+  "otbn": ["https://reports.opentitan.org/hw/ip/otbn/dv/uvm/latest/"],
+  "otp_ctrl": ["https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/"],
+  "pattgen": ["https://reports.opentitan.org/hw/ip/pattgen/dv/latest/"],
+  "prim_alert": ["https://reports.opentitan.org/hw/ip/prim/dv/prim_alert/latest/"],
+  "prim_esc": ["https://reports.opentitan.org/hw/ip/prim/dv/prim_esc/latest/"],
+  "prim_lfsr": ["https://reports.opentitan.org/hw/ip/prim/dv/prim_lfsr/latest/"],
+  "prim_present": ["https://reports.opentitan.org/hw/ip/prim/dv/prim_present/latest/"],
+  "prim_prince": ["https://reports.opentitan.org/hw/ip/prim/dv/prim_prince/latest/"],
+  "pwm": ["https://reports.opentitan.org/hw/ip/pwm/dv/latest/"],
+  "pwrmgr": ["https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/"],
+  "rom_ctrl": ["https://reports.opentitan.org/hw/ip/rom_ctrl/dv/latest/"],
+  "rstmgr": ["https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/"],
+  "rstmgr_cnsty_chk": ["https://reports.opentitan.org/hw/ip/rstmgr/dv/rstmgr_cnsty_chk/latest/"],
+  "rv_dm": ["https://reports.opentitan.org/hw/ip/rv_dm/dv/latest/"],
+  "rv_timer": ["https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/"],
+  "spi_device": ["https://reports.opentitan.org/hw/ip/spi_device/dv/latest/"],
+  "spi_host": ["https://reports.opentitan.org/hw/ip/spi_host/dv/latest/"],
+  "sram_ctrl": ["https://reports.opentitan.org/hw/ip/sram_ctrl_main/dv/latest/", "https://reports.opentitan.org/hw/ip/sram_ctrl_ret/dv/latest/"],
+  "sysrst_ctrl": ["https://reports.opentitan.org/hw/ip/sysrst_ctrl/dv/latest/"],
+  "tl_agent": ["https://reports.opentitan.org/hw/dv/sv/tl_agent/dv/latest/"],
+  "uart": ["https://reports.opentitan.org/hw/ip/uart/dv/latest/"],
+  "usbdev": ["https://reports.opentitan.org/hw/ip/usbdev/dv/latest/"],
+  "xbar": ["https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_main/dv/autogen/latest/", "https://reports.opentitan.org/hw/top_earlgrey/ip/xbar_peri/dv/autogen/latest/"],
+  "rv_core_ibex": ["https://ibex.reports.lowrisc.org/opentitan/latest/"],
+};
 
-async function fetch_block_report(block_report_url) {
+const chip_level_urls = {
+  "chip_earlgrey": ["https://reports.opentitan.org/hw/top_earlgrey/dv/latest/"],
+};
+
+/**
+ * @param {string} name - Optional name to override the block name pulled from the report.
+ * @param {string} report_url - Url of the report to be fetched.
+ * @returns {BlockLevelResults} Object containing report data after some processing.
+ */
+async function fetch_and_process_report(name, report_url) {
   try {
-    let fetch_response = await fetch(block_report_url + "report.json");
+    let fetch_response = await fetch(report_url + "report.json");
     let block_info = await fetch_response.json();
-    let block_results = new BlockLevelResults(block_info, block_report_url);
-
+    let block_results = new BlockLevelResults(name, block_info, report_url);
     return block_results;
   } catch (error) {
-    console.error(`Saw error whilst processing block URL ${block_report_url}`);
+    console.error(`Saw error whilst processing report URL ${report_url}`);
     console.error(error);
   }
 
   return null;
 }
 
-async function fetch_results(block_report_urls) {
-  let report_promises = block_report_urls.map((url) => fetch_block_report(url));
-
+/**
+ * @param {Object} report_urls - An object mapping names to report urls
+ * @param {boolean} override_names - Takes the name from the 'report_urls' key rather than the report
+ * @returns {Array[BlockLevelResults]}
+ */
+async function fetch_results(report_urls, override_names = false) {
+  const name_url_pairs = [];
+  for (const [key, value] of Object.entries(report_urls)) {
+    // Each value may be an array, one item for each 'variant' of a block
+    for (const variant of value) {
+      name_url_pairs.push([key, variant]);
+    }
+  }
+  let report_promises = name_url_pairs.map(pair => fetch_and_process_report(
+    (override_names ? pair[0] : undefined), // name
+    pair[1]));                              // url
   let report_results = await Promise.allSettled(report_promises);
 
   return report_results
@@ -71,14 +91,19 @@ async function fetch_results(block_report_urls) {
     .map((report_result) => report_result.value);
 }
 
+
+/**
+ * This function is used for the block-dashboard on the homepage of each HWIP block.
+ *
+ * @param {string} block_name - The name of the block to generate the dashboard for.
+ * @returns {Array[BlockLevelResults]} A array with the processed block report(s) for all variants.
+ */
 async function fetch_block_results(block_name) {
-  let block_report_urls = all_report_urls.find((block_info) => block_info[0] == block_name);
-
-  return fetch_results(block_report_urls[1]);
-}
-
-async function fetch_all_results() {
-  block_report_urls = all_report_urls.flatMap((url_info) => url_info[1]);
-
+  // Filter-out all the blocks that don't match the 'block_name' argument
+  const block_report_urls = Object.fromEntries(
+    Object.entries(block_level_urls).filter(
+      ([key, val]) => key.includes(block_name)
+    )
+  );
   return fetch_results(block_report_urls);
 }


### PR DESCRIPTION
This PR includes some minor refactoring to the DV Dashboard javascript

- Change declaration of blocks to report urls to use Objects rather than nested lists
- Add a way to override the name of each row of the dashboard
  - We use this to show 'chip_earlgrey' instead of just 'chip'

---

![Screenshot from 2023-07-10 17-27-47](https://github.com/lowRISC/opentitan/assets/102029880/e4b9943e-1a92-4c3b-a2f8-36f4bd1c97d4)
