### PR TITLE
[otbn,dv] Disable RTL assertions in otbn_zero_state_err_urnd test

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -7,6 +7,14 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
   `uvm_object_new
 
   task body();
+    // Disable some assertions in the RTL which assert that the base registers don't get
+    // secure-wiped to zero. Of course, they do in this test, so we need to disable the assertions.
+    //
+    // Note that we can't disable them more specifically because there is at least one assertion for
+    // each register and you can't use a "for" loop because $assertoff() expects a hierarchical
+    // identifier for the assertion to control, rather than just an expression.
+    $assertoff(0, tb.dut);
+
     do_end_addr_check = 0;
     fork
       begin


### PR DESCRIPTION
The problem is that the design RTL contains assertions like `InitSecWipeNonZeroBaseRegs_A`, which assert that each register has been initialised to a nonzero value during secure wipe. This is reasonable, but isn't true in this test: that's kind of the point!