### PR TITLE
[manuf] add function to provision secret0 OTP partition

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -40,12 +40,30 @@ extern "C" {
 UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
                    wrapped_rma_unlock_token_t, \
                    STRUCT_WRAPPED_RMA_UNLOCK_TOKEN);
+// clang-format on
 
+/**
+ * Data exported during device personalization.
+ */
+// clang-format off
 #define STRUCT_MANUF_PERSONALIZE(field, string) \
     field(wrapped_rma_unlock_token, wrapped_rma_unlock_token_t)
 UJSON_SERDE_STRUCT(ManufPersonalize, \
                    manuf_personalize_t, \
                    STRUCT_MANUF_PERSONALIZE);
+// clang-format on
+
+/**
+ * Data imported during device individualization.
+ */
+// clang-format off
+#define STRUCT_MANUF_INDIVIDUALIZE_TEST_TOKENS(field, string) \
+    field(test_unlock_token, uint32_t, 4) \
+    field(test_exit_token, uint32_t, 4)
+UJSON_SERDE_STRUCT(ManufIndividualizeTestTokens, \
+                   manuf_individualize_test_tokens_t, \
+                   STRUCT_MANUF_INDIVIDUALIZE_TEST_TOKENS);
+// clang-format on
 
 #undef MODULE_ID
 // clang-format on

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -41,11 +41,11 @@ UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
                    wrapped_rma_unlock_token_t, \
                    STRUCT_WRAPPED_RMA_UNLOCK_TOKEN);
 
-#define STRUCT_MANUF_PROVISIONING(field, string) \
+#define STRUCT_MANUF_PERSONALIZE(field, string) \
     field(wrapped_rma_unlock_token, wrapped_rma_unlock_token_t)
-UJSON_SERDE_STRUCT(ManufProvisioning, \
-                   manuf_provisioning_t, \
-                   STRUCT_MANUF_PROVISIONING);
+UJSON_SERDE_STRUCT(ManufPersonalize, \
+                   manuf_personalize_t, \
+                   STRUCT_MANUF_PERSONALIZE);
 
 #undef MODULE_ID
 // clang-format on

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -57,12 +57,15 @@ cc_library(
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/json:provisioning_data",
     ],
 )
 
