### PR TITLE
[chip,dv] Increase ping timeout

### DIFF
--- a/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_normal_sleep_all_reset_reqs_test.c
@@ -217,7 +217,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = 256,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,


### PR DESCRIPTION
Resubmit #19449 with relevant commit only
pwrmgr_normal_sleep_all_reset_reqs_test.c shows
spurious ping timeout issues.
Update timeout value to 256 ( recommended by design engineer).