### PR TITLE
[sw/silicon_creator] Refactor ROM bootstrap into a common lib

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -9,8 +9,6 @@ load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["bootstrap.c"])
-
 dual_cc_library(
     name = "boot_data",
     srcs = dual_inputs(
@@ -394,5 +392,19 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
+    ],
+)
+
+cc_library(
+    name = "bootstrap",
+    srcs = ["bootstrap.c"],
+    hdrs = ["bootstrap.h"],
+    deps = [
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:spi_device",
     ],
 )

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -9,6 +9,8 @@ load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["bootstrap.c"])
+
 dual_cc_library(
     name = "boot_data",
     srcs = dual_inputs(

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -408,3 +408,11 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:spi_device",
     ],
 )
+
+filegroup(
+    name = "bootstrap_srcs",
+    srcs = [
+        "bootstrap.c",
+        "bootstrap.h",
+    ],
+)

--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/rom/bootstrap.h"
-
 #include <stdalign.h>
 
 #include "sw/device/lib/base/abs_mmio.h"
@@ -15,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/spi_device.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/rom/bootstrap.h"
 
 #include "flash_ctrl_regs.h"
 #include "gpio_regs.h"

--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -2,23 +2,19 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/silicon_creator/lib/bootstrap.h"
+
 #include <stdalign.h>
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
-#include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
-#include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/spi_device.h"
 #include "sw/device/silicon_creator/lib/error.h"
-#include "sw/device/silicon_creator/rom/bootstrap.h"
 
 #include "flash_ctrl_regs.h"
-#include "gpio_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "otp_ctrl_regs.h"
 
 enum {
   /*
@@ -337,33 +333,9 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
   return error;
 }
 
-hardened_bool_t bootstrap_requested(void) {
-  uint32_t bootstrap_dis =
-      otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET);
-  if (launder32(bootstrap_dis) == kHardenedBoolTrue) {
-    return kHardenedBoolFalse;
-  }
-  HARDENED_CHECK_NE(bootstrap_dis, kHardenedBoolTrue);
-
-  // A single read is sufficient since we expect strong pull-ups on the strap
-  // pins.
-  uint32_t res = launder32(kHardenedBoolTrue) ^ SW_STRAP_BOOTSTRAP;
-  res ^=
-      abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET) &
-      SW_STRAP_MASK;
-  if (launder32(res) != kHardenedBoolTrue) {
-    return kHardenedBoolFalse;
-  }
-  HARDENED_CHECK_EQ(res, kHardenedBoolTrue);
-  return res;
-}
-
-rom_error_t bootstrap(void) {
-  hardened_bool_t requested = bootstrap_requested();
-  if (launder32(requested) != kHardenedBoolTrue) {
-    return kErrorBootstrapNotRequested;
-  }
-  HARDENED_CHECK_EQ(requested, kHardenedBoolTrue);
+rom_error_t enter_bootstrap(hardened_bool_t protect_rom_ext) {
+  // TODO(lowRISC/opentitan#19151): Implement `protect_rom_ext` behavior.
+  HARDENED_CHECK_EQ(protect_rom_ext, kHardenedBoolFalse);
 
   spi_device_init();
 

--- a/sw/device/silicon_creator/lib/bootstrap.h
+++ b/sw/device/silicon_creator/lib/bootstrap.h
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOTSTRAP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOTSTRAP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+/**
+ * Enters flash programming mode. This function initializes the SPI device and
+ * uses incoming SPI commands to drive an internal state machine.
+ *
+ * Bootstrapping uses the typical SPI flash EEPROM commands. A typical session
+ * involves:
+ * - Asserting bootstrap pins to enter bootstrap mode,
+ * - Erasing the chip (WREN, CHIP_ERASE, busy loop ...),
+ * - Programming the chip (WREN, PAGE_PROGRAM, busy loop ...), and
+ * - Resetting the chip (RESET).
+ *
+ * This function only returns on error since a successful session ends with a
+ * chip reset.
+ *
+ * @param protect_rom_ext Whether to prevent changes to to ROM_EXT.
+ * @return The result of the flash loop.
+ */
+rom_error_t enter_bootstrap(hardened_bool_t protect_rom_ext);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOTSTRAP_H_

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -276,6 +276,7 @@ filegroup(
     srcs = [
         "bootstrap.c",
         "bootstrap.h",
+        "//sw/device/silicon_creator/lib:bootstrap_srcs",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -281,7 +281,7 @@ filegroup(
 
 cc_library(
     name = "bootstrap",
-    srcs = ["bootstrap.c"],
+    srcs = ["//sw/device/silicon_creator/lib:bootstrap.c"],
     hdrs = ["bootstrap.h"],
     deps = [
         "//hw/ip/gpio/data:gpio_regs",

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -281,7 +281,7 @@ filegroup(
 
 cc_library(
     name = "bootstrap",
-    srcs = ["//sw/device/silicon_creator/lib:bootstrap.c"],
+    srcs = ["bootstrap.c"],
     hdrs = ["bootstrap.h"],
     deps = [
         "//hw/ip/gpio/data:gpio_regs",
@@ -291,6 +291,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:bootstrap",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",

--- a/sw/device/silicon_creator/rom/bootstrap.c
+++ b/sw/device/silicon_creator/rom/bootstrap.c
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/bootstrap.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "gpio_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+hardened_bool_t bootstrap_requested(void) {
+  uint32_t bootstrap_dis =
+      otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET);
+  if (launder32(bootstrap_dis) == kHardenedBoolTrue) {
+    return kHardenedBoolFalse;
+  }
+  HARDENED_CHECK_NE(bootstrap_dis, kHardenedBoolTrue);
+
+  // A single read is sufficient since we expect strong pull-ups on the strap
+  // pins.
+  uint32_t res = launder32(kHardenedBoolTrue) ^ SW_STRAP_BOOTSTRAP;
+  res ^=
+      abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET) &
+      SW_STRAP_MASK;
+  if (launder32(res) != kHardenedBoolTrue) {
+    return kHardenedBoolFalse;
+  }
+  HARDENED_CHECK_EQ(res, kHardenedBoolTrue);
+  return res;
+}
+
+rom_error_t bootstrap(void) {
+  hardened_bool_t requested = bootstrap_requested();
+  if (launder32(requested) != kHardenedBoolTrue) {
+    return kErrorBootstrapNotRequested;
+  }
+  HARDENED_CHECK_EQ(requested, kHardenedBoolTrue);
+
+  return enter_bootstrap(/*protect_rom_ext=*/kHardenedBoolFalse);
+}


### PR DESCRIPTION
This behavior-preserving refactor moves the implementation of ROM bootstrap into a common library for use by ROM and ROM_EXT. This will support the implementation of ROM_EXT Recovery.

Note to reviewers: this is significantly easier to read one commit at a time. I was careful to preserve the original history of rom/bootstrap.c when I moved it to ~reflash.c~ lib/bootstrap.c, but looking at the PR as a whole obscures the actual changes.

Issue #19151