### PR TITLE
[util]: Fix tag support for get_workspace_status.sh

### DIFF
--- a/util/get_workspace_status.sh
+++ b/util/get_workspace_status.sh
@@ -20,7 +20,7 @@ then
 fi
 echo "BUILD_SCM_REVISION ${git_rev}"
 
-git_version=$(git describe --always)
+git_version=$(git describe --always --tags)
 if [[ $? != 0 ]];
 then
   exit 1


### PR DESCRIPTION
This changes fix bug causing generating incorrect
`BUILD_GIT_VERSION` string for unannotated tags.

As result of this changes command `make -C hw topgen_rust_pkg` 
now should generated files with correct version stamp.

To test this change please compare output of command below,
 with and without applying this changes.
Command: `util/get_workspace_status.sh`