### PR TITLE
[opentitantool] Allow sending arbitrary commands to transport

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -29,7 +29,8 @@ use crate::transport::chip_whisperer::ChipWhisperer;
 use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
 use crate::transport::common::uart::{flock_serial, SerialPortExclusiveLock, SerialPortUart};
 use crate::transport::{
-    Capabilities, Capability, Transport, TransportError, TransportInterfaceType, UpdateFirmware,
+    Capabilities, Capability, Transport, TransportCommand, TransportCommandTextResponse,
+    TransportError, TransportInterfaceType, UpdateFirmware,
 };
 use crate::util::openocd::OpenOcdServer;
 use crate::util::usb::UsbBackend;
@@ -396,7 +397,7 @@ impl Inner {
             .ok_or(TransportError::UnicodePathError)?;
         let _lock = SerialPortExclusiveLock::lock(port_name)?;
         let mut port = TTYPort::open(
-            &serialport::new(port_name, 115_200).timeout(std::time::Duration::from_millis(100)),
+            &serialport::new(port_name, 115_200).timeout(std::time::Duration::from_millis(1000)),
         )
         .context("Failed to open HyperDebug console")?;
         flock_serial(&port, port_name)?;
@@ -579,6 +580,13 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
             T::load_bitstream(self, fpga_program).map(|_| None)
         } else if let Some(clear) = action.downcast_ref::<ClearBitstream>() {
             T::clear_bitstream(clear).map(|_| None)
+        } else if let Some(cmd) = action.downcast_ref::<TransportCommand>() {
+            let mut lines = vec![];
+            self.inner
+                .execute_command(cmd.command.join(" ").as_str(), |line| {
+                    lines.push(line.to_string());
+                })?;
+            Ok(Some(Box::new(TransportCommandTextResponse { lines })))
         } else {
             Err(TransportError::UnsupportedOperation.into())
         }

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -202,6 +202,18 @@ pub struct UpdateFirmware<'a> {
     pub force: bool,
 }
 
+/// Command for Transport::dispatch().  Runs arbitrary command, interpretation completely depends
+/// on backend transport.
+pub struct TransportCommand {
+    pub command: Vec<String>,
+}
+
+/// Textual response to `TransportCommand`, as received from the transport (e.g. HyperDebug).
+#[derive(serde::Serialize)]
+pub struct TransportCommandTextResponse {
+    pub lines: Vec<String>,
+}
+
 /// An `EmptyTransport` provides no communications backend.
 pub struct EmptyTransport;
 

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::{StagedProgressBar, TransportWrapper};
 use opentitanlib::transport::verilator::transport::Watch;
-use opentitanlib::transport::UpdateFirmware;
+use opentitanlib::transport::{self, UpdateFirmware};
 
 /// Initialize state of a transport debugger device to fit the device under test.  This
 /// typically involves setting pins as input/output, open drain, etc. according to configuration
@@ -143,6 +143,32 @@ impl CommandDispatch for TransportQueryAll {
     }
 }
 
+/// Transmit an arbitrary textual command to the debugger/transport.  Interpretation depends
+/// entirely on the transport driver.  The HyperDebug driver for instance passes the command to be
+/// interpreted by the microcontroller on the HyperDebug board.  A list of output lines will be
+/// returned.
+#[derive(Debug, Args)]
+pub struct TransportCmd {
+    #[arg(
+        name = "CMD",
+        help = "Command to be sent verbatim to transport (e.g. HyperDebug)"
+    )]
+    pub cmd: Vec<String>,
+}
+
+impl CommandDispatch for TransportCmd {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        let operation = transport::TransportCommand {
+            command: self.cmd.clone(),
+        };
+        transport.dispatch(&operation)
+    }
+}
+
 /// Commands for interacting with the transport debugger device itself.
 #[derive(Debug, Subcommand, CommandDispatch)]
 pub enum TransportCommand {
@@ -151,4 +177,5 @@ pub enum TransportCommand {
     UpdateFirmware(TransportUpdateFirmware),
     Query(TransportQuery),
     QueryAll(TransportQueryAll),
+    Cmd(TransportCmd),
 }


### PR DESCRIPTION
Add a generic way of sending arbitrary string-based commands to be interpreted by the backend transport driver.  The HyperDebug driver passes these commands to evaluate on the HyperDebug debugger microcontroller, allowing access to nonstandard or debugging features through opentitantool.