### PR TITLE
[bazel,ci,util,doc] Manage Verible tools with Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,6 +106,9 @@ riscv_compliance_repos()
 load("//third_party/coremark:repos.bzl", "coremark_repos")
 coremark_repos()
 
+load("//third_party/verible:repos.bzl", "verible_repos")
+verible_repos()
+
 # The standard Keccak algorithms
 load("//third_party/xkcp:repos.bzl", "xkcp_repos")
 xkcp_repos()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ variables:
   #
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
@@ -281,7 +280,6 @@ jobs:
       python3 --version
       fusesoc --version
       verilator --version
-      verible-verilog-lint --version
     displayName: Display environment
   - bash: ci/scripts/build-chip-verilator.sh englishbreakfast
     displayName: Build simulation with Verilator

--- a/check_tool_requirements.core
+++ b/check_tool_requirements.core
@@ -12,16 +12,6 @@ filesets:
       - ./tool_requirements.py : { copyto: tool_requirements.py }
 
 scripts:
-  check_tool_requirements_verible:
-    cmd:
-      - python3
-      - util/check_tool_requirements.py
-      - 'verible'
-    # TODO: Use this syntax once https://github.com/olofk/fusesoc/issues/353 is
-    # fixed. Remove the filesets from the default target, and also remove the
-    # copyto.
-    #filesets:
-    #  - files_check_tool_requirements
   check_tool_requirements_verilator:
     cmd:
       - python3
@@ -35,4 +25,3 @@ targets:
     hooks:
       pre_build:
         - tool_verilator   ? (check_tool_requirements_verilator)
-        - tool_veriblelint ? (check_tool_requirements_verible)

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -23,7 +23,6 @@ variables:
   # the definitions in util/container/Dockerfile as well.
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
     # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -8,6 +8,8 @@ set -e
 usage()
 {
     echo "Usage: install-package-dependencies.sh --verilator-version V"
+    # TODO: Remove vestigial `--verible-version` flag once the "CI (private)"
+    # pipeline stops passing it.
     echo "                                       --verible-version V"
     exit 1
 }
@@ -22,14 +24,13 @@ long="verilator-version:,verible-version:"
 ARGS="$(getopt -o "" -l "$long" -- "$@")" || usage
 
 VERILATOR_VERSION=
-VERIBLE_VERSION=
 
 eval set -- "$ARGS"
 while :
 do
     case "$1" in
         --verilator-version) VERILATOR_VERSION="$2"; shift 2 ;;
-        --verible-version)   VERIBLE_VERSION="$2";   shift 2 ;;
+        --verible-version) echo "##[warning]Ignoring deprecated flag: --verible-version"; shift 2 ;;
         --) shift; break ;;
         *)  error "getopt / case statement mismatch"
     esac
@@ -37,7 +38,6 @@ done
 
 # Check that we've seen all the expected versions
 test -n "$VERILATOR_VERSION" || error "Missing --verilator-version"
-test -n "$VERIBLE_VERSION"   || error "Missing --verible-version"
 
 # Check that there aren't any positional arguments
 test $# = 0 || error "Unexpected positional arguments"
@@ -99,25 +99,8 @@ python3 -m pip install --user -U pip "setuptools<66.0.0"
 
 pip3 install --user -r python-requirements.txt
 
-# Install Verible
-lsb_sr="$(lsb_release -sr)"
-lsb_sc="$(lsb_release -sc)"
-VERIBLE_BASE_URL="https://github.com/google/verible/releases/download"
-VERIBLE_TARBALL="verible-${VERIBLE_VERSION}-Ubuntu-${lsb_sr}-${lsb_sc}-x86_64.tar.gz"
-VERIBLE_URL="${VERIBLE_BASE_URL}/${VERIBLE_VERSION}/${VERIBLE_TARBALL}"
-
-verible_tar="$TMPDIR/verible.tar.gz"
-
-curl -f -Ls -o "$verible_tar" "${VERIBLE_URL}" || {
-    error "Failed to download verible from ${VERIBLE_URL}"
-}
-
-sudo mkdir -p /tools/verible
-sudo chmod 777 /tools/verible
-tar -C /tools/verible -xf "$verible_tar" --strip-components=1
-export PATH=/tools/verible/bin:$PATH
-
 # Install verilator
+lsb_sr="$(lsb_release -sr)"
 if [ $lsb_sr = "18.04" ]; then
   UBUNTU_SUFFIX="-u18"
 fi

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -25,7 +25,6 @@ steps:
       set -e
       cd ${{ parameters.REPO_TOP }}
       ci/install-package-dependencies.sh \
-        --verilator-version $(VERILATOR_VERSION) \
-        --verible-version $(VERIBLE_VERSION)
+        --verilator-version $(VERILATOR_VERSION)
     retryCountOnTaskFailure: 3
     displayName: 'Install package dependencies'

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -20,8 +20,8 @@ ci/scripts/check-bazel-banned-rules.sh
 echo -e "\n### Ensure all generated files are clean and up-to-date"
 ci/scripts/check-generated.sh
 
-echo -e "\n### Use buiildifier to check Bazel coding style"
-bazel test //quality:buildifier_check --test_output=streamed
+echo -e "\n### Use buildifier to check Bazel coding style"
+ci/bazelisk.sh test //quality:buildifier_check --test_output=streamed
 
 echo "### Check vendored directories are up-to-date"
 ci/scripts/check-vendoring.sh

--- a/ci/scripts/show-env.sh
+++ b/ci/scripts/show-env.sh
@@ -18,20 +18,9 @@ required_tools=(
     doxygen
 )
 
