### PR TITLE
[site] Fix dashboard in dark theme

### DIFF
--- a/util/site-dashboard/dashboard.js
+++ b/util/site-dashboard/dashboard.js
@@ -39,6 +39,7 @@ function render_dashboard_value(value, kind, node) {
         g_colour.toString() + ",0)";
 
       node.style.backgroundColor = color_str;
+      node.style.color = "#3D1067";
 
       break;
     case DashValueKindLink:


### PR DESCRIPTION
Currently the dashboard is unreadable because dark theme defaults to light text color.