### PR TITLE
[flash_ctrl,dv] use fast alert responder for back to back error event

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -54,6 +54,9 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   int unsigned ping_delay_min = 0;
   int unsigned ping_delay_max = 10;
 
+  // When this bit is set, alert agent responds to alert without delay
+  // This is set by plusarg "+fast_rcvr_{alert_name}"
+  bit          fast_rcvr = 0;
   // this timeout is to ensure handshake protocol did not hang, this timeout is not implemented in
   // design. In design, if protocol hangs, the period ping check will catch the issue
   int unsigned handshake_timeout_cycle = 100_000;

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -131,6 +131,11 @@ class alert_receiver_driver extends alert_esc_base_driver;
                               $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
     int unsigned ack_stable = (cfg.use_seq_item_ack_stable) ? req.ack_stable :
                                $urandom_range(cfg.ack_stable_max, cfg.ack_stable_min);
+    if (cfg.fast_rcvr) begin
+      ack_delay = cfg.ack_delay_min;
+      ack_stable = cfg.ack_stable_min;
+    end
+
     if (!req.int_err) begin
       @(cfg.vif.receiver_cb);
       repeat (ack_delay) @(cfg.vif.receiver_cb);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -276,6 +276,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   virtual function void initialize(addr_t csr_base_addr = '1);
     string prim_ral_name = "flash_ctrl_prim_reg_block";
+    string fast_rcvr_name = "";
 
     list_of_alerts = flash_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_std_err";
@@ -289,6 +290,10 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
     super.initialize(csr_base_addr);
 
+    void'($value$plusargs("fast_rcvr_%s", fast_rcvr_name));
+    if (fast_rcvr_name != "") begin
+      m_alert_agent_cfgs[fast_rcvr_name].fast_rcvr = 1;
+    end
     tl_intg_alert_fields[ral.std_fault_status.reg_intg_err] = 1;
     shadow_update_err_status_fields[ral.err_code.update_err] = 1;
     shadow_storage_err_status_fields[ral.std_fault_status.storage_err] = 1;

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -149,7 +149,8 @@
     {
       name: flash_ctrl_mp_regions
       uvm_test_seq: flash_ctrl_mp_regions_vseq
-      run_opts: ["+multi_alert=1", "+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+multi_alert=1", "+test_timeout_ns=300_000_000_000",
+                 "+fast_rcvr_recov_err"]
       reseed: 20
     }
     {


### PR DESCRIPTION
flash_ctrl_mp_regions test generates recov_err event in the loop. 
If test uses normal alert responder, it can be missed back to back alert 
because responder has ack delay and stable ack period.
Add 'fast rcvr mode' to use minimum value for those parameters.