### PR TITLE
[ci] Actually build all software in the sw_build job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -267,14 +267,17 @@ jobs:
       # copy the rom to a specific location
       ROM_TARGET="${BIN_DIR}/sw/device/silicon_creator/rom"
       mkdir -p "${ROM_TARGET}"
-      AUTHENTICITY=(fake real)
-      for authenticity in "${AUTHENTICITY[@]}"; do
-        ROM=$(ci/scripts/target-location.sh "//sw/device/silicon_creator/rom:rom_with_${authenticity}_keys_fpga_cw310_scr_vmem")
-        cp $ROM "${ROM_TARGET}/$(basename "${ROM}")"
-        ROM_DIR=$(dirname $ROM)
-        cp "${ROM_DIR}/rom_with_${authenticity}_keys_fpga_cw310.elf" "${ROM_TARGET}/"
-        cp "${ROM_DIR}/rom_with_${authenticity}_keys_fpga_cw310.bin" "${ROM_TARGET}/"
-      done
+      # To make the correct query to get the ELF output file, we have to start
+      # from a node that is built for our usual target platform (the host) and
+      # follow the edges in the graph across the configuration transition (to
+      # riscv32). The deps 2 levels down from the opentitan_rom_binary include
+      # all the important files.
+      ROM_REAL_TARGETS="deps(//sw/device/silicon_creator/rom:rom_with_real_keys_from_src_fpga_cw310, 2)"
+      ROM_FAKE_TARGETS="deps(//sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310, 2)"
+      QUERY_CMD_ARGS=(outquery-all --noinclude_aspects --noimplicit_deps)
+      ROM_REAL_FILES=($(./bazelisk.sh "${QUERY_CMD_ARGS[@]}" "${ROM_REAL_TARGETS}" | sort | uniq))
+      ROM_FAKE_FILES=($(./bazelisk.sh "${QUERY_CMD_ARGS[@]}" "${ROM_FAKE_TARGETS}" | sort | uniq))
+      cp -Lvt "${ROM_TARGET}" "${ROM_FAKE_FILES[@]}" "${ROM_REAL_FILES[@]}"
   - template: ci/upload-artifacts-template.yml
     parameters:
       includePatterns:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,6 +249,11 @@ jobs:
         --define DISABLE_VERILATOR_BUILD=true \
         -- "rdeps(//..., kind(bitstream_splice, //...))" \
         >> "${TARGET_PATTERN_FILE}"
+      ci/bazelisk.sh build \
+        --build_tests_only=false \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --test_tag_filters=-broken,-cw310,-verilator,-dv \
+        --target_pattern_file="${TARGET_PATTERN_FILE}"
       ci/bazelisk.sh test \
         --build_tests_only=false \
         --test_output=errors \


### PR DESCRIPTION
The sw_build job was missing many targets, as the build and test commands resolve wildcards very differently, even with --nobuild_tests_only.