### PR TITLE
[site] Match header tags in block diagram

### DIFF
--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -21,7 +21,7 @@ window.onload = (event) => {
     <div class="top">
         <div class="domains" grid="2">
             <div class="domain">
-                <h3 class="domain-title">High speed domain</h2>
+                <h3 class="domain-title">High speed domain</h3>
                 <div class="blocks" grid="4">
                     <a class="block clock1 dual" href="https://opentitan.org/book/hw/ip/rv_core_ibex/" id="ibex" grid-rows="2" grid-cols="2">
                         <span class="dual-label">DUAL LOCKSTEP</span>
@@ -55,7 +55,7 @@ window.onload = (event) => {
                 </div>
             </div>
             <div class="domain">
-                <h3 class="domain-title">Peripheral domain</h2>
+                <h3 class="domain-title">Peripheral domain</h3>
                 <div class="blocks" grid="4">
                     <a class="block clock4" href="https://opentitan.org/book/hw/ip/tlul/" id="peripheral-crossbar" grid-rows="6">TL-UL Crossbar</a>
                     <a class="block clock4" href="https://opentitan.org/book/hw/ip/otp_ctrl/" id="otp-fuse-controller">OTP (Fuse) Controller</a>
@@ -68,7 +68,7 @@ window.onload = (event) => {
                     <a class="block clock4" href="https://opentitan.org/book/hw/ip/spi_device/" id="spi-device" subclock1="clock1">SPI<br>Device</a>
                     <a class="block clock4" href="https://opentitan.org/book/hw/ip/pattgen/" id="pattern-generators">Pattern Generators</a>
                     <div class="domain always-on" grid-rows="3" grid-cols="3" id="interior-aon-domain">
-                        <h3 class="domain-title">Always-on domain</h2>
+                        <h3 class="domain-title">Always-on domain</h3>
                         <div class="blocks" grid="3">
                             <a class="block clock4" href="https://opentitan.org/book/hw/ip/pwm/" id="pwm" subclock1="clock5">PWM</a>
                             <a class="block clock4" href="https://opentitan.org/book/hw/ip/sram_ctrl/" id="retention-sram">Retention SRAM</a>


### PR DESCRIPTION
In the Earl Grey block diagram the `<h3>` tags were matched with `</h2>` I changed the end tag to be `</h3>`.