### PR TITLE
[sw] Eliminate false positives from Clang-Tidy

### DIFF
--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -195,6 +195,8 @@ def _cc_aspect_impl(target, ctx, action_callback):
 #  ./bazelisk.sh run @lowrisc_rv32imcb_files//:bin/clang-tidy -- --checks='*' --list-checks
 _CLANG_TIDY_CHECKS = [
     "clang-analyzer-core.*",
+    # Disable advice to replace `memcpy` with `mempcy_s`.
+    "-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling",
 ]
 
 def _clang_tidy_run_action(ctx, cc_toolchain, cc_compile_ctx, generated_file, command_line, src):

--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -240,6 +240,12 @@ inline uint32_t launder32(uint32_t val) {
   // > instead require that reordering be prevented through careful sequencing
   // > of statements.
 
+  // When we're building for static analysis, reduce false positives by
+  // short-circuiting the inline assembly block.
+#if OT_BUILD_FOR_STATIC_ANALYZER
+  return val;
+#endif
+
   // The +r constraint tells the compiler that this is an "inout" parameter: it
   // means that not only does the black box depend on `val`, but it also mutates
   // it in an unspecified way.

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -453,6 +453,17 @@ extern "C++" {
 #define OT_USED __attribute__((used))
 
 /**
+ * OT_BUILD_FOR_STATIC_ANALYZER indicates whether we are compiling for the
+ * purpose of static analysis. Currently, this macro only detects
+ * Clang-Analyzer, which is used as a backend by Clang-Tidy.
+ */
+#ifdef __clang_analyzer__
+#define OT_BUILD_FOR_STATIC_ANALYZER 1
+#else
+#define OT_BUILD_FOR_STATIC_ANALYZER 0
+#endif
+
+/**
  *  This macro is used to align an offset to point to a 32b value.
  */
 #define OT_ALIGN_MEM(x) (uint32_t)(4 + (((uintptr_t)(x)-1) & ~3u))

--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "sw/device/lib/base/macros.h"
@@ -121,6 +122,10 @@ int OT_PREFIX_IF_NOT_RV32(memcmp)(const void *lhs, const void *rhs,
     }
   }
   for (; i < tail_offset; i += sizeof(uint32_t)) {
+#if OT_BUILD_FOR_STATIC_ANALYZER
+    assert(&lhs8[i] != NULL);
+    assert(&rhs8[i] != NULL);
+#endif
     uint32_t word_left = __builtin_bswap32(read_32(&lhs8[i]));
     uint32_t word_right = __builtin_bswap32(read_32(&rhs8[i]));
     static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
@@ -157,6 +162,10 @@ int memrcmp(const void *lhs, const void *rhs, size_t len) {
   }
   for (; end > body_offset; end -= sizeof(uint32_t)) {
     const size_t i = end - sizeof(uint32_t);
+#if OT_BUILD_FOR_STATIC_ANALYZER
+    assert(&lhs8[i] != NULL);
+    assert(&rhs8[i] != NULL);
+#endif
     uint32_t word_left = read_32(&lhs8[i]);
     uint32_t word_right = read_32(&rhs8[i]);
     static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/rom/rom.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -224,8 +225,8 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   HARDENED_RETURN_IF_ERROR(sigverify_rsa_key_get(
       sigverify_rsa_key_id_get(&manifest->rsa_modulus), lc_state, &rsa_key));
 
-  const sigverify_spx_key_t *spx_key;
-  const sigverify_spx_signature_t *spx_signature;
+  const sigverify_spx_key_t *spx_key = NULL;
+  const sigverify_spx_signature_t *spx_signature = NULL;
   uint32_t sigverify_spx_en = sigverify_spx_verify_enabled(lc_state);
   if (launder32(sigverify_spx_en) != kSigverifySpxDisabledOtp) {
     const manifest_ext_spx_key_t *ext_spx_key;
@@ -474,6 +475,10 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
       HARDENED_TRAP();
   }
   HARDENED_CHECK_EQ(manifest, manifest_check);
+
+#if OT_BUILD_FOR_STATIC_ANALYZER
+  assert(manifest_check != NULL);
+#endif
 
   if (launder32(manifest_check->address_translation) == kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(manifest_check->address_translation, kHardenedBoolTrue);


### PR DESCRIPTION
cfrantz@opentitan.org noticed that //quality:clang_tidy_check was failing. It turns out that Clang-Tidy was generating false positives, mostly about potentially uninitialized variables.

Brief timeline:

* In PR #18773, I temporarily removed Clang-Tidy's --warnings-as-errors flag until my work on C warning flags was complete (issue #12553).

* I attempted to fix these false positives in #18774 (never merged) by creating pure C definitions of the HARDENED* macros. That technique may have been workable, but it enabled the compiler to see through the analysis barrier for real builds, which would obviously be a problem.

* In PR #18719, I mistakenly brought back the --warnings-as-errors flag without fixing Clang-Tidy's false positives.

The main fix in this commit is to short-circuit the launder32() barrier *only* when the code is built for static analysis. It also adds some conditionally-compiled assertions to convince the analyzer that certain pointers in memory.c are not NULL.

Closes #18774
Fixes #19412