### PR TITLE
[SiVal] Test plan updates for keymgr

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -254,6 +254,61 @@
       local: "true"
     },
   ],
+  features: [
+    {
+      name: "KEYMGR.SIDELOAD.KMAC",
+      desc: '''Generation of keys for KMAC. The key is only visible to hardware. This is tracked in
+            KMAC as KMAC.KEY.SIDELOAD.
+            '''
+    }
+    {
+      name: "KEYMGR.SIDELOAD.AES",
+      desc: '''Generation of keys for AES. The key is only visible to hardware.
+            '''
+    }
+    {
+      name: "KEYMGR.SIDELOAD.OTBN",
+      desc: '''Generation of keys for KMAC. The key is only visible to hardware and OTBN code.
+            '''
+    }
+    {
+      name: "KEYMGR.DERIVE.ATTESTATION",
+      desc: '''DICE compliant key derivation. Used to generate attestation keys. Derived keys can
+            be directed to registers exposed to software, or sideloaded to OTBN
+            (KEYMGR.SIDELOAD.OTBN). 256Bit measurements can be provided to the key derivation
+            function using a dedicated set of registers.
+            '''
+    }
+    {
+      name: "KEYMGR.DERIVE.SEALING",
+      desc: '''Derivation of sealing keys. Derived keys can be directed to software registers, or
+            sideloaded to hardware security blocks. 256Bit binding words can be provided to the the
+            key derivation function using a dedicated set of registers.
+            '''
+    }
+    {
+      name: "KEYMGR.GENERATE.OUTPUT",
+      desc: '''Derivation of output keys with additional salt and version. Software provided
+            salt and version values are used as inputs in the key derivation function along with
+            the internal key manager state. The derived keys can be directed to software registers,
+            or sideloaded to hardware security blocks.
+            '''
+    }
+    {
+      name: "KEYMGR.GENERATE.IDENTITY",
+      desc: '''Derivation of output keys to software registers. Unlike KEYMGR.GENERATE.OUTPUT, the
+            key derivation function does not support salt or version inputs.
+            '''
+    }
+    {
+      name: "KEYMGR.KEY_VERSIONING",
+      desc: '''The maximum version value supported by KEYMGR.GENERATE.OUTPUT is configurable via a
+            set of write-lockable registers. KEYMGR.GENERATE.OUTPUT will fail to derive a key with
+            a version greater than the version set in the write lockable register for any given
+            key manager internal state.
+            '''
+    }
+  ]
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -17,6 +17,7 @@
 
     // IP block specific top level test plans.
     "hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson",
   ]
 
@@ -2277,100 +2278,6 @@
       stage: V2
       tests: ["chip_sw_edn_entropy_reqs",
               "chip_sw_csrng_edn_concurrency"]
