### PR TITLE
ROM_EXT bootstrap flash memory protection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,8 +180,6 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check status_t Module IDs (Experimental)
     continueOnError: True
-  - bash: ci/bazelisk.sh run //util/py/scripts:audit_sec_mmio_calls -- --log-level info
-    displayName: Audit calls to sec_mmio functions
 
 - job: sw_build
   displayName: Earl Grey SW Build & Test

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -157,6 +157,7 @@ cc_test(
     srcs = ["flash_ctrl_unittest.cc"],
     deps = [
         dual_cc_device_library_of(":flash_ctrl"),
+        "@com_google_absl//absl/strings:str_format",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -471,6 +471,164 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
   sec_mmio_write32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET, reg);
 }
 
+flash_ctrl_cfg_t flash_ctrl_data_default_cfg_get(void) {
+  const uint32_t default_region =
+      sec_mmio_read32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET);
+  return (flash_ctrl_cfg_t){
+      .scrambling = bitfield_field32_read(
+          default_region, FLASH_CTRL_DEFAULT_REGION_SCRAMBLE_EN_FIELD),
+      .ecc = bitfield_field32_read(default_region,
+                                   FLASH_CTRL_DEFAULT_REGION_ECC_EN_FIELD),
+      .he = bitfield_field32_read(default_region,
+                                  FLASH_CTRL_DEFAULT_REGION_HE_EN_FIELD),
+  };
+}
+
+// This X macro helps to generate code that operates on each of the flash_ctrl
+// memory protection regions.
+#define FLASH_CTRL_MP_REGIONS(X) \
+  X(0)                           \
+  X(1)                           \
+  X(2)                           \
+  X(3)                           \
+  X(4)                           \
+  X(5)                           \
+  X(6)                           \
+  X(7)
+
+// Defines the bounds of the given memory protection region by setting the
+// MP_REGION_${region} register.
+static void flash_ctrl_mp_region_write(flash_ctrl_region_index_t region,
+                                       uint32_t page_offset,
+                                       uint32_t num_pages) {
+#define FLASH_CTRL_MP_REGION_WRITE_(region_macro_arg)                              \
+  case ((region_macro_arg)): {                                                     \
+    HARDENED_CHECK_EQ(region, (region_macro_arg));                                 \
+    uint32_t mp_region = FLASH_CTRL_MP_REGION_##region_macro_arg##_REG_RESVAL;     \
+    /* Write the region's base address into the bitfield. */                       \
+    mp_region = bitfield_field32_write(                                            \
+        mp_region,                                                                 \
+        FLASH_CTRL_MP_REGION_##region_macro_arg##_BASE_##region_macro_arg##_FIELD, \
+        page_offset);                                                              \
+    /* Write the region's size in pages into the bitfield. */                      \
+    mp_region = bitfield_field32_write(                                            \
+        mp_region,                                                                 \
+        FLASH_CTRL_MP_REGION_##region_macro_arg##_SIZE_##region_macro_arg##_FIELD, \
+        num_pages);                                                                \
+    /* Write the bitfield to the MP_REGION_${region} register. */                  \
+    sec_mmio_write32(                                                              \
+        kBase + FLASH_CTRL_MP_REGION_##region_macro_arg##_REG_OFFSET,              \
+        mp_region);                                                                \
+    return;                                                                        \
+  }
+
+  switch (launder32(region)) {
+    FLASH_CTRL_MP_REGIONS(FLASH_CTRL_MP_REGION_WRITE_)
+    default:
+      OT_UNREACHABLE();
+  }
+
+#undef FLASH_CTRL_MP_REGION_WRITE_
+}
+
+// Resets the given region's memory protection config by resetting the
+// MP_REGION_CFG_${region} register, which implicitly disables the region.
+static void flash_ctrl_mp_region_cfg_reset(flash_ctrl_region_index_t region) {
+#define FLASH_CTRL_MP_REGION_CFG_RESET_(region_macro_arg)                               \
+  case ((region_macro_arg)): {                                                          \
+    HARDENED_CHECK_EQ(region, (region_macro_arg));                                      \
+    static_assert(                                                                      \
+        (FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_REG_RESVAL &                     \
+         FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_EN_##region_macro_arg##_MASK) == \
+            kMultiBitBool4False,                                                        \
+        "FLASH_CTRL_MP_REGION_CFG_" #region_macro_arg                                   \
+        "'s reset value should disable the region");                                    \
+    /* Reset the MP_REGION_CFG_${region} register. */                                   \
+    sec_mmio_write32(                                                                   \
+        kBase + FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_REG_OFFSET,               \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_REG_RESVAL);                      \
+    return;                                                                             \
+  }
+
+  switch (launder32(region)) {
+    FLASH_CTRL_MP_REGIONS(FLASH_CTRL_MP_REGION_CFG_RESET_)
+    default:
+      OT_UNREACHABLE();
+  }
+
+#undef FLASH_CTRL_MP_CFG_RESET_
+}
+
+// Configures permissions for the given MP region by setting the appropriate
+// MP_REGION_CFG register.
+static void flash_ctrl_mp_region_cfg_write(flash_ctrl_region_index_t region,
+                                           flash_ctrl_cfg_t cfg,
+                                           flash_ctrl_perms_t perms,
+                                           multi_bit_bool_t en) {
+#define FLASH_CTRL_MP_REGION_CFG_WRITE_(region_macro_arg)                                     \
+  case ((region_macro_arg)): {                                                                \
+    HARDENED_CHECK_EQ(region, (region_macro_arg));                                            \
+    uint32_t mp_region_cfg =                                                                  \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_REG_RESVAL;                             \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_HE_EN_##region_macro_arg##_FIELD,       \
+        cfg.he);                                                                              \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_ECC_EN_##region_macro_arg##_FIELD,      \
+        cfg.ecc);                                                                             \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_SCRAMBLE_EN_##region_macro_arg##_FIELD, \
+        cfg.scrambling);                                                                      \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_ERASE_EN_##region_macro_arg##_FIELD,    \
+        perms.erase);                                                                         \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_PROG_EN_##region_macro_arg##_FIELD,     \
+        perms.write);                                                                         \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_RD_EN_##region_macro_arg##_FIELD,       \
+        perms.read);                                                                          \
+    mp_region_cfg = bitfield_field32_write(                                                   \
+        mp_region_cfg,                                                                        \
+        FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_EN_##region_macro_arg##_FIELD,          \
+        en);                                                                                  \
+    sec_mmio_write32(                                                                         \
+        kBase + FLASH_CTRL_MP_REGION_CFG_##region_macro_arg##_REG_OFFSET,                     \
+        mp_region_cfg);                                                                       \
+    return;                                                                                   \
+  }
+
+  switch (launder32(region)) {
+    FLASH_CTRL_MP_REGIONS(FLASH_CTRL_MP_REGION_CFG_WRITE_)
+    default:
+      OT_UNREACHABLE();
+  }
+
+#undef FLASH_CTRL_MP_REGION_CFG_WRITE_
+}
+
+void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
+                                    uint32_t page_offset, uint32_t num_pages,
+                                    flash_ctrl_perms_t perms,
+                                    flash_ctrl_cfg_t cfg) {
+  // Reset the region's configuration via the MP_REGION_CFG_${region} register.
+  // This temporarily disables memory protection for the region.
+  flash_ctrl_mp_region_cfg_reset(region);
+
+  // Set the region's bounds in the MP_REGION_${region} register.
+  flash_ctrl_mp_region_write(region, page_offset, num_pages);
+
+  // Write the new value of MP_REGION_CFG_${region}.
+  flash_ctrl_mp_region_cfg_write(region, cfg, perms,
+                                 /*en=*/kMultiBitBool4True);
+}
+
 void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
                              flash_ctrl_cfg_t cfg) {
   SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgSet, 1);

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
@@ -65,9 +65,21 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
   MockFlashCtrl::Instance().DataDefaultCfgSet(cfg);
 }
 
