### PR TITLE
[opentitantool] Add OK printing to opentitantool console

### DIFF
--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -27,6 +27,13 @@ pub struct Console {
     #[arg(short, long, help = "Do not print console start end exit messages.")]
     quiet: bool,
 
+    #[arg(
+        short,
+        long,
+        help = "String to print upon successful startup.  Useful when called from scripts, that want to collect and propagate any startup error messages, and need to know for how long to wait."
+    )]
+    stderr_handshake: Option<String>,
+
     #[arg(short, long, help = "Log console output to a file")]
     logfile: Option<String>,
 
@@ -106,6 +113,11 @@ impl CommandDispatch for Console {
             if let Some(send) = self.send.as_ref() {
                 log::info!("Sending: {:?}", send);
                 uart.write(send.as_bytes())?;
+            }
+            if let Some(handshake) = &self.stderr_handshake {
+                // Inform caller that we have reached the event loop without hitting any fatal
+                // errors.
+                eprintln!("{}", handshake);
             }
             console.interact(&*uart, Some(&mut stdin), Some(&mut stdout))?
         };


### PR DESCRIPTION
The automated test systems used at Google will routinely start `opentitantool console -q` as a sub-process to pipe data back and forth.  When such a sub-process is started, it would be ideal that the parent could wait long enough to be able to "see" error output such as "could not open /dev/ttyUSB6: permission denied", or any other error that happens in the setup phase.

This CL introduces an optional command line flag, allowing the parent to request that `opentitantool console` outputs a message amounting to "setup success, entering main loop" on standard error. This allows the parent to wait, collecting error output from the `opentitantool console` subprocess, until either the stream terminates (and the sub-process exits with an error), or the parent sees the new "OK" message, at which point it can start processing the actual data through standard input/output of the sub-process.