### PR TITLE
Usbdev Pin Configuration test

### DIFF
--- a/hw/dv/dpi/usbdpi/usb_transfer.h
+++ b/hw/dv/dpi/usbdpi/usb_transfer.h
@@ -4,6 +4,8 @@
 
 #ifndef OPENTITAN_HW_DV_DPI_USBDPI_USB_TRANSFER_H_
 #define OPENTITAN_HW_DV_DPI_USBDPI_USB_TRANSFER_H_
+#include <assert.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -1203,8 +1203,8 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       } else {
         // This normally means that we did not get the expected response to
         // a Control Transfer stage (Data/Status), so retry if we haven't
-        // already exhausted our retry attempts.
-        if (ctx->num_tries++ >= USBDPI_MAX_RETRIES) {
+        // already exhausted our attempts.
+        if (++ctx->num_tries >= USBDPI_MAX_TRIES) {
           ctx->num_tries = 0U;
           assert(!"USBDPI: no response to Control Transfer");
         } else {

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -158,8 +158,8 @@ typedef uint32_t svBitVecVal;
 // Maximum length of test status message
 #define USBDPI_MAX_TEST_MSG_LEN 80U
 
-// Maximum number of times to /re/try a Control Transfer before faulting it.
-#define USBDPI_MAX_RETRIES 2U
+// Maximum number of attempts to perform a Control Transfer before faulting it.
+#define USBDPI_MAX_TRIES 3U
 
 // Vendor-specific commands used for test framework
 #define USBDPI_VENDOR_TEST_CONFIG 0x7CU

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -158,6 +158,9 @@ typedef uint32_t svBitVecVal;
 // Maximum length of test status message
 #define USBDPI_MAX_TEST_MSG_LEN 80U
 
+// Maximum number of times to /re/try a Control Transfer before faulting it.
+#define USBDPI_MAX_RETRIES 2U
+
 // Vendor-specific commands used for test framework
 #define USBDPI_VENDOR_TEST_CONFIG 0x7CU
 #define USBDPI_VENDOR_TEST_STATUS 0x7EU
@@ -342,6 +345,10 @@ struct usbdpi_ctx {
    * Test step number
    */
   usbdpi_test_step_t step;
+  /**
+   * Number of attempts to complete the current Control Transfer stage
+   */
+  uint8_t num_tries;
 
   /**
    * Current bus frame number

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -23,6 +23,7 @@ typedef uint32_t svBitVecVal;
 #include "usb_transfer.h"
 #include "usb_utils.h"
 #include "usbdpi_stream.h"
+#include "usbdpi_test.h"
 
 // Shall we employ a proper simulation of the frame interval (1ms)?
 // TODO - Because we cannot perform multiple control transfers in a
@@ -179,45 +180,6 @@ typedef enum {
   ST_EOP0 = 5
 } usbdpi_drv_state_t;
 
-// Test steps
-typedef enum {
-
-  STEP_BUS_RESET = 0u,
-  STEP_SET_DEVICE_ADDRESS,
-  STEP_GET_DEVICE_DESCRIPTOR,
-  STEP_GET_CONFIG_DESCRIPTOR,
-  STEP_GET_FULL_CONFIG_DESCRIPTOR,
-  STEP_SET_DEVICE_CONFIG,
-
-  // Read test configuration
-  // This is a bespoke 'vendor' command via which we inquire of the CPU
-  // software what behaviour is required
-  STEP_GET_TEST_CONFIG,
-  // Report test status (pass/failure) to the CPU software
-  STEP_SET_TEST_STATUS,
-
-  // usbdev_test
-  STEP_FIRST_READ,
-  STEP_READ_BAUD,
-  STEP_SECOND_READ,
-  STEP_SET_BAUD,
-  STEP_THIRD_READ,
-  STEP_TEST_ISO1,
-  STEP_TEST_ISO2,
-  STEP_ENDPT_UNIMPL_SETUP,
-  STEP_ENDPT_UNIMPL_OUT,
-  STEP_ENDPT_UNIMPL_IN,
-  STEP_DEVICE_UK_SETUP,
-  STEP_IDLE_START,
-  STEP_IDLE_END = STEP_IDLE_START + 4,
-
-  // usbdev_stream_test
-  STEP_STREAM_SERVICE = 0x20u,
-
-  // Disconnect the device and stop
-  STEP_BUS_DISCONNECT = 0x7fu
-} usbdpi_test_step_t;
-
 // Host states
 typedef enum {
   HS_STARTFRAME = 0,
@@ -288,7 +250,7 @@ struct usbdpi_ctx {
   /**
    * Test number, retrieved from the software
    */
-  uint16_t test_number;
+  usb_testutils_test_number_t test_number;
   /**
    * Test-specific arguments
    */
@@ -381,11 +343,15 @@ struct usbdpi_ctx {
    */
   usbdpi_test_step_t step;
 
-  // Bus framing
-  // Note: USB frame numbers are transmitted as 11-bit fields [0,0x7ffU]
+  /**
+   * Current bus frame number
+   * Note: USB frame numbers are transmitted as 11-bit fields [0,0x7ffU]
+   */
   uint16_t frame;
-  uint16_t framepend;
-
+  /**
+   * New bus frame pending
+   */
+  bool framepend;
   /**
    * Time at which the current frame started (bit intervals)
    */

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -137,6 +137,7 @@ module usbdpi #(
 
   // USB monitor state
   // Note: MUST be kept consistent with usbdpi_monitor_state_t in usb_monitor.c
+  // to aid in reading waveform traces.
   typedef enum bit [1:0] {
     MS_IDLE = 0,
     MS_GET_PID,
@@ -144,7 +145,8 @@ module usbdpi #(
   } usb_monitor_state_t;
 
   // USB driver state
-  // Note: MUST be kept consistent with usbdpi_drv_state_t in usbdpi.h
+  // Note: MUST be kept consistent with usbdpi_drv_state_t in usbdpi.h to
+  // aid in reading waveform traces.
   typedef enum bit [3:0] {
     ST_IDLE = 0,
     ST_SEND = 1,
@@ -155,6 +157,8 @@ module usbdpi #(
   } usbdpi_drv_state_t;
 
   // Test steps
+  // Note: MUST be kept consistent with usbdpi_test_step_t in usbdpi_test.h to
+  // aid in reading waveform traces.
   typedef enum bit [6:0] {
 
     STEP_BUS_RESET = 7'h0,

--- a/hw/dv/dpi/usbdpi/usbdpi_test.c
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.c
@@ -6,7 +6,7 @@
 
 #include <assert.h>
 
-#include "usbdpi_stream.h"
+#include "usbdpi.h"
 
 // Test-specific initialization
 void usbdpi_test_init(usbdpi_ctx_t *ctx) {

--- a/hw/dv/dpi/usbdpi/usbdpi_test.h
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.h
@@ -11,7 +11,10 @@ typedef enum usb_testutils_test_number {
   kUsbTestNumberSmoke = 0,
   kUsbTestNumberStreams,
   kUsbTestNumberIso,
-  kUsbTestNumberMixed
+  kUsbTestNumberMixed,
+  kUsbTestNumberSuspend,
+  kUsbTestNumberExc,
+  kUsbTestNumberPinCfg,
 } usb_testutils_test_number_t;
 
 // Test steps

--- a/hw/dv/dpi/usbdpi/usbdpi_test.h
+++ b/hw/dv/dpi/usbdpi/usbdpi_test.h
@@ -4,7 +4,7 @@
 
 #ifndef OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_
 #define OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_TEST_H_
-#include "usbdpi.h"
+#include "usb_transfer.h"
 
 // DPI test numbers
 typedef enum usb_testutils_test_number {
@@ -13,6 +13,44 @@ typedef enum usb_testutils_test_number {
   kUsbTestNumberIso,
   kUsbTestNumberMixed
 } usb_testutils_test_number_t;
+
+// Test steps
+typedef enum {
+  STEP_BUS_RESET = 0u,
+  STEP_SET_DEVICE_ADDRESS,
+  STEP_GET_DEVICE_DESCRIPTOR,
+  STEP_GET_CONFIG_DESCRIPTOR,
+  STEP_GET_FULL_CONFIG_DESCRIPTOR,
+  STEP_SET_DEVICE_CONFIG,
+
+  // Read test configuration
+  // This is a bespoke 'vendor' command via which we inquire of the CPU
+  // software what behaviour is required
+  STEP_GET_TEST_CONFIG,
+  // Report test status (pass/failure) to the CPU software
+  STEP_SET_TEST_STATUS,
+
+  // usbdev_test
+  STEP_FIRST_READ,
+  STEP_READ_BAUD,
+  STEP_SECOND_READ,
+  STEP_SET_BAUD,
+  STEP_THIRD_READ,
+  STEP_TEST_ISO1,
+  STEP_TEST_ISO2,
+  STEP_ENDPT_UNIMPL_SETUP,
+  STEP_ENDPT_UNIMPL_OUT,
+  STEP_ENDPT_UNIMPL_IN,
+  STEP_DEVICE_UK_SETUP,
+  STEP_IDLE_START,
+  STEP_IDLE_END = STEP_IDLE_START + 4,
+
+  // usbdev_stream_test
+  STEP_STREAM_SERVICE = 0x20u,
+
+  // Disconnect the device and stop
+  STEP_BUS_DISCONNECT = 0x7fu
+} usbdpi_test_step_t;
 
 // Test-specific initialization
 void usbdpi_test_init(usbdpi_ctx_t *ctx);

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -300,7 +300,15 @@
     // USB (pre-verified IP) integration tests:
     {
       name: chip_sw_usbdev_dpi
-      desc: '''Sketch of USBDPI integration.
+      desc: '''Integration of USBDPI at chip level to test connection and communications.
+
+            - DPI model provides a simulation of a simple USB host; asserts VBUS
+            - SW sets up the USB device, and enables the interface.
+            - DPI detects presence of pull up and VBUS, and initiates communications.
+            - SW receives device address and configuration from DPI model.
+            - A small data packet is transmitted from the device to the DPI model.
+            - DPI model returns a small data packet to the device and SW.
+            - SW checks the content of the received data packet.
             '''
       stage: V2
       tests: ["chip_sw_usbdev_dpi"]
@@ -389,13 +397,18 @@
       tests: []
     }
     {
-      name: chip_usb_enumeration
-      desc: '''Verify USB enumeration. Details are not clear.
+      name: chip_sw_usbdev_pincfg
+      desc: '''Verify that the USB device can operate in all pin configurations.
 
-            - TODO
+            - This test extends from `chip_sw_usbdev_dpi`
+            - Cycles the device through each of the supported bus modes/pin configurations.
+            - Checks that the DPI model can set up the device with a given pin configuration,
+              before resetting the device and advancing to the next pin configuration.
+            - Exercises all permutations of (i) pinflipping on/off, (ii) single-ended transmission
+              on/off, and (iii) external differential receiver yes/no
             '''
-      stage: V3
-      tests: []
+      stage: V2
+      tests: ["chip_sw_usbdev_pincfg"]
     }
 
     // PINMUX & PADRING (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -560,6 +560,15 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_pincfg
+      uvm_test_seq: chip_sw_usbdev_dpi_vseq
+      sw_images: ["//sw/device/tests:usbdev_pincfg_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1", "+sw_test_timeout_ns=100_000_000"]
+      run_timeout_mins: 300
+      reseed: 1
+    }
+    {
       name: chip_sw_usbdev_stream
       uvm_test_seq: chip_sw_usbdev_stream_vseq
       sw_images: ["//sw/device/tests:usbdev_stream_test:1"]

--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -16,7 +16,10 @@ typedef enum usb_testutils_test_number {
   kUsbTestNumberSmoke = 0,
   kUsbTestNumberStreams,
   kUsbTestNumberIso,
-  kUsbTestNumberMixed
+  kUsbTestNumberMixed,
+  kUsbTestNumberSuspend,
+  kUsbTestNumberExc,
+  kUsbTestNumberPinCfg,
 } usb_testutils_test_number_t;
 
 typedef enum usb_testutils_ctstate {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2340,6 +2340,30 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "usbdev_pincfg_test",
+    srcs = ["usbdev_pincfg_test.c"],
+    targets = [
+        "verilator",
+        "cw310_test_rom",
+        "dv",
+    ],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
     cw310 = cw310_params(

--- a/sw/device/tests/usbdev_pincfg_test.c
+++ b/sw/device/tests/usbdev_pincfg_test.c
@@ -1,0 +1,223 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB pincfg test
+//
+// For each of the pin/bus configurations in turn, this test runs the USB test
+// software, device and DPI model through all of the initial communications to
+// set up the device and select a confgiguration.
+//
+// It is necessary to perform a complete reset of the usbdev hardware block
+// before starting the next test because the DIF keeps the 'Available buffers'
+// FIFO topped up with buffers, but would itself forget about those buffers
+// when reinitialized for the next test.
+//
+// This test works best with the DPI model in Verilator top-level simulation
+// because it is capable of reading and adapting to the pin configuration and
+// thus implementing all bus types:
+//
+// - differential vs single-ended, in each direction
+// - pin-swapped vs unswapped
+//
+// With DV sim at chip level, where we have just the physical two wire USB
+// between the chip and DPI model, 4 configurations may be exercised.
+//
+// On the CW310 target, only two configurations may be tested programmatically
+// without the manual intervention required to flip pins. No host-side
+// application support is required in this case - just a physical wire to the
+// host controller, and the OS/device layer will configure the device.
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Configuration values for USB.
+ */
+static const uint8_t kConfigDescriptors[] = {
+    USB_CFG_DSCR_HEAD(
+        USB_CFG_DSCR_LEN + 2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
+        2),
+    VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4),
+    VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 2, 32, 0),
+    USB_BULK_EP_DSCR(1, 2, 32, 4),
+};
+
+/**
+ * Test descriptor
+ */
+static const uint8_t kTestDescriptor[] = {
+    USB_TESTUTILS_TEST_DSCR(kUsbTestNumberPinCfg, 0, 0, 0, 0)};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+/**
+ * Rstmgr handler
+ */
+static dif_rstmgr_t rstmgr;
+
+/**
+ * Verbose reporting?
+ */
+static bool verbose = false;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK(kDeviceType == kDeviceSimVerilator || kDeviceType == kDeviceFpgaCw310 ||
+            kDeviceType == kDeviceSimDV,
+        "This test is not expected to run on platforms other than the "
+        "Veriltor/DV simulation or CW310 FPGA. It needs the USB DPI model "
+        "or host. No host-side application software required.");
+
+  LOG_INFO("Running USBDEV PINCFG test");
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // Construct the test list appropriate to this target
+  struct {
+    bool pinflip;
+    bool en_diff_rcvr;
+    bool tx_use_d_se0;
+  } test_cfg[8U];
+
+  unsigned ntests;
+  switch (kDeviceType) {
+    case kDeviceSimDV:
+      // DV simulation can exercise pin-flipping and differential rcvr on/off
+      // but there's no point wasting simulation time trying both tx modes;
+      // D+/D- are always used directly as differential signals.
+      ntests = 4U;
+      for (unsigned test = 0U; test < ntests; ++test) {
+        test_cfg[test].pinflip = ((test & 1U) != 0U);
+        test_cfg[test].en_diff_rcvr = ((test & 2U) != 0U);
+        test_cfg[test].tx_use_d_se0 = false;
+      }
+      break;
+
+    case kDeviceFpgaCw310:
+      LOG_INFO(" - CW310 does not support pinflipping; ignoring");
+      LOG_INFO(" - CW310 employs only differential transmission");
+      ntests = 2U;
+      for (unsigned test = 0U; test < ntests; ++test) {
+        // For the CW310 pin-flipping is only useful if the SBU signals of the
+        // USB-C connector are being driven; this is not the case we're testing.
+        test_cfg[test].pinflip = false;
+        test_cfg[test].en_diff_rcvr = ((test & 1U) != 0U);
+        // D+/D- signals are always used directly as differential signals.
+        test_cfg[test].tx_use_d_se0 = false;
+      }
+      // Fine to employ verbose logging because behavior on FPGA is not
+      // timing-sensitive.
+      verbose = true;
+      break;
+
+    // Verilator can operate with any pin/bus configuration because it has
+    // ready access to the configuration information.
+    default:
+      CHECK(kDeviceType == kDeviceSimVerilator);
+      ntests = 8U;
+      for (unsigned test = 0U; test < ntests; ++test) {
+        test_cfg[test].pinflip = ((test & 1U) != 0U);
+        test_cfg[test].en_diff_rcvr = ((test & 2U) != 0U);
+        test_cfg[test].tx_use_d_se0 = ((test & 4U) != 0U);
+      }
+      break;
+  }
+
+  for (unsigned test = 0U; test < ntests; ++test) {
+    bool tx_use_d_se0 = test_cfg[test].tx_use_d_se0;
+    bool en_diff_rcvr = test_cfg[test].en_diff_rcvr;
+    bool pinflip = test_cfg[test].pinflip;
+
+    if (verbose) {
+      LOG_INFO("Init test %u pinflip %!b en_diff_rcvr %!b tx_use_d_se0 %!b",
+               test, pinflip, en_diff_rcvr, tx_use_d_se0);
+    }
+
+    // Note: this call will result in the buffer pool being (re)initialised and
+    // as such it _would_ be in disagreement with the hardware if usbdev were
+    // not reset after the previous test
+    CHECK_STATUS_OK(
+        usb_testutils_init(&usbdev, pinflip, en_diff_rcvr, tx_use_d_se0));
+
+    // Set up the control endpoint and see that we enter the configured state,
+    // implying successful communication between the DPI model and device
+    CHECK_STATUS_OK(usb_testutils_controlep_init(
+        &usbdev_control, &usbdev, 0, kConfigDescriptors,
+        sizeof(kConfigDescriptors), kTestDescriptor, sizeof(kTestDescriptor)));
+
+    // Configuration shall have been selected only after the host/DPI model has
+    // successfully concluded the SET_CONFIGURATION control transfer
+    const uint32_t kTimeoutUsecs = 30 * 1000000;
+    ibex_timeout_t timeout = ibex_timeout_init(kTimeoutUsecs);
+    while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured &&
+           !ibex_timeout_check(&timeout)) {
+      CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+    }
+    // Check that we were configured, implying that communication is working.
+    CHECK(usbdev_control.device_state == kUsbTestutilsDeviceConfigured);
+
+    if (kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator) {
+      // TODO: We shall probably want simply to drop the connection and control
+      // the DPI in time, as we do for the physical host at present.
+      dif_usbdev_link_state_t link_state;
+      do {
+        CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+        CHECK_DIF_OK(dif_usbdev_status_get_link_state(usbdev.dev, &link_state));
+      } while (link_state == kDifUsbdevLinkStateActive);
+    }
+
+    // Shut down the usb_testutils layer, in preparation for restarting;
+    // this disconnects usbdev from the bus. The DPI model will detect this and
+    // restart, awaiting a further connection attempt.
+    CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
+
+    // We must force a reset of the entire usbdev block in order to perform
+    // the next test successfully, because otherwise buffers remain in the
+    // internal FIFOs
+    if (verbose) {
+      LOG_INFO(" - Hold reset");
+    }
+    CHECK_DIF_OK(dif_rstmgr_software_reset(&rstmgr,
+                                           kTopEarlgreyResetManagerSwResetsUsb,
+                                           kDifRstmgrSoftwareResetHold));
+    if (verbose) {
+      LOG_INFO(" - Release reset");
+    }
+    CHECK_DIF_OK(dif_rstmgr_software_reset(&rstmgr,
+                                           kTopEarlgreyResetManagerSwResetsUsb,
+                                           kDifRstmgrSoftwareResetRelease));
+  }
+
+  return true;
+}


### PR DESCRIPTION
Adds a top-level test that cycles the usbdev through all pin configurations using the DPI model, checking that the device may be enumerated and configured in each configuration.

Verilator top-level simulation is capable of exercising all available configurations. On FPGA and in top-level DV simulation (with a two wire bus and no visibility to the device itself) a restricted subset of configurations is available; all available configurations are exercised.

The DPI changes also introduce a bit more functionality that is required for the full suspend-resume behavior, so the handling of bus resets, in particular, in this PR is tentative and a more complete and accurate model is available to be integrated later.

Commit 1: Tidy ups and restructuring to support later commits. No functional change to DPI model.

Commit 2: Changes localized to the DPI model, to support the pin configuration test. This mostly concerns the ability to reset the bus/device part-way through the test and resume communication with a different bus configuration.

Commit 3: Adds the device-side software test.


**To run on FPGA:**
```
bazel test --test_output=streamed //sw/device/tests:usbdev_pincfg_test_fpga_cw310_test_rom
```
_(Does NOT need any host-side code; if the host is connected via a USB Type-A socket and cable to the 'USRUSB' socket on the CW310 board, then the host will detect and automatically configure the device for each pin configuration in turn.)_


**To run pin configuration test with Verilator and DPI model:**
```
bazel test --test_output=streamed --test_tag_filters=verilator //sw/device/tests:usbdev_pincfg_test
```
**To run pin configuration test with EDA tools:**
```
./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_usbdev_pincfg --fixed-seed=1 --tool vcs --waves vpd
```
(or equivalent xcelium command)
