### PR TITLE
[ci] Update version checks in ci/scripts/show-env.sh

### DIFF
--- a/ci/scripts/show-env.sh
+++ b/ci/scripts/show-env.sh
@@ -13,7 +13,6 @@ tools=(
     python3
     yapf
     isort
-    clang-format
     flake8
     ninja
     doxygen

--- a/ci/scripts/show-env.sh
+++ b/ci/scripts/show-env.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-tools=(
+required_tools=(
     git
     python3
     yapf
@@ -16,12 +16,22 @@ tools=(
     flake8
     ninja
     doxygen
+)
+
+optional_tools=(
     verible-verilog-lint
 )
 
-for tool in "${tools[@]}"; do
+for tool in "${required_tools[@]}"; do
     set -x
     $tool --version
+    { set +x; } 2>/dev/null
+    echo
+done
+
+for tool in "${optional_tools[@]}"; do
+    set -x
+    $tool --version || echo "Warning: failed to determine version of $tool"
     { set +x; } 2>/dev/null
     echo
 done


### PR DESCRIPTION
Changes to ci/scripts/show-env.sh:

* No longer checking the version of `clang-format` because we only use the Bazel-managed binary.
* No longer failing the script (and thus ci/jobs/quick-lint.sh) when `verible-verilog-lint` is missing. Per the Getting Started guide, it's an optional tool.