### PR TITLE
[bazel] Rework module ID check aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -132,5 +132,9 @@ build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
 build --@rules_rust//:clippy_flags="-Aclippy::bool_assert_comparison,-Aclippy::uninlined_format_args,-Dwarnings"
 
+# Configure the module ID check.
+build --aspects=rules/quality.bzl%modid_check_aspect
+build --output_groups=+modid_checks
+
 # Import site-specific configuration.
 try-import .bazelrc-site

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,10 +176,6 @@ jobs:
   - bash: ci/scripts/verible-lint.sh fpv
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Verible FPV (Verilog lint)
-  - bash: ci/scripts/check-module-ids.sh
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Check status_t Module IDs (Experimental)
-    continueOnError: True
 
 - job: sw_build
   displayName: Earl Grey SW Build & Test

--- a/sw/device/lib/ujson/example.h
+++ b/sw/device/lib/ujson/example.h
@@ -9,6 +9,8 @@
 extern "C" {
 #endif
 
+#define MODULE_ID MAKE_MODULE_ID('e', 'x', 'j')
+
 // clang-format off
 /////////////////////////////////////////////////////////////////////////////
 // Automatic generation of structs with serialize/deserialize functions:
@@ -104,6 +106,8 @@ C_ONLY(UJSON_SERDE_ENUM(FuzzyBool, fuzzy_bool, ENUM_FUZZY_BOOL, WITH_UNKNOWN));
     field(value, bool) \
     field(status, status_t)
 UJSON_SERDE_STRUCT(Misc, misc_t, STRUCT_MISC);
+
+#undef MODULE_ID
 
 // clang-format on
 


### PR DESCRIPTION
The goal of this PR is to rework the way module ID are checked to save time.

NOTE: the first commit is #19578 which is necessary for CI to pass