### PR TITLE
[opentitantool] Avoid required --help argument

### DIFF
--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -50,14 +50,9 @@ impl CommandDispatch for I2cRawRead {
 
 /// Write plain data bytes to a I2C device.
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct I2cRawWrite {
-    #[arg(short, long, help = "Hex data bytes to write.")]
+    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
     hexdata: String,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 impl CommandDispatch for I2cRawWrite {
@@ -79,9 +74,8 @@ impl CommandDispatch for I2cRawWrite {
 
 /// Write data bytes to a I2C device, then read back a response.
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct I2cRawWriteRead {
-    #[arg(short, long, help = "Hex data bytes to write.")]
+    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
     hexdata: String,
     #[arg(
         short = 'n',
@@ -90,10 +84,6 @@ pub struct I2cRawWriteRead {
         help = "Number of bytes to read."
     )]
     length: usize,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -130,7 +130,6 @@ impl CommandDispatch for SpiReadId {
 
 /// Read data from a SPI EEPROM.
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct SpiRead {
     #[arg(short, long, default_value = "0", help = "Start offset.")]
     start: u32,
@@ -150,14 +149,10 @@ pub struct SpiRead {
         help = "Read mode"
     )]
     pub mode: ReadMode,
-    #[arg(short, long, help = "Hexdump the data.")]
+    #[arg(long, help = "Hexdump the data.")]
     hexdump: bool,
     #[arg(name = "FILE", default_value = "-")]
     filename: PathBuf,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -367,14 +362,9 @@ impl CommandDispatch for SpiRawRead {
 
 /// Write plain data bytes to a SPI device (not necessarily SPI EEPROM/flash).
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct SpiRawWrite {
-    #[arg(short, long, help = "Hex data bytes to write.")]
+    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
     hexdata: String,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 impl CommandDispatch for SpiRawWrite {
@@ -393,17 +383,12 @@ impl CommandDispatch for SpiRawWrite {
 
 /// Write data bytes to a SPI device then read data (not necessarily SPI EEPROM/flash).
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct SpiRawWriteRead {
-    #[arg(short, long, help = "Hex data bytes to write.")]
+    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
     hexdata: String,
 
     #[arg(short = 'n', long, help = "Number of bytes to read.")]
     length: usize,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 impl CommandDispatch for SpiRawWriteRead {
@@ -428,14 +413,9 @@ impl CommandDispatch for SpiRawWriteRead {
 
 /// Simultaneously write and read plain data bytes to a SPI device (not SPI EEPROM/flash).
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct SpiRawTransceive {
-    #[arg(short, long, help = "Hex data bytes to write.")]
+    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
     hexdata: String,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 impl CommandDispatch for SpiRawTransceive {

--- a/sw/host/opentitantool/src/command/tpm.rs
+++ b/sw/host/opentitantool/src/command/tpm.rs
@@ -124,14 +124,9 @@ impl CommandDispatch for TpmWriteRegister {
 
 /// Write to a given TPM register.
 #[derive(Debug, Args)]
-#[command(disable_help_flag = true)]
 pub struct TpmExecuteCommand {
     #[arg(short = 'd', long, help = "Hex encoding of TPM command to execute.")]
     hexdata: String,
-
-    // `disable_help_flag` disable both short and long help flags. Add long help back.
-    #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
-    help: bool,
 }
 
 #[derive(Annotate, Serialize, Deserialize, Debug, PartialEq, Eq)]


### PR DESCRIPTION
A few subcommands used a `--hexdata` option with the short form `-h`, conflicting with standard `-h` for `--help`.  The tpm.rs file used `-d` as the short form of `--hexdata`, though.

This PR standardizes on `-d` as the short form of `--hexdata`, eliminating the conflict with build in help.  The immediate need for this CL is that somehow, the explicit declarations of long-form only `--help` cases errors about "Required argument: help".  And rather than figuring our how to properly declare `--help` as optional, I think it makes sense to standardize on a short form that does not conflict with `-h`.
