### PR TITLE
[dv/clkmgr] Fix occasional clkmgr_peri test failure

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -30,6 +30,10 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
       // Flip all bits of clk_enables.
       flipped_enables = initial_enables ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
       csr_wr(.ptr(ral.clk_enables), .value(flipped_enables));
+      // Allow some time for the side-effects to be observed: the dv environment sets the CSRs
+      // clock frequency randomly, so it may run too fast and the the updates may become a glitch
+      // that ends up not sampled in the SVAs.
+      cfg.clk_rst_vif.wait_clks(4);
     end
     // And set it back to the reset value for stress tests.
     cfg.clk_rst_vif.wait_clks(1);


### PR DESCRIPTION
Wait some cycles before changing clk_enables CSR again to make sure the side-effects are visible in the outputs. Otherwise the random setting of the clock for the CSR block can occasionally be too fast and the slower clocks won't have time to be disabled in the outputs.