### PR TITLE
[flash_ctrl,dv] clean up block regression

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -44,10 +44,15 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
+    // 8Byte (2 words) aligned.
+    // With scramble enabled, odd size of word access (or address) will cause
+    // ecc errors.
+    flash_op.addr[2:0] == 3'h0;
     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
     flash_op.num_words < FlashPgmRes - flash_op.addr[TL_SZW+:FlashPgmResWidth];
+    flash_op.num_words % 2 == 0;
   }
 
   // Memory protection regions settings.

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
@@ -89,4 +89,8 @@ class flash_ctrl_rd_ooo_vseq extends flash_ctrl_legacy_base_vseq;
     flash_ctrl_default_info_cfg(scr_mode, ecc_mode);
     update_p2r_map(cfg.mp_regions);
   endtask // flash_otf_region_cfg
+  task post_start();
+    flash_init = otf_flash_init;
+    super.post_start();
+  endtask
 endclass // flash_ctrl_rd_ooo_vseq


### PR DESCRIPTION
Update word size / location constraint for non-otf test. (flash_ctrl_invalid_op) 
Update flash_init to the right value after post_start reset.