### PR TITLE
[reggen] Support for multi-bit REGWEN signals

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -289,15 +289,16 @@ multireg | optional | group | group defining registers generated from a base ins
 
 
 Registers can protect themselves from software writes by using the
-register attribute regwen. When not an emptry string (the default
+register attribute regwen. When not an empty string (the default
 value), regwen indicates that another register must be true in order
-to allow writes to this register.  This is useful for the prevention
+to allow writes to this register. This is useful for the prevention
 of software modification.  The register-enable register (call it
-REGWEN) must be one bit in width, and should default to 1 and be rw1c
-for preferred security control.  This allows all writes to proceed
+REGWEN) must be either one bit or 4 bit in width to support a FI-protected
+multi-bit REGWEN. The default value should be true and be rw1c for
+preferred security control. This allows all writes to proceed
 until at some point software disables future modifications by clearing
 REGWEN. An error is reported if REGWEN does not exist, contains more
-than one bit, is not `rw1c` or does not default to 1. One REGWEN can
+than one bit, is not `rw1c` or does not default to true. One REGWEN can
 protect multiple registers. The REGWEN register must precede those
 registers that refer to it in the .hjson register list. An example:
 

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -164,15 +164,16 @@ for things that are not registers (for example access to a buffer ram).
 regwen_intro = """
 
 Registers can protect themselves from software writes by using the
-register attribute regwen. When not an emptry string (the default
+register attribute regwen. When not an empty string (the default
 value), regwen indicates that another register must be true in order
-to allow writes to this register.  This is useful for the prevention
+to allow writes to this register. This is useful for the prevention
 of software modification.  The register-enable register (call it
-REGWEN) must be one bit in width, and should default to 1 and be rw1c
-for preferred security control.  This allows all writes to proceed
+REGWEN) must be either one bit or 4 bit in width to support a FI-protected
+multi-bit REGWEN. The default value should be true and be rw1c for
+preferred security control. This allows all writes to proceed
 until at some point software disables future modifications by clearing
 REGWEN. An error is reported if REGWEN does not exist, contains more
-than one bit, is not `rw1c` or does not default to 1. One REGWEN can
+than one bit, is not `rw1c` or does not default to true. One REGWEN can
 protect multiple registers. The REGWEN register must precede those
 registers that refer to it in the .hjson register list. An example:
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -255,7 +255,7 @@ module ${mod_name} (
 % else:
   always_ff @(posedge ${reg_clk_expr} or negedge ${reg_rst_expr}) begin
     if (!${reg_rst_expr}) begin
-% endif    
+% endif
       err_q <= '0;
     end else if (intg_err || reg_we_err) begin
       err_q <= 1'b1;
@@ -601,6 +601,9 @@ ${reg_hdr}
     we_expr = f'{we_signal} & {clk_base_name}{sr_name}_regwen'
   elif sr.regwen:
     we_expr = f'{we_signal} & {sr.regwen.lower()}_qs'
+    for reg in regs_flat:
+      if reg.name == sr.regwen and reg.fields[0].mubi:
+        we_expr = f'{we_signal} & prim_mubi_pkg::mubi4_test_true_strict({sr.regwen.lower()}_qs)'
   else:
     we_expr = we_signal
 


### PR DESCRIPTION
This is a cherry-pick PR of the first commit of https://github.com/lowRISC/opentitan-integrated/pull/189

This PR adds support for multi-bit encoded REGWEN signals to the reggen utility.

Closes https://github.com/lowRISC/opentitan/issues/5763