### PR TITLE
[prim lfsr] Replace randomize() calls with $urandom in prim_lfsr_tb

### DIFF
--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_tb.sv
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_tb.sv
@@ -50,6 +50,8 @@ module prim_lfsr_tb;
   logic [MaxLfsrDw-1:0] lfsr_periods [MaxLfsrDw+1];
   logic [MaxLfsrDw-1:0] entropy      [MaxLfsrDw+1];
   logic [MaxLfsrDw-1:0] seed         [MaxLfsrDw+1];
+  logic [MaxLfsrDw-1:0] rand_entropy;
+  logic [MaxLfsrDw-1:0] rand_seed;
 
 
   for (genvar k = MinLfsrDw; k <= MaxLfsrDw; k++) begin : gen_duts
@@ -224,10 +226,12 @@ module prim_lfsr_tb;
       repeat ($urandom_range(5000, 10000)) begin
         // Do random reset sometimes
         if ($urandom_range(0, 10) == 0) main_clk.apply_reset();
-        randomize(seed[k]);
-        randomize(entropy[k]);
-        randomize(lfsr_en[k]);
-        randomize(seed_en[k]);
+        randomize(rand_seed);
+        randomize(rand_entropy);
+        seed[k] = rand_seed;
+        entropy[k] = rand_entropy;
+        lfsr_en[k] = $urandom_range(0, 1);
+        seed_en[k] = $urandom_range(0, 1);
         main_clk.wait_clks(1);
       end
 


### PR DESCRIPTION
Some prim_lfsr tests are currently only working with VCS but not with Xcelium. This commit modifies prim_lfsr_tb.sv to enable `prim_lfsr_gal_smoke`, `prim_lfsr_fib_smoke`, `prim_lfsr_gal_test` and `prim_lfsr_fib_test` to work in Xcelium simulations.