### PR TITLE
[tools,vcs] Make flops use the sampled value of data to avoid races

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -106,6 +106,9 @@
                "-error=ENUMASSIGN",
                // Tasks must not be enabled in functions. Other tools do not allow this.
                "-error=TEIF"
+               // This helps avoid races in flops per Synopsys CASE 01552811.
+               // It causes flops to always use the sampled data value.
+               "-deraceclockdata"
                ]
 
   run_opts:   ["-licqueue",


### PR DESCRIPTION
The "-deraceclockdata" flag changes the simulation model to always use sampled data values in flops.