### PR TITLE
[ci] further reduce set of items built by airgapped test job

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -25,7 +25,7 @@ sudo ip netns exec airgapped sudo -u "$USER" bash -c \
   export BITSTREAM=\"--offline latest\";
   export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
   TARGET_PATTERN_FILE=\$(mktemp)
-  echo //sw/device/silicon_creator/rom/... > \"\${TARGET_PATTERN_FILE}\"
+  echo //sw/device/silicon_creator/rom:rom_with_fake_keys > \"\${TARGET_PATTERN_FILE}\"
   bazel-airgapped/bazel cquery \
     --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
     --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \


### PR DESCRIPTION
This CI job was running out of space again. This a temporary fix until we can figure out why this is causing an issue.