### PR TITLE
[release] Revert hyperdebug release back to ordinary files

### DIFF
--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -226,7 +226,9 @@ pkg_files(
     name = "hyperdebug",
     testonly = True,
     srcs = [
-        ":fpga_cw310_hyperdebug_manifest",
+        ":fpga_cw310_test_rom_hyp",
+        ":otp_mmi_hyp",
+        ":rom_mmi_hyp",
     ],
     prefix = "earlgrey/fpga_cw310/hyperdebug",
     tags = ["manual"],


### PR DESCRIPTION
The bitstreams cache work included an errant change to the release fileset, one that picked out the manifest fragment outputs for the release instead of the ordinary files from the bitstream build. Revert that change, so the release build may continue as it was.