### PR TITLE
[bitstreams] Add rules to generate manifests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -425,20 +425,17 @@ jobs:
       set -ex
       trap 'get_logs' EXIT
       get_logs() {
-        SUB_PATH="hw/top_earlgrey"
-        mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
-        cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
+        mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310/
+        cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310/ \
           $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310)
-        cp -rLvt "$BIN_DIR/$SUB_PATH/" \
-          $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:standard)
-        # Rename bitstreams to be compatible with subsequent steps
-        # TODO(#13807): replace this after choosing a naming scheme
-        mv "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit" "$BIN_DIR/$SUB_PATH/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
+        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery \
+          //hw/bitstream/vivado:earlgrey_cw310_archive)
+        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
       }
 
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh build //hw/bitstream/vivado:standard
+      ci/bazelisk.sh build //hw/bitstream/vivado:earlgrey_cw310_archive
     condition: ne(variables.bitstreamStrategy, 'cached')
     displayName: Build and splice bitstream with Vivado
   - bash: |
@@ -450,10 +447,9 @@ jobs:
       cat $OBJ_DIR/hw/top_earlgrey/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
     condition: ne(variables.bitstreamStrategy, 'cached')
     displayName: Display synthesis & implementation logs
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      includePatterns:
-        - "/hw/***"
+  - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
+    artifact: partial-build-bin-$(System.PhaseName)
+    displayName: Upload step outputs
   - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: chip_earlgrey_cw310-build-out
     displayName: Upload artifacts for CW310
@@ -475,16 +471,16 @@ jobs:
       trap 'get_logs' EXIT
       get_logs() {
         mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/
-        mkdir -p $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/
         cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
           $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310_hyperdebug)
-        cp -rLvt $BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
-          $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:hyperdebug)
+        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery \
+          //hw/bitstream/vivado:earlgrey_cw310_hyperdebug_archive)
+        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
       }
 
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh build //hw/bitstream/vivado:fpga_cw310_hyperdebug
+      ci/bazelisk.sh build //hw/bitstream/vivado:earlgrey_cw310_hyperdebug_archive
     displayName: Build bitstream with Vivado
   - bash: |
       . util/build_consts.sh
@@ -547,14 +543,9 @@ jobs:
         . util/build_consts.sh
     - template: ci/gcp-upload-bitstream-template.yml
       parameters:
-        parentDir: "$BIN_DIR/hw/top_earlgrey"
-        includeFiles:
-          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
-          - "rom.mmi"
-          - "otp.mmi"
-          - "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit"
-          - "chip_earlgrey_cw310_hyperdebug/rom.mmi"
-          - "chip_earlgrey_cw310_hyperdebug/otp.mmi"
+        fragmentFiles:
+          - "$BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310/manifest.json"
+          - "$BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/manifest.json"
         gcpKeyFile: "gcpkey.json"
         bucketURI: "gs://opentitan-bitstreams/master"
 

--- a/ci/gcp-upload-bitstream-template.yml
+++ b/ci/gcp-upload-bitstream-template.yml
@@ -1,14 +1,14 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-  
+
 # Azure template for uploading artifacts to a Google Cloud Platform (GCP)
 # bucket.
 #
 # This template first installs gsutil to interact with GCP resources. Then,
-# files located under parentDir and at paths specified by includeFiles will be
-# packed into archiveName (a tar.gz file) and uploaded to a GCP bucket located
-# at bucketURI using gsutil.
+# files indicated by bitstream manifest fragments specified by fragmentFiles
+# will be packed into an archive (a tar.gz file) and uploaded to a GCP bucket
+# located at bucketURI using gsutil.
 #
 # Writing to a GCP bucket requires a GCP service account key with sufficient
 # permisions. This key must be uploaded to Azure as a Secure File. The name of
@@ -16,10 +16,7 @@
 #
 
 parameters:
-  - name: parentDir
-    type: string
-    default: ""
-  - name: includeFiles
+  - name: fragmentFiles
     type: object
     default: []
   - name: gcpKeyFile
@@ -40,7 +37,7 @@ steps:
       echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
         sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
       echo "vvvvvvvvv cat /etc/apt/sources.list.d/google-cloud-sdk.list"
