### PR TITLE
[otbn,dv] Add a "safe" mode to RIG; use it in otbn_ctrl_redun test

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/safe.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/safe.yml
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# An example configuration that tries to make programs that don't
+# "die".
+#
+# This boils down to avoiding calls of stop_at_end_of_cycle() with
+# error bits in the simulator. For example, programs should not try to
+# read sideload keys that don't have a value.
+
+inherit: base
+
+# Squash some snippet generators that we might expect to kill the
+# program.
+gen-weights:
+  BadAtEnd: 0
+  BadBNMovr: 0
+  BadBranch: 0
+  BadCallStackRW: 0
+  BadDeepLoop: 0
+  BadLoadStore: 0
+  BadInsn: 0
+  BadGiantLoop: 0
+  BadZeroLoop: 0
+  MisalignedLoadStore: 0
+  BadIspr: 0
+
+insn-weights:
+  # Avoid using the WSRR instruction, which might try to read from a
+  # sideload WSR (that may not have a value).
+  bn.wsrr: 0

--- a/hw/ip/otbn/dv/uvm/gen-binaries.py
+++ b/hw/ip/otbn/dv/uvm/gen-binaries.py
@@ -106,6 +106,8 @@ def main() -> int:
                         nargs='?',
                         const='unlimited',
                         help='Number of parallel jobs.')
+    parser.add_argument('--config', type=str, default='default',
+                        help='Configuration to use for any RIG calls')
     parser.add_argument('--gen-only',
                         action='store_true',
                         help="Generate the ninja file but don't run it")
@@ -151,7 +153,7 @@ def main() -> int:
     with open(os.path.join(args.destdir, ninja_fname), 'w') as ninja_handle:
         if args.src_dir is None:
             write_ninja_rnd(ninja_handle, toolchain, otbn_dir, args.count,
-                            args.seed, args.size)
+                            args.seed, args.size, args.config)
         else:
             write_ninja_fixed(ninja_handle, toolchain, otbn_dir, args.src_dir)
 
@@ -176,7 +178,8 @@ def main() -> int:
 
 
 def write_ninja_rnd(handle: TextIO, toolchain: Toolchain, otbn_dir: str,
-                    count: int, start_seed: int, size: int) -> None:
+                    count: int, start_seed: int,
+                    size: int, config: str) -> None:
     '''Write a build.ninja to build random binaries.
 
     The rules build everything in the same directory as the build.ninja file.
@@ -191,8 +194,8 @@ def write_ninja_rnd(handle: TextIO, toolchain: Toolchain, otbn_dir: str,
 
     handle.write(
         'rule rig-gen\n'
-        '  command = {rig} gen --size {size} --seed $seed -o $out\n\n'.format(
-            rig=otbn_rig, size=size))
+        '  command = {rig} gen --size {size} --config {config} '
+        '--seed $seed -o $out\n\n'.format(rig=otbn_rig, size=size, config=config))
 
     handle.write('rule rig-asm\n'
                  '  command = {rig} asm -o $seed $in\n\n'.format(rig=otbn_rig))

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -98,13 +98,23 @@ name:
   multi_err_dir: "{otbn_dir}/dv/otbnsim/test/simple/multi"
 
   run_modes: [
-    // Run the random instruction generator and builds the one resulting binary
+    // Run the random instruction generator and build the one resulting binary
     // in {otbn_elf_dir}. If you override the otbn_elf_dir plusarg with
     // --run-opts, we'll still build the binary (but will ignore it).
     {
       name: build_otbn_rig_binary_mode
       pre_run_cmds: [
         "{gen_rnd} --count 1 {otbn_elf_dir}"
+      ]
+    }
+
+    // Run the random instruction generator in a "safe mode" and build
+    // resulting binary in {otbn_elf_dir}. Other than the choice of
+    // RIG config, this the same as build_otbn_rig_binary_mode.
+    {
+      name: build_otbn_rig_safe_binary_mode
+      pre_run_cmds: [
+        "{gen_rnd} --count 1 {otbn_elf_dir} --config safe"
       ]
     }
 
@@ -293,6 +303,8 @@ name:
     {
       name: "otbn_pc_ctrl_flow_redun"
       uvm_test_seq: "otbn_pc_ctrl_flow_redun_vseq"
+      // Use a "safe" binary, in the hope that it will run for long
+      // enough that we can interrupt it with an error.
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
@@ -305,7 +317,7 @@ name:
     {
       name: "otbn_ctrl_redun"
       uvm_test_seq: "otbn_ctrl_redun_vseq"
-      en_run_modes: ["build_otbn_rig_binary_mode"]
+      en_run_modes: ["build_otbn_rig_safe_binary_mode"]
       reseed: 12
     }
     {


### PR DESCRIPTION
The otbn_ctrl_redun test wants to run a well-behaved binary. While the binary is running, the vseq wants to poke something to cause an error. Unfortunately, this doesn't work if the test binary happens to stop really quickly. The "safe mode" is designed to try to avoid this happening.

This is related to the change in #19385 (which makes the test more likely to fail if the binary does something naughty). I think the patches can land in either order, but things will be a bit cleaner after both of them have arrived.