### PR TITLE
[bazel] Add `//quality:rustfmt_fix` and switch CI to use `//quality:rustfmt_check`

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -4,7 +4,7 @@
 
 load("@ot_hack_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 load("@lowrisc_lint//rules:rules.bzl", "licence_test")
-load("//rules:quality.bzl", "clang_format_check", "clang_format_test", "clang_tidy_rv_test", "clang_tidy_test", "html_coverage_report")
+load("//rules:quality.bzl", "clang_format_check", "clang_format_test", "clang_tidy_rv_test", "clang_tidy_test", "html_coverage_report", "rustfmt_fix")
 load("@rules_rust//rust:defs.bzl", "rustfmt_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -80,7 +80,7 @@ licence_test(
     workspace = "//:WORKSPACE",
 )
 
-clang_format_exclude = [
+format_exclude = [
     # Vendored source code dirs
     "./**/vendor/**",
     # Rust cargo build dirs
@@ -94,14 +94,14 @@ clang_format_exclude = [
 
 clang_format_test(
     name = "clang_format_check",
-    exclude_patterns = clang_format_exclude,
+    exclude_patterns = format_exclude,
     mode = "diff",
     workspace = "//:WORKSPACE",
 )
 
 clang_format_check(
     name = "clang_format_fix",
-    exclude_patterns = clang_format_exclude,
+    exclude_patterns = format_exclude,
     mode = "fix",
 )
 
@@ -189,6 +189,11 @@ RUST_TARGETS = [
 rustfmt_test(
     name = "rustfmt_check",
     targets = RUST_TARGETS,
+)
+
+rustfmt_fix(
+    name = "rustfmt_fix",
+    exclude_patterns = format_exclude,
 )
 
 html_coverage_report(

--- a/rules/scripts/rustfmt.template.sh
+++ b/rules/scripts/rustfmt.template.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+RUSTFMT=@@RUSTFMT@@
+WORKSPACE="@@WORKSPACE@@"
+rustfmt=$(realpath "$RUSTFMT")
+
+if [[ ! -z "${WORKSPACE}" ]]; then
+    REPO="$(dirname "$(realpath ${WORKSPACE})")"
+    cd ${REPO} || exit 1
+elif [[ ! -z "${BUILD_WORKSPACE_DIRECTORY+is_set}" ]]; then
+    cd ${BUILD_WORKSPACE_DIRECTORY} || exit 1
+else
+    echo "Neither WORKSPACE nor BUILD_WORKSPACE_DIRECTORY were set."
+    echo "If this is a test rule, add 'workspace = \"//:WORKSPACE\"' to your rule."
+    exit 1
+fi
+
+if [[ $# != 0 ]]; then
+    FILES="$*"
+else
+    FILES=$(find . \
+        -type f \
+        @@EXCLUDE_PATTERNS@@ \
+        \( @@INCLUDE_PATTERNS@@ \) \
+        -print)
+fi
+
+echo "$FILES" | xargs ${rustfmt}


### PR DESCRIPTION
We have already switched Rust building to Bazel, and currently the only place where one needs to have rust toolchain installed is to run `rustfmt`.