### PR TITLE
[sca, sha3, kmac] Fix SHA3 captures by properly initializing KMAC config

### DIFF
--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -429,10 +429,13 @@ static void kmac_init(void) {
 
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_fast_process = kDifToggleDisabled,
       .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
                        0x70410fef},
-      .entropy_fast_process = false,
-      .msg_mask = true,
+      .message_big_endian = kDifToggleDisabled,
+      .output_big_endian = kDifToggleDisabled,
+      .sideload = kDifToggleDisabled,
+      .msg_mask = kDifToggleEnabled,
   };
   SS_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -71,6 +71,20 @@ enum {
 static dif_kmac_t kmac;
 
 /**
+ * The KMAC config.
+ */
+static dif_kmac_config_t config = (dif_kmac_config_t){
+    .entropy_mode = kDifKmacEntropyModeSoftware,
+    .entropy_fast_process = kDifToggleDisabled,
+    .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
+                     0x70410fef},
+    .message_big_endian = kDifToggleDisabled,
+    .output_big_endian = kDifToggleDisabled,
+    .sideload = kDifToggleDisabled,
+    .msg_mask = kDifToggleEnabled,
+};
+
+/**
  * KMAC operation state.
  */
 static dif_kmac_operation_state_t kmac_operation_state;
@@ -344,14 +358,6 @@ static void kmac_init(void) {
   SS_CHECK_DIF_OK(
       dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
-  dif_kmac_config_t config = (dif_kmac_config_t){
-      .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0xaa25b4bf, 0x48ce8fff, 0x5a78282a, 0x48465647,
-                       0x70410fef},
-      .entropy_fast_process = false,
-      .msg_mask = true,
-  };
-
   SS_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   kmac_block_until_idle();
@@ -367,14 +373,13 @@ static void kmac_disable_masking(const uint8_t *masks_off, size_t off_len) {
   SS_CHECK_DIF_OK(
       dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
-  dif_kmac_config_t config;
   if (masks_off[0]) {
-    config.entropy_fast_process = true;
-    config.msg_mask = false;
+    config.entropy_fast_process = kDifToggleEnabled;
+    config.msg_mask = kDifToggleDisabled;
     LOG_INFO("Initializing the KMAC peripheral with masking disabled.");
   } else {
-    config.entropy_fast_process = false;
-    config.msg_mask = true;
+    config.entropy_fast_process = kDifToggleDisabled;
+    config.msg_mask = kDifToggleEnabled;
     LOG_INFO("Initializing the KMAC peripheral with masking enabled.");
   }
   SS_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));


### PR DESCRIPTION
Previously, kmac_disable_masking() did not correctly initialize the full KMAC config struct. As a result of using uninitialized memory, it could happen that the endianness when reading the state got changed which completely broke all SHA3 captures.

This commit fixes that by creating a static KMAC config which, for the sake of documentation, initializes all relevant struct variables to the correct value. kmac_disable_masking() then just modifies the variables required to switch off the masking.