### PR TITLE
Otbn rf base intg err

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -11,6 +11,11 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
   `uvm_object_new
   rand bit insert_intg_err_to_a;
 
+  // Wait until the selected register file is being used
+  //
+  // This will normally just be a couple of cycles (because most instructions read from the register
+  // file), but it might be a bit longer if we happen to be stalled waiting for the EDN, which
+  // happens on a RND read.
   task await_use();
     logic rd_en;
     `uvm_info(`gfn, "Waiting for selected RF to be used", UVM_LOW)
@@ -20,7 +25,7 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
         rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_en_a :
                                        cfg.trace_vif.rf_base_rd_en_b;
       end while(!rd_en);,
-      cfg.clk_rst_vif.wait_clks(2000);
+      cfg.clk_rst_vif.wait_clks(20000);
     )
     if (!rd_en) begin
       `uvm_fatal(`gfn, "Register file was not used before time limit")


### PR DESCRIPTION
This PR has two commits. The first also appears in #19222 (which also needs it). The interesting bit of this PR is the second commit, which fixes an occasional failure in the `otbn_rf_base_intg_err` test when CDC is enabled. Its commit message is:

**[otbn,dv] Wait long enough for RF read in otbn_rf_base_intg_err_vseq**

This vseq wants to start an OTBN run and then, at some time after the
run has started, corrupt the next read of the base register file. Of
course, this needs a bit of a wait: we need to wait until the base
register file is being read. This wait is usually very short (we read
from the RF with most instructions) but is rather longer if we happen
to be stalled reading from RND!

The stall for a RND read is longer when CDC is enabled, and pushed us
over the 2000 cycle max wait. Increasing by another multiple of 10
seems to fix things.


This vseq wants to start an OTBN run and then, at some time after the
run has started, corrupt the next read of the base register file. Of
course, this needs a bit of a wait: we need to wait until the base
register file is being read. This wait is usually very short (we read
from the RF with most instructions) but is rather longer if we happen
to be stalled reading from RND!

The stall for a RND read is longer when CDC is enabled, and pushed us
over the 2000 cycle max wait. Increasing by another multiple of 10
seems to fix things.
