### PR TITLE
[doc] Updated markdown style guide and added documentation docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -442,6 +442,8 @@
 - [Contributing](./doc/contributing/README.md)
   - [Detailed Contribution Guide](./doc/contributing/detailed_contribution_guide/README.md)
   - [Directory Structure](./doc/contributing/directory_structure.md)
+  - [Contributing to Documentation](./doc/contributing/doc/README.md)
+    - [An Example IP Block's Documentation](./doc/contributing/doc/example_ip_block.md)
   - [Continuous Intergration](./doc/contributing/ci/README.md)
   - [Top-Level Design and Targets](./doc/contributing/system_list.md)
   - [GitHub Notes](./doc/contributing/github_notes.md)

--- a/doc/contributing/doc/README.md
+++ b/doc/contributing/doc/README.md
@@ -1,0 +1,52 @@
+# Contributing to Documentation
+
+## Summary
+
+In the OpenTitan project, documentation is captured in Markdown placed close to what they are documenting in the repository.
+It is viewable on the [OpenTitan website](https://opentitan.org/) or in [GitHub](https://github.com/lowrisc/opentitan) web interface, as well as in plain text.
+Unlike the GitHub and plain text view, the website supplements the markdown documentation with auto-generated documentation from tools such as [rustdoc][].
+
+The Markdown is rendered into a book for the website using [mdBook][] with the structure being determined by the `SUMMARY.md` in the root of the repository.
+The [getting started guide](https://opentitan.org/guides/getting_started/) is rendered as a separate book with the content laid out in `doc/guides/getting_started/src/SUMMARY.md`.
+The `util/site/build-docs.sh` script is used to build these books as well as the landing page and auto-generated documentation.
+
+*Before contributing to documentation, please read **[the markdown style guide](../style_guides/markdown_usage_style.md)***.
+
+## File Structure
+
+Documentation pertaining to the content of a directory in the repo should be within a `README.md` in that repository.
+Any additional documentation that does not belong to a subdirectory should be put in a `doc` sub-directory.
+Images and other assets should also be put in this doc directory.
+This structure is used from the very root of the project where the `README.md` describes the project as a whole and the `doc` directory holds general information about the project that cannot be wholly contained by another subdirectory.
+
+See [An Example IP Block's Documentation](./example_ip_block.md) to get a better sense of this structure.
+
+## `CMDGEN`
+
+In an effort to make as much content viewable in plain text and GitHub as possible, auto-generated markdown is checked in within documentation files.
+This is done with a tool called `CMDGEN`, that lives at `./util/cmdgen.py`.
+When invoked this script will search all given files for `<!-- BEGIN CMDGEN * -->` and `<!-- END CMDGEN -->` delimiters.
+On each encounter, it will run the command in the 'begin' delimiter and check the commands output (`stdout`) matches the content that is between the delimiters.
+
+Commonly one will run the following, which will go through every markdown file in the repository and, because the `-u` flag is given, update the content between the delimiters.
+
+```sh
+./util/cmdgen.py -u '**/*.md'
+```
+
+If run, the following snippet will have the register tables of the AES block (output by `util/regtool.py -d ./hw/ip/aes/data/aes.hjson`) inserted into it.
+
+````md
+# Registers
+
+<!-- BEGIN CMDGEN #util/regtool.py -d ./hw/ip/aes/data/aes.hjson -->
+
+<!-- END CMDGEN -->
+````
+
+*Note, one should remove the `#` before the commands.
+This is there so that `CMDGEN` doesn't generate registers in this file.*
+
+
+[mdBook]: https://rust-lang.github.io/mdBook/
+[rustdoc]: https://doc.rust-lang.org/rustdoc/index.html

--- a/doc/contributing/doc/example_ip_block.md
+++ b/doc/contributing/doc/example_ip_block.md
@@ -1,0 +1,162 @@
+# An Example IP Block's Documentation
+
+## The summary/index file
+
+Typically the documentation of an IP block follows the same broad outline.
+`README.md` at the root of the blocks directory holds a summary of the block.
+This starts with the name of the IP block as a title followed by an overview section with some boiler-plate comments.
+
+````md
+# Example IP Block
+## Overview
+
+This document specifies Name hardware IP functionality.
+This module conforms to the [Comportable guideline for peripheral functionality.](/doc/contributing/hw/comportability/README.md)
+See that document for integration overview within the broader top level system.
+````
+
+The next section summarizes the feature set of the IP block.
+
+````md
+### Features
+
+- Bulleted list
+- Of main features
+````
+
+There then follows a general description of the IP.
+
+````md
+### Description
+
+Description of the IP.
+````
+
+The Compatibility information will allow device driver writers to identify existing code that can be used directly or with minor changes.
+*This section is primarily of interest to software engineers.*
+
+````md
+### Compatability
+
+Notes on if the IP register interface is compatible with any existing register interface.
+Also note any differences.
+For example: Matches 16550 UART interface but registers are at 32-bit word offsets.
+````
+
+The reader is then given links to more detailed documentation.
+Notice, the Design Verification page is the index of the subdirectory, `./dv/README.md`, it describes.
+
+````md
+## Further Reading
+
+- [Theory of Operation](./doc/theory_of_operation.md)
+- [Programmer's Guide](./doc/programmers_guide.md)
+- [Design Verification](./dv/README.md)
+- [Hardware Interfaces](./doc/interfaces.md)
+- [Register](./doc/registers.md)
+````
+
+## The Theory of Operations file
+
+In the `doc/theory_of_operation.md` file lives a more detailed operational description of the module.
+Conventionally one of the first sections includes a block diagram and a description.
+*This should be useful to hardware designers, verification engineers and software engineers.*
+There is then a design details section the organization of which is done to suit the module.
+
+````md
+# Theory of Operations
+## Block Diagram
+
+![Name Block Diagram](block_diagram.svg)
+
+## Design Details
+
+Details of the design.
+
+### Many third level headings
+
+There are probably waveforms embedded here:
+````
+
+
+## The Programmer's Guide file
+
+In the `doc/programmers_guide.md` file is the software user guide and describes using the IP and notes on writing device drivers.
+Code fragments are encouraged.
+*This section is primarily for software engineers, but it is expected that the code fragments are used by verification engineers.*
+
+````md
+# Programmers Guide
+````
+
+One important thing here is to show the order of initialization that has been tested in the verification environment.
+In most cases other orders will work, and may be needed by the software environment, but it can be helpful in tracking down bugs for the validated sequence to be described!
+
+````md
+## Initialization
+
+```c
+
+ if (...) {
+   a = ...
+ }
+```
+````
+
+Other sections cover different use cases and example code fragments.
+
+````md
+
+## Use case A (e.g. Transmission)
+
+## Use case B (e.g. Reception)
+
+````
+
+It is important to include a discussion of error conditions.
+
+````md
+## Error conditions
+
+````
+
+Also comment on anything special about interrupts, potentially including the priority order for servicing interrupts.
+
+````md
+## Interrupt Handling
+
+````
+
+## Hardware Interfaces and Registers files
+
+The `doc/interfaces.md` and `doc/registers.md` contain primarily generated content.
+The hardware interfaces and register tables respectively.
+
+Hardware interfaces containing a description of the IP including the signals, interrupts and alerts that the block uses.
+*Primary user is the SoC integrator, but useful for everyone.*
+Note that the interrupt descriptions are also automatically placed in the interrupt status register bit descriptions, which is the most likely place for software engineers to reference them.
+
+The generated content is inserted using [`CMDGEN`](./README.md#cmdgen).
+
+````md
+# Hardware Interfaces
+
+Additional information before
+
+<!-- BEGIN CMDGEN #util/regtool.py --interfaces ./hw/ip/example/data/example.hjson -->
+
+<!-- END CMDGEN -->
+
+and after the generated content.
+````
+
+````md
+# Registers
+
+<!-- BEGIN CMDGEN #util/regtool.py -d ./hw/ip/example/data/example.hjson -->
+
+<!-- END CMDGEN -->
+````
+
+*Note, one should remove the `#` before the commands.
+This is there so that `CMDGEN` doesn't try to generate registers for the non existent 'example' block.*

--- a/doc/contributing/style_guides/markdown_usage_style.md
+++ b/doc/contributing/style_guides/markdown_usage_style.md
@@ -1,20 +1,22 @@
 # Markdown Usage and Style Guide
 
-## Basics
+## Summary
 
-### Summary
+Markdown is used to write most documentation, specifically [Commonmark][] with [minimal extensions](#extensions).
+The main Markdown tool is [mdBook](https://rust-lang.github.io/mdBook/).
+It is normally run as part of the `./util/site/build-docs.sh` script that builds all `mdbook` books as well as run documentation generators such as `doxygen`.
+*See [Contributing to Documentation](../doc/README.md) for more information.*
 
-Markdown files are used to write most documentation.
-The main Markdown tool is [mdbook](https://rust-lang.github.io/mdBook/).
+In OpenTitan, most readers will read the documentation once it has been rendered to HTML on the website or GitHub.
+However, it is important that files are pleasant to read in plain text because viewing in the plain text can be more convenient when working in the codebase and when contributing to documentation the plain text form is what has to be read and edited.
 
-There exists a script, `./util/site/build-docs.sh`, to build all `mdbook` books as well as run documentation generators such as `doxygen`.
+## About this Style Guide
 
 As with all style guides the intention is to:
 
-*   promote consistency across projects
-*   promote best practices
-*   increase code sharing and re-use
-
+* Promote consistency across projects.
+* Promote best practices.
+* Increase code sharing and re-use.
 
 ### Terminology Conventions
 
@@ -37,277 +39,141 @@ No style guide is perfect.
 There are times when the best path to a working design, or for working around a tool issue, is to simply cut the Gordian Knot and create code that is at variance with this style guide.
 It is always okay to deviate from the style guide by necessity, as long as that necessity is clearly justified by a brief comment.
 
-## General Markdown Style
 
-### Line length
+## Filename
 
-In OpenTitan, most--but not all--Markdown documents will be rendered to HTML before they are presented to the reader.
-However, README files are an important exception, and so the recommended line-wrapping style differs for these two types of files.
+The Markdown file names should be in snake case and should use the `.md` file extension.
 
-1. ***Rendered Files***:
-Files which are intended to be rendered before viewing should have exactly one sentence per line, with no line breaks in the middle of a sentence.
+## Extensions
+
+One must only use [CommonMark][] with the exception of the following extensions:
+- [GFM Tables](https://github.github.com/gfm/#tables-extension-)
+- [GFM Task Items](https://github.github.com/gfm/#task-list-items-extension-)
+- [Inline maths and maths blocks](#maths)
+
+## Line length and Whitespace
+
+Files must have exactly one sentence per line, with no line breaks in the middle of a sentence.
 This way change reviews will highlight only those sentences which are modified.
 Though the long line lengths make the files slightly less convenient to read from the command-line, this greatly simplifies the review process.
 When reviewing Markdown changes, every altered sentence will be included in its entirety in the file diff.
 
-2. ***README Files***:
-README files should wrap lines at under 80 characters.
-This ensures that the source is readable without any Markdown processing.
-Please note, however, that re-wrapping a paragraph after an insertion or deletion tends to cause longer diffs when the change is reviewed.
-When making changes to a document using this style, please consider allowing short lines rather than a full re-wrap after minor edits.
-Then occasionally separate commits can be used that only do re-wrapping of the paragraphs.
+Markdown files must contain no trailing white space.
+As a result, two or more spaces must not be used for [hard line breaks][].
+Instead, a double new line is recommended.
+[Backslash hard breaks][] can also be used.
 
-### Headings and sections
+## HTML
 
-The title of the document should be provided using the `title` field in the frontmatter.
+Do not use inline HTML within markdown documents.
+Although it offers a lot of flexibility, this flexibility is hard to handle.
+- It is possible to break the website
+- Markdown renderers often support different subsets of HTML.
+- The use of HTML restricts the ease at which documentation could be converted to other forms in the future, such as PDF.
 
-Headings and sections are given ID tags to allow cross references.
-The ID is the text of the heading, converted to lower case and with spaces converted to `-`.
+Reaching for HTML may suggest that:
+- You need to split the concepts into more smaller parts that can be expressed in markdown syntax.
+- The concept would be better explained in an svg diagram.
+
+*The one exception to this is [comments](#comments).*
+
+## Links
+
+The [GFM autolinks extention][] is not used so links should be flanked by `<` and `>` characters.
+
+One must not use [shortcut reference link][]s, but instead use [collapsed reference link][]s.
+This is because it can be ambiguious whether [shortcut reference link][] are meant to be links or not.
+Consequently, linters and other tool, such as [marksman](https://github.com/artempyanykh/marksman), cannot warn you of referencing errors.
+*Note: [link labels are case insensitive](https://spec.commonmark.org/0.30/#example-554).*
+
+Example of reference syntaxes:
+
+````md
+Don't use shortcut references like [this].
+Instead use collapsed references like [this][].
+[These][this] full reference links are fine as well of course.
+
+[this]: https://example.com
+````
+
+## Headings and Sections
+
+Only [ATX headings][] must be used.
+Do not use [Setext headings][] for the following reasons.
+- Their depth isn't as immediately obvious.
+- They only go to a maximum depth of 2.
+- They take longer to type and maintain in a nice manner.
+
+Headings and sections are given ID tags, by the mdBook and GitHub when rendering, to allow cross references.
+The ID is the text of the heading, converted to lower case with spaces converted to `-` and non-alphanumeric characters removed.
 Thus `### Headings and sections` gets the ID `headings-and-sections` and can be referenced using the Markdown hyperlink syntax `[link text](#headings-and-sections)`.
 
-Headings and sections are added to the table of contents.
+## Code Blocks
 
-### Images
+Only [fenced code blocks][] must be used and not [indented code blocks][].
+Fenced blocks allow more context through [info string][]s and are easier to distinguish from the rest of the text than indented blocks, especially when nested in lists.
 
-Pictures can be included using the standard Markdown syntax (`![Alt Text](url)`).
+Shell code blocks should default using `sh` in their [info string][], unless a non posix shell syntax is used.
+These blocks must not include `$` at the beginning of lines, and one must make sure to escape new lines when splitting up a command for readability.
+It is recommended that arguments a user is likely to change are made variables; this highlights them to the user.
+
+```sh
+util/dvsim/dvsim.py \
+    hw/ip/uart/dv/uart_sim_cfg.hjson \
+    -i uart_smoke \
+    --fixed-seed=$SEED
+```
+
+When one wants to show the output of an interactive session in the same code block, for example as part of a guide, one may use the `console` [info string][].
+In this case, it is recommended to use `$` or `#` at the beginning of command lines, where `$` denotes the command being run as a non-root user and `#` a root user.
+
+```console
+$ echo "Hello world"
+Hello World
+# sudo apt install cowsay
+...
+```
+
+## Images
+
+Pictures can be included using the standard Commonmark syntax (`![Alt Text](url)`).
 The preferred format is Scalable Vector Graphics (`.svg`), alternatively Portable Network Graphics (`.png`).
 
-### Waveforms
+## Waveforms
 
-Waveforms can be included by adding [wavejson](https://github.com/wavedrom/schema/blob/master/WaveJSON.md) code surrounded by `{{</* wavejson */>}}` shortcode tags.
+Waveforms can be included by describing them in [wavejson](https://github.com/wavedrom/schema/blob/master/WaveJSON.md) within a code block with a `wavejson` [info string][].
 
-### Text Format
+## Maths
 
-Where possible, please restrict Markdown text to the ASCII character set to avoid downstream tool issues.
-Unicode may be used when referring to proper names.
+Maths can be included inline or within blocks using a single or double `$` respectively.
+As a result, the `$` symbol has to be escaped when not wishing to write mathematical notation.
 
-### Comments
+````md
+$$
+\nabla \cdot \boldsymbol{B} = 0
+$$
+
+where $\boldsymbol{B}$ is the magnetic field.
+
+That's saved you \$100 on a text book.
+````
+
+## Comments
 
 Comments are rare, but should be used where needed.
 Use the HTML `<!--` and `-->` as the comment delimiters.
 
-### Markdown file extensions
 
-The Markdown files should use the `.md` file extension.
-
-## Markdown file format for IP module descriptions
-
-Typically the Markdown file for an IP block follows the same outline.
-
-The header instantiates the standard document header and reads the Hjson description of the module.
-
-```
----
-title: "Example IP Block"
----
-```
-
-This is followed by some boiler-plate comments.
-
-```
-This document specifies Name hardware IP functionality.
-This module conforms to the [Comportable guideline for peripheral functionality.]({{</* relref "doc/rm/comportability_specification" */>}})
-See that document for integration overview within the broader top level system.
-```
-
-The next section summarizes the feature set of the IP block.
-
-```
-## Features
-
-* Bulleted list
-* Of main features
-```
-
-There then follows a general description of the IP
-
-```
-## Description
-
-Description of the IP.
-```
-The Compatibility information will allow device driver writers to identify existing code that can be used directly or with minor changes.
-
-_This section is primarily of interest to software engineers._
-
-
-```
-## Compatability
-
-Notes on if the IP register interface is compatible with any existing register interface.
-Also note any differences.
-For example: Matches 16550 UART interface but registers are at 32-bit word offsets.
-```
-
-The next major section is a more detailed operational description of the module.
-
-```
-# Theory of Operations
-
-```
-
-Conventionally one of the first sections includes a block diagram and a description.
-
-_Should be useful to hardware designers, verification engineers and software engineers._
-
-
-```
-
-## Block Diagram
-
-![Name Block Diagram](block_diagram.svg)
-
-```
-
-There should be a section containing the automatically generated description of the IP including the signals, interrupts and alerts that it uses.
-
-_Primary user is the SoC integrator, but useful for everyone._
-
-Note that the interrupt descriptions are also automatically placed in the interrupt status register bit descriptions, which is the most likely place for software engineers to reference them.
-
-
-```
-
-## Hardware Interfaces
-
-
-```
-
-The organization of the design details section is done to suit the module.
-
-```
-
-## Design Details
-
-Details of the design.
-
-### Many third level headings
-```
-There are probably waveforms embedded here:
-
-```
-
-{{</* wavejson */>}}
-{
-  signal: [
-    { name: 'Clock',        wave: 'p............' },
-  ]
-}
-{{</* /wavejson */>}}
-
-```
-
-The final major section is the software user guide and describes using the IP and notes on writing device drivers.
-Code fragments are encouraged.
-
-_This section is primarily for software engineers, but it is expected that the code fragments are used by verification engineers._
-
-```
-
-# Programmers Guide
-
-```
-
-One important thing here is to show the order of initialization that has been tested in the verification environment.
-In most cases other orders will work, and may be needed by the software environment, but it can be helpful in tracking down bugs for the validated sequence to be described!
-
-```
-## Initialization
-```
-```c
-
- if (...) {
-   a = ...
- }
-```
-
-Other sections cover different use cases and example code fragments.
-
-```
-
-## Use case A (eg Transmission)
-
-## Use case B (eg Reception)
-
-```
-
-It is important to include a discussion of error conditions.
-
-```
-## Error conditions
-
-```
-
-Also comment on anything special about interrupts, potentially including the priority order for servicing interrupts.
-
-
-```
-
-## Interrupt Handling
-
-```
-
-The document should end with the automatically generated register tables.
-
-```
-## Register Table
-
-{{</* registers "hw/ip/component/data/component.hjson" */>}}
-
-```
-
-To allow cut/paste of the default structure, here is an uncommented version:
-
-```
----
-title: Name HWIP Technical Specification
----
-
-# Overview
-
-This document specifies Name hardware IP functionality.
-This module conforms to the [Comportable guideline for peripheral functionality.](../hw/comportability/README.md)
-See that document for integration overview within the broader top level system.
-
-## Features
-
-* Bulleted list
-
-## Description
-
-
-## Compatibility
-
-
-# Theory of Operations
-
-
-## Block Diagram
-
-![Name Block Diagram](block_diagram.svg)
-
-## Hardware Interfaces
-
-{{</* incGenFromIpDesc "../data/component.hjson" "hwcfg" */>}}
-
-## Design Details
-
-### Many third level headings
-
-# Programmers Guide
-
-## Initialization
-
-## Use case A (eg Transmission)
-
-## Use case B (eg Reception)
-
-## Error conditions
-
-## Interrupt Handling
-
-## Register Table
-
-{{</* incGenFromIpDesc "../data/component.hjson" "registers" */>}}
-
-```
+[commonmark]: https://spec.commonmark.org/
+[atx headings]: https://spec.commonmark.org/0.30/#atx-headings
+[setext headings]: https://spec.commonmark.org/0.30/#setext-heading
+[collapsed reference link]: https://spec.commonmark.org/0.30/#collapsed-reference-link
+[shortcut reference link]: https://spec.commonmark.org/0.30/#shortcut-reference-link
+[indented code blocks]: https://spec.commonmark.org/0.30/#indented-code-block
+[fenced code blocks]: https://spec.commonmark.org/0.30/#fenced-code-blocks
+[info string]: https://spec.commonmark.org/0.30/#info-string
+[hard line breaks]: https://spec.commonmark.org/0.30/#hard-line-breaks
+[backslash hard breaks]: https://spec.commonmark.org/0.30/#example-634
+[gfm tables]: https://github.github.com/gfm/#tables-extension-
+[gfm list items]: https://github.github.com/gfm/#task-list-items-extension-
+[gfm autolinks extention]: https://github.github.com/gfm/#autolinks-extension-


### PR DESCRIPTION
Updated the markdown style guide to fit the new purer markdown (commonmark) documentation flow. All the changes have come from discussions I've had when reviewing PRs and setting up new documentation flow.

Updated the content of 'Markdown file format for IP module description' from the style guide and moved into it's own file (`doc/contributing/doc/example_ip_block.md`) .

Created a 'contributing to documentation' page. I will add to this in the future. It currently contains a summary of the documentation set up, as well as an explanation of the file structure and CMDGEN.