### PR TITLE
[tock] Create a basic tock test 

### DIFF
--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -4,7 +4,7 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//rules:linker.bzl", "ld_library")
-load("//rules:opentitan.bzl", "elf_to_disassembly", "obj_transform")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "elf_to_disassembly", "obj_transform")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -47,10 +47,9 @@ rust_binary(
         #"-Clink-arg=-icf=all",
         #"-Cforce-frame-pointers=no",
     ],
-    # We don't want to build the kernel automatically if matched
-    # by a bazel wildcard because the kernel will not fit in the allocated
-    # space if built in `fastbuild` or `dbg` modes.
-    tags = ["manual"],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because tock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":layout",
         ":nostartfiles",

--- a/sw/device/silicon_owner/tock/tests/BUILD
+++ b/sw/device/silicon_owner/tock/tests/BUILD
@@ -1,0 +1,29 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "kernel",
+    build_setting_default = "downstream",
+    values = [
+        "downstream",
+        "upstream",
+    ],
+)
+
+config_setting(
+    name = "upstream_kernel",
+    flag_values = {":kernel": "upstream"},
+)
+
+alias(
+    name = "test_kernel",
+    actual = select({
+        ":upstream_kernel": "//sw/device/silicon_owner/tock/upstream_kernel:kernel",
+        "//conditions:default": "//sw/device/silicon_owner/tock/kernel",
+    }),
+)

--- a/sw/device/silicon_owner/tock/tests/basic/BUILD
+++ b/sw/device/silicon_owner/tock/tests/basic/BUILD
@@ -1,0 +1,61 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
+load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest")
+load("//sw/device/silicon_owner/tock/tests:defs.bzl", "tock_functest_setup")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "basic",
+    srcs = [
+        "src/basic.rs",
+    ],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because libtock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/silicon_owner/tock/apps:single_app_layout",
+        "@libtock",
+    ],
+)
+
+tock_elf2tab(
+    name = "tab",
+    src = ":basic",
+    arch = "rv32imc",
+)
+
+tock_image(
+    name = "image",
+    app_flash_start = 0x20040000,
+    apps = [":tab"],
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel",
+)
+
+# This macro creates aliases to meet the naming conventions assumed by opentitan_functest.
+tock_functest_setup(
+    name = "image",
+)
+
+opentitan_functest(
+    name = "basic_test",
+    # TODO(tock#3639, opentitan#19479): Tock needs to update the earlgrey chip
+    # config to use the new fpga_cw310 clock frequencies.
+    cw310 = cw310_params(
+        tags = ["broken"],
+    ),
+    ot_flash_binary = ":image",
+    signed = False,
+    targets = [
+        # For now, this only runs on the FPGA.  The verilator target requires
+        # a vmem file, which is currently expected to be created by the rule
+        # supplying the binary.  Since we don't do that yet, the verilator
+        # target is not supported.
+        "cw310_test_rom",
+    ],
+)

--- a/sw/device/silicon_owner/tock/tests/basic/src/basic.rs
+++ b/sw/device/silicon_owner/tock/tests/basic/src/basic.rs
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+#![no_std]
+use core::fmt::Write;
+use libtock::console::Console;
+use libtock::runtime::{set_main, stack_size};
+
+set_main!(main);
+stack_size!(0x200);
+
+fn main() {
+    write!(Console::writer(), "Hello world!\r\n").unwrap();
+    // opentitan_functest's default test harness looks for `PASS` or `FAIL` in
+    // the test output to determine the test result.
+    write!(Console::writer(), "PASS!\r\n").unwrap();
+}

--- a/sw/device/silicon_owner/tock/tests/defs.bzl
+++ b/sw/device/silicon_owner/tock/tests/defs.bzl
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(opentitan#19493): These aliases are required because of a defect in the
+# implementation of the opentitan_functest rule.  Remove them after fixing the
+# opentitan_functest rule.
+def tock_functest_setup(name):
+    native.alias(
+        name = name + "_fpga_cw310",
+        actual = ":" + name,
+    )
+    native.alias(
+        name = name + "_fpga_cw310_bin",
+        actual = ":" + name,
+    )

--- a/sw/device/silicon_owner/tock/upstream_kernel/BUILD
+++ b/sw/device/silicon_owner/tock/upstream_kernel/BUILD
@@ -4,7 +4,7 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//rules:linker.bzl", "ld_library")
-load("//rules:opentitan.bzl", "elf_to_disassembly", "obj_transform")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "elf_to_disassembly", "obj_transform")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -45,10 +45,9 @@ rust_binary(
         #"-Clink-arg=-icf=all",
         #"-Cforce-frame-pointers=no",
     ],
-    # We don't want to build the kernel automatically if matched
-    # by a bazel wildcard because the kernel will not fit in the allocated
-    # space if built in `fastbuild` or `dbg` modes.
-    tags = ["manual"],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because tock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":layout",
         ":nostartfiles",


### PR DESCRIPTION
1. Create a basic test that runs under tock.  Tests that run with the
   default `opentitantool` test harness should emit `PASS` or `FAIL` to
   indicate their status.
2. Create a build setting that can select between the upstream and
   downstream tock kernel.  Defaults to the downstream kernel.
   ```
   bazel test \
       --//sw/device/silicon_owner/tock/tests:kernel=<upstream|downstream> \
       <label-of-the-test>
   ```

This PR depends on #19478.  You need only review the last commit.