### PR TITLE
[doc] Add glossary of terms

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -522,3 +522,7 @@
 # Rust for C Developers
 
 - [Rust for Embedded C Programmers](./doc/rust_for_c_devs.md)
+
+# Appendix
+
+- [Glossary](./doc/glossary.md)

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,0 +1,335 @@
+# Glossary
+
+#### ADC
+
+Analog-to-Digital Converter.
+
+#### AES
+
+Advanced Encryption Standard.
+
+#### Airgapped
+
+Isolated from the surrounding environment, particularly from networks or the operating system.
+
+#### AON
+
+Always On.
+
+#### ASM
+
+Assembly code.
+
+#### Attestation
+
+The process of a device taking some measurement and checking it matches what is expected.
+
+#### Baud
+
+Unit of measurement for "symbols per second" where symbols are some unit being communicated over a channel.
+
+Often abbreviated to Bd, kBd (1000 Bd), MBd (1000 kBd), and GBd (1000 MBd).
+
+#### CIP
+
+Comportable (hardware) Intellectual Property.
+
+#### Comportable
+
+See the [comportability specification](./contributing/hw/comportability/README.md).
+
+#### CRC
+
+Cyclic Redundancy Check.
+
+#### CSR
+
+Control/Status Register.
+
+#### CSRNG
+
+Cryptographically Secure Random Number Generator.
+
+#### CTAP
+
+Client to Authenticator Protocol.
+
+A protocol for authentication devices to communicate with a host computer.
+
+#### CW310
+
+[ChipWhisperer CW310](https://rtfm.newae.com/Targets/CW310%20Bergen%20Board/) "Bergen" FPGA board.
+
+#### CW340
+
+[ChipWhisperer CW340](https://github.com/newaetech/cw340-luna-board) "Luna" FPGA baseboard.
+
+#### Darjeeling
+
+A work-in-progress integrated OpenTitan top level.
+
+#### DD
+
+Digital Design.
+
+#### DIF
+
+Device Interface Function.
+
+#### DV
+
+Design Verification.
+
+#### dvsim
+
+Design verification simulator tool.
+
+#### E2E
+
+End-to-End.
+
+#### Earl Grey
+
+The first discrete OpenTitan top level.
+See [Earl Grey](../hw/top_earlgrey/README.md) for a the full specification.
+
+#### EDA
+
+Electronic Design Automation.
+
+#### EDN
+
+Entropy Distribution Network.
+
+#### ePIC
+
+Embedded Position Independent Code.
+
+#### ePMP
+
+Enhanced Physical Memory Protection.
+
+A RISC-V extension to the physical memory protection part of the RISC-V privileged architecture specification.
+Also known as "Smepmp".
+
+#### FI
+
+Fault Injection.
+
+#### FIDO2
+
+Fast Identity Online version 2.
+
+A collection of protocol specifications for authenticating a user with a device or server.
+
+#### FIPS
+
+Federal Information Process Standards.
+
+#### Flash
+
+A type of non-volatile reprogrammable memory.
+
+#### FPGA
+
+Field Programmable Gate Array.
+
+#### FPV
+
+Formal Property Verification.
+
+#### GF2
+
+Galois Field of order 2.
+
+#### GPIO
+
+General-Purpose Input/Output.
+
+#### HDL
+
+Hardware Description Language.
+
+#### HMAC
+
+Hash-based Message Authentication Code.
+
+#### HSM
+
+Hardware Security Module.
+
+#### HyperDebug
+
+A custom OpenTitan development harness for testing and debugging deployments on CW310 and CW340 FPGA boards.
+
+#### I<sup>2</sup>C
+
+Inter-Integrated Circuit.
+
+#### Ibex
+
+The 32-bit RISC-V core used in OpenTitan chips.
+
+#### IP
+
+Intellectual Property.
+
+#### KMAC
+
+Keccak Message Authentication Code.
+
+#### LC
+
+Life-Cycle (controller).
+
+#### Mask ROM
+
+Read-Only Memory encoded into the "mask" used to fabricate silicon.
+
+#### MCU
+
+Microcontroller Unit.
+
+#### Mux
+
+Multiplexer.
+
+#### Netlist
+
+A list of connections between nodes of a circuit.
+
+#### OTBN
+
+OpenTitan Big Number accelerator - a RISC-V-like programmable coprocessor for asymmetric cryptographic algorithms.
+
+#### OTP
+
+One-Time Programmable (memory).
+
+#### PIC
+
+Position-Independent Code.
+
+#### Pinmux
+
+Pin Multiplexer.
+
+### PKI
+
+Public Key Infrastructure.
+
+#### PMP
+
+Physical Memory Protection.
+
+### POR
+
+Power-On Reset.
+
+#### PQC
+
+Post-Quantum Cryptography.
+
+#### PRNG
+
+Pseudorandom Number Generator.
+
+#### PWM
+
+Pulse-Width Modulation.
+
+#### RAM
+
+Random-Access Memory.
+
+#### RFC
+
+Request For Comments.
+
+#### RISC-V
+
+The open source instruction set architecture used for OpenTitan cores.
+
+#### RNG
+
+Random Number Generator.
+
+#### ROM
+
+Read-Only Memory.
+
+#### RoT
+
+Root of Trust.
+
+#### RTL
+
+Register-Transfer Level.
+
+#### RV DM
+
+RISC-V Debug Module.
+
+#### SCA
+
+Side-Channel Analysis.
+
+#### SHA
+
+Secure Hash Algorithms.
+
+#### Silicon
+
+The semiconductor material that most microchips are made from.
+
+#### Smoketest
+
+A simple test used to check that some feature works to some degree, even if not in depth.
+
+#### SoC
+
+System on a Chip.
+
+#### SPI
+
+Serial Peripheral Interface.
+
+#### SRAM
+
+Static Random-Access Memory.
+
+#### Configuration Straps / Pin Straps
+
+Externally-exposed pins used to provide early-boot configuration to OpenTitan.
+
+#### TAP
+
+Test Access Port.
+
+#### Tapeout
+
+The process of fabricating a chip.
+
+#### TCB
+
+Trusted Computing Base.
+
+#### TL-UL
+
+TileLink Uncached Lightweight (bus/crossbar).
+
+#### Tock
+
+An embedded operating system implemented in Rust.
+
+#### Top(-level)
+
+A full chip design, including all its components and external connections.
+
+#### TPM
+
+Trusted Platform Module.
+
+#### UART
+
+Universal Asynchronous Receiver-Transmitter.


### PR DESCRIPTION
This PR adds a glossary of terms to the documentation. Resolves https://github.com/lowRISC/opentitan/issues/19437.

Many of these entries only state the expansion of an acronym without defining what it means.

Please feel free to suggest changes to explanations or for new entries.

Future PRs:

- Add short explanations of what acronyms actually mean.
- Link to the glossary from terms used around the documentation.
- Consolidate glossaries found in block-level documentation into this page.