### PR TITLE
[sw/silicon_creator] Add Set Miniumum Security Version service message

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -77,6 +77,31 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "boot_svc_min_bl0_sec_ver",
+    srcs = ["boot_svc_min_bl0_sec_ver.c"],
+    hdrs = ["boot_svc_min_bl0_sec_ver.h"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_min_bl0_sec_ver_unittest",
+    srcs = ["boot_svc_min_bl0_sec_ver_unittest.cc"],
+    deps = [
+        ":boot_svc_min_bl0_sec_ver",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_test(
     name = "boot_svc_empty_unittest",
     srcs = ["boot_svc_empty_unittest.cc"],
@@ -93,6 +118,7 @@ cc_library(
     deps = [
         ":boot_svc_empty",
         ":boot_svc_header",
+        ":boot_svc_min_bl0_sec_ver",
         ":boot_svc_next_boot_bl0_slot",
         "//sw/device/lib/base:macros",
     ],

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h"
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_sec_version,
+                                       boot_svc_min_bl0_sec_ver_req_t *msg) {
+  msg->min_bl0_sec_ver = min_sec_version;
+  boot_svc_header_finalize(kBootSvcMinBl0SecVerReqType,
+                           sizeof(boot_svc_min_bl0_sec_ver_req_t),
+                           &msg->header);
+}
+
+void boot_svc_min_bl0_sec_ver_res_init(rom_error_t status,
+                                       boot_svc_min_bl0_sec_ver_res_t *msg) {
+  msg->status = status;
+  boot_svc_header_finalize(kBootSvcMinBl0SecVerResType,
+                           sizeof(boot_svc_min_bl0_sec_ver_res_t),
+                           &msg->header);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_MIN_BL0_SEC_VER_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_MIN_BL0_SEC_VER_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/*
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
+ *     -s 1625797253 --language=c
+ *
+ * Minimum Hamming distance: 20
+ * Maximum Hamming distance: 20
+ * Minimum Hamming weight: 17
+ * Maximum Hamming weight: 19
+ */
+enum {
+  kBootSvcMinBl0SecVerReqType = 0xdac59e6e,
+  kBootSvcMinBl0SecVerResType = 0x756385f1,
+};
+
+/**
+ * A Set Minimum Security Version request.
+ */
+typedef struct boot_svc_min_bl0_sec_ver_req {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Minimum security version to set.
+   */
+  uint32_t min_bl0_sec_ver;
+} boot_svc_min_bl0_sec_ver_req_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_req_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_req_t, min_bl0_sec_ver,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_min_bl0_sec_ver_req_t, 48);
+
+/**
+ * A Set Minimum Security Version response.
+ */
+typedef struct boot_svc_min_bl0_sec_ver_res {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Minimum security version to set.
+   */
+  rom_error_t status;
+} boot_svc_min_bl0_sec_ver_res_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, status,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_min_bl0_sec_ver_res_t, 48);
+
+/**
+ * Initialize a set minimum security version request message.
+ *
+ * @param min_bl0_sec_ver_version The minimum security version to set.
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_bl0_sec_ver_version,
+                                       boot_svc_min_bl0_sec_ver_req_t *msg);
+
+/**
+ * Initialize a set minimum security version response message.
+ *
+ * @param status The result of this request.
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_min_bl0_sec_ver_res_init(rom_error_t status,
+                                       boot_svc_min_bl0_sec_ver_res_t *msg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_MIN_BL0_SEC_VER_H_

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver_unittest.cc
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace boot_svc_min_bl0_sec_ver_unittest {
+namespace {
+
+class BootSvcMinBl0SecVerTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockBootSvcHeader boot_svc_header_;
+};
+
+TEST_F(BootSvcMinBl0SecVerTest, ReqInit) {
+  boot_svc_min_bl0_sec_ver_req_t msg{};
+  constexpr uint32_t kMinBl0SecVersion = 0x12345678;
+  EXPECT_CALL(boot_svc_header_,
+              Finalize(kBootSvcMinBl0SecVerReqType, sizeof(msg), &msg.header));
+
+  boot_svc_min_bl0_sec_ver_req_init(kMinBl0SecVersion, &msg);
+
+  EXPECT_EQ(msg.min_bl0_sec_ver, kMinBl0SecVersion);
+}
+
+TEST_F(BootSvcMinBl0SecVerTest, ResInit) {
+  boot_svc_min_bl0_sec_ver_res_t msg{};
+  constexpr rom_error_t kStatus = kErrorOk;
+  EXPECT_CALL(boot_svc_header_,
+              Finalize(kBootSvcMinBl0SecVerResType, sizeof(msg), &msg.header));
+
+  boot_svc_min_bl0_sec_ver_res_init(kStatus, &msg);
+
+  EXPECT_EQ(msg.status, kStatus);
+}
+
+}  // namespace
+}  // namespace boot_svc_min_bl0_sec_ver_unittest

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h"
 
 #ifdef __cplusplus
@@ -27,7 +28,12 @@ extern "C" {
    * Next Boot BL0 Slot request and response.
    */ \
   X(boot_svc_next_boot_bl0_slot_req_t, next_boot_bl0_slot_req) \
-  X(boot_svc_next_boot_bl0_slot_res_t, next_boot_bl0_slot_res)
+  X(boot_svc_next_boot_bl0_slot_res_t, next_boot_bl0_slot_res) \
+  /**
+   * Set Minimum Security Version request and response.
+   */ \
+  X(boot_svc_min_bl0_sec_ver_req_t, min_bl0_sec_ver_req) \
+  X(boot_svc_min_bl0_sec_ver_res_t, min_bl0_sec_ver_res)
 // clang-format on
 
 /**


### PR DESCRIPTION
Adds the messages for the [Set Minimum Required BL0 Security Version](https://github.com/lowRISC/opentitan/issues/19156) rom_ext boot service.

This is the first of two PRs, the second will implement the service in rom_ext.