@@ -89,6 +92,7 @@ opentitan_functest(
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -7,16 +7,34 @@
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 
 #include "otp_ctrl_regs.h"
 
 enum {
+  /**
+   * Secret0 Parition OTP fields.
+   */
+  kSecret0TestUnlockTokenOffset =
+      OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_OFFSET - OTP_CTRL_PARAM_SECRET0_OFFSET,
+  kSecret0TestUnlockTokenSizeInBytes = OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_SIZE,
+  kSecret0TestUnlockTokenSizeIn64BitWords =
+      kSecret0TestUnlockTokenSizeInBytes / sizeof(uint64_t),
+
+  kSecret0TestExitTokenOffset =
+      OTP_CTRL_PARAM_TEST_EXIT_TOKEN_OFFSET - OTP_CTRL_PARAM_SECRET0_OFFSET,
+  kSecret0TestExitTokenSizeInBytes = OTP_CTRL_PARAM_TEST_EXIT_TOKEN_SIZE,
+  kSecret0TestExitTokenSizeIn64BitWords =
+      kSecret0TestExitTokenSizeInBytes / sizeof(uint64_t),
+
   /**
    * Secret1 Parition OTP fields.
    */
@@ -203,6 +221,49 @@ static status_t flash_info_read(dif_flash_ctrl_state_t *flash_state,
   return OK_STATUS();
 }
 
+/**
+ * Hashes a lifecycle transition token to prepare it to be written to OTP.
+ *
+ * According to the Lifecycle Controller's specification:
+ *
+ * "All 128bit lock and unlock tokens are passed through a cryptographic one way
+ * function in hardware before the life cycle controller compares them to the
+ * provisioned values ...", and
+ * "The employed one way function is a 128bit cSHAKE hash with the function name
+ * “” and customization string “LC_CTRL”".
+ *
+ * @param raw_token The raw token to be hashed.
+ * @param token_size The expected hashed token size in bytes.
+ * @param[out] hashed_token The hashed token.
+ * @return Result of the hash operation.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t hash_lc_transition_token(const uint32_t *raw_token,
+                                         size_t token_size,
+                                         uint64_t *hashed_token) {
+  crypto_const_uint8_buf_t input = {
+      .data = (uint8_t *)raw_token,
+      .len = token_size,
+  };
+  crypto_const_uint8_buf_t function_name_string = {
+      .data = (uint8_t *)"",
+      .len = 0,
+  };
+  crypto_const_uint8_buf_t customization_string = {
+      .data = (uint8_t *)"LC_CTRL",
+      .len = 7,
+  };
+  crypto_uint8_buf_t output = {
+      .data = (uint8_t *)hashed_token,
+      .len = token_size,
+  };
+
+  TRY(otcrypto_xof(input, kXofModeSha3Cshake128, function_name_string,
+                   customization_string, token_size, &output));
+
+  return OK_STATUS();
+}
+
 status_t manuf_individualize_device_hw_cfg(dif_flash_ctrl_state_t *flash_state,
                                            const dif_lc_ctrl_t *lc_ctrl,
                                            const dif_otp_ctrl_t *otp_ctrl) {
@@ -287,6 +348,49 @@ static status_t otp_secret_write(const dif_otp_ctrl_t *otp_ctrl,
   TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret1,
                                      offset, data, len));
   return OK_STATUS();
+}
+
+status_t manuf_individualize_device_secret0(
+    const dif_lc_ctrl_t *lc_ctrl, const dif_otp_ctrl_t *otp_ctrl,
+    const manuf_individualize_test_tokens_t *tokens) {
+  // Check life cycle in TEST_UNLOCKED0.
+  TRY(lc_ctrl_testutils_check_lc_state(lc_ctrl, kDifLcCtrlStateTestUnlocked0));
+
+  bool is_locked;
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+                                      &is_locked));
+  if (is_locked) {
+    return OK_STATUS();
+  }
+
+  uint64_t hashed_test_unlock_token[kSecret0TestUnlockTokenSizeInBytes];
+  uint64_t hashed_test_exit_token[kSecret0TestExitTokenSizeInBytes];
+  TRY(hash_lc_transition_token(tokens->test_unlock_token,
+                               kSecret0TestUnlockTokenSizeInBytes,
+                               hashed_test_unlock_token));
+  TRY(hash_lc_transition_token(tokens->test_exit_token,
+                               kSecret0TestExitTokenSizeInBytes,
+                               hashed_test_exit_token));
+
+  TRY(otp_ctrl_testutils_dai_write64(
+      otp_ctrl, kDifOtpCtrlPartitionSecret0, kSecret0TestUnlockTokenOffset,
+      hashed_test_unlock_token, kSecret0TestUnlockTokenSizeIn64BitWords));
+  TRY(otp_ctrl_testutils_dai_write64(
+      otp_ctrl, kDifOtpCtrlPartitionSecret0, kSecret0TestExitTokenOffset,
+      hashed_test_exit_token, kSecret0TestExitTokenSizeIn64BitWords));
+
+  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+                                        /*digest=*/0));
+
+  return OK_STATUS();
+}
+
+status_t manuf_individualize_device_secret0_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  bool is_locked;
+  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret0,
+                                      &is_locked));
+  return is_locked ? OK_STATUS() : INTERNAL();
 }
 
 status_t manuf_individualize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -9,6 +9,7 @@
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 
 /**
  * Provision the HW_CFG OTP partition.
@@ -45,6 +46,39 @@ status_t manuf_individualize_device_hw_cfg(dif_flash_ctrl_state_t *flash_state,
  * @return OK_STATUS if the HW_CFG partition is locked.
  */
 status_t manuf_individualize_device_hw_cfg_check(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Configures the SECRET0 OTP partition.
+ *
+ * The SECRET0 partition contains the test unlock and exit tokens.
+ *
+ * Preconditions:
+ * - Device is in TEST_UNLOCKED lifecycle stage.
+ *
+ * Note: The test will skip all programming steps and succeed if the SECRET0
+ * parition is already locked. This is to facilitate test re-runs.
+ *
+ * The caller should reset the device after calling this function and call
+ * `manuf_individualize_device_secret0_check()` afterwards to confirm that the
+ * OTP partition was successfully locked.
+ *
+ * @param lc_ctrl Lifecycle controller instance.
+ * @param otp_ctrl OTP controller instance.
+ * @param test_tokens Test unlock and exit tokens to provision.
+ * @return OK_STATUS if the HW_CFG partition is locked.
+ */
+status_t manuf_individualize_device_secret0(
+    const dif_lc_ctrl_t *lc_ctrl, const dif_otp_ctrl_t *otp_ctrl,
+    const manuf_individualize_test_tokens_t *tokens);
+
+/**
+ * Checks the SECRET0 OTP partition end state.
+ *
+ * @param otp_ctrl OTP controller interface.
+ * @return OK_STATUS if the SECRET1 partition is locked.
+ */
+status_t manuf_individualize_device_secret0_check(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -384,7 +384,7 @@ static status_t otp_partition_secret2_configure(
 status_t manuf_personalize_device(dif_flash_ctrl_state_t *flash_state,
                                   const dif_lc_ctrl_t *lc_ctrl,
                                   const dif_otp_ctrl_t *otp_ctrl,
-                                  manuf_provisioning_t *export_data) {
+                                  manuf_personalize_t *export_data) {
   // Check life cycle in either PROD, PROD_END, or DEV.
   TRY(lc_ctrl_testutils_operational_state_check(lc_ctrl));
 

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -56,7 +56,7 @@ enum {
 status_t manuf_personalize_device(dif_flash_ctrl_state_t *flash_state,
                                   const dif_lc_ctrl_t *lc_ctrl,
                                   const dif_otp_ctrl_t *otp_ctrl,
-                                  manuf_provisioning_t *export_data);
+                                  manuf_personalize_t *export_data);
 
 /**
  * Checks the device personalization end state.

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -49,15 +49,15 @@ static status_t peripheral_handles_init(void) {
   return OK_STATUS();
 }
 
-status_t personalize_test(manuf_provisioning_t *export_data) {
+status_t personalize_test(manuf_personalize_t *export_data) {
   LOG_INFO("Personalizing device.");
   TRY(manuf_personalize_device(&flash_state, &lc_ctrl, &otp_ctrl, export_data));
   return OK_STATUS();
 }
 
-status_t export_data_over_ujson(ujson_t *uj,
-                                manuf_provisioning_t *export_data) {
-  RESP_OK(ujson_serialize_manuf_provisioning_t, uj, export_data);
+status_t export_data_over_console(ujson_t *uj,
+                                  manuf_personalize_t *export_data) {
+  RESP_OK(ujson_serialize_manuf_personalize_t, uj, export_data);
   return OK_STATUS();
 }
 
@@ -70,8 +70,8 @@ bool test_main(void) {
   // retention SRAM (namely in the creator partition) as it is faster than
   // storing it in flash, and still persists across a SW initiated reset.
   retention_sram_t *ret_sram_data = retention_sram_get();
-  manuf_provisioning_t *export_data =
-      (manuf_provisioning_t *)&ret_sram_data->creator.reserved;
+  manuf_personalize_t *export_data =
+      (manuf_personalize_t *)&ret_sram_data->creator.reserved;
 
   dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
   if (info & kDifRstmgrResetInfoPor) {
@@ -89,7 +89,7 @@ bool test_main(void) {
 
     // Send the RMA unlock token data (stored in the retention SRAM) over the
     // console using ujson framework.
-    CHECK_STATUS_OK(export_data_over_ujson(&uj, export_data));
+    CHECK_STATUS_OK(export_data_over_console(&uj, export_data));
   } else {
     LOG_FATAL("Unexpected reset reason: %08x", info);
   }

--- a/sw/host/tests/manuf/personalize/src/main.rs
+++ b/sw/host/tests/manuf/personalize/src/main.rs
@@ -25,7 +25,7 @@ use opentitanlib::test_utils::rpc::UartRecv;
 use opentitanlib::uart::console::UartConsole;
 
 mod provisioning_data;
-use provisioning_data::ManufProvisioning;
+use provisioning_data::ManufPersonalize;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -59,7 +59,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
     )?;
 
     // Wait for exported data to be transimitted over the console.
-    let export_data = ManufProvisioning::recv(&*uart, opts.timeout, false)?;
+    let export_data = ManufPersonalize::recv(&*uart, opts.timeout, false)?;
     log::info!("{:x?}", export_data);
 
     // Load HSM-generated EC private key.


### PR DESCRIPTION
This adds functions to the individualization library to provision the TEST_{UNLOCK,EXIT} tokens into the SECRET0 OTP partition.

Updates to the corresponding functest to test this new functionality are coming in a followup.