### PR TITLE
[chip,dv] Add early cpu init option

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -121,6 +121,14 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // it will be updated in chip_base_test::build
   uint flash_write_latency_in_us = 0;
 
+  // Add early cpu init
+  // early_cpu_init has been introduced to address the issue
+  // that cpu_init is called during the boot time when pre_start task takes too long
+  // to finish.
+  // When this knob is set, call cpu_init task during reset period, chip_base_vseq::dut_init,
+  // and skip cpu_init in chip_sw_base_vseq::body
+  bit early_cpu_init = 0;
+
   // NOTE: The clk_freq_mhz variable created in the base class was meant to be used by clk_rst_vif
   // interface that is passed by default by the testbench (retrieved by dv_base_env class). It was
   // meant for a CIP-compliant testbench to drive the clock and reset to the DUT. The chip level

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -23,10 +23,6 @@ class chip_base_vseq #(
   // Skip POR_N : required for closed source test
   bit skip_por_n_during_first_pwrup = 0;
 
-  // Knob to start cpu_init in pre_start phase
-  // You have to set this knob before or within dut_init task
-  bit early_cpu_init = 0;
-
   `uvm_object_new
 
   virtual function void set_handles();
@@ -161,7 +157,7 @@ class chip_base_vseq #(
       cfg.mem_bkdr_util_h[chip_mem_e'(OtbnDmem0 + ram_idx)].clear_mem();
     end
     // Early cpu init
-    if (early_cpu_init) cpu_init();
+    if (cfg.early_cpu_init) cpu_init();
     // Bring the chip out of reset.
     super.dut_init(reset_kind);
     alert_ping_en_shorten();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -222,7 +222,13 @@ class chip_sw_base_vseq extends chip_base_vseq;
   virtual task body();
     cfg.sw_test_status_vif.set_num_iterations(num_trans);
     // Initialize the CPU to kick off the sw test. TODO: Should be called in pre_start() instead.
-    cpu_init();
+    if (cfg.early_cpu_init) begin
+      // if early_cpu_init is set, cpu_init is called from
+      // dut_init
+      `uvm_info(`gfn, "early_cpu_init is set. cpu_init is called during dut init", UVM_LOW)
+    end else begin
+      cpu_init();
+    end
   endtask
 
   virtual task post_start();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_base_vseq.sv
@@ -29,7 +29,7 @@ class chip_sw_lc_base_vseq extends chip_sw_base_vseq;
   endfunction : backdoor_override_otp
 
   virtual task dut_init(string reset_kind = "HARD");
-    early_cpu_init = 1;
+    cfg.early_cpu_init = 1;
     super.dut_init(reset_kind);
 
     // If init state is not reset state (DecLcStInvalid),

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -79,6 +79,9 @@ class chip_base_test extends cip_base_test #(
     // Knob to add vendor flash write latency
     void'($value$plusargs("flash_write_latency_in_us=%d", cfg.flash_write_latency_in_us));
 
+    // Knob to set early_cpu_init
+    void'($value$plusargs("early_cpu_init=%b", cfg.early_cpu_init));
+
     // Set the test timeout value to be sufficiently large.
     test_timeout_ns = 50_000_000;
     test_timeout_ns = `DV_MAX2(test_timeout_ns, 5 * cfg.sw_test_timeout_ns);


### PR DESCRIPTION
cpu_init is called from chip_sw_base_vseq::body.
If there is a task taking large latency, this can causes to call cpu_init much later 
then reset de-assert and creates false errors. 
Add early cpu init option to avoid these false errors