### PR TITLE
Minor lint fixes in OTBN DV code

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -332,7 +332,7 @@ interface otbn_trace_if
         ((u_otbn_alu_bignum.alu_predec_bignum_i.flags_adder_update[i_fg] |
           u_otbn_alu_bignum.alu_predec_bignum_i.flags_logic_update[i_fg] |
           u_otbn_alu_bignum.alu_predec_bignum_i.flags_mac_update[i_fg] |
-          |u_otbn_alu_bignum.alu_predec_bignum_i.flags_ispr_wr) &
+          (|u_otbn_alu_bignum.alu_predec_bignum_i.flags_ispr_wr)) &
           u_otbn_alu_bignum.operation_commit_i)) & ~ispr_init;
     assign flags_write_data[i_fg] = u_otbn_alu_bignum.flags_d[i_fg];
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `mod_intg_q` to be used", UVM_LOW)
     cfg.alu_bignum_vif.wait_for_mod_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.alu_bignum_vif.mod_intg_q,
                                                         '{default: 50},
                                                         corrupted_words);
@@ -29,7 +29,7 @@ class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.alu_bignum_vif.release_mod_intg_q();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `ispr_rdata_intg` to be used", UVM_LOW)
     cfg.controller_vif.wait_for_ispr_rdata_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     int unsigned corrupt_word_pct[otbn_pkg::BaseWordsPerWLEN];
     bit [otbn_pkg::ExtWLEN-1:0] new_data;
 
@@ -43,7 +43,7 @@ class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.controller_vif.release_ispr_rdata_intg_i();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -20,6 +20,15 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     join_any
   endtask: body
 
+  // Wait until the value at path becomes nonzero
+  task wait_for_flag(string path);
+    uvm_hdl_data_t flag;
+    `DV_SPINWAIT(do begin
+                   @(cfg.clk_rst_vif.cb);
+                   `DV_CHECK_FATAL(uvm_hdl_read(path, flag) == 1);
+                 end while(!flag);)
+  endtask
+
   task inject_redun_err();
     bit [3:0] err_type;
     string err_path;
@@ -31,14 +40,8 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     case(err_type)
       // Injecting error on ispr_addr during a write
       0: begin
-        bit wr_en;
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_addr_i";
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_wr_en", wr_en);
-          end while(!wr_en);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_wr_en");
         uvm_hdl_read(err_path, good_addr);
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
@@ -47,14 +50,8 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
       // Injecting error on ispr_addr during a read
       1: begin
-        bit rd_en;
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_addr_i";
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_rd_en_i", rd_en);
-          end while(!rd_en);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_rd_en_i");
         uvm_hdl_read(err_path, good_addr);
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
@@ -64,14 +61,8 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       // injecting error on opcode
       2: begin
         logic [3:0] good_op, bad_op;
-        bit op_valid;
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.operation_i.op";
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.alu_bignum_operation_valid", op_valid);
-          end while(!op_valid);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.alu_bignum_operation_valid");
         uvm_hdl_read(err_path, good_op);
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_op,
                                            bad_op != good_op;
@@ -80,16 +71,10 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
       // injecting error on lsu_addr_en
       3: begin
-        bit insn_valid;
         bit choose_err;
         otbn_pkg::insn_dec_shared_t insn_dec_shared_i;
         err_path = "tb.dut.u_otbn_core.u_otbn_controller.insn_dec_shared_i";
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_controller.insn_valid_i", insn_valid);
-          end while(!insn_valid);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.u_otbn_controller.insn_valid_i");
         uvm_hdl_read(err_path, insn_dec_shared_i);
         `DV_CHECK_STD_RANDOMIZE_FATAL(choose_err)
         case(choose_err)
@@ -107,15 +92,9 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
       // injects error into otbn_core
       4: begin
-        bit insn_valid;
         bit [1:0] choose_err;
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid);
-          end while(!insn_valid);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.insn_valid");
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(choose_err, choose_err inside {[0:2]};)
         case(choose_err)
           0: begin
@@ -154,18 +133,12 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       5: begin
         bit mac_en;
         bit choose_err;
-        bit insn_valid;
         `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute)
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
         `DV_CHECK_STD_RANDOMIZE_FATAL(choose_err)
         // Wait for valid instruction, because `otbn_core` only propagates bignum MAC predec errors
         // for valid instructions.
-        `DV_SPINWAIT(
-          do begin
-            @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_otbn_core.insn_valid", insn_valid);
-          end while(!insn_valid);
-        )
+        wait_for_flag("tb.dut.u_otbn_core.insn_valid");
         case(choose_err)
           0: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i";
