### PR TITLE
[sw/silicon_creator] Update and add assertions for CHIP_BOOT_SVC_MSG_SIZE_MAX

### DIFF
--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -43,16 +43,15 @@
 #define CHIP_BOOT_SVC_MSG_HEADER_SIZE 44
 
 /**
- * Maximum payload size for a boot services message.
- */
-#define CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX 256
-
-/**
  * Maximum size of a boot services message.
  */
-// TODO: Has to be a literal because of OT_ASSERT_SIZE. Add an assertion that
-// checks if this is equal to header + max_payload.
-#define CHIP_BOOT_SVC_MSG_SIZE_MAX 300
+#define CHIP_BOOT_SVC_MSG_SIZE_MAX 48
+
+/**
+ * Maximum payload size for a boot services message.
+ */
+#define CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX \
+  (CHIP_BOOT_SVC_MSG_SIZE_MAX - CHIP_BOOT_SVC_MSG_HEADER_SIZE)
 
 /**
  * First owner boot stage, e.g. BL0, manifest identifier (ASCII "OTB0").

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
@@ -60,9 +60,45 @@ typedef union boot_svc_msg {
   BOOT_SVC_MSGS_DEFINE(BOOT_SVC_MSG_FIELD);
 } boot_svc_msg_t;
 
-// TODO: Add an assertion for checking that CHIP_BOOT_SVC_MSG_SIZE_MAX is
-// up to date after defining structs for other messages.
-OT_ASSERT_SIZE(boot_svc_msg_t, CHIP_BOOT_SVC_MSG_SIZE_MAX);
+/**
+ * Helper macro for generating the equalities for checking that the value of
+ * `CHIP_BOOT_SVC_MSG_SIZE_MAX` is equal to the size of at least one of the boot
+ * services messages.
+ *
+ * Note that the macro expands to an incomplete expression that must be
+ * terminated with `false`.
+ *
+ * @param type_ Data type.
+ * @param field_name_ `boot_svc_msg_t` union field name.
+ */
+#define BOOT_SVC_SIZE_EQ_(type_, field_name_) \
+  sizeof(type_) == CHIP_BOOT_SVC_MSG_SIZE_MAX ||
+
+static_assert(BOOT_SVC_MSGS_DEFINE(BOOT_SVC_SIZE_EQ_) false,
+              "CHIP_BOOT_SVC_MSG_SIZE_MAX must equal to the size of at least "
+              "one of the boot services messages");
+
+#undef BOOT_SVC_SIZE_EQ_
+
+/**
+ * Helper macro for generating the inequalities for checking that the value of
+ * `CHIP_BOOT_SVC_MSG_SIZE_MAX` is greater than or equal to the sizes of all
+ * boot services messages.
+ *
+ * Note that the macro expands to an incomplete expression that must be
+ * terminated with `true`.
+ *
+ * @param type_ Data type.
+ * @param field_name_ `boot_svc_msg_t` union field name.
+ */
+#define BOOT_SVC_SIZE_LE_(type_, field_name_) \
+  sizeof(type_) <= CHIP_BOOT_SVC_MSG_SIZE_MAX &&
+
+static_assert(BOOT_SVC_MSGS_DEFINE(BOOT_SVC_SIZE_LE_) true,
+              "CHIP_BOOT_SVC_MSG_SIZE_MAX must be greater than or equal to the "
+              "sizes of all of the boot services messages");
+
+#undef BOOT_SVC_SIZE_LE_
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
@@ -15,6 +15,30 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Table of boot services request and response types.
+ *
+ * Columns: Data type, `boot_svc_msg_t` union field name.
+ * We use an X macro to generate the assertion that checks
+ * the value of `CHIP_BOOT_SVC_MSG_SIZE_MAX`.
+ */
+// clang-format off
+#define BOOT_SVC_MSGS_DEFINE(X) \
+  /**
+   * Next Boot BL0 Slot request and response.
+   */ \
+  X(boot_svc_next_boot_bl0_slot_req_t, next_boot_bl0_slot_req) \
+  X(boot_svc_next_boot_bl0_slot_res_t, next_boot_bl0_slot_res)
+// clang-format on
+
+/**
+ * Helper macro for declaring fields for boot services messages
+ *
+ * @param type_ Data type.
+ * @param field_name_ `boot_svc_msg_t` union field name.
+ */
+#define BOOT_SVC_MSG_FIELD(type_, field_name_) type_ field_name_;
+
+/**
  * A Boot Services message.
  *
  * This is defined as a union where the common initial sequence is a
@@ -31,14 +55,11 @@ typedef union boot_svc_msg {
    */
   boot_svc_empty_t empty;
   /**
-   * Next Boot BL0 Slot request message.
+   * Boot services request and response messages.
    */
-  boot_svc_next_boot_bl0_slot_req_t next_boot_bl0_slot_req;
-  /**
-   * Next Boot BL0 Slot response message.
-   */
-  boot_svc_next_boot_bl0_slot_res_t next_boot_bl0_slot_res;
+  BOOT_SVC_MSGS_DEFINE(BOOT_SVC_MSG_FIELD);
 } boot_svc_msg_t;
+
 // TODO: Add an assertion for checking that CHIP_BOOT_SVC_MSG_SIZE_MAX is
 // up to date after defining structs for other messages.
 OT_ASSERT_SIZE(boot_svc_msg_t, CHIP_BOOT_SVC_MSG_SIZE_MAX);


### PR DESCRIPTION
Thanks to @milesdai's work in #19286 we can now add an assertion for `CHIP_BOOT_SVC_SIZE_MAX`.

This PR adds an X macro for ease of maintenance -- going forward we should add the new messages to this table.