### PR TITLE
[chip,dv] increase ping timeout value for all_escalation_resets_test

### DIFF
--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -739,7 +739,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = 256,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,


### PR DESCRIPTION
0 ping timeout value can causes spurious alert
when alert event takes long enough to expire ping timer. 
Increase ping timeout value to make sure ping timeout happens after expected alert event.