@@ -175,12 +148,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           1: begin
             bit zero_acc;
             err_path = "tb.dut.u_otbn_core.u_otbn_mac_bignum.operation_i.zero_acc";
-            `DV_SPINWAIT(
-              do begin
-                @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i", mac_en);
-              end while(!mac_en);
-            )
+            wait_for_flag("tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i");
             uvm_hdl_read(err_path, zero_acc);
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, !zero_acc) == 1);
           end
@@ -197,42 +165,24 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(choose_err, choose_err inside {[0:2]};)
         case(choose_err)
           0: begin
-            bit [1:0] en;
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_addr_i[4:0]";
-            `DV_SPINWAIT(
-              do begin
-                @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_en_i[1:0]", en);
-              end while(!en);
-            )
+            wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_en_i[1:0]");
             uvm_hdl_read(err_path, addr);
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
           end
           1: begin
-            bit en;
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_addr_a_i";
-            `DV_SPINWAIT(
-              do begin
-                @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_a_i", en);
-              end while(!en);
-            )
+            wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_a_i");
             uvm_hdl_read(err_path, addr);
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
           end
           2: begin
-            bit en;
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_addr_b_i";
-            `DV_SPINWAIT(
-              do begin
-                @(cfg.clk_rst_vif.cb);
-                uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_b_i", en);
-              end while(!en);
-            )
+            wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_b_i");
             uvm_hdl_read(err_path, addr);
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -42,7 +42,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       0: begin
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_addr_i";
         wait_for_flag("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_wr_en");
-        uvm_hdl_read(err_path, good_addr);
+        `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_addr));
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
         bad_addr = good_addr ^ mask;
@@ -52,7 +52,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       1: begin
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_addr_i";
         wait_for_flag("tb.dut.u_otbn_core.u_otbn_alu_bignum.ispr_rd_en_i");
-        uvm_hdl_read(err_path, good_addr);
+        `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_addr));
         // Mask to corrupt 1 to 2 bits of the ispr addr
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
         bad_addr = good_addr ^ mask;
@@ -63,7 +63,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         logic [3:0] good_op, bad_op;
         err_path = "tb.dut.u_otbn_core.u_otbn_alu_bignum.operation_i.op";
         wait_for_flag("tb.dut.u_otbn_core.alu_bignum_operation_valid");
