### PR TITLE
[opentitanlib] Make `wait_read_timeout` use std io_safety

### DIFF
--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -14,7 +14,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
 use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsRawFd, BorrowedFd};
 use std::time::Duration;
 
 //use crate::io::uart::{Uart, UartError};
@@ -159,7 +159,8 @@ impl Uart for SerialPortUart {
                         // this one file descriptor to again become ready for writing.  Since this
                         // is a UART, we know that it will become ready in bounded time.
                         util::file::wait_timeout(
-                            port.as_raw_fd(),
+                            // SAFETY: The file descriptor is owned by `port` and is valid.
+                            unsafe { BorrowedFd::borrow_raw(port.as_raw_fd()) },
                             poll::PollFlags::POLLOUT,
                             Duration::from_secs(5),
                         )?;

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -475,7 +475,7 @@ impl CommandDispatch for GpioMonitoringVcd {
             } else {
                 Duration::from_millis(0)
             };
-            if file::wait_fd_read_timeout(stdin.as_raw_fd(), delay).is_ok() {
+            if file::wait_read_timeout(&stdin, delay).is_ok() {
                 let mut buf = [0u8; 1];
                 let len = stdin.read(&mut buf)?;
                 if len == 1 && buf[0] == 3 {


### PR DESCRIPTION
Rust 1.63+ have BorrowedFd, OwnedFd and AsFd trait for IO-safety. We should be using these as much as possible instead of dealing with RawFds directly. (The way nix crate is dealing with raw fds is a bit fishy, many functions interacting with RawFd is marked as safe while they shouldn't. I plan to move from nix to rustix, which implements IO-safety properly, but that'll be a separate PR).

I also identified a place where a `select` call is used instead of this helper function. `select` really shouldn't be used due to its limitations on FD number. The use is converted.