### PR TITLE
[dv/formal] Update fomal CSVs with the updated sensor_ctrl path

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_infra.csv
@@ -12,7 +12,7 @@
 #################################
 CONNECTION, AST_PAD0,            u_ast,                      ast2pad_t0_ao,                                       , IOA2,
 CONNECTION, AST_PAD1,            u_ast,                      ast2pad_t1_ao,                                       , IOA3,
-CONNECTION, AST_PINMUX,          u_ast,                      ast2padmux_o,              top_earlgrey.u_sensor_ctrl, ast2pinmux_i,
+CONNECTION, AST_PINMUX,          u_ast,                      ast2padmux_o,              top_earlgrey.u_sensor_ctrl_aon, ast2pinmux_i,
 CONNECTION, PAD_AST,                  ,                      "{AST_MISC, IOC3, IOC2, IOC1, IOB2, IOB1, IOB0, IOA5, IOA4}", u_ast, padmux2ast_i,
 
 #################################

--- a/hw/top_earlgrey/formal/conn_csvs/clkmgr_secure.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/clkmgr_secure.csv
@@ -35,7 +35,7 @@ CONNECTION, CLKMGR_SECURE_CLK_RV_CORE_IBEX_OTP_CLK, top_earlgrey.u_clkmgr_aon, c
 
 CONNECTION, CLKMGR_SECURE_CLK_RV_PLIC_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_secure, top_earlgrey.u_rv_plic, clk_i
 
-CONNECTION, CLKMGR_SECURE_CLK_SENSOR_CTRL_CLK,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_secure, top_earlgrey.u_sensor_ctrl, clk_i
-CONNECTION, CLKMGR_SECURE_CLK_SENSOR_CTRL_AON_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_aon_secure,     top_earlgrey.u_sensor_ctrl, clk_aon_i
+CONNECTION, CLKMGR_SECURE_CLK_SENSOR_CTRL_CLK,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_secure, top_earlgrey.u_sensor_ctrl_aon, clk_i
+CONNECTION, CLKMGR_SECURE_CLK_SENSOR_CTRL_AON_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_aon_secure,     top_earlgrey.u_sensor_ctrl_aon, clk_aon_i
 
 CONNECTION, CLKMGR_SECURE_CLK_SYSRST_CTRL_AON_CLK, top_earlgrey.u_clkmgr_aon, clocks_o.clk_aon_secure,     top_earlgrey.u_sysrst_ctrl_aon, clk_aon_i

--- a/hw/top_earlgrey/formal/conn_csvs/rstmgr_resets_o.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/rstmgr_resets_o.csv
@@ -61,8 +61,8 @@ CONNECTION, RSTMGR_LC_IO_DIV4_AON_PINMUX_RST_NI, top_earlgrey.u_rstmgr_aon, rese
 CONNECTION, RSTMGR_LC_AON_AON_PINMUX_RST_AON_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_aon_n[0], top_earlgrey.u_pinmux_aon, rst_aon_ni
 CONNECTION, RSTMGR_LC_IO_DIV4_AON_AON_TIMER_RST_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_io_div4_n[0], top_earlgrey.u_aon_timer_aon, rst_ni
 CONNECTION, RSTMGR_LC_AON_AON_AON_TIMER_RST_AON_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_aon_n[0], top_earlgrey.u_aon_timer_aon, rst_aon_ni
-CONNECTION, RSTMGR_LC_IO_DIV4_AON_SENSOR_CTRL_RST_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_io_div4_n[0], top_earlgrey.u_sensor_ctrl, rst_ni
-CONNECTION, RSTMGR_LC_AON_AON_SENSOR_CTRL_RST_AON_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_aon_n[0], top_earlgrey.u_sensor_ctrl, rst_aon_ni
+CONNECTION, RSTMGR_LC_IO_DIV4_AON_SENSOR_CTRL_RST_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_io_div4_n[0], top_earlgrey.u_sensor_ctrl_aon, rst_ni
+CONNECTION, RSTMGR_LC_AON_AON_SENSOR_CTRL_RST_AON_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_aon_n[0], top_earlgrey.u_sensor_ctrl_aon, rst_aon_ni
 CONNECTION, RSTMGR_LC_IO_DIV4_AON_SRAM_CTRL_RET_RST_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_io_div4_n[0], top_earlgrey.u_sram_ctrl_ret_aon, rst_ni
 CONNECTION, RSTMGR_LC_IO_DIV4_AON_SRAM_CTRL_RET_RST_OTP_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_io_div4_n[0], top_earlgrey.u_sram_ctrl_ret_aon, rst_otp_ni
 CONNECTION, RSTMGR_LC_D0_FLASH_CTRL_RST_NI, top_earlgrey.u_rstmgr_aon, resets_o.rst_lc_n[1], top_earlgrey.u_flash_ctrl, rst_ni


### PR DESCRIPTION
Hi,

This PR is updating the sensor_ctrl name  with suffix "_aon" in the formal CSVs that weren't updated.

Thanks!