### PR TITLE
[ci] switch lint report from comment to check annotation

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -48,6 +48,7 @@ jobs:
         uses: chipsalliance/verible-linter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          reviewdog_reporter: 'github-pr-check'
           suggest_fixes: 'false'
           config_file: ${{ env.verible_config }}
           extra_args: "--waiver_files=verible_waiver"


### PR DESCRIPTION
Switch from posting comments to use check annotation. This should reduce the noise of the lints.

Example:
* no comments in the conversation pane (just shows up as a failing check): https://github.com/nbdd0121/opentitan/pull/3 
* lints reported in the files changed pane: https://github.com/nbdd0121/opentitan/pull/3/files