### PR TITLE
[dv] Add list of "base CSRs" to CIP scoreboard

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -319,6 +319,25 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endtask
 
+  // Returns true if the register passed in is one of the generic "CIP" CSRs
+  virtual function bit is_cip_csr(uvm_reg csr);
+    string name = csr.get_name();
+
+    // There are a few "magic names" that are used by all comportable IPs. Check whether this is one
+    // of them.
+    bit is_cip;
+    case (name)
+      "cip_id": is_cip = 1'b1;
+      "revision": is_cip = 1'b1;
+      "parameter_block_type": is_cip = 1'b1;
+      "parameter_block_length": is_cip = 1'b1;
+      "next_parameter_block": is_cip = 1'b1;
+      default: is_cip = 1'b0;
+    endcase
+
+    return is_cip;
+  endfunction
+
   virtual task process_mem_write(tl_seq_item item, string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
     if (!cfg.under_reset)  exp_mem[ral_name].write(addr, item.a_data, item.a_mask);

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -363,7 +363,9 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -340,7 +340,9 @@ class csrng_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -154,7 +154,9 @@ class edn_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1416,7 +1416,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       "main_sm_state": begin
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -913,7 +913,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         // Do nothing
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -311,7 +311,9 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -223,7 +223,9 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
         end
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -217,7 +217,9 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
         end else if (!uvm_re_match("sw_rst_regwen_*", csr.get_name())) begin
           // RW0C, so check.
         end else begin
-          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+          if (!is_cip_csr(csr)) begin
+            `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+          end
         end
       end
     endcase

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -524,7 +524,9 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
         end
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -519,7 +519,9 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
         // no special handling is needed
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -115,7 +115,9 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
         end // read & data phase
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -442,6 +442,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
                 !uvm_re_match("class*_clr_regwen", csr_name) ||
                 !uvm_re_match("class*_regwen", csr_name) ||
                 !uvm_re_match("*alert_regwen_*", csr_name)) begin
+            end else if (is_cip_csr(csr)) begin
             end else begin
               `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
             end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -442,6 +442,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
                 !uvm_re_match("class*_clr_regwen", csr_name) ||
                 !uvm_re_match("class*_regwen", csr_name) ||
                 !uvm_re_match("*alert_regwen_*", csr_name)) begin
+            end else if (is_cip_csr(csr)) begin
             end else begin
               `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
             end

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -105,7 +105,9 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
         // FIXME
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        if (!is_cip_csr(csr)) begin
+          `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
       end
     endcase
 


### PR DESCRIPTION
Recent changes to the code have added some general CSRs to all comportable IPs. It turns out that the testbenches for these IPs have scoreboards that (by default) throw an error if they see an access for a CSR that isn't on a specified list. Of course, things like "cip_id" aren't on the list!

Fortunately, the code that generates the errors came from a template (scoreboard.sv.tpl) so it's not too hard to make things a bit more general. This commit changes this code so that it doesn't special case CSRs if they are in a known list.

This isn't as general as it could be: there are some IPs which will still fail at the moment (because their scoreboards are more different from the template, so will take a bit more effort to get in line). Also, there are several other more general CSRs (like ALERT_TEST) that might be nice to handle in a uniform way.

But this should be a minimal-ish change that will avoid having to rewrite DV code for quite so many IP blocks.

(See #17117 for the PR that added the new CSRs)