### PR TITLE
[bazel] add second `manufacturer_test_hooks` repo for secure domain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,16 +107,24 @@ hsm_repos()
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
 
-# Setup for linking in external test hooks.
-load("//rules:hooks_setup.bzl", "hooks_setup")
+# Setup for linking in external test hooks for both secure/non-secure
+# manufacturer domains.
+load("//rules:hooks_setup.bzl", "hooks_setup", "secure_hooks_setup")
 hooks_setup(
     name = "hooks_setup",
     dummy = "sw/device/tests/closed_source",
 )
+secure_hooks_setup(
+    name = "secure_hooks_setup",
+    dummy = "sw/device/tests/closed_source",
+)
 
-# Declare the external test_hooks repository.
+# Declare the external test_hooks repositories. One for both manufacturer secure
+# and non-secure domains.
 load("@hooks_setup//:repos.bzl", "hooks_repo")
+load("@secure_hooks_setup//:repos.bzl", "secure_hooks_repo")
 hooks_repo(name = "manufacturer_test_hooks")
+secure_hooks_repo(name = "secure_manufacturer_test_hooks")
 
 # The nonhermetic_repo imports environment variables needed to run vivado.
 load("//rules:nonhermetic.bzl", "nonhermetic_repo")

--- a/rules/hooks_setup.bzl
+++ b/rules/hooks_setup.bzl
@@ -2,8 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-_TEMPLATE = """
+_HOOKS_TEMPLATE = """
 def hooks_repo(name):
+    native.local_repository(
+        name = name,
+        path = "{hooks_dir}",
+    )
+"""
+
+_SECURE_HOOKS_TEMPLATE = """
+def secure_hooks_repo(name):
     native.local_repository(
         name = name,
         path = "{hooks_dir}",
@@ -16,7 +24,7 @@ exports_files(glob(["**"]))
 
 def _hooks_setup_impl(rctx):
     hooks_dir = rctx.os.environ.get("MANUFACTURER_HOOKS_DIR", rctx.attr.dummy)
-    rctx.file("repos.bzl", _TEMPLATE.format(hooks_dir = hooks_dir))
+    rctx.file("repos.bzl", _HOOKS_TEMPLATE.format(hooks_dir = hooks_dir))
     rctx.file("BUILD.bazel", _BUILD)
 
 hooks_setup = repository_rule(
@@ -28,4 +36,20 @@ hooks_setup = repository_rule(
         ),
     },
     environ = ["MANUFACTURER_HOOKS_DIR"],
+)
+
+def _secure_hooks_setup_impl(rctx):
+    secure_hooks_dir = rctx.os.environ.get("SECURE_MANUFACTURER_HOOKS_DIR", rctx.attr.dummy)
+    rctx.file("repos.bzl", _SECURE_HOOKS_TEMPLATE.format(hooks_dir = secure_hooks_dir))
+    rctx.file("BUILD.bazel", _BUILD)
+
+secure_hooks_setup = repository_rule(
+    implementation = _secure_hooks_setup_impl,
+    attrs = {
+        "dummy": attr.string(
+            mandatory = True,
+            doc = "Location of the dummy hooks directory.",
+        ),
+    },
+    environ = ["SECURE_MANUFACTURER_HOOKS_DIR"],
 )


### PR DESCRIPTION
Manufacturing partners have both a secure and non-secure domain they develop test code in that does not get pushed upstream, but makes use of upstream code. This adds a second external Bazel repo for the secure domain test hooks, which are stored in a separate system location than the non-secure domain test code.