### PR TITLE
[test] Fix lack of entropy for wycheproof test

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -208,8 +208,7 @@ opentitan_functest(
     name = "rsa_3072_verify_functest_wycheproof",
     srcs = ["rsa_3072_verify_functest.c"],
     cw310 = cw310_params(
-        timeout = "long",
-        tags = ["broken"],  # FIXME #16805 hangs at vector 170
+        timeout = "moderate",
     ),
     targets = [
         "cw310_test_rom",
@@ -218,10 +217,10 @@ opentitan_functest(
     ],
     verilator = verilator_params(
         timeout = "eternal",
-        tags = ["broken"],  # FIXME #16805 hangs at vector 165 after ~3h
     ),
     deps = [
         ":rsa_3072_verify_testvectors_wycheproof_header",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl/rsa:rsa_3072_verify",
@@ -245,6 +244,7 @@ opentitan_functest(
     ),
     deps = [
         ":rsa_3072_verify_testvectors_hardcoded_header",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl/rsa:rsa_3072_verify",

--- a/sw/device/tests/crypto/rsa_3072_verify_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_verify_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_3072_verify.h"
 #include "sw/device/lib/runtime/log.h"
@@ -59,6 +60,9 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   // Stays true only if all tests pass.
   bool result = true;
+
+  // Set entropy complex to auto mode.
+  CHECK_STATUS_OK(entropy_complex_init());
 
   // The definition of `RULE_NAME` comes from the autogen Bazel rule.
   LOG_INFO("Starting rsa_3072_verify_test:%s", RULE_NAME);


### PR DESCRIPTION
The test did not initialize the entropy complex to auto mode, and it would exhaust the available, finite entropy generated during boot, leading to freezing and timeouts.

Fixes #16805 