### PR TITLE
[otbn,dv] Tweak length of time to wait for reset

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -348,11 +348,11 @@ class otbn_base_vseq extends cip_base_vseq #(
     `DV_CHECK_FATAL(!cfg.under_reset)
 
     // Wait for OTBN to be idle. After a reset, getting an URND value from EDN and performing an
-    // initial secure wipe can take up to 500 cycles if the EDN is held in reset for much longer
-    // than OTBN, so use that as timeout.  Stop waiting on a reset.
+    // initial secure wipe can take up to 5000 cycles if the EDN is held in reset for much longer
+    // than OTBN, so use that as timeout. Stop waiting on a reset.
     fork : wait_for_idle_fork
       wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle);
-      repeat (500) @(cfg.clk_rst_vif.cbn);
+      repeat (5000) @(cfg.clk_rst_vif.cbn);
       wait(cfg.under_reset);
     join_any
 


### PR DESCRIPTION
Without this change, the following test fails when CDC is enabled:

```
  ./util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson \
    -i otbn_alu_bignum_mod_err --fixed-seed 123 \
    --waves shm --run-only
```

It turns out that the failure is because it takes too long to get URND data from the EDN. Looking at the waves, the timeout arrived when we were partway through the first of three EDN requests.

If we wanted to make the test more robust here, we'd have to wait a fixed time for each EDN request to come up and then allow the test environment an arbitrary time to respond. But I don't expect this to change again, so let's do the simple, silly fix for now.

This fixes one of the failure modes tracked in #19045 ("Timeout waiting for secure wipe, timeout value too short").