### PR TITLE
[CL-adc]-Added a method for forcing adc_d_o signal.

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -697,6 +697,33 @@ interface chip_if;
   wire flash_core1_host_req = `FLASH_CTRL_HIER.u_eflash.gen_flash_cores[1].u_core.host_req_i;
 `endif
   wire adc_data_valid = `AST_HIER.u_adc.adc_d_val_o;
+  wire [9:0] adc_data_o = `AST_HIER.adc_d_o;
+
+  task static force_adc_d_o(input bit [9:0] channel_val);
+    force adc_data_o[0] = channel_val[0];
+    force adc_data_o[1] = channel_val[1];
+    force adc_data_o[2] = channel_val[2];
+    force adc_data_o[3] = channel_val[3];
+    force adc_data_o[4] = channel_val[4];
+    force adc_data_o[5] = channel_val[5];
+    force adc_data_o[6] = channel_val[6];
+    force adc_data_o[7] = channel_val[7];
+    force adc_data_o[8] = channel_val[8];
+    force adc_data_o[9] = channel_val[9];
+  endtask
+
+  task static release_adc_d_o();
+    release adc_data_o[0];
+    release adc_data_o[1];
+    release adc_data_o[2];
+    release adc_data_o[3];
+    release adc_data_o[4];
+    release adc_data_o[5];
+    release adc_data_o[6];
+    release adc_data_o[7];
+    release adc_data_o[8];
+    release adc_data_o[9];
+  endtask
 
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv
@@ -48,9 +48,9 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
         forever begin
           // force ADC channel0,1
           @(adc_valid_rising_edge_event);
-          `DV_CHECK(uvm_hdl_force(ADC_CHANNEL_OUT_HDL_PATH, (channel0_value)));
+          cfg.chip_vif.force_adc_d_o(channel0_value);
           @(adc_valid_rising_edge_event);
-          `DV_CHECK(uvm_hdl_force(ADC_CHANNEL_OUT_HDL_PATH, (channel1_value)));
+          cfg.chip_vif.force_adc_d_o(channel1_value);
         end
       end
       begin
@@ -153,7 +153,7 @@ class chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq extends chip_sw_base_vseq;
     case(round)
       0: cfg.chip_vif.pwrb_in_if.drive(1'b1);
       1: begin
-        `DV_CHECK(uvm_hdl_release(ADC_CHANNEL_OUT_HDL_PATH))
+        cfg.chip_vif.release_adc_d_o();
         ->release_adc_force;
       end
       2:     cfg.chip_vif.pinmux_wkup_if.drive(1'b0);


### PR DESCRIPTION
Add a method in the chip interface for forcing and releasing adc_d_o signal.
Changed uvm_hdl_force with this method in a test vseq.
Because we do not use uvm_hdl_force in gate level environment and we needed a replacement.