### PR TITLE
[usbdev] Truncate RX after receiving a PRE PID

### DIFF
--- a/hw/ip/usbdev/rtl/usb_consts_pkg.sv
+++ b/hw/ip/usbdev/rtl/usb_consts_pkg.sv
@@ -30,7 +30,9 @@ package usb_consts_pkg;
     UsbPidAck   = 4'b0010,
     UsbPidNak   = 4'b1010,
     UsbPidStall = 4'b1110,
-    UsbPidNyet  = 4'b0110
+    UsbPidNyet  = 4'b0110,
+    // SPECIAL
+    UsbPidPre   = 4'b1100
   } usb_pid_e;
 
 


### PR DESCRIPTION
Trigger EOP response when the receiver sees a PRE PID. Because the preamble is not a full packet and does not terminate with an EOP until after the low-speed transmission is complete, stop processing the packet immediately after receiving the PID. The low-speed portion of the packet will trigger error conditions otherwise.

Resolves #19148