### PR TITLE
[hsmtool] Improve attribute redactions

### DIFF
--- a/sw/host/hsmtool/src/util/attribute/data.rs
+++ b/sw/host/hsmtool/src/util/attribute/data.rs
@@ -13,6 +13,12 @@ use crate::util::attribute::{
 };
 use crate::util::escape::{as_hex, escape, unescape};
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Redacted {
+    RedactedByHsm,
+    RedactedByTool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(untagged)]
 pub enum AttrData {
@@ -24,6 +30,7 @@ pub enum AttrData {
     KeyType(KeyType),
     MechanismType(MechanismType),
     ObjectClass(ObjectClass),
+    Redacted(Redacted),
     Str(String),
     List(Vec<AttrData>),
 }

--- a/sw/host/hsmtool/src/util/attribute/mod.rs
+++ b/sw/host/hsmtool/src/util/attribute/mod.rs
@@ -46,7 +46,7 @@ mod mechanism_type;
 mod object_class;
 
 pub use attr::AttributeMap;
-pub use data::AttrData;
+pub use data::{AttrData, Redacted};
 pub use error::AttributeError;
 
 pub use attribute_type::AttributeType;


### PR DESCRIPTION
When showing objects, manually redact private key components.

The HSM normally redacts these, however, if you have extractable keys, the show command might dump their contents to the console.  By default, we'll redact these components to avoid accidentally exposing private key material.