### PR TITLE
[bazel] Do fusesoc builds in the sandbox

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "WORKSPACE",
     "python-requirements.txt",
+    "tool_requirements.py",
 ])
 
 filegroup(

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -111,8 +111,10 @@ filegroup(
         # TODO(lowRISC/opentitan#15882): make Verilator work with foundry repo present.
         exclude = ["foundry/**"],
     ) + [
+        "//:tool_requirements.py",
         "//hw/ip:all_files",
         "//hw/top_earlgrey:all_files",
+        "//util:check_tool_requirements.py",
     ],
     visibility = ["//visibility:public"],
 )

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -76,9 +76,6 @@ def _fusesoc_build_impl(ctx):
         arguments = [args],
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
-        execution_requirements = {
-            "no-sandbox": "",
-        },
         env = ENV,
     )
     return [


### PR DESCRIPTION
Fix up deps and do the fusesoc builds in the sandbox. Since the Python interpreter was switched to the bazel-provided one, it is now possible to use the sandbox. Note that this doesn't make the build *hermetic*, since it still relies on system-provided tools (e.g. vivado, verilator).