### PR TITLE
[EXPERIMENT][ci] Publish nightly ROM E2E tests on azure using JUnit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,6 +246,7 @@ jobs:
         --test_tag_filters=-broken,-cw310,-verilator,-dv \
         --target_pattern_file="${TARGET_PATTERN_FILE}"
     displayName: Build & test SW
+  - template: ci/publish-bazel-test-results.yml
   - bash: |
       set -x -e
       . util/build_consts.sh
@@ -317,6 +318,7 @@ jobs:
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
       ci/scripts/run-verilator-tests.sh
     displayName: Build & execute tests
+  - template: ci/publish-bazel-test-results.yml
   # TODO: build and cache the verilator model to avoid building twice (#12574)
   - bash: |
       . util/build_consts.sh
@@ -615,6 +617,7 @@ jobs:
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/guides/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
 
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
@@ -638,6 +641,7 @@ jobs:
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/run-fpga-cw310-tests.sh cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/guides/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
 
 - job: execute_fpga_manuf_tests_cw310
   displayName: CW310 Manufacturing Tests
@@ -661,6 +665,7 @@ jobs:
       module load "xilinx/vivado/$(VIVADO_VERSION)"
       ci/scripts/run-fpga-cw310-tests.sh manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/guides/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
 
 
 - job: deploy_release_artifacts

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -67,6 +67,7 @@ jobs:
         --test_output=errors \
         //sw/device/silicon_creator/rom/e2e/...
     displayName: "Run all ROM E2E tests"
+  - template: ../ci/publish-bazel-test-results.yml
 
 - job: bob_spi_i2c
   displayName: "BoB: SPI and I2C Tests"
@@ -86,3 +87,4 @@ jobs:
         --test_output=errors \
         $(bash ./bazelisk.sh query 'attr("tags", "[\[ ]bob[,\]]", attr("tags", "[\[ ]cw310[,\]]", tests(//...)))')
     displayName: "Run all the SPI and I2C Tests with BoB"
+  - template: ../ci/publish-bazel-test-results.yml

--- a/ci/publish-bazel-test-results.yml
+++ b/ci/publish-bazel-test-results.yml
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Azure template for publishing `bazel test` results on Azure and GitHub
+# checks.
+#
+# This template can be included from pipelines in other repositories.
+# It expects the source code to be checked out at $(Build.SourcesDirectory).
+#
+
+steps:
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '**/test.xml'
+      searchFolder: ' $(Build.SourcesDirectory)/bazel-out'
+    displayName: 'Publish bazel test results'
+    condition: succeededOrFailed()


### PR DESCRIPTION
The goal of this PR is to improve the usefulness of the GitHub CI reports. At the moment, failing tests are just reported as "bash exited with error 1" and one has to go to the Azure page and scroll the logs to find the problem.

Since bazel test produces JUnit reports, we can ask Azure to publish them and they are automatically displayed by GitHub and it also improves the Azure view. Example on this PR:
- [GitHub check view](https://github.com/lowRISC/opentitan/pull/19409/checks?check_run_id=15814529615)
- [Azure test view](https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=123774&view=ms.vss-test-web.build-test-results-tab)

For testing, I have only enabled them on the nightly CI but in fact it is very easy to add them to any bazel test so this could be added to bazel test in the daily CI as well.