### PR TITLE
[opentitantool] migrate deprecated clap attributes

### DIFF
--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -48,7 +48,7 @@ pub struct BackendOpts {
     #[command(flatten)]
     pub ti50emulator_opts: ti50emulator::Ti50EmulatorOpts,
 
-    #[arg(long, number_of_values = 1, help = "Configuration files")]
+    #[arg(long, num_args = 1, help = "Configuration files")]
     pub conf: Vec<PathBuf>,
 }
 

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -35,7 +35,7 @@ pub struct BootstrapCommand {
     )]
     mirror: bool,
     #[arg(
-        name = "FILE",
+        value_name = "FILE",
         required = true,
         num_args = 1..,
         help = "An image to bootstrap or multiple filename@offset specifiers to assemble into a bootstrap image."

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -26,7 +26,7 @@ use opentitanlib::util::voltage::Voltage;
 #[derive(Debug, Args)]
 /// Reads a GPIO pin.
 pub struct GpioRead {
-    #[arg(name = "PIN", help = "The GPIO pin to read")]
+    #[arg(help = "The GPIO pin to read")]
     pub pin: String,
 }
 
@@ -55,10 +55,9 @@ impl CommandDispatch for GpioRead {
 #[derive(Debug, Args)]
 /// Writes a GPIO pin.
 pub struct GpioWrite {
-    #[arg(name = "PIN", help = "The GPIO pin to write")]
+    #[arg(help = "The GPIO pin to write")]
     pub pin: String,
     #[arg(
-        name = "VALUE",
         action = clap::ArgAction::Set,
         help = "The value to write to the pin"
     )]
@@ -82,14 +81,9 @@ impl CommandDispatch for GpioWrite {
 #[derive(Debug, Args)]
 /// Set the I/O mode of a GPIO pin (Input/OpenDrain/PushPull).
 pub struct GpioSetMode {
-    #[arg(name = "PIN", help = "The GPIO pin to modify")]
+    #[arg(help = "The GPIO pin to modify")]
     pub pin: String,
-    #[arg(
-        name = "MODE",
-        value_enum,
-        ignore_case = true,
-        help = "The I/O mode of the pin"
-    )]
+    #[arg(value_enum, ignore_case = true, help = "The I/O mode of the pin")]
     pub mode: PinMode,
 }
 
