### PR TITLE
[topgen] Update hjson headers

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7,7 +7,6 @@
 //
 // util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson \
 //                -o hw/top_earlgrey/ \
-//                --hjson-only \
 //                --rnd_cnst_seed 4881560218908238235
 {
   name: earlgrey

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1256,14 +1256,12 @@ def main():
         gencmd = """//
 // util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson \\
 //                -o hw/top_{topname}/ \\
-//                --hjson-only \\
 //                --entropy-buffer {path}
 """.format(topname=topname, path = args.entropy_buffer)
     else:
         gencmd = """//
 // util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson \\
 //                -o hw/top_{topname}/ \\
-//                --hjson-only \\
 //                --rnd_cnst_seed {seed}
 """.format(topname=topname, seed=completecfg["rnd_cnst_seed"])
 


### PR DESCRIPTION
Option `--hjson-only` was removed from `topgen.py` long time ago in https://github.com/lowRISC/opentitan/commit/66f7ae29795bec0831b872a7171b0f6921371cb7 but it is still listed in hjson files. This PR removes it from the header template in topgen and updates the autogenerated file.