### PR TITLE
[doc] Add an unofficial setup guide for Fedora

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,10 @@
 
 - [Getting Started](./doc/getting_started/README.md)
 
+## Unofficial Setup Guides
+
+- [RedHat/Fedora](unofficial/fedora.md)
+
 - [Workflows](./doc/getting_started/workflows.md)
   - [Design Verification](./doc/getting_started/setup_dv.md)
   - [Formal Verification](./doc/getting_started/setup_formal.md)

--- a/doc/getting_started/README.md
+++ b/doc/getting_started/README.md
@@ -54,6 +54,10 @@ If you are building another form of simulation, this constraint does not apply.
 If you are specifying a new machine to run top-level simulations of the whole of OpenTitan using Verilator, it is recommended that you
 have a minimum of **32GiB of physical RAM** and at least **512GiB of disk storage** for the build tools, repository and Ubuntu installation.
 
+There are unofficial guides for alternate Linux environments.
+The unofficial guides are not formally supported by the OpenTitan project. YMMV.
+- [RedHat/Fedora](unofficial/fedora.md)
+
 ## Step 2: Install dependencies using the package manager
 
 *Skip this step if using the Docker container.*

--- a/doc/getting_started/unofficial/fedora.md
+++ b/doc/getting_started/unofficial/fedora.md
@@ -1,0 +1,20 @@
+# Unofficial Setup Guide for Fedora
+
+This is an unofficial guide detailing how to set up a Fedora system for OpenTitan development.
+This guide differs from the main guide only in step 2.
+
+## Step 2: Install dependencies using the package manager
+
+Fedora uses a different package manager than the officially supported Ubuntu development environment.
+You can install equivalent packages to the `apt-requirements.txt` file with the following command:
+
+```shell
+sudo dnf install autoconf bison make automake gcc gcc-c++ kernel-devel \
+         clang-tools-extra clang cmake curl \
+         doxygen flex g++ git golang lcov elfutils-libelf \
+         libftdi libftdi-devel ncurses-compat-libs openssl-devel \
+         systemd-devel libusb redhat-lsb-core \
+         make ninja-build perl pkgconf python3 python3-pip python3-setuptools \
+         python3-urllib3 python3-wheel srecord tree xsltproc zlib-devel xz clang-tools-extra \
+         clang11-libs clang-devel elfutils-libelf-devel
+```


### PR DESCRIPTION
The Fedora `dnf install` command comes from the
[Tock](https://github.com/tock/tock) project documentation.