### PR TITLE
[dv,c] Ensure strdup() is defined when compiling tcp_server.c

### DIFF
--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -4,6 +4,11 @@
 
 #include "tcp_server.h"
 
+// Strictly speaking, versions of C older than C23 might not declare
+// strdup in string.h. With e.g. glibc, this macro tells it to declare
+// what we need.
+#define __STDC_WANT_LIB_EXT2__ 1
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Given the filename, this code is technically supposed to be C. It uses strdup(), which isn't necessarily defined until C23(!). With standard libraries like glibc, it can be requested by defining a magic __STDC_WANT_LIB_EXT2__ preprocessor variable, so we should probably do that.

With this change,

    gcc -std=c99 -c hw/dv/dpi/common/tcp_server/tcp_server.c

runs to completion.
