### PR TITLE
[rust] disable aes/avx2 acceleration of pqcrypto-sphicsplus

### DIFF
--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -45,7 +45,7 @@ object = "0.25.3"
 once_cell = "1.17"
 p256 = "0.13.2"
 pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
-pqcrypto-sphincsplus = "0.6.4"
+pqcrypto-sphincsplus = { version = "0.6.4", default-features = false, features = ["std"] }
 pqcrypto-traits = "0.3.4"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0.45"

--- a/third_party/rust/crates/BUILD.pqcrypto-sphincsplus-0.6.4.bazel
+++ b/third_party/rust/crates/BUILD.pqcrypto-sphincsplus-0.6.4.bazel
@@ -29,9 +29,6 @@ rust_library(
         ],
     ),
     crate_features = [
-        "aes",
-        "avx2",
-        "default",
         "std",
     ],
     crate_root = "src/lib.rs",
@@ -60,9 +57,6 @@ cargo_build_script(
         "DEP_PQCRYPTO_INTERNALS_INCLUDEPATH": "../crate_index__pqcrypto-internals-0.2.4/include",
     },
     crate_features = [
-        "aes",
-        "avx2",
-        "default",
         "std",
     ],
     crate_name = "build_script_build",


### PR DESCRIPTION
This crate is always the limiting factor of Rust builds, and disabling the acceleration making building it twice as fast.