### PR TITLE
[site] Tweak site nav experience

### DIFF
--- a/site/book-theme/css/chrome.css
+++ b/site/book-theme/css/chrome.css
@@ -176,7 +176,7 @@ a > .hljs {
 }
 
 .nav-wrapper {
-    margin-top: 50px;
+    margin: 50px 0 var(--page-padding) 0;
     display: none;
 }
 
@@ -186,7 +186,7 @@ a > .hljs {
     text-decoration: none;
     width: 90px;
     border-radius: 5px;
-    background-color: var(--sidebar-bg);
+    background-color: var(--theme-hover);
 }
 
 .previous {
@@ -203,7 +203,7 @@ a > .hljs {
     .nav-wrapper { display: block; }
 }
 
-@media only screen and (max-width: 1380px) {
+@media only screen and (max-width: 1720px) {
     .sidebar-visible .nav-wide-wrapper { display: none; }
     .sidebar-visible .nav-wrapper { display: block; }
 }

--- a/site/book-theme/css/general.css
+++ b/site/book-theme/css/general.css
@@ -124,6 +124,7 @@ h6:target::before {
 .content {
     overflow-y: auto;
     padding: 0 5px 50px 5px;
+    margin: 0 calc(var(--page-padding));
 }
 .content main {
     max-width: var(--content-max-width);

--- a/site/book-theme/index.hbs
+++ b/site/book-theme/index.hbs
@@ -108,7 +108,7 @@
         <!-- Hide / unhide sidebar before it is displayed -->
         <script>
             var html = document.querySelector('html');
-            var sidebar = 'hidden';
+            var sidebar = 'visible';
             if (document.body.clientWidth >= 1080) {
                 try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';

--- a/site/book-theme/pagetoc.css
+++ b/site/book-theme/pagetoc.css
@@ -14,7 +14,7 @@
 @media only screen and (min-width:1440px) {
     .sidetoc {
         position: sticky;
-        margin: 0 calc(var(--page-padding) + 15px);
+        margin: 0 calc(var(--page-padding) + 15px) 0 0;
         width: calc(40% - 15vw + 100px);
         max-width: 400px;
         top: calc(var(--menu-bar-height) + 8rem);


### PR DESCRIPTION
Some minor tweaks to the mdbook style to address recent feedback.

1) Make the side fwd/back nav buttons only appear when the window is wider, preventing them from overlapping content on the page.
2) Tweak the background colour of the bottom-of-the-page fwd/back nav buttons to make them more visible.
3) Change the default state of the left-side navigation menu to be visible, to improve the new user experience.

I would appreciate a couple of people building the site locally to verify the changes look okay. Thanks