### PR TITLE
[doc] Add basic documentation for host software

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -414,7 +414,12 @@
     - [Crypto Library Tests](./sw/device/tests/crypto/README.md)
 
 - [Host Software](./sw/host/README.md)
-
+  - [Hardware Security Module (HSM) tool](./sw/host/hsmtool/README.md)
+    - [Requirements](./sw/host/hsmtool/doc/requirements.md)
+  - [OpenTitanLib](./sw/host/opentitanlib/README.md)
+  - [OpenTitanSession](./sw/host/opentitansession/README.md)
+  - [OpenTitanTool](./sw/host/opentitantool/README.md)
+  - [TPM2 Test Server](./sw/host/tpm2_test_server/README.md)
 
 # Tooling
 

--- a/sw/host/hsmtool/README.md
+++ b/sw/host/hsmtool/README.md
@@ -1,0 +1,5 @@
+# OpenTitan Hardware Security Module Tool
+
+The OpenTitan Hardware Security Module (HSM) tool can be used to generate and manage keys that will be installed into OpenTitan devices during manufacturing.
+
+This tool is still a work-in-progress, but its requirements can be found [here](./doc/requirements.md).

--- a/sw/host/opentitanlib/README.md
+++ b/sw/host/opentitanlib/README.md
@@ -1,0 +1,5 @@
+# OpenTitanLib
+
+The OpenTitanLib is a Rust library that can be used to connect to and run tests on OpenTitan devices.
+
+OpenTitanLib is used by OpenTitanTool and by some tests which need finer grained control over the device under test.

--- a/sw/host/opentitansession/README.md
+++ b/sw/host/opentitansession/README.md
@@ -1,0 +1,11 @@
+# OpenTitanSession Tool
+
+The OpenTitanSession tool can be used to start a proxy server for OpenTitanTool clients to connect to.
+
+This allows for resources like FPGAs to be connected to a remote machine and used remotely by one or more users.
+
+The tool can be built and run using Bazel:
+
+```sh
+bazel run //sw/host/opentitansession -- help
+```

--- a/sw/host/opentitantool/README.md
+++ b/sw/host/opentitantool/README.md
@@ -1,0 +1,28 @@
+# OpenTitanTool
+
+The OpenTitanTool is a CLI tool for interacting with an OpenTitan device via the various platforms available for development.
+
+Operations supported by OpenTitanTool include:
+
+* Flashing an OpenTitan bitstream to an FPGA board.
+* Bootstrapping (flashing) software onto a device.
+* Connecting to a device's console.
+* Manipulating a device's GPIO pins, particularly for "[strapping][]".
+
+## Building
+
+OpenTitanTool is written in Rust and built using Bazel.
+It is used throughout the OpenTitan repository for executing tests.
+
+To build and run the tool manually:
+
+```sh
+bazel build //sw/host/opentitantool
+bazel run //sw/host/opentitantool -- help
+```
+
+## Configuration
+
+OpenTitanTool reads additional CLI arguments from the file at `$HOME/.config/opentitantool/config`.
+
+[strapping]: https://opentitan.org/book/hw/ip/pinmux/doc/theory_of_operation.html?highlight=strapping#strap-sampling-and-tap-isolation

--- a/sw/host/tpm2_test_server/README.md
+++ b/sw/host/tpm2_test_server/README.md
@@ -1,0 +1,3 @@
+# TPM2 Test Server
+
+The TPM2 Test Server is a tool for processing TPM commands over a TCP port.


### PR DESCRIPTION
This PR adds just the minimum documentation for OpenTitan's host software.

This will need expanding in the future, but hopefully adding these files will prompt people to add to them and keep them up to date in the future.

Future work:

* If anybody can provide more detailed documentation here, that would be greatly appreciated.
* I couldn't work out exactly what the `cryptotest` library was so have left that out for now.
* I couldn't work out what the `tpm2_test_server` was used for, but have copied its `about` line from the code.