+flash_ctrl_cfg_t flash_ctrl_data_default_cfg_get() {
+  return MockFlashCtrl::Instance().DataDefaultCfgGet();
+}
+
 void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
                              flash_ctrl_cfg_t cfg) {
   MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
+}
+
+void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
+                                    uint32_t page_offset, uint32_t num_pages,
+                                    flash_ctrl_perms_t perms,
+                                    flash_ctrl_cfg_t cfg) {
+  MockFlashCtrl::Instance().DataRegionProtect(region, page_offset, num_pages,
+                                              perms, cfg);
 }
 
 void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
@@ -33,7 +33,12 @@ class MockFlashCtrl : public global_mock::GlobalMock<MockFlashCtrl> {
   MOCK_METHOD(void, DataDefaultPermsSet, (flash_ctrl_perms_t));
   MOCK_METHOD(void, InfoPermsSet,
               (const flash_ctrl_info_page_t *, flash_ctrl_perms_t));
+  MOCK_METHOD(flash_ctrl_cfg_t, DataDefaultCfgGet, ());
   MOCK_METHOD(void, DataDefaultCfgSet, (flash_ctrl_cfg_t));
+  MOCK_METHOD(void, DataRegionProtect,
+              (flash_ctrl_region_index_t region, uint32_t page_offset,
+               uint32_t num_pages, flash_ctrl_perms_t perms,
+               flash_ctrl_cfg_t cfg));
   MOCK_METHOD(void, InfoCfgSet,
               (const flash_ctrl_info_page_t *, flash_ctrl_cfg_t));
   MOCK_METHOD(void, BankErasePermsSet, (hardened_bool_t));

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -96,6 +96,7 @@ cc_test(
     deps = [
         ":bootstrap",
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//sw/device/lib/base:memory",
         "//sw/device/silicon_creator/lib:bootstrap",
         "//sw/device/silicon_creator/lib:bootstrap_unittest_util",
         "//sw/device/silicon_creator/lib:error_unittest_util",
@@ -104,6 +105,7 @@ cc_test(
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
         "//sw/device/silicon_creator/lib/drivers:spi_device",
         "//sw/device/silicon_creator/testing:rom_test",
+        "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/rom_ext/bootstrap.h
+++ b/sw/device/silicon_creator/rom_ext/bootstrap.h
@@ -29,15 +29,12 @@ hardened_bool_t rom_ext_bootstrap_enabled(void);
  * spi_device. This function will never erase or reprogram ROM_EXT's flash
  * regions in slot A or slot B.
  *
- * OpenTitan bootstrap uses the typical SPI flash EEPROM commands. A typical
- * bootstrap session involves:
+ * OpenTitan's ROM_EXT bootstrap uses the typical SPI flash EEPROM commands. A
+ * typical bootstrap session involves:
  * - Asserting bootstrap pins to enter bootstrap mode,
  * - Erasing the chip (WREN, CHIP_ERASE, busy loop ...),
  * - Programming the chip (WREN, PAGE_PROGRAM, busy loop ...), and
  * - Resetting the chip (RESET).
- *
- * TODO(#19151) Configure flash memory protection hardware. Until we do this,
- * the flash restrictions described below are not enforced.
  *
  * This function configures flash memory protection to control which operations
  * can be performed on individual regions, e.g. the ROM_EXT in slot A should be

--- a/sw/device/silicon_creator/rom_ext/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/bootstrap_unittest.cc
@@ -4,11 +4,14 @@
 
 #include "sw/device/silicon_creator/rom_ext/bootstrap.h"
 
+#include <stdint.h>
 #include <vector>
 
+#include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/bootstrap.h"
 #include "sw/device/silicon_creator/lib/bootstrap_unittest_util.h"
@@ -23,12 +26,18 @@
 #include "flash_ctrl_regs.h"
 #include "hw/ip/otp_ctrl/data/otp_ctrl_regs.h"
 
+// Custom equality operator for `flash_ctrl_cfg_t`. This must be defined outside
+// the test's namespace for GTest to find it.
+bool operator==(const flash_ctrl_cfg_t a, const flash_ctrl_cfg_t b) {
+  return memcmp(&a, &b, sizeof(a)) == 0;
+}
+
 namespace rom_ext_bootstrap_unittest {
 namespace {
 
+using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Each;
-using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::Return;
 
@@ -37,12 +46,29 @@ using bootstrap_unittest_util::PageProgramCmd;
 using bootstrap_unittest_util::ResetCmd;
 using bootstrap_unittest_util::SectorEraseCmd;
 
+constexpr size_t kNumFlashCtrlMpRegions = 8;
+
 /**
  * A collection of functions for simulating flash_ctrl operations on a chunk
  * of host memory.
  */
 class FlashCtrlSim {
+ private:
+  // This struct defines the protection configuration for a single region.
+  struct MpRegion {
+    size_t page_offset = 0;
+    size_t num_pages = 0;
+    bool read_enabled = false;
+    bool prog_enabled = false;
+    bool erase_enabled = false;
+    bool enabled = false;
+  };
+
  public:
+  // A human-readable byte value that represents the last operation performed on
+  // an address in the simulated flash. This is intentionally written as a
+  // regular enum rather than an enum class so implicit conversions and type
+  // inferences on `Span<char>` work automatically.
   enum FlashByte : char {
     kDefault = 'd',
     kErased = 'e',
@@ -51,6 +77,27 @@ class FlashCtrlSim {
 
   FlashCtrlSim() : memory_(flash_size(), FlashByte::kDefault) {}
 
+  void BankErasePermsSet(hardened_bool_t enable) {
+    bank_erase_perms_ = enable == kHardenedBoolTrue;
+  }
+
+  rom_error_t DataRegionProtect(flash_ctrl_region_index_t region,
+                                uint32_t page_offset, uint32_t num_pages,
+                                flash_ctrl_perms_t perms,
+                                flash_ctrl_cfg_t cfg) {
+    EXPECT_LT(region, kNumFlashCtrlMpRegions);
+    EXPECT_LT(page_offset, FlashCtrlSim::num_pages());
+    mp_regions_[region] = MpRegion{
+        .page_offset = page_offset,
+        .num_pages = num_pages,
+        .read_enabled = perms.read == kMultiBitBool4True,
+        .prog_enabled = perms.write == kMultiBitBool4True,
+        .erase_enabled = perms.erase == kMultiBitBool4True,
+        .enabled = true,
+    };
+    return kErrorOk;
+  }
+
   rom_error_t DataErase(uint32_t addr, flash_ctrl_erase_type_t erase_type) {
     using ::testing::Eq;
 
@@ -58,11 +105,20 @@ class FlashCtrlSim {
     switch (erase_type) {
       case kFlashCtrlEraseTypeBank: {
         EXPECT_EQ(addr % bank_size(), 0);
+        for (size_t i = 0; i < num_pages(); ++i) {
+          uint32_t page_addr = addr + i * page_size();
+          if (!ErasePageOk(page_addr)) {
+            return kErrorFlashCtrlDataErase;
+          }
+        }
         region = GetFlash().subspan(addr, bank_size());
         break;
       }
       case kFlashCtrlEraseTypePage: {
         EXPECT_EQ(addr % page_size(), 0);
+        if (!ErasePageOk(addr)) {
+          return kErrorFlashCtrlDataErase;
+        }
         region = GetFlash().subspan(addr, page_size());
         break;
       }
@@ -86,6 +142,12 @@ class FlashCtrlSim {
     switch (erase_type) {
       case kFlashCtrlEraseTypeBank: {
         EXPECT_EQ(addr % bank_size(), 0);
+        for (size_t i = 0; i < num_pages(); ++i) {
+          uint32_t page_addr = addr + i * page_size();
+          if (!ReadPageOk(page_addr)) {
+            return kErrorFlashCtrlDataEraseVerify;
+          }
+        }
         region = GetFlash().subspan(addr, bank_size());
         break;
       }
@@ -107,6 +169,10 @@ class FlashCtrlSim {
   }
 
   rom_error_t DataWrite(uint32_t addr, uint32_t word_count, const void *data) {
+    if (!WritePageOk(addr)) {
+      return kErrorFlashCtrlDataWrite;
+    }
+
     const size_t num_bytes = word_count * sizeof(uint32_t);
     absl::Span<char> region = GetFlash().subspan(addr, num_bytes);
     EXPECT_EQ(region.size(), num_bytes);
@@ -136,7 +202,50 @@ class FlashCtrlSim {
   static constexpr size_t page_size() {
     return FLASH_CTRL_PARAM_BYTES_PER_PAGE;
   }
+  static constexpr size_t num_pages() {
+    constexpr size_t kFlashSize = bank_size() * num_banks();
+    static_assert(kFlashSize % page_size() == 0,
+                  "Flash size must be divisible by page size");
+    return kFlashSize / page_size();
+  }
   static constexpr size_t rom_ext_size() { return CHIP_ROM_EXT_SIZE_MAX; }
+
+  // Finds the first enabled region that covers the given address. If no regions
+  // cover the address, returns `absl::nullopt`.
+  absl::optional<MpRegion> FindMpRegion(uint32_t addr) const {
+    const size_t page = addr / page_size();
+    for (const MpRegion &region : mp_regions_) {
+      if (region.enabled && region.page_offset <= page &&
+          page < region.page_offset + region.num_pages) {
+        return region;
+      }
+    }
+    return absl::nullopt;
+  }
+  // Returns true iff memory protection rules allow this address to be erased.
+  // If there is no matching rule, it returns the the last flash-wide
+  // erasability configured with `flash_ctrl_bank_erase_perms_set()`.
+  bool ErasePageOk(uint32_t addr) const {
+    absl::optional<MpRegion> region = FindMpRegion(addr);
+    return region ? region->erase_enabled : bank_erase_perms_;
+  }
+  // Returns true iff memory protection rules allow this address to be read.
+  // If there is no matching rule, it returns the the last flash-wide
+  // readability configured with `flash_ctrl_bank_erase_perms_set()`.
+  bool ReadPageOk(uint32_t addr) const {
+    absl::optional<MpRegion> region = FindMpRegion(addr);
+    return region ? region->read_enabled : bank_erase_perms_;
+  }
+  // Returns true iff memory protection rules allow programming pages at this
+  // address. Otherwise, returns false.
+  bool WritePageOk(uint32_t addr) const {
+    absl::optional<MpRegion> region = FindMpRegion(addr);
+    return region ? region->prog_enabled : false;
+  }
+
+  bool bank_erase_perms_ = false;
+
+  MpRegion mp_regions_[kNumFlashCtrlMpRegions]{};
 
   std::vector<char> memory_;
 };
@@ -175,6 +284,17 @@ class RomExtBootstrapTest : public bootstrap_unittest_util::BootstrapTest {
   void DelegateToFlashCtrlSim() {
     using ::testing::_;
 
+    ON_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, _))
+        .WillByDefault([&](flash_ctrl_region_index_t region,
+                           uint32_t page_offset, uint32_t num_pages,
+                           flash_ctrl_perms_t perms, flash_ctrl_cfg_t cfg) {
+          return flash_ctrl_sim_.DataRegionProtect(region, page_offset,
+                                                   num_pages, perms, cfg);
+        });
+    ON_CALL(flash_ctrl_, BankErasePermsSet(_))
+        .WillByDefault([&](hardened_bool_t enable) {
+          return flash_ctrl_sim_.BankErasePermsSet(enable);
+        });
     ON_CALL(flash_ctrl_, DataErase(_, _))
         .WillByDefault([&](uint32_t addr, flash_ctrl_erase_type_t type) {
           return flash_ctrl_sim_.DataErase(addr, type);
@@ -216,6 +336,12 @@ class RomExtBootstrapTest : public bootstrap_unittest_util::BootstrapTest {
   }
 
   FlashCtrlSim flash_ctrl_sim_;
+
+  const flash_ctrl_cfg_t kFlashCtrlCfg = {
+      .scrambling = kMultiBitBool4True,
+      .ecc = kMultiBitBool4True,
+      .he = kMultiBitBool4True,
+  };
 };
 
 // ROM_EXT bootstrap is disabled when the OTP value is `kHardenedBoolFalse`.
@@ -287,6 +413,11 @@ TEST_F(RomExtBootstrapTest, BootstrapEnabledSimple) {
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
 
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
+
   EXPECT_CALL(spi_device_, Init());
 
   // bootstrap_handle_erase
@@ -331,6 +462,11 @@ TEST_F(RomExtBootstrapTest, BootstrapEnabledJunkBeforeEraseCmd) {
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
 
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
+
   EXPECT_CALL(spi_device_, Init());
 
   // bootstrap_handle_erase
@@ -374,13 +510,9 @@ TEST_F(RomExtBootstrapTest, BootstrapEnabledJunkBeforeEraseCmd) {
   ExpectSuffixSlotB(FlashByte::kErasedVerified);
 }
 
-// Bootstrap does not refuse to act on SECTOR_ERASE commands that would erase
-// part of ROM_EXT in slot A.
-//
-// TODO(#19151) Update this test once ROM_EXT bootstrap configures flash memory
-// protection hardware.
-TEST_F(RomExtBootstrapTest,
-       BootstrapNoProtectionForRomExtWithSectorEraseInSlotA) {
+// Bootstrap refuses to act on SECTOR_ERASE commands that would erase part of
+// ROM_EXT in slot A.
+TEST_F(RomExtBootstrapTest, BootstrapProtectsRomExtWithSectorEraseInSlotA) {
   using FlashByte = FlashCtrlSim::FlashByte;
 
   // This test will forward calls to flash_ctrl functions to
@@ -390,6 +522,11 @@ TEST_F(RomExtBootstrapTest,
 
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
+
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
 
   EXPECT_CALL(spi_device_, Init());
 
@@ -415,38 +552,24 @@ TEST_F(RomExtBootstrapTest,
   EXPECT_CALL(flash_ctrl_, DataErase(testing::_, kFlashCtrlEraseTypePage))
       .Times(2);
   ExpectFlashCtrlAllDisable();
-  EXPECT_CALL(spi_device_, FlashStatusClear());
-
-  ExpectSpiCmd(ResetCmd());
-  EXPECT_CALL(rstmgr_, Reset());
 
   EXPECT_THAT(flash_ctrl_sim_.GetFlash(), Each(Eq(FlashByte::kDefault)))
       << "Before rom_ext_bootstrap(), flash should be unmodified.";
 
-  // Host-specific behavior causes bootstrap to return `kErrorUnknown` on RESET.
-  EXPECT_EQ(rom_ext_bootstrap(), kErrorUnknown);
+  EXPECT_EQ(rom_ext_bootstrap(), kErrorFlashCtrlDataErase);
 
   // The ROM_EXT region in slot A should have been untouched by initial chip
   // erase. Later, during the programming loop, the SECTOR_ERASE command should
-  // have caused us to erase the first two pages of the ROM_EXT.
-  const absl::Span<char> rom_ext_slot_a = flash_ctrl_sim_.GetRomExtSlotA();
-  EXPECT_THAT(rom_ext_slot_a.first(FLASH_CTRL_PARAM_BYTES_PER_PAGE * 2),
-              Each(Eq(FlashByte::kErased)));
-  EXPECT_THAT(rom_ext_slot_a.subspan(FLASH_CTRL_PARAM_BYTES_PER_PAGE * 2),
-              Each(Eq(FlashByte::kDefault)));
-
+  // have been caught by the memory protection rules.
+  ExpectRomExtSlotA(FlashByte::kDefault);
   ExpectSuffixSlotA(FlashByte::kErasedVerified);
   ExpectRomExtSlotB(FlashByte::kDefault);
   ExpectSuffixSlotB(FlashByte::kErasedVerified);
 }
 
-// Bootstrap does not refuse to act on SECTOR_ERASE commands that would erase
-// any part of ROM_EXT in slot B.
-//
-// TODO(#19151) Update this test once ROM_EXT bootstrap configures flash memory
-// protection hardware.
-TEST_F(RomExtBootstrapTest,
-       BootstrapNoProtectionForRomExtWithSectorEraseInSlotB) {
+// Bootstrap refuses to act on SECTOR_ERASE commands that would erase any part
+// of ROM_EXT in slot B.
+TEST_F(RomExtBootstrapTest, BootstrapProtectsRomExtWithSectorEraseInSlotB) {
   using FlashByte = FlashCtrlSim::FlashByte;
 
   // This test will forward calls to flash_ctrl functions to
@@ -456,6 +579,11 @@ TEST_F(RomExtBootstrapTest,
 
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
+
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
 
   EXPECT_CALL(spi_device_, Init());
 
@@ -482,43 +610,27 @@ TEST_F(RomExtBootstrapTest,
   EXPECT_CALL(flash_ctrl_, DataErase(testing::_, kFlashCtrlEraseTypePage))
       .Times(2);
   ExpectFlashCtrlAllDisable();
-  EXPECT_CALL(spi_device_, FlashStatusClear());
-
-  ExpectSpiCmd(ResetCmd());
-  EXPECT_CALL(rstmgr_, Reset());
 
   EXPECT_THAT(flash_ctrl_sim_.GetFlash(), Each(Eq(FlashByte::kDefault)))
       << "Before rom_ext_bootstrap(), flash should be unmodified.";
 
   // Host-specific behavior causes bootstrap to return `kErrorUnknown` on RESET.
-  EXPECT_EQ(rom_ext_bootstrap(), kErrorUnknown);
+  EXPECT_EQ(rom_ext_bootstrap(), kErrorFlashCtrlDataErase);
 
   ExpectRomExtSlotA(FlashByte::kDefault);
   ExpectSuffixSlotA(FlashByte::kErasedVerified);
 
   // The ROM_EXT region in slot B should have been untouched by initial chip
   // erase. Later, during the programming loop, the SECTOR_ERASE command should
-  // have caused us to erase the two pages in the middle of the ROM_EXT.
-  const absl::Span<char> rom_ext_slot_b = flash_ctrl_sim_.GetRomExtSlotB();
-  EXPECT_THAT(rom_ext_slot_b.first(rom_ext_slot_b.size() / 2),
-              Each(Eq(FlashByte::kDefault)));
-  EXPECT_THAT(rom_ext_slot_b.subspan(rom_ext_slot_b.size() / 2,
-                                     FLASH_CTRL_PARAM_BYTES_PER_PAGE * 2),
-              Each(Eq(FlashByte::kErased)));
-  EXPECT_THAT(rom_ext_slot_b.subspan(rom_ext_slot_b.size() / 2 +
-                                     FLASH_CTRL_PARAM_BYTES_PER_PAGE * 2),
-              Each(Eq(FlashByte::kDefault)));
-
+  // have been caught by the memory protection rules rather than erasing two
+  // pages in the middle of the ROM_EXT.
+  ExpectRomExtSlotB(FlashByte::kDefault);
   ExpectSuffixSlotB(FlashByte::kErasedVerified);
 }
 
-// Bootstrap does not refuse to act on PAGE_PROGRAM commands that would
-// overwrite any part of ROM_EXT in slot A.
-//
-// TODO(#19151) Update this test once ROM_EXT bootstrap configures flash memory
-// protection hardware.
-TEST_F(RomExtBootstrapTest,
-       BootstrapNoProtectionForRomExtWithPageProgramInSlotA) {
+// Bootstrap refuses to act on PAGE_PROGRAM commands that would overwrite any
+// part of ROM_EXT in slot A.
+TEST_F(RomExtBootstrapTest, BootstrapProtectsRomExtWithPageProgramInSlotA) {
   using FlashByte = FlashCtrlSim::FlashByte;
 
   // This test will forward calls to flash_ctrl functions to
@@ -528,6 +640,11 @@ TEST_F(RomExtBootstrapTest,
 
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
+
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
 
   EXPECT_CALL(spi_device_, Init());
 
@@ -550,41 +667,26 @@ TEST_F(RomExtBootstrapTest,
   ExpectFlashCtrlWriteEnable();
   EXPECT_CALL(flash_ctrl_, DataWrite(testing::_, 4, testing::_));
   ExpectFlashCtrlAllDisable();
-  EXPECT_CALL(spi_device_, FlashStatusClear());
-
-  ExpectSpiCmd(ResetCmd());
-  EXPECT_CALL(rstmgr_, Reset());
 
   EXPECT_THAT(flash_ctrl_sim_.GetFlash(), Each(Eq(FlashByte::kDefault)))
       << "Before rom_ext_bootstrap(), flash should be unmodified.";
 
   // Host-specific behavior causes bootstrap to return `kErrorUnknown` on RESET.
-  EXPECT_EQ(rom_ext_bootstrap(), kErrorUnknown);
+  EXPECT_EQ(rom_ext_bootstrap(), kErrorFlashCtrlDataWrite);
 
   // The ROM_EXT region in slot A should have been untouched by initial chip
   // erase. Later, during the programming loop, the PAGE_PROGRAM command should
-  // have caused us to erase 16 words in the middle of the ROM_EXT.
-  const absl::Span<char> rom_ext_slot_a = flash_ctrl_sim_.GetRomExtSlotA();
-  EXPECT_THAT(rom_ext_slot_a.first(CHIP_ROM_EXT_SIZE_MAX / 2),
-              Each(Eq(FlashByte::kDefault)));
-  EXPECT_THAT(
-      rom_ext_slot_a.subspan(CHIP_ROM_EXT_SIZE_MAX / 2, 16),
-      ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
-  EXPECT_THAT(rom_ext_slot_a.subspan(CHIP_ROM_EXT_SIZE_MAX / 2 + 16),
-              Each(Eq(FlashByte::kDefault)));
-
+  // have been caught by the memory protection rules rather than erasing 16
+  // words in the middle of the ROM_EXT.
+  ExpectRomExtSlotA(FlashByte::kDefault);
   ExpectSuffixSlotA(FlashByte::kErasedVerified);
   ExpectRomExtSlotB(FlashByte::kDefault);
   ExpectSuffixSlotB(FlashByte::kErasedVerified);
 }
 
-// Bootstrap does not refuse to act on PAGE_PROGRAM commands that would
-// overwrite any part of ROM_EXT in slot B.
-//
-// TODO(#19151) Update this test once ROM_EXT bootstrap configures flash memory
-// protection hardware.
-TEST_F(RomExtBootstrapTest,
-       BootstrapNoProtectionForRomExtWithPageProgramInSlotB) {
+// Bootstrap refuses to act on PAGE_PROGRAM commands that would overwrite any
+// part of ROM_EXT in slot B.
+TEST_F(RomExtBootstrapTest, BootstrapProtectsRomExtWithPageProgramInSlotB) {
   using FlashByte = FlashCtrlSim::FlashByte;
 
   // This test will forward calls to flash_ctrl functions to
@@ -594,6 +696,11 @@ TEST_F(RomExtBootstrapTest,
 
   SetRomExtBootstrapEnabledInOtp(kHardenedBoolTrue);
   SetResetReason(1 << kRstmgrReasonPowerOn | 1 << kRstmgrReasonSoftwareRequest);
+
+  EXPECT_CALL(flash_ctrl_, DataDefaultCfgGet()).WillOnce(Return(kFlashCtrlCfg));
+
+  EXPECT_CALL(flash_ctrl_, DataRegionProtect(_, _, _, _, kFlashCtrlCfg))
+      .Times(3);
 
   EXPECT_CALL(spi_device_, Init());
 
@@ -616,27 +723,20 @@ TEST_F(RomExtBootstrapTest,
   ExpectFlashCtrlWriteEnable();
   EXPECT_CALL(flash_ctrl_, DataWrite(testing::_, 4, testing::_));
   ExpectFlashCtrlAllDisable();
-  EXPECT_CALL(spi_device_, FlashStatusClear());
-
-  ExpectSpiCmd(ResetCmd());
-  EXPECT_CALL(rstmgr_, Reset());
 
   EXPECT_THAT(flash_ctrl_sim_.GetFlash(), Each(Eq(FlashByte::kDefault)))
       << "Before rom_ext_bootstrap(), flash should be unmodified.";
 
   // Host-specific behavior causes bootstrap to return `kErrorUnknown` on RESET.
-  EXPECT_EQ(rom_ext_bootstrap(), kErrorUnknown);
-
-  ExpectRomExtSlotA(FlashByte::kDefault);
-  ExpectSuffixSlotA(FlashByte::kErasedVerified);
+  EXPECT_EQ(rom_ext_bootstrap(), kErrorFlashCtrlDataWrite);
 
   // The ROM_EXT region in slot B should have been untouched by initial chip
   // erase. Later, during the programming loop, the PAGE_PROGRAM command should
-  // have caused us to erase 16 words at the front of the ROM_EXT.
-  const absl::Span<char> rom_ext_slot_b = flash_ctrl_sim_.GetRomExtSlotB();
-  EXPECT_THAT(rom_ext_slot_b.first(16), ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8,
-                                                    9, 10, 11, 12, 13, 14, 15));
-  EXPECT_THAT(rom_ext_slot_b.subspan(16), Each(Eq(FlashByte::kDefault)));
+  // have been caught by the memory protection rules rather than erasing 16
+  // words at the front of the ROM_EXT.
+  ExpectRomExtSlotA(FlashByte::kDefault);
+  ExpectSuffixSlotA(FlashByte::kErasedVerified);
+  ExpectRomExtSlotB(FlashByte::kDefault);
   ExpectSuffixSlotB(FlashByte::kErasedVerified);
 }
 

--- a/util/py/packages/lib/register_usage_report_test.py
+++ b/util/py/packages/lib/register_usage_report_test.py
@@ -11,7 +11,6 @@ from util.py.packages.lib.register_usage_report import (
 
 
 class TestSingleFileSourceRange(unittest.TestCase):
-
     def test_hash(self):
         """Test that the hash function incorporates all fields.
 
@@ -54,7 +53,6 @@ class TestSingleFileSourceRange(unittest.TestCase):
 
 
 class TestRegisterUsageReport(unittest.TestCase):
-
     def test_merge_trivial(self):
         reports = [
             RegisterUsageReport("foo", dict(), set()),
@@ -167,7 +165,6 @@ class TestRegisterUsageReport(unittest.TestCase):
 
 
 class TestRegisterUsageReportGroup(unittest.TestCase):
-
     def test_serialization_roundtrips(self):
         report_groups = [
             RegisterUsageReportGroup({}),
@@ -243,7 +240,6 @@ class TestRegisterUsageReportGroup(unittest.TestCase):
 
 
 class TestRegisterTokenPattern(unittest.TestCase):
-
     def test_empty(self):
         pattern = RegisterTokenPattern([])
         self.assertEqual(pattern.count_wildcards(), 0)


### PR DESCRIPTION
This PR adds a new memory protection feature to the flash_ctrl driver.

This is how ROM_EXT bootstrap implements its [promises](https://cs.opensource.google/opentitan/opentitan/+/master:sw/device/silicon_creator/rom_ext/bootstrap.h;l=46-51;drc=934678a120ca7d8ef7c8facf4780c80688856979) without explicit bounds checks in software.

Issues #19151, #19438