### PR TITLE
[bazel] Add bazel rules to import the QEMU OT port

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,3 +148,7 @@ hyperdebug_repos()
 # Bazel skylib library
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
+
+# QEMU OT port
+load("//third_party/qemu_ot:repos.bzl", "qemu_ot_repos")
+qemu_ot_repos()

--- a/rules/qemu.bzl
+++ b/rules/qemu.bzl
@@ -1,0 +1,110 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper rules for generating artefacts used by QEMU.
+
+The QEMU OT port uses a custom data format for both the flash and the OTP
+images. This file provide rules to produce those from the "standard" format
+used by the rest of the build system.
+"""
+
+load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
+
+def _qemu_flashgen_impl(ctx):
+    raw_flash = ctx.actions.declare_file(ctx.attr.output)
+    outputs = [raw_flash]
+    outputs.append(raw_flash)
+    inputs = []
+
+    # These flags tell flashgen  (an OpenTitan-specific script) to create an image from scratch
+    # and not to check that input files are valid before processing them for QEMU. This is
+    # necessary because some of the tests involved using invalid files on purpose.
+    arguments = ["-D", "-A"]
+    for binary, offset in ctx.attr.binaries.items():
+        inputs.extend(binary.files.to_list())
+        arguments.append("--otdesc")
+        arguments.append("{}@{}".format(binary.files.to_list()[0].path, offset))
+    arguments.append(raw_flash.path)
+
+    # TODO add ELF file support
+    ctx.actions.run(
+        outputs = outputs,
+        inputs = inputs,
+        arguments = arguments,
+        executable = ctx.executable._flashgen,
+    )
+    return [DefaultInfo(
+        files = depset(outputs),
+        data_runfiles = ctx.runfiles(files = outputs),
+    )]
+
+# TODO add ELF file support
+qemu_flashgen = rv_rule(
+    implementation = _qemu_flashgen_impl,
+    doc = """
+Generate a QEMU flash image from a one or more binaries.
+This rule calls the flashgen.py script from QEMU OT port under the hood.
+
+Since the flash only contains the binary, all debug information is lost.
+To remedy this, the QEMU OT port supports adding information about the ELF
+files in the flashthat can then be loaded by the emulator when disassembling
+code using the console.
+""",
+    attrs = {
+        "output": attr.string(doc = "Output file containing the QEMU flash image"),
+        "binaries": attr.label_keyed_string_dict(
+            allow_empty = False,
+            doc = """
+A dictionary where keys are the binaries and values are the offsets where to put
+them in the flash. This is the same format accepted by the assemble_flash_image rule.
+""",
+        ),
+        "_flashgen": attr.label(
+            default = "@//third_party/qemu_ot:flashgen",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _qemu_otpconv_impl(ctx):
+    outputs = []
+    raw_otp = ctx.actions.declare_file("{}.raw".format(ctx.label.name))
+    outputs.append(raw_otp)
+    ctx.actions.run(
+        outputs = [raw_otp],
+        inputs = [
+            ctx.file.img,
+        ],
+        arguments = [
+            "--input",
+            ctx.file.img.path,
+            "--output",
+            raw_otp.path,
+        ],
+        executable = ctx.executable._otpconv,
+    )
+    return [DefaultInfo(
+        files = depset(outputs),
+        data_runfiles = ctx.runfiles(files = outputs),
+    )]
+
+qemu_otpconv = rv_rule(
+    implementation = _qemu_otpconv_impl,
+    doc = """
+Generate a QEMU OTP image from a "standard" OTP image.
+This rule calls the otpconv.py script from QEMU OT port under the hood.
+""",
+    attrs = {
+        "img": attr.label(
+            allow_single_file = True,
+            doc = "The OTP image (produced by otp_image) to use.",
+        ),
+        "_otpconv": attr.label(
+            default = "@//third_party/qemu_ot:otpconv",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/rules/repo.bzl
+++ b/rules/repo.bzl
@@ -2,30 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@crt//rules:repo.bzl", _crt_http_archive_or_local = "http_archive_or_local")
 load("@python3//:defs.bzl", "interpreter")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def http_archive_or_local(local = None, **kwargs):
-    if not local:
-        http_archive(**kwargs)
-    elif ("build_file" in kwargs or
-          "build_file_content" in kwargs or
-          "workspace_file" in kwargs or
-          "workspace_file_content" in kwargs):
-        native.new_local_repository(
-            name = kwargs.get("name"),
-            path = local,
-            build_file = kwargs.get("build_file"),
-            build_file_content = kwargs.get("build_file_content"),
-            workspace_file = kwargs.get("workspace_file"),
-            workspace_file_content = kwargs.get("workspace_file_content"),
-        )
-    else:
-        native.local_repository(
-            name = kwargs.get("name"),
-            path = local,
-        )
+http_archive_or_local = _crt_http_archive_or_local
 
 def _bare_repository_impl(rctx):
     if rctx.attr.local:

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -230,5 +230,8 @@ opentitan_functest(
     key_struct = "multislot",
     ot_flash_binary = ":rom_ext_virtual_ottf_bl0_virtual",
     signed = True,
-    targets = ["cw310_rom_with_fake_keys"],
+    targets = [
+        "cw310_rom_with_fake_keys",
+        "qemu_cw310_rom_with_fake_keys",
+    ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7,10 +7,12 @@ load(
     "//rules:opentitan_test.bzl",
     "OPENTITANTOOL_OPENOCD_DATA_DEPS",
     "OPENTITANTOOL_OPENOCD_TEST_CMDS",
+    "QEMU_ARG_DISABLE_AES_FAST_MODE",
     "ROM_BOOT_FAILURE_MSG",
     "cw310_params",
     "dv_params",
     "opentitan_functest",
+    "qemu_params",
     "verilator_params",
 )
 load("//rules:splice.bzl", "bitstream_splice")
@@ -66,10 +68,16 @@ opentitan_functest(
 opentitan_functest(
     name = "aes_idle_test",
     srcs = ["aes_idle_test.c"],
+    qemu = qemu_params(
+        icount = 6,  # just an example
+        machine_props = ["no_epmp_cfg=true"],  # just an example
+        qemu_args = QEMU_ARG_DISABLE_AES_FAST_MODE,
+    ),
     targets = [
         "dv",
         "verilator",
         "cw310_test_rom",
+        "qemu_cw310_test_rom",
     ],
     deps = [
         "//hw/ip/aes:model",

--- a/third_party/qemu_ot/BUILD
+++ b/third_party/qemu_ot/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "otpconv",
+    srcs = ["@qemu-ot//:scripts/opentitan/otpconv.py"],
+)
+
+py_binary(
+    name = "flashgen",
+    srcs = ["@qemu-ot//:scripts/opentitan/flashgen.py"],
+)
+
+alias(
+    name = "qemu_system_riscv32",
+    actual = "@qemu-ot//:build/qemu-system-riscv32",
+)
+
+alias(
+    name = "qemu_img",
+    actual = "@qemu-ot//:build/qemu-img",
+)

--- a/third_party/qemu_ot/repos.bzl
+++ b/third_party/qemu_ot/repos.bzl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def qemu_ot_repos(local = None):
+    QEMU_OT_VERSION = "v8.0.2-2023-09-07"
+
+    url = "/".join([
+        "https://github.com/lowRISC/qemu/releases/download",
+        QEMU_OT_VERSION,
+        "qemu-ot-earlgrey-{}-x86_64-unknown-linux-gnu.tar.gz".format(QEMU_OT_VERSION),
+    ])
+
+    # FIXME: @crt already defines @qemu but that's the vanilla QEMU, not the OT port
+    http_archive_or_local(
+        name = "qemu-ot",
+        url = url,
+        local = local,
+        build_file_content = """
+package(default_visibility = ["//visibility:public"])
+exports_files(glob(["**"]))
+""",
+        sha256 = "89451f9e613db10814776e15661564854edde322129da4afb491b4bad3f48e25",
+    )


### PR DESCRIPTION
This imports the QEMU release with bazel and adds the necessary code so that bazel can generate QEMU tests. This PR does not implement the opentitanlib part, nor the manual QEMU test tagging that might be necesary for some tests. The opentitanlib part is done in #19471.

How to test:
```bash
bazel test --test_output=streamed --cache_test_results=no //sw/device/tests/crypto:aes_functest_qemu_cw310_rom_with_fake_keys
bazel test --test_output=streamed --cache_test_results=no //sw/device/tests:aes_idle_test_qemu_cw310_test_rom
```