-    }
-
-    // KEYMGR (pre-verified IP) integration tests:
-    {
-      name: chip_sw_keymgr_key_derivation
-      desc: '''Verify the keymgr advances to all states and generate identity / SW output.
-
-            - In the SW test, write fixed value to OTP for root_key and write creator and owner
-              seeds in flash. And then roboot the chip.
-            - In the SV sequence, backdoor read Device ID and ROM digest through CSRs.
-            - For HardwareRevisionSecret, use the constant values in design.
-            - Configure the keymgr and advance to `CreatorRootKey` and `OwnerIntermediateKey`.
-            - Check keymgr internal keys after advance operations.
-            - Generate identity / SW output for the Sealing CDI.
-               - No need to test the Attestation CDI in chip-level as the only difference is to
-                 use another set of CSR values, and the rest of inputs are the same as the Sealing
-                 CDI.
-            - KMAC should finish hashing successfully (not visible to SW) and return digest to
-              keymgr.
-            - Read keymgr CSRs `SW_SHARE*` and verify the return values.
-            - Advance to `Disabled` and verify keymgr enters the state successfully.
-
-            - For each operation, wait for the interrupt `op_done` to be triggered and check CSR
-              `op_status` is `DONE_SUCCESS`.
-
-            - Note: there are 3 ways of calculating the expected digest for comparison. Any of them
-              is acceptable.
-              - Use SW to calculate that, and it will also exercise the Ibex.
-              - SW sends all the keys through CSRs to KMAC to generate the degist data.
-              - DV calls C functions to generate and backdoor load to a specific memory location
-                for SW. (Adpot this approach.)
-
-            X-ref'ed with kmac test.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_key_derivation", "chip_sw_keymgr_key_derivation_jitter_en"]
-    }
-    {
-      name: chip_sw_keymgr_sideload_kmac
-      desc: '''Verify the keymgr sideload interface to KMAC.
-
-            - Configure the keymgr and advance to the `OwnerIntKey` state.
-            - Request keymgr to generate hw key for KMAC sideload key slot.
-            - Request KMAC operation with sideload key configuration.
-            - Verify the digest for correctness (should match the DV-side result).
-            - Clear keymer's KMAC sideload key slot.
-            - Request KMAC operation with sideload key configuration.
-            - Verify the digest value has changed.
-            - Request keymgr to derive the same key for the KMAC sideload key slot.
-            - Request KMAC operation with sideload key configuration.
-            - Verify the digest for correctness (should match the DV-side result again).
-
-            X-ref'ed with chip_kmac_app_keymgr test.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_sideload_kmac"]
-    }
-    {
-      name: chip_sw_keymgr_sideload_aes
-      desc: '''Verify the keymgr sideload interface to AES.
-
-               Same as `chip_keymgr_sideload_kmac`, except, sideload to AES.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_sideload_aes"]
-    }
-    {
-      name: chip_sw_keymgr_sideload_otbn
-      desc: '''Verify the keymgr sideload interface to OTBN.
-
-               Load OTBN binary image, the rest is similar to `chip_keymgr_sideload_kmac`, except
-               sideloading to otbn.
-
-               Clear the sideload key once done.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_sideload_otbn"]
-    }
-    {
-      name: chip_sw_keymgr_sideload_kmac_error
-      desc: '''
-            Verify the effect of KMAC returning an error during a keymgr operation.
-
-            - Configure keymgr to enter any of the 3 working states.
-            - Issue a keymgr operation.
-            - While the KMAC is actively computing the digest, glitch the KMAC app sparse FSM to
-              trigger a fault.
-            - Verify that KMAC returns an error signal to the keymgr via checking keymgr CSRs, when
-              the operation is done:
-              - Check `op_status` is set to `DONE_ERROR`.
-              - Check `fault_status.kmac_done` is set to 1.
-            '''
-      stage: V3
-      tests: []
     }
 
     // OTBN (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -1,0 +1,189 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_kmac
