### PR TITLE
[aon_timer,dv] Remove false WkupStable_A assertion

### DIFF
--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -167,10 +167,6 @@ module aon_timer import aon_timer_reg_pkg::*;
   // cause register resides in AON domain.
   assign wkup_req_o = reg2hw.wkup_cause.q;
 
-  // The wakeup signal is not latched in the pwrmgr so must be held until acked by software
-  `ASSERT(WkupStable_A, wkup_req_o |=> wkup_req_o ||
-      $fell(reg2hw.wkup_cause.q) && !aon_sleep_mode, clk_aon_i, !rst_aon_ni)
-
   ////////////////////////
   // Interrupt Handling //
   ////////////////////////


### PR DESCRIPTION
This assertion said "If `wkup_req_o` drops, then it must do so at the same time the `wkup_cause` register gets written with a zero, and `aon_sleep_mode_i` must be false".

Without the requirement about `aon_sleep_mode_i`, the assertion was true. But it was true for spurious reasons: the two signals are actually equal!

With the requirement about `aon_sleep_mode_i`, it is false. Running several iterations of the `aon_timer_same_csr_outstanding` test turns up a failure about one time in 10:

    util/dvsim/dvsim.py \
        hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson \
        -i aon_timer_same_csr_outstanding \
        --tool=xcelium --reseed=10

I can't really see any reason that it should have been true: the `reg2hw` signal whose behaviour we're asserting can indeed be written by SW, and this causes the assertion to fail.

@msfschaffner: I think the code in question came from b3d08450722f2cdbd228cccc56209c34f1f0e534 (back in August 2021!). I don't think I can see why the assertion should have been true, but it's totally possible that I've misunderstood something. Please tell me if so! :-)