### PR TITLE
[python] fix package dep that is incompatible with nightly infra

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -7,6 +7,7 @@ beautifulsoup4==4.12.2
 hjson==3.1.0
 jsonschema==4.17.3; python_version >= "3.7"
 libcst==0.4.1
+lxml==4.9.2
 mako==1.1.6
 pluralizer==1.2.0
 pycryptodome==3.15.0


### PR DESCRIPTION
The `lxml` package is not a direct dependency of the OT project, rather it is a transitive dependency. Since it is a transitive dependency, it was not pinned to a specific version. As a result, a newer version was pulled down onto our CentOS-based infrastructure that runs the nightly regressions. The newer version was incompatible with CentOS7, and therefore wiped out our nightly regressions. This makes the last known compatible version a direct dependency of the project now to fix the broken nightly regressions.