### PR TITLE
[rom_e2e] change `asm_watchdog_bite` test timeout threshold

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -60,6 +60,7 @@ impl InitializeTest {
             env_logger::Builder::from_default_env()
                 .format_target(true)
                 .format_module_path(false)
+                .format_timestamp_millis()
                 .filter(None, level)
                 .init();
         }


### PR DESCRIPTION
The current threshold (1 second) causes rare failure in CI. Increase it to 2 seconds in this test to reduce flakiness.

The opentitanlib log is changed to print milliseconds instead of just seconds to aid future debugging.