### PR TITLE
[flash_ctrl,dv] regression cleanup

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -830,7 +830,7 @@ class flash_ctrl_scoreboard #(
       end
     end
 
-    if (exp_tl_rsp_intg_err) begin
+    if (exp_tl_rsp_intg_err == 1 && channel == DataChannel) begin
       return (!item.is_d_chan_intg_ok(.throw_error(0)));
     end
     return (super.predict_tl_err(item, channel, ral_name));

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -403,7 +403,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   virtual task flash_ctrl_intr_read(flash_op_t flash_op, ref data_q_t rdata);
     uvm_reg_data_t data;
     bit[31:0] intr_st;
-    int       rd_timeout_ns = 400000; // 400 us
+    int       rd_timeout_ns = 1000000; // 1 ms
     int       curr_rd, rd_idx = 0;
 
     `uvm_info("flash_ctrl_intr_read", $sformatf("num_rd:%0d",

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -1027,7 +1027,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask : flash_ctrl_write_extra
 
-  // Task to Program the Entire Flash Memory
+  // Task to Read the Entire Flash Memory
   virtual task flash_ctrl_read_extra(flash_op_t flash_op, ref data_q_t data);
 
     // Local Signals
@@ -1066,7 +1066,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       `uvm_info(`gfn, $sformatf("Read Cycle : %0d, flash_addr = 0x%0x", cycle, flash_addr),
                 UVM_MEDIUM)
 
-      csr_wr(.ptr(ral.addr), .value(flash_addr));  // Write Address
+      csr_wr(.ptr(ral.addr), .value(flash_addr));  // Read Address
 
       reg_data = '0;
       reg_data = get_csr_val_with_updated_field(ral.control.start, reg_data, 1'b1) |
@@ -1152,7 +1152,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   endtask : enable_small_rma
 
   // Task to send an RMA Request (with a given seed) to the Flash Controller
-  virtual task send_rma_req(lc_flash_rma_seed_t rma_seed = LC_FLASH_RMA_SEED_DEFAULT);
+  virtual task send_rma_req(lc_flash_rma_seed_t rma_seed = LC_FLASH_RMA_SEED_DEFAULT,
+                            bit ignore_short_rma = 0);
 
     // Local Variables
     lc_ctrl_pkg::lc_tx_t done;
@@ -1177,7 +1178,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     fork
       begin
         // If small_rma enabled
-        if (cfg.en_small_rma) begin
+        if (cfg.en_small_rma & !ignore_short_rma) begin
           `uvm_info(`gfn, "small_rma mode is enabled", UVM_LOW)
           enable_small_rma();
         end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_prog_rma_wipe_err_vseq.sv
@@ -11,7 +11,10 @@ class flash_ctrl_hw_prog_rma_wipe_err_vseq extends flash_ctrl_err_base_vseq;
 
   task run_main_event();
     logic [RmaSeedWidth-1:0] rma_seed = $urandom;
-    send_rma_req(rma_seed);
+    // This test needs long rma.
+    // In case en_small_rma is set for all tests,
+    // force to long rma.
+    send_rma_req(.rma_seed(rma_seed), .ignore_short_rma(1));
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
   endtask // run_main_event

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -305,6 +305,9 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     // Select a Random Data Partition Page
     page = $urandom_range(0, MaxNumPages-1);
 
+    // Small rma only stash 2 pages
+    if (cfg.en_small_rma) page = page % 2;
+
     // Assign Address based on Partition Selected, and fixed number of words
     unique case (part)
       FlashData0Part: addr = FlashData0StartAddr+(page*(FullPageNumWords*4)); // Base+Page Offset

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -43,6 +43,13 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint flash_op_c {
+    // Add read only constraint for closed source env
+    if (cfg.seq_cfg.op_readonly_on_info_partition) {
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+    }
+    if (cfg.seq_cfg.op_readonly_on_info1_partition) {
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+    }
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
     // 8Byte (2 words) aligned.
     // With scramble enabled, odd size of word access (or address) will cause

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -16,22 +16,25 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
 
    // fatal_std_err
    task run_error_event();
-      int wait_timeout_ns = 50_000;
-      string path = "tb.dut.u_flash_hw_if.rdata_i[38:32]";
+     int wait_timeout_ns = 50_000;
+     string path = "tb.dut.u_flash_hw_if.rdata_i[38:32]";
+     int    err_intg = $urandom_range(0, 127);
 
-      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
-                   , wait_timeout_ns)
-      cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
-      cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
-      cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
+     `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
+                  , wait_timeout_ns)
+     cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
+     cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
+     cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;
 
-      $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
-      `DV_CHECK(uvm_hdl_force(path, $urandom))
-      // Make sure this is not too long.
-      // If this is too long, it will causes other fatal errors.
-      cfg.clk_rst_vif.wait_clks(5);
-      `DV_CHECK(uvm_hdl_release(path))
-      collect_err_cov_status(ral.std_fault_status);
-      csr_rd_check(.ptr(ral.std_fault_status.lcmgr_intg_err), .compare_value(1));
+     $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
+     #0;
+     @(posedge cfg.flash_ctrl_vif.hw_rvalid);
+     `DV_CHECK(uvm_hdl_force(path, err_intg))
+     // Make sure this is not too long.
+     // If this is too long, it will causes other fatal errors.
+     cfg.clk_rst_vif.wait_clks(5);
+     `DV_CHECK(uvm_hdl_release(path))
+     collect_err_cov_status(ral.std_fault_status);
+     csr_rd_check(.ptr(ral.std_fault_status.lcmgr_intg_err), .compare_value(1));
    endtask
 endclass // flash_ctrl_lcmgr_intg_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -20,8 +20,12 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
       bit             saw_err, completed;
       data_4s_t rdata;
 
+      // Read buffer can be skipped if descramble is not enabled and there is
+      // no backlog at the read response pipeline
+      // (https://cs.opensource.google/opentitan/opentitan/+/master:
+      //  hw/ip/flash_ctrl/rtl/flash_phy_rd.sv;drc=8046c2896fa50aaf3a186a7ce8c0570db9f99eaf;l=481)
       // Enable ecc for all regions
-      flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
+      flash_otf_region_cfg(.scr_mode(OTFCfgTrue), .ecc_mode(OTFCfgTrue));
       idx1 = $urandom_range(0, 63);
       idx2 = $urandom_range(0, 63);
       path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_evict_vseq.sv
@@ -17,6 +17,9 @@ class flash_ctrl_rw_evict_vseq extends flash_ctrl_legacy_base_vseq;
     flash_op_t init_ctrl;
     flash_dv_part_e part;
 
+    // Enable interrupt for more visibility
+    flash_ctrl_intr_enable(6'h3f);
+
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
 


### PR DESCRIPTION
Following test regression errors are fixed
- flash_ctrl_rw_evict
- flash_ctrl_intr_rd_slow_flash
- flash_ctrl_invalid_op
- flash_ctrl_rd_path_intg
- flash_ctrl_hw_rma
- flash_ctrl_lcmgr_intg