### PR TITLE
[tools] Use bazel-provided Python for fusesoc subprocesses

### DIFF
--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -105,7 +105,7 @@ fusesoc_build = rule(
         "verilator_options": attr.label(),
         "make_options": attr.label(),
         "_fusesoc": attr.label(
-            default = entry_point("fusesoc"),
+            default = "//util:fusesoc_build",
             executable = True,
             cfg = "exec",
         ),

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@ot_python_deps//:requirements.bzl", "requirement")
+load("@ot_python_deps//:requirements.bzl", "all_requirements", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -93,4 +93,10 @@ py_binary(
         requirement("rich"),
         requirement("pluralizer"),
     ],
+)
+
+py_binary(
+    name = "fusesoc_build",
+    srcs = ["fusesoc_build.py"],
+    deps = all_requirements,
 )

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Command-line tool to add the calling interpreter to fusesoc's PATH, so it
+is used for generators.
+"""
+
+
+import os
+import sys
+from fusesoc.main import main
+
+if __name__ == "__main__":
+    # First, ensure the calling interpreter is on the PATH first, so any
+    # generators asking /usr/bin/env for python3 will use the same version.
+    path_env = os.environ["PATH"]
+    if path_env is not None:
+        path_env = ":" + path_env
+    path_env = os.path.dirname(sys.executable) + path_env
+    os.environ["PATH"] = path_env
+
+    # Start fusesoc
+    rc = main()
+    sys.exit(rc)


### PR DESCRIPTION
Add a py_binary shim that modifies the PATH environment variable to hold the bazel-provided Python interpreter directory first, so /usr/bin/env will point to it for the shebang method of running Python scripts. Add the entire set of packages from ot_python_deps as deps for that shim, so they're available to any generator fusesoc might call.