### PR TITLE
[regtool] Fix QE assignment bug

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -18846,6 +18846,7 @@ module spi_device_reg_top (
   // R[tpm_cmd_addr]: V(True)
   logic tpm_cmd_addr_qe;
   logic [1:0] tpm_cmd_addr_flds_we;
+  // In case all fields are read-only the aggregated register QE will be zero as well.
   assign tpm_cmd_addr_qe = &tpm_cmd_addr_flds_we;
   //   F[addr]: 23:0
   prim_subreg_ext #(
@@ -18903,6 +18904,7 @@ module spi_device_reg_top (
   // R[tpm_write_fifo]: V(True)
   logic tpm_write_fifo_qe;
   logic [0:0] tpm_write_fifo_flds_we;
+  // In case all fields are read-only the aggregated register QE will be zero as well.
   assign tpm_write_fifo_qe = &tpm_write_fifo_flds_we;
   prim_subreg_ext #(
     .DW    (8)


### PR DESCRIPTION
This patch fixes cases where read-only and writable fields are mixed in a single register, whereby the hwext register QE would have been tied to 0 previously due to the logical AND of all field QEs.

The patch ignores field QEs that are always 0 when calculating the register QE, except in the case where all fields are RO.

Fixes #19127.

CC @meisnere