### PR TITLE
[crypto] Connect CSRNG to the cryptolib API.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -34,6 +34,7 @@ cc_library(
     hdrs = ["//sw/device/lib/crypto/include:drbg.h"],
     deps = [
         ":status",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )
@@ -45,6 +46,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":keyblob",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/impl/ecc:ecdh_p256",
         "//sw/device/lib/crypto/impl/ecc:ecdsa_p256",
@@ -129,6 +131,7 @@ cc_library(
         ":integrity",
         ":status",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl/rsa:rsa_keygen",
         "//sw/device/lib/crypto/impl/rsa:rsa_signature",
         "//sw/device/lib/crypto/include:datatypes",

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -4,39 +4,183 @@
 
 #include "sw/device/lib/crypto/include/drbg.h"
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('r', 'b', 'g')
 
-crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t nonce,
-                                          crypto_uint8_buf_t perso_string) {
-  // TODO: Connect entropy driver to API.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+/**
+ * Construct seed material for the CSRNG.
+ *
+ * Returns `OTCRYPTO_BAD_ARGS` if the provided value is longer than the entropy
+ * complex can absorb. If the value is shorter, it will be padded with zeroes.
+ *
+ * This operation is not constant-time relative to `value.len`.
+ *
+ * @param value Seed data.
+ * @param[out] seed_material Resulting entropy complex seed.
+ * @return OK or error.
+ */
+static crypto_status_t seed_material_construct(
+    crypto_uint8_buf_t value, entropy_seed_material_t *seed_material) {
+  if (value.len > kEntropySeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  size_t nwords = (value.len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  seed_material->len = nwords;
+
+  // Initialize the set words to zero.
+  memset(seed_material->data, 0, nwords * sizeof(uint32_t));
+
+  if (value.len == 0) {
+    return OTCRYPTO_OK;
+  }
+
+  // Copy seed data.
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(seed_material->data, value.data, value.len);
+
+  return OTCRYPTO_OK;
+}
+
+/**
+ * XOR the entropy seed with another value.
+ *
+ * Returns `OTCRYPTO_BAD_ARGS` if the provided value is longer than the seed.
+ * If the value is shorter, only the prefix will be XOR'ed.
+ *
+ * This operation is not constant-time relative to `value.len`.
+ *
+ * @param value Value to XOR with seed data.
+ * @param seed_material Entropy complex seed, modified in-place.
+ * @return OK or error.
+ */
+static crypto_status_t seed_material_xor(
+    crypto_uint8_buf_t value, entropy_seed_material_t *seed_material) {
+  if (value.len > kEntropySeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (value.len == 0) {
+    return OTCRYPTO_OK;
+  }
+
+  // Copy into a word-aligned buffer. Using a word-wise XOR is slightly safer
+  // from a side channel perspective than byte-wise.
+  size_t nwords = (value.len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t value_words[nwords];
+  value_words[nwords - 1] = 0;
+  memcpy(value_words, value.data, value.len);
+
+  // XOR with seed value.
+  for (size_t i = 0; i < nwords; i++) {
+    seed_material->data[i] ^= value_words[i];
+  }
+
+  return OTCRYPTO_OK;
+}
+
+crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string) {
+  // Check for NULL pointers or bad length.
+  if (perso_string.len != 0 && perso_string.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  entropy_seed_material_t seed_material;
+  seed_material_construct(perso_string, &seed_material);
+
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+  return entropy_csrng_instantiate(/*disable_trng_input=*/kHardenedBoolFalse,
+                                   &seed_material);
 }
 
 crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input) {
-  // TODO: Connect entropy driver to API.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  // Check for NULL pointers or bad length.
+  if (additional_input.len != 0 && additional_input.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  entropy_seed_material_t seed_material;
+  seed_material_construct(additional_input, &seed_material);
+
+  return entropy_csrng_reseed(/*disable_trng_input=*/kHardenedBoolFalse,
+                              &seed_material);
 }
 
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t nonce,
-    crypto_uint8_buf_t perso_string) {
-  // TODO: Connect entropy driver to API.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t perso_string) {
+  // Check for NULL pointers or bad length.
+  if (perso_string.len != 0 && perso_string.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (entropy.data == NULL || entropy.len != kEntropySeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  entropy_seed_material_t seed_material;
+  seed_material_construct(entropy, &seed_material);
+  seed_material_xor(perso_string, &seed_material);
+
+  HARDENED_CHECK_EQ(seed_material.len, kEntropySeedWords);
+
+  return entropy_csrng_instantiate(/*disable_trng_input=*/kHardenedBoolTrue,
+                                   &seed_material);
 }
 
 crypto_status_t otcrypto_drbg_manual_reseed(
     crypto_uint8_buf_t entropy, crypto_uint8_buf_t additional_input) {
-  // TODO: Connect entropy driver to API.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  // Check for NULL pointers or bad length.
+  if (additional_input.len != 0 && additional_input.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (entropy.data == NULL || entropy.len != kEntropySeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  entropy_seed_material_t seed_material;
+  seed_material_construct(entropy, &seed_material);
+  seed_material_xor(additional_input, &seed_material);
+
+  HARDENED_CHECK_EQ(seed_material.len, kEntropySeedWords);
+
+  return entropy_csrng_reseed(/*disable_trng_input=*/kHardenedBoolTrue,
+                              &seed_material);
 }
 
 crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
                                        size_t output_len,
                                        crypto_uint8_buf_t *drbg_output) {
-  // TODO: Connect entropy driver to API.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  if (output_len == 0) {
+    // Nothing to do.
+    return OTCRYPTO_OK;
+  }
+
+  // Check for NULL pointers or bad length.
+  if (additional_input.len != 0 && additional_input.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (drbg_output == NULL || drbg_output->data == NULL ||
+      drbg_output->len != output_len) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  entropy_seed_material_t seed_material;
+  seed_material_construct(additional_input, &seed_material);
+
+  size_t nwords = (output_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t output_words[nwords];
+  HARDENED_TRY(entropy_csrng_generate(&seed_material, output_words, nwords,
+                                      /*fips_check=*/kHardenedBoolFalse));
+
+  // Copy result into destination buffer.
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(drbg_output->data, output_words, output_len);
+
+  return OTCRYPTO_OK;
+}
+
+crypto_status_t otcrypto_drbg_uninstantiate(void) {
+  return entropy_csrng_uninstantiate();
 }

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/ecc.h"
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/ecc/ecdh_p256.h"
 #include "sw/device/lib/crypto/impl/ecc/ecdsa_p256.h"
@@ -156,6 +157,9 @@ crypto_status_t otcrypto_ecdsa_keygen_async_start(
 
   // Check the key configuration.
   HARDENED_TRY(key_config_check(elliptic_curve, config, kKeyModeEcdsa));
+
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
 
   // Select the correct keygen operation and start it.
   switch (launder32(elliptic_curve->curve_type)) {
@@ -399,6 +403,9 @@ crypto_status_t otcrypto_ecdsa_sign_async_start(
   HARDENED_TRY(
       key_config_check(elliptic_curve, &private_key->config, kKeyModeEcdsa));
 
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
   // Select the correct signing operation and start it.
   switch (launder32(elliptic_curve->curve_type)) {
     case kEccCurveTypeNistP256:
@@ -641,6 +648,9 @@ crypto_status_t otcrypto_ecdh_keygen_async_start(
 
   // Check the key configuration.
   HARDENED_TRY(key_config_check(elliptic_curve, config, kKeyModeEcdh));
+
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
 
   // Select the correct keygen operation and start it.
   switch (launder32(elliptic_curve->curve_type)) {

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/include/rsa.h"
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_keygen.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_signature.h"
@@ -165,6 +166,9 @@ static status_t key_length_from_modulus(const crypto_unblinded_key_t *modulus,
 
 crypto_status_t otcrypto_rsa_keygen_async_start(
     rsa_key_size_t required_key_len) {
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
   switch (required_key_len) {
     case kRsaKeySize2048:
       return rsa_keygen_2048_start();

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -22,12 +22,10 @@ extern "C" {
  * Initializes the DRBG and the context for DRBG. Gets the required
  * entropy input automatically from the entropy source.
  *
- * @param nonce Pointer to the nonce bit-string.
  * @param perso_string Pointer to personalization bitstring.
  * @return Result of the DRBG instantiate operation.
  */
-crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t nonce,
-                                          crypto_uint8_buf_t perso_string);
+crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -46,13 +44,16 @@ crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input);
  * Initializes DRBG and the DRBG context. Gets the required entropy
  * input from the user through the `entropy` parameter.
  *
+ * The entropy input must be exactly 384 bits long (48 bytes). The
+ * personalization string must not be longer than the entropy input, and may be
+ * empty.
+ *
  * @param entropy Pointer to the user defined entropy value.
- * @param nonce Pointer to the nonce bit-string.
  * @param personalization_string Pointer to personalization bitstring.
  * @return Result of the DRBG manual instantiation.
  */
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t nonce,
+    crypto_uint8_buf_t entropy,
     crypto_uint8_buf_t perso_string);
 
 /**
@@ -79,6 +80,10 @@ crypto_status_t otcrypto_drbg_manual_reseed(
  * output in the `len` field of `drbg_output`. If the user-set length
  * and the output length does not match, an error message will be
  * returned.
+ *
+ * The output is generated in 16-byte blocks; if `output_len` is not a multiple
+ * of 16, some output from the hardware will be discarded. This detail may be
+ * important for known-answer tests.
  *
  * @param additional_input Pointer to the additional data.
  * @param output_len Required len of pseudorandom output, in bytes.

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -53,8 +53,7 @@ crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input);
  * @return Result of the DRBG manual instantiation.
  */
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_uint8_buf_t entropy,
-    crypto_uint8_buf_t perso_string);
+    crypto_uint8_buf_t entropy, crypto_uint8_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -89,6 +89,20 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "drbg_functest",
+    srcs = ["drbg_functest.c"],
+    verilator = verilator_params(
+        timeout = "eternal",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "ecdh_p256_functest",
     srcs = ["ecdh_p256_functest.c"],
     verilator = verilator_params(

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/include/drbg.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static uint32_t kTestSeed[12] = {
+    0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5, 0xdfec9db3,
+    0xcb7a879d, 0x5600419c, 0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa};
+// Note that the word order in the expected output is reversed compared to the
+// NIST reference.
+static uint32_t kExpOutput[16] = {
+    0xd1c07cd9, 0x5af8a7f1, 0x1012c84c, 0xe48bb8cb, 0x87189e99, 0xd40fccb1,
+    0x771c619b, 0xdf82ab22, 0x80b1dc2f, 0x2581f391, 0x64f7ac0c, 0x510494b3,
+    0xa43c41b7, 0xdb17514c, 0x87b107ae, 0x793e01c5,
+};
+static const crypto_uint8_buf_t kEmptyBuffer = {
+    .data = NULL,
+    .len = 0,
+};
+
+static status_t entropy_complex_init_test(void) {
+  // This initialization should happen in ROM_EXT, so there is no public API
+  // for it in cryptolib.
+  TRY(entropy_complex_init());
+
+  // Check the configuration.
+  return entropy_complex_check();
+}
+
+static status_t kat_test(void) {
+  crypto_uint8_buf_t entropy = {
+      .data = (unsigned char *)kTestSeed,
+      .len = sizeof(kTestSeed),
+  };
+
+  // Instantiate DRBG.
+  TRY(otcrypto_drbg_manual_instantiate(entropy, /*perso_string=*/kEmptyBuffer));
+
+  uint32_t actual_output_words[ARRAYSIZE(kExpOutput)];
+  crypto_uint8_buf_t actual_output = {
+      .data = (unsigned char *)actual_output_words,
+      .len = sizeof(actual_output_words),
+  };
+
+  // Generate output twice.
+  LOG_INFO("Generating...");
+  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer,
+                             sizeof(kExpOutput), &actual_output));
+  LOG_INFO("Generating again...");
+  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer,
+                             sizeof(kExpOutput), &actual_output));
+
+  // Compare second result to expected output.
+  TRY_CHECK_ARRAYS_EQ(kExpOutput, actual_output_words, ARRAYSIZE(kExpOutput));
+  TRY_CHECK_ARRAYS_EQ(kExpOutput, kExpOutput, 0);
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  EXECUTE_TEST(result, entropy_complex_init_test);
+  EXECUTE_TEST(result, kat_test);
+  return status_ok(result);
+}


### PR DESCRIPTION
- Adds a layer connecting the entropy complex driver to the API
- Adds checks that the entropy complex is in a good state before generating sensitive values on OTBN
- Adds a basic functional test

@moidx , this is the change I mentioned to you yesterday. The KAT test (on FPGA) hangs on `instantiate`, whether I use the top-level interface or call the CSRNG driver directly. It doesn't hang if I insert ~5 print statements before `instantiate`, or run `entropy_complex_check` in a loop 10000 times, which makes me suspect a timing issue.