### PR TITLE
[rules_rust] update rules_rust to fix patch

### DIFF
--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -95,9 +95,9 @@ def rust_repos(rules_rust = None, safe_ftdi = None, serde_annotate = None):
     http_archive_or_local(
         name = "rules_rust",
         local = rules_rust,
-        sha256 = "3df12ac1fc4377bf9a54753e2d421d7f9f4c6c7345639846d79420319f378156",
-        strip_prefix = "rules_rust-rebase-20230814_01",
-        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/rebase-20230814_01.tar.gz",
+        sha256 = "a5cd81f9ffbe4dfff73767ecc1f5469d17f4f819fd4bc6b482fd775c6b08b11f",
+        strip_prefix = "rules_rust-rebase-20230822_01",
+        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/rebase-20230822_01.tar.gz",
     )
 
     http_archive_or_local(

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -156,6 +156,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rules_foreign_cc//toolchains/... \
     @ninja_1.10.2_linux//... \
     @cmake-3.22.2-linux-x86_64//... \
+    @rustfmt_nightly-2023-07-13__x86_64-unknown-linux-gnu_tools//... \
     @rust_analyzer_1.67.0_tools//... \
     @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//... \
     @rust_linux_x86_64__riscv32imc-unknown-none-elf__nightly_tools//...


### PR DESCRIPTION
We rely on a forked/patched version of rules_rust to enable airgapped builds. Recently, the forked version's patches were updated, but bugs were introduced, causing airgapped builds (i.e. our nightly regressions to fail). This updates the rules_rust version to fix said bugs.