### PR TITLE
[doc] Add the block-dashboards to the LR primitives page

### DIFF
--- a/hw/ip/prim/README.md
+++ b/hw/ip/prim/README.md
@@ -1,5 +1,7 @@
 # lowRISC Hardware Primitives
 
+{{#block-dashboard prim}}
+
 ## Concepts
 
 This directory contains basic building blocks to create a hardware design,


### PR DESCRIPTION
This expands to all the keys that contain 'prim' in `ot-nightly-results.js` (Currently 5)

@GregAC was there any reason not to add this the first time around? Just to double-check. Thanks