### PR TITLE
[sw/examples] Turn hello_world into a functest

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -411,3 +411,57 @@ opentitan_test = rv_rule(
     toolchains = ["@rules_cc//cc:toolchain_type"],
     test = True,
 )
+
+opentitan_example = rv_rule(
+    implementation = _opentitan_test,
+    attrs = dict(common_binary_attrs.items() + {
+        "exec_env": attr.label(
+            providers = [ExecEnvInfo],
+            doc = "List of exeuction environments for this target.",
+        ),
+        "test_harness": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+        "binaries": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "Opentitan binaries to use with this test (keys are labels, values are the string to use as a subsitution parameter in test_cmd)",
+        ),
+        "rom": attr.label(
+            allow_files = True,
+            doc = "ROM image override for this test",
+        ),
+        "rom_ext": attr.label(
+            allow_files = True,
+            doc = "ROM_EXT image override for this test",
+        ),
+        "otp": attr.label(
+            allow_single_file = True,
+            doc = "OTP image override for this test",
+        ),
+        "bitstream": attr.label(
+            allow_single_file = True,
+            doc = "Bitstream override for this test",
+        ),
+        # Note: an `args` attr exists as an override for exec_env.args.  It is
+        # not listed here because all test rules have an implicit `args`
+        # attribute which is a list of strings subject to location and make
+        # variable substitution.
+        "test_cmd": attr.string(
+            doc = "Test command override for this test",
+        ),
+        "param": attr.string_dict(
+            doc = "Additional parameters for this test",
+        ),
+        "data": attr.label_list(
+            doc = "Additonal dependencies for this test",
+            allow_files = True,
+            cfg = "exec",
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    }.items()),
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+    executable = True,
+)

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -11,6 +11,7 @@ load(
 load(
     "@lowrisc_opentitan//rules/opentitan:cc.bzl",
     _opentitan_binary = "opentitan_binary",
+    _opentitan_example = "opentitan_example",
     _opentitan_test = "opentitan_test",
 )
 load(
@@ -211,3 +212,101 @@ def opentitan_test(
         tests = all_tests,
         tags = ["manual"],
     )
+
+def opentitan_example(
+        name,
+        srcs = [],
+        kind = "flash",
+        deps = [],
+        copts = [],
+        defines = [],
+        local_defines = [],
+        includes = [],
+        linkopts = [],
+        linker_script = None,
+        rsa_key = None,
+        spx_key = None,
+        manifest = None,
+        exec_env = {},
+        cw310 = _cw310_params(),
+        dv = _dv_params(),
+        verilator = _verilator_params(),
+        **kwargs):
+    """Instantiate a test per execution environment.
+
+    Args:
+      name: The base name of the test.  The name will be extended with the name
+            of the execution environment.
+      srcs: The source files for this test.
+      kind: The kind of test (flash, ram, rom).
+      deps: Dependecies for this test.
+      copts: Compiler options for this test.
+      defines: Compiler defines for this test.
+      local_defines: Compiler defines for this test.
+      includes: Additional compiler include dirs for this test.
+      linker_script: Linker script for this test.
+      rsa_key: RSA key to sign the binary for this test.
+      spx_key: SPX key to sign the binary for this test.
+      manifest: manifest used during signing for this test.
+      linkopts: Linker options for this test.
+      exec_env: A dictionary of execution environments.  The keys are labels to
+                execution environments.  The values are the kwargs parameter names
+                of the exec_env override or None.  If None, the default parameter
+                names of `cw310`, `dv` or `verilator` will be guessed.
+      cw310: Execution overrides for a CW310-based test.
+      dv: Execution overrides for a DV-based test.
+      verilator: Execution overrides for a verilator-based test.
+      kwargs: Additional execution overrides identified by the `exec_env` dict.
+    """
+    test_parameters = {
+        "cw310": cw310,
+        "dv": dv,
+        "verilator": verilator,
+    }
+    test_parameters.update(kwargs)
+    kwargs_unused = kwargs.keys()
+
+    all_tests = []
+    for (env, pname) in exec_env.items():
+        pname = _parameter_name(env, pname)
+        extra_tags = _hacky_tags(env)
+        tparam = test_parameters[pname]
+        if pname in kwargs_unused:
+            kwargs_unused.remove(pname)
+        (_, suffix) = env.split(":")
+        test_name = "{}_{}".format(name, suffix)
+        all_tests.append(":" + test_name)
+        _opentitan_example(
+            name = test_name,
+            srcs = srcs,
+            kind = kind,
+            deps = deps,
+            copts = copts,
+            defines = defines,
+            local_defines = local_defines,
+            includes = includes,
+            linker_script = linker_script,
+            linkopts = linkopts,
+            exec_env = env,
+            naming_convention = "{name}",
+            # Tagging and timeout info always comes from a param block.
+            tags = tparam.tags + extra_tags,
+            # Override parameters in the test rule.
+            test_harness = tparam.test_harness,
+            binaries = tparam.binaries,
+            rom = tparam.rom,
+            rom_ext = tparam.rom_ext,
+            otp = tparam.otp,
+            bitstream = tparam.bitstream,
+            test_cmd = tparam.test_cmd,
+            param = tparam.param,
+            data = tparam.data,
+            rsa_key = rsa_key,
+            spx_key = spx_key,
+            manifest = manifest,
+            testonly = True,
+        )
+
+    # Make sure that we used all elements in kwargs
+    if len(kwargs_unused) > 0:
+        fail("the following arguments passed to opentitan_test were not used: {}".format(", ".join(kwargs_unused)))

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -2,11 +2,30 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:defs.bzl", "opentitan_binary")
+load("//rules/opentitan:defs.bzl", "cw310_params", "opentitan_binary", "opentitan_example", "verilator_params")
 load("//rules:files.bzl", "exclude_files")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
+
+opentitan_example(
+    name = "hello_world_example",
+    cw310 = cw310_params(
+        binaries = {
+            ":hello_world": "firmware",
+        },
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    verilator = verilator_params(
+        binaries = {
+            ":hello_world": "firmware",
+        },
+    ),
+)
 
 opentitan_binary(
     name = "hello_world",
@@ -21,6 +40,7 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_dv",
         "//hw/top_earlgrey:sim_verilator",
     ],
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     deps = [
         ":hello_world_lib",
         "//sw/device/lib/base:mmio",


### PR DESCRIPTION
There are currently no clear instruction on how to use this example.
Those that exists are scattered in the documentation (FPGA) and for
verilator the only good reference is the english breakfast verilator
script. By adding a rule, it makes it much easier to actually
run it without manual fiddling. Unfortunately, a test is still
not quite right because hello_world never returns so this will make
the "test" fails. This is why we use the previously introduced
notion of example. This example can be run by using
```./bazelisk.sh run //sw/device/examples/hello_world:hello_world_example_fpga_cw310_test_rom```
and
```./bazelisk.sh run //sw/device/examples/hello_world:hello_world_example_sim_verilator```