### PR TITLE
[build] Add missing prim_xilinx_ultrascale to bazel deps

### DIFF
--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -28,6 +28,7 @@ filegroup(
         "//hw/ip/prim:all_files",
         "//hw/ip/prim_generic:all_files",
         "//hw/ip/prim_xilinx:all_files",
+        "//hw/ip/prim_xilinx_ultrascale:all_files",
         "//hw/ip/pwm:all_files",
         "//hw/ip/pwrmgr:all_files",
         "//hw/ip/rom_ctrl:all_files",


### PR DESCRIPTION
With the sandbox now enabled for fusesoc runs, the CW340 build was failing. It was missing the Ultrascale prim library in the bazel deps.