### PR TITLE
Three separate simple commits

### DIFF
--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -51,7 +51,7 @@ clang_format_attrs = {
         doc = "Filename patterns for format checking",
     ),
     "exclude_patterns": attr.string_list(
-        doc = "Filename patterns to exlucde from format checking",
+        doc = "Filename patterns to exclude from format checking",
     ),
     "mode": attr.string(
         default = "diff",

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -266,11 +266,6 @@ dif_result_t dif_clkmgr_enable_measure_counts(const dif_clkmgr_t *clkmgr,
 #undef PICK_COUNT_CTRL_FIELDS
   }
 
-  uint32_t measure_en_reg = 0;
-  measure_en_reg =
-      bitfield_field32_write(measure_en_reg, en_field, kMultiBitBool4True);
-  mmio_region_write32(clkmgr->base_addr, (ptrdiff_t)en_offset, measure_en_reg);
-
   uint32_t measure_ctrl_reg = 0;
   measure_ctrl_reg =
       bitfield_field32_write(measure_ctrl_reg, lo_field, lo_threshold);
@@ -281,6 +276,11 @@ dif_result_t dif_clkmgr_enable_measure_counts(const dif_clkmgr_t *clkmgr,
                       measure_ctrl_reg);
   mmio_region_write32(clkmgr->base_addr, (ptrdiff_t)reg_offset,
                       measure_ctrl_reg);
+
+  uint32_t measure_en_reg = 0;
+  measure_en_reg =
+      bitfield_field32_write(measure_en_reg, en_field, kMultiBitBool4True);
+  mmio_region_write32(clkmgr->base_addr, (ptrdiff_t)en_offset, measure_en_reg);
 
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -399,7 +399,6 @@ TEST_F(MeasureCountTest, Enable) {
 #undef PICK_COUNT_CTRL_FIELDS
     }
     EXPECT_READ32(CLKMGR_MEASURE_CTRL_REGWEN_REG_OFFSET, 1);
-    EXPECT_WRITE32(en_offset, kMultiBitBool4True);
     std::vector<mock_mmio::BitField> thresholds_val = {
         {
             .offset = (uintptr_t)lo_field.index,
@@ -411,6 +410,7 @@ TEST_F(MeasureCountTest, Enable) {
         }};
     EXPECT_WRITE32(reg_offset, thresholds_val);
     EXPECT_WRITE32(reg_offset, thresholds_val);
+    EXPECT_WRITE32(en_offset, kMultiBitBool4True);
     EXPECT_DIF_OK(
         dif_clkmgr_enable_measure_counts(&clkmgr_, clk, lo_val, hi_val));
   }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2552,10 +2552,6 @@ opentitan_functest(
 opentitan_functest(
     name = "ast_clk_outs_test",
     srcs = ["ast_clk_outs_test.c"],
-    cw310 = cw310_params(
-        # FIXME #13611
-        tags = ["broken"],
-    ),
     verilator = verilator_params(
         # FIXME #13611
         timeout = "eternal",


### PR DESCRIPTION
Enables ast_clk_outs_test top_level test.
Fixes dif_clkmgr_enable_measure_counts to enable measurements after setting thresholds.
Fixes a commen typo.