### PR TITLE
[otbn,dv] Strengthen otbn_ctrl_redun_vseq

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -22,7 +22,11 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
 
   // Wait until the value at path becomes nonzero
   task wait_for_flag(string path);
-    uvm_hdl_data_t flag;
+    // Initialise flag to zero. With some simulators (one version of Xcelium, at least), it seems
+    // that the call to uvm_hdl_read might leave its destination set to X. The HDL path exists and
+    // the signal is not X, so this is rather confusing. Initialising flag to zero before calling
+    // uvm_hdl_read seems to fix the behaviour.
+    uvm_hdl_data_t flag = 0;
     `DV_SPINWAIT(do begin
                    @(cfg.clk_rst_vif.cb);
                    `DV_CHECK_FATAL(uvm_hdl_read(path, flag) == 1);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -8,8 +8,16 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
   `uvm_object_utils(otbn_ctrl_redun_vseq)
   `uvm_object_new
 
+  bit have_injected_error;
+
   task body();
     do_end_addr_check = 0;
+
+    // Run the otbn_single_vseq body, which runs a single OTBN application to completion. At the
+    // same time, try to inject an error and check that the RTL (and model) both spot the error. If
+    // we didn't find a good moment to inject the error, fail the test: sadly, it hasn't actually
+    // tested anything.
+    have_injected_error = 1'b0;
     fork
       begin
         super.body();
@@ -18,6 +26,11 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
         inject_redun_err();
       end
     join_any
+
+    if (!have_injected_error) begin
+      `uvm_fatal(`gfn, "Never found a time to inject an error.")
+    end
+
   endtask: body
 
   // Wait until the value at path becomes nonzero
@@ -202,6 +215,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
     endcase
     `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
+    have_injected_error = 1'b1;
     cfg.model_agent_cfg.vif.send_err_escalation(err_val);
     `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
     `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1);


### PR DESCRIPTION
The test that this vseq is supposed to be doing currently passes for spurious reasons. The test is supposed to be checking that OTBN notices if someone injects an error. Unfortunately, it might decide to inject an error at all. Then it's checking that OTBN doesn't notice an error that wasn't injected!

I'm sad to say that making this change seems to cause the test to fail unconditionally (boo!), but I don't think it was actually testing anything before. So this is *probably* an improvement.