### PR TITLE
[ci] reduce targets built in airgapped setup

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -25,7 +25,7 @@ sudo ip netns exec airgapped sudo -u "$USER" bash -c \
   export BITSTREAM=\"--offline latest\";
   export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
   TARGET_PATTERN_FILE=\$(mktemp)
-  echo //sw/device/silicon_creator/... > \"\${TARGET_PATTERN_FILE}\"
+  echo //sw/device/silicon_creator/rom/... > \"\${TARGET_PATTERN_FILE}\"
   bazel-airgapped/bazel cquery \
     --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
     --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \


### PR DESCRIPTION
The airgapped build test was building too many targets which caused CI resources to be exhausted.