### PR TITLE
[RV_DM]cmderr_not_supported_test

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -360,6 +360,18 @@
       tests: ["rv_dm_cmderr_busy"]
     }
     {
+      name: jtag_dmi_cmderr_not_supported
+      desc: '''
+            Verify that attempt to generate command error result in cmderr field of abstractcs
+            register are set.
+
+            - Try to execute abstract command that is not supported like Quick Access & Access Memory command.
+            - Verify that the cmderr field of abstractcs register is set to 2.
+            '''
+      stage: V1
+      tests: ["rv_dm_cmderr_not_supported"]
+    }
+    {
       name: stress_all
       desc: '''
             A 'bug hunt' test that stresses the DUT to its limits.

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -32,6 +32,7 @@ filesets:
       - seq_lib/rv_dm_sba_tl_access_vseq_lib.sv: {is_include_file: true}
       - seq_lib/rv_dm_tap_fsm_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_cmderr_busy_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_cmderr_not_supported_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_cmderr_not_supported_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_cmderr_not_supported_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  task body();
+    write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(2),.command(32'h10231000));
+    write_chk(.ptr(jtag_dmi_ral.command),.cmderr(2),.command(32'h10231000));
+    write_chk(.ptr(jtag_dmi_ral.abstractauto),.cmderr(2),.command(32'h10231000));
+    write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(2),.command(32'h20231000));
+    write_chk(.ptr(jtag_dmi_ral.command),.cmderr(2),.command(32'h20231000));
+    write_chk(.ptr(jtag_dmi_ral.abstractauto),.cmderr(2),.command(32'h20231000));
+  endtask
+
+endclass : rv_dm_cmderr_not_supported_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "rv_dm_sba_tl_access_vseq_lib.sv"
 `include "rv_dm_tap_fsm_vseq.sv"
 `include "rv_dm_cmderr_busy_vseq.sv"
+`include "rv_dm_cmderr_not_supported_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -185,6 +185,11 @@
       uvm_test_seq: rv_dm_cmderr_busy_vseq
       reseed: 2
     }
+    {
+      name: jtag_dmi_cmderr_not_supported
+      uvm_test_seq: rv_dm_cmderr_not_supported_vseq
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
 This test verify that if try to execute abstract command that is not supported will result in cmderr field of abstractcs register set to 2.