### PR TITLE
[dv,flash_ctrl_testutils] Fix flash_ctrl_testutils_backdoor_wait_update

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -60,7 +60,7 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
   bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] sram_main_nonce;
   bit [  sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0] sram_main_key;
 
-  typedef enum {
+  typedef enum byte {
     PhaseSetup           = 0,
     kTestPhaseMainSram   = 1,
     kTestPhaseRetSram    = 2,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv
@@ -38,7 +38,7 @@ class chip_sw_sysrst_ctrl_ec_rst_l_vseq extends chip_sw_base_vseq;
     cfg.chip_vif.pwrb_in_if.pins_pd[0] = 1;
   endtask
 
-  virtual function void write_test_phase(input test_phases_e phase);
+  virtual function void write_test_phase(input byte phase);
     `uvm_info(`gfn, $sformatf("Writing test phase %0d", phase), UVM_MEDIUM)
     sw_symbol_backdoor_overwrite("kTestPhase", {<<8{phase}});
   endfunction

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -311,23 +311,27 @@ status_t flash_ctrl_testutils_backdoor_init(
                                                     /*he_en*/ false);
 }
 
-status_t flash_ctrl_testutils_backdoor_wait_update(
-    dif_flash_ctrl_state_t *flash_state, uintptr_t addr, size_t timeout) {
-  static uint32_t data = UINT32_MAX;
-  TRY(flash_ctrl_testutils_write(
-      flash_state, (uint32_t)addr - TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR, 0,
-      &data, kDifFlashCtrlPartitionTypeData, 1));
-  IBEX_TRY_SPIN_FOR(UINT32_MAX != *(uint32_t *)addr, timeout);
-  return OK_STATUS();
+static void flash_ctrl_testutils_flush_read_buffers(void) {
+  // Cause read buffers to flush since it reads 32 bytes, which is the
+  // size of the read buffers.
+  enum { kBufferBytes = 32 };
+  static volatile const uint8_t kFlashFlusher[kBufferBytes];
+  for (int i = 0; i < sizeof(kFlashFlusher); ++i) {
+    (void)kFlashFlusher[i];
+  }
 }
 
-status_t flash_ctrl_testutils_flush_read_buffers(void) {
-  static volatile const uint32_t kFlashFlusher[8];
-  // Cause read buffers to flush.
-  uint32_t count = 0;
-  for (int i = 0; i < sizeof(kFlashFlusher); ++i) {
-    count += kFlashFlusher[i];
-  }
-  (void)count;
+status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
+                                                   uint8_t prior_data,
+                                                   size_t timeout_usec) {
+  uint8_t new_data = 0;
+  const ibex_timeout_t timeout = ibex_timeout_init(timeout_usec);
+  do {
+    if (ibex_timeout_check(&timeout)) {
+      return DEADLINE_EXCEEDED();
+    }
+    flash_ctrl_testutils_flush_read_buffers();
+    new_data = addr[0];
+  } while (new_data == prior_data);
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -249,35 +249,22 @@ status_t flash_ctrl_testutils_backdoor_init(
     dif_flash_ctrl_state_t *flash_state);
 
 /**
- * This is a backdoor API to be used with dvsim testbench.
- * Backdoor variables present on flash may not be updated when read by software
- * after written in the testbench due to the cache. So this function implements
- * a workaround to invalidate the cache and force it to update. Before using
- * this function `flash_ctrl_testutils_backdoor_init` should be called.
+ * This detects changes in a specific byte in flash memory contents with a
+ * timeout. In some cases the party updating it uses a backdoor overwrite,
+ * so this code flushes the read buffers since the backdoor API has no
+ * mechanism to flush.
  *
- * Note:
- * Given typical flash write latency (a few 10s of us),
- * this api can causes following misbehavior with real flash model.
+ * The `flash_ctrl_testutils_backdoor_init` function should be called prior
+ * to this.
  *
- * While flash write with all 1's in progress, backdoor write from
- * sv finished. When that happens, this function can complete without
- * detecting proper backdoor update value. So it is highly discouraged to use
- * this api without opensource flash model.
- *
- * @param flash_state A flash_ctrl handle.
- * @param addr The address to a `const uint32_t` variable where the testbench
- * will write to.
- * @param timeout Timeout.
+ * @param addr The volatile address of a uint8_t variable where an update
+ * is expected.
+ * @param prior_data The prior data value.
+ * @param timeout_usec Timeout in microseconds.
  */
 OT_WARN_UNUSED_RESULT
-status_t flash_ctrl_testutils_backdoor_wait_update(
-    dif_flash_ctrl_state_t *flash_state, uintptr_t addr, size_t timeout);
-
-/**
- * This flushes the read buffers. It assumes there are 4 buffers,
- * each holding 8 byte aligned data previously read.
- */
-OT_WARN_UNUSED_RESULT
-status_t flash_ctrl_testutils_flush_read_buffers(void);
+status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
+                                                   uint8_t prior_data,
+                                                   size_t timeout_usec);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -205,6 +205,7 @@ opentitan_functest(
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",


### PR DESCRIPTION
This function waits until a flash memory location changes value. It flushes the read buffers before each read to account for SV updates done via backdoor overwrites.

Fix some tests to use this API.