### PR TITLE
[flash_ctrl,dv] Regression fix week of 7 Aug 23

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -796,11 +796,13 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Function to enable changing of the expected data to be checked in the post-transaction
   // checks.
   virtual function data_q_t calculate_expected_data(flash_op_t flash_op,
-                                                    ref data_q_t exp_data);
+                                                    const ref data_q_t exp_data);
     data_q_t rdata;
+    data_q_t data;
     flash_mem_bkdr_read(flash_op, rdata);
-    foreach(exp_data[i]) exp_data[i] &= rdata[i];
-    return exp_data;
+    foreach(exp_data[i]) data[i] = exp_data[i] & rdata[i];
+
+    return data;
   endfunction : calculate_expected_data
 
   // Writing data to the scoreboard memory model, this writes one word of data to the selected

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -796,7 +796,10 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Function to enable changing of the expected data to be checked in the post-transaction
   // checks.
   virtual function data_q_t calculate_expected_data(flash_op_t flash_op,
-                                                    const ref data_q_t exp_data);
+                                                    ref data_q_t exp_data);
+    data_q_t rdata;
+    flash_mem_bkdr_read(flash_op, rdata);
+    foreach(exp_data[i]) exp_data[i] &= rdata[i];
     return exp_data;
   endfunction : calculate_expected_data
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -52,7 +52,7 @@ class flash_ctrl_scoreboard #(
   uvm_tlm_analysis_fifo #(tl_seq_item)       eflash_tl_d_chan_fifo;
 
   bit skip_read_check = 0;
-
+  bit skip_alert_chk[string];
   // Prevent to execute predict_tl_err during fatal error test
   bit stop_tl_err_chk = 0;
   flash_phy_pkg::rd_buf_t evict_q[NumBanks][$];
@@ -67,6 +67,7 @@ class flash_ctrl_scoreboard #(
     eflash_tl_a_chan_fifo = new("eflash_tl_a_chan_fifo", this);
     eflash_tl_d_chan_fifo = new("eflash_tl_d_chan_fifo", this);
     hs_state = AlertComplete;
+    foreach(LIST_OF_ALERTS[i]) skip_alert_chk[i] = 1'b0;
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
@@ -918,6 +919,12 @@ class flash_ctrl_scoreboard #(
         expected_alert[alert_name].expected = 1;
         exp_alert_contd[alert_name]--;
       end
+    end
+  endfunction
+
+  virtual function void on_alert(string alert_name, alert_esc_seq_item item);
+    if(!skip_alert_chk[alert_name]) begin
+      super.on_alert(alert_name, item);
     end
   endfunction
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -18,7 +18,11 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
    task run_error_event();
      int wait_timeout_ns = 50_000;
      string path = "tb.dut.u_flash_hw_if.rdata_i[38:32]";
-     int    err_intg = $urandom_range(0, 127);
+     int    err_data = $urandom() + 1;
+     logic [38:0] enc_data;
+     // Generate error intg from random data to ensure
+     // error to occur when test force this field.
+     enc_data = prim_secded_pkg::prim_secded_39_32_enc(err_data);
 
      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
                   , wait_timeout_ns)
@@ -29,7 +33,7 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
      $assertoff(0, "tb.dut.u_flash_mp.NoReqWhenErr_A");
      #0;
      @(posedge cfg.flash_ctrl_vif.hw_rvalid);
-     `DV_CHECK(uvm_hdl_force(path, err_intg))
+     `DV_CHECK(uvm_hdl_force(path, enc_data[38:32]))
      // Make sure this is not too long.
      // If this is too long, it will causes other fatal errors.
      cfg.clk_rst_vif.wait_clks(5);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -14,6 +14,12 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     string path1 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.ctrl_rsp_vld";
     string path2 = "tb.dut.u_eflash.gen_flash_cores[0].u_core.host_req_done_o";
 
+    // Once error event is triggered, corrupted data propagate all the way down to flash phy interface and terminated.
+    // This can causes unexpected errors.
+    // Therefore, ignore potential unexpected err and check
+    // expected error only.
+    cfg.scb_h.skip_alert_chk["recov_err"] = 1;
+
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
     cfg.scb_h.expected_alert["fatal_err"].max_delay = 20000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
@@ -53,6 +59,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
           end
         endcase // randcase
         cfg.otf_scb_h.comp_off = 1;
+        cfg.otf_scb_h.mem_mon_off = 1;
       end
     end // repeat (2)
     check_fault(ral.fault_status.spurious_ack);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
@@ -38,7 +38,7 @@ class flash_ctrl_prog_reset_vseq extends flash_ctrl_otf_base_vseq;
   virtual task body();
     flash_op_t ctrl;
     int num, bank, iter;
-    int state_long_timeout_ns = 10000000; // 10ms
+    int state_long_timeout_ns = 50_000_000; // 50ms
     int state_timeout_ns = 100000; // 100us
 
     // Don't select a partition defined as read-only

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -53,6 +53,9 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
                 // prog_err and mp_err
                 set_otf_exp_alert("recov_err");
                 prog_flash(ctrl, bank, 1, fractions, 1);
+                // Wait for op_done or op_err
+                csr_spinwait(.ptr(ral.op_status), .exp_data(2'b0),
+                             .compare_op(CompareOpCaseNe), .backdoor(1));
               end
               cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
             endcase

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -319,7 +319,7 @@
       name: flash_ctrl_intr_wr_slow_flash
       uvm_test_seq: flash_ctrl_intr_wr_vseq
       run_opts: ["+scb_otf_en=1", "+flash_read_latency=50", "+flash_program_latency=500",
-                 "+rd_buf_en_to=500_000", "+test_timeout_ns=500_000_000"]
+                 "+rd_buf_en_to=500_000", "+test_timeout_ns=1_000_000_000"]
       reseed: 10
     }
     {


### PR DESCRIPTION
Following test failures have been fixed.
- flash_ctrl_rand_ops: update scoreboard memory with bank erase command
- flash_ctrl_intr_wr_slow_flash : increase timeout
- flash_ctrl_prog_reset : increase timeout
- flash_ctrl_lcmgr_intg : create false intg from random data
- flash_ctrl_wr_intg : Add op done between consecutive program operation
- flash_ctrl_phy_ack : Add selective alert check
- flash_ctrl_phy_arb : Add `calculate_expected_data` implementation

