### PR TITLE
[flash_ctrl,dv] fix phy_host_grant_err test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -265,6 +265,8 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     send.mem_addr = exp.start_addr >> 3;
     send.ctrl_rd_region_q = exp.ctrl_rd_region_q;
 
+    // Mask descramble error chk whem comp_off is set.
+    if (comp_off) send.skip_err_chk = 1;
     send.descramble(exp.addr_key, exp.data_key);
     send.print("exp_read: raw_data");
     `dv_info($sformatf("RDATA size: %d x 8B bank:%0d sent_cnt:%0d",

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -53,6 +53,8 @@ class flash_ctrl_scoreboard #(
 
   bit skip_read_check = 0;
 
+  // Prevent to execute predict_tl_err during fatal error test
+  bit stop_tl_err_chk = 0;
   flash_phy_pkg::rd_buf_t evict_q[NumBanks][$];
 
   // utility function to word-align an input TL address
@@ -780,6 +782,10 @@ class flash_ctrl_scoreboard #(
   // when using Code Access Restrictions (EXEC)
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     bit   ecc_err, in_err;
+
+    // Skip this routine when fatal error event is asserted
+    if (stop_tl_err_chk) return 1;
+
     // For flash, address has to be 8byte aligned.
     ecc_err = ecc_error_addr.exists({item.a_addr[AddrWidth-1:3],3'b0});
     in_err = in_error_addr.exists({item.a_addr[AddrWidth-1:3],3'b0});

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_err_base_vseq.sv
@@ -26,9 +26,10 @@ class flash_ctrl_err_base_vseq extends flash_ctrl_rw_vseq;
   virtual task run_error_event(); endtask
 
   task check_fault(input uvm_object ptr,
-                   input uvm_reg_data_t exp_data = 1);
+                   input uvm_reg_data_t exp_data = 1,
+                   input bit back_door = 0);
     `uvm_info(`gfn, "err assert is done", UVM_MEDIUM)
-    csr_spinwait(.ptr(ptr), .exp_data(exp_data));
+    csr_spinwait(.ptr(ptr), .exp_data(exp_data), .backdoor(back_door));
     `uvm_info(`gfn, "csr wait is done is done", UVM_MEDIUM)
   endtask
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -17,6 +17,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
     cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+    $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt");
 
     repeat (2) begin
       // unit 100 ns;
@@ -34,6 +35,13 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
         $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
         randcase
           1: begin
+            // This error injection can cause catastrophic event
+            // Set fatal_std_err and stop tl response check
+            cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+            cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
+            cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+            cfg.scb_h.stop_tl_err_chk = 1;
+            cfg.m_tl_agent_cfg.check_tl_errs = 0;
             add_err1 = 1;
             @(posedge cfg.flash_ctrl_vif.ctrl_fsm_idle);
             `DV_CHECK(uvm_hdl_force(path1, 1))

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -415,7 +415,7 @@
     {
       name: flash_ctrl_phy_ack_consistency
       uvm_test_seq: flash_ctrl_phy_ack_consistency_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10", "+ecc_mode=1",
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=5", "+otf_num_hr=10", "+ecc_mode=1", "+bank0_pct=8",
                  "+otf_rd_pct=4", "+en_always_all=1", "+bypass_alert_ready_to_end_check=1"]
       reseed: 5
     }


### PR DESCRIPTION
Kill on-going assertion thread after detecting fatal error to make sure test run to complete.