### PR TITLE
[dv/cov] Fix coverage handling in some common items

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -83,18 +83,23 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         tl_errors_cgs_wrap[ral_name] = new($sformatf("tl_errors_cgs_wrap[%0s]", ral_name));
         if (!has_csr) begin
           tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_csr_size_err.option.weight = 0;
+          tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_csr_size_err.option.at_least = 0;
         end
         if (!has_unmapped) begin
           tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_unmapped_err.option.weight = 0;
+          tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_unmapped_err.option.at_least = 0;
         end
         if (!has_mem_byte_access_err) begin
           tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_byte_access_err.option.weight = 0;
+          tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_byte_access_err.option.at_least = 0;
         end
         if (!has_wo_mem) begin
           tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_wo_err.option.weight = 0;
+          tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_wo_err.option.at_least = 0;
         end
         if (!has_ro_mem) begin
           tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_ro_err.option.weight = 0;
+          tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_ro_err.option.at_least = 0;
         end
 
       end
@@ -107,6 +112,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         tl_intg_err_cgs_wrap[ral_name] = new($sformatf("tl_intg_err_cgs_wrap[%0s]", ral_name));
         if (!has_mem || !has_csr) begin
           tl_intg_err_cgs_wrap[ral_name].tl_intg_err_cg.cp_is_mem.option.weight = 0;
+          tl_intg_err_cgs_wrap[ral_name].tl_intg_err_cg.cp_is_mem.option.at_least = 0;
         end
       end
     end

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -55,10 +55,12 @@ interface prim_onehot_check_if #(
       }
       cp_onehot_enable_fault: coverpoint onehot_fault_type {
         option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
+        option.at_least = EnableCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotEnableFault};
       }
       cp_onehot_addr_fault: coverpoint onehot_fault_type {
         option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
+        option.at_least = AddrCheck; // If 0, we expect 0 hits.
         bins hit = {OnehotAddrFault};
       }
     endgroup

--- a/hw/ip/prim/rtl/prim_subreg_arb.sv
+++ b/hw/ip/prim/rtl/prim_subreg_arb.sv
@@ -32,7 +32,11 @@ module prim_subreg_arb
     assign wr_data = (we == 1'b1) ? wd : d; // SW higher priority
     // Unused q - Prevent lint errors.
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_q = q;
+    //VCS coverage on
+    // pragma coverage on
   end else if (SwAccess == SwAccessRO) begin : gen_ro
     assign wr_en   = de;
     assign wr_data = d;
@@ -40,9 +44,13 @@ module prim_subreg_arb
     logic          unused_we;
     logic [DW-1:0] unused_wd;
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_we = we;
     assign unused_wd = wd;
     assign unused_q  = q;
+    //VCS coverage on
+    // pragma coverage on
   end else if (SwAccess == SwAccessW1S) begin : gen_w1s
     // If SwAccess is W1S, then assume hw tries to clear.
     // So, give a chance HW to clear when SW tries to set.
@@ -65,7 +73,11 @@ module prim_subreg_arb
     assign wr_data = (de ? d : q) & (we ? '0 : '1);
     // Unused wd - Prevent lint errors.
     logic [DW-1:0] unused_wd;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_wd = wd;
+    //VCS coverage on
+    // pragma coverage on
   end else begin : gen_hw
     assign wr_en   = de;
     assign wr_data = d;
@@ -73,9 +85,13 @@ module prim_subreg_arb
     logic          unused_we;
     logic [DW-1:0] unused_wd;
     logic [DW-1:0] unused_q;
+    //VCS coverage off
+    // pragma coverage off
     assign unused_we = we;
     assign unused_wd = wd;
     assign unused_q  = q;
+    //VCS coverage on
+    // pragma coverage on
   end
 
 endmodule


### PR DESCRIPTION
Set coverage option "at_least" besides "weigth" for items that won't be covered so they don't show up as coverage holes.
Disable coverage for unused signals in prim_subreg_arb.

Fixes #19404