### PR TITLE
[flash_ctrl,dv] regression cleanup

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -87,4 +87,16 @@ class flash_ctrl_env #(
     cfg.m_fpp_agent_cfg.scb_otf_en = cfg.scb_otf_en;
   endfunction
 
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    // For fast receiver, set the range of asyn frequency between 1/5 and 10 times
+    // of core frequency
+    foreach (cfg.m_alert_agent_cfgs[i]) begin
+      if (cfg.m_alert_agent_cfgs[i].fast_rcvr) begin
+        int freq_mhz = cfg.clk_freq_mhz / 5;
+        cfg.m_alert_agent_cfgs[i].vif.clk_rst_async_if.set_freq_mhz(
+                                      $urandom_range(freq_mhz, cfg.clk_freq_mhz * 10));
+      end
+    end
+  endfunction
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -280,7 +280,7 @@ class flash_ctrl_scoreboard #(
                         erase_addr
                         ), UVM_LOW)
               if (erase_access) begin
-                if (erase_sel) erase_bank(erase_addr[OTFBankId]);
+                if (erase_sel) erase_bank(erase_addr[OTFBankId], part_sel);
                 else erase_data(part, erase_addr, erase_sel);
               end
             end
@@ -410,8 +410,9 @@ class flash_ctrl_scoreboard #(
   endtask
 
   // Update scb_flash_* with bank erase command.
-  // When bank erase is set, all partitions in the bank will be erased.
-  function void erase_bank(int bank);
+  // If data partition is selected, erase data partition only,
+  // otherwise all partitions in the bank will be erased.
+  function void erase_bank(int bank, bit part_sel);
     uint partition_words_num;
     data_model_t scb_flash_model;
     flash_mem_addr_attrs addr_attr;
@@ -421,17 +422,19 @@ class flash_ctrl_scoreboard #(
       scb_flash_model = cfg.get_partition_mem_model(part);
       addr_attr = new();
       addr_attr.set_attrs(bank * BytesPerBank);
-      for (int j = 0; j < partition_words_num; j++) begin
-        scb_flash_model[addr_attr.addr] = ALL_ONES;
-        addr_attr.incr(flash_ctrl_pkg::BusBytes);
+      if (part_sel == 1 || part == FlashPartData) begin
+        for (int j = 0; j < partition_words_num; j++) begin
+          scb_flash_model[addr_attr.addr] = ALL_ONES;
+          addr_attr.incr(flash_ctrl_pkg::BusBytes);
+        end
+        case (part)
+          FlashPartData: cfg.scb_flash_data = scb_flash_model;
+          FlashPartInfo: cfg.scb_flash_info = scb_flash_model;
+          FlashPartInfo1: cfg.scb_flash_info1 = scb_flash_model;
+          FlashPartInfo2: cfg.scb_flash_info2 = scb_flash_model;
+          default: `uvm_fatal(`gfn, "flash_ctrl_scoreboard: Partition type not supported!")
+        endcase
       end
-      case (part)
-        FlashPartData: cfg.scb_flash_data = scb_flash_model;
-        FlashPartInfo: cfg.scb_flash_info = scb_flash_model;
-        FlashPartInfo1: cfg.scb_flash_info1 = scb_flash_model;
-        FlashPartInfo2: cfg.scb_flash_info2 = scb_flash_model;
-        default: `uvm_fatal(`gfn, "flash_ctrl_scoreboard: Partition type not supported!")
-      endcase
       part = part.next();
     end while (part != part.first());
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_lcmgr_intg_vseq.sv
@@ -18,11 +18,10 @@ class flash_ctrl_lcmgr_intg_vseq extends flash_ctrl_err_base_vseq;
    task run_error_event();
      int wait_timeout_ns = 50_000;
      string path = "tb.dut.u_flash_hw_if.rdata_i[38:32]";
-     int    err_data = $urandom() + 1;
      logic [38:0] enc_data;
      // Generate error intg from random data to ensure
      // error to occur when test force this field.
