### PR TITLE
[usbdev] Save/restore data toggles for Deep Sleep

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -858,25 +858,67 @@
         ]
       }
     }
-    { multireg: {
-        name: "data_toggle_clear",
-        count: "NEndpoints"
-        cname: "Endpoint"
-        desc: "Clear the data toggle flag",
-        swaccess: "wo",
-        hwaccess: "hro",
-        hwqe: "true",
-        fields: [
-          {
-            bits: "0",
-            name: "clear",
-            desc: '''
-                  Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions.
-                  The register must no be written again within 200 ns.
-                  '''
-          }
-        ]
-      }
+    {
+      name: "out_data_toggle",
+      desc: "OUT Endpoints Data Toggles",
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe: "true",
+      fields: [
+        {
+          bits: "11:0",
+          name: "status",
+          desc: '''
+                Reading returns the current state of the OUT endpoint Data Toggle flags.
+                Writing sets the Data Toggle flag for each endpoint if the corresponding mask bit
+                in the upper half of this register is set.
+                '''
+        }
+        {
+          bits: "27:16",
+          name: "mask",
+          desc: '''
+                Reads as zero.
+                When writing, a set bit will cause the Data Toggle flag of the corresponding
+                OUT endpoint to be updated. A clear bit will leave the flag for the corresponding
+                endpoint unchanged.
+                '''
+        }
+      ],
+      tags: [// This CSR has mask bits that gate writes.
+             "excl:CsrNonInitTests:CsrExclWrite"]
+    }
+    {
+      name: "in_data_toggle",
+      desc: "IN Endpoints Data Toggles",
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe: "true",
+      fields: [
+        {
+          bits: "11:0",
+          name: "status",
+          desc: '''
+                Reading returns the current state of the IN endpoint Data Toggle flags.
+                Writing sets the Data Toggle flag for each endpoint if the corresponding mask bit
+                in the upper half of this register is set.
+                '''
+        }
+        {
+          bits: "27:16",
+          name: "mask",
+          desc: '''
+                Reads as zero.
+                When writing, a set bit will cause the Data Toggle flag of the corresponding
+                IN endpoint to be updated. A clear bit will leave the flag for the corresponding
+                endpoint unchanged.
+                '''
+        }
+      ],
+      tags: [// This CSR has mask bits that gate writes.
+             "excl:CsrNonInitTests:CsrExclWrite"]
     }
     { name: "phy_pins_sense",
       desc: '''

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -3,45 +3,46 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/usbdev/data/usbdev.hjson -->
 ## Summary
 
-| Name                                             | Offset   |   Length | Description                                                                |
-|:-------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------|
-| usbdev.[`INTR_STATE`](#intr_state)               | 0x0      |        4 | Interrupt State Register                                                   |
-| usbdev.[`INTR_ENABLE`](#intr_enable)             | 0x4      |        4 | Interrupt Enable Register                                                  |
-| usbdev.[`INTR_TEST`](#intr_test)                 | 0x8      |        4 | Interrupt Test Register                                                    |
-| usbdev.[`ALERT_TEST`](#alert_test)               | 0xc      |        4 | Alert Test Register                                                        |
-| usbdev.[`usbctrl`](#usbctrl)                     | 0x10     |        4 | USB Control                                                                |
-| usbdev.[`ep_out_enable`](#ep_out_enable)         | 0x14     |        4 | Enable an endpoint to respond to transactions in the downstream direction. |
-| usbdev.[`ep_in_enable`](#ep_in_enable)           | 0x18     |        4 | Enable an endpoint to respond to transactions in the upstream direction.   |
-| usbdev.[`usbstat`](#usbstat)                     | 0x1c     |        4 | USB Status                                                                 |
-| usbdev.[`avbuffer`](#avbuffer)                   | 0x20     |        4 | Available Buffer FIFO                                                      |
-| usbdev.[`rxfifo`](#rxfifo)                       | 0x24     |        4 | Received Buffer FIFO                                                       |
-| usbdev.[`rxenable_setup`](#rxenable_setup)       | 0x28     |        4 | Receive SETUP transaction enable                                           |
-| usbdev.[`rxenable_out`](#rxenable_out)           | 0x2c     |        4 | Receive OUT transaction enable                                             |
-| usbdev.[`set_nak_out`](#set_nak_out)             | 0x30     |        4 | Set NAK after OUT transactions                                             |
-| usbdev.[`in_sent`](#in_sent)                     | 0x34     |        4 | IN Transaction Sent                                                        |
-| usbdev.[`out_stall`](#out_stall)                 | 0x38     |        4 | OUT Endpoint STALL control                                                 |
-| usbdev.[`in_stall`](#in_stall)                   | 0x3c     |        4 | IN Endpoint STALL control                                                  |
-| usbdev.[`configin_0`](#configin)                 | 0x40     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_1`](#configin)                 | 0x44     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_2`](#configin)                 | 0x48     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_3`](#configin)                 | 0x4c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_4`](#configin)                 | 0x50     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_5`](#configin)                 | 0x54     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_6`](#configin)                 | 0x58     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_7`](#configin)                 | 0x5c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_8`](#configin)                 | 0x60     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_9`](#configin)                 | 0x64     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_10`](#configin)                | 0x68     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_11`](#configin)                | 0x6c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`out_iso`](#out_iso)                     | 0x70     |        4 | OUT Endpoint isochronous setting                                           |
-| usbdev.[`in_iso`](#in_iso)                       | 0x74     |        4 | IN Endpoint isochronous setting                                            |
-| usbdev.[`data_toggle_clear`](#data_toggle_clear) | 0x78     |        4 | Clear the data toggle flag                                                 |
-| usbdev.[`phy_pins_sense`](#phy_pins_sense)       | 0x7c     |        4 | USB PHY pins sense.                                                        |
-| usbdev.[`phy_pins_drive`](#phy_pins_drive)       | 0x80     |        4 | USB PHY pins drive.                                                        |
-| usbdev.[`phy_config`](#phy_config)               | 0x84     |        4 | USB PHY Configuration                                                      |
-| usbdev.[`wake_control`](#wake_control)           | 0x88     |        4 | USB wake module control for suspend / resume                               |
-| usbdev.[`wake_events`](#wake_events)             | 0x8c     |        4 | USB wake module events and debug                                           |
-| usbdev.[`buffer`](#buffer)                       | 0x800    |     2048 | 2 kB packet buffer. Divided into 32 64-byte buffers.                       |
+| Name                                         | Offset   |   Length | Description                                                                |
+|:---------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------|
+| usbdev.[`INTR_STATE`](#intr_state)           | 0x0      |        4 | Interrupt State Register                                                   |
+| usbdev.[`INTR_ENABLE`](#intr_enable)         | 0x4      |        4 | Interrupt Enable Register                                                  |
+| usbdev.[`INTR_TEST`](#intr_test)             | 0x8      |        4 | Interrupt Test Register                                                    |
+| usbdev.[`ALERT_TEST`](#alert_test)           | 0xc      |        4 | Alert Test Register                                                        |
+| usbdev.[`usbctrl`](#usbctrl)                 | 0x10     |        4 | USB Control                                                                |
+| usbdev.[`ep_out_enable`](#ep_out_enable)     | 0x14     |        4 | Enable an endpoint to respond to transactions in the downstream direction. |
+| usbdev.[`ep_in_enable`](#ep_in_enable)       | 0x18     |        4 | Enable an endpoint to respond to transactions in the upstream direction.   |
+| usbdev.[`usbstat`](#usbstat)                 | 0x1c     |        4 | USB Status                                                                 |
+| usbdev.[`avbuffer`](#avbuffer)               | 0x20     |        4 | Available Buffer FIFO                                                      |
+| usbdev.[`rxfifo`](#rxfifo)                   | 0x24     |        4 | Received Buffer FIFO                                                       |
+| usbdev.[`rxenable_setup`](#rxenable_setup)   | 0x28     |        4 | Receive SETUP transaction enable                                           |
+| usbdev.[`rxenable_out`](#rxenable_out)       | 0x2c     |        4 | Receive OUT transaction enable                                             |
+| usbdev.[`set_nak_out`](#set_nak_out)         | 0x30     |        4 | Set NAK after OUT transactions                                             |
+| usbdev.[`in_sent`](#in_sent)                 | 0x34     |        4 | IN Transaction Sent                                                        |
+| usbdev.[`out_stall`](#out_stall)             | 0x38     |        4 | OUT Endpoint STALL control                                                 |
+| usbdev.[`in_stall`](#in_stall)               | 0x3c     |        4 | IN Endpoint STALL control                                                  |
+| usbdev.[`configin_0`](#configin)             | 0x40     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_1`](#configin)             | 0x44     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_2`](#configin)             | 0x48     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_3`](#configin)             | 0x4c     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_4`](#configin)             | 0x50     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_5`](#configin)             | 0x54     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_6`](#configin)             | 0x58     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_7`](#configin)             | 0x5c     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_8`](#configin)             | 0x60     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_9`](#configin)             | 0x64     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_10`](#configin)            | 0x68     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`configin_11`](#configin)            | 0x6c     |        4 | Configure IN Transaction                                                   |
+| usbdev.[`out_iso`](#out_iso)                 | 0x70     |        4 | OUT Endpoint isochronous setting                                           |
+| usbdev.[`in_iso`](#in_iso)                   | 0x74     |        4 | IN Endpoint isochronous setting                                            |
+| usbdev.[`out_data_toggle`](#out_data_toggle) | 0x78     |        4 | OUT Endpoints Data Toggles                                                 |
+| usbdev.[`in_data_toggle`](#in_data_toggle)   | 0x7c     |        4 | IN Endpoints Data Toggles                                                  |
+| usbdev.[`phy_pins_sense`](#phy_pins_sense)   | 0x80     |        4 | USB PHY pins sense.                                                        |
+| usbdev.[`phy_pins_drive`](#phy_pins_drive)   | 0x84     |        4 | USB PHY pins drive.                                                        |
+| usbdev.[`phy_config`](#phy_config)           | 0x88     |        4 | USB PHY Configuration                                                      |
+| usbdev.[`wake_control`](#wake_control)       | 0x8c     |        4 | USB wake module control for suspend / resume                               |
+| usbdev.[`wake_events`](#wake_events)         | 0x90     |        4 | USB wake module events and debug                                           |
+| usbdev.[`buffer`](#buffer)                   | 0x800    |     2048 | 2 kB packet buffer. Divided into 32 64-byte buffers.                       |
 
 ## INTR_STATE
 Interrupt State Register
@@ -1093,39 +1094,49 @@ No handshake packet will be expected for an IN transaction.
 Note that if a rxenable_setup is set for this endpoint's number, this bit will not take effect.
 Control endpoint configuration trumps isochronous endpoint configuration.
 
-## data_toggle_clear
-Clear the data toggle flag
+## out_data_toggle
+OUT Endpoints Data Toggles
 - Offset: `0x78`
 - Reset default: `0x0`
-- Reset mask: `0xfff`
+- Reset mask: `0xfff0fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "clear_0", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_1", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_2", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_3", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_4", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_5", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_6", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_7", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_8", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_9", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_10", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "clear_11", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 20}], "config": {"lanes": 1, "fontsize": 10, "vspace": 100}}
+{"reg": [{"name": "status", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}, {"name": "mask", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name     | Description                                                                                                                                                         |
-|:------:|:------:|:-------:|:---------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:12  |        |         |          | Reserved                                                                                                                                                            |
-|   11   |   wo   |   0x0   | clear_11 | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   10   |   wo   |   0x0   | clear_10 | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   9    |   wo   |   0x0   | clear_9  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   8    |   wo   |   0x0   | clear_8  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   7    |   wo   |   0x0   | clear_7  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   6    |   wo   |   0x0   | clear_6  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   5    |   wo   |   0x0   | clear_5  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   4    |   wo   |   0x0   | clear_4  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   3    |   wo   |   0x0   | clear_3  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   2    |   wo   |   0x0   | clear_2  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   1    |   wo   |   0x0   | clear_1  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
-|   0    |   wo   |   0x0   | clear_0  | Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions. The register must no be written again within 200 ns. |
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                                           |
+|:------:|:------:|:-------:|:-------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:28  |        |         |        | Reserved                                                                                                                                                                                              |
+| 27:16  |   rw   |    x    | mask   | Reads as zero. When writing, a set bit will cause the Data Toggle flag of the corresponding OUT endpoint to be updated. A clear bit will leave the flag for the corresponding endpoint unchanged.     |
+| 15:12  |        |         |        | Reserved                                                                                                                                                                                              |
+|  11:0  |   rw   |    x    | status | Reading returns the current state of the OUT endpoint Data Toggle flags. Writing sets the Data Toggle flag for each endpoint if the corresponding mask bit in the upper half of this register is set. |
+
+## in_data_toggle
+IN Endpoints Data Toggles
+- Offset: `0x7c`
+- Reset default: `0x0`
+- Reset mask: `0xfff0fff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "status", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}, {"name": "mask", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                                          |
+|:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:28  |        |         |        | Reserved                                                                                                                                                                                             |
+| 27:16  |   rw   |    x    | mask   | Reads as zero. When writing, a set bit will cause the Data Toggle flag of the corresponding IN endpoint to be updated. A clear bit will leave the flag for the corresponding endpoint unchanged.     |
+| 15:12  |        |         |        | Reserved                                                                                                                                                                                             |
+|  11:0  |   rw   |    x    | status | Reading returns the current state of the IN endpoint Data Toggle flags. Writing sets the Data Toggle flag for each endpoint if the corresponding mask bit in the upper half of this register is set. |
 
 ## phy_pins_sense
 USB PHY pins sense.
 This register can be used to read out the state of the USB device inputs and outputs from software.
 This is designed to be used for debugging purposes or during chip testing.
-- Offset: `0x7c`
+- Offset: `0x80`
 - Reset default: `0x0`
 - Reset mask: `0x11f07`
 
@@ -1154,7 +1165,7 @@ This is designed to be used for debugging purposes or during chip testing.
 USB PHY pins drive.
 This register can be used to control the USB device inputs and outputs from software.
 This is designed to be used for debugging purposes or during chip testing.
-- Offset: `0x80`
+- Offset: `0x84`
 - Reset default: `0x0`
 - Reset mask: `0x100ff`
 
@@ -1180,7 +1191,7 @@ This is designed to be used for debugging purposes or during chip testing.
 
 ## phy_config
 USB PHY Configuration
-- Offset: `0x84`
+- Offset: `0x88`
 - Reset default: `0x4`
 - Reset mask: `0xe7`
 
@@ -1235,7 +1246,7 @@ This bit also feeds the rx_enable pin, activating the receiver when the device i
 
 ## wake_control
 USB wake module control for suspend / resume
-- Offset: `0x88`
+- Offset: `0x8c`
 - Reset default: `0x0`
 - Reset mask: `0x3`
 
@@ -1269,7 +1280,7 @@ Activation may not happen immediately, and its status can be verified by checkin
 
 ## wake_events
 USB wake module events and debug
-- Offset: `0x8c`
+- Offset: `0x90`
 - Reset default: `0x0`
 - Reset mask: `0x301`
 

--- a/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
@@ -35,7 +35,14 @@ module usb_fs_nb_pe #(
   input  logic                   cfg_pinflip_i, // 1: USB-side D+ and D- pins are flipped.
                                                 // Change values in logic to accommodate.
   input  logic                   tx_osc_test_mode_i, // Oscillator test mode (constantly output JK)
-  input  logic [NumOutEps-1:0]   data_toggle_clear_i, // Clear the data toggles for an EP
+  output logic [NumOutEps-1:0]   out_data_toggle_o, // Current state of OUT data toggles
+  input  logic                   out_datatog_we_i, // OUT data toggles write strobe from software
+  input  logic [NumOutEps-1:0]   out_datatog_status_i, // New state of selected OUT data toggles
+  input  logic [NumOutEps-1:0]   out_datatog_mask_i, // Which OUT EP data toggles to modify
+  output logic [NumInEps-1:0]    in_data_toggle_o, // Current state of IN data toggles
+  input  logic                   in_datatog_we_i, // IN data toggles write strobe from software
+  input  logic [NumInEps-1:0]    in_datatog_status_i, // New state of selected IN data toggles
+  input  logic [NumInEps-1:0]    in_datatog_mask_i, // Which IN EP data toggles to modify
   input  logic                   diff_rx_ok_i, // 1: received differential data symbols are valid.
                                                // Set low if K and J symbols might be invalid, such
                                                // as when an external differential receiver is
@@ -174,7 +181,10 @@ module usb_fs_nb_pe #(
     .in_ep_data_done_i     (in_ep_data_done_i),
     .in_ep_iso_i           (in_ep_iso_not_control),
 
-    .data_toggle_clear_i   (data_toggle_clear_i),
+    .in_data_toggle_o      (in_data_toggle_o),
+    .in_datatog_we_i       (in_datatog_we_i),
+    .in_datatog_status_i   (in_datatog_status_i),
+    .in_datatog_mask_i     (in_datatog_mask_i),
 
     // rx path
     .rx_pkt_start_i        (rx_pkt_start),
@@ -218,7 +228,10 @@ module usb_fs_nb_pe #(
     .out_ep_stall_i         (out_ep_stall_i),
     .out_ep_iso_i           (out_ep_iso_i),
 
-    .data_toggle_clear_i    (data_toggle_clear_i),
+    .out_data_toggle_o      (out_data_toggle_o),
+    .out_datatog_we_i       (out_datatog_we_i),
+    .out_datatog_status_i   (out_datatog_status_i),
+    .out_datatog_mask_i     (out_datatog_mask_i),
 
     // rx path
     .rx_pkt_start_i         (rx_pkt_start),

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -294,9 +294,26 @@ package usbdev_reg_pkg;
   } usbdev_reg2hw_in_iso_mreg_t;
 
   typedef struct packed {
-    logic        q;
-    logic        qe;
-  } usbdev_reg2hw_data_toggle_clear_mreg_t;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } mask;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } status;
+  } usbdev_reg2hw_out_data_toggle_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } mask;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } status;
+  } usbdev_reg2hw_in_data_toggle_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -513,6 +530,24 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [11:0] d;
+    } status;
+    struct packed {
+      logic [11:0] d;
+    } mask;
+  } usbdev_hw2reg_out_data_toggle_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [11:0] d;
+    } status;
+    struct packed {
+      logic [11:0] d;
+    } mask;
+  } usbdev_hw2reg_in_data_toggle_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
     } rx_dp_i;
     struct packed {
@@ -558,25 +593,26 @@ package usbdev_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [437:421]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [420:404]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [403:370]
-    usbdev_reg2hw_alert_test_reg_t alert_test; // [369:368]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [367:358]
-    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [357:346]
-    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [345:334]
-    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [333:328]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [327:307]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [306:295]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [294:283]
-    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [282:271]
-    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [270:259]
-    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [258:247]
-    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [246:235]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [234:67]
-    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [66:55]
-    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [54:43]
-    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [42:19]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [465:449]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [448:432]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [431:398]
+    usbdev_reg2hw_alert_test_reg_t alert_test; // [397:396]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [395:386]
+    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [385:374]
+    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [373:362]
+    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [361:356]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [355:335]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [334:323]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [322:311]
+    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [310:299]
+    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [298:287]
+    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [286:275]
+    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [274:263]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [262:95]
+    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [94:83]
+    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [82:71]
+    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [70:45]
+    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [44:19]
     usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [18:10]
     usbdev_reg2hw_phy_config_reg_t phy_config; // [9:4]
     usbdev_reg2hw_wake_control_reg_t wake_control; // [3:0]
@@ -584,15 +620,17 @@ package usbdev_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [243:210]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [209:202]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [201:176]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [175:159]
-    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [158:135]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [134:111]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [110:87]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [86:63]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [62:15]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [291:258]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [257:250]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [249:224]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [223:207]
+    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [206:183]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [182:159]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [158:135]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [134:111]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [110:63]
+    usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [62:39]
+    usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [38:15]
     usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [14:6]
     usbdev_hw2reg_wake_events_reg_t wake_events; // [5:0]
   } usbdev_hw2reg_t;
@@ -628,12 +666,13 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_11_OFFSET = 12'h 6c;
   parameter logic [BlockAw-1:0] USBDEV_OUT_ISO_OFFSET = 12'h 70;
   parameter logic [BlockAw-1:0] USBDEV_IN_ISO_OFFSET = 12'h 74;
-  parameter logic [BlockAw-1:0] USBDEV_DATA_TOGGLE_CLEAR_OFFSET = 12'h 78;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 7c;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 80;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 84;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 88;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 8c;
+  parameter logic [BlockAw-1:0] USBDEV_OUT_DATA_TOGGLE_OFFSET = 12'h 78;
+  parameter logic [BlockAw-1:0] USBDEV_IN_DATA_TOGGLE_OFFSET = 12'h 7c;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 80;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 84;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 88;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 8c;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 90;
 
   // Reset values for hwext registers and their fields
   parameter logic [16:0] USBDEV_INTR_TEST_RESVAL = 17'h 0;
@@ -659,6 +698,8 @@ package usbdev_reg_pkg;
   parameter logic [31:0] USBDEV_USBSTAT_RESVAL = 32'h 80000000;
   parameter logic [0:0] USBDEV_USBSTAT_RX_EMPTY_RESVAL = 1'h 1;
   parameter logic [23:0] USBDEV_RXFIFO_RESVAL = 24'h 0;
+  parameter logic [27:0] USBDEV_OUT_DATA_TOGGLE_RESVAL = 28'h 0;
+  parameter logic [27:0] USBDEV_IN_DATA_TOGGLE_RESVAL = 28'h 0;
   parameter logic [16:0] USBDEV_PHY_PINS_SENSE_RESVAL = 17'h 0;
   parameter logic [1:0] USBDEV_WAKE_CONTROL_RESVAL = 2'h 0;
   parameter logic [0:0] USBDEV_WAKE_CONTROL_SUSPEND_REQ_RESVAL = 1'h 0;
@@ -701,7 +742,8 @@ package usbdev_reg_pkg;
     USBDEV_CONFIGIN_11,
     USBDEV_OUT_ISO,
     USBDEV_IN_ISO,
-    USBDEV_DATA_TOGGLE_CLEAR,
+    USBDEV_OUT_DATA_TOGGLE,
+    USBDEV_IN_DATA_TOGGLE,
     USBDEV_PHY_PINS_SENSE,
     USBDEV_PHY_PINS_DRIVE,
     USBDEV_PHY_CONFIG,
@@ -710,7 +752,7 @@ package usbdev_reg_pkg;
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [36] = '{
+  parameter logic [3:0] USBDEV_PERMIT [37] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -741,12 +783,13 @@ package usbdev_reg_pkg;
     4'b 1111, // index[27] USBDEV_CONFIGIN_11
     4'b 0011, // index[28] USBDEV_OUT_ISO
     4'b 0011, // index[29] USBDEV_IN_ISO
-    4'b 0011, // index[30] USBDEV_DATA_TOGGLE_CLEAR
-    4'b 0111, // index[31] USBDEV_PHY_PINS_SENSE
-    4'b 0111, // index[32] USBDEV_PHY_PINS_DRIVE
-    4'b 0001, // index[33] USBDEV_PHY_CONFIG
-    4'b 0001, // index[34] USBDEV_WAKE_CONTROL
-    4'b 0011  // index[35] USBDEV_WAKE_EVENTS
+    4'b 1111, // index[30] USBDEV_OUT_DATA_TOGGLE
+    4'b 1111, // index[31] USBDEV_IN_DATA_TOGGLE
+    4'b 0111, // index[32] USBDEV_PHY_PINS_SENSE
+    4'b 0111, // index[33] USBDEV_PHY_PINS_DRIVE
+    4'b 0001, // index[34] USBDEV_PHY_CONFIG
+    4'b 0001, // index[35] USBDEV_WAKE_CONTROL
+    4'b 0011  // index[36] USBDEV_WAKE_EVENTS
   };
 
 endpackage

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -59,9 +59,9 @@ module usbdev_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [35:0] reg_we_check;
+  logic [36:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(36)
+    .OneHotWidth(37)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -642,19 +642,18 @@ module usbdev_reg_top (
   logic in_iso_iso_10_wd;
   logic in_iso_iso_11_qs;
   logic in_iso_iso_11_wd;
-  logic data_toggle_clear_we;
-  logic data_toggle_clear_clear_0_wd;
-  logic data_toggle_clear_clear_1_wd;
-  logic data_toggle_clear_clear_2_wd;
-  logic data_toggle_clear_clear_3_wd;
-  logic data_toggle_clear_clear_4_wd;
-  logic data_toggle_clear_clear_5_wd;
-  logic data_toggle_clear_clear_6_wd;
-  logic data_toggle_clear_clear_7_wd;
-  logic data_toggle_clear_clear_8_wd;
-  logic data_toggle_clear_clear_9_wd;
-  logic data_toggle_clear_clear_10_wd;
-  logic data_toggle_clear_clear_11_wd;
+  logic out_data_toggle_re;
+  logic out_data_toggle_we;
+  logic [11:0] out_data_toggle_status_qs;
+  logic [11:0] out_data_toggle_status_wd;
+  logic [11:0] out_data_toggle_mask_qs;
+  logic [11:0] out_data_toggle_mask_wd;
+  logic in_data_toggle_re;
+  logic in_data_toggle_we;
+  logic [11:0] in_data_toggle_status_qs;
+  logic [11:0] in_data_toggle_status_wd;
+  logic [11:0] in_data_toggle_mask_qs;
+  logic [11:0] in_data_toggle_mask_wd;
   logic phy_pins_sense_re;
   logic phy_pins_sense_rx_dp_i_qs;
   logic phy_pins_sense_rx_dn_i_qs;
@@ -6928,354 +6927,78 @@ module usbdev_reg_top (
   );
 
 
-  // Subregister 0 of Multireg data_toggle_clear
-  // R[data_toggle_clear]: V(False)
-  logic data_toggle_clear_qe;
-  logic [11:0] data_toggle_clear_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_data_toggle_clear0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&data_toggle_clear_flds_we),
-    .q_o(data_toggle_clear_qe)
-  );
-  //   F[clear_0]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[0]),
-    .q      (reg2hw.data_toggle_clear[0].q),
+  // R[out_data_toggle]: V(True)
+  logic out_data_toggle_qe;
+  logic [1:0] out_data_toggle_flds_we;
+  assign out_data_toggle_qe = &out_data_toggle_flds_we;
+  //   F[status]: 11:0
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_out_data_toggle_status (
+    .re     (out_data_toggle_re),
+    .we     (out_data_toggle_we),
+    .wd     (out_data_toggle_status_wd),
+    .d      (hw2reg.out_data_toggle.status.d),
+    .qre    (),
+    .qe     (out_data_toggle_flds_we[0]),
+    .q      (reg2hw.out_data_toggle.status.q),
     .ds     (),
-
-    // to register interface (read)
-    .qs     ()
+    .qs     (out_data_toggle_status_qs)
   );
-  assign reg2hw.data_toggle_clear[0].qe = data_toggle_clear_qe;
+  assign reg2hw.out_data_toggle.status.qe = out_data_toggle_qe;
 
-  //   F[clear_1]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[1]),
-    .q      (reg2hw.data_toggle_clear[1].q),
+  //   F[mask]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_out_data_toggle_mask (
+    .re     (out_data_toggle_re),
+    .we     (out_data_toggle_we),
+    .wd     (out_data_toggle_mask_wd),
+    .d      (hw2reg.out_data_toggle.mask.d),
+    .qre    (),
+    .qe     (out_data_toggle_flds_we[1]),
+    .q      (reg2hw.out_data_toggle.mask.q),
     .ds     (),
-
-    // to register interface (read)
-    .qs     ()
+    .qs     (out_data_toggle_mask_qs)
   );
-  assign reg2hw.data_toggle_clear[1].qe = data_toggle_clear_qe;
+  assign reg2hw.out_data_toggle.mask.qe = out_data_toggle_qe;
 
-  //   F[clear_2]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
 
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[2]),
-    .q      (reg2hw.data_toggle_clear[2].q),
+  // R[in_data_toggle]: V(True)
+  logic in_data_toggle_qe;
+  logic [1:0] in_data_toggle_flds_we;
+  assign in_data_toggle_qe = &in_data_toggle_flds_we;
+  //   F[status]: 11:0
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_in_data_toggle_status (
+    .re     (in_data_toggle_re),
+    .we     (in_data_toggle_we),
+    .wd     (in_data_toggle_status_wd),
+    .d      (hw2reg.in_data_toggle.status.d),
+    .qre    (),
+    .qe     (in_data_toggle_flds_we[0]),
+    .q      (reg2hw.in_data_toggle.status.q),
     .ds     (),
-
-    // to register interface (read)
-    .qs     ()
+    .qs     (in_data_toggle_status_qs)
   );
-  assign reg2hw.data_toggle_clear[2].qe = data_toggle_clear_qe;
+  assign reg2hw.in_data_toggle.status.qe = in_data_toggle_qe;
 
-  //   F[clear_3]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[3]),
-    .q      (reg2hw.data_toggle_clear[3].q),
+  //   F[mask]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_in_data_toggle_mask (
+    .re     (in_data_toggle_re),
+    .we     (in_data_toggle_we),
+    .wd     (in_data_toggle_mask_wd),
+    .d      (hw2reg.in_data_toggle.mask.d),
+    .qre    (),
+    .qe     (in_data_toggle_flds_we[1]),
+    .q      (reg2hw.in_data_toggle.mask.q),
     .ds     (),
-
-    // to register interface (read)
-    .qs     ()
+    .qs     (in_data_toggle_mask_qs)
   );
-  assign reg2hw.data_toggle_clear[3].qe = data_toggle_clear_qe;
-
-  //   F[clear_4]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[4]),
-    .q      (reg2hw.data_toggle_clear[4].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[4].qe = data_toggle_clear_qe;
-
-  //   F[clear_5]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[5]),
-    .q      (reg2hw.data_toggle_clear[5].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[5].qe = data_toggle_clear_qe;
-
-  //   F[clear_6]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[6]),
-    .q      (reg2hw.data_toggle_clear[6].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[6].qe = data_toggle_clear_qe;
-
-  //   F[clear_7]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[7]),
-    .q      (reg2hw.data_toggle_clear[7].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[7].qe = data_toggle_clear_qe;
-
-  //   F[clear_8]: 8:8
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_8 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_8_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[8]),
-    .q      (reg2hw.data_toggle_clear[8].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[8].qe = data_toggle_clear_qe;
-
-  //   F[clear_9]: 9:9
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_9 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[9]),
-    .q      (reg2hw.data_toggle_clear[9].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[9].qe = data_toggle_clear_qe;
-
-  //   F[clear_10]: 10:10
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_10 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_10_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[10]),
-    .q      (reg2hw.data_toggle_clear[10].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[10].qe = data_toggle_clear_qe;
-
-  //   F[clear_11]: 11:11
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_data_toggle_clear_clear_11 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (data_toggle_clear_we),
-    .wd     (data_toggle_clear_clear_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (data_toggle_clear_flds_we[11]),
-    .q      (reg2hw.data_toggle_clear[11].q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     ()
-  );
-  assign reg2hw.data_toggle_clear[11].qe = data_toggle_clear_qe;
+  assign reg2hw.in_data_toggle.mask.qe = in_data_toggle_qe;
 
 
   // R[phy_pins_sense]: V(True)
@@ -7947,7 +7670,7 @@ module usbdev_reg_top (
 
 
 
-  logic [35:0] addr_hit;
+  logic [36:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
@@ -7980,12 +7703,13 @@ module usbdev_reg_top (
     addr_hit[27] = (reg_addr == USBDEV_CONFIGIN_11_OFFSET);
     addr_hit[28] = (reg_addr == USBDEV_OUT_ISO_OFFSET);
     addr_hit[29] = (reg_addr == USBDEV_IN_ISO_OFFSET);
-    addr_hit[30] = (reg_addr == USBDEV_DATA_TOGGLE_CLEAR_OFFSET);
-    addr_hit[31] = (reg_addr == USBDEV_PHY_PINS_SENSE_OFFSET);
-    addr_hit[32] = (reg_addr == USBDEV_PHY_PINS_DRIVE_OFFSET);
-    addr_hit[33] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
-    addr_hit[34] = (reg_addr == USBDEV_WAKE_CONTROL_OFFSET);
-    addr_hit[35] = (reg_addr == USBDEV_WAKE_EVENTS_OFFSET);
+    addr_hit[30] = (reg_addr == USBDEV_OUT_DATA_TOGGLE_OFFSET);
+    addr_hit[31] = (reg_addr == USBDEV_IN_DATA_TOGGLE_OFFSET);
+    addr_hit[32] = (reg_addr == USBDEV_PHY_PINS_SENSE_OFFSET);
+    addr_hit[33] = (reg_addr == USBDEV_PHY_PINS_DRIVE_OFFSET);
+    addr_hit[34] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
+    addr_hit[35] = (reg_addr == USBDEV_WAKE_CONTROL_OFFSET);
+    addr_hit[36] = (reg_addr == USBDEV_WAKE_EVENTS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -8028,7 +7752,8 @@ module usbdev_reg_top (
                (addr_hit[32] & (|(USBDEV_PERMIT[32] & ~reg_be))) |
                (addr_hit[33] & (|(USBDEV_PERMIT[33] & ~reg_be))) |
                (addr_hit[34] & (|(USBDEV_PERMIT[34] & ~reg_be))) |
-               (addr_hit[35] & (|(USBDEV_PERMIT[35] & ~reg_be)))));
+               (addr_hit[35] & (|(USBDEV_PERMIT[35] & ~reg_be))) |
+               (addr_hit[36] & (|(USBDEV_PERMIT[36] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -8510,33 +8235,20 @@ module usbdev_reg_top (
   assign in_iso_iso_10_wd = reg_wdata[10];
 
   assign in_iso_iso_11_wd = reg_wdata[11];
-  assign data_toggle_clear_we = addr_hit[30] & reg_we & !reg_error;
+  assign out_data_toggle_re = addr_hit[30] & reg_re & !reg_error;
+  assign out_data_toggle_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign data_toggle_clear_clear_0_wd = reg_wdata[0];
+  assign out_data_toggle_status_wd = reg_wdata[11:0];
 
-  assign data_toggle_clear_clear_1_wd = reg_wdata[1];
+  assign out_data_toggle_mask_wd = reg_wdata[27:16];
+  assign in_data_toggle_re = addr_hit[31] & reg_re & !reg_error;
+  assign in_data_toggle_we = addr_hit[31] & reg_we & !reg_error;
 
-  assign data_toggle_clear_clear_2_wd = reg_wdata[2];
+  assign in_data_toggle_status_wd = reg_wdata[11:0];
 
-  assign data_toggle_clear_clear_3_wd = reg_wdata[3];
-
-  assign data_toggle_clear_clear_4_wd = reg_wdata[4];
-
-  assign data_toggle_clear_clear_5_wd = reg_wdata[5];
-
-  assign data_toggle_clear_clear_6_wd = reg_wdata[6];
-
-  assign data_toggle_clear_clear_7_wd = reg_wdata[7];
-
-  assign data_toggle_clear_clear_8_wd = reg_wdata[8];
-
-  assign data_toggle_clear_clear_9_wd = reg_wdata[9];
-
-  assign data_toggle_clear_clear_10_wd = reg_wdata[10];
-
-  assign data_toggle_clear_clear_11_wd = reg_wdata[11];
-  assign phy_pins_sense_re = addr_hit[31] & reg_re & !reg_error;
-  assign phy_pins_drive_we = addr_hit[32] & reg_we & !reg_error;
+  assign in_data_toggle_mask_wd = reg_wdata[27:16];
+  assign phy_pins_sense_re = addr_hit[32] & reg_re & !reg_error;
+  assign phy_pins_drive_we = addr_hit[33] & reg_we & !reg_error;
 
   assign phy_pins_drive_dp_o_wd = reg_wdata[0];
 
@@ -8555,7 +8267,7 @@ module usbdev_reg_top (
   assign phy_pins_drive_dn_pullup_en_o_wd = reg_wdata[7];
 
   assign phy_pins_drive_en_wd = reg_wdata[16];
-  assign phy_config_we = addr_hit[33] & reg_we & !reg_error;
+  assign phy_config_we = addr_hit[34] & reg_we & !reg_error;
 
   assign phy_config_use_diff_rcvr_wd = reg_wdata[0];
 
@@ -8568,7 +8280,7 @@ module usbdev_reg_top (
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
   assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
-  assign wake_control_we = addr_hit[34] & reg_we & !reg_error;
+  assign wake_control_we = addr_hit[35] & reg_we & !reg_error;
 
 
 
@@ -8605,12 +8317,13 @@ module usbdev_reg_top (
     reg_we_check[27] = configin_11_we;
     reg_we_check[28] = out_iso_we;
     reg_we_check[29] = in_iso_we;
-    reg_we_check[30] = data_toggle_clear_we;
-    reg_we_check[31] = 1'b0;
-    reg_we_check[32] = phy_pins_drive_we;
-    reg_we_check[33] = phy_config_we;
-    reg_we_check[34] = wake_control_we;
-    reg_we_check[35] = 1'b0;
+    reg_we_check[30] = out_data_toggle_we;
+    reg_we_check[31] = in_data_toggle_we;
+    reg_we_check[32] = 1'b0;
+    reg_we_check[33] = phy_pins_drive_we;
+    reg_we_check[34] = phy_config_we;
+    reg_we_check[35] = wake_control_we;
+    reg_we_check[36] = 1'b0;
   end
 
   // Read data return
@@ -8944,21 +8657,16 @@ module usbdev_reg_top (
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[0] = '0;
-        reg_rdata_next[1] = '0;
-        reg_rdata_next[2] = '0;
-        reg_rdata_next[3] = '0;
-        reg_rdata_next[4] = '0;
-        reg_rdata_next[5] = '0;
-        reg_rdata_next[6] = '0;
-        reg_rdata_next[7] = '0;
-        reg_rdata_next[8] = '0;
-        reg_rdata_next[9] = '0;
-        reg_rdata_next[10] = '0;
-        reg_rdata_next[11] = '0;
+        reg_rdata_next[11:0] = out_data_toggle_status_qs;
+        reg_rdata_next[27:16] = out_data_toggle_mask_qs;
       end
 
       addr_hit[31]: begin
+        reg_rdata_next[11:0] = in_data_toggle_status_qs;
+        reg_rdata_next[27:16] = in_data_toggle_mask_qs;
+      end
+
+      addr_hit[32]: begin
         reg_rdata_next[0] = phy_pins_sense_rx_dp_i_qs;
         reg_rdata_next[1] = phy_pins_sense_rx_dn_i_qs;
         reg_rdata_next[2] = phy_pins_sense_rx_d_i_qs;
@@ -8970,7 +8678,7 @@ module usbdev_reg_top (
         reg_rdata_next[16] = phy_pins_sense_pwr_sense_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[0] = phy_pins_drive_dp_o_qs;
         reg_rdata_next[1] = phy_pins_drive_dn_o_qs;
         reg_rdata_next[2] = phy_pins_drive_d_o_qs;
@@ -8982,7 +8690,7 @@ module usbdev_reg_top (
         reg_rdata_next[16] = phy_pins_drive_en_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[0] = phy_config_use_diff_rcvr_qs;
         reg_rdata_next[1] = phy_config_tx_use_d_se0_qs;
         reg_rdata_next[2] = phy_config_eop_single_bit_qs;
@@ -8991,10 +8699,10 @@ module usbdev_reg_top (
         reg_rdata_next[7] = phy_config_tx_osc_test_mode_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next = DW'(wake_control_qs);
       end
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next = DW'(wake_events_qs);
       end
       default: begin
@@ -9013,10 +8721,10 @@ module usbdev_reg_top (
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_busy_sel = wake_control_busy;
       end
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_busy_sel = wake_events_busy;
       end
       default: begin

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -84,7 +84,14 @@ module usbdev_usbif  #(
   input  logic                     cfg_pinflip_i, // 1: Treat outputs and inputs as though D+/D-
                                                   // are flipped
   input  logic                     tx_osc_test_mode_i, // Oscillator test mode: constant JK output
-  input  logic [NEndpoints-1:0]    data_toggle_clear_i, // Clear the data toggles for an EP
+  output logic [NEndpoints-1:0]    out_data_toggle_o, // Current state of OUT data toggles
+  input  logic                     out_datatog_we_i, // OUT data toggles write strobe from software
+  input  logic [NEndpoints-1:0]    out_datatog_status_i, // New state of selected OUT data toggles
+  input  logic [NEndpoints-1:0]    out_datatog_mask_i, // Which OUT EP data toggles to modify
+  output logic [NEndpoints-1:0]    in_data_toggle_o, // Current state of IN data toggles
+  input  logic                     in_datatog_we_i, // IN data toggles write strobe from software
+  input  logic [NEndpoints-1:0]    in_datatog_status_i, // New state of selected IN data toggles
+  input  logic [NEndpoints-1:0]    in_datatog_mask_i, // Which IN EP data toggles to modify
   input  logic                     resume_link_active_i, // Jump from LinkPowered to LinkResuming
 
   // status
@@ -282,7 +289,14 @@ module usbdev_usbif  #(
     .cfg_use_diff_rcvr_i   (cfg_use_diff_rcvr_i),
     .cfg_pinflip_i         (cfg_pinflip_i),
     .tx_osc_test_mode_i    (tx_osc_test_mode_i),
-    .data_toggle_clear_i   (data_toggle_clear_i),
+    .out_data_toggle_o     (out_data_toggle_o),
+    .out_datatog_we_i      (out_datatog_we_i),
+    .out_datatog_status_i  (out_datatog_status_i),
+    .out_datatog_mask_i    (out_datatog_mask_i),
+    .in_data_toggle_o      (in_data_toggle_o),
+    .in_datatog_we_i       (in_datatog_we_i),
+    .in_datatog_status_i   (in_datatog_status_i),
+    .in_datatog_mask_i     (in_datatog_mask_i),
     .diff_rx_ok_i          (diff_rx_ok_i),
 
     .usb_d_i               (usb_d_i),

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -667,13 +667,72 @@ dif_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev, uint8_t *addr) {
   return kDifOk;
 }
 
+dif_result_t dif_usbdev_data_toggle_out_read(const dif_usbdev_t *usbdev,
+                                             uint16_t *toggles) {
+  if (usbdev == NULL || toggles == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(usbdev->base_addr, USBDEV_OUT_DATA_TOGGLE_REG_OFFSET);
+  // Note: only 12 OUT endpoints defined.
+  *toggles = (uint16_t)reg_val;
+
+  return kDifOk;
+}
+
+dif_result_t dif_usbdev_data_toggle_in_read(const dif_usbdev_t *usbdev,
+                                            uint16_t *toggles) {
+  if (usbdev == NULL || toggles == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(usbdev->base_addr, USBDEV_IN_DATA_TOGGLE_REG_OFFSET);
+  // Note: only 12 OUT endpoints defined.
+  *toggles = (uint16_t)reg_val;
+
+  return kDifOk;
+}
+
+dif_result_t dif_usbdev_data_toggle_out_write(const dif_usbdev_t *usbdev,
+                                              uint16_t mask, uint16_t state) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  // Note: only 12 OUT endpoints defined.
+  mmio_region_write32(usbdev->base_addr, USBDEV_OUT_DATA_TOGGLE_REG_OFFSET,
+                      ((uint32_t)mask << 16) | state);
+
+  return kDifOk;
+}
+
+dif_result_t dif_usbdev_data_toggle_in_write(const dif_usbdev_t *usbdev,
+                                             uint16_t mask, uint16_t state) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  // Note: only 12 OUT endpoints defined.
+  mmio_region_write32(usbdev->base_addr, USBDEV_IN_DATA_TOGGLE_REG_OFFSET,
+                      ((uint32_t)mask << 16) | state);
+
+  return kDifOk;
+}
+
 dif_result_t dif_usbdev_clear_data_toggle(const dif_usbdev_t *usbdev,
                                           uint8_t endpoint) {
   if (usbdev == NULL) {
     return kDifBadArg;
   }
-  mmio_region_write32(usbdev->base_addr, USBDEV_DATA_TOGGLE_CLEAR_REG_OFFSET,
-                      1u << endpoint);
+
+  uint32_t reg_val = (uint32_t)1u << (endpoint + 16u);
+  mmio_region_write32(usbdev->base_addr, USBDEV_OUT_DATA_TOGGLE_REG_OFFSET,
+                      reg_val);
+  mmio_region_write32(usbdev->base_addr, USBDEV_IN_DATA_TOGGLE_REG_OFFSET,
+                      reg_val);
+
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -614,6 +614,56 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev, uint8_t *addr);
 
 /**
+ * Read the data toggle bits of the OUT endpoints.
+ *
+ * @param usbdev A USB device.
+ * @param[out]toggles Current state of OUT data toggle bits.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_data_toggle_out_read(const dif_usbdev_t *usbdev,
+                                             uint16_t *toggles);
+
+/**
+ * Read the data toggle bits of the IN endpoints.
+ *
+ * @param usbdev A USB device.
+ * @param[out]toggles Current state of IN data toggle bits.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_data_toggle_in_read(const dif_usbdev_t *usbdev,
+                                            uint16_t *toggles);
+
+/**
+ * Write to the data toggle bits of a subset of the OUT endpoints.
+ * Set 1 in `mask` to change the data toggle bit of an OUT endpoint to the value
+ * of the corresponding bit in `state`.
+ *
+ * @param usbdev A USB device.
+ * @param mask Mask of OUT endpoint data toggles to be changed.
+ * @param state New states of that OUT endpoint data toggles being changed.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_data_toggle_out_write(const dif_usbdev_t *usbdev,
+                                              uint16_t mask, uint16_t state);
+
+/**
+ * Write to the data toggle bits of a subset of the IN endpoints.
+ * Set 1 in `mask` to change the data toggle bit of an IN endpoint to the value
+ * of the corresponding bit in `state`.
+ *
+ * @param usbdev A USB device.
+ * @param mask Mask of IN endpoint data toggles to be changed.
+ * @param state New states of that IN endpoint data toggles being changed.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_data_toggle_in_write(const dif_usbdev_t *usbdev,
+                                             uint16_t mask, uint16_t state);
+
+/**
  * Clear the data toggle bits for the selected endpoint.
  *
  * @param usbdev A USB device.


### PR DESCRIPTION
This PR proposes register modifications to the usbdev to support resume from Deep Sleep; it addresses #19042 by introducing the ability to read and to restore the Data Toggle bits of all of the IN and OUT endpoints.

~~Comments and guidance are requested on the way that the registers are described, and whether this is apt to cause any issues for our automated CSR tests. Specifically, there's some inelegance in that the register interface contains unnecessary flip flops that mirror the state of the data toggle flops themselves (which are in the packet engines), and the fact that there are register bits at all for the 'mask' bits in the upper half of each register; these 'mask' bits control which of the lower bits cause data toggles to be modified, and which are left unchanged~~.

The implementation has been tested using some hand-written directed code, ~~which I can turn into a unittest for the DIF~~, and has been observed to work when cycling CW310 FPGA into and out of Deep Sleep whilst streaming traffic to all endpoints in both directions.
dif_usbdev_unittest was modified to exercise the new CSRs.

Update: reimplemented registers using 'hwext' and have tested again in simulation and FPGA.