### PR TITLE
Add go dependencies for ARM64

### DIFF
--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -25,9 +25,17 @@ def go_deps():
                 "go1.19.1.linux-amd64.tar.gz",
                 "acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde",
             ),
+            "linux_arm64": (
+                "go1.19.1.linux-arm64.tar.gz",
+                "49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f",
+            ),
             "darwin_amd64": (
                 "go1.19.1.darwin-amd64.tar.gz",
                 "b2828a2b05f0d2169afc74c11ed010775bf7cf0061822b275697b2f470495fb7",
+            ),
+            "darwin_arm64": (
+                "go1.19.1.darwin-arm64.tar.gz",
+                "e46aecce83a9289be16ce4ba9b8478a5b89b8aa0230171d5c6adbc0c66640548",
             ),
         },
     )


### PR DESCRIPTION
When building OT from an ARM-based system, e.g., Apple silicon, bazel fails out with the following error message:

```
rschilling@ubuntu:~/opentitan-integrated$ bazel build //hw:verilator
INFO: Repository go_sdk instantiated at:
  /home/rschilling/opentitan-integrated/WORKSPACE:29:8: in <toplevel>
  /home/rschilling/opentitan-integrated/third_party/go/deps.bzl:13:20: in go_deps
  /home/rschilling/.cache/bazel/_bazel_rschilling/294f71981fe1f7ffbbc1298f58c32d5e/external/io_bazel_rules_go/go/private/sdk.bzl:129:21: in go_download_sdk
Repository rule _go_download_sdk defined at:
  /home/rschilling/.cache/bazel/_bazel_rschilling/294f71981fe1f7ffbbc1298f58c32d5e/external/io_bazel_rules_go/go/private/sdk.bzl:116:35: in <toplevel>
ERROR: An error occurred during the fetch of repository 'go_sdk':
   Traceback (most recent call last):
	File "/home/rschilling/.cache/bazel/_bazel_rschilling/294f71981fe1f7ffbbc1298f58c32d5e/external/io_bazel_rules_go/go/private/sdk.bzl", line 98, column 13, in _go_download_sdk_impl
		fail("unsupported platform {}".format(platform))
Error in fail: unsupported platform linux_arm64
ERROR: /home/rschilling/opentitan-integrated/WORKSPACE:29:8: fetching _go_download_sdk rule //external:go_sdk: Traceback (most recent call last):
	File "/home/rschilling/.cache/bazel/_bazel_rschilling/294f71981fe1f7ffbbc1298f58c32d5e/external/io_bazel_rules_go/go/private/sdk.bzl", line 98, column 13, in _go_download_sdk_impl
		fail("unsupported platform {}".format(platform))
Error in fail: unsupported platform linux_arm64
INFO: Repository rules_cc instantiated at:
  /home/rschilling/opentitan-integrated/WORKSPACE:52:13: in <toplevel>
  /home/rschilling/opentitan-integrated/third_party/google/repos.bzl:12:26: in google_repos
  /home/rschilling/opentitan-integrated/rules/repo.bzl:9:21: in http_archive_or_local
Repository rule http_archive defined at:
  /home/rschilling/.cache/bazel/_bazel_rschilling/294f71981fe1f7ffbbc1298f58c32d5e/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31: in <toplevel>
ERROR: Analysis of target '//hw:verilator' failed; build aborted: unsupported platform linux_arm64
INFO: Elapsed time: 4.502s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (55 packages loaded, 1824 targets configured)
    currently loading: @crt//toolchains/lowrisc_rv32imcb ... (39 packages)
    Fetching https://github.com/bazelbuild/rules_cc/archive/a636005ba28c0344da5110bd8532184c74b6ffdf.tar.gz
  ````

This PR adds the required Go dependencies for ARM-based systems, in particular for Mac OS and Linux running on ARM. This includes Linux VMs running on a Mac.
