### PR TITLE
[top-level,tests] Fix chip_sw_sysrst_ctrl_ulp_z3_wakeup

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq.sv
@@ -69,6 +69,7 @@ class chip_sw_sysrst_ctrl_ulp_z3_wakeup_vseq extends chip_sw_base_vseq;
   virtual function void write_test_phase(test_phases_e phase);
     bit [7:0] test_phase[1];
     test_phase[0] = phase;
+    `uvm_info(`gfn, $sformatf("Writing test phase %0d", phase), UVM_MEDIUM)
     sw_symbol_backdoor_overwrite("kTestPhase", test_phase);
   endfunction
 

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -320,3 +320,14 @@ status_t flash_ctrl_testutils_backdoor_wait_update(
   IBEX_TRY_SPIN_FOR(UINT32_MAX != *(uint32_t *)addr, timeout);
   return OK_STATUS();
 }
+
+status_t flash_ctrl_testutils_flush_read_buffers(void) {
+  static volatile const uint32_t kFlashFlusher[8];
+  // Cause read buffers to flush.
+  uint32_t count = 0;
+  for (int i = 0; i < sizeof(kFlashFlusher); ++i) {
+    count += kFlashFlusher[i];
+  }
+  (void)count;
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -273,4 +273,11 @@ OT_WARN_UNUSED_RESULT
 status_t flash_ctrl_testutils_backdoor_wait_update(
     dif_flash_ctrl_state_t *flash_state, uintptr_t addr, size_t timeout);
 
+/**
+ * This flushes the read buffers. It assumes there are 4 buffers,
+ * each holding 8 byte aligned data previously read.
+ */
+OT_WARN_UNUSED_RESULT
+status_t flash_ctrl_testutils_flush_read_buffers(void);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_


### PR DESCRIPTION
This test used backdoor overwrites but the mechanism broke when enabling CDC instrumentation: there were many problems with the overwrites, most important they don't flush read buffers, so the test often got stale data. The fix is to flush the read buffers before each attempt to read new data.

Partially addresses #16689