### PR TITLE
[prim_lfsr] Remove redundant list of LFSR_COEFF

### DIFF
--- a/hw/ip/prim/doc/prim_lfsr.md
+++ b/hw/ip/prim/doc/prim_lfsr.md
@@ -10,8 +10,7 @@ with the shift register, whereas the latter combines several shift register taps
 and reduces them with an XNOR tree. For more information, refer to
 [this page](https://en.wikipedia.org/wiki/Linear-feedback_shift_register). Both
 LFSR flavors have maximal period (`2^LfsrDw - 1`). The recommendation is to use
-the Galois type and fall back to the Fibonacci type depending on the polynomial
-width availability in the lookup table (see below).
+the Galois type.
 
 
 ## Parameters
@@ -70,18 +69,15 @@ LFSR with the `DefaultSeed` in the next cycle.
 
 The LFSR coefficients are taken from an internal set of lookup tables with
 precomputed coefficients. Alternatively, a custom polynomial can be provided
-using the `Custom` parameter. The lookup tables contain polynomials for both
-LFSR forms and range from 4bit to 64bit for the Galois form and 3bit to 168bit
-for the Fibonacci form. The polynomial coefficients have been obtained from
-[this page](https://users.ece.cmu.edu/~koopman/lfsr/) and
+using the `Custom` parameter. The lookup table contains polynomials for both
+LFSR forms and range from 3bit to 168bit.
+The polynomial coefficients have been obtained from
 [Xilinx application note 52](https://www.xilinx.com/support/documentation/application_notes/xapp052.pdf).
 The script `./script/get-lfsr-coeffs.py` can be used to download, parse and dump
 these coefficients in SV format as follows:
 ```
 $ script/get-lfsr-coeffs.py -o <output_file>
 ```
-The default is to get the Galois coefficients. If the Fibonacci coefficients
-are needed, add the `--fib` switch to the above command.
 
 The implementation of the state transition function of both polynomials have
 been formally verified. Further, all polynomials up to 34bit in length have been

--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -5,8 +5,8 @@
 // This module implements different LFSR types:
 //
 // 0) Galois XOR type LFSR ([1], internal XOR gates, very fast).
-//    Parameterizable width from 4 to 64 bits.
-//    Coefficients obtained from [2].
+//    Parameterizable width from 3 to 168 bits.
+//    Coefficients obtained from [3].
 //
 // 1) Fibonacci XNOR type LFSR, parameterizable from 3 to 168 bits.
 //    Coefficients obtained from [3].
@@ -73,73 +73,8 @@ module prim_lfsr #(
 );
 
   // automatically generated with util/design/get-lfsr-coeffs.py script
-  localparam int unsigned GAL_XOR_LUT_OFF = 4;
-  localparam logic [63:0] GAL_XOR_COEFFS [61] =
-    '{ 64'h9,
-       64'h12,
-       64'h21,
-       64'h41,
-       64'h8E,
-       64'h108,
-       64'h204,
-       64'h402,
-       64'h829,
-       64'h100D,
-       64'h2015,
-       64'h4001,
-       64'h8016,
-       64'h10004,
-       64'h20013,
-       64'h40013,
-       64'h80004,
-       64'h100002,
-       64'h200001,
-       64'h400010,
-       64'h80000D,
-       64'h1000004,
-       64'h2000023,
-       64'h4000013,
-       64'h8000004,
-       64'h10000002,
-       64'h20000029,
-       64'h40000004,
-       64'h80000057,
-       64'h100000029,
-       64'h200000073,
-       64'h400000002,
-       64'h80000003B,
-       64'h100000001F,
-       64'h2000000031,
-       64'h4000000008,
-       64'h800000001C,
-       64'h10000000004,
-       64'h2000000001F,
-       64'h4000000002C,
-       64'h80000000032,
-       64'h10000000000D,
-       64'h200000000097,
-       64'h400000000010,
-       64'h80000000005B,
-       64'h1000000000038,
-       64'h200000000000E,
-       64'h4000000000025,
-       64'h8000000000004,
-       64'h10000000000023,
-       64'h2000000000003E,
-       64'h40000000000023,
-       64'h8000000000004A,
-       64'h100000000000016,
-       64'h200000000000031,
-       64'h40000000000003D,
-       64'h800000000000001,
-       64'h1000000000000013,
-       64'h2000000000000034,
-       64'h4000000000000001,
-       64'h800000000000000D };
-
-  // automatically generated with get-lfsr-coeffs.py script
-  localparam int unsigned FIB_XNOR_LUT_OFF = 3;
-  localparam logic [167:0] FIB_XNOR_COEFFS [166] =
+  localparam int unsigned LUT_OFF = 3;
+  localparam logic [167:0] LFSR_COEFFS [166] =
     '{ 168'h6,
        168'hC,
        168'h14,
@@ -351,10 +286,10 @@ module prim_lfsr #(
     if (CustomCoeffs > 0) begin : gen_custom
       assign coeffs = CustomCoeffs[LfsrDw-1:0];
     end else begin : gen_lut
-      assign coeffs = GAL_XOR_COEFFS[LfsrDw-GAL_XOR_LUT_OFF][LfsrDw-1:0];
+      assign coeffs = LFSR_COEFFS[LfsrDw-LUT_OFF][LfsrDw-1:0];
       // check that the most significant bit of polynomial is 1
-      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(GAL_XOR_COEFFS)+GAL_XOR_LUT_OFF)
-      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(GAL_XOR_COEFFS)+GAL_XOR_LUT_OFF)
+      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(LFSR_COEFFS)+LUT_OFF)
+      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(LFSR_COEFFS)+LUT_OFF)
     end
 
     // calculate next state using internal XOR feedback and entropy input
