### PR TITLE
[kmac, rtl] Very minor tweaks around LFSR reseeding

### DIFF
--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -696,6 +696,7 @@ module kmac_entropy
           // operation while waiting for the EDN response.
           st_d = StRandEdn;
 
+          lfsr_en = 1'b 1;
           rand_valid_clear = 1'b 1;
         end else begin
           st_d = StRandEdn;


### PR DESCRIPTION
This is a small follow-up PR to #19248 with two changes:
- Refine an SVA. I found this after investigating a test failure of a full regression.
- Advance the LFSR during reseeding when the Keccak core consumes the randomness. We did already mark the randomness as being consumed before but the LFSR didn't get advanced. This is very minor.