### PR TITLE
[otbn,dv] Wait more carefully for secure wipes, fixing CDC errors

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -187,6 +187,33 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
     return (d_user_data_q.size() > 0);
   endfunction
 
+  // Return true if the interface is completely silent
+  virtual function logic is_silent();
+    return !((agent_type == PushAgent) ?
+             (vif.mon_cb.valid || vif.mon_cb.ready) :
+             (vif.mon_cb.req || vif.mon_cb.ack));
+  endfunction
+
+  // Return true if there's a stalled transaction
+  //
+  // If this is a pull agent, there is a stalled transaction when the req signal is high (so
+  // something is trying to read data), but the ack signal is low (there's no data available). If it
+  // is a push agent, there is a stalled transaction when the valid signal is high (so something is
+  // trying to provide data) but the ready signal is low (the data isn't being consumed).
+  virtual function logic is_stalled();
+    return ((agent_type == PushAgent) ?
+            (vif.mon_cb.valid && !vif.mon_cb.ready) :
+            (vif.mon_cb.req && !vif.mon_cb.ack));
+  endfunction
+
+  // Wait for any current transaction to finish
+  //
+  virtual task wait_while_running();
+    while (is_stalled()) @(vif.mon_cb);
+    // Add one last cycle to wait past the final cycle for the transaction that was stalled.
+    @(vif.mon_cb);
+  endtask
+
   `uvm_object_param_utils_begin(push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
     `uvm_field_enum(push_pull_agent_e, agent_type,         UVM_DEFAULT)
     `uvm_field_enum(pull_handshake_e, pull_handshake_type, UVM_DEFAULT)

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -570,13 +570,13 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     end
     else `uvm_fatal(`gfn, $sformatf("Bad alert name: %0s", alert_name));
 
-    // Wait up to 400 cycles for the prediction to come through (giving up on reset).  This is a
-    // long time, but that's needed because an error that comes in when we're running will cause an
-    // immediate alert but the status change will only appear after secure wipe is done.  A secure
-    // wipe includes a reseed of the URND, and the time for that depends on the EDN.  Note that
-    // the alert might be here already, in which case `wait_for_expected_alert` will take zero time.
+    // Wait some time for the prediction to come through (giving up on reset). We have to wait quite
+    // a while, but that's needed because an error that comes in when we're running will cause an
+    // immediate alert but the status change will only appear after secure wipe is done. A secure
+    // wipe includes a reseed of the URND, and the time for that depends on the EDN. Note that the
+    // alert might be here already, in which case `wait_for_expected_alert` will take zero time.
     fork
-      wait_for_expected_alert(alert_name, 400);
+      wait_for_expected_alert(alert_name, 4000);
     join_none
   endfunction
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -854,4 +854,66 @@ class otbn_base_vseq extends cip_base_vseq #(
       dut_init("HARD");
     end
   endtask
+
+  // Wait for a single beat of data on an EDN interface
+  //
+  // This waits until it has seen the end of a beat. If we are in the middle of a beat, it will just
+  // wait until the end of this one. Otherwise, it will wait for the next one to start.
+  protected task wait_edn_beat(edn_idx_e iface_idx, int max_wait_before);
+    // Wait at least one cycle (EDN clock) to clear any finishing beat on the EDN interface. Then
+    // wait up to max_wait_before cycles (main clock) for OTBN to ask for some data.
+    @(cfg.m_edn_pull_agent_cfgs[iface_idx].vif.mon_cb);
+    for (int i = 0; i < max_wait_before; ++i) begin
+      if (!cfg.m_edn_pull_agent_cfgs[iface_idx].is_silent()) break;
+      @(cfg.clk_rst_vif.cbn);
+    end
+
+    // Now we know that OTBN is asking for *something*. Wait until the beat has completed.
+    cfg.m_edn_pull_agent_cfgs[iface_idx].wait_while_running();
+  endtask
+
+   // Wait for a reseed on RND or URND
+   //
+   // This assumes that none of the 8 beats of data had been transferred so far, so it waits for each
+   // of them. The max_wait_before argument gives the number of cycles allowed before OTBN asks for
+   // each beat of data.
+   //
+   // If we are called when some beats have already been transferred then we'll end up waiting some
+   // multiple of max_wait_before cycles after the reseed has finished.
+   protected task wait_edn_reseed(edn_idx_e iface_idx, int max_wait_before);
+     repeat (8) wait_edn_beat(iface_idx, max_wait_before);
+   endtask
+
+   // Wait for one phase of a secure wipe
+   //
+   // This might take a bit of time because it needs to reseed over URND and also walk over the
+   // registers. To give ourselves enough time, we wait for the URND reseed and then an extra 64
+   // cycles.
+   protected task wait_secure_wipe_phase();
+     // A secure wipe phase consists of wiping with whatever data we've currently got from the EDN
+     // (takes 64 cycles), then reseeding over the EDN (depends on EDN timing).
+     //
+     // As a special case, the RTL doesn't bother reseeding over the EDN on the second pass if it
+     // knows it's done because it's locking anyway. In that case, this task will wait too long
+     // because it will wait some extra cycles for an EDN transaction that doesn't happen.
+     //
+     // Wipe with whatever we've currently got from the EDN
+     repeat (64) @(cfg.clk_rst_vif.cbn);
+
+     // Ask the EDN for more data
+     //
+     // We pass 10 as max_wait_before in the call to wait_edn_reseed: we expect the secure wipe to
+     // start immediately, but wish to allow a couple of cycles leeway, in case the thing that
+     // caused the wipe is *now*.
+     wait_edn_reseed(UrndEdnIdx, 10);
+
+   endtask
+
+   // Wait for a secure wipe
+   //
+   // This is just waiting for the two phases, one after the other.
+   task wait_secure_wipe();
+     repeat (2) wait_secure_wipe_phase();
+   endtask
+
 endclass : otbn_base_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -81,10 +81,9 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
     @(cfg.clk_rst_vif.cbn);
     release_force();
 
-    // OTBN should now do a secure wipe. Give it up to 400 cycles to do so (because it needs to go
-    // twice over all registers and reseed URND in between, the time of which depends on the delay
-    // configured in the EDN model).
-    cfg.clk_rst_vif.wait_n_clks(400);
+    // OTBN should now do a secure wipe
+    wait_secure_wipe();
+
     // We should now be in a locked state after the secure wipe.
     `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
     // The scoreboard will have seen the transition to locked state and inferred that it should


### PR DESCRIPTION
This change fixes a failure that you could see when CDC was enabled by running:
```
    util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_rf_base_intg_err --fixed-seed 123
```

There were actually two problems. The first failure was caused by the fact that we weren't waiting long enough in the vseq for the RTL's status to become Locked. This is because the secure wipe takes longer with CDC and the existing 400 cycle wait wasn't enough. Fixing this isn't too hard: you just have to track the phases of the secure wipe more carefully.

Fixing that turned out not to be enough! We've also got some logic that does a similar wait in `otbn_scoreboard.sv`. Rather than duplicating the "wait for secure wipe" logic yet again, I just bumped the timeout. If this turns out to be fragile, we could do some more careful tracking.