### PR TITLE
[aes, dv] Prepare test sequences for enabling stress_all(_with_rand_reset) tests

### DIFF
--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -101,6 +101,7 @@
 
   // List of test specifications.
   tests: [
+    // (basic) Directed tests for which the scoreboard is disabled.
     {
       name: aes_wake_up
       uvm_test: aes_wake_up_test
@@ -113,6 +114,22 @@
       uvm_test_seq: aes_nist_vectors_vseq
       reseed: 1
     }
+    {
+      name: aes_deinit
+      uvm_test: aes_deinit_test
+      uvm_test_seq: aes_deinit_vseq
+    }
+    {
+      name: aes_man_cfg_err
+      uvm_test: aes_manual_config_err_test
+      uvm_test_seq: aes_manual_config_err_vseq
+    }
+    {
+      name: aes_readability
+      uvm_test: aes_fi_test
+      uvm_test_seq: aes_readability_vseq
+    }
+    // Regular tests for which the scoreboard is active.
     {
       name: aes_smoke
       uvm_test: aes_smoke_test
@@ -149,20 +166,11 @@
       uvm_test_seq: aes_stress_vseq
     }
     {
-      name: aes_deinit
-      uvm_test: aes_deinit_test
-      uvm_test_seq: aes_deinit_vseq
-    }
-    {
-      name: aes_man_cfg_err
-      uvm_test: aes_manual_config_err_test
-      uvm_test_seq: aes_manual_config_err_vseq
-    }
-    {
       name: aes_reseed
       uvm_test: aes_reseed_test
       uvm_test_seq: aes_reseed_vseq
     }
+    // FI tests for which the scoreboard is disabled.
     {
       name: aes_fi
       uvm_test: aes_alert_reset_test
@@ -193,11 +201,6 @@
       uvm_test: aes_fi_test
       uvm_test_seq: aes_core_fi_vseq
       reseed: 70 // Test must cover 35 bins. Overseed by 2x to get reasonable coverage.
-    }
-    {
-      name: aes_readability
-      uvm_test: aes_fi_test
-      uvm_test_seq: aes_readability_vseq
     }
   ]
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -13,16 +13,24 @@ class aes_stress_vseq extends aes_base_vseq;
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
                               cfg.convert2string()), UVM_LOW)
 
-
+    // Create one thread such that we can kill all its children without unwanted side effects on the
+    // caller.
     fork
-      // generate list of messages //
-      generate_message_queue();
-      // start sideload (even if not used)
-      start_sideload_seq();
-    join_any
-    // process all messages //
-    send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+      begin
 
+        fork
+          // generate list of messages //
+          generate_message_queue();
+          // start sideload (even if not used)
+          start_sideload_seq();
+        join_any
+        // process all messages //
+        send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+
+      end
+    // Kill all children.
+    disable fork;
+    join
 
   endtask : body
 endclass


### PR DESCRIPTION
The changes in this PR should be totally uncontroversial as the functionality of the sequences isn't changed. But this PR prepares these sequences for enabling the stress_all(_with_rand_reset) tests.

This is related to #19025.