@@ -376,10 +311,10 @@ module prim_lfsr #(
     if (CustomCoeffs > 0) begin : gen_custom
       assign coeffs = CustomCoeffs[LfsrDw-1:0];
     end else begin : gen_lut
-      assign coeffs = FIB_XNOR_COEFFS[LfsrDw-FIB_XNOR_LUT_OFF][LfsrDw-1:0];
+      assign coeffs = LFSR_COEFFS[LfsrDw-LUT_OFF][LfsrDw-1:0];
       // check that the most significant bit of polynomial is 1
-      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(FIB_XNOR_COEFFS)+FIB_XNOR_LUT_OFF)
-      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(FIB_XNOR_COEFFS)+FIB_XNOR_LUT_OFF)
+      `ASSERT_INIT(MinLfsrWidth_A, LfsrDw >= $low(LFSR_COEFFS)+LUT_OFF)
+      `ASSERT_INIT(MaxLfsrWidth_A, LfsrDw <= $high(LFSR_COEFFS)+LUT_OFF)
     end
 
     // calculate next state using external XNOR feedback and entropy input

--- a/util/design/README.md
+++ b/util/design/README.md
@@ -165,12 +165,12 @@ TODO
 
 The `get-lfsr-coeffs.py` script is used to fetch a list of primitive polynomials for Galois and Fibonacci type LFSRs.
 
-Galois coefficients are downloaded from [https://users.ece.cmu.edu/~koopman/lfsr/](https://users.ece.cmu.edu/~koopman/lfsr/).
+By default, the coefficients are downloaded from [https://users.ece.cmu.edu/~koopman/lfsr/](https://users.ece.cmu.edu/~koopman/lfsr/).
 The script downloads text files containing the first 100 primitive polynomials for LFSR widths ranging from 4 to 64 and places them into a temporary folder.
 The script also produces an output file containing a SystemVerilog template with LFSR polynomials for widths 4 to 64.
 This template contains exactly one polynomial for each LFSR width, which is always the first polynomial listed in the corresponding file.
 
-When used with the `--fib <pdf file>` option, the script outputs polynomials for the XNOR Fibonacci-type LFSR.
+When used with the `--pdf <pdf file>` option, the script outputs polynomials extracted from the Xilinx application note.
 To run this option, the user first needs to download the Xilinx application note from [https://docs.xilinx.com/v/u/en-US/xapp052](https://docs.xilinx.com/v/u/en-US/xapp052).
 The produced output file contains a SystemVerilog template with LFSR polynomials for widths ranging from 3 to 168.
 


### PR DESCRIPTION
At the moment prim_lfsr.sv uses two lists of feedback polynomials downloaded from two different sources, one for each LfsrType (GAL_XOR and FIB_XNOR). However, this is not necessary because each polynomial works equally well with either type. Moreover, some polynomials are the same in both lists (e.g. for LfsrDw = 12, 13, 14, 19, 27, 30, 37, 38).

To simplify the primitive, this PR removes the list downloaded from https://users.ece.cmu.edu/~koopman/lfsr/ and makes both lfsr types use the list obtained from 
https://www.xilinx.com/support/documentation/application_notes/xapp052.pdf 