### PR TITLE
[lc_ctrl/eco] Fix ECO issue inside lc_ctrl

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
@@ -18,7 +18,8 @@ class lc_ctrl_common_vseq extends lc_ctrl_base_vseq;
         `DV_ASSERT_CTRL_REQ("StateRegs_A", enable)
         `DV_ASSERT_CTRL_REQ("CountRegs_A", enable)
         `DV_ASSERT_CTRL_REQ("FsmStateRegs_A", enable)
-        `DV_ASSERT_CTRL_REQ("KmacFsmStateRegs_A", enable)
+        // TODO(#19200): Due to the ECO hack we're removing this.
+        // `DV_ASSERT_CTRL_REQ("KmacFsmStateRegs_A", enable)
         `DV_ASSERT_CTRL_REQ("SecCmCFILinear_A", enable)
       end
       SecCmPrimOnehot: begin

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -786,9 +786,10 @@ class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
   // Flip bits in KMAC FSM registers
   protected virtual task kmac_fsm_backdoor_err_inj();
     logic [KMAC_FSM_WIDTH-1:0] state;
-    sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
-        "tb.dut.u_lc_ctrl_kmac_if.u_state_regs");
-    if_proxy.inject_fault();
+    // TODO(#19200): Due to the ECO hack we're removing this.
+    // sec_cm_base_if_proxy if_proxy = sec_cm_pkg::find_sec_cm_if_proxy(
+    //     "tb.dut.u_lc_ctrl_kmac_if.u_state_regs");
+    // if_proxy.inject_fault();
   endtask
 
   // Flip bits in OTP State input

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
@@ -9,6 +9,8 @@ class lc_ctrl_state_failure_vseq extends lc_ctrl_errors_vseq;
 
   constraint num_trans_c {num_trans inside {[50 : 100]};}
 
+  // TODO(#19200): Removed due to ECO.
+  // err_inj.kmac_fsm_backdoor_err,
   constraint lc_state_failure_c {
     $onehot(
         {
@@ -19,7 +21,6 @@ class lc_ctrl_state_failure_vseq extends lc_ctrl_errors_vseq;
           err_inj.count_illegal_err,
           err_inj.count_backdoor_err,
           err_inj.lc_fsm_backdoor_err,
-          err_inj.kmac_fsm_backdoor_err,
           err_inj.otp_lc_data_i_valid_err
         }
     );

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_post_trans_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_post_trans_vseq.sv
@@ -9,6 +9,8 @@ class lc_ctrl_state_post_trans_vseq extends lc_ctrl_errors_vseq;
 
   constraint num_trans_c {num_trans inside {[10 : 15]};}
   constraint post_trans_c {
+    // TODO(#19200): Due to the ECO hack we're disabling error injection on this FSM.
+    err_inj.kmac_fsm_backdoor_err == 0;
     err_inj.post_trans_err == 1;
     // Allow for post_trans_err plus one other error
     // 50% just post_trans_err

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -283,7 +283,8 @@ module tb;
   `DV_ASSERT_CTRL("FsmStateRegs_A", tb.dut.FpvSecCmCtrlLcFsmCheck_A)
   `DV_ASSERT_CTRL("CountRegs_A", tb.dut.u_lc_ctrl_fsm.u_cnt_regs_A)
   `DV_ASSERT_CTRL("CountRegs_A", tb.dut.FpvSecCmCtrlLcCntCheck_A)
-  `DV_ASSERT_CTRL("KmacFsmStateRegs_A", tb.dut.u_lc_ctrl_kmac_if.u_state_regs_A)
-  `DV_ASSERT_CTRL("KmacFsmStateRegs_A", tb.dut.FpvSecCmCtrlKmacIfFsmCheck_A)
+  // TODO(#19200): Due to the ECO hack we're disabling the SVA.
+  // `DV_ASSERT_CTRL("KmacFsmStateRegs_A", tb.dut.u_lc_ctrl_kmac_if.u_state_regs_A)
+  // `DV_ASSERT_CTRL("KmacFsmStateRegs_A", tb.dut.FpvSecCmCtrlKmacIfFsmCheck_A)
   `DV_ASSERT_CTRL("EscStaysOnOnceAsserted_A", tb.dut.u_lc_ctrl_fsm.EscStaysOnOnceAsserted_A)
 endmodule

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -813,11 +813,12 @@ module lc_ctrl
       u_lc_ctrl_fsm.fsm_state_q inside {ResetSt, EscalateSt, PostTransSt, InvalidSt, ScrapSt} ||
       u_lc_ctrl_fsm.esc_scrap_state0_i ||
       u_lc_ctrl_fsm.esc_scrap_state1_i)
- `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlKmacIfFsmCheck_A,
-      u_lc_ctrl_kmac_if.u_state_regs, alert_tx_o[1],
-      u_lc_ctrl_fsm.fsm_state_q inside {EscalateSt} ||
-      u_lc_ctrl_fsm.esc_scrap_state0_i ||
-      u_lc_ctrl_fsm.esc_scrap_state1_i)
+  // TODO(#19200): Due to the ECO hack we're disabling the SVA.
+  // `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlKmacIfFsmCheck_A,
+  //      u_lc_ctrl_kmac_if.u_state_regs, alert_tx_o[1],
+  //      u_lc_ctrl_fsm.fsm_state_q inside {EscalateSt} ||
+  //      u_lc_ctrl_fsm.esc_scrap_state0_i ||
+  //      u_lc_ctrl_fsm.esc_scrap_state1_i)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[2])


### PR DESCRIPTION
Tying this signal off to zero will eliminate the CDC issue. Note that this will functionally not impair the design - the error signal would otherwise only be set to 1 in case the interface FSM is glitched into an invalid state.

See #19200 for more information.