### PR TITLE
[ci/private] Use earlgrey_es branch

### DIFF
--- a/ci/azp-private.yml
+++ b/ci/azp-private.yml
@@ -26,6 +26,7 @@ resources:
     type: github
     endpoint: lowRISC
     name: lowrisc/opentitan-private-ci
+    ref: earlgrey_es
 
 extends:
   template: jobs.yml@opentitan-private-ci


### PR DESCRIPTION
Use a preserved earlgrey_es branch for private CI.

I created an earlgrey_es branch for opentitan-private-ci, as we overlooked the need to preserve that as well. This PR would bring have opentitan@earlgrey_es use opentitan-private-ci@earlgrey_es (instead of master) for its jobs.

Please tell me if this isn't the path we want to take. Thanks! :smile: 