### PR TITLE
[chip,dv] Increase ping timeout

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -60,4 +60,10 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
                                  top_earlgrey_pkg::DioPadSpiHostD0] = '0;
   endtask
 
+  // Wait for cpu fetch enable before primary sequence start
+  // in stub cpu test.
+  virtual task run_common_vseq_wrapper(int num_times = 1);
+    wait(cfg.chip_vif.pwrmgr_cpu_fetch_en == 1);
+    super.run_common_vseq_wrapper(num_times);
+  endtask
 endclass

--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -217,7 +217,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = 256,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,


### PR DESCRIPTION
`pwrmgr_normal_sleep_all_reset_reqs_test.c` shows
spurious ping timeout issues.
Update timeout value to 256 ( recommended by design engineer).