### PR TITLE
Module id check improvements

### DIFF
--- a/ci/scripts/check-module-ids.sh
+++ b/ci/scripts/check-module-ids.sh
@@ -23,6 +23,7 @@ query_elfs='
         )
     )'
 target_file=$(mktemp)
+trap 'rm -f "$target_file"' EXIT
 ./bazelisk.sh query "$query_elfs" >"$target_file"
 # We now ask bazel to build all targets but we also add the module ID checker aspect
 # and we query the corresponding output group to force bazel to run the checks.

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -39,3 +39,8 @@ py_test(
         ":bitstreams_workspace",
     ],
 )
+
+sh_binary(
+    name = "modid_check",
+    srcs = ["modid_check.sh"],
+)

--- a/rules/scripts/modid_check.sh
+++ b/rules/scripts/modid_check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+# Arguments:
+# - path to opentitantool
+# - output file to create
+# - (one or more) elf files to check
+if [ $# -lt 3 ]; then
+    echo "This script needs at least 3 arguments"
+    exit 42
+fi
+ott="$1"
+out_file="$2"
+# forget first two arguments so we can access elf files
+shift 2
+
+# run tool, capture output to avoid polutting the CI log
+if ! "$ott" status lint "$@" >"$out_file" 2>&1; then
+    if ! cat "$out_file"; then
+        echo "Unable to print the output log, something is very wrong"
+        exit 43
+    fi
+    exit 1
+fi


### PR DESCRIPTION
The output of the module ID check in CI is unreadable because opentitantool prints too many useless messages.
This PR fixes this to only show errors. It also contains a small improvement to remove a temporary file used in a script.