### PR TITLE
[manuf] Fix JTAG problems in manufacturing tests 

### DIFF
--- a/sw/host/tests/manuf/cp_provision_init/src/main.rs
+++ b/sw/host/tests/manuf/cp_provision_init/src/main.rs
@@ -61,6 +61,8 @@ fn unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let token = DifLcCtrlToken::from(lc_raw_unlock_token::RND_CNST_RAW_UNLOCK_TOKEN.to_le_bytes());
     let token_words = token.into_register_values();
 
+    // ROM execution is not enabled in the OTP so we can safely reconnect to the LC TAP after
+    // the transition without risking the chip to be reset.
     trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -68,6 +70,7 @@ fn unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         Some(token_words),
         true,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap),
     )
     .context("failed to transition to TEST_UNLOCKED0")?;
 

--- a/sw/host/tests/manuf/manuf_cp_test_lock/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_test_lock/src/main.rs
@@ -93,6 +93,9 @@ fn test_lock(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> {
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     assert_eq!(state, DifLcCtrlState::TestUnlocked0.redundant_encoding());
 
+    // CPU execution is not enabled in the `TEST_LOCKED0` state so we can
+    // safely reconnect to the LC TAP after the transition without risking
+    // the chip to be resetting.
     lc_transition::trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -100,6 +103,7 @@ fn test_lock(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> {
         None,
         true,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap),
     )
     .context("failed to trigger transition to TEST_LOCKED0")?;
 
@@ -121,6 +125,8 @@ fn test_unlock(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> 
     let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     assert_eq!(state, DifLcCtrlState::TestLocked0.redundant_encoding());
 
+    // ROM execution is not enabled in the OTP so we can safely reconnect to the LC TAP after
+    // the transition without risking the chip resetting.
     lc_transition::trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -128,6 +134,7 @@ fn test_unlock(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> 
         Some(TEST_UNLOCK_TOKEN_PREIMAGE),
         true,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap),
     )
     .context("failed to trigger transition to TEST_UNLOCKED1")?;
 

--- a/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
@@ -42,6 +42,8 @@ fn manuf_cp_unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
     let token = DifLcCtrlToken::from(lc_raw_unlock_token::RND_CNST_RAW_UNLOCK_TOKEN.to_le_bytes());
     let token_words = token.into_register_values();
 
+    // ROM execution is not enabled in the OTP so we can safely reconnect to the LC TAP after
+    // the transition without risking the chip resetting.
     lc_transition::trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -49,6 +51,7 @@ fn manuf_cp_unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
         Some(token_words),
         true,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap)
     )
     .context("failed to transition to TEST_UNLOCKED0")?;
 

--- a/sw/host/tests/manuf/manuf_scrap/src/main.rs
+++ b/sw/host/tests/manuf/manuf_scrap/src/main.rs
@@ -40,6 +40,8 @@ fn manuf_scrap(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         "Invalid initial LC state.",
     );
 
+    // CPU execution is disabled in the SCRAP state so we can safely reconnect
+    // to the LC TAP after the transition without risking the chip resetting.
     trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -47,6 +49,7 @@ fn manuf_scrap(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         None,
         /*use_external_clk=*/ false,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap),
     )?;
 
     // Check the LC state is SCRAP.

--- a/sw/host/tests/manuf/personalize/src/main.rs
+++ b/sw/host/tests/manuf/personalize/src/main.rs
@@ -116,6 +116,8 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
     );
 
     // Issue an LC transition to RMA to verify unlock token.
+    // The device program will spin when it detects the RMA state so we can safely
+    // reconnect to the LC TAP after the transition without risking the chip resetting.
     trigger_lc_transition(
         transport,
         jtag.clone(),
@@ -123,6 +125,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
         Some(rma_unlock_token),
         /*use_external_clk=*/ false,
         opts.init.bootstrap.options.reset_delay,
+        Some(JtagTap::LcTap),
     )?;
 
     // Check the LC state is RMA.


### PR DESCRIPTION
See #19086

Several manufacturing tests suffer from random JTAG issues because
they try to connect over JTAG while the device is rebooting in a
loop. Since a chip reset kills the JTAG, it can make the test fail
when a reboot occurs during the JTAG session. This is particular
problematic for the trigger_lc_transition() function that performs
an LC transition, a reboot and attempts to connect over JTAG: it
can happen that the initial LC state has CPU execution disabled
but that the target test has execution enabled. When this happens,
and unless a program was bootstrapped that can prevent a reboot
loop, connecting over JTAG is unsafe.

This commit solves this issue by
- make trigger_lc_transition() only optionally reconnect over JTAG,
- carefully documenting for each trigger_lc_transition() usage
  what the execution situation is after the transition,
- fix the problematic ones.

There are two problematic tests:
- manuf_cp_device_info_flash_wr gets into a reboot loop after the
  transition: since the host already bootstraps a program that
  check that the transition was successful, simply remove the JTAG
  based test to avoid the program.
- personalize_functest: the device program go into a reboot loop
  after personalizing the device and can cause the JTAG connection
  to break during the entire LC transition (it's unsafe even before
  the transition). Fix this by adding a loop in the device code after
  personalizing to wait for the transition, and after the transition
  when the RMA state is detected.