### PR TITLE
[dv_macros] Fix `disable fork` in `DV_SPINWAIT_EXIT`

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -372,18 +372,24 @@
 `define DV_SPINWAIT_EXIT(WAIT_, EXIT_, MSG_ = "exit condition occurred!", ID_ =`gfn) \
   begin \
     fork begin \
+      bit exit_completed_ = 0; \
+      bit wait_completed_ = 0; \
       fork \
         begin \
           WAIT_ \
+          wait_completed_ = 1; \
         end \
         begin \
           EXIT_ \
-          if (MSG_ != "") begin \
+          if (!wait_completed_ && MSG_ != "") begin \
             `dv_info(MSG_, uvm_pkg::UVM_HIGH, ID_) \
           end \
+          exit_completed_ = 1; \
         end \
       join_any \
-      disable fork; \
+      if (exit_completed_) begin \
+        disable fork; \
+      end \
     end join \
   end
 `endif


### PR DESCRIPTION
Prior to this commit, `DV_SPINWAIT_EXIT` would always execute `disable fork` when either the Wait or the Exit thread completed.  `disable fork` terminates all threads that were started by the same thread as the one that executes the `disable fork`.  When the Exit thread completes, this is the intended behavior.  Also, when the Wait thread completes, it should terminate the Exit thread.  However, when the Wait thread completes, it would also terminate any background threads (`join_none`) it created.  This is counter-intuitive and most likely unintended, and users of `DV_SPINWAIT_EXIT` can do nothing to prevent it.

This commit changes `DV_SPINWAIT_EXIT` so that `disable fork` only gets executed if the Exit thread completes before the Wait thread. Additionally, this commit only lets the Exit message get printed if the Exit thread completes before the Wait thread (now relevant as the Exit thread no longer gets killed when the Wait thread completes).  The Exit thread usually consists of a single wait statement, so not killing it should have only a negligible performance impact.