-optional_tools=(
-    verible-verilog-lint
-)
-
 for tool in "${required_tools[@]}"; do
     set -x
     $tool --version
-    { set +x; } 2>/dev/null
-    echo
-done
-
-for tool in "${optional_tools[@]}"; do
-    set -x
-    $tool --version || echo "Warning: failed to determine version of $tool"
     { set +x; } 2>/dev/null
     echo
 done

--- a/doc/contributing/hw/methodology.md
+++ b/doc/contributing/hw/methodology.md
@@ -84,8 +84,15 @@ Note that a pull request cannot be merged if it is not lint-clean, since the con
 
 To complement the Verilator lint explained above, we also leverage the Verible style linter, which captures different aspects of the code and detects style elements that are in violation of our [Verilog Style Guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md).
 
-The tool is open source and freely available on the [Verible GitHub page](https://github.com/google/verible/).
-Hence, we recommend IP designers install the tool as described [here](../../getting_started/README.md#step-6a-install-verible-optional) and in the [Lint Flow README](../../../hw/lint/README.md), and use the flow locally to close the errors and warnings.
+Verible is an open source SystemVerilog style linter and formatting tool (see the [Verible GitHub page](https://github.com/chipsalliance/verible)).
+The style linter is relatively mature and we use it as part of our [RTL design flow](https://opentitan.org/book/doc/contributing/hw/methodology.html).
+The formatter is still under active development, and hence its usage is more experimental in OpenTitan.
+
+You do not need to install Verible manually; OpenTitan manages it automatically with Bazel.
+The tool can be invoked on specific SystemVerilog files with the following command:
+```shell
+./bazelisk.sh run //third_party/verible:verible-verilog-lint -- path/to/file.sv
+```
 
 Developers should run their code through the Verible style lint tool before creating a design pull request.
 Linting errors and warnings can be closed by fixing the code in question (preferred), or waiving the error.
@@ -203,8 +210,8 @@ The formatter follows our [Verilog Style Guide](https://github.com/lowRISC/style
 Note that this formatter is still under development and not entirely production ready yet due to some remaining formatting bugs and discrepancies - hence automatic code formatting is not enforced in CI at this point.
 However, the tool is mature enough for manual use on individual files (i.e., certain edits may have to be manually amended after using it).
 
-The tool is open source and freely available on the [Verible GitHub page](https://github.com/google/verible/).
-Hence, we encourage IP designers to install the tool as described [here](../../getting_started/README.md#step-6a-install-verible-optional), and run their code through the formatter tool before creating a design pull request.
+The tool is open source and freely available on the [Verible GitHub page](https://github.com/chipsalliance/verible).
+Hence, we encourage IP designers to run their code through the formatter tool before creating a design pull request.
 
 The tool can be invoked on specific SystemVerilog files with the following command:
 ```shell

--- a/doc/getting_started/README.md
+++ b/doc/getting_started/README.md
@@ -149,55 +149,16 @@ Hopefully you got a "Hello World!" demo running on OpenTitan using either the Ve
 
 Depending on the specific way you want to use or contribute to OpenTitan, there may be a few extra steps you want to do.
 In particular:
-* *If you want to contribute SystemVerilog code upstream to OpenTitan*, follow step 7a to install Verible.
-* *If you want to run supported formal verification flows for OpenTitan, using tools like JasperGold,* follow step 7b to set up formal verification.
-* *If you want to simulate OpenTitan using Siemens Questa,* follow step 7c to set it up.
+* *If you want to run supported formal verification flows for OpenTitan, using tools like JasperGold,* follow step 7a to set up formal verification.
+* *If you want to simulate OpenTitan using Siemens Questa,* follow step 7b to set it up.
 
 It also may make sense to stick with the basic setup and come back to these steps if you find you need them later.
 
-### Step 7a: Install Verible (optional)
-
-Verible is an open source SystemVerilog style linter and formatting tool.
-The style linter is relatively mature and we use it as part of our [RTL design flow](../contributing/hw/methodology.md).
-The formatter is still under active development, and hence its usage is more experimental in OpenTitan.
-
-You can download and build Verible from scratch as explained on the [Verible GitHub page](https://github.com/google/verible/).
-But since this requires the Bazel build system the recommendation is to download and install a pre-built binary as described below.
-
-Go to [this page](https://github.com/google/verible/releases) and download the correct binary archive for your machine.
-
-The example below is for Ubuntu 20.04:
-
-```
-export VERIBLE_VERSION={{#tool-version verible }}
-wget https://github.com/google/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
-tar -xf verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
-```
-
-If you are using Ubuntu 18.04 then instead use:
-
-```console
-export VERIBLE_VERSION={{#tool-version verible }}
-wget https://github.com/google/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
-tar -xf verible-${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
-```
-
-Then install Verible within 'tools' using:
-
-```
-sudo mkdir -p /tools/verible/${VERIBLE_VERSION}/
-sudo mv verible-${VERIBLE_VERSION}/* /tools/verible/${VERIBLE_VERSION}/
-```
-
-After installation you need to add `/tools/verible/$VERIBLE_VERSION/bin` to your `PATH` environment variable.
-
-Note that we currently use version {{#tool-version verible }}, but it is expected that this version is going to be updated frequently, since the tool is under active development.
-
-### Step 7b: Set up formal verification (optional)
+### Step 7a: Set up formal verification (optional)
 
 See the [formal verification setup guide](./setup_formal.md)
 
-### Step 7c: Set up Siemens Questa (optional)
+### Step 7b: Set up Siemens Questa (optional)
 
 Once a standard installation of Questa has been completed, add `QUESTA_HOME` as an environment variable which points to the Questa installation directory.
 

--- a/hw/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/hw/lint/tools/dvsim/common_lint_cfg.hjson
@@ -19,7 +19,16 @@
   build_log:  "{build_dir}/{tool}.log"
 
   // We rely on fusesoc to run lint for us.
-  build_cmd:  "{job_prefix} fusesoc"
+  build_cmd:
+    '''
+    touch "$$("{proj_root}/bazelisk.sh" info execution_root)/FUSESOC_IGNORE"
+    env -v
+      DVSIM_PROJ_ROOT="{proj_root}" \
+      DVSIM_SCRATCH_PATH="{scratch_path}" \
+      PATH="$$(realpath {lint_root}/tools/dvsim/tool_wrappers):$$PATH" \
+      {job_prefix} fusesoc
+    '''
+
   build_opts: ["--cores-root {proj_root}",
                "run",
                "--flag=fileset_{design_level}",

--- a/hw/lint/tools/dvsim/tool_wrappers/common.sh
+++ b/hw/lint/tools/dvsim/tool_wrappers/common.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This function uses Bazel to run the named Verible tool.
+#
+# @param VERIBLE_TOOL The name of the tool to run, e.g. "verible-verilog-lint".
+# @param ARGS,...  Arguments that are forwarded to the Verible tool.
+verible_wrapper_run () {
+    set -e
+    VERIBLE_TOOL="$1"
+    shift
+
+    [ -v DVSIM_PROJ_ROOT ]
+    [ -v DVSIM_SCRATCH_PATH ]
+
+    # Dvsim invokes fusesoc on various IP blocks in parallel, and fusesoc runs
+    # the Verible tools, e.g. verible-verilog-lint. As a result, multiple
+    # instances of this function may be running simultaneously.
+    #
+    # We need to use Bazel to get the binary for the desired Verible tool, but
+    # simply offloading to `bazel run` would create a performance bottleneck;
+    # each parallel Bazel invocation will wait for the others to complete.
+    #
+    # Instead, this script does its own lock management to guarantee that the
+    # Verible tool's binary is present before executing it. Critically, it
+    # releases the lock *before* running the tool.
+    LOCKFILE="$DVSIM_SCRATCH_PATH/../dvsim-tool-wrapper.lock"
+
+    BAZEL_EXECROOT_CACHE_FILE="$DVSIM_SCRATCH_PATH/../bazel_execroot_cache.txt"
+    if [ ! -e "$BAZEL_EXECROOT_CACHE_FILE" ]; then
+        (
+            # Acquire an exclusive lock on the file descriptor.
+            flock --exclusive 9
+
+            # Run the tool with Bazel to ensure the binary is present.
+            #
+            # Bazel prints an unhelpful warning to stderr when running an
+            # external binary that it considers to be a source file. Silencing
+            # this warning prevents the veriblelint report parser from taking it
+            # seriously.
+            SPURIOUS_WARNING_PATTERN="is a source file, nothing will be built for it. If you want to build a target that consumes this file, try --compile_one_dependency"
+            "$DVSIM_PROJ_ROOT/bazelisk.sh" run "@verible//:bin/$VERIBLE_TOOL" \
+                -- --version 2> >(grep -v "$SPURIOUS_WARNING_PATTERN")
+
+            # Cache Bazel's execution root so we can find the binary without
+            # running Bazel next time.
+            "$DVSIM_PROJ_ROOT/bazelisk.sh" info execution_root > "$BAZEL_EXECROOT_CACHE_FILE"
+        ) 9>"$LOCKFILE"
+    fi
+
+    BAZEL_EXECROOT="$(cat "$BAZEL_EXECROOT_CACHE_FILE")"
+    "$BAZEL_EXECROOT/external/verible/bin/$VERIBLE_TOOL" "$@"
+}

--- a/hw/lint/tools/dvsim/tool_wrappers/verible-verilog-lint
+++ b/hw/lint/tools/dvsim/tool_wrappers/verible-verilog-lint
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+[ -v DVSIM_SCRATCH_PATH ]
+
+SRC_DIR="$(realpath ../src/)"
+
+# If we pass an empty waiver file to verible-verilog-lint, it will fail with the
+# message: "Broken waiver config handle". To work around this behavior, we can
+# preemptively add a comment to all empty waiver files in the scratch directory.
+#
+# Note that multiple invocations of this script may race each other, so we use
+# an exclusive file lock.
+#
+# This empty file adjustment only needs to happen once per dvsim run. Otherwise
+# we'll spend a lot of time running the `find` command. The presence of the
+# marker file is insufficient to determine we can skip the adjustment. For
+# instance, if the user runs dvsim twice on the same scratch directory, the
+# source files will be re-copied, but the marker file won't be deleted. A quick
+# hack to detect this situation is to compare the ctime of the marker file to
+# the source directory. directory.
+ADJUSTED_EMPTY_FILES_MARKER="$SRC_DIR/adjusted_empty_files.done"
+if [ ! -e "$ADJUSTED_EMPTY_FILES_MARKER" ] || [ "$ADJUSTED_EMPTY_FILES_MARKER" -ot "$SRC_DIR" ]; then
+    (
+        flock --exclusive 9
+        find "$SRC_DIR" \
+            -type f \
+            \( -name '*.vbl' -o -name '*.vbw' \) \
+            -size 0 \
+            -printf 'Adjusting empty waiver file: %p\n' \
+            -exec bash -c 'echo "# Autogen comment to make file non-empty" >> "$1"' shellname {} \; || true
+        touch "$ADJUSTED_EMPTY_FILES_MARKER"
+    ) 9>"$DVSIM_SCRATCH_PATH/../dvsim-verible-verilog-lint.lock"
+fi
+
+source "$(dirname "$0")/common.sh"
+verible_wrapper_run verible-verilog-lint "$@"

--- a/hw/lint/tools/dvsim/tool_wrappers/verible-verilog-syntax
+++ b/hw/lint/tools/dvsim/tool_wrappers/verible-verilog-syntax
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+source "$(dirname "$0")/common.sh"
+verible_wrapper_run verible-verilog-syntax "$@"

--- a/hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
+++ b/hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
@@ -14,3 +14,7 @@ parameter-name-style=localparam_style:CamelCase|ALL_CAPS
 
 # we allow nested struct definitions
 -typedef-structs-unions
+
+# TODO(lowRISC/opentitan#19556): remove this suppression and fix the resulting
+# lint warnings.
+-always-comb

--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -24,7 +24,6 @@ variables:
   # definitions in util/container/Dockerfile as well.
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
     # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/third_party/verible/BUILD
+++ b/third_party/verible/BUILD
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:private"])
+
+# This package provides a few convenience aliases into the @verible repository.
+# To see all available targets, run `./bazelisk.sh query '@verible//:*'`.
+
+alias(
+    name = "verible-verilog-format",
+    actual = "@verible//:bin/verible-verilog-format",
+)
+
+alias(
+    name = "verible-verilog-lint",
+    actual = "@verible//:bin/verible-verilog-lint",
+)
+
+alias(
+    name = "verible-verilog-syntax",
+    actual = "@verible//:bin/verible-verilog-syntax",
+)

--- a/third_party/verible/repos.bzl
+++ b/third_party/verible/repos.bzl
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def verible_repos(local = None):
+    VERIBLE_VERSION = "v0.0-3410-g398a8505"
+
+    http_archive_or_local(
+        name = "verible",
+        local = local,
+        url = "https://github.com/chipsalliance/verible/releases/download/{version}/verible-{version}-linux-static-x86_64.tar.gz".format(
+            version = VERIBLE_VERSION,
+        ),
+        sha256 = "c1e6b6ff514a737c3e9a2330628a057b48d5042be72f67a68864d7d4fc35e72d",
+        strip_prefix = "verible-" + VERIBLE_VERSION,
+        build_file_content = """
+package(default_visibility = ["//visibility:public"])
+exports_files(glob(["**"]))
+""",
+    )

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -29,10 +29,6 @@ __TOOL_REQUIREMENTS__ = {
         'min_version': '0.82.0',
         'as_needed': True
     },
-    'verible': {
-        'min_version': 'v0.0-2135-gb534c1fe',
-        'as_needed': True
-    },
     'vcs': {
         'min_version': '2022.06-SP2',
         'as_needed': True

--- a/util/BUILD
+++ b/util/BUILD
@@ -101,3 +101,11 @@ py_binary(
     srcs = ["fusesoc_build.py"],
     deps = all_requirements,
 )
+
+py_test(
+    name = "verible_format_test",
+    srcs = [
+        "verible-format.py",
+        "verible_format_test.py",
+    ],
+)

--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -19,8 +19,8 @@ log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
 def get_tool_requirements_path():
     '''Return the path to tool_requirements.py, at the top of the repo'''
     # top_src_dir is the top of the repository
-    top_src_dir = os.path.normpath(os.path.join(os.path.dirname(__file__),
-                                                '..'))
+    top_src_dir = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), '..'))
 
     return os.path.join(top_src_dir, 'tool_requirements.py')
 
@@ -31,8 +31,8 @@ class ReqErr(Exception):
         self.msg = msg
 
     def __str__(self):
-        return ('Error parsing tool requirements from {!r}: {}'
-                .format(self.path, self.msg))
+        return ('Error parsing tool requirements from {!r}: {}'.format(
+            self.path, self.msg))
 
 
 class ToolReq:
@@ -113,22 +113,23 @@ class ToolReq:
                                   env=env)
         except (subprocess.CalledProcessError, FileNotFoundError) as err:
             env_msg = ('' if not self.tool_env else
-                       ' (with environment overrides: {})'
-                       .format(', '.join('{}={}'.format(k, v)
-                                         for k, v in self.tool_env.items())))
-            raise RuntimeError('Failed to run {!r}{} to check version: {}'
-                               .format(cmd_txt, env_msg, err))
+                       ' (with environment overrides: {})'.format(', '.join(
+                           '{}={}'.format(k, v)
+                           for k, v in self.tool_env.items())))
+            raise RuntimeError(
+                'Failed to run {!r}{} to check version: {}'.format(
+                    cmd_txt, env_msg, err))
 
         if not proc.stdout:
-            raise RuntimeError('No output from running {!r} to check version.'
-                               .format(cmd_txt))
+            raise RuntimeError(
+                'No output from running {!r} to check version.'.format(
+                    cmd_txt))
 
         try:
             return self._parse_version_output(proc.stdout)
         except ValueError as err:
             raise RuntimeError('Bad output from running {!r} '
-                               'to check version: {}'
-                               .format(cmd_txt, err))
+                               'to check version: {}'.format(cmd_txt, err))
 
     def to_semver(self, version, from_req):
         '''Convert a tool version to semantic versioning format
@@ -153,14 +154,15 @@ class ToolReq:
             min_semver = self.to_semver(self.min_version, True)
         except ValueError as err:
             return (False,
-                    'Failed to convert requirement to semantic version: {}'
-                    .format(err))
+                    'Failed to convert requirement to semantic version: {}'.
+                    format(err))
         try:
             min_sv = StrictVersion(min_semver)
         except ValueError as err:
-            return (False,
-                    'Bad semver inferred from required version ({}): {}'
-                    .format(min_semver, err))
+            return (
+                False,
+                'Bad semver inferred from required version ({}): {}'.format(
+                    min_semver, err))
 
         try:
             actual_version = self.get_version()
@@ -171,24 +173,24 @@ class ToolReq:
             actual_semver = self.to_semver(actual_version, False)
         except ValueError as err:
             return (False,
-                    'Failed to convert installed to semantic version: {}'
-                    .format(err))
+                    'Failed to convert installed to semantic version: {}'.
+                    format(err))
         try:
             actual_sv = StrictVersion(actual_semver)
         except ValueError as err:
-            return (False,
-                    'Bad semver inferred from installed version ({}): {}'
-                    .format(actual_semver, err))
+            return (
+                False,
+                'Bad semver inferred from installed version ({}): {}'.format(
+                    actual_semver, err))
 
         if actual_sv < min_sv:
-            return (False,
-                    'Installed version is too old: '
-                    'found version {}, but need at least {}'
-                    .format(actual_version, self.min_version))
+            return (False, 'Installed version is too old: '
+                    'found version {}, but need at least {}'.format(
+                        actual_version, self.min_version))
 
         return (True,
-                'Sufficiently recent version (found {}; needed {})'
-                .format(actual_version, self.min_version))
+                'Sufficiently recent version (found {}; needed {})'.format(
+                    actual_version, self.min_version))
 
 
 class VerilatorToolReq(ToolReq):
@@ -197,13 +199,16 @@ class VerilatorToolReq(ToolReq):
             # Note: "verilator" needs to be called through a shell and with all
             # arguments in a string, as it doesn't have a shebang, but instead
             # relies on perl magic to parse command line arguments.
-            version_str = subprocess.run('verilator --version', shell=True,
-                                         check=True, stdout=subprocess.PIPE,
+            version_str = subprocess.run('verilator --version',
+                                         shell=True,
+                                         check=True,
+                                         stdout=subprocess.PIPE,
                                          stderr=subprocess.STDOUT,
                                          universal_newlines=True)
         except subprocess.CalledProcessError as err:
-            raise RuntimeError('Unable to call Verilator to check version: {}'
-                               .format(err)) from None
+            raise RuntimeError(
+                'Unable to call Verilator to check version: {}'.format(
+                    err)) from None
 
         return version_str.stdout.split(' ')[1].strip()
 
@@ -217,8 +222,8 @@ class VeribleToolReq(ToolReq):
         # Example: v0.0-808-g1e17daa -> 0.0.808
         m = re.fullmatch(r'v([0-9]+)\.([0-9]+)-([0-9]+)-g[0-9a-f]+$', version)
         if m is None:
-            raise ValueError("{} has invalid version string format."
-                             .format(version))
+            raise ValueError(
+                "{} has invalid version string format.".format(version))
 
         return '.'.join(m.group(1, 2, 3))
 
@@ -232,8 +237,8 @@ class VivadoToolReq(ToolReq):
         # In this case, we set the patch level to 0.
         m = re.fullmatch(r'([0-9]+)\.([0-9]+)(?:\.([0-9]+))?', version)
         if m is None:
-            raise ValueError("{} has invalid version string format."
-                             .format(version))
+            raise ValueError(
+                "{} has invalid version string format.".format(version))
 
         return '.'.join((m.group(1), m.group(2), m.group(3) or '0'))
 
@@ -265,8 +270,8 @@ class VcsToolReq(ToolReq):
 
         match = re.match(regex, version)
         if match is None:
-            raise ValueError("{!r} is not a recognised VCS version string."
-                             .format(version))
+            raise ValueError(
+                "{!r} is not a recognised VCS version string.".format(version))
         major = match.group(1)
         minor = match.group(2)
         sp = int(match.group(3) or 0)
@@ -286,8 +291,8 @@ class NinjaToolReq(ToolReq):
         # three digits and ignores the rest.
         m = re.fullmatch(r'([0-9]+)\.([0-9]+)\.([0-9]+).*', version)
         if m is None:
-            raise ValueError("{} has invalid version string format."
-                             .format(version))
+            raise ValueError(
+                "{} has invalid version string format.".format(version))
 
         return '.'.join(m.group(1, 2, 3))
 
@@ -312,14 +317,12 @@ def dict_to_tool_req(path, tool, raw):
     raw = raw.copy()
 
     if 'min_version' not in raw:
-        raise ReqErr(path,
-                     '{} is missing required key: "min_version".'
-                     .format(where))
+        raise ReqErr(
+            path, '{} is missing required key: "min_version".'.format(where))
     min_version = raw['min_version']
     if not isinstance(min_version, str):
         raise ReqErr(path,
-                     '{} has min_version that is not a string.'
-                     .format(where))
+                     '{} has min_version that is not a string.'.format(where))
     del raw['min_version']
 
     as_needed = False
@@ -327,14 +330,13 @@ def dict_to_tool_req(path, tool, raw):
         as_needed = raw['as_needed']
         if not isinstance(as_needed, bool):
             raise ReqErr(path,
-                         '{} has as_needed that is not a bool.'
-                         .format(where))
+                         '{} has as_needed that is not a bool.'.format(where))
         del raw['as_needed']
 
     if raw:
-        raise ReqErr(path,
-                     '{} has unexpected keys: {}.'
-                     .format(where, ', '.join(raw.keys())))
+        raise ReqErr(
+            path, '{} has unexpected keys: {}.'.format(where,
+                                                       ', '.join(raw.keys())))
 
     classes = {
         'edalize': PyModuleToolReq,
@@ -364,9 +366,9 @@ def read_tool_requirements(path=None):
         # __TOOL_REQUIREMENTS__ dictionary.
         raw = globs.get('__TOOL_REQUIREMENTS__')
         if raw is None:
-            raise ReqErr(path,
-                         'The Python file at did not define '
-                         '__TOOL_REQUIREMENTS__.')
+            raise ReqErr(
+                path, 'The Python file at did not define '
+                '__TOOL_REQUIREMENTS__.')
 
         # raw should be a dictionary (keyed by tool name)
         if not isinstance(raw, dict):
@@ -375,9 +377,9 @@ def read_tool_requirements(path=None):
         reqs = {}
         for tool, raw_val in raw.items():
             if not isinstance(tool, str):
-                raise ReqErr(path,
-                             'Invalid key in __TOOL_REQUIREMENTS__: {!r}'
-                             .format(tool))
+                raise ReqErr(
+                    path,
+                    'Invalid key in __TOOL_REQUIREMENTS__: {!r}'.format(tool))
 
             if isinstance(raw_val, str):
                 # Shorthand notation: value is just a string, which we
@@ -385,9 +387,9 @@ def read_tool_requirements(path=None):
                 raw_val = {'min_version': raw_val}
 
             if not isinstance(raw_val, dict):
-                raise ReqErr(path,
-                             'Value for {} in __TOOL_REQUIREMENTS__ '
-                             'is not a string or dict.'.format(tool))
+                raise ReqErr(
+                    path, 'Value for {} in __TOOL_REQUIREMENTS__ '
+                    'is not a string or dict.'.format(tool))
 
             reqs[tool] = dict_to_tool_req(path, tool, raw_val)
 
@@ -415,24 +417,22 @@ def main():
 
         good, msg = req.check()
         if not good:
-            log.error('Failed tool requirement for {}: {}'
-                      .format(tool, msg))
+            log.error('Failed tool requirement for {}: {}'.format(tool, msg))
             missing_tools.append(tool)
         else:
-            log.info('Tool {} present: {}'
-                     .format(tool, msg))
+            log.info('Tool {} present: {}'.format(tool, msg))
 
     all_good = True
     if missing_tools:
         log.error("Tool requirements not fulfilled. "
-                  "Please update tools ({}) and retry."
-                  .format(', '.join(missing_tools)))
+                  "Please update tools ({}) and retry.".format(
+                      ', '.join(missing_tools)))
         all_good = False
 
     if pending_tools:
         log.error("Some tools specified on command line don't appear in "
-                  "tool requirements file: {}"
-                  .format(', '.join(sorted(pending_tools))))
+                  "tool requirements file: {}".format(', '.join(
+                      sorted(pending_tools))))
         all_good = False
 
     return 0 if all_good else 1

--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -213,21 +213,6 @@ class VerilatorToolReq(ToolReq):
         return version_str.stdout.split(' ')[1].strip()
 
 
-class VeribleToolReq(ToolReq):
-    tool_cmd = ['verible-verilog-lint', '--version']
-
-    def to_semver(self, version, from_req):
-        # Drop the hash suffix and convert into version string that
-        # is compatible with StrictVersion in check_version below.
-        # Example: v0.0-808-g1e17daa -> 0.0.808
-        m = re.fullmatch(r'v([0-9]+)\.([0-9]+)-([0-9]+)-g[0-9a-f]+$', version)
-        if m is None:
-            raise ValueError(
-                "{} has invalid version string format.".format(version))
-
-        return '.'.join(m.group(1, 2, 3))
-
-
 class VivadoToolReq(ToolReq):
     tool_cmd = ['vivado', '-version']
     version_regex = re.compile(r'Vivado v(.*)\s')
@@ -341,7 +326,6 @@ def dict_to_tool_req(path, tool, raw):
     classes = {
         'edalize': PyModuleToolReq,
         'vcs': VcsToolReq,
-        'verible': VeribleToolReq,
         'verilator': VerilatorToolReq,
         'vivado': VivadoToolReq,
         'ninja': NinjaToolReq

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,7 +7,6 @@
 
 # Global configuration options.
 ARG VERILATOR_VERSION=4.210
-ARG VERIBLE_VERSION=v0.0-2135-gb534c1fe
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
 # This should match the version in bazelish.sh.
@@ -20,7 +19,6 @@ ARG CLANG_VERSION=16
 # Main container image.
 FROM ubuntu:20.04 AS opentitan
 ARG VERILATOR_VERSION
-ARG VERIBLE_VERSION
 ARG RISCV_TOOLCHAIN_TAR_VERSION
 ARG BAZELISK_VERSION
 ARG GCC_VERSION
@@ -144,13 +142,6 @@ RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add \
         done; \
         ${cmd} ; \
     )
-
-# Install Verible
-RUN curl -f -Ls -o verible.tar.gz \
-        https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz \
-    && mkdir -p /tools/verible \
-    && tar -C /tools/verible -xf verible.tar.gz --strip-components=1
-ENV PATH "/tools/verible/bin:${PATH}"
 
 # Set Locale to utf-8 everywhere
 ENV LC_ALL en_US.UTF-8

--- a/util/verible-format.py
+++ b/util/verible-format.py
@@ -13,15 +13,17 @@ import difflib
 
 logger = logging.getLogger('verible_format')
 
-VERIBLE_ARGS = ["--formal_parameters_indentation=indent",
-                "--named_parameter_indentation=indent",
-                "--named_port_indentation=indent",
-                "--port_declarations_indentation=indent"]
+VERIBLE_ARGS = [
+    "--formal_parameters_indentation=indent",
+    "--named_parameter_indentation=indent", "--named_port_indentation=indent",
+    "--port_declarations_indentation=indent"
+]
 
 
 def get_repo_top():
     return subprocess.run(['git', 'rev-parse', '--show-toplevel'],
-                          check=True, universal_newlines=True,
+                          check=True,
+                          universal_newlines=True,
                           stdout=subprocess.PIPE).stdout.strip()
 
 
@@ -31,19 +33,26 @@ def get_verible_executable_path():
 
 def get_verible_version(verible_exec_path):
     return subprocess.run([verible_exec_path, '--version'],
-                          check=True, universal_newlines=True,
+                          check=True,
+                          universal_newlines=True,
                           stdout=subprocess.PIPE).stdout.strip().split('\n')[0]
 
 
-def process_file(filename_abs, verible_exec_path,
-                 inplace=False, show_diff=False, show_cst=False):
+def process_file(filename_abs,
+                 verible_exec_path,
+                 inplace=False,
+                 show_diff=False,
+                 show_cst=False):
     args = [verible_exec_path] + VERIBLE_ARGS
     if inplace:
         args.append('--inplace')
     args.append(filename_abs)
 
-    verible = subprocess.run(args, check=False, universal_newlines=True,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    verible = subprocess.run(args,
+                             check=False,
+                             universal_newlines=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
 
     ret = 0
 
@@ -57,9 +66,13 @@ def process_file(filename_abs, verible_exec_path,
 
         formatted = verible.stdout.split('\n')
 
-        diff = list(difflib.unified_diff(orig, formatted, lineterm='', n=3,
-                                         fromfile=filename_abs,
-                                         tofile=filename_abs + '.formatted'))
+        diff = list(
+            difflib.unified_diff(orig,
+                                 formatted,
+                                 lineterm='',
+                                 n=3,
+                                 fromfile=filename_abs,
+                                 tofile=filename_abs + '.formatted'))
         ret = len(diff) > 0
 
         if not show_diff and len(diff) > 0:
@@ -71,34 +84,62 @@ def process_file(filename_abs, verible_exec_path,
                 logger.info(line)
 
         if len(diff) > 0 and show_cst:
-            cst = subprocess.run(['verible-verilog-syntax',
-                                  '--printtree', filename_abs],
-                                 check=False, universal_newlines=True,
-                                 stdout=subprocess.PIPE)
+            cst = subprocess.run(
+                ['verible-verilog-syntax', '--printtree', filename_abs],
+                check=False,
+                universal_newlines=True,
+                stdout=subprocess.PIPE)
             logger.info(cst.stdout)
 
     return ret
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Format source code with Verible formatter')
-    parser.add_argument('-q', '--quiet', action='store_true', default=False,
+    parser = argparse.ArgumentParser(
+        description='Format source code with Verible formatter')
+    parser.add_argument('-q',
+                        '--quiet',
+                        action='store_true',
+                        default=False,
                         help='print only errors and warnings')
-    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        default=False,
                         help='print extra debug messages')
-    parser.add_argument('--show-diff', action='store_true', default=False,
+    parser.add_argument('--show-diff',
+                        action='store_true',
+                        default=False,
                         help='print diff (when files differ)')
-    parser.add_argument('--show-cst', action='store_true', default=False,
+    parser.add_argument('--show-cst',
+                        action='store_true',
+                        default=False,
                         help='print CST tree')
-    parser.add_argument('--progress', action='store_true', default=False,
+    parser.add_argument('--progress',
+                        action='store_true',
+                        default=False,
                         help='show progress')
-    parser.add_argument('--inplace', action='store_true', default=False,
-                        help='format files in place (overwrite original files)')
-    parser.add_argument('-l', '--allowlist', action='store_true', default=False,
+    parser.add_argument(
+        '--inplace',
+        action='store_true',
+        default=False,
+        help='format files in place (overwrite original files)')
+    parser.add_argument('-l',
+                        '--allowlist',
+                        action='store_true',
+                        default=False,
                         help='process only files from allow list')
-    parser.add_argument('-a', '--all', action='store_true', default=False,
+    parser.add_argument('-a',
+                        '--all',
+                        action='store_true',
+                        default=False,
                         help='process all files in repository (.sv and .svh)')
-    parser.add_argument('-f', '--files', metavar='file', type=str, nargs='+', default=[],
+    parser.add_argument('-f',
+                        '--files',
+                        metavar='file',
+                        type=str,
+                        nargs='+',
+                        default=[],
                         help='process provided files')
     args = parser.parse_args()
 
@@ -110,16 +151,20 @@ def main():
             logger.setLevel(logging.DEBUG)
 
     if args.inplace:
-        logger.warning('WARNING: Operating in-place - so make sure to make a backup or '
-                       'run this on an experimental branch')
+        logger.warning(
+            'WARNING: Operating in-place - so make sure to make a backup or '
+            'run this on an experimental branch')
 
     verible_exec_path = get_verible_executable_path()
 
     if not verible_exec_path:
-        logger.error('verible-verilog-format either not installed or not visible in PATH')
+        logger.error(
+            'verible-verilog-format either not installed or not visible in PATH'
+        )
         sys.exit(1)
     else:
-        logger.info('Using Verible formatter version: ' + get_verible_version(verible_exec_path))
+        logger.info('Using Verible formatter version: ' +
+                    get_verible_version(verible_exec_path))
 
     logger.debug('repo_top: ' + get_repo_top())
     logger.debug('verible exec: ' + verible_exec_path)
@@ -140,7 +185,8 @@ def main():
             verible_files.append(filename_abs)
 
     if args.allowlist:
-        with open(repo_top_dir + '/util/verible-format-allowlist.txt', 'r') as fp:
+        with open(repo_top_dir + '/util/verible-format-allowlist.txt',
+                  'r') as fp:
             for line in fp:
                 if line[0] == '#':
                     continue
@@ -169,7 +215,8 @@ def main():
 
     ret = 0
     for i, f in enumerate(verible_files):
-        r = process_file(f, verible_exec_path,
+        r = process_file(f,
+                         verible_exec_path,
                          inplace=args.inplace,
                          show_diff=args.show_diff,
                          show_cst=args.show_cst)

--- a/util/verible_format_test.py
+++ b/util/verible_format_test.py
@@ -1,0 +1,59 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import unittest
+from collections import namedtuple
+from unittest.mock import patch
+
+# The name of the module under test contains a hyphen, so we cannot
+# syntactically say `import verible-format`.
+vf = importlib.import_module("verible-format")
+
+# This object is based on `subprocess.CompletedProcess`. It's useful for mocking
+# the return value of `subprocess.run`.
+MockProc = namedtuple("MockProc", ["stdout", "stderr"])
+
+
+class Test(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_get_repo_top(self, mock_run):
+        mock_run.side_effect = (MockProc(stdout="/path/to/opentitan\n",
+                                         stderr=""), )
+        self.assertEqual(vf.get_repo_top(), "/path/to/opentitan")
+
+    @patch("subprocess.run")
+    def test_get_repo_top_ignores_stderr(self, mock_run):
+        mock_run.side_effect = (MockProc(stdout="/path/to/opentitan\n",
+                                         stderr="foo"), )
+        self.assertEqual(vf.get_repo_top(), "/path/to/opentitan")
+
+    @patch("subprocess.run")
+    def test_build_bazel_args(self, mock_run):
+        mock_run.side_effect = (MockProc(stdout="/path/to/opentitan\n",
+                                         stderr=""), )
+        self.assertEqual(vf.VeribleTool.FORMAT.build_bazel_args(), [
+            "/path/to/opentitan/bazelisk.sh",
+            "run",
+            "--ui_event_filters=-info,-stdout,-stderr",
+            "--noshow_progress",
+            "//third_party/verible:verible-verilog-format",
+            "--",
+        ])
+
+    @patch("subprocess.run")
+    def test_get_verible_version(self, mock_run):
+        mock_run.side_effect = (
+            MockProc(stdout="/path/to/opentitan\n", stderr=""),
+            MockProc(stdout="v0.0-2135-gb534c1fe\n"
+                     "Commit  2022-04-07 12:23:30 -0700\n"
+                     "Built   2022-04-07T19:55:11Z\n",
+                     stderr=""),
+        )
+        self.assertEqual(vf.VeribleTool.FORMAT.get_version(),
+                         "v0.0-2135-gb534c1fe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **note**
> I recommend reviewing this PR one commit at a time. The Python diffs look a little hairy due to autoformatting, but I did the autoformat in its own commit before layering my changes on top.


This PR:

* Automates the installation of Verible tools with Bazel and removes those steps from CI.
* Simplifies the Getting Started guide by deleting a few paragraphs.
* Bumps the version of Verible so we can use the distro-agnostic `linux-static` binaries.
* Updates Python scripts that assumed Verible tools would be on PATH. This change required some nontrivial work around dvsim.

## Changes to dvsim

This PR creates wrapper scripts for Verible binaries in `hw/lint/tools/dvsim/tool_wrappers/` that obtain Verible binaries from Bazel on demand. The wrappers are admittedly a hack. I believe we a more elegant solution would be possible if dvsim supported "startup commands", configurable commands that run *once* when dvsim starts. The closest thing I could find  was `build_cmd`, which runs once per fusesoc invocation.

During the course of this PR, I fixed some preexisting issues.


1. Apparently, verible-verilog-lint considers empty waiver files to be a fatal error (see [lint_waiver.cc](https://github.com/chipsalliance/verible/blob/398a8505af01f61e930bd95fc2a4f1131dc0d467/common/analysis/lint_waiver.cc#L422C1-L424)). Ibex has a few such empty waiver files. The wrapper scripts were a convenient place to touch up these empty waiver files, but the proper solution would be to fix the waivers upstream in Ibex.

    (Addressed upstream by https://github.com/lowRISC/ibex/pull/2076)

1. Bazel symlinks are not excluded from fusesoc's search path. As a result, fusesoc may find files under e.g. `bazel-opentitan/` depending on the most recent Bazel commands. I discovered this by running ci/jobs/slow-lint.sh locally. I kept running into errors about missing SystemVerilog source files. I noticed that if I commented out one of the earlier tasks in slow-lint.sh the errors disappeared.  
     I modified the linting build_cmd to create a `FUSESOC_IGNORE` file in the Bazel execRoot directory (see <https://bazel.build/remote/output-directories>).

1. Verible warns that SV sources in `hw/top_earlgrey/ip/ast/` fail the [always-comb](https://chipsalliance.github.io/verible/verilog_lint.html#always-comb) rule. I worked around this by disabling the always-comb rule in `lowrisc-styleguide.rules.verible_lint`.

   (Tracked in https://github.com/lowRISC/opentitan/issues/19556.)