### PR TITLE
[sw/silicon_creator] Add kErrorRomExtInterrupt and kErrorRomExtBootFailed

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -26,25 +26,27 @@ extern "C" {
 enum module_ {
   // clang-format off
   kModuleUnknown = 0,
-  kModuleAlertHandler = MODULE_CODE('A', 'H'),
-  kModuleSigverify =    MODULE_CODE('S', 'V'),
-  kModuleKeymgr =       MODULE_CODE('K', 'M'),
-  kModuleManifest =     MODULE_CODE('M', 'A'),
-  kModuleRom =          MODULE_CODE('M', 'R'),
-  kModuleInterrupt =    MODULE_CODE('I', 'R'),
-  kModuleEpmp =         MODULE_CODE('E', 'P'),
-  kModuleKmac =         MODULE_CODE('K', 'C'),
-  kModuleOtbn =         MODULE_CODE('B', 'N'),
-  kModuleFlashCtrl =    MODULE_CODE('F', 'C'),
-  kModuleBootPolicy =   MODULE_CODE('B', 'P'),
-  kModuleBootstrap =    MODULE_CODE('B', 'S'),
-  kModuleLog =          MODULE_CODE('L', 'G'),
-  kModuleBootData =     MODULE_CODE('B', 'D'),
-  kModuleSpiDevice =    MODULE_CODE('S', 'P'),
-  kModuleAst =          MODULE_CODE('A', 'S'),
-  kModuleRstmgr =       MODULE_CODE('R', 'S'),
-  KModuleRnd =          MODULE_CODE('R', 'N'),
-  kModuleBootSvc =      MODULE_CODE('B', 'C'),
+  kModuleAlertHandler =    MODULE_CODE('A', 'H'),
+  kModuleSigverify =       MODULE_CODE('S', 'V'),
+  kModuleKeymgr =          MODULE_CODE('K', 'M'),
+  kModuleManifest =        MODULE_CODE('M', 'A'),
+  kModuleRom =             MODULE_CODE('M', 'R'),
+  kModuleInterrupt =       MODULE_CODE('I', 'R'),
+  kModuleEpmp =            MODULE_CODE('E', 'P'),
+  kModuleKmac =            MODULE_CODE('K', 'C'),
+  kModuleOtbn =            MODULE_CODE('B', 'N'),
+  kModuleFlashCtrl =       MODULE_CODE('F', 'C'),
+  kModuleBootPolicy =      MODULE_CODE('B', 'P'),
+  kModuleBootstrap =       MODULE_CODE('B', 'S'),
+  kModuleLog =             MODULE_CODE('L', 'G'),
+  kModuleBootData =        MODULE_CODE('B', 'D'),
+  kModuleSpiDevice =       MODULE_CODE('S', 'P'),
+  kModuleAst =             MODULE_CODE('A', 'S'),
+  kModuleRstmgr =          MODULE_CODE('R', 'S'),
+  KModuleRnd =             MODULE_CODE('R', 'N'),
+  kModuleBootSvc =         MODULE_CODE('B', 'C'),
+  kModuleRomExt =          MODULE_CODE('R', 'E'),
+  kModuleRomExtInterrupt = MODULE_CODE('R', 'I'),
   // clang-format on
 };
 
@@ -145,7 +147,12 @@ enum module_ {
   \
   X(kErrorRndBadCrc32,                ERROR_(1, KModuleRnd, kInvalidArgument)), \
   \
-  X(kErrorBootSvcBadHeader,           ERROR_(1, kModuleBootSvc, kInternal))
+  X(kErrorBootSvcBadHeader,           ERROR_(1, kModuleBootSvc, kInternal)), \
+  \
+  X(kErrorRomExtBootFailed,           ERROR_(1, kModuleRomExt, kFailedPrecondition)), \
+  \
+  /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
+  X(kErrorRomExtInterrupt,            ERROR_(0, kModuleRomExtInterrupt, kUnknown))
 // clang-format on
 
 #define ERROR_ENUM_INIT(name_, value_) name_ = value_

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -45,7 +45,7 @@ static rom_error_t rom_ext_irq_error(void) {
   uint32_t mcause;
   CSR_READ(CSR_REG_MCAUSE, &mcause);
   // Shuffle the mcause bits into the uppermost byte of the word and report
-  // the cause as kErrorInterrupt.
+  // the cause as kErrorRomExtInterrupt.
   // Based on the ibex verilog, it appears that the most significant bit
   // indicates whether the cause is an exception (0) or external interrupt (1),
   // and the 5 least significant bits indicate which exception/interrupt.
@@ -55,7 +55,7 @@ static rom_error_t rom_ext_irq_error(void) {
   // as zero and those would be the next bits used should the number of
   // interrupt causes increase).
   mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
-  return kErrorInterrupt + mcause;
+  return kErrorRomExtInterrupt + mcause;
 }
 
 void rom_ext_init(void) {
@@ -168,7 +168,7 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   OT_DISCARD(rom_printf("entry: 0x%x\r\n", (unsigned int)entry_point));
   ((owner_stage_entry_point *)entry_point)();
 
-  return kErrorRomBootFailed;
+  return kErrorRomExtBootFailed;
 }
 
 OT_WARN_UNUSED_RESULT
@@ -194,7 +194,7 @@ static rom_error_t boot_svc_next_boot_bl0_slot_handler(
   RETURN_IF_ERROR(rom_ext_boot(kNextSlot));
   // `rom_ext_boot()` should never return `kErrorOk`, but if it does
   // we must shut down the chip instead of trying the next ROM_EXT.
-  return kErrorRomBootFailed;
+  return kErrorRomExtBootFailed;
 }
 
 OT_WARN_UNUSED_RESULT
@@ -215,7 +215,7 @@ static rom_error_t rom_ext_try_boot(void) {
 
   rom_ext_boot_policy_manifests_t manifests =
       rom_ext_boot_policy_manifests_get();
-  rom_error_t error = kErrorRomBootFailed;
+  rom_error_t error = kErrorRomExtBootFailed;
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     error = rom_ext_verify(manifests.ordered[i]);
     if (error != kErrorOk) {
@@ -225,7 +225,7 @@ static rom_error_t rom_ext_try_boot(void) {
     RETURN_IF_ERROR(rom_ext_boot(manifests.ordered[i]));
     // `rom_ext_boot()` should never return `kErrorOk`, but if it does
     // we must shut down the chip instead of trying the next ROM_EXT.
-    return kErrorRomBootFailed;
+    return kErrorRomExtBootFailed;
   }
   return error;
 }


### PR DESCRIPTION
While reviewing #19286 I noticed that we are using the same errors as ROM in rom_ext.c. This PR adds two new enums `kErrorRomExtInterrupt` and `kErrorRomExtBootFailed` for ease of debugging.