### PR TITLE
[crypto] Modify RSA to infer the size of signatures.

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.h
@@ -17,6 +17,20 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Block until a modexp operation is complete and get the result size.
+ *
+ * After OTBN finishes processing, this function reads the mode and infers the
+ * size of the modulus/signature for the just-finished operation. It then
+ * populates the `num_words` parameter with this size (expressed in 32b words).
+ * This is designed so that callers can call `rsa_modexp_wait()` and then use
+ * the size to select the appropriate `finalize()` call.
+ *
+ * @param[out] num_words Number of words for result buffers.
+ * @return Status of the operation (OK or error).
+ */
+status_t rsa_modexp_wait(size_t *num_words);
+
+/**
  * Start a constant-time RSA-2048 modular exponentiation.
  *
  * This construct is for secret exponents, and is much slower than the

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.h
@@ -87,10 +87,11 @@ status_t rsa_signature_verify_2048_start(
     const rsa_2048_public_key_t *public_key, const rsa_2048_int_t *signature);
 
 /**
- * Waits for an RSA-2048 signature generation to complete.
+ * Waits for an signature generation to complete.
  *
- * Should be invoked only after `rsa_2048_signature_verify_start`. Blocks until
- * OTBN is done processing.
+ * Should be invoked only after a `rsa_signature_verify_{size}_start` call, but
+ * can be invoked for any size. Blocks until OTBN is done processing, and then
+ * infers the size from the OTBN application mode.
  *
  * The caller must check the `result` parameter to see if the signature passed
  * or failed verification; the return value of this function will always return
@@ -104,7 +105,7 @@ status_t rsa_signature_verify_2048_start(
  * @param[out] verification_result Whether verification succeeded or failed.
  * @return Result of the operation (OK or error).
  */
-status_t rsa_signature_verify_2048_finalize(
+status_t rsa_signature_verify_finalize(
     const uint8_t *message, const size_t message_len,
     const rsa_signature_padding_t padding_mode,
     const rsa_signature_hash_t hash_mode, hardened_bool_t *verification_result);

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -53,7 +53,7 @@ status_t keygen_then_sign_test(void) {
   LOG_INFO("Starting signature verification...");
   TRY(rsa_signature_verify_2048_start(&public_key, &signature));
   hardened_bool_t verification_result;
-  TRY(rsa_signature_verify_2048_finalize(
+  TRY(rsa_signature_verify_finalize(
       kTestMessage, kTestMessageLen, kRsaSignaturePaddingPkcs1v15,
       kRsaSignatureHashSha256, &verification_result));
   LOG_INFO("Signature verification complete.");

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -142,7 +142,7 @@ status_t pkcs1v15_verify_valid_test(void) {
   TRY(rsa_signature_verify_2048_start(&kTestPublicKey,
                                       &kValidSignaturePkcs1v15));
   hardened_bool_t verification_result;
-  TRY(rsa_signature_verify_2048_finalize(
+  TRY(rsa_signature_verify_finalize(
       kTestMessage, kTestMessageLen, kRsaSignaturePaddingPkcs1v15,
       kRsaSignatureHashSha256, &verification_result));
 
@@ -155,7 +155,7 @@ status_t pkcs1v15_verify_invalid_test(void) {
   // Try to verify an invalid signature (wrong padding mode).
   TRY(rsa_signature_verify_2048_start(&kTestPublicKey, &kValidSignaturePss));
   hardened_bool_t verification_result;
-  TRY(rsa_signature_verify_2048_finalize(
+  TRY(rsa_signature_verify_finalize(
       kTestMessage, kTestMessageLen, kRsaSignaturePaddingPkcs1v15,
       kRsaSignatureHashSha256, &verification_result));
 


### PR DESCRIPTION
Previously, the RSA signature code had separate `finalize()` functions for each size of signature verification. Now, it will read the mode from OTBN and infer the correct size. This provides more safety against size mismatches and also an interface that better matches the top-level cryptolib API.

This commit also modifies the key generation routine to double-check the mode during `finalize()` as an extra sanity check/countermeasure.