### PR TITLE
[i2c,dv] Don't write to CTRL register in CSR tests

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -141,9 +141,14 @@
                 Enable I2C line loopback test
                 If line loopback is enabled, the internal design sees ACQ and RX data as "1"
                 '''
-          tags: [// Exclude from write-checks: writing 1'b1 to this bit causes interrupts unexpectedly asserted
-                "excl:CsrAllTests:CsrExclWrite"]
         }
+      ]
+      tags: [
+        // Exclude the CTRL register from write checks. These checks
+        // don't know about I2C as a protocol, so will get confused by
+        // other CSRs changing values and interrupts getting asserted
+        // if they write to this register.
+        "excl:CsrAllTests:CsrExclWrite"
       ]
     }
     { name:     "STATUS"


### PR DESCRIPTION
This avoids failures in tests that like `i2c_same_csr_outstanding`. There, it writes some stuff and then tries to clear all interrupts that the I2C block has asserted. The problem is that the I2C might keep trying to assert an interrupt, which can't be cleared.

One example I've seen is the "SDA interference" interrupt, which complains if we're trying to start an I2C transaction in host mode when the SDA line is low. And it will be re-asserted if cleared directly because we're not also changing the value on the SDA line. The generic CSR code doesn't know about that sort of thing, so we need to tell it not to start transactions if we want to avoid this sort of error.