### PR TITLE
[sw/silicon_creator] Add Primary BL0 Slot message types

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -670,9 +670,13 @@ rom_error_t boot_data_check(const boot_data_t *boot_data) {
 rom_error_t boot_data_as_v2(boot_data_t *boot_data) {
   switch (launder32(boot_data->version)) {
     case kBootDataVersion1:
+      HARDENED_CHECK_EQ(boot_data->version, kBootDataVersion1);
       boot_data->primary_bl0_slot = kBootDataSlotA;
+      boot_data->version = kBootDataVersion2;
+      boot_data_digest_compute(boot_data, &boot_data->digest);
       return kErrorOk;
     case kBootDataVersion2:
+      HARDENED_CHECK_EQ(boot_data->version, kBootDataVersion2);
       return kErrorOk;
     default:
       HARDENED_TRAP();

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -545,12 +545,13 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
 
   boot_data->is_valid = kBootDataValidEntry;
   boot_data->identifier = kBootDataIdentifier;
-  boot_data->version = kBootDataVersion1;
+  boot_data->version = kBootDataVersion2;
   boot_data->counter = kBootDataDefaultCounterVal;
   boot_data->min_security_version_rom_ext =
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT_OFFSET);
   boot_data->min_security_version_bl0 =
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_BL0_OFFSET);
+  boot_data->primary_bl0_slot = kBootDataSlotA;
   // We cannot use a constant digest since some fields are read from the OTP
   // and we check the digest of the cached boot data entry in rom.c
   boot_data_digest_compute(boot_data, &boot_data->digest);
@@ -664,4 +665,17 @@ rom_error_t boot_data_check(const boot_data_t *boot_data) {
   }
 
   return kErrorBootDataInvalid;
+}
+
+rom_error_t boot_data_as_v2(boot_data_t *boot_data) {
+  switch (launder32(boot_data->version)) {
+    case kBootDataVersion1:
+      boot_data->primary_bl0_slot = kBootDataSlotA;
+      return kErrorOk;
+    case kBootDataVersion2:
+      return kErrorOk;
+    default:
+      HARDENED_TRAP();
+      OT_UNREACHABLE();
+  }
 }

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -32,11 +32,12 @@ boot_data_t kTestBootData = (boot_data_t){
     .digest = {{0x58dbe282, 0x57d7c3f6, 0x1f3f6647, 0xbe7e27b6, 0x334bd1c5,
                 0xdb2c57b5, 0x134933c9, 0xd8fa260c}},
     .identifier = kBootDataIdentifier,
-    .version = kBootDataVersion1,
+    .version = kBootDataVersion2,
     .is_valid = kBootDataValidEntry,
     // `kBootDataDefaultCounterVal` + 1 for consistency.
     .counter = kBootDataDefaultCounterVal + 1,
     .min_security_version_rom_ext = 0,
+    .primary_bl0_slot = kBootDataSlotA,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -29,8 +29,8 @@ static const flash_ctrl_info_page_t *kPages[2] = {
  * Boot data entry used in tests.
  */
 boot_data_t kTestBootData = (boot_data_t){
-    .digest = {{0x58dbe282, 0x57d7c3f6, 0x1f3f6647, 0xbe7e27b6, 0x334bd1c5,
-                0xdb2c57b5, 0x134933c9, 0xd8fa260c}},
+    .digest = {{0x8ee18396, 0xbc21d5de, 0x288c27bb, 0x7388061c, 0xe7382e8a,
+                0x8af122bc, 0xd851f67a, 0xdcc440a2}},
     .identifier = kBootDataIdentifier,
     .version = kBootDataVersion2,
     .is_valid = kBootDataValidEntry,

--- a/sw/device/silicon_creator/lib/boot_data_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_data_unittest.cc
@@ -54,6 +54,21 @@ constexpr boot_data_t kValidEntry1 = {
 };
 
 /**
+ * Example version2 boot data entry.
+ */
+constexpr boot_data_t kValidEntry2 = {
+    .digest = {kBootDataIdentifier, kBootDataIdentifier, kBootDataIdentifier,
+               0x00000000, 0x11111111, 0x22222222, 0x33333333, 0x44444444},
+    .is_valid = kBootDataValidEntry,
+    .identifier = kBootDataIdentifier,
+    .version = kBootDataVersion2,
+    .counter = kBootDataDefaultCounterVal,
+    .min_security_version_rom_ext = 0,
+    .min_security_version_bl0 = 0,
+    .primary_bl0_slot = kBootDataSlotA,
+};
+
+/**
  * Default boot data entry loaded by `boot_data_default_get`.
  */
 constexpr boot_data_t kDefaultEntry = {
@@ -411,6 +426,25 @@ TEST_F(BootDataReadTest, ReadDefaultNotAllowedInProdTest) {
 
   boot_data_t boot_data = {{0}};
   EXPECT_EQ(boot_data_read(kLcStateProd, &boot_data), kErrorBootDataNotFound);
+}
+
+TEST_F(BootDataReadTest, ReadV1AsV2Test) {
+  // Expect both to be searched, but only provide an entry in one.
+  ExpectPageScan(&kFlashCtrlInfoPageBootData0, EntryPage(kValidEntry0));
+  ExpectPageScan(&kFlashCtrlInfoPageBootData1, ErasedPage());
+
+  // Expect to read the version 1 boot data.
+  boot_data_t boot_data = {{0}};
+  EXPECT_EQ(boot_data_read(kLcStateTest, &boot_data), kErrorOk);
+  EXPECT_EQ(boot_data, kValidEntry0);
+
+  // Expect a new digest computation on version 2 of the boot data.
+  ExpectDigestCompute(kValidEntry2, true);
+
+  // Populate the version 1 fields with default version 2 data.
+  EXPECT_EQ(boot_data_as_v2(&boot_data), kErrorOk);
+
+  EXPECT_EQ(boot_data, kValidEntry2);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/boot_data_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_data_unittest.cc
@@ -61,10 +61,11 @@ constexpr boot_data_t kDefaultEntry = {
                0xcc761df1, 0xff42f0f2, 0x3f1955ee, 0x9465b3e7, 0x81ce0fdb},
     .is_valid = kBootDataValidEntry,
     .identifier = kBootDataIdentifier,
-    .version = kBootDataVersion1,
+    .version = kBootDataVersion2,
     .counter = kBootDataDefaultCounterVal,
     .min_security_version_rom_ext = 0x01234567,
     .min_security_version_bl0 = 0x89abcdef,
+    .primary_bl0_slot = kBootDataSlotA,
 };
 
 namespace boot_data_unittest {

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -52,6 +52,31 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "boot_svc_primary_bl0_slot",
+    srcs = ["boot_svc_primary_bl0_slot.c"],
+    hdrs = ["boot_svc_primary_bl0_slot.h"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_primary_bl0_slot_unittest",
+    srcs = ["boot_svc_primary_bl0_slot_unittest.cc"],
+    deps = [
+        ":boot_svc_primary_bl0_slot",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_test(
     name = "boot_svc_empty_unittest",
     srcs = ["boot_svc_empty_unittest.cc"],

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h"
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+void boot_svc_primary_bl0_slot_req_init(uint32_t primary_bl0_slot,
+                                        boot_svc_primary_bl0_slot_req_t *msg) {
+  msg->primary_bl0_slot = primary_bl0_slot;
+  boot_svc_header_finalize(kBootSvcPrimaryBl0SlotReqType,
+                           sizeof(boot_svc_primary_bl0_slot_req_t),
+                           &msg->header);
+}
+
+void boot_svc_primary_bl0_slot_res_init(rom_error_t status,
+                                        boot_svc_primary_bl0_slot_res_t *msg) {
+  msg->status = status;
+  boot_svc_header_finalize(kBootSvcPrimaryBl0SlotResType,
+                           sizeof(boot_svc_primary_bl0_slot_res_t),
+                           &msg->header);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_PRIMARY_BL0_SLOT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_PRIMARY_BL0_SLOT_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/*
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
+ *     -s 3799858683 --language=c
+ *
+ * Minimum Hamming distance: 17
+ * Maximum Hamming distance: 17
+ * Minimum Hamming weight: 14
+ * Maximum Hamming weight: 17
+ */
+enum {
+  kBootSvcPrimaryBl0SlotReqType = 0x3d6c47b8,
+  kBootSvcPrimaryBl0SlotResType = 0xf2a4a609,
+} my_state_t;
+
+/**
+ * A Set Primary Boot Slot request message.
+ */
+typedef struct boot_svc_primary_bl0_slot_req {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * BL0 slot to set as primary.
+   */
+  uint32_t primary_bl0_slot;
+} boot_svc_primary_bl0_slot_req_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_primary_bl0_slot_req_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_primary_bl0_slot_req_t, primary_bl0_slot,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_primary_bl0_slot_req_t, 48);
+
+/**
+ * A Set Primary Boot Slot response message.
+ */
+typedef struct boot_svc_primary_bl0_slot_res {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Response from ROM_EXT.
+   */
+  rom_error_t status;
+} boot_svc_primary_bl0_slot_res_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_primary_bl0_slot_res_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_primary_bl0_slot_res_t, status,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_primary_bl0_slot_res_t, 48);
+
+/**
+ * Initialize an empty set primary bl0 slot request message.
+ *
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_primary_bl0_slot_req_init(uint32_t primary_bl0_slot,
+                                        boot_svc_primary_bl0_slot_req_t *msg);
+
+/**
+ * Initialize an empty set primary bl0 slot response message.
+ *
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_primary_bl0_slot_res_init(rom_error_t status,
+                                        boot_svc_primary_bl0_slot_res_t *msg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_PRIMARY_BL0_SLOT_H_

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot_unittest.cc
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace boot_svc_primary_bl0_slot_unittest {
+namespace {
+
+class BootSvcPrimaryBl0SlotTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockBootSvcHeader boot_svc_header_;
+};
+
+TEST_F(BootSvcPrimaryBl0SlotTest, ReqInit) {
+  boot_svc_primary_bl0_slot_req_t msg{};
+  constexpr uint32_t kPrimarySlot = kBootDataSlotB;
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcPrimaryBl0SlotReqType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_primary_bl0_slot_req_init(kPrimarySlot, &msg);
+
+  EXPECT_EQ(msg.primary_bl0_slot, kPrimarySlot);
+}
+
+TEST_F(BootSvcPrimaryBl0SlotTest, ResInit) {
+  boot_svc_primary_bl0_slot_res_t msg{};
+  constexpr rom_error_t kStatus = kErrorOk;
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcPrimaryBl0SlotResType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_primary_bl0_slot_res_init(kStatus, &msg);
+
+  EXPECT_EQ(msg.status, kStatus);
+}
+
+}  // namespace
+}  // namespace boot_svc_primary_bl0_slot_unittest


### PR DESCRIPTION
Adds the message types for the Select Primary BL0 Slot ROM_EXT boot service messages.