### PR TITLE
[chip,dv] update otp_ctrl_vendor_test with closed source ip

### DIFF
--- a/sw/device/tests/sim_dv/otp_ctrl_vendor_test_csr_access_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_vendor_test_csr_access_test.c
@@ -40,5 +40,7 @@ static void init_peripherals(void) {
  */
 bool test_main(void) {
   init_peripherals();
+  // This is an anker for sv wait
+  LOG_INFO("init peripheral is done");
   return true;
 }


### PR DESCRIPTION
When real vendor test happens in closed source test, it can collide with tlul transactions. 
Add wait event to avoid such collisions.