### PR TITLE
[dv/clkmgr] Increase wait cycles in clkmgr_lost_calib_ctrl_en_sva_if

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_lost_calib_ctrl_en_sva_if.sv
@@ -14,7 +14,7 @@ interface clkmgr_lost_calib_ctrl_en_sva_if (
   // The latter is io_div4 so it is pretty slow compared to all others. There
   // are a number of clock domain crossings, so this needs a large number of
   // wait cycles to account for the worst case.
-  localparam int MAX_CYCLES = 40;
+  localparam int MAX_CYCLES = 45;
   `ASSERT(CtrlEnOn_A,
           (calib_rdy == prim_mubi_pkg::MuBi4False && meas_ctrl_en != prim_mubi_pkg::MuBi4False) |=>
           ##[0:MAX_CYCLES] (meas_ctrl_en == prim_mubi_pkg::MuBi4False),


### PR DESCRIPTION
When the clocks loose calibration (flagged by the AST) the cycle counters in clkmgr get disabled. The delay between enabling counters and disabling them due to loss of calibration needs to go through a prim_reg_cdc on the path to enable it and another one to make the enable value visible to software. The previous number of wait cycles still left room for some failures.