### PR TITLE
[doc,report] Fix the dvsim report links to the testplans

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -4,6 +4,7 @@
 {
   project:          opentitan
   repo_server:      "github.com/lowrisc/opentitan"
+  book:             opentitan.org/book
   doc_server:       docs.opentitan.org
   results_server:   reports.opentitan.org
 

--- a/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
@@ -21,8 +21,8 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: "lowrisc:dv:{top_chip}_{dut}_sim:0.1"
 
-  // Set the path to testplan md file as it's not in the default location.
-  testplan_doc_path: "hw/ip/tlul/doc/dv/#testplan"
+  // Give the path to the testplan file since it's not in the default location.
+  testplan_doc_path: "{proj_root}/hw/ip/tlul/data/tlul_testplan.hjson"
 
   // Bypass VCS CHECK_SUM check as the exclusion file is generated without proper CHECK_SUM value
   vcs_cov_analyze_opts: ["-excl_bypass_checks"]

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -790,12 +790,34 @@ class SimCfg(FlowCfg):
         # Add path to testplan, only if it has entries (i.e., its not dummy).
         if self.testplan.testpoints:
             if hasattr(self, "testplan_doc_path"):
-                testplan = "https://{}/{}".format(self.doc_server,
-                                                  self.testplan_doc_path)
+                # The key 'testplan_doc_path' can override the path to the testplan file
+                # if it's not in the default location relative to the sim_cfg.
+                relative_path_to_testplan = (Path(self.testplan_doc_path)
+                                             .relative_to(Path(self.proj_root)))
+                testplan = "https://{}/{}".format(
+                    self.book,
+                    str(relative_path_to_testplan).replace("hjson", "html")
+                )
             else:
-                testplan = "https://{}/{}".format(self.doc_server,
-                                                  self.rel_path)
-                testplan = testplan.replace("/dv", "/doc/dv/#testplan")
+                # Default filesystem layout for an ip block
+                # ├── data
+                # │   ├── gpio_testplan.hjson
+                # │   └── <...>
+                # ├── doc
+                # │   ├── checklist.md
+                # │   ├── programmers_guide.md
+                # │   ├── theory_of_operation.md
+                # │   └── <...>
+                # ├── dv
+                # │   ├── gpio_sim_cfg.hjson
+                # │   └── <...>
+
+                # self.rel_path gives us the path to the directory
+                # containing the sim_cfg file...
+                testplan = "https://{}/{}".format(
+                    self.book,
+                    Path(self.rel_path).parent / 'data' / f"{self.name}_testplan.html"
+                )
 
             results_str += f"### [Testplan]({testplan})\n"
 


### PR DESCRIPTION
This was broken by the new documentation site structure.

This fix works for all blocks except the primitives, as some do not have testplans, and some have testplans which we do not currently render on the site. This can be fixed as a follow-up task.
Note. that the 'testplan_doc_path' key is a slighly hacky way of resolving the testplan path when a sim_cfg is imported by another one.