-     enc_data = prim_secded_pkg::prim_secded_39_32_enc(err_data);
+     enc_data = prim_secded_pkg::prim_secded_39_32_enc(($urandom() + 1));
 
      `DV_SPINWAIT(wait(cfg.flash_ctrl_vif.hw_rvalid == 1);,
                   , wait_timeout_ns)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -22,8 +22,8 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
     `DV_CHECK(uvm_hdl_force(path, 2'h0))
 
-    delay = $urandom_range(1, 10);
-    #(delay * 1us);
+    delay = $urandom_range(5, 10);
+    #(delay * 10us);
     `DV_CHECK(uvm_hdl_release(path))
     check_fault(ral.fault_status.arb_err);
     collect_err_cov_status(ral.fault_status);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -10,7 +10,6 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
   `uvm_object_new
 
   task body();
-    int idx1, idx2;
     string path1, path2;
     int    state_timeout_ns = 100000; // 100us
 
@@ -26,17 +25,16 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
       //  hw/ip/flash_ctrl/rtl/flash_phy_rd.sv;drc=8046c2896fa50aaf3a186a7ce8c0570db9f99eaf;l=481)
       // Enable ecc for all regions
       flash_otf_region_cfg(.scr_mode(OTFCfgTrue), .ecc_mode(OTFCfgTrue));
-      idx1 = $urandom_range(0, 63);
-      idx2 = $urandom_range(0, 63);
+      // Set path to subset of both upperword [63:32] and lowerword[31:0]
       path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",
-               $sformatf(".u_rd.gen_bufs[0].u_rd_buf.data_i[%0d]", idx1)};
+               ".u_rd.gen_bufs[0].u_rd_buf.data_i[35:28]"};
       path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
-               $sformatf(".u_rd.gen_bufs[0].u_rd_buf.data_i[%0d]", idx2)};
+               ".u_rd.gen_bufs[0].u_rd_buf.data_i[35:28]"};
 
       cfg.clk_rst_vif.wait_clks(10);
-      `uvm_info(`gfn, $sformatf("Assert read path err idx1:%0d idx2:%0d", idx1, idx2), UVM_LOW)
-      `DV_CHECK(uvm_hdl_force(path1, 1'b0))
-      `DV_CHECK(uvm_hdl_force(path2, 1'b0))
+
+      `DV_CHECK(uvm_hdl_force(path1, $urandom()))
+      `DV_CHECK(uvm_hdl_force(path2, $urandom()))
       cfg.scb_h.expected_alert["fatal_err"].expected = 1;
       cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
       cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -72,7 +72,7 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
                     end
                   join_any
                   wait_no_outstanding_access();
-                  disable fork
+                  disable fork;
                 end join
               end
               cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -337,7 +337,8 @@
     {
       name: flash_ctrl_rw_evict_all_en
       uvm_test_seq: flash_ctrl_rw_evict_vseq
-      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1", "+en_always_prog=1"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+en_always_read=1",
+                 "+en_always_prog=1", "en_rnd_data=0"]
       reseed: 40
     }
     {

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -70,6 +70,7 @@ class flash_ctrl_base_test #(
     void'($value$plusargs("en_always_prog=%0d", cfg.en_always_prog));
     void'($value$plusargs("en_all_info_acc=%0d", cfg.en_all_info_acc));
     void'($value$plusargs("rd_buf_en_to=%0d", cfg.wait_rd_buf_en_timeout_ns));
+    void'($value$plusargs("en_rnd_data=%0b", cfg.wr_rnd_data));
     if (cfg.en_always_all) begin
       cfg.en_always_read = 1;
       cfg.en_always_prog = 1;


### PR DESCRIPTION
Following tests have been fixed.
Please see the commit message for detail
- flash_ctrl_rw_evict_all_en
- flash_ctrl_wr_intg
- flash_ctrl_lcmgr_intg
- flash_ctrl_phy_arb_redun
- flash_ctrl_mp_regions
- flash_ctrl_rd_intg