### PR TITLE
[dv/top-level] Fix sram data integrity error injection

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
@@ -5,6 +5,7 @@
 // Wrapper functions for SRAM's encrypted read/write operations.
 // This file is included in `mem_bkdr_util.sv` as a continuation of `mem_bkdr_util` class.
 
+// Returns the address after scrambling it using the given nonce.
 function logic [bus_params_pkg::BUS_AW-1:0] get_sram_encrypt_addr (
   logic [bus_params_pkg::BUS_AW-1:0] addr,
   logic [SRAM_BLOCK_WIDTH-1:0] nonce,
@@ -22,27 +23,27 @@ function logic [bus_params_pkg::BUS_AW-1:0] get_sram_encrypt_addr (
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // calculate scrambled address
   scr_addr_arr = sram_scrambler_pkg::encrypt_sram_addr(addr_arr, full_addr_width, nonce_arr);
 
-  // convert to bus address output
+  // Convert to bus address output.
   for (int i = 0; i < addr_lsb; i++) begin
     scr_addr[i] = addr[i];
   end
-
   for (int i = 0; i < full_addr_width; i++) begin
     scr_addr[addr_lsb + i] = scr_addr_arr[i];
   end
-
   return scr_addr;
-
 endfunction : get_sram_encrypt_addr
 
+// Returns the data after adding integrity bits and encrypting it with the given key and nonce.
+// If flip_bits is non-zero it may introduce integrity errors, but notice there is a small chance
+// after descrambling the data the errors will not be detected.
 function logic [38:0] get_sram_encrypt32_intg_data (
   logic [bus_params_pkg::BUS_AW-1:0] addr,
   logic [31:0]                       data,
   logic [SRAM_KEY_WIDTH-1:0]         key,
   logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
+  bit   [38:0]                       flip_bits = '0,
   int                                extra_addr_bits=0);
 
   logic [38:0]                       integ_data;
@@ -61,25 +62,35 @@ function logic [38:0] get_sram_encrypt32_intg_data (
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // Calculate the integrity constant
   integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+  integ_data ^= flip_bits;
 
-  // Calculate the scrambled data
   wdata_arr = {<<{integ_data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
       wdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
-
   return scrambled_data;
-
 endfunction : get_sram_encrypt32_intg_data
 
+// Returns the data at the given address after descrambling the address and decrypting the data.
+// It simply ignores the integrity bits.
 virtual function logic [38:0] sram_encrypt_read32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                         logic [SRAM_KEY_WIDTH-1:0]         key,
                                                         logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
-  logic [bus_params_pkg::BUS_AW-1:0] scr_addr;
-  logic [38:0]                       rdata = '0;
+  logic [bus_params_pkg::BUS_AW-1:0] scr_addr = get_sram_encrypt_addr(addr, nonce);
+  logic [38:0] rdata39 = _sram_decrypt_read39(addr, scr_addr, key, nonce);
+  return rdata39[31:0];
+endfunction : sram_encrypt_read32_integ
+
+// This reads the data at a scrambled address and decrypts it. It returns the data and
+// integrity bits.
+local function logic [38:0] _sram_decrypt_read39(
+    logic [bus_params_pkg::BUS_AW-1:0] addr,
+    logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+    logic [SRAM_KEY_WIDTH-1:0]   key,
+    logic [SRAM_BLOCK_WIDTH-1:0] nonce);
+  logic [38:0]                       rdata39 = '0;
 
   logic rdata_arr     [] = new[39];
   logic addr_arr      [] = new[addr_width];
@@ -92,59 +103,68 @@ virtual function logic [38:0] sram_encrypt_read32_integ(logic [bus_params_pkg::B
     addr_arr[i] = addr[addr_lsb + i];
   end
 
-  // Calculate the scrambled address
-  scr_addr = get_sram_encrypt_addr(addr, nonce);
-
-  // Read memory and return the decrypted data
-  rdata = read39integ(scr_addr);
-  `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata), UVM_HIGH)
-  rdata_arr = {<<{rdata}};
+  rdata39 = read39integ(scr_addr);
+  `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata39), UVM_HIGH)
+  rdata_arr = {<<{rdata39}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
       rdata_arr, 39, 39, addr_arr, addr_width, key_arr, nonce_arr
   );
-  rdata = {<<{rdata_arr}};
-  // Only return the data payload without ECC bits.
-  return rdata[31:0];
+  rdata39 = {<<{rdata_arr}};
+  return rdata39;
+endfunction : _sram_decrypt_read39
 
-endfunction
-
+// Writes the data at the given address. It scrambles the address and encrypts the data after
+// adding integrity bits. If flip_bits is non-zero it may introduce ecc errors.
 virtual function void sram_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                  logic [31:0]                       data,
                                                  logic [SRAM_KEY_WIDTH-1:0]         key,
                                                  logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
                                                  bit   [38:0]                       flip_bits = 0);
-  logic [bus_params_pkg::BUS_AW-1:0] scr_addr;
-  logic [38:0]                       integ_data;
-  logic [38:0]                       scrambled_data;
+  logic [bus_params_pkg::BUS_AW-1:0] scr_addr = get_sram_encrypt_addr(addr, nonce);
+  _sram_encrypt_write39(addr, scr_addr, data, key, nonce, flip_bits);
+endfunction : sram_encrypt_write32_integ
 
-  logic wdata_arr      [] = new[39];
-  logic addr_arr       [] = new[addr_width];
-  logic key_arr        [] = new[SRAM_KEY_WIDTH];
-  logic nonce_arr      [] = new[SRAM_BLOCK_WIDTH];
-
-  key_arr   = {<<{key}};
-  nonce_arr = {<<{nonce}};
-
-  for (int i = 0; i < addr_width; i++) begin
-    addr_arr[i] = addr[addr_lsb + i];
-  end
-
-  // Calculate the scrambled address
-  scr_addr = get_sram_encrypt_addr(addr, nonce);
-
-  // Calculate the integrity constant
-  integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
-
-  // flip some bits to inject integrity fault
-  integ_data ^= flip_bits;
-
-  // Calculate the scrambled data
-  wdata_arr = {<<{integ_data}};
-  wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 39, 39, addr_arr, addr_width, key_arr, nonce_arr
-  );
-  scrambled_data = {<<{wdata_arr}};
-
-  // Write the scrambled data to memory
+// This encrypts, possibly flips some bits to inject errors, and writes the resulting data
+// to a scrambled address.
+local function void _sram_encrypt_write39(logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                          logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+                                          logic [31:0]                 data,
+                                          logic [SRAM_KEY_WIDTH-1:0]   key,
+                                          logic [SRAM_BLOCK_WIDTH-1:0] nonce,
+                                          bit [38:0]                   flip_bits);
+  logic [38:0] scrambled_data = get_sram_encrypt32_intg_data(addr, data, key, nonce, flip_bits);
   write39integ(scr_addr, scrambled_data);
-endfunction
+endfunction : _sram_encrypt_write39
+
+// This injects integrity errors in sram for an original address and the corresponding
+// scrambled address. It needs to pass both addresses even though only the scrambled address
+// is affected, since the original address is used to encrypt the data.
+//
+// This code needs to try multiple random data since it is possible after encryption the
+// bit pattern will not result in a data error, as described in issue #10976
+virtual function void sram_inject_integ_error(logic [bus_params_pkg::BUS_AW-1:0] addr,
+                                              logic [bus_params_pkg::BUS_AW-1:0] scr_addr,
+                                              logic [SRAM_KEY_WIDTH-1:0]   key,
+                                              logic [SRAM_BLOCK_WIDTH-1:0] nonce);
+  int max_attempts = 40;
+  int attempt = 0;
+
+  while (attempt < max_attempts) begin
+    bit [31:0] data = $urandom();
+    bit [38:0] rdata_integ;
+    prim_secded_pkg::secded_inv_39_32_t dec;
+    // The specific bits to be flipped should be irrelevant.
+    _sram_encrypt_write39(addr, scr_addr, data, key, nonce, 39'h1001);
+    rdata_integ = _sram_decrypt_read39(addr, scr_addr, key, nonce);
+    dec = prim_secded_pkg::prim_secded_inv_39_32_dec(rdata_integ);
+    if (dec.err) begin
+      `uvm_info(`gfn, $sformatf(
+                "sram_inject_integ_error addr 0x%x, data 0x%x injects error %b after %0d attempts",
+                addr, rdata_integ, dec.err, attempt),
+                UVM_MEDIUM)
+      break;
+    end
+    ++attempt;
+  end
+  `DV_CHECK_LT(attempt, max_attempts, "Too many attempts in sram_inject_ecc_error")
+endfunction : sram_inject_integ_error

--- a/hw/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
@@ -211,7 +211,7 @@ package sram_scrambler_pkg;
 
   endfunction : encrypt_sram_addr
 
-  // Deccrypts the target SRAM address using the custom S&P network.
+  // Decrypts the target SRAM address using the custom S&P network.
   function automatic state_t decrypt_sram_addr(logic addr[], int addr_width,
                                                logic full_nonce[]);
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
@@ -13,6 +13,7 @@ class sram_ctrl_mem_bkdr_scb extends mem_bkdr_scb;
   protected otp_ctrl_pkg::sram_nonce_t nonce;
 
   virtual function mem_data_t get_bkdr_val(mem_addr_t addr);
+    // This chops the integrity bits since mem_data_t is just the data portion.
     return mem_bkdr_util_h.sram_encrypt_read32_integ(addr, key, nonce);
   endfunction
 


### PR DESCRIPTION
The previous fix in #19332 was unfortunately flawed, since ecc errors were checked on the scrambled data, but it should really be done after descrambling it.

This checks for errors after descrambling, and improves the mem backdoor code organization in this area.

Fixes #19268