### PR TITLE
[manuf] move LC token hash function to separate lib

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -66,14 +66,24 @@ cc_library(
 )
 
 cc_library(
+    name = "util",
+    srcs = ["util.c"],
+    hdrs = ["util.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
     name = "individualize",
     srcs = ["individualize.c"],
-    hdrs = [
-        "individualize.h",
-    ],
+    hdrs = ["individualize.h"],
     deps = [
         ":flash_info_fields",
         ":otp_fields",
+        ":util",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:hash",
@@ -169,6 +179,7 @@ cc_library(
     deps = [
         ":flash_info_fields",
         ":otp_fields",
+        ":util",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:aes",

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/manuf/lib/util.h"
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/hash.h"
+
+status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
+                                             size_t token_size,
+                                             uint64_t *hashed_token) {
+  crypto_const_uint8_buf_t input = {
+      .data = (uint8_t *)raw_token,
+      .len = token_size,
+  };
+  crypto_const_uint8_buf_t function_name_string = {
+      .data = (uint8_t *)"",
+      .len = 0,
+  };
+  crypto_const_uint8_buf_t customization_string = {
+      .data = (uint8_t *)"LC_CTRL",
+      .len = 7,
+  };
+  crypto_uint8_buf_t output = {
+      .data = (uint8_t *)hashed_token,
+      .len = token_size,
+  };
+
+  TRY(otcrypto_xof(input, kXofModeSha3Cshake128, function_name_string,
+                   customization_string, token_size, &output));
+
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/util.h
+++ b/sw/device/silicon_creator/manuf/lib/util.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+
+/**
+ * Hashes a lifecycle transition token to prepare it to be written to OTP.
+ *
+ * According to the Lifecycle Controller's specification:
+ *
+ * "All 128bit lock and unlock tokens are passed through a cryptographic one way
+ * function in hardware before the life cycle controller compares them to the
+ * provisioned values ...", and
+ * "The employed one way function is a 128bit cSHAKE hash with the function name
+ * “” and customization string “LC_CTRL”".
+ *
+ * @param raw_token The raw token to be hashed.
+ * @param token_size The expected hashed token size in bytes.
+ * @param[out] hashed_token The hashed token.
+ * @return Result of the hash operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
+                                             size_t token_size,
+                                             uint64_t *hashed_token);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_


### PR DESCRIPTION
The LC token hashing function is used by multiple libraries, and was duplicated in them. This moves the LC token hashing function to a separate library that can be shared between the two.

Additionally, this will enable sharing said library with the CP provisioning binary.

This depends on #19514, only review the last commit.