@@ -109,7 +103,7 @@ impl CommandDispatch for GpioSetMode {
 #[derive(Debug, Args)]
 /// Set the I/O weak pull mode of a GPIO pin (PullUp/PullDown/None).
 pub struct GpioSetPullMode {
-    #[arg(name = "PIN", help = "The GPIO pin to modify")]
+    #[arg(help = "The GPIO pin to modify")]
     pub pin: String,
     #[arg(
         name = "PULLMODE",
@@ -136,7 +130,7 @@ impl CommandDispatch for GpioSetPullMode {
 #[derive(Debug, Args)]
 /// Simultaneously set mode, pull and output value of a GPIO pin.
 pub struct GpioSet {
-    #[arg(name = "PIN", help = "The GPIO pin to modify")]
+    #[arg(help = "The GPIO pin to modify")]
     pub pin: String,
     #[arg(long, ignore_case = true, help = "The I/O mode of the pin")]
     pub mode: Option<PinMode>,
@@ -178,7 +172,7 @@ impl CommandDispatch for GpioSet {
 #[derive(Debug, Args)]
 /// Reads a GPIO pin.
 pub struct GpioAnalogRead {
-    #[arg(name = "PIN", help = "The GPIO pin to read")]
+    #[arg(help = "The GPIO pin to read")]
     pub pin: String,
 }
 
@@ -207,10 +201,9 @@ impl CommandDispatch for GpioAnalogRead {
 #[derive(Debug, Args)]
 /// Writes an analog voltage to a GPIO pin.
 pub struct GpioAnalogWrite {
-    #[arg(name = "PIN", help = "The GPIO pin to write")]
+    #[arg(help = "The GPIO pin to write")]
     pub pin: String,
     #[arg(
-        name = "VOLTS",
         value_parser = bool::from_str,
         help = "The analog value to write to the pin in volts, has effect only in AnalogOutput mode"
     )]
@@ -234,7 +227,7 @@ impl CommandDispatch for GpioAnalogWrite {
 #[derive(Debug, Args)]
 /// Apply a configuration-named pin strapping
 pub struct GpioApplyStrapping {
-    #[arg(name = "NAME", help = "The pin strapping to apply")]
+    #[arg(help = "The pin strapping to apply")]
     pub name: String,
 }
 
@@ -260,10 +253,7 @@ pub enum GpioMonitoringCommand {
 #[derive(Debug, Args)]
 /// Begin logic-analyzer style monitoring of a set of pins.
 pub struct GpioMonitoringStart {
-    #[arg(
-        name = "PINS",
-        help = "The list of GPIO pins to monitor (space separated)"
-    )]
+    #[arg(help = "The list of GPIO pins to monitor (space separated)")]
     pub pins: Vec<String>,
 }
 
@@ -319,10 +309,7 @@ impl CommandDispatch for GpioMonitoringStart {
 /// Retrieve logic-analyzer style monitoring events detected so far, on a set of pins.  Optionally
 /// continue monitoring, in which case `monitoring read` must be called again later.
 pub struct GpioMonitoringRead {
-    #[arg(
-        name = "PINS",
-        help = "The list of GPIO pins being monitored (space separated)"
-    )]
+    #[arg(help = "The list of GPIO pins being monitored (space separated)")]
     pub pins: Vec<String>,
 
     #[arg(long)]
@@ -387,10 +374,7 @@ impl CommandDispatch for GpioMonitoringRead {
 /// standard VCD format, which can be loaded into e.g. Pulseview (or probably also Saleae
 /// software), to get a logic analyzer view of what transpired.
 pub struct GpioMonitoringVcd {
-    #[arg(
-        name = "PINS",
-        help = "The list of GPIO pins to monitor (space separated)"
-    )]
+    #[arg(help = "The list of GPIO pins to monitor (space separated)")]
     pub pins: Vec<String>,
 
     #[arg(short, long, help = "Output file")]
@@ -543,7 +527,7 @@ impl CommandDispatch for GpioMonitoringVcd {
 #[derive(Debug, Args)]
 /// Remove a configuration-named pin strapping
 pub struct GpioRemoveStrapping {
-    #[arg(name = "NAME", help = "The pin strapping to release")]
+    #[arg(help = "The pin strapping to release")]
     pub name: String,
 }
 

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -106,7 +106,7 @@ pub struct GpioSetPullMode {
     #[arg(help = "The GPIO pin to modify")]
     pub pin: String,
     #[arg(
-        name = "PULLMODE",
+        value_name = "PULLMODE",
         value_enum,
         ignore_case = true,
         help = "The weak pull mode of the pin"

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -47,7 +47,7 @@ pub struct AssembleCommand {
     #[arg(short, long, help = "Filename to write the assembled image to")]
     output: PathBuf,
     #[arg(
-        name = "FILE",
+        value_name = "FILE",
         required = true,
         num_args = 1..,
         help = "One or more filename@offset specifiers to assemble into an image"

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -77,7 +77,7 @@ impl CommandDispatch for AssembleCommand {
 /// Manifest show command.
 #[derive(Debug, Args)]
 pub struct ManifestShowCommand {
-    #[arg(name = "IMAGE", help = "Filename for the image to display")]
+    #[arg(help = "Filename for the image to display")]
     image: PathBuf,
 }
 
@@ -96,7 +96,7 @@ impl CommandDispatch for ManifestShowCommand {
 /// Manifest update command.
 #[derive(Debug, Args)]
 pub struct ManifestUpdateCommand {
-    #[arg(name = "IMAGE", help = "Filename for the image to update")]
+    #[arg(help = "Filename for the image to update")]
     image: PathBuf,
     #[arg(
         short,
@@ -258,7 +258,7 @@ impl CommandDispatch for ManifestUpdateCommand {
 /// Manifest verify command.
 #[derive(Debug, Args)]
 pub struct ManifestVerifyCommand {
-    #[arg(name = "IMAGE", help = "Filename for the image to verify")]
+    #[arg(help = "Filename for the image to verify")]
     image: PathBuf,
     #[arg(short, long, help = "Run verification for SPHINCS+")]
     spx: bool,
@@ -297,10 +297,7 @@ impl CommandDispatch for ManifestVerifyCommand {
 /// Compute digest command.
 #[derive(Debug, Args)]
 pub struct DigestCommand {
-    #[arg(
-        name = "IMAGE",
-        help = "Filename for the image to calculate the digest for"
-    )]
+    #[arg(help = "Filename for the image to calculate the digest for")]
     image: PathBuf,
     #[arg(short, long, help = "Filename for an output bin file")]
     bin: Option<PathBuf>,
@@ -335,10 +332,7 @@ impl CommandDispatch for DigestCommand {
 /// Compute spx-message command.
 #[derive(Debug, Args)]
 pub struct SpxMessageCommand {
-    #[arg(
-        name = "IMAGE",
-        help = "Filename for the image to calculate the digest for"
-    )]
+    #[arg(help = "Filename for the image to calculate the digest for")]
     image: PathBuf,
     #[arg(short, long, help = "Filename for an output bin file")]
     output: PathBuf,

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -17,7 +17,7 @@ use opentitanlib::transport::common::fpga::FpgaProgram;
 /// Load a bitstream into the FPGA.
 #[derive(Debug, Args)]
 pub struct LoadBitstream {
-    #[arg(name = "FILE")]
+    #[arg(value_name = "FILE")]
     filename: PathBuf,
 
     #[arg(

--- a/sw/host/opentitantool/src/command/rsa.rs
+++ b/sw/host/opentitantool/src/command/rsa.rs
@@ -262,13 +262,13 @@ pub struct RsaSignCommand {
     output: Option<PathBuf>,
 
     #[arg(
-        name = "DER_FILE",
+        value_name = "DER_FILE",
         value_parser = load_priv_key,
         help = "RSA private key file in PKCS#1 DER format"
     )]
     private_key: RsaPrivateKey,
     #[arg(
-        name = "SHA256_DIGEST",
+        value_name = "SHA256_DIGEST",
         value_parser = Sha256Digest::from_str,
         required_unless_present = "input",
         help = "SHA256 digest of the message"
@@ -301,10 +301,10 @@ impl CommandDispatch for RsaSignCommand {
 
 #[derive(Debug, Args)]
 pub struct RsaVerifyCommand {
-    #[arg(name = "KEY", help = "Key file in DER format")]
+    #[arg(value_name = "KEY", help = "Key file in DER format")]
     der_file: PathBuf,
     #[arg(
-        name = "SHA256_DIGEST",
+        value_name = "SHA256_DIGEST",
         help = "SHA256 digest of the message as a hex string (big-endian), i.e. 0x..."
     )]
     digest: String,

--- a/sw/host/opentitantool/src/command/rsa.rs
+++ b/sw/host/opentitantool/src/command/rsa.rs
@@ -56,10 +56,7 @@ pub struct RsaKeyInfoInWords {
 /// Show public information of a private or public RSA key
 #[derive(Debug, Args)]
 pub struct RsaKeyShowCommand {
-    #[arg(
-        name = "DER_FILE",
-        help = "RSA public or private key file in DER format"
-    )]
+    #[arg(help = "RSA public or private key file in DER format")]
     der_file: PathBuf,
 }
 
@@ -86,9 +83,9 @@ impl CommandDispatch for RsaKeyShowCommand {
 /// <OUTPUT_DIR>/<BASENAME>.pub.der
 #[derive(Debug, Args)]
 pub struct RsaKeyGenerateCommand {
-    #[arg(name = "OUTPUT_DIR", help = "Output directory")]
+    #[arg(help = "Output directory")]
     output_dir: PathBuf,
-    #[arg(name = "BASENAME", help = "Basename for the generated key pair")]
+    #[arg(help = "Basename for the generated key pair")]
     basename: String,
 }
 
@@ -115,12 +112,9 @@ impl CommandDispatch for RsaKeyGenerateCommand {
 /// to a C header that can be used in the ROM or ROM_EXT
 #[derive(Debug, Args)]
 pub struct RsaKeyExportCommand {
-    #[arg(
-        name = "DER_FILE",
-        help = "RSA public or private key file in DER format"
-    )]
+    #[arg(help = "RSA public or private key file in DER format")]
     der_file: PathBuf,
-    #[arg(name = "OUTPUT_FILE", help = "output header file to generate")]
+    #[arg(help = "output header file to generate")]
     output_file: Option<PathBuf>,
 }
 
@@ -314,10 +308,7 @@ pub struct RsaVerifyCommand {
         help = "SHA256 digest of the message as a hex string (big-endian), i.e. 0x..."
     )]
     digest: String,
-    #[arg(
-        name = "SIGNATURE",
-        help = "Signature to be verified as a hex string (big-endian), i.e. 0x..."
-    )]
+    #[arg(help = "Signature to be verified as a hex string (big-endian), i.e. 0x...")]
     signature: String,
 }
 

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -151,7 +151,7 @@ pub struct SpiRead {
     pub mode: ReadMode,
     #[arg(long, help = "Hexdump the data.")]
     hexdump: bool,
-    #[arg(name = "FILE", default_value = "-")]
+    #[arg(value_name = "FILE", default_value = "-")]
     filename: PathBuf,
 }
 
@@ -278,7 +278,7 @@ impl CommandDispatch for SpiErase {
 pub struct SpiProgram {
     #[arg(short, long, default_value = "0", help = "Start offset.")]
     start: u32,
-    #[arg(name = "FILE")]
+    #[arg(value_name = "FILE")]
     filename: PathBuf,
 }
 

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -92,7 +92,7 @@ pub struct SpxSignCommand {
     #[arg(help = "The filename for the message to sign")]
     message: PathBuf,
 
-    #[arg(name = "KEY_FILE", help = "The file contianing SPHICS+ keypair")]
+    #[arg(value_name = "KEY_FILE", help = "The file contianing SPHICS+ keypair")]
     keypair: PathBuf,
     #[arg(short, long, help = "The filename to write the signature to")]
     output: Option<PathBuf>,
@@ -119,7 +119,7 @@ impl CommandDispatch for SpxSignCommand {
 
 #[derive(Debug, Args)]
 pub struct SpxVerifyCommand {
-    #[arg(name = "KEY", help = "Key file")]
+    #[arg(value_name = "KEY", help = "Key file")]
     key_file: PathBuf,
     #[arg(help = "Message file to verify the signature against")]
     message: PathBuf,

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -23,10 +23,7 @@ pub struct SpxPublicKeyInfo {
 /// Show public information of a SPHINCS+ public key or key pair.
 #[derive(Debug, Args)]
 pub struct SpxKeyShowCommand {
-    #[arg(
-        name = "KEY_FILE",
-        help = "SPHINCS+ key file (either just the public key or full keypair)"
-    )]
+    #[arg(help = "SPHINCS+ key file (either just the public key or full keypair)")]
     key_file: PathBuf,
 }
 
@@ -54,9 +51,9 @@ impl CommandDispatch for SpxKeyShowCommand {
 /// <OUTPUT_DIR>/<BASENAME>.pub.key.
 #[derive(Debug, Args)]
 pub struct SpxKeyGenerateCommand {
-    #[arg(name = "OUTPUT_DIR", help = "Output directory")]
+    #[arg(help = "Output directory")]
     output_dir: PathBuf,
-    #[arg(name = "BASENAME", help = "Basename for the generated key pair")]
+    #[arg(help = "Basename for the generated key pair")]
     basename: String,
 }
 
@@ -92,7 +89,7 @@ pub struct SpxSignResult {
 
 #[derive(Debug, Args)]
 pub struct SpxSignCommand {
-    #[arg(name = "MESSAGE", help = "The filename for the message to sign")]
+    #[arg(help = "The filename for the message to sign")]
     message: PathBuf,
 
     #[arg(name = "KEY_FILE", help = "The file contianing SPHICS+ keypair")]
@@ -124,12 +121,9 @@ impl CommandDispatch for SpxSignCommand {
 pub struct SpxVerifyCommand {
     #[arg(name = "KEY", help = "Key file")]
     key_file: PathBuf,
-    #[arg(
-        name = "MESSAGE",
-        help = "Message file to verify the signature against"
-    )]
+    #[arg(help = "Message file to verify the signature against")]
     message: PathBuf,
-    #[arg(name = "SIGNATURE", help = "SPHINCS+ signature file to verify")]
+    #[arg(help = "SPHINCS+ signature file to verify")]
     signature: PathBuf,
 }
 

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -30,7 +30,7 @@ pub enum StatusCommand {
 pub struct ListCommand {
     #[arg(short, long, help = "Display the raw status create records.")]
     raw_records: bool,
-    #[arg(name = "ELF_FILE", help = "Filename for the executable to analyze.")]
+    #[arg(help = "Filename for the executable to analyze.")]
     elf_file: PathBuf,
 }
 
@@ -73,7 +73,7 @@ pub struct LintCommand {
     // an empty file to make bazel happy.
     #[arg(short, long, help = "Create an empty file to make bazel happy.")]
     touch: Option<PathBuf>,
-    #[arg(name = "ELF_FILES", help = "Filenames of the executable to analyze.")]
+    #[arg(help = "Filenames of the executable to analyze.")]
     elf_files: Vec<PathBuf>,
 }
 

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -141,7 +141,7 @@ pub struct DecodeCommand {
     raw_status: u32,
     #[arg(
         long,
-        name = "ELF_FILE",
+        value_name = "ELF_FILE",
         help = "Filename for the executable to analyze."
     )]
     elf: Option<PathBuf>,

--- a/sw/host/opentitantool/src/command/tpm.rs
+++ b/sw/host/opentitantool/src/command/tpm.rs
@@ -15,12 +15,7 @@ use opentitanlib::tpm;
 /// Read the value of a given TPM register.
 #[derive(Debug, Args)]
 pub struct TpmReadRegister {
-    #[arg(
-        name = "REGISTER",
-        value_enum,
-        ignore_case = true,
-        help = "The TPM register to inspect"
-    )]
+    #[arg(value_enum, ignore_case = true, help = "The TPM register to inspect")]
     register: tpm::Register,
 
     #[arg(long, help = "Number of bytes to read.")]
@@ -70,12 +65,7 @@ impl CommandDispatch for TpmReadRegister {
 /// Write to a given TPM register.
 #[derive(Debug, Args)]
 pub struct TpmWriteRegister {
-    #[arg(
-        name = "REGISTER",
-        value_enum,
-        ignore_case = true,
-        help = "The TPM register to modify"
-    )]
+    #[arg(value_enum, ignore_case = true, help = "The TPM register to modify")]
     register: tpm::Register,
 
     #[arg(

--- a/sw/host/opentitantool/src/command/update_usr_access.rs
+++ b/sw/host/opentitantool/src/command/update_usr_access.rs
@@ -17,10 +17,10 @@ use opentitanlib::util::usr_access::{usr_access_crc32, usr_access_set};
 /// Update the USR_ACCESS value of an FPGA bitstream with the current timestamp.
 #[derive(Debug, Args)]
 pub struct UpdateUsrAccess {
-    #[arg(name = "INPUT_FILE")]
+    #[arg(value_name = "INPUT_FILE")]
     input: PathBuf,
 
-    #[arg(name = "OUTPUT_FILE")]
+    #[arg(value_name = "OUTPUT_FILE")]
     output: PathBuf,
 
     #[arg(

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -104,7 +104,7 @@ struct Opts {
 
     #[arg(
         long,
-        number_of_values(1),
+        num_args = 1,
         help = "Parse and execute the argument as a command"
     )]
     exec: Vec<String>,

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -21,7 +21,7 @@ bitvec = "1.0.1"
 byteorder = "1.4.3"
 chrono = "0.4"
 # We're hitting a rustc bug in the nightly version we use that's exposed by clap >= 4.3
-clap = { version = "4.1, <=4.2.7", features = ["derive", "env"] }
+clap = { version = "4.1, <=4.2.7", features = ["derive", "env", "deprecated"] }
 crc = "3.0"
 deser-hjson = "1.0.2"
 directories = "4.0.1"

--- a/third_party/rust/crates/BUILD.clap-4.2.7.bazel
+++ b/third_party/rust/crates/BUILD.clap-4.2.7.bazel
@@ -32,6 +32,7 @@ rust_library(
         "cargo",
         "color",
         "default",
+        "deprecated",
         "derive",
         "env",
         "error-context",

--- a/third_party/rust/crates/BUILD.clap_builder-4.2.7.bazel
+++ b/third_party/rust/crates/BUILD.clap_builder-4.2.7.bazel
@@ -31,6 +31,7 @@ rust_library(
     crate_features = [
         "cargo",
         "color",
+        "deprecated",
         "env",
         "error-context",
         "help",

--- a/third_party/rust/crates/BUILD.clap_derive-4.2.0.bazel
+++ b/third_party/rust/crates/BUILD.clap_derive-4.2.0.bazel
@@ -30,6 +30,7 @@ rust_proc_macro(
     ),
     crate_features = [
         "default",
+        "deprecated",
     ],
     crate_root = "src/lib.rs",
     edition = "2021",


### PR DESCRIPTION
`number_of_values` is renamed to `num_args` and `name` is deprecated in favour of `value_name`. They are still allowed in clap v4 but when the opt-in `deprecated` feature is enabled, the former will cause a warning and the latter is rejected.
