### PR TITLE
[opentitanlib] add jtag capability to hyperdebug transport

### DIFF
--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -137,7 +137,11 @@ impl CW310 {
 impl Transport for CW310 {
     fn capabilities(&self) -> Result<Capabilities> {
         Ok(Capabilities::new(
-            Capability::SPI | Capability::GPIO | Capability::UART | Capability::UART_NONBLOCKING,
+            Capability::SPI
+                | Capability::GPIO
+                | Capability::UART
+                | Capability::UART_NONBLOCKING
+                | Capability::JTAG,
         ))
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -475,7 +475,8 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
                 | Capability::SPI
                 | Capability::SPI_DUAL
                 | Capability::SPI_QUAD
-                | Capability::I2C,
+                | Capability::I2C
+                | Capability::JTAG,
         ))
     }
 


### PR DESCRIPTION
This fixes #19467 so JTAG/OpenOCD can be used with hyper310 setup for testing provisioning binaries.