### PR TITLE
[bazel] Clean up transition to host platform in sign_bin rule

### DIFF
--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -385,12 +385,11 @@ sign_bin = rv_rule(
             doc = "SPX public key to validate this image",
         ),
         "manifest": attr.label(allow_single_file = True, mandatory = True),
-        # TODO(lowRISC/opentitan:#11199): explore other options to side-step the
-        # need for this transition, in order to build the ROM_EXT signer tool.
-        "platform": attr.string(default = "@local_config_platform//:host"),
         "_tool": attr.label(
             default = "//sw/host/opentitantool:opentitantool",
             allow_single_file = True,
+            executable = True,
+            cfg = "exec",
         ),
     },
 )


### PR DESCRIPTION
The standard way to achieve is to use the `cfg` attribute on labels. Bazel documentation recommands to mark all tool requirements with `executable` which then requires `cfg` to be set to determine whether it should be built for the host or the target and avoid potential toolchain errors.