+  testpoints: [
+    // KEYMGR integration tests
+    {
+      name: chip_sw_keymgr_key_derivation
+      desc: '''Verify the keymgr advances to all states and generate identity / SW output.
+
+            - In the SW test, write fixed value to OTP for root_key and write creator and owner
+              seeds in flash. And then roboot the chip.
+            - In the SV sequence, backdoor read Device ID and ROM digest through CSRs.
+            - For HardwareRevisionSecret, use the constant values in design.
+            - Configure the keymgr and advance to `CreatorRootKey` and `OwnerIntermediateKey`.
+            - Check keymgr internal keys after advance operations.
+            - Generate identity / SW output for the Sealing CDI.
+               - No need to test the Attestation CDI in chip-level as the only difference is to
+                 use another set of CSR values, and the rest of inputs are the same as the Sealing
+                 CDI.
+            - KMAC should finish hashing successfully (not visible to SW) and return digest to
+              keymgr.
+            - Read keymgr CSRs `SW_SHARE*` and verify the return values.
+            - Advance to `Disabled` and verify keymgr enters the state successfully.
+
+            - For each operation, wait for the interrupt `op_done` to be triggered and check CSR
+              `op_status` is `DONE_SUCCESS`.
+
+            - Note: there are 3 ways of calculating the expected digest for comparison. Any of them
+              is acceptable.
+              - Use SW to calculate that, and it will also exercise the Ibex.
+              - SW sends all the keys through CSRs to KMAC to generate the degist data.
+              - DV calls C functions to generate and backdoor load to a specific memory location
+                for SW. (Adpot this approach.)
+
+            X-ref'ed with kmac test.
+            '''
+      stage: V2
+      tests: [
+        "chip_sw_keymgr_key_derivation",
+        "chip_sw_keymgr_key_derivation_jitter_en",
+      ]
+    }
+    {
+      name: chip_sw_keymgr_sideload_kmac_error
+      desc: '''
+            Verify the effect of KMAC returning an error during a keymgr operation.
+
+            - Configure keymgr to enter any of the 3 working states.
+            - Issue a keymgr operation.
+            - While the KMAC is actively computing the digest, glitch the KMAC app sparse FSM to
+              trigger a fault.
+            - Verify that KMAC returns an error signal to the keymgr via checking keymgr CSRs, when
+              the operation is done:
+              - Check `op_status` is set to `DONE_ERROR`.
+              - Check `fault_status.kmac_done` is set to 1.
+            '''
+      stage: V3
+      tests: []
+    }
+    {
+      name: chip_sw_keymgr_sideload_kmac
+      desc: '''Verify the keymgr sideload interface to KMAC.
+
+            - Configure the keymgr and advance to the `OwnerIntKey` state.
+            - Request keymgr to generate hw key for KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - Verify the digest for correctness (should match the DV-side result).
+            - Clear keymgr's KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - Verify the digest value has changed.
+            - Request keymgr to derive the same key for the KMAC sideload key slot.
+            - Request KMAC operation with sideload key configuration.
+            - In simulation environments, verify the digest for correctness (should match the
+              DV-side result again).
+
+            Notes for silicon targets:
+
+            - The device needs to be personalized before the test can be executed. See
+              `manuf_ft_provision_rma_token_and_personalization` for more details.
+            - Sideload is expected to work in the following keymgr states: `CreatorRootKey`,
+              `OwnerIntKey` and `OwnerKey`. The test program should try to cover as many states
+              as possible give the initial device state.
+            - Key derivations must be reproducible across boot cycles during regular operating
+              conditions.
+
+            X-ref'ed with chip_kmac_app_keymgr test.
+
+            For SV2 X-ref'ed with chip_sw_kmac_kmac_key_sideload.
+            '''
+      features: ["KEYMGR.SIDELOAD.KMAC"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_keymgr_sideload_kmac"]
+      bazel: []
+    }
+    {
+      name: chip_sw_keymgr_sideload_aes
+      desc: '''Verify the keymgr sideload interface to AES.
+
+               Same as `chip_keymgr_sideload_kmac`, except, sideload to AES.
+            '''
+      features: ["KEYMGR.SIDELOAD.AES"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_keymgr_sideload_aes"]
+      bazel: []
+    }
+    {
+      name: chip_sw_keymgr_sideload_otbn
+      desc: '''Verify the keymgr sideload interface to OTBN.
+
+               Load OTBN binary image, the rest is similar to `chip_keymgr_sideload_kmac`, except
+               sideloading to otbn.
+
+               Clear the sideload key once done.
+            '''
+      features: ["KEYMGR.SIDELOAD.OTBN"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_keymgr_sideload_otbn"]
+      bazel: []
+    }
+    {
+      name: chip_sw_keymgr_derive_attestation
+      desc: '''Verify the Attestation CDI.
+
+            - For each keymgr operational state: `CreatorRootKey`, `OwnerIntKey` and `OwnerKey`:
+              - Generate identity SW output for the Attestation CDI.
+              - Generate SW output for the Attestation CDI.
+              - Generate OTBN sideload output for the Attestation CDI.
+            - Ensure that the key output changes after calculating the previous steps after a
+              keymgr advance operation.
+            - The keymgr shall be able to reproduce the same keys for a give device configuration
+              and known set of inputs.
+            - The softwre binding registers must be locked after configuration until a keymgr
+              advance operation.
+
+            Notes:
+
+            - The device initial state needs to be equivalent to the end state of the
+              `manuf_ft_provision_rma_token_and_personalization` testpoint, otherwise they keymgr
+              will fail to advance into operational states.
+            - Ensure the entropy complex is running in continuous mode, and that KMAC is configured
+              to extract entropy from EDN.
+            - The test should check for any error or fault code status, to ensure all operations
+              executed successfully.
+            '''
+            features: [
+              "KEYMGR.DERIVE.ATTESTATION",
+              "KEYMGR.GENERATE.OUTPUT",
+              "KEYMGR.GENERATE.IDENTITY",
+            ]
+            stage: V3
+            si_stage: SV2
+            lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+            tests: []
+            bazel: []
+    }
+    {
+      name: chip_sw_keymgr_derive_sealing
+      desc: '''Verify the Sealing CDI.
+
+            Same as `chip_sw_keymgr_derive_attestation`, except using Sealing CDI outputs.
+
+            To test key versioning:
+
+            - Configure the max version register for each keymgr operational state.
+            - Test a valid and an invalid key version when generating SW and sideload keys.
+
+            '''
+            features: [
+              "KEYMGR.DERIVE.SEALING",
+              "KEYMGR.GENERATE.OUTPUT",
+              "KEYMGR.GENERATE.IDENTITY",
+              "KEYMGR.KEY_VERSIONING",
+            ]
+            stage: V3
+            si_stage: SV2
+            lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+            tests: []
+            bazel: []
+    }
+  ]
+}


### PR DESCRIPTION
1. Added list of features to keymgr specification.
2. Moved keymgr chip tests to chip_keymgr_testplan.hjson.
3. Added `si_stage: SV*` test cases to cover functionality enumerated in the list of features.
4. Updated the pre-silicon test cases with relevant `SV1`, `SV2`, or `SV3` labels.