-        uvm_hdl_read(err_path, good_op);
+        `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_op));
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_op,
                                            bad_op != good_op;
                                            bad_op != otbn_pkg::AluOpBignumNone;);
@@ -75,7 +75,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         otbn_pkg::insn_dec_shared_t insn_dec_shared_i;
         err_path = "tb.dut.u_otbn_core.u_otbn_controller.insn_dec_shared_i";
         wait_for_flag("tb.dut.u_otbn_core.u_otbn_controller.insn_valid_i");
-        uvm_hdl_read(err_path, insn_dec_shared_i);
+        `DV_CHECK_FATAL(uvm_hdl_read(err_path, insn_dec_shared_i));
         `DV_CHECK_STD_RANDOMIZE_FATAL(choose_err)
         case(choose_err)
           0: begin
@@ -101,7 +101,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [31:0] bad_rf_ren_a;
             bit [31:0] good_rf_ren_a;
             err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_a";
-            uvm_hdl_read(err_path, good_rf_ren_a);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_rf_ren_a));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_a,  $countones(bad_rf_ren_a) == 1;
                                                bad_rf_ren_a != good_rf_ren_a;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_rf_ren_a) == 1);
@@ -110,7 +110,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [31:0] bad_rf_ren_b;
             bit [31:0] good_rf_ren_b;
             err_path = "tb.dut.u_otbn_core.rf_predec_bignum.rf_ren_b";
-            uvm_hdl_read(err_path, good_rf_ren_b);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_rf_ren_b));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_rf_ren_b,  $countones(bad_rf_ren_b) == 1;
                                                bad_rf_ren_b != good_rf_ren_b;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_rf_ren_b) == 1);
@@ -119,7 +119,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
             bit [8:0] bad_ispr_rd_en;
             bit [8:0] good_ispr_rd_en;
             err_path = "tb.dut.u_otbn_core.ispr_predec_bignum.ispr_rd_en";
-            uvm_hdl_read(err_path, good_ispr_rd_en);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_ispr_rd_en));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(bad_ispr_rd_en,  $countones(bad_ispr_rd_en) == 1;
                                                bad_ispr_rd_en != good_ispr_rd_en;)
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_ispr_rd_en) == 1);
@@ -142,14 +142,14 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         case(choose_err)
           0: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i";
-            uvm_hdl_read(err_path, mac_en);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, mac_en));
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, !mac_en) == 1);
           end
           1: begin
             bit zero_acc;
             err_path = "tb.dut.u_otbn_core.u_otbn_mac_bignum.operation_i.zero_acc";
             wait_for_flag("tb.dut.u_otbn_core.u_otbn_mac_bignum.mac_en_i");
-            uvm_hdl_read(err_path, zero_acc);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, zero_acc));
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, !zero_acc) == 1);
           end
           default: begin
@@ -167,7 +167,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           0: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_addr_i[4:0]";
             wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.wr_en_i[1:0]");
-            uvm_hdl_read(err_path, addr);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
@@ -175,7 +175,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           1: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_addr_a_i";
             wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_a_i");
-            uvm_hdl_read(err_path, addr);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);
@@ -183,7 +183,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
           2: begin
             err_path = "tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_addr_b_i";
             wait_for_flag("tb.dut.u_otbn_core.u_otbn_rf_bignum.rd_en_b_i");
-            uvm_hdl_read(err_path, addr);
+            `DV_CHECK_FATAL(uvm_hdl_read(err_path, addr));
             `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
             addr = addr ^ mask;
             `DV_CHECK_FATAL(uvm_hdl_force(err_path, addr) == 1);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
