### PR TITLE
[flash_ctrl,dv] update path for block tb enable_small_rma

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -412,7 +412,7 @@ class flash_ctrl_scoreboard #(
   // Update scb_flash_* with bank erase command.
   // If data partition is selected, erase data partition only,
   // otherwise all partitions in the bank will be erased.
-  function void erase_bank(int bank, bit part_sel);
+  virtual function void erase_bank(int bank, bit part_sel);
     uint partition_words_num;
     data_model_t scb_flash_model;
     flash_mem_addr_attrs addr_attr;
@@ -504,6 +504,9 @@ class flash_ctrl_scoreboard #(
     endcase
   endfunction
 
+  // In opensource, `sel` is always 0.
+  // When `sel` is 1, which indicates bank erase,
+  // task `erase_bank` is called.
   virtual function void erase_data(flash_dv_part_e part, addr_t addr, bit sel);
     case (part)
       FlashPartData: begin

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -77,6 +77,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   bit use_vendor_flash = 0;
   string vendor_flash_path = "";  // Use to indicate a vendor flash hierarchical path.
   bit exclude_info2 = 0;
+  // Used for expected_alert["fatal_err"].max_delay
+  // Vendor can use larger value
+  int long_fatal_err_delay = 2000;
 
   uint op_erase_type_bank_pc;
   uint op_prog_type_repair_pc;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -1120,7 +1120,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   // Before rma wipe for data partition started (256 pages),
   // this task force total page to 9 pages. So rma process is completed faster.
   virtual task enable_small_rma();
-    string path = "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if";
+    string path = "tb.dut.u_flash_hw_if";
     string mypath;
     logic [2:0] rma_wipe_idx;
     logic [3:0] rma_ack;
@@ -1135,9 +1135,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       "waiting for rma index = 3", 50_000_000
     )
 
-    // Reduce page size to 'd9
+    // Reduce page size to 'd2
     mypath = {path, ".end_page"};
-    `DV_CHECK(uvm_hdl_force(mypath, 'h9));
+    `DV_CHECK(uvm_hdl_force(mypath, 'h2));
 
     // Wait for rma complete
     mypath = {path, ".rma_ack_q"};
@@ -1146,7 +1146,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         @(cfg.clk_rst_vif.cb);
         uvm_hdl_read(mypath, rma_ack);
       end while (rma_ack != lc_ctrl_pkg::On);,
-      "waiting for rma ack == On", 50_000_000
+      "waiting for rma ack == On", 100_000_000
     )
     mypath = {path, ".end_page"};
     `DV_CHECK(uvm_hdl_release(mypath));

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -833,7 +833,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.ecc_mode > FlashSerrTestMode) begin
         if (derr & cfg.scb_h.do_alert_check) begin
           cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-          cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
+          cfg.scb_h.expected_alert["fatal_err"].max_delay = cfg.seq_cfg.long_fatal_err_delay;
           cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
         end
       end


### PR DESCRIPTION
- Enable_small_rma had chip level path by mistake.
- Correct the path for block tb.
- Reduce data page size to 3.
- Increase wait ack timeout
- Increase expected alert max_delay : flash_ctrl_derr_detect