### PR TITLE
[sw/silicon_creator] Add rom_ext_check_rom_expectations()

### DIFF
--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -223,6 +223,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:pinmux",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/lib/sigverify",
         "//sw/device/silicon_creator/rom_ext/keys/fake",


### PR DESCRIPTION
This PR adds a function for checking the expectations stored in `.static_critical` by ROM.

@moidx PLMK if you'd like me to anything else into this function.