-      cat /etc/apt/sources.list.d/google-cloud-sdk.list 
+      cat /etc/apt/sources.list.d/google-cloud-sdk.list
       echo "^^^^^^^^"
       curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.gpg
       sudo apt-get update || {
@@ -50,8 +47,15 @@ steps:
 
       . util/build_consts.sh
       printf "$(date -u +%Y-%m-%dT%H:%M:%S)\n$(Build.SourceVersion)" > latest.txt
-      printf "${{ join('\n', parameters.includeFiles) }}" > include_files.txt
-      tar -C ${{ parameters.parentDir }} -zcvf bitstream-latest.tar.gz -T include_files.txt
+      ci/bazelisk.sh build //util/py/scripts:bitstream_cache_create
+      printf "${{ join('\n', parameters.fragmentFiles) }}" > fragment_files.txt
+      mapfile -t fragments < fragment_files.txt
+      ./util/py/scripts/bitstream_cache_create.py \
+        --schema rules/scripts/bitstreams_manifest.schema.json \
+        --stamp-file bazel-out/volatile-status.txt \
+        --out $BIN_DIR/bitstream-cache \
+        "${fragments[@]}"
+      mv $BIN_DIR/bitstream-cache/bitstream-cache.tar.gz bitstream-latest.tar.gz
 
       gsutil -o Credentials:gs_service_key_file=$(gcpkey.secureFilePath) \
         cp latest.txt ${{ parameters.bucketURI }}/latest.txt
@@ -62,4 +66,3 @@ steps:
     condition: succeeded()
     continueOnError: true
     displayName: Upload bitstreams to GCP bucket
-

--- a/ci/scripts/get-bitstream-fragment-dir.bzl
+++ b/ci/scripts/get-bitstream-fragment-dir.bzl
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def format(target):
+    provider_name = "//rules:bitstreams.bzl%BitstreamManifestFragmentInfo"
+    return providers(target)[provider_name].fragment.dirname

--- a/ci/scripts/get-bitstream-fragment-files-relative.bzl
+++ b/ci/scripts/get-bitstream-fragment-files-relative.bzl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def format(target):
+    provider_name = "//rules:bitstreams.bzl%BitstreamManifestFragmentInfo"
+    manifest_dir = providers(target)[provider_name].fragment.dirname
+    file_list = target.files.to_list()
+    rel_paths = [x.path.removeprefix(manifest_dir + "/") for x in file_list]
+    return "\n".join(rel_paths)

--- a/ci/scripts/make_distribution.sh
+++ b/ci/scripts/make_distribution.sh
@@ -25,8 +25,7 @@ readonly DIST_ARTIFACTS=(
   'sw/device/*.bin'
   'sw/device/*.vmem'
   'hw/top_earlgrey/Vchip_earlgrey_verilator'
-  'hw/top_earlgrey/lowrisc_systems_chip_earlgrey_*.bit.*'
-  'hw/top_earlgrey/*.mmi'
+  'hw/top_earlgrey/chip_earlgrey_cw310/*'
 )
 
 DIST_DIR="$OBJ_DIR/$OT_VERSION"

--- a/ci/scripts/run-fpga-cw310-tests.sh
+++ b/ci/scripts/run-fpga-cw310-tests.sh
@@ -21,16 +21,10 @@ cw310_tags=("$@")
 
 # Copy bitstreams and related files into the cache directory so Bazel will have
 # the corresponding targets in the @bitstreams workspace.
-#
-# TODO(#13807) Update this when we change the naming scheme.
 readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${SHA}"
-readonly BIT_SRC_DIR="${BIN_DIR}/hw/top_earlgrey"
-readonly BIT_NAME_PREFIX="lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+readonly BIT_SRC_DIR="${BIN_DIR}/hw/top_earlgrey/chip_earlgrey_cw310"
 mkdir -p "${BIT_CACHE_DIR}"
-cp "${BIT_SRC_DIR}/${BIT_NAME_PREFIX}.orig" \
-    "${BIT_SRC_DIR}/otp.mmi"  \
-    "${BIT_SRC_DIR}/rom.mmi" \
-    "${BIT_CACHE_DIR}"
+cp -rt "${BIT_CACHE_DIR}" "${BIT_SRC_DIR}"/*
 
 echo -n "$SHA" > "${BIT_CACHE_DIR}/../../latest.txt"
 export BITSTREAM="--offline --list ${SHA}"

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -5,6 +5,7 @@
 load("//rules:splice.bzl", "bitstream_splice")
 load("//rules:otp.bzl", "get_otp_images")
 load("//rules:const.bzl", "KEY_AUTHENTICITY")
+load("//rules:bitstreams.bzl", "bitstream_fragment_from_manifest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -161,3 +162,28 @@ bitstream_splice(
     for (otp_name, img_target) in get_otp_images()
     for authenticity in KEY_AUTHENTICITY
 ]
+
+# Create manifest fragments for all the cached bitstreams
+bitstream_fragment_from_manifest(
+    name = "chip_earlgrey_cw310_cached_fragment",
+    srcs = [
+        "@bitstreams//:chip_earlgrey_cw310_bitstream",
+        "@bitstreams//:chip_earlgrey_cw310_otp_mmi",
+        "@bitstreams//:chip_earlgrey_cw310_rom_mmi",
+    ],
+    design = "chip_earlgrey_cw310",
+    manifest = "@bitstreams//:manifest",
+    tags = ["manual"],
+)
+
+bitstream_fragment_from_manifest(
+    name = "chip_earlgrey_cw310_hyperdebug_cached_fragment",
+    srcs = [
+        "@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream",
+        "@bitstreams//:chip_earlgrey_cw310_hyperdebug_otp_mmi",
+        "@bitstreams//:chip_earlgrey_cw310_hyperdebug_rom_mmi",
+    ],
+    design = "chip_earlgrey_cw310_hyperdebug",
+    manifest = "@bitstreams//:manifest",
+    tags = ["manual"],
+)

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -173,10 +173,10 @@ bitstream_manifest_fragment(
 pkg_tar(
     name = "earlgrey_cw310_archive",
     testonly = True,
-    mode = "0444",
     srcs = [":earlgrey_cw310_manifest"],
-    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_manifest",
+    mode = "0444",
     package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw310",
+    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_manifest",
     tags = ["manual"],
 )
 
@@ -196,10 +196,10 @@ bitstream_manifest_fragment(
 pkg_tar(
     name = "earlgrey_cw310_hyperdebug_archive",
     testonly = True,
-    mode = "0444",
     srcs = [":earlgrey_cw310_hyperdebug_manifest"],
-    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_hyperdebug_manifest",
+    mode = "0444",
     package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug",
+    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_hyperdebug_manifest",
     tags = ["manual"],
 )
 
@@ -226,9 +226,7 @@ pkg_files(
     name = "hyperdebug",
     testonly = True,
     srcs = [
-        ":fpga_cw310_test_rom_hyp",
-        ":otp_mmi_hyp",
-        ":rom_mmi_hyp",
+        ":fpga_cw310_hyperdebug_manifest",
     ],
     prefix = "earlgrey/fpga_cw310/hyperdebug",
     tags = ["manual"],

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:const.bzl", "KEY_AUTHENTICITY")
 load("//rules:fusesoc.bzl", "fusesoc_build")
 load("//rules:otp.bzl", "get_otp_images")
 load("//rules:splice.bzl", "bitstream_splice")
 load("//rules:const.bzl", "KEY_AUTHENTICITY")
+load("//rules:bitstreams.bzl", "bitstream_manifest_fragment")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -151,6 +153,53 @@ filegroup(
     testonly = True,
     srcs = [":fpga_cw310_hyperdebug"],
     output_group = "otp_mmi",
+    tags = ["manual"],
+)
+
+# Bitstream cache manifest fragment targets
+bitstream_manifest_fragment(
+    name = "earlgrey_cw310_manifest",
+    testonly = True,
+    srcs = [":fpga_cw310"],
+    bitstream = "bitstream",
+    design = "chip_earlgrey_cw310",
+    memory_maps = {
+        "rom_mmi": "rom",
+        "otp_mmi": "otp",
+    },
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "earlgrey_cw310_archive",
+    testonly = True,
+    mode = "0444",
+    srcs = [":earlgrey_cw310_manifest"],
+    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_manifest",
+    package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw310",
+    tags = ["manual"],
+)
+
+bitstream_manifest_fragment(
+    name = "earlgrey_cw310_hyperdebug_manifest",
+    testonly = True,
+    srcs = [":fpga_cw310_hyperdebug"],
+    bitstream = "bitstream",
+    design = "chip_earlgrey_cw310_hyperdebug",
+    memory_maps = {
+        "rom_mmi": "rom",
+        "otp_mmi": "otp",
+    },
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "earlgrey_cw310_hyperdebug_archive",
+    testonly = True,
+    mode = "0444",
+    srcs = [":earlgrey_cw310_hyperdebug_manifest"],
+    strip_prefix = "/hw/bitstream/vivado/earlgrey_cw310_hyperdebug_manifest",
+    package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug",
     tags = ["manual"],
 )
 

--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -1,6 +1,53 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+"""Rules to interface with bitstreams caches
+
+This Starlark library comprises several rules for interfacing with bitstreams
+caches.
+
+`bitstreams_repo` is a `repository_rule` that reaches out to a remote bitstreams
+cache, downloads files to create a local cache, and creates a @bitstreams
+external repository (for bazel) with filegroup targets that represent the
+designs present in the selected cache entry.
+
+The rest of the rules are ordinary build rules for creating cache entries,
+which ultimately are tarballs containing the bitstream build outputs and a
+manifest file (manifest.json at the root of the tarball) that describes how
+the files are grouped to represent a particular design.
+
+A full cache entry contains information about multiple designs, but the rules
+below also create a notion of "manifest fragments," which are essentially
+conforming directories with a manifest and the files for a single design. These
+fragments combine to create a full cache entry. Bazel targets are made aware of
+these fragments via the BitstreamManifestFragmentInfo provider, which contains
+all the relevant information to process them.
+
+The cache entry is broken into fragments here to enable different build flows,
+where bitstreams may be built on independent agents / bazel services and may be
+passed to downstream jobs as though they were part of a bitstreams cache. In
+addition, the cache entry to be uploaded may continue to be made up of both
+freshly-built bitstreams and cached bitstreams (i.e. mix-and-match). Optimized
+build flows may not build every bitstream merely because one isolated design's
+files have changed.
+
+For the manifest.json file, the schema describing its format is at
+`//rules/scripts:bitstreams_manifest_schema` at the time of writing.
+
+The rules:
+    - `bitstream_generate_manifest_fragment`
+        - Takes the outputs of a bitstream build and generates a manifest
+          fragment.
+    - `bitstreams_fragment_from_manifest`
+        - Takes a cache entry (e.g. from the @bitstreams external repository)
+          and creates a manifest fragment for a selected design.
+
+Together, these rules enable flexibility in choosing whether to build a
+particular bitstream or use cached version for the next cache entry, for each
+design (i.e. mix-and-match).
+"""
+
 load("@python3//:defs.bzl", "interpreter")
 load("@ot_python_deps//:requirements.bzl", "all_requirements")
 
@@ -94,4 +141,208 @@ bitstreams_repo = repository_rule(
     # `bazel sync --configure` when checking out new revisions. For historical
     # context, see <https://github.com/lowRISC/opentitan/issues/16832>.
     configure = True,
+)
+
+# Bitstream manifests follow a schema written in the JSON Schema language, and
+# all file paths in the manifest are relative to the manifest's directory.
+# The tools provided to operate on bitstream cache entries currently create
+# directories with the following layout:
+#   <manifest_dir>:
+#       design_name_1:
+#           bitstream.bit
+#           mem_map_1.mmi
+#           mem_map_2.mmi
+#       design_name_2:
+#           bitstream.bit
+#           mem_map_1.mmi
+#           mem_map_2.mmi
+# Thus, the tools impose one additional requirement beyond the JSON schema, that
+# every file in a design's fileset has a unique basename.
+BitstreamManifestFragmentInfo = provider(
+    doc = """Collection of variables describing a manifest fragment.""",
+    fields = {
+        "fragment": "Manifest fragment dictionary",
+        "srcs": "Depset of files that are described by this manifest fragment",
+    },
+)
+
+def _bitstream_generate_manifest_fragment(design, srcs, bitstream, memory_maps):
+    fragment = {
+        "schema_version": 2,
+        "designs": {},
+    }
+    metadata = {}
+    deps = []
+    for src in srcs:
+        if OutputGroupInfo not in src:
+            msg = "Unexpected source {} without OutputGroupInfo provider"
+            fail(msg.format(src))
+        output_groups = src[OutputGroupInfo]
+        if bitstream in output_groups:
+            bitstream_outputs = output_groups[bitstream].to_list()
+            if len(bitstream_outputs) != 1:
+                fail("Too many bitstream outputs for output group")
+            file_path = "/".join([design, bitstream_outputs[0].basename])
+            metadata["bitstream"] = {
+                "file": file_path,
+                "build_target": str(src.label),
+            }
+            deps.append(bitstream_outputs[0])
+
+        memory_map_info = {}
+        for output_group, mem_id in memory_maps.items():
+            if output_group in output_groups:
+                memory_files = output_groups[output_group].to_list()
+                if len(memory_files) != 1:
+                    fail("Too many memory map outputs for output group")
+                file_path = "/".join([design, memory_files[0].basename])
+                memory_map_info[mem_id] = {
+                    "file": file_path,
+                    "build_target": str(src.label),
+                }
+                deps.append(memory_files[0])
+        metadata["memory_map_info"] = memory_map_info
+    fragment["designs"][design] = metadata
+    return (fragment, deps)
+
+def _bitstream_manifest_fragment_impl(ctx):
+    outputs = []
+    fragment_file = ctx.actions.declare_file(ctx.attr.name + "/manifest.json")
+    (fragment, deps) = _bitstream_generate_manifest_fragment(
+        ctx.attr.design,
+        ctx.attr.srcs,
+        ctx.attr.bitstream,
+        ctx.attr.memory_maps,
+    )
+    for dep in deps:
+        file_path = "/".join([ctx.attr.name, ctx.attr.design, dep.basename])
+        symlink = ctx.actions.declare_file(file_path)
+        ctx.actions.symlink(output = symlink, target_file = dep)
+        outputs.append(symlink)
+    ctx.actions.write(fragment_file, json.encode_indent(fragment))
+    outputs.append(fragment_file)
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+        ),
+        BitstreamManifestFragmentInfo(
+            fragment = fragment_file,
+            srcs = depset(outputs),
+        ),
+    ]
+
+bitstream_manifest_fragment = rule(
+    doc = """Generates a bitstream cache manifest fragment from a built design.
+
+        The rules creates a directory with the same name as the build target's,
+        places the selected files into the directory, and generates a
+        manifest.json file with the metadata describing this manifest fragment.
+        This rule is purely implemented in bazel, and symlinks are used instead
+        of copies to avoid redundant large files.
+        """,
+    implementation = _bitstream_manifest_fragment_impl,
+    attrs = {
+        "design": attr.string(
+            doc = "The design's name, a unique identifier to group the files.",
+            mandatory = True,
+        ),
+        "srcs": attr.label_list(
+            doc = "The labels or files that make up this cache entry.",
+            allow_empty = False,
+            allow_files = True,
+            providers = [OutputGroupInfo],
+        ),
+        "bitstream": attr.string(
+            doc = "The output group for the programmable bitstream file.",
+            mandatory = True,
+        ),
+        "memory_maps": attr.string_dict(
+            doc = """A map from memory map files' output groups to their memory
+IDs (e.g. rom, otp, etc.)""",
+        ),
+    },
+)
+
+def _bitstream_fragment_from_manifest_impl(ctx):
+    fragment_file = ctx.actions.declare_file(ctx.attr.name + "/manifest.json")
+    outputs = [fragment_file]
+    for src in ctx.files.srcs:
+        if src.path == ctx.file.manifest.path:
+            continue
+        file_path = "/".join([ctx.attr.name, ctx.attr.design, src.basename])
+        symlink = ctx.actions.declare_file(file_path)
+        ctx.actions.symlink(output = symlink, target_file = src)
+        outputs.append(symlink)
+
+    inputs = [ctx.file.manifest]
+    inputs.extend(ctx.files._schema)
+    inputs.extend(ctx.files._fragment_extractor_tool)
+    args = ctx.actions.args()
+    args.add("--manifest", ctx.file.manifest.path)
+    args.add("--schema", ctx.file._schema.path)
+    args.add("--design", ctx.attr.design)
+    args.add("--out", fragment_file.dirname)
+    ctx.actions.run(
+        outputs = [fragment_file],
+        inputs = inputs,
+        executable = ctx.executable._fragment_extractor_tool,
+        arguments = [args],
+    )
+    outputs.append(fragment_file)
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+        ),
+        BitstreamManifestFragmentInfo(
+            fragment = fragment_file,
+            srcs = depset(outputs),
+        ),
+    ]
+
+bitstream_fragment_from_manifest = rule(
+    doc = """Creates the selected design's manifest fragment from a full
+        manifest.
+
+        This rule uses the bitstreams_fragment_from_manifest.py Python script
+        to analyze the manifest and extract the design's manifest fragment. A
+        new directory is created, and currently, the symlinks are done in
+        Starlark for explicit tracking, though the Python script also has the
+        capability to generate them. The output of this rule is the same as
+        bitstreams_fragment_from_manifest, a manifest fragment directory with
+        symlnks pointing to bitstream and MMI files and a manifest.json tailored
+        to the one design.
+
+        This rule enables reusing components from a cache entry, before they are
+        assembled together other designs that were freshly-built, to make a new
+        cache entry.
+        """,
+    implementation = _bitstream_fragment_from_manifest_impl,
+    attrs = {
+        "design": attr.string(
+            doc = "The design's name, a unique identifier to group the files.",
+            mandatory = True,
+        ),
+        "manifest": attr.label(
+            doc = "Label referencing the manifest to extract from.",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "srcs": attr.label_list(
+            doc = "The labels for files that make up this cache entry.",
+            allow_empty = False,
+            allow_files = True,
+            mandatory = True,
+        ),
+        "_schema": attr.label(
+            doc = "Path to bitstream cache manifest schema",
+            default = "//rules/scripts:bitstreams_manifest_schema",
+            allow_single_file = True,
+        ),
+        "_fragment_extractor_tool": attr.label(
+            doc = "Path to bitstream manifest fragment extractor tool",
+            executable = True,
+            default = "//util/py/scripts:bitstreams_fragment_from_manifest",
+            cfg = "exec",
+        ),
+    },
 )

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -30,6 +30,11 @@ py_library(
     ],
 )
 
+filegroup(
+    name = "bitstreams_manifest_schema",
+    srcs = ["bitstreams_manifest.schema.json"],
+)
+
 py_test(
     name = "bitstreams_workspace_test",
     srcs = [

--- a/rules/scripts/bitstreams_manifest.example.json
+++ b/rules/scripts/bitstreams_manifest.example.json
@@ -1,51 +1,38 @@
 {
-  "schemaVersion": 1,
-  "buildId": "abcdefg",
-  "outputFiles": {
-    "lowrisc_systems_chip_earlgrey_cw310_0.1.bit": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
-      "outputInfo": {
-        "@type": "bitstreamInfo",
-        "design": "chip_earlgrey_cw310"
+  "schema_version": 2,
+  "designs": {
+    "chip_earlgrey_cw310": {
+      "build_id": "aabbcc",
+      "bitstream": {
+        "file": "lowrisc_systems_chip_earlgrey_cw310_0.1.bit",
+        "build_target": "//hw/bitstream/vivado:fpga_cw310"
+      },
+      "memory_map_info": {
+        "otp": {
+          "file": "otp.mmi",
+          "build_target": "//hw/bitstream/vivado:fpga_cw310"
+        },
+        "rom": {
+          "file": "rom.mmi",
+          "build_target": "//hw/bitstream/vivado:fpga_cw310"
+        }
       }
     },
-    "otp.mmi": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
-      "outputInfo": {
-        "@type": "memoryMapInfo",
-        "design": "chip_earlgrey_cw310",
-        "memoryId": "otp"
-      }
-    },
-    "rom.mmi": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310",
-      "outputInfo": {
-        "@type": "memoryMapInfo",
-        "design": "chip_earlgrey_cw310",
-        "memoryId": "rom"
-      }
-    },
-    "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
-      "outputInfo": {
-        "@type": "bitstreamInfo",
-        "design": "chip_earlgrey_cw310_hyperdebug"
-      }
-    },
-    "chip_earlgrey_cw310_hyperdebug/otp.mmi": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
-      "outputInfo": {
-        "@type": "memoryMapInfo",
-        "design": "chip_earlgrey_cw310_hyperdebug",
-        "memoryId": "otp"
-      }
-    },
-    "chip_earlgrey_cw310_hyperdebug/rom.mmi": {
-      "buildTarget": "//hw/bitstream/vivado:fpga_cw310_hyperdebug",
-      "outputInfo": {
-        "@type": "memoryMapInfo",
-        "design": "chip_earlgrey_cw310_hyperdebug",
-        "memoryId": "rom"
+    "chip_earlgrey_cw310_hyperdebug": {
+      "build_id": "ddeeff",
+      "bitstream": {
+        "file": "chip_earlgrey_cw310_hyperdebug/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.bit",
+        "build_target": "//hw/bitstream/vivado:fpga_cw310_hyperdebug"
+      },
+      "memory_map_info": {
+        "otp": {
+          "file": "chip_earlgrey_cw310_hyperdebug/otp.mmi",
+          "build_target": "//hw/bitstream/vivado:fpga_cw310_hyperdebug"
+        },
+        "rom": {
+          "file": "chip_earlgrey_cw310_hyperdebug/rom.mmi",
+          "build_target": "//hw/bitstream/vivado:fpga_cw310_hyperdebug"
+        }
       }
     }
   }

--- a/rules/scripts/bitstreams_manifest.schema.json
+++ b/rules/scripts/bitstreams_manifest.schema.json
@@ -1,93 +1,79 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/rules/scripts/bitstreams_manifest.schema.json",
-  "title": "Bitstreams Cache Manifest v1",
+  "title": "Bitstreams Cache Manifest v2",
   "description":
       "A manifest of bitstreams in a cache entry, informing what is there and how to reproduce",
   "type": "object",
   "properties": {
-    "schemaVersion": {
+    "schema_version": {
       "description": "Version number of this manifest's schema",
       "type": "number",
-      "minimum": 1,
-      "maximum": 1
+      "minimum": 2,
+      "maximum": 2
     },
-    "buildId": {
-      "description": "Build ID associated with this entry (typically a git hash)",
-      "type": "string"
-    },
-    "outputFiles": {
-      "description": "Map of output file paths to their metadata objects",
+    "designs": {
+      "description": "Map of designs to their files and metadata objects",
       "type": "object",
-      "additionalProperties": { "$ref": "#/$defs/outputFile" }
+      "additionalProperties": { "$ref": "#/$defs/design" }
     }
   },
   "required": [
-    "schemaVersion",
-    "buildId",
-    "outputFiles"
+    "schema_version",
+    "designs"
   ],
   "$defs": {
-    "bitstreamInfo": {
+    "bitstream_info": {
       "description": "Bitstream build output",
       "type": "object",
       "properties": {
-        "@type": {
-          "description": "Tag for type of this object",
-          "type": "string",
-          "const": "bitstreamInfo"
+        "file": {
+          "description": "Path to bitstream file relative to root",
+          "type": "string"
         },
-        "design": {
-          "description": "Design name / top for the bitstream",
+        "build_target": {
+          "description": "Build target that generated the output",
           "type": "string"
         }
       },
       "required": [
-        "@type",
-        "design"
+        "file"
       ]
     },
-    "memoryMapInfo": {
+    "memory_map_info": {
       "description": "Build output that maps memories to cells in a hardware implementation",
       "type": "object",
       "properties": {
-        "@type": {
-          "description": "Tag for type of this object",
-          "type": "string",
-          "const": "memoryMapInfo"
-        },
-        "design": {
-          "description": "Design name / top for the bitstream",
+        "file": {
+          "description": "Path to file with memory contents, relative to root",
           "type": "string"
         },
-        "memoryId": {
-          "description": "Name or key identifying the associated memory",
-          "type": "string"
-        }
-      },
-      "required": [
-        "@type",
-        "design",
-        "memoryId"
-      ]
-    },
-    "outputFile": {
-      "description": "Information about a build output file",
-      "type": "object",
-      "properties": {
-        "buildTarget": {
+        "build_target": {
           "description": "Build target that generated the output",
           "type": "string"
-        },
-        "outputInfo": {
-          "oneOf": [
-            { "$ref": "#/$defs/bitstreamInfo" },
-            { "$ref": "#/$defs/memoryMapInfo" }
-          ]
         }
       },
       "required": [
-        "outputInfo"
+        "file"
+      ]
+    },
+    "design": {
+      "description": "Files and metadata related to a design",
+      "type": "object",
+      "properties": {
+        "build_id": {
+          "description": "Build ID associated with this design's output (typically a git hash)",
+          "type": "string"
+        },
+        "bitstream": { "$ref": "#/$defs/bitstream_info" },
+        "memory_map_info": {
+          "description": "Map of name or key identifying the associated memory to file describing contents",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/memory_map_info" }
+        }
+      },
+      "required": [
+        "bitstream"
       ]
     }
   }

--- a/util/py/scripts/BUILD
+++ b/util/py/scripts/BUILD
@@ -42,3 +42,21 @@ py_binary(
         "//util/py/packages/lib:register_usage_report",
     ],
 )
+
+py_binary(
+    name = "bitstream_cache_create",
+    srcs = ["bitstream_cache_create.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
+    name = "bitstreams_fragment_from_manifest",
+    srcs = ["bitstreams_fragment_from_manifest.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("jsonschema"),
+    ],
+)

--- a/util/py/scripts/bitstream_cache_create.py
+++ b/util/py/scripts/bitstream_cache_create.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import os
+import stat
+import sys
+import tarfile
+
+from pathlib import Path
+from typing import Dict
+
+"""Creates bitstreams cache directory entry from an input manifest.
+The input manifest has the same set of keys as a bitstreams cache manifest,
+except the file paths are relative to the bazel execution root. This script
+prepares a proper cache directory named by the SCM revision, the manifest in the
+root of that directory, and the files in directories below.
+
+This script creates symlinks to the real files. If creating a distributable
+archive, make sure to dereference the symlinks and copy the real files into the
+archive.
+"""
+
+parser = argparse.ArgumentParser(
+    description='Bitstream Cache Entry Generator')
+parser.add_argument('fragment', nargs='+',
+                    help='Path to manifest fragment file')
+parser.add_argument('--schema', required=True, help='Path to validation schema')
+parser.add_argument('--stamp-file', required=True,
+                    help='A file supplying the stamp in BUILD_SCM_REVISION')
+parser.add_argument('--out', required=True, help='Path to the output directory.')
+
+
+def collect_file_map(fragment: Dict, fragment_dir: Path):
+    """Get a map of files to their shortened paths in the tar files. The new
+    paths will consist of a flat directory collecting all files related to a
+    design. The directory will be named the same as the design.
+    """
+    file_map = {}
+    for design, metadata in fragment['designs'].items():
+        bitstream = os.path.join(fragment_dir, metadata['bitstream']['file'])
+        bitstream_renamed = os.path.join(design, os.path.basename(bitstream))
+        file_map[bitstream] = bitstream_renamed
+        for mmi in metadata['memory_map_info'].values():
+            mmi_file = os.path.join(fragment_dir, mmi['file'])
+            mmi_renamed = os.path.join(design, os.path.basename(mmi_file))
+            file_map[mmi_file] = mmi_renamed
+    return file_map
+
+
+def get_scm_revision(volatile_status_file: Path):
+    """Get BUILD_SCM_REVISION string from the volatile status file.
+    """
+    with open(volatile_status_file, 'r') as f:
+        for line in f:
+            tokens = line.strip().split(' ')
+            if len(tokens) == 2 and tokens[0] == 'BUILD_SCM_REVISION':
+                return tokens[1]
+    raise Exception('Could not get BUILD_SCM_REVISION from {}.'.format(volatile_status_file))
+
+
+def update_manifest_stamps(manifest: Dict, stamp: str):
+    """Stamp build_id objects for any files in the manifest that do not have
+    them already. The build_id objects should only be missing for files that
+    need the new stamp.
+    """
+    for metadata in manifest['designs'].values():
+        if 'build_id' not in metadata:
+            metadata['build_id'] = stamp
+
+
+def create_archive(outfile: str, manifest: Dict, file_map: Dict):
+    def reset_info(info):
+        info.uname = 'root'
+        info.uid = 0
+        info.gname = 'root'
+        info.gid = 0
+        info.mode = stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+        return info
+    tar = tarfile.open(outfile, 'w:gz', dereference=True)
+    tar.add(manifest, arcname='manifest.json',
+            filter=reset_info)
+    for file_path, short_path in file_map.items():
+        tar.add(file_path, arcname=short_path,
+                filter=reset_info)
+    tar.close()
+
+
+def main(argv: list[str]):
+    args = parser.parse_args(args=argv[1:])
+    stamp = get_scm_revision(args.stamp_file)
+    manifest = {
+        'schema_version': 2,
+        'designs': {},
+    }
+    file_map = {}
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    for fragment_path in args.fragment:
+        with open(fragment_path, 'r') as fragment_file:
+            fragment = json.load(fragment_file)
+            jsonschema.validate(fragment, schema)
+            fragment_dir = os.path.dirname(fragment_path)
+            file_map.update(collect_file_map(fragment, fragment_dir))
+            manifest['designs'].update(fragment['designs'])
+
+    # Check that all required files are present
+    for file_path in file_map.keys():
+        if not os.path.exists(file_path):
+            raise Exception('Could not locate file {}'.format(file_path))
+
+    # Update build IDs and write out the manifest
+    update_manifest_stamps(manifest, stamp)
+    os.makedirs(args.out, exist_ok=True)
+    manifest_path = os.path.join(args.out, 'manifest.json')
+    with open(manifest_path, 'w') as manifest_file:
+        json.dump(manifest, manifest_file, indent=True)
+
+    # Create the tarfile
+    outfile = os.path.join(args.out, 'bitstream-cache.tar.gz')
+    create_archive(outfile, manifest_path, file_map)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/util/py/scripts/bitstreams_fragment_from_manifest.py
+++ b/util/py/scripts/bitstreams_fragment_from_manifest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import os
+import sys
+
+parser = argparse.ArgumentParser(
+    description='Bitstream Manifest Fragment Extractor')
+parser.add_argument('--manifest', required=True, help='Path to manifest file')
+parser.add_argument('--schema', required=True, help='Path to validation schema')
+parser.add_argument('--create-symlinks', default=False,
+                    help='Populate files that the manifest refers to. If ' +
+                         'symlinks are not created, another tool must ' +
+                         'complete the entry with the expected directory ' +
+                         'layout')
+parser.add_argument('--design', required=True,
+                    help='Name of the design to extract')
+parser.add_argument('--out', required=True, help='Path to the output directory.')
+
+
+def main(argv):
+    args = parser.parse_args(args=argv[1:])
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    with open(args.manifest, 'r') as manifest_file:
+        manifest = json.load(manifest_file)
+        jsonschema.validate(manifest, schema)
+
+    # Extract only the indicated design.
+    if args.design not in manifest['designs']:
+        raise Exception('Design {} not present in manifest'.format(args.design))
+    metadata = manifest['designs'][args.design]
+    manifest['designs'] = {
+        args.design: metadata
+    }
+
+    # Create symlinks to all the files if requested
+    design_dir = os.path.join(args.out, args.design)
+    os.makedirs(design_dir, exist_ok=True)
+
+    # Replace the bitstream path.
+    manifest_dir = os.path.dirname(os.path.realpath(args.manifest))
+    bitstream = os.path.join(manifest_dir, metadata['bitstream']['file'])
+    bitstream_renamed = os.path.join(args.design, os.path.basename(bitstream))
+    metadata['bitstream']['file'] = bitstream_renamed
+    if (args.create_symlinks):
+        os.symlink(bitstream, os.path.join(args.out, bitstream_renamed))
+
+    # Replace the MMI paths.
+    for mmi in metadata['memory_map_info'].values():
+        mmi_file = os.path.join(manifest_dir, mmi['file'])
+        mmi_renamed = os.path.join(args.design, os.path.basename(mmi_file))
+        mmi['file'] = mmi_renamed
+        if (args.create_symlinks):
+            os.symlink(mmi_file, os.path.join(args.out, mmi_renamed))
+
+    # Dump the manifest to the specified location.
+    manifest_path = os.path.join(args.out, 'manifest.json')
+    with open(manifest_path, 'w') as manifest_file:
+        json.dump(manifest, manifest_file, indent=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
...and update the schema to invert the hierarchy and group files under designs.

The commits create a notion of "manifest fragments," which are essentially conforming directories with a manifest and the files for a single design. These fragments combine to create a full cache entry, where all desired designs are collected together into a tarball suitable for upload. Bazel targets are made aware of these fragments via the `BitstreamManifestFragmentInfo` provider, which contains all the relevant information to process them.

The cache entry is broken into fragments here to enable using the current CI flow, where bitstreams may be built on independent agents / bazel services and may be passed to downstream jobs as through they were part of a bitstreams cache. In addition, the cache entry to be uploaded may continue to be made up of both freshly-built bitstreams and cached bitstreams (i.e. mix-and-match)--Ideally, we would not build every bitstream merely because one design's files changed.

### The bazel rules

The `bitstream_generate_manifest_fragment` rule takes the outputs of a bitstream build and generates a manifest fragment. This rule is purely implemented in bazel, and symlinks are used instead of copies to avoid redundant large files.

The `bitstreams_fragment_from_manifest` rule takes a cache entry (e.g. from the `@bitstreams` external repository) and creates a manifest fragment for a selected design. This rule uses the `bitstreams_fragment_from_manifest.py` Python script to analyze the manifest and extract the design's manifest fragment. A new directory is created, and currently, the symlinks are done in Starlark for explicit tracking, though the Python script also has the capability to generate them. The output of this rule is the same as `bitstreams_fragment_from_manifest`.

The `bitstream_cache_create` rule takes in manifest fragments (targets that output `BitstreamManifestFragmentInfo` providers) and creates a full cache entry, a tarball with the real file contents added and a manifest that covers all designs. Due to how CI currently works, this rule isn't used for anything in particular right now--`//hw/bitstream:cache_from_cache` is a toy example that recreates the cache entry `@bitstreams` already points to.

However, these rules enable flexibility in choosing whether to build a particular bitstream or use cached version for the next cache entry, for _each_ design (i.e. mix-and-match).

Resolves #13807