### PR TITLE
[device] make module IDs unique in USB test

### DIFF
--- a/sw/device/lib/testing/usb_testutils_controlep.c
+++ b/sw/device/lib/testing/usb_testutils_controlep.c
@@ -9,6 +9,8 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/usb_testutils.h"
 
+#define MODULE_ID MAKE_MODULE_ID('u', 't', 'c')
+
 // Device descriptor
 static const uint8_t kDevDscr[] = {
     18,    // bLength

--- a/sw/device/lib/testing/usb_testutils_simpleserial.c
+++ b/sw/device/lib/testing/usb_testutils_simpleserial.c
@@ -8,6 +8,9 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/usb_testutils.h"
 
+// "uts" is used by usb_testutils_streams.c
+#define MODULE_ID MAKE_MODULE_ID('u', 't', 'i')
+
 #define MAX_GATHER 16
 
 static status_t ss_rx(void *ssctx_v, dif_usbdev_rx_packet_info_t packet_info,


### PR DESCRIPTION
Fix #19190

Example of broken test: https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=121584&view=logs&j=1a082425-b540-5a45-e7d8-d21f721d187f&t=3583c471-2f95-531c-7145-0be3f8c0aecd