### PR TITLE
[ci] Initialize bazelCacheGcpKeyPath in execute_verilated_tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,6 +297,9 @@ jobs:
   pool: ci-public
   timeoutInMinutes: 240
   dependsOn: lint
+  variables:
+    - name: bazelCacheGcpKeyPath
+      value: ''
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml


### PR DESCRIPTION
I noticed a surprising error message in a CI run for a PR: `bazelCacheGcpKeyPath: command not found`. For CI runs on the master branch, that error message is nowhere to be found.

milesdai@opentitan.org pointed out that the step that sets the variable, named "GCP key path", only runs when the current branch is "master".

It seems that Azure Pipelines has not been replacing the macro expression `$(bazelCacheGcpKeyPath)` with a value for PR runs because the variable was undefined. Then, at runtime, bash attempted to interpret the expression as command substitution, but complained because the command does not exist. (Why didn't this prevent "Build & execute tests" from running the verilator tests? Because `export` masked the error! See SC2155[^0].)

This hypothesis is backed up by the Azure Pipelines docs[^1]:

> If there's no variable by that name, then the macro expression does
> not change. For example, if $(var) can't be replaced, $(var) won't be
> replaced by anything.

More context on the error from the PR run:

```
Starting: Build & execute tests
==============================================================================
Task         : Bash
Description  : Run a Bash script on macOS, Linux, or Windows
Version      : 3.226.2
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/bash
==============================================================================
Generating script.
========================== Starting Command Output ===========================
/usr/bin/bash /azp/agent/_work/_temp/d9fb36b5-1d40-4f45-8f7c-9f762b39e3e4.sh
++ bazelCacheGcpKeyPath
/azp/agent/_work/_temp/d9fb36b5-1d40-4f45-8f7c-9f762b39e3e4.sh: line 2: bazelCacheGcpKeyPath: command not found
+ export GCP_BAZEL_CACHE_KEY=
+ GCP_BAZEL_CACHE_KEY=
+ ci/scripts/run-verilator-tests.sh
```

[^0]: https://www.shellcheck.net/wiki/SC2155
[^1]: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#macro-syntax-variables