### PR TITLE
[sparse-fsm-encode] Refactor and add unit tests

### DIFF
--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -55,3 +55,16 @@ py_binary(
         requirement("hjson"),
     ],
 )
+
+py_binary(
+    name = "sparse-fsm-encode",
+    srcs = ["sparse-fsm-encode.py"],
+    imports = ["."],
+    deps = ["//util/design/lib:common"],
+)
+
+py_test(
+    name = "sparse-fsm-encode-test",
+    srcs = ["sparse-fsm-encode-test.py"],
+    deps = [":sparse-fsm-encode"],
+)

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -15,6 +15,12 @@ py_library(
     ],
 )
 
+py_test(
+    name = "common_test",
+    srcs = ["common_test.py"],
+    deps = [":common"],
+)
+
 py_library(
     name = "lc_st_enc",
     srcs = ["LcStEnc.py"],

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -145,10 +145,15 @@ def hist_to_bars(hist, m):
     return bars
 
 
-def get_hd(word1, word2):
+def get_hd(word1: str, word2: str) -> int:
     '''Calculate Hamming distance between two words.'''
     if len(word1) != len(word2):
         raise RuntimeError('Words are not of equal size')
+    # Python's int(n, 2) function will accept both strings of bits and
+    # 0b-prefixed strings. This can lead to edge cases such as get_hd('1001',
+    # '0b01'). We forbid the usage of "0b" with this function.
+    if '0b' in word1 or '0b' in word2:
+        raise ValueError('Words should not contain the "0b" prefix')
     return bin(int(word1, 2) ^ int(word2, 2)).count('1')
 
 

--- a/util/design/lib/common_test.py
+++ b/util/design/lib/common_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from common import get_hd
+
+
+class TestGetHd(unittest.TestCase):
+
+    def test_different_length_words(self):
+        with self.assertRaises(RuntimeError):
+            get_hd('010101', '0101010101')
+
+    def test_0b_prefixed_words(self):
+        with self.assertRaises(ValueError):
+            get_hd('10101', '0b101')
+
+    def test_all_zeros(self):
+        self.assertEqual(get_hd('0000', '0000'), 0)
+
+    def test_all_ones(self):
+        self.assertEqual(get_hd('1111', '1111'), 0)
+
+    def test_nonzero_hd(self):
+        self.assertEqual(get_hd('100101', '010100'), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util/design/sparse-fsm-encode-test.py
+++ b/util/design/sparse-fsm-encode-test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+import unittest.mock
+
+import io
+import contextlib
+import re
+
+from lib.common import get_hd
+import importlib
+
+enc = importlib.import_module("sparse-fsm-encode")
+
+
+class TestCheckCandidate(unittest.TestCase):
+
+    def setUp(self):
+        self.generator = enc.EncodingGenerator(min_hd=3,
+                                               num_states=8,
+                                               encoding_len=8,
+                                               seed=1234567890,
+                                               language="c",
+                                               avoid_zero=True)
+        self.generator.encodings = ['00111010']
+
+    def test_reject_existing_candidate(self):
+        self.assertFalse(self.generator._check_candidate('00111010'))
+
+    def test_valid_candidate(self):
+        candidate = '01001010'
+        self.assertEqual(get_hd(candidate, self.generator.encodings[0]), 3)
+        self.assertTrue(self.generator._check_candidate(candidate))
+
+    def test_low_hamming_dist(self):
+        candidate = '10011010'
+        self.assertEqual(get_hd(candidate, self.generator.encodings[0]), 2)
+        self.assertFalse(self.generator._check_candidate(candidate))
+
+    def test_inverse_candidate(self):
+        self.assertFalse(self.generator._check_candidate('11000101'))
+
+    def test_all_ones(self):
+        self.assertFalse(self.generator._check_candidate('11111111'))
+
+    def test_all_zeros(self):
+        self.assertFalse(self.generator._check_candidate('00000000'))
+
+    def test_avoid_zero(self):
+        self.assertFalse(self.generator._check_candidate('10000100'))
+
+    def test_no_avoid_zero(self):
+        noAvoidZeroGenerator = enc.EncodingGenerator(min_hd=3,
+                                                     num_states=8,
+                                                     encoding_len=8,
+                                                     seed=1234567890,
+                                                     language="c",
+                                                     avoid_zero=False)
+        self.assertTrue(noAvoidZeroGenerator._check_candidate('00000100'))
+
+
+class TestArgsParsing(unittest.TestCase):
+
+    def test_disallowed_encoding_lengths(self):
+        # Only 8, 16, and 32-bit encodings can be generated for C and Rust
+        # languages.
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '8', '-m', '30', '-n', '30',
+                '-s', '1234567890', '--language', 'c'
+        ]):
+            with self.assertRaises(SystemExit) as e, self.assertLogs(
+                    'root', level='ERROR') as logs:
+                enc.main()
+            self.assertEqual(e.exception.code, 1)
+            self.assertTrue(
+                any('When using C or Rust, widths must be a power-of-two' in
+                    log for log in logs.output))
+
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '8', '-m', '30', '-n', '30',
+                '-s', '1234567890', '--language', 'rust'
+        ]):
+            with self.assertRaises(SystemExit) as e, self.assertLogs(
+                    'root', level='ERROR') as logs:
+                enc.main()
+            self.assertEqual(e.exception.code, 1)
+            self.assertTrue(
+                any('When using C or Rust, widths must be a power-of-two' in
+                    log for log in logs.output))
+
+    def test_too_few_states(self):
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '8', '-m', '1', '-n', '32', '-s',
+                '1234567890', '--language', 'rust'
+        ]):
+            with self.assertRaises(SystemExit) as e, self.assertLogs(
+                    'root', level='ERROR') as logs:
+                enc.main()
+            self.assertEqual(e.exception.code, 1)
+            self.assertTrue(
+                any('Number of states (m) must be at least 2' in log
+                    for log in logs.output))
+
+    def test_too_many_states(self):
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '4', '-m', '1024', '-n', '8',
+                '-s', '1234567890', '--language', 'rust'
+        ]):
+            with self.assertRaises(SystemExit) as e, self.assertLogs(
+                    'root', level='ERROR') as logs:
+                enc.main()
+            self.assertEqual(e.exception.code, 1)
+            r = r'.*Statespace 2\^[0-9]+ not large enough to accommodate [0-9]+ states.*'
+            self.assertTrue(any(re.match(r, log) for log in logs.output))
+
+    def test_encoding_too_small(self):
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '8', '-m', '10', '-n', '8', '-s',
+                '1234567890', '--language', 'sv'
+        ]):
+            with self.assertRaises(SystemExit) as e, self.assertLogs(
+                    'root', level='ERROR') as logs:
+                enc.main()
+            self.assertEqual(e.exception.code, 1)
+            r = (r'.*State is only [0-9]+ bits wide, which is not enough to '
+                 r'fulfill a minimum Hamming distance constraint of [0-9]\.')
+            self.assertTrue(any(re.match(r, log) for log in logs.output))
+
+    def test_too_small_hamming_dist(self):
+        with unittest.mock.patch('sys.argv', [
+                'sparse-fsm-encode.py', '-d', '2', '-m', '12', '-n', '32',
+                '-s', '1234567890', '--language', 'sv'
+        ]):
+            with self.assertLogs('root', level='WARN') as logs:
+                enc.main()
+            warning_string = (
+                'A value of 4-5 is recommended for the minimum Hamming '
+                'distance constraint. At a minimum, this should be set to 3.')
+            self.assertTrue(any(warning_string in log for log in logs.output))
+
+
+class TestIdempotency(unittest.TestCase):
+
+    def test_idempotency(self):
+        """Call the script 10 times and check that the output doesn't change."""
+        outputs = list()
+        for i in range(10):
+            f = io.StringIO()
+            with contextlib.redirect_stdout(f):
+                with unittest.mock.patch('sys.argv', [
+                        'sparse-fsm-encode.py', '-d', '8', '-m', '30', '-n',
+                        '32', '-s', '1234567890', '--language', 'sv'
+                ]):
+                    enc.main()
+            outputs.append(f.getvalue())
+        self.assertTrue(len(set(outputs)) == 1)
+
+
+class TestBackwardsCompatibility(unittest.TestCase):
+
+    def test_backwards_compatibility(self):
+        """Ensure that a known seed generates the expected encodings."""
+        generator = enc.EncodingGenerator(min_hd=6,
+                                          num_states=10,
+                                          encoding_len=32,
+                                          seed=3775359077,
+                                          language="c",
+                                          avoid_zero=True)
+        generator.generate()
+        self.assertEqual(generator.encodings, [
+            '11101110000100110101010110000000',
+            '01100100010000110011010000111111',
+            '10100111000000100111001101000101',
+            '00110010100011110010111100111110',
+            '01110000111111001011001001111111',
+            '00111010110011111010000111000111',
+            '01111101000110010011000110010100',
+            '11100000101111000001010011100000',
+            '10010001001000000111011110000101',
+            '11010100110010100111001010100010'
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)  # hide the printed output with buffer = True


### PR DESCRIPTION
This PR adds unit tests for `sparse-fsm-encode.py` and the `get_hd` function it uses. Additionally, it does a refactoring to make the testing easier. The refactoring should preserve the behavior of this script.

The unit testing uncovered #19244.

I'm not sure if this is an issue we're worried about, but the unit tests also check for non-backwards-compatible changes that would prevent the generated constants from being reproduced. This has already happened before, for instance, in #8665. Commit f2c848c7e1f09018e4cae16d2b30ffd5eca6c3c2 changed the output of the script by not pre-populating the encoding array with the first random value, effectively discarding the first call to random. This is not inherently an issue, but it does means that encodings generated prior to this commit are not directly reproducible with this script using the command from the comments. For example, from `alert.h`: https://github.com/lowRISC/opentitan/blob/9e6df0d9b7c721a50fe45934dd0b0c792a579c71/sw/device/silicon_creator/lib/drivers/alert.h#L19-L41

Invoking this script on `master` today yields a different result with a smaller minimum Hamming distance:
```c
/*
 * Encoding generated with
 * $ ./util/design/sparse-fsm-encode.py -d 2 -m 5 -n 8 \
 *     -s 3775359077 --language=c
 *
 * Hamming distance histogram:
 *
 *  0: --
 *  1: --
 *  2: ||||||||||||| (20.00%)
 *  3: ||||||||||||| (20.00%)
 *  4: |||||||||||||||||||| (30.00%)
 *  5: ||||||||||||| (20.00%)
 *  6: |||||| (10.00%)
 *  7: --
 *  8: --
 *
 * Minimum Hamming distance: 2
 * Maximum Hamming distance: 6
 * Minimum Hamming weight: 3
 * Maximum Hamming weight: 6
 */
typedef enum my_state {
  kMyState0 = 0xee,
  kMyState1 = 0x64,
  kMyState2 = 0xa7,
  kMyState3 = 0x32,
  kMyState4 = 0x70,
} my_state_t;
```