### PR TITLE
[opentitantool] Add RESET gpio to RESET strap for C2D2

### DIFF
--- a/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
+++ b/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
@@ -12,7 +12,13 @@
   ],
   "strappings": [
     {
-      "name": "RESET"
+      "name": "RESET",
+      "pins": [
+        {
+          "name": "RESET",
+          "level": false
+        }
+      ]
     },
     {
       "name": "ROM_BOOTSTRAP"


### PR DESCRIPTION
Flesh out the built-in config for C2D2 debugger to include holding the `RESET` gpio low for the `RESET` strapping option.