@@ -10,14 +10,14 @@ class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
 
   `uvm_object_new
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     used_words = '0;
     `uvm_info(`gfn, "Waiting for `acc_intg_q` to be used", UVM_LOW)
     cfg.mac_bignum_vif.wait_for_acc_used(200, used_words);
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.mac_bignum_vif.acc_intg_q,
                                                         '{default: 50},
                                                         corrupted_words);
@@ -29,7 +29,7 @@ class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     cfg.mac_bignum_vif.release_acc_intg_q();
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -35,7 +35,8 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_dmem.req_i", req);
+            if (!uvm_hdl_read("tb.dut.u_dmem.req_i", req))
+              `uvm_fatal(`gfn, "failed to read u_dmem.req_i");
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)
@@ -45,7 +46,8 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
         `DV_SPINWAIT(
           do begin
             @(cfg.clk_rst_vif.cb);
-            uvm_hdl_read("tb.dut.u_imem.req_i", req);
+            if (!uvm_hdl_read("tb.dut.u_imem.req_i", req))
+              `uvm_fatal(`gfn, "failed to read u_imem.req_i");
           end while(!req);
         )
         `DV_CHECK_FATAL(uvm_hdl_force(gnt_path, 0) == 1)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
@@ -32,13 +32,16 @@ class otbn_pc_ctrl_flow_redun_vseq extends otbn_single_vseq;
 
     do begin
       @(cfg.clk_rst_vif.cb);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.imem_rvalid_i", imem_rvalid);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_fetch_req_valid_raw_i",
-                    insn_fetch_req_valid);
-      uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.prefetch_ignore_errs_i",
-                    prefetch_ignore_err);
+      if (!uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.imem_rvalid_i", imem_rvalid))
+        `uvm_fatal(`gfn, "failed to read imem_rvalid_i");
+      if (!uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_fetch_req_valid_raw_i",
+                        insn_fetch_req_valid))
+        `uvm_fatal(`gfn, "failed to read insn_fetch_req_valid_raw_i");
+      if (!uvm_hdl_read("tb.dut.u_otbn_core.u_otbn_instruction_fetch.prefetch_ignore_errs_i",
+                        prefetch_ignore_err))
+        `uvm_fatal(`gfn, "failed to read prefetch_ignore_errs_i");
     end while(!(imem_rvalid & insn_fetch_req_valid & !prefetch_ignore_err));
-    uvm_hdl_read(addr_path, good_addr);
+    `DV_CHECK_FATAL(uvm_hdl_read(addr_path, good_addr));
     // Mask to corrupt 1 to 2 bits of the prefetch addr
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
     bad_addr = good_addr ^ mask;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_bignum_intg_err_vseq.sv
@@ -11,7 +11,7 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
   `uvm_object_new
   rand bit insert_intg_err_to_a;
 
-  task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
+  protected task await_use(output bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words);
     logic rd_en;
     used_words = '0;
     `uvm_info(`gfn, "Waiting for selected RF to be used", UVM_LOW)
@@ -26,8 +26,8 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
     )
   endtask
 
-  task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
-                     output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
+  protected task inject_errors(input  bit [otbn_pkg::BaseWordsPerWLEN-1:0] used_words,
+                               output bit [otbn_pkg::BaseWordsPerWLEN-1:0] corrupted_words);
     logic [otbn_pkg::ExtWLEN-1:0] orig_data;
     bit   [otbn_pkg::ExtWLEN-1:0] new_data;
 
@@ -47,7 +47,7 @@ class otbn_rf_bignum_intg_err_vseq extends otbn_intg_err_vseq;
     end
   endtask
 
-  task release_force();
+  protected task release_force();
     if (insert_intg_err_to_a) begin
       cfg.trace_vif.release_rf_bignum_rd_data_a_intg();
     end else begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
@@ -53,11 +53,11 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
     `DV_SPINWAIT(
       do begin
         @(cfg.clk_rst_vif.cb);
-        uvm_hdl_read(top_valid_path, top_valid);
+        `DV_CHECK_FATAL(uvm_hdl_read(top_valid_path, top_valid));
       end while (!top_valid);
     )
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
-    uvm_hdl_read(top_valid_path, top_valid);
+    `DV_CHECK_FATAL(uvm_hdl_read(top_valid_path, top_valid));
     if (top_valid) begin
       fork
         begin: isolation_fork
@@ -67,7 +67,7 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
                 `DV_SPINWAIT(
                   do begin
                     @(cfg.clk_rst_vif.cb);
-                    uvm_hdl_read(stack_read_path, stack_read);
+                    `DV_CHECK_FATAL(uvm_hdl_read(stack_read_path, stack_read));
                   end while (!stack_read);
                 )
                 cfg.model_agent_cfg.vif.send_err_escalation(err_val);
@@ -84,7 +84,7 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
                 `DV_SPINWAIT(
                   do begin
                     @(cfg.clk_rst_vif.cb);
-                    uvm_hdl_read(stack_write_path, stack_write);
+                    `DV_CHECK_FATAL(uvm_hdl_read(stack_write_path, stack_write));
                   end while (!stack_write);
                 )
                 @(cfg.clk_rst_vif.cb);
@@ -107,18 +107,18 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
     bit [38:0] bad_data;
     bit [31:0] mask;
     bit [31:0] err_val = 32'd1 << 20;
-    uvm_hdl_read(stack_wr_idx_path, stack_wr_idx);
+    `DV_CHECK_FATAL(uvm_hdl_read(stack_wr_idx_path, stack_wr_idx));
     if (stack_wr_idx != 0) begin
       if (err_type) begin
         $sformat(err_path, "tb.dut.u_otbn_core.u_otbn_rf_base.u_call_stack.stack_storage[%0d]",
                  (stack_wr_idx-1));
       end else begin
-        uvm_hdl_read(stack_wr_idx_path, stack_wr_idx);
+        `DV_CHECK_FATAL(uvm_hdl_read(stack_wr_idx_path, stack_wr_idx));
         $sformat(err_path,
     "tb.dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.stack_storage[%0d]"
                  , (stack_wr_idx - 1));
       end
-      uvm_hdl_read(err_path, good_data);
+      `DV_CHECK_FATAL(uvm_hdl_read(err_path, good_data));
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
       bad_data = good_data ^ mask;
       `DV_CHECK_FATAL(uvm_hdl_force(err_path, bad_data))


### PR DESCRIPTION
These are all minor tweaks that silence Xcelium warnings when building OTBN DV code. There's nothing that will change behaviour, but it makes it a bit easier to read through a compilation log when something else has gone wrong.