### PR TITLE
[aes, dv] fix aes_manual_config_err sequence

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -93,7 +93,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   //   [2]: reseed error
   //   [1]: mode error
   //   [0]: key_len
-  cfg_error_type_t   config_error_type          = 3'b000;
+  cfg_error_type_t   config_error_type          = 3'b111;
   int                config_error_pct           = 30;
 
   // min and max wait (clk) before an error injection

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -202,9 +202,9 @@ class aes_message_item extends uvm_sequence_item;
     solve sideload_en before cfg_error_type;
     if (has_config_error) {
       cfg_error_type inside {[1:7]};
-      config_error_type_en[0] -> cfg_error_type[0] == 0;
-      config_error_type_en[1] -> cfg_error_type[1] == 0;
-      config_error_type_en[2] -> cfg_error_type[2] == 0;
+      config_error_type_en[0] == 0 -> cfg_error_type[0] == 0;
+      config_error_type_en[1] == 0 -> cfg_error_type[1] == 0;
+      config_error_type_en[2] == 0 -> cfg_error_type[2] == 0;
     } else {
       cfg_error_type == 3'b000;
     }

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -18,6 +18,7 @@ class aes_config_error_test extends aes_base_test;
 
     cfg.error_types              = 4'b0001;
     cfg.config_error_pct         = 75;
+    cfg.config_error_type        = 3'b111;
     cfg.num_messages_min         = 3;
     cfg.num_messages_max         = 10;
     // message related knobs


### PR DESCRIPTION
This is required for lowRISC/OpenTitan#19025 .