### PR TITLE
[tlgen] General "tidy up" changes

### DIFF
--- a/util/example/tlgen/xbar_main.hjson
+++ b/util/example/tlgen/xbar_main.hjson
@@ -10,7 +10,7 @@
     clk_periph_i: "fixed"
     clk_crypt_i:  "main"
   }
-  reset: "rst_main_ni" 
+  reset: "rst_main_ni"
   reset_connections: {
     rst_main_ni:   "sys"
     rst_jtag_ni:   "sys"
@@ -24,7 +24,7 @@
       reset: "rst_main_ni",
 
       xbar: false
-      pipeline: "false"
+      pipeline: false
     },
     { name:  "ibexlsu",
       type:  "host",
@@ -32,7 +32,7 @@
       reset: "rst_periph_ni",
 
       xbar: false
-      pipeline: "false"
+      pipeline: false
     },
     { name:  "dm_sba", // DM
       type:  "host",
@@ -40,7 +40,7 @@
       reset: "rst_jtag_ni",
 
       xbar: false
-      pipeline_byp: "false"
+      pipeline_byp: false
     },
     { name:  "rom",
       type:  "device",

--- a/util/tlgen.py
+++ b/util/tlgen.py
@@ -2,8 +2,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-r""" TileLink-Uncached Lightweight Xbar generator
-"""
+"""TileLink Uncached Lightweight crossbar generator."""
 
 import argparse
 import logging as log
@@ -16,6 +15,7 @@ import tlgen
 
 
 def main():
+    """Run tlgen as a script."""
     parser = argparse.ArgumentParser(prog="tlgen")
     parser.add_argument('--topcfg',
                         '-t',

--- a/util/tlgen/__init__.py
+++ b/util/tlgen/__init__.py
@@ -6,6 +6,6 @@ from .doc import selfdoc  # noqa: F401
 from .elaborate import elaborate  # noqa: F401
 from .generate import generate  # noqa: F401
 from .generate_tb import generate_tb  # noqa: F401
-from .item import Edge, Node, NodeType  # noqa: F401
+from .item import Edge, Node  # noqa: F401
 from .validate import validate  # noqa: F401
 from .xbar import Xbar  # noqa: F401

--- a/util/tlgen/__init__.py
+++ b/util/tlgen/__init__.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Collection of helper modules for the tlgen tool."""
+
 from .doc import selfdoc  # noqa: F401
 from .elaborate import elaborate  # noqa: F401
 from .generate import generate  # noqa: F401

--- a/util/tlgen/doc.py
+++ b/util/tlgen/doc.py
@@ -1,8 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-"""TileLink-Uncached Lightweight Xbar self document
-"""
+"""Generate self-documentation for a TL-UL crossbar."""
+
+from typing import Any, Dict
+
 from reggen.validate import val_types
 
 from .validate import root
@@ -17,12 +19,11 @@ Type | Description
 """
 
 
-def print_control(control, heading):
-    """Print a control group and its subgroup recursively
-    """
+def print_control(control: Dict[Any, Any], heading: int) -> str:
+    """Print a control group and its subgroup recursively."""
     subgroup = []  # added if the field hit sub control group
 
-    outstr = '#' * heading + ' ' + control['name'] + '\n'
+    outstr: str = '#' * heading + ' ' + control['name'] + '\n'
     outstr += '\n'
 
     outstr += control['description']
@@ -68,7 +69,8 @@ Field | Kind | Type | Description
     return outstr
 
 
-def selfdoc(heading, cmd=""):
+def selfdoc(heading: int, cmd: str = "") -> str:
+    """Return self-documentation for TL crossbar."""
     # heading : Markdown header depth
     # value type
     outstr = doc_intro

--- a/util/tlgen/elaborate.py
+++ b/util/tlgen/elaborate.py
@@ -78,36 +78,22 @@ def process_node(node: Node, xbar: Xbar) -> Xbar:
     # If a node has multiple edges having it as a end node and not SOCKET_M1:
     elif len(node.us) > 1 and not isinstance(node, SocketM1):
         # (New node) Create SOCKET_M1 node
-        new_node = SocketM1(name="sm1_" + str(len(xbar.nodes)),
+        new_node = SocketM1(hwidth=len(node.us),
+                            name="sm1_" + str(len(xbar.nodes)),
                             clock=xbar.clock,
                             reset=xbar.reset)
 
-        # By default, assume connecting to SOCKET_1N upstream and bypass all FIFOs
-        # If upstream requires pipelining, it will be added through process pipeline
-        new_node.hdepth = 0
-        new_node.hreq_pass = 2**len(node.us) - 1
-        new_node.hrsp_pass = 2**len(node.us) - 1
-        new_node.ddepth = 0
-        new_node.dreq_pass = 1
-        new_node.drsp_pass = 1
         xbar.insert_node(new_node, node)
         process_node(new_node, xbar)
 
     # If a node has multiple edges having it as a start node and not SOCKET_1N:
     elif len(node.ds) > 1 and not isinstance(node, Socket1N):
         # (New node) Create SOCKET_1N node
-        new_node = Socket1N(name="s1n_" + str(len(xbar.nodes)),
+        new_node = Socket1N(dwidth=len(node.ds),
+                            name="s1n_" + str(len(xbar.nodes)),
                             clock=xbar.clock,
                             reset=xbar.reset)
 
-        # By default, assume connecting to SOCKET_M1 downstream and bypass all FIFOs
-        # If upstream requires pipelining, it will be added through process pipeline
-        new_node.hdepth = 0
-        new_node.hreq_pass = 1
-        new_node.hrsp_pass = 1
-        new_node.ddepth = 0
-        new_node.dreq_pass = 2**len(node.ds) - 1
-        new_node.drsp_pass = 2**len(node.ds) - 1
         xbar.insert_node(new_node, node)
 
         # (for loop) Repeat the algorithm with SOCKET_1N's other side node

--- a/util/tlgen/generate.py
+++ b/util/tlgen/generate.py
@@ -8,7 +8,6 @@ from mako import exceptions
 from mako.template import Template
 from pkg_resources import resource_filename
 
-from .item import NodeType
 from .xbar import Xbar
 
 
@@ -26,10 +25,9 @@ def generate(xbar: Xbar, library_name: str = "ip") -> str:
     xbar_hjson_tpl = Template(
         filename=resource_filename('tlgen', 'xbar.hjson.tpl'))
     try:
-        out_rtl = xbar_rtl_tpl.render(xbar=xbar, ntype=NodeType)
+        out_rtl = xbar_rtl_tpl.render(xbar=xbar)
         out_pkg = xbar_pkg_tpl.render(xbar=xbar)
         out_core = xbar_core_tpl.render(xbar=xbar,
-                                        ntype=NodeType,
                                         library_name=library_name)
         out_hjson = xbar_hjson_tpl.render(xbar=xbar)
     except:  # noqa: E722

--- a/util/tlgen/generate.py
+++ b/util/tlgen/generate.py
@@ -2,20 +2,24 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging as log
+"""Code to generate crossbar RTL."""
 
-from mako import exceptions
-from mako.template import Template
+import logging as log
+from typing import Any, List, Tuple
+
+from mako import exceptions  # type: ignore
+from mako.template import Template  # type: ignore
 from pkg_resources import resource_filename
 
 from .xbar import Xbar
 
 
-def generate(xbar: Xbar, library_name: str = "ip") -> str:
-    """generate uses elaborated model then creates top level Xbar module
-    with prefix.
-    """
+def generate(xbar: Xbar, library_name: str = "ip") -> List[Tuple[str, Any]]:
+    """Create top-level crossbar module.
 
+    This assumes that the model has been elaborated already. Returns a list of
+    pairs of files to write, each in the form (path, contents).
+    """
     xbar_rtl_tpl = Template(
         filename=resource_filename('tlgen', 'xbar.rtl.sv.tpl'))
     xbar_pkg_tpl = Template(

--- a/util/tlgen/generate_tb.py
+++ b/util/tlgen/generate_tb.py
@@ -2,11 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Code to generate crossbar testbench."""
+
 import logging as log
 from pathlib import Path
 
-from mako import exceptions
-from mako.template import Template
+from mako import exceptions  # type: ignore
+from mako.template import Template  # type: ignore
 from pkg_resources import resource_filename
 
 from .xbar import Xbar
@@ -14,8 +16,8 @@ from .xbar import Xbar
 
 def generate_tb(xbar: Xbar,
                 dv_path: Path,
-                library_name: str = "ip") -> str:  # xbar: Xbar -> str
-    # list all the generate files for TB
+                library_name: str = "ip") -> None:
+    """Generate the testbench RTL."""
     tb_files = [
         "xbar_env_pkg__params.sv", "tb__xbar_connect.sv", "xbar.sim.core",
         "xbar.bind.core", "xbar.bind.sv", "xbar.sim_cfg.hjson",

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -15,9 +15,6 @@ class Edge:
         self.us = us
         self.ds = ds
 
-    def __repr__(self):
-        return "U(%s) D(%s)" % (self.us.name, self.ds.name)
-
 
 # Edges = List[Edge]
 # Clocks = List[str]  # If length is more than one, should be exactly two

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
+"""Classes to represent the crossbar's dataflow graph."""
+
+from typing import List
 
 
 class Edge:
@@ -16,29 +18,13 @@ class Edge:
         self.ds = ds
 
 
-# Edges = List[Edge]
-# Clocks = List[str]  # If length is more than one, should be exactly two
-
-# [UpstreamClock, DownstreamClock]
-
-
-class NodeType(Enum):
-    HOST = 1
-    DEVICE = 2
-    ASYNC_FIFO = 3
-    SOCKET_1N = 4
-    SOCKET_M1 = 5
-
-
 class Node:
-    """Node class is a port that communicates from/to other Node or TL-UL
-    input/output.
-    """
+    """Base class representing a node in the data graph."""
 
-    name = ""  # name: str
-    # node_type: NodeType
-    clocks = []  # Clocks  # clock domains of the node
-    resets = []  # Resets  # resets of the node
+    name: str = ""
+
+    clocks: List[str] = []  # clock domains of the node. Should have at most 2.
+    resets: List[str] = []  # resets of the node
     # e.g. async_fifo in : clk_core , out : clk_main
 
     # If NodeType is Socket out from 1:N then address steering is used
@@ -66,9 +52,12 @@ class Node:
     req_fifo_pass = True
     rsp_fifo_pass = True
 
-    def __init__(self, name, node_type, clock, reset):
+    def __init__(self,
+                 name: str,
+                 clock: str,
+                 reset: str):
+        """Construct a node with the given name and main clock/reset."""
         self.name = name
-        self.node_type = node_type
         self.clocks = [clock]
         self.resets = [reset]
         self.us = []
@@ -84,3 +73,27 @@ class Node:
 
         '''
         return self.name.replace('.', '__')
+
+
+class Host(Node):
+    """A host node."""
+
+
+class Device(Node):
+    """A device node."""
+
+
+class AsyncFifo(Node):
+    """A node representing an async fifo."""
+
+
+class Socket(Node):
+    """A node representing a socket (1N or M1)."""
+
+
+class Socket1N(Socket):
+    """A 1N socket."""
+
+
+class SocketM1(Socket):
+    """An M1 socket."""

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -4,16 +4,18 @@
 
 """Classes to represent the crossbar's dataflow graph."""
 
-from typing import List
+from typing import List, Tuple
 
 
 class Edge:
-    """Edge class contains the connection from a node to a node.
+    """A connection between two nodes.
 
-    a Node can be a host port, output of async_fifo, port in a socket,
+    A node can be a host port, output of async_fifo, port in a socket,
     or a device port.
     """
-    def __init__(self, us, ds):
+
+    def __init__(self, us: 'Node', ds: 'Node'):
+        """Create an edge between us and ds."""
         self.us = us
         self.ds = ds
 
@@ -29,14 +31,16 @@ class Node:
 
     # If NodeType is Socket out from 1:N then address steering is used
     # But this value is also propagated up to a Host from multiple Devices
-    # Device Node should have address_from, address_to
-    # address_from = 0  #: int
-    # address_to = 0  #: int
-    addr_range = []
+    # A device Node should have address_from, address_to.
+    #
+    # Other nodes have this fields set to -1.
+    address_from: int = -1
+    address_to: int = -1
+    addr_range: List[Tuple[int, int]] = []
 
-    us = []  # Edges  # Number of Ports depends on the NodeType
+    us: List[Edge] = []  # Number of Ports depends on the NodeType
     # 1 for Host, Device, 2 for Async FIFO, N for Sockets
-    ds = []  # Edges
+    ds: List[Edge] = []
 
     # Req/Rsp FIFO. default False
     # when False, no storage element
@@ -81,6 +85,8 @@ class Host(Node):
 
 class Device(Node):
     """A device node."""
+
+    xbar: bool = False
 
 
 class AsyncFifo(Node):

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -90,10 +90,39 @@ class AsyncFifo(Node):
 class Socket(Node):
     """A node representing a socket (1N or M1)."""
 
+    hdepth: int
+    hreq_pass: int
+    hrsp_pass: int
+
+    ddepth: int
+    dreq_pass: int
+    drsp_pass: int
+
+    def __init__(self, hwidth: int, dwidth: int,
+                 name: str, clock: str, reset: str):
+        """Construct a socket with given host/device width."""
+        super().__init__(name, clock, reset)
+        self.hdepth = 0
+        self.hreq_pass = 2 ** hwidth - 1
+        self.hrsp_pass = 2 ** hwidth - 1
+        self.ddepth = 0
+        self.dreq_pass = 2 ** dwidth - 1
+        self.drsp_pass = 2 ** dwidth - 1
+
 
 class Socket1N(Socket):
     """A 1N socket."""
 
+    def __init__(self, dwidth: int,
+                 name: str, clock: str, reset: str):
+        """Construct a 1N socket with given device width."""
+        super().__init__(1, dwidth, name, clock, reset)
+
 
 class SocketM1(Socket):
     """An M1 socket."""
+
+    def __init__(self, hwidth: int,
+                 name: str, clock: str, reset: str):
+        """Construct a socket with given host width."""
+        super().__init__(hwidth, 1, name, clock, reset)

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 import logging as log
-from collections import OrderedDict
 from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
 
 from reggen.validate import check_bool, check_int, val_types
 
-from .item import Host, Device, AsyncFifo, Socket1N, SocketM1
+from .item import Node, Host, Device, AsyncFifo, Socket1N, SocketM1
 from .lib import simplify_addr
 from .xbar import Xbar
 
@@ -119,7 +119,9 @@ Crossbar configuration format.
 MIN_DEVICE_SPACING = 0x1000
 
 
-def check_keys(obj, control, prefix=""):
+def check_keys(obj: Dict[Any, Any],
+               control: Dict[Any, Any],
+               prefix: str = "") -> int:
     """ Check the keys recursively.
 
     The control parameter is a control group to check obj data structure.
@@ -196,7 +198,7 @@ def check_keys(obj, control, prefix=""):
     return error
 
 
-def mk_node(typ: str, name: str, clock: str, reset: str):
+def mk_node(typ: str, name: str, clock: str, reset: str) -> Node:
     """Create a graph node with the requested node type.
 
     This is just a wrapper around the constructors in item.py, and picks the
@@ -220,51 +222,52 @@ def mk_node(typ: str, name: str, clock: str, reset: str):
     raise
 
 
-def checkNameExist(name, xbar):  # name: str -> xbar: Xbar -> bool
+def checkNameExist(name: str, xbar: Xbar) -> bool:
     return name.lower() in [x.name for x in xbar.nodes]
 
 
-def isOverlap(range1, range2):  # Tuple[int,int] -> Tuple[int,int] -> bool
+def isOverlap(range1: Tuple[int, int], range2: Tuple[int, int]) -> bool:
     return not (range2[1] < range1[0] or range2[0] > range1[1])
 
 
-def isNotMinSpacing(range1, range2):  # Tuple[int,int] -> Tuple[int,int] -> bool
+def isNotMinSpacing(range1: Tuple[int, int], range2: Tuple[int, int]) -> bool:
     return not (range2[0] < range1[0] - MIN_DEVICE_SPACING or
                 range2[0] >= range1[0] + MIN_DEVICE_SPACING)
 
 
-def isNotAligned(base):  # Tuple[int,int] -> bool
+def isNotAligned(base: int) -> bool:
     return ((base & (MIN_DEVICE_SPACING - 1)) != 0)
 
 
-# Tuple[int,int] -> List[Tuple[]] -> bool
-def checkAddressOverlap(addr, ranges):
+def checkAddressOverlap(addr: Tuple[int, int],
+                        ranges: List[Tuple[int, int]]) -> bool:
     result = [x for x in ranges if isOverlap(x, addr)]
     return len(result) != 0
 
 
-# Tuple[int,int] -> List[Tuple[]] -> bool
-def checkAddressSpacing(addr, ranges):
+def checkAddressSpacing(addr: Tuple[int, int],
+                        ranges: List[Tuple[int, int]]) -> bool:
     result = [x for x in ranges if isNotMinSpacing(x, addr)]
     return len(result) != 0
 
 
 # this returns 1 if the size mask overlapps with the address base
-def checkBaseSizeOverlap(addr_base, size):
+def checkBaseSizeOverlap(addr_base: int, size: int) -> int:
     return ((size - 1) & addr_base)
 
 
-def validate(obj: OrderedDict) -> Xbar:  # OrderedDict -> Xbar
+def validate(obj: Dict[Any, Any]) -> Optional[Xbar]:
     xbar = Xbar()
     xbar.name = obj["name"].lower()
     xbar.clock = obj["clock"].lower()
     xbar.reset = obj["reset"].lower()
-    addr_ranges = []
+    addr_ranges: List[Tuple[int, int]] = []
 
-    obj, err = validate_hjson(obj)  # validate Hjson format first
-    if err > 0:
+    # validate Hjson format first
+    hjson_good = validate_hjson(obj)
+    if not hjson_good:
         log.error("Hjson structure error")
-        return
+        return None
 
     # collection of all clocks and resets of this xbar
     xbar.clocks = [clock for clock in obj["clock_connections"].keys()]
@@ -365,17 +368,22 @@ def validate(obj: OrderedDict) -> Xbar:  # OrderedDict -> Xbar
     return xbar
 
 
-def validate_hjson(obj):
+def validate_hjson(obj: Dict[Any, Any]) -> bool:
+    """Check well-formedness of obj as a parsed hjson crossbar.
+
+    Return True if well-formed and False otherwise. This may modify obj.
+    """
     if "type" not in obj:
         obj["type"] = "xbar"
     if "name" not in obj:
         log.error("Component has no name. Aborting.")
-        return None, 1
+        return False
 
     component = obj["name"]
     error = check_keys(obj, root, component)
 
     if error > 0:
         log.error("{} has top level error. Aborting".format(component))
-        return None, error
-    return obj, 0
+        return False
+
+    return True

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -212,9 +212,9 @@ def mk_node(typ: str, name: str, clock: str, reset: str):
     if typ == "async_fifo":
         return AsyncFifo(name, clock, reset)
     if typ == "socket_1n":
-        return Socket1N(name, clock, reset)
+        return Socket1N(1, name, clock, reset)
     if typ == "socket_m1":
-        return SocketM1(name, clock, reset)
+        return SocketM1(1, name, clock, reset)
 
     log.error("Cannot process type {}".format(typ))
     raise

--- a/util/tlgen/xbar.py
+++ b/util/tlgen/xbar.py
@@ -16,7 +16,6 @@ class Xbar:
         self.name = ""  # str  # e.g. "main" --> main_xbar
         self.ip_path = ""  # additional path to generated rtl/dv folders: outdir/ip_path/rtl
 
-        self.blocks = []
         self.nodes = []
         self.edges = []
         self.clocks = []

--- a/util/tlgen/xbar.py
+++ b/util/tlgen/xbar.py
@@ -22,28 +22,6 @@ class Xbar:
         self.clocks = []
         self.resets = []
 
-    def __repr__(self):
-        out = "<Xbar(%s) #nodes:%d clock:%s" % (self.name, len(
-            self.nodes), self.clock)
-        out += " #edges:%d>\n" % (len(self.edges))
-
-        # print nodes
-        out += "  Nodes:\n"
-        for node in self.nodes:
-            out += "    - " + node.name + "\n"
-
-        out += "  Edges:\n"
-        for edge in self.edges:
-            out += "    - " + edge.us.name + " => " + edge.ds.name + "\n"
-        # print edges
-        return out
-
-    def get_edges_from_node(self, node):  # Node -> Edges
-        return [
-            edge for edge in self.edges
-            if node.name in (edge.us.name, edge.ns.name)
-        ]
-
     def get_node(self, node):  # str -> Node
         result = [x for x in self.nodes if x.name == node]
         if len(result) != 1:

--- a/util/tlgen/xbar.py
+++ b/util/tlgen/xbar.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging as log
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 from .item import Edge, Node, Host, Device, AsyncFifo, Socket1N, SocketM1
 
@@ -11,18 +11,18 @@ from .item import Edge, Node, Host, Device, AsyncFifo, Socket1N, SocketM1
 class Xbar:
     """Xbar contains configurations to generate TL-UL crossbar.
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self.clock = ""  # str  # primary clock of xbar
         self.reset = ""  # str  # primary reset of xbar
         self.name = ""  # str  # e.g. "main" --> main_xbar
         self.ip_path = ""  # additional path to generated rtl/dv folders: outdir/ip_path/rtl
 
-        self.nodes = []
-        self.edges = []
-        self.clocks = []
-        self.resets = []
+        self.nodes: List[Node] = []
+        self.edges: List[Edge] = []
+        self.clocks: List[Any] = []
+        self.resets: List[Any] = []
 
-    def get_node(self, node):  # str -> Node
+    def get_node(self, node: str) -> Node:
         result = [x for x in self.nodes if x.name == node]
         if len(result) != 1:
             raise  # Exception
@@ -63,7 +63,7 @@ class Xbar:
         """
         return self.get_downstream_device(node.ds[idx].ds)
 
-    def get_s1n_if_exist(self, node):  # Node -> Node
+    def get_s1n_if_exist(self, node: Node) -> Node:
         """ return SOCKET_1N if exists down from the node, if not return itself
         """
         if isinstance(node, Device):
@@ -73,7 +73,7 @@ class Xbar:
             return node
         return self.get_s1n_if_exist(node.ds[0].ds)
 
-    def get_leaf_from_node(self, node, idx):  # Node -> int -> Node
+    def get_leaf_from_node(self, node: Node, idx: int) -> Node:
         """ get end device node from any node, idx is given to look down.
         """
         num_dev = len(self.get_s1n_if_exist(node).ds)
@@ -83,7 +83,7 @@ class Xbar:
 
         return self.get_leaf_from_s1n(self.get_s1n_if_exist(node), idx)
 
-    def get_devices_from_host(self, host):  # Node -> Nodes
+    def get_devices_from_host(self, host: Node) -> List[Device]:
         devices = list(
             map(self.get_downstream_device_from_edge,
                 self.get_s1n_if_exist(host).ds))
@@ -96,7 +96,7 @@ class Xbar:
 
         return (device.address_from, device.address_to)
 
-    def connect_nodes(self, u_node, d_node):  # str -> str -> bool
+    def connect_nodes(self, u_node: str, d_node: str) -> bool:
         # Create edges between Nodes
         # Return false if Nodes aren't exist or same connection exists
         upNode = self.get_node(u_node)
@@ -134,7 +134,7 @@ class Xbar:
                 # insert node to upstream
                 edge = Edge(new_node, node)
                 new_node.us = node.us
-                new_node.ds = node
+                new_node.ds = node.ds
                 node.us = [edge]
                 new_node.ds = [edge]
                 self.nodes.append(new_node)
@@ -174,7 +174,7 @@ class Xbar:
 
         return self
 
-    def repr_tree(self, node, indent):
+    def repr_tree(self, node: Node, indent: int) -> str:
         """string format of tree connection from node to devices
 
         Desired output:


### PR DESCRIPTION
The commits move things around enough that we can add mypy types to the code. Once we're done, we can run `mypy --strict util/tlgen/*.py` and no longer get any error reports.

The original code had lots of Python typing comments (although not machine readable), which made it reasonably easy to figure out what was supposed to do what.

This should hopefully be a good starting point for developing a more strongly-typed equivalent. We could probably move more of the typing logic into Python's type system, which might make it easier to work on.