### PR TITLE
[doc] Removed url from getting started `SUMMARY.md`

### DIFF
--- a/doc/guides/getting_started/src/SUMMARY.md
+++ b/doc/guides/getting_started/src/SUMMARY.md
@@ -8,7 +8,6 @@
 - [Formal Verification](setup_formal.md)
 - [Building (and Testing) Software](build_sw.md)
 - [Building Documentation](build_docs.md)
-- [Running e2e Tests](https://opentitan.org/book/sw/device/silicon_creator/rom/doc/e2e_tests.html)
 - [Using OpenOCD](using_openocd.md)
 
 # Tools Setup


### PR DESCRIPTION
There shouldn't really be url in `SUMMARY.md` files.

One effect is the creation of `doc/guides/getting_started/src/https\:/opentitan.org/book/sw/device/silicon_creator/rom/doc/e2e_tests.html` when the docs are built.

https://github.com/lowRISC/opentitan/pull/17483#discussion_r1140195384
https://github.com/lowRISC/opentitan/pull/17656#discussion_r1146012195