### PR TITLE
[otbn,dv] Fix missing connections when binding in otbn_loop_if

### DIFF
--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -167,7 +167,9 @@ module tb;
       .current_loop_d_iterations (prefetch_loop_iterations_o),
       .current_loop_q_iterations (current_loop.loop_iterations),
 
-      .loop_stack_rd_idx
+      .loop_stack_rd_idx,
+      .loop_stack_push,
+      .loop_stack_pop
     );
 
   bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);


### PR DESCRIPTION
This causes a warning in the build log (from `xmelab` with Xcelium) and causes these signals to have value `'z` instead of 0 or 1. Once that has happened, any test with a loop warp will fail (because it checks that we're not pushing/popping the loop stack and the check doesn't pass when the signal happens to be `'z`).