### PR TITLE
[opentitantool] Workaround for HyperDebug quirk

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -35,8 +35,9 @@ impl_serializable_error!(BootstrapError);
 /// `BootstrapProtocol` describes the supported types of bootstrap.
 /// The `Primitive` SPI protocol is used by OpenTitan during development.
 /// The `Legacy` SPI protocol is used by previous generations of Google Titan-class chips.
+/// The `LegacyRescue` UART protocol is used by previous generations of Google Titan-class chips.
 /// The `Eeprom` SPI protocol is planned to be implemented for OpenTitan.
-/// The `Rescue` UART protocol is used by Google Ti50 firmware.
+/// The `Rescue` value is a deprecated alias for `LegacyRescue`.
 /// The 'Emulator' value indicates that this tool has a direct way
 /// of communicating with the OpenTitan emulator, to replace the
 /// contents of the emulated flash storage.
@@ -44,6 +45,7 @@ impl_serializable_error!(BootstrapError);
 pub enum BootstrapProtocol {
     Primitive,
     Legacy,
+    LegacyRescue,
     Eeprom,
     Rescue,
     Emulator,
@@ -152,6 +154,7 @@ impl<'a> Bootstrap<'a> {
         let updater: Box<dyn UpdateProtocol> = match options.protocol {
             BootstrapProtocol::Primitive => Box::new(primitive::Primitive::new(options)),
             BootstrapProtocol::Legacy => Box::new(legacy::Legacy::new(options)),
+            BootstrapProtocol::LegacyRescue => Box::new(rescue::Rescue::new(options)),
             BootstrapProtocol::Rescue => Box::new(rescue::Rescue::new(options)),
             BootstrapProtocol::Eeprom => Box::new(eeprom::Eeprom::new()),
             BootstrapProtocol::Emulator => {

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -260,7 +260,7 @@ impl Rescue {
             eprint!("Resetting...");
             container.reset_pin.write(false)?; // Low active
             uart.write(&[3])?; // Send a character to ensure that HyperDebug UART->USB
-                               // forwarding has "woken up", see b/298075416.
+                               // forwarding has "woken up", see issue #19564.
             self.flush_rx(uart, container.reset_delay);
             container.reset_pin.write(true)?; // Release reset
 

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -111,9 +111,9 @@ impl Frame {
 
         // Round up to multiple of 128 bytes, this is to ensure that the bootloader flushes the
         // last data transmitted, even in the absense of the "EOF" flag.  The reason we do not
-        // send that flag is that it causes immediate boot into the code just programmed, and we
-        // want to allow the user to use --leave_in_reset to control exactly when the newly
-        // programmed code should first run.
+        // send that flag is that doing so would cause an immediate boot into the code just
+        // programmed, and we want to allow the user to use --leave_in_reset to control exactly
+        // when the newly programmed code should first run.
         let max_addr = (max_addr + Self::FLASH_BUFFER_SIZE - 1) & !Self::FLASH_BUFFER_MASK;
 
         let mut frames = Vec::new();
@@ -125,7 +125,7 @@ impl Frame {
                 + payload[addr..]
                     .chunks(4)
                     .position(|c| c != [0xff; 4])
-                    .unwrap()
+                    .unwrap_or(0)
                     * 4;
             let skip_addr = nonempty_addr & !Self::FLASH_SECTOR_MASK;
             if skip_addr > addr && (addr == 0 || addr & Self::FLASH_BUFFER_MASK != 0) {


### PR DESCRIPTION
HyperDebug forwarding of UART data via USB suffers from a condition, that right out of reset it may be that HyperDebug does not forward any UART data until it has received at least one character from USB to be forwarded to the UART.  See issue #19564.
    
This is not normally an issue for interactive consoles, as the operator would hit enter to see if a prompt appears, or simply start typing a command.

In rare occasions, where one wants to wait for output coming out of the USB link before "typing" anything, the flaw can cause issues, as it did for the legacy serial rescue protocol.

This CL adds a little workaround, by sending a single ^C character into the USB->UART link, while the GSC is held under reset, just to wake up HyperDebug forwarding.

Also, this PR has a tiny bugfix for a panic condition in the legacy rescue protocol.
