### PR TITLE
[opentitantool] Bool command line arg does not work with "ignore_case"

### DIFF
--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -325,7 +325,7 @@ pub struct GpioMonitoringRead {
     )]
     pub pins: Vec<String>,
 
-    #[arg(long, ignore_case = true)]
+    #[arg(long)]
     pub continue_monitoring: bool,
 }
 


### PR DESCRIPTION
"ignore_case" applies to enum arguments and such, which take a value to be compared against a list of valid values.  This boolean argument is present (without value) or not present, and it seems that putting "ignore_case" on it results in a runtime exception during parsing.
