### PR TITLE
[ci] curl downgrade, attempt 2

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -31,7 +31,11 @@ jobs:
       # https://github.com/curl/curl/issues/11475
       # https://bugs.launchpad.net/ubuntu/+source/curl/+bug/2028170
       - name: Workaround curl bug
-        run: sudo apt-get install --allow-downgrades -y curl=7.81.0-1 libcurl4=7.81.0-1
+        run: |
+          # Mark broken packages to have a lower priority than the currently installed
+          printf "Package: curl\nPin: version 7.81.0-1ubuntu1.11\nPin-Priority: 99\n\n" | sudo tee -a /etc/apt/preferences.d/curl-workaround.pref
+          printf "Package: libcurl4\nPin: version 7.81.0-1ubuntu1.11\nPin-Priority: 99\n\n" | sudo tee -a /etc/apt/preferences.d/curl-workaround.pref
+          sudo apt-get install --allow-downgrades -y curl=7.81.0-1 libcurl4=7.81.0-1
       - uses: actions/checkout@v3
         with:
           # Because `pull_request_target` runs at the PR's base, we need to


### PR DESCRIPTION
Continue #19239 

The first attempt doesn't fix the issue because chipsalliance/verible-linter-action upgrades the downgraded package back up to the broken version.

So also update /etc/apt/preferences.d to prevent these broken versions from being selected.

Tested here: https://github.com/nbdd0121/opentitan/actions/runs/5602237791/jobs/10247206074?pr=1