### PR TITLE
[top_level,tests] Allow two more tests to run with CW310

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -533,10 +533,6 @@ cc_library(
 opentitan_functest(
     name = "clkmgr_external_clk_src_for_sw_fast_test",
     srcs = ["clkmgr_external_clk_src_for_sw_fast_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         tags = [
             "broken",
@@ -1585,10 +1581,6 @@ opentitan_functest(
 opentitan_functest(
     name = "pwrmgr_sleep_disabled_test",
     srcs = ["pwrmgr_sleep_disabled_test.c"],
-    cw310 = cw310_params(
-        # FIXME #12486 [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         tags = ["broken"],
     ),

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -18,6 +18,7 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static const uint32_t kSourcePriority = 1;
 static dif_aon_timer_t aon_timer;
 static dif_rv_plic_t plic;
 
@@ -39,16 +40,7 @@ bool is_pwrmgr_irq_pending(void) {
  */
 void ottf_external_isr(void) {
   dif_rv_plic_irq_id_t irq_id;
-  if (is_pwrmgr_irq_pending()) {
-    interrupt_failed = true;
-    return;
-  }
-
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
-  if (irq_id != kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired) {
-    interrupt_failed = true;
-    return;
-  }
 
   peripheral = (top_earlgrey_plic_peripheral_t)
       top_earlgrey_plic_interrupt_for_peripheral[irq_id];
@@ -66,8 +58,8 @@ void ottf_external_isr(void) {
     return;
   }
 
-  // Complete the IRQ by writing the IRQ source to the Ibex specific CC.
-  // register
+  // Complete the IRQ by writing the IRQ source to the Ibex specific CC
+  // register.
   CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
   interrupt_serviced = true;
   interrupt_failed = false;
@@ -78,13 +70,14 @@ bool test_main(void) {
 
   // Issue a wakeup signal in 200us through the AON timer.
   //
-  // At 200kHz, threshold of 40 is equal to 200us.
-  //
-  // Adjust the threshold for Verilator since it runs on different clock
+  // Adjust the cycles for Verilator since it runs on different clock
   // frequencies.
-  uint32_t wakeup_threshold = 40;
+  uint32_t wakeup_cycles = 0;
+  uint32_t wakeup_time_micros = 200;
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(wakeup_time_micros,
+                                                             &wakeup_cycles));
   if (kDeviceType == kDeviceSimVerilator) {
-    wakeup_threshold *= 10;
+    wakeup_cycles *= 10;
   }
 
   interrupt_serviced = false;
@@ -103,8 +96,6 @@ bool test_main(void) {
   if (UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) == true) {
     LOG_INFO("POR reset");
 
-    CHECK_STATUS_OK(
-        aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold));
     // Enable aon wakeup.
     CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
         &pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceFive,
@@ -117,7 +108,8 @@ bool test_main(void) {
         kDifToggleEnabled));
     LOG_INFO("Enabled aon wakeup interrupt");
     CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
-        &plic, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired, 3));
+        &plic, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
+        kSourcePriority));
     LOG_INFO("Set aon wakeup interrupt priority");
 
     // Enable pwrmgr wakeup interrupt, so it triggers an interrupt even though
@@ -129,11 +121,16 @@ bool test_main(void) {
                                     kPlicTarget, kDifToggleEnabled));
     LOG_INFO("Enabled pwrmgr wakeup interrupt");
     CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
-        &plic, kTopEarlgreyPlicIrqIdPwrmgrAonWakeup, 3));
+        &plic, kTopEarlgreyPlicIrqIdPwrmgrAonWakeup, kSourcePriority));
     LOG_INFO("Set pwrmgr wakeup interrupt priority");
 
     // Prepare for interrupt.
     LOG_INFO("Issue WFI without sleep");
+
+    // Start wakeup timer close enough to the WFI to avoid it happening
+    // too early.
+    CHECK_STATUS_OK(
+        aon_timer_testutils_wakeup_config(&aon_timer, wakeup_cycles));
     irq_global_ctrl(true);
     irq_external_ctrl(true);
     wait_for_interrupt();
@@ -146,10 +143,9 @@ bool test_main(void) {
     CHECK(!is_pwrmgr_irq_pending());
 
     return true;
-
   } else if (UNWRAP(pwrmgr_testutils_is_wakeup_reason(
                  &pwrmgr, kDifPwrmgrWakeupRequestSourceFive)) == true) {
-    LOG_ERROR("Unexpected wakeup reset");
+    LOG_ERROR("Unexpected wakeup request");
     return false;
   }
 


### PR DESCRIPTION
Test clkmgr_external_clk_src_for_sw_fast_test was ready to go. Test pwrmgr_sleep_disabled_test was failing because the wakeup timer was started too early, and probably fired before everything was configured.

//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_fpga_cw310_test_rom (cached) PASSED in 19.5s //sw/device/tests:pwrmgr_sleep_disabled_test_fpga_cw310_test_rom (cached) PASSED in 3.0s