### PR TITLE
[dv,top_level] Fix a couple top-level sysrst_ctrl tests for CDC

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_outputs_vseq.sv
@@ -70,6 +70,8 @@ class chip_sw_sysrst_ctrl_outputs_vseq extends chip_sw_base_vseq;
   virtual task sync_with_sw();
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
+    // Wait some additional aon cycles for the synchronizers.
+    cfg.chip_vif.aon_clk_por_rst_if.wait_clks(3);
   endtask
 
   virtual task check_loopback_pattern();

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
@@ -195,6 +195,7 @@ bool test_main(void) {
       &sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, kDifToggleDisabled));
 
   while (kTestPhase < kTestPhaseDone) {
+    LOG_INFO("Running test phase %d", kTestPhase);
     switch (kTestPhase) {
       case kTestPhaseSetup:
         CHECK(rstmgr_reset_info == kDifRstmgrResetInfoPor);


### PR DESCRIPTION
These tests need some additional wait cycles for synchronizers to percolate.

Partially addresses #16689