### PR TITLE
[tlgen] Remove an ancient "error" debug print

### DIFF
--- a/util/tlgen/doc.py
+++ b/util/tlgen/doc.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """TileLink-Uncached Lightweight Xbar self document
 """
-import logging as log
-
 from reggen.validate import val_types
 
 from .validate import root
@@ -49,7 +47,6 @@ Field | Kind | Type | Description
 
         if v[0] == 'lg':
             subgroup.append(v[1])
-            log.error(val_types[v[0]])
             outstr += '{} | {} | {} | List of {} group\n'.format(
                 k, kind, v_type, k)
             continue


### PR DESCRIPTION
This has been in the file since 2019 but causes our "Check CMDGEN Blocks" CI job to spit out confusing junk in its logs. Fortunately, it wasn't doing anything useful so we can just delete the line!