### PR TITLE
[tlul,dv] assign proper name for visibility

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -131,6 +131,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
   virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     foreach (m_tl_agents[i]) begin
+      m_tl_agents[i].monitor.agent_name = i;
       m_tl_agents[i].monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifos[i].analysis_export);
       m_tl_agents[i].monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifos[i].analysis_export);
       m_tl_agents[i].monitor.channel_dir_port.connect(scoreboard.tl_dir_fifos[i].analysis_export);

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -75,9 +75,9 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     end
     if (cfg.csr_access_abort_pct_in_adapter > $urandom_range(0, 100)) begin
       bus_req.req_abort_after_a_valid_len = 1;
-      `uvm_info(`gtn, $sformatf("tl reg req item is allowed to be aborted"), UVM_MEDIUM)
+      `uvm_info(this.get_name(), $sformatf("tl reg req item is allowed to be aborted"), UVM_MEDIUM)
     end
-    `uvm_info(`gtn, {"tl_reg_adapter::reg2bus: ", bus_req.convert2string()}, UVM_HIGH)
+    `uvm_info(this.get_name(), {"tl_reg_adapter::reg2bus: ", bus_req.convert2string()}, UVM_HIGH)
     return bus_req;
   endfunction : reg2bus
 
@@ -95,7 +95,7 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     end
     // indicate if the item is completed successfully for upper level to update predict value
     rw.status  = !bus_rsp.req_completed ? UVM_NOT_OK : UVM_IS_OK;
-    `uvm_info(`gtn, {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)
+    `uvm_info(this.get_name(), {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)
   endfunction: bus2reg
 
 endclass : tl_reg_adapter


### PR DESCRIPTION
The name of tl_reg_adapter (parameterized class) cannot be captured by gtn macro. 
Replace with plain string based name.
Assign correct agent name to tlul monitor.