### PR TITLE
[dv/GL] Regression fixes for gate level

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -641,8 +641,8 @@ interface chip_if;
   clk_rst_if cpu_clk_rst_if(.clk(cpu_clk), .rst_n(cpu_rst_n));
 
 `ifdef GATE_LEVEL
-  wire aon_clk = 1'b0;
-  wire aon_rst_n = 1'b1;
+  wire aon_clk = `CLKMGR_HIER.clocks_o_clk_aon_powerup;
+  wire aon_rst_n = `RSTMGR_HIER.resets_o_rst_por_aon_n_0_;
 `else
   wire aon_clk = `CLKMGR_HIER.clocks_o.clk_aon_powerup;
   wire aon_rst_n = `RSTMGR_HIER.resets_o.rst_por_aon_n[0];
@@ -1103,11 +1103,12 @@ interface chip_if;
 `define _ADC_FSM_STATE_Q(i) \
    `ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q_``i``_
 
-  assign adc_ctrl_state = {1'b0,
-                           1'b0,
-                           1'b0,
-                           1'b0, // JDON need to check later
-                           1'b0};
+  assign adc_ctrl_state = {`ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q_CDR1_4_
+                          ,`ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q_CDR1_3_
+                          ,`ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q[2]
+                          ,`ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q_CDR1_1_
+                          ,`ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q[0]
+                          };
 `undef _ADC_FSM_STATE_Q
 `else
   assign adc_ctrl_state = `ADC_CTRL_HIER.u_adc_ctrl_core.u_adc_ctrl_fsm.fsm_state_q;
@@ -1143,7 +1144,7 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   // Signal probe function for `acmd_q` of CSRNG core
   wire [2:0] csrng_acmd_q;
 `ifdef GATE_LEVEL
-  assign csrng_acmd_q = 0;
+  assign csrng_acmd_q = `CSRNG_HIER.u_csrng_core.acmd_q[2:0];
 `else
   assign csrng_acmd_q = `CSRNG_HIER.u_csrng_core.acmd_q;
 `endif
@@ -1153,7 +1154,7 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   wire [3:0] aes_ctrl_rnd_ctr;
   assign aes_ctrl_rnd_ctr =
 `ifdef GATE_LEVEL
-                             0;
+      `AES_HIER.u_aes_core.u_aes_cipher_core.u_aes_cipher_control.mr_rnd_ctr[3:0];
 `else
       `AES_HIER.u_aes_core.u_aes_cipher_core.u_aes_cipher_control.rnd_ctr;
 `endif
@@ -1163,9 +1164,9 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   // Signal probe function for `st_q` of HMAC
   wire [2:0] hmac_fsm_state;
 `ifdef GATE_LEVEL
-  assign hmac_fsm_state = {`HMAC_HIER.u_hmac.st_q_reg_2_.Q
-                          ,`HMAC_HIER.u_hmac.st_q_reg_1_.Q
-                          ,`HMAC_HIER.u_hmac.st_q_reg_0_.Q
+  assign hmac_fsm_state = {`HMAC_HIER.u_hmac.dftopt19
+                          ,`HMAC_HIER.u_hmac.dftopt10
+                          ,`HMAC_HIER.u_hmac.dftopt1
                           };
 `else
   assign hmac_fsm_state = `HMAC_HIER.u_hmac.st_q;
@@ -1218,7 +1219,8 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   // Signal probe function for `chan0.enable` and `chan1.enable`of PATTGEN
   wire [1:0] pattgen_chan_1_0_enable;
 `ifdef GATE_LEVEL
-  assign pattgen_chan_1_0_enable = 0;
+  assign pattgen_chan_1_0_enable = {`PATTGEN_HIER.u_pattgen_core.chan1.ctrl_i_enable
+                                   ,`PATTGEN_HIER.u_pattgen_core.chan0.ctrl_i_enable};
 `else
   assign pattgen_chan_1_0_enable = {`PATTGEN_HIER.u_pattgen_core.chan1.enable,
                                     `PATTGEN_HIER.u_pattgen_core.chan0.enable};
@@ -1229,7 +1231,7 @@ assign spi_host_1_state = {tb.dut.top_earlgrey.u_spi_host1.u_spi_core.u_fsm.stat
   // tb.dut.top_earlgrey.u_pwm_aon.u_pwm_core.cntr_en
   wire pwm_core_cntr_en;
 `ifdef GATE_LEVEL
-  assign pwm_core_cntr_en = 0;
+  assign pwm_core_cntr_en = `PWM_HIER.u_reg.u_cfg_cntr_en.q;
 `else
   assign pwm_core_cntr_en = `PWM_HIER.u_pwm_core.cntr_en;
 `endif

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -54,6 +54,7 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
       forever @(cfg.chip_vif.rom_ctrl_done or rom_ctrl_done_checker_stop) begin
         if (rom_ctrl_done_checker_stop) break;
         if (cfg.chip_vif.rom_ctrl_done) begin
+          #(1ns);
           `DV_CHECK(!cfg.chip_vif.rom_ctrl_good)
         end
       end

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -95,8 +95,8 @@ static void execute_test(dif_aon_timer_t *aon_timer, uint64_t irq_time_us,
   uint64_t sleep_range_h = irq_time_us + variation;
   uint64_t sleep_range_l = irq_time_us - variation;
 
-  // Add 600 cpu cycles of overhead to cover irq handling.
-  sleep_range_h += udiv64_slow(600 * 1000000, kClockFreqCpuHz, NULL);
+  // Add 1500 cpu cycles of overhead to cover irq handling.
+  sleep_range_h += udiv64_slow(1500 * 1000000, kClockFreqCpuHz, NULL);
 
   uint32_t count_cycles = 0;
   CHECK_STATUS_OK(

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -1212,7 +1212,6 @@ static void max_power_task(void *task_parameters) {
                       csrng_reseed_cmd_header);
 
   // Issue HMAC process and KMAC squeeze commands.
-  mmio_region_write32(hmac.base_addr, HMAC_CMD_REG_OFFSET, hmac_cmd_reg);
   kmac_operation_state.squeezing = true;
   mmio_region_write32(kmac.base_addr, KMAC_CMD_REG_OFFSET, kmac_cmd_reg);
 
@@ -1221,6 +1220,11 @@ static void max_power_task(void *task_parameters) {
   // propagates to the pin, the AES will already be active.
   mmio_region_write32(gpio.base_addr, GPIO_MASKED_OUT_LOWER_REG_OFFSET,
                       gpio_on_reg_val);
+
+  mmio_region_write32(hmac.base_addr, HMAC_CMD_REG_OFFSET,
+                      hmac_cmd_reg);  // see note
+  // moved HMAC activation here because it is too fast and returns to idle
+  // before GPIO pin IOB8 is toggled.
 
   // Issue AES trigger commands.
   mmio_region_write32(aes.base_addr, AES_TRIGGER_REG_OFFSET, aes_trigger_reg);


### PR DESCRIPTION
Hi,
This PR is fixing some failures came from regressions in gate-level:

* power-virus & jtag-debug tests : add some undefined paths for GL in the chip_if & small change to the power-virus C test.
* rom_ctrl integrity check test : Add small delay between rom_ctrl_done assertion and the check of rom_ctrl_good to avoid states where the done is asserting in parallel to the deassertion of the good signal.
* aon_timer_irq : increase the overhead value to match the change in the timing between the OS and the CS.
Thanks!
