### PR TITLE
Fix logic in start_running_otbn to get some CDC tests working

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -732,8 +732,7 @@ class otbn_base_vseq extends cip_base_vseq #(
           // from the model (which is also in sync with the RTL). Because we wait on the negedge
           // when updating cycle_counter above, we know we've got the "new version" of the status at
           // this point.
-          if (cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
-                                                   otbn_pkg::StatusBusySecWipeInt}) begin
+          if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute) begin
             timed_out = 1'b1;
           end else begin
             timed_out = 1'b0;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -20,9 +20,11 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
         rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_en_a :
                                        cfg.trace_vif.rf_base_rd_en_b;
       end while(!rd_en);,
-      cfg.clk_rst_vif.wait_clks(2000);,
-      "Not getting selected rd_en from OTBN for 2000 cycles!"
+      cfg.clk_rst_vif.wait_clks(2000);
     )
+    if (!rd_en) begin
+      `uvm_fatal(`gfn, "Register file was not used before time limit")
+    end
   endtask
 
   function bit [otbn_pkg::BaseIntgWidth-1:0] corrupt_data(


### PR DESCRIPTION
The first of the two commits is not too important: it just makes a vseq fail more understandably if something goes wrong. The second commit is the core of the change: it ensures that `start_running_otbn` has the behaviour that I think I originally intended, and that the vseqs using it expect! :-)