### PR TITLE
[sw/silicon_creator] Implement set minimum required BL0 security version boot service

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.c
@@ -6,16 +6,18 @@
 
 #include "sw/device/silicon_creator/lib/error.h"
 
-void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_sec_version,
+void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_bl0_sec_ver,
                                        boot_svc_min_bl0_sec_ver_req_t *msg) {
-  msg->min_bl0_sec_ver = min_sec_version;
+  msg->min_bl0_sec_ver = min_bl0_sec_ver;
   boot_svc_header_finalize(kBootSvcMinBl0SecVerReqType,
                            sizeof(boot_svc_min_bl0_sec_ver_req_t),
                            &msg->header);
 }
 
-void boot_svc_min_bl0_sec_ver_res_init(rom_error_t status,
+void boot_svc_min_bl0_sec_ver_res_init(uint32_t min_bl0_sec_ver,
+                                       rom_error_t status,
                                        boot_svc_min_bl0_sec_ver_res_t *msg) {
+  msg->min_bl0_sec_ver = min_bl0_sec_ver;
   msg->status = status;
   boot_svc_header_finalize(kBootSvcMinBl0SecVerResType,
                            sizeof(boot_svc_min_bl0_sec_ver_res_t),

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
@@ -58,32 +58,40 @@ typedef struct boot_svc_min_bl0_sec_ver_res {
    */
   boot_svc_header_t header;
   /**
-   * Minimum security version to set.
+   * Minimum security version read from flash.
+   */
+  uint32_t min_bl0_sec_ver;
+  /**
+   * Status response from ROM_EXT.
    */
   rom_error_t status;
 } boot_svc_min_bl0_sec_ver_res_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, header, 0);
-OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, status,
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, min_bl0_sec_ver,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE);
-OT_ASSERT_SIZE(boot_svc_min_bl0_sec_ver_res_t, 48);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, status,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
+OT_ASSERT_SIZE(boot_svc_min_bl0_sec_ver_res_t, 52);
 
 /**
  * Initialize a set minimum security version request message.
  *
- * @param min_bl0_sec_ver_version The minimum security version to set.
+ * @param min_bl0_sec_ver The minimum security version to set.
  * @param[out] msg Output buffer for the message.
  */
-void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_bl0_sec_ver_version,
+void boot_svc_min_bl0_sec_ver_req_init(uint32_t min_bl0_sec_ver,
                                        boot_svc_min_bl0_sec_ver_req_t *msg);
 
 /**
  * Initialize a set minimum security version response message.
  *
+ * @param min_bl0_sec_ver The minimum security version read from flash.
  * @param status The result of this request.
  * @param[out] msg Output buffer for the message.
  */
-void boot_svc_min_bl0_sec_ver_res_init(rom_error_t status,
+void boot_svc_min_bl0_sec_ver_res_init(uint32_t min_bl0_sec_ver,
+                                       rom_error_t status,
                                        boot_svc_min_bl0_sec_ver_res_t *msg);
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver_unittest.cc
@@ -31,11 +31,13 @@ TEST_F(BootSvcMinBl0SecVerTest, ReqInit) {
 TEST_F(BootSvcMinBl0SecVerTest, ResInit) {
   boot_svc_min_bl0_sec_ver_res_t msg{};
   constexpr rom_error_t kStatus = kErrorOk;
+  constexpr uint32_t kMinBl0SecVersion = 0x12345678;
   EXPECT_CALL(boot_svc_header_,
               Finalize(kBootSvcMinBl0SecVerResType, sizeof(msg), &msg.header));
 
-  boot_svc_min_bl0_sec_ver_res_init(kStatus, &msg);
+  boot_svc_min_bl0_sec_ver_res_init(kMinBl0SecVersion, kStatus, &msg);
 
+  EXPECT_EQ(msg.min_bl0_sec_ver, kMinBl0SecVersion);
   EXPECT_EQ(msg.status, kStatus);
 }
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -215,7 +215,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical",
-        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_min_bl0_sec_ver",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -215,6 +215,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_min_bl0_sec_ver",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -31,7 +31,8 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
   }
 }
 
-rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest) {
+rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
+                                               const boot_data_t *boot_data) {
   if (manifest->identifier != CHIP_BL0_IDENTIFIER) {
     return kErrorBootPolicyBadIdentifier;
   }
@@ -39,12 +40,13 @@ rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest) {
       manifest->length > CHIP_BL0_SIZE_MAX) {
     return kErrorBootPolicyBadLength;
   }
-  RETURN_IF_ERROR(manifest_check(manifest));
-  // TODO(#7879): Implement anti-rollback.
-  uint32_t min_security_version = 0;
-  if (manifest->security_version < min_security_version) {
+  if (manifest->security_version < boot_data->min_security_version_bl0) {
     return kErrorBootPolicyRollback;
   }
+  HARDENED_CHECK_GE(manifest->security_version,
+                    boot_data->min_security_version_bl0);
+
+  RETURN_IF_ERROR(manifest_check(manifest));
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h
@@ -57,10 +57,12 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
  * or equal to the minimum required security version.
  *
  * @param manifest A first boot owner boot stage manifest.
+ * @param boot_data The boot data for the current lifecycle state.
  * @return Result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest);
+rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest,
+                                               const boot_data_t *boot_data);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Implements the Set minimum required BL0 security version boot service.

This PR is based off https://github.com/lowRISC/opentitan/pull/19348

Resolves https://github.com/lowRISC/opentitan/issues/19156