### PR TITLE
[rust] convert explicit clap "help = " to doc comments.

### DIFF
--- a/sw/host/hsmtool/src/commands/object/list.rs
+++ b/sw/host/hsmtool/src/commands/object/list.rs
@@ -16,7 +16,8 @@ use crate::util::attribute::{AttributeMap, AttributeType};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct List {
-    #[arg(short, long, value_parser=AttributeType::from_str, help="Attributes to show")]
+    /// Attributes to show.
+    #[arg(short, long, value_parser=AttributeType::from_str)]
     #[serde(default)]
     attribute: Vec<AttributeType>,
 }

--- a/sw/host/hsmtool/src/commands/object/show.rs
+++ b/sw/host/hsmtool/src/commands/object/show.rs
@@ -21,11 +21,8 @@ pub struct Show {
     id: Option<String>,
     #[arg(short, long)]
     label: Option<String>,
-    #[arg(long,
-        action = clap::ArgAction::Set,
-        default_value = "true",
-        help="Redact senitive data",
-    )]
+    /// Redact senitive data.
+    #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     redact: bool,
 }
 

--- a/sw/host/hsmtool/src/commands/object/show.rs
+++ b/sw/host/hsmtool/src/commands/object/show.rs
@@ -21,7 +21,7 @@ pub struct Show {
     id: Option<String>,
     #[arg(short, long)]
     label: Option<String>,
-    /// Redact senitive data.
+    /// Redact sensitive data.
     #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     redact: bool,
 }

--- a/sw/host/hsmtool/src/commands/object/update.rs
+++ b/sw/host/hsmtool/src/commands/object/update.rs
@@ -20,7 +20,7 @@ pub struct Update {
     id: Option<String>,
     #[arg(short, long)]
     label: Option<String>,
-    #[arg(help = "Attributes to update")]
+    /// Attributes to update.
     attribute: AttributeMap,
 }
 

--- a/sw/host/hsmtool/src/commands/rsa/export.rs
+++ b/sw/host/hsmtool/src/commands/rsa/export.rs
@@ -25,9 +25,11 @@ pub struct Export {
     id: Option<String>,
     #[arg(short, long)]
     label: Option<String>,
-    #[arg(long, help = "Export the private key")]
+    /// Export the private key.
+    #[arg(long)]
     private: bool,
-    #[arg(long, help = "Wrap the exported key a wrapping key")]
+    /// Wrap the exported key a wrapping key.
+    #[arg(long)]
     wrap: Option<String>,
     #[arg(short, long, value_enum, default_value = "pem")]
     format: KeyEncoding,

--- a/sw/host/hsmtool/src/commands/rsa/generate.rs
+++ b/sw/host/hsmtool/src/commands/rsa/generate.rs
@@ -26,16 +26,17 @@ pub struct Generate {
     key_length: u64,
     #[arg(short = 'e', long, default_value = "65537")]
     public_exponent: u64,
-    #[arg(
-        long,
-        help = "Permit the generated key to be used for wrapping other keys"
-    )]
+    /// Permit the generated key to be used for wrapping other keys.
+    #[arg(long)]
     wrapping: bool,
-    #[arg(long, help = "Permit the generated key to be extractable")]
+    /// Permit the generated key to be extractable.
+    #[arg(long)]
     extractable: bool,
-    #[arg(long, help = "Template for creating the public key")]
+    /// Template for creating the public key.
+    #[arg(long)]
     public_template: Option<AttributeMap>,
-    #[arg(long, help = "Template for creating the private key")]
+    /// Template for creating the private key.
+    #[arg(long)]
     private_template: Option<AttributeMap>,
 }
 

--- a/sw/host/hsmtool/src/commands/rsa/import.rs
+++ b/sw/host/hsmtool/src/commands/rsa/import.rs
@@ -24,13 +24,17 @@ pub struct Import {
     id: Option<String>,
     #[arg(short, long)]
     label: Option<String>,
-    #[arg(short, long, help = "The key is a public key only")]
+    /// The key is a public key only.
+    #[arg(short, long)]
     public: bool,
-    #[arg(long, help = "Attributes to apply to the public key")]
+    /// Attributes to apply to the public key.
+    #[arg(long)]
     public_attrs: Option<AttributeMap>,
-    #[arg(long, help = "Attributes to apply to the private key")]
+    /// Attributes to apply to the private key.
+    #[arg(long)]
     private_attrs: Option<AttributeMap>,
-    #[arg(long, help = "Unwrap the imported key with a wrapping key")]
+    /// Unwrap the imported key with a wrapping key.
+    #[arg(long)]
     unwrap: Option<String>,
     filename: PathBuf,
 }

--- a/sw/host/hsmtool/src/commands/rsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/rsa/sign.rs
@@ -25,11 +25,8 @@ pub struct Sign {
     label: Option<String>,
     #[arg(short, long, value_enum, default_value = "sha256-hash")]
     format: SignData,
-    #[arg(
-        short = 'r',
-        long,
-        help = "Reverse the input data and result (for little-endian targets)"
-    )]
+    /// Reverse the input data and result (for little-endian targets).
+    #[arg(short = 'r', long)]
     little_endian: bool,
     #[arg(short, long)]
     output: Option<PathBuf>,

--- a/sw/host/hsmtool/src/commands/rsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/rsa/verify.rs
@@ -25,11 +25,8 @@ pub struct Verify {
     label: Option<String>,
     #[arg(short, long, value_enum, default_value = "sha256-hash")]
     format: SignData,
-    #[arg(
-        short = 'r',
-        long,
-        help = "Reverse the input data and result (for little-endian targets)"
-    )]
+    /// Reverse the input data and result (for little-endian targets).
+    #[arg(short = 'r', long)]
     little_endian: bool,
     input: PathBuf,
     signature: PathBuf,

--- a/sw/host/hsmtool/src/hsmtool.rs
+++ b/sw/host/hsmtool/src/hsmtool.rs
@@ -15,54 +15,44 @@ use hsmtool::util::attribute::AttributeMap;
 
 #[derive(Debug, Parser)]
 struct Args {
-    #[arg(long, default_value = "warn", help = "Logging level")]
+    /// Logging level.
+    #[arg(long, default_value = "warn")]
     logging: LevelFilter,
 
-    #[arg(
-        short,
-        long,
-        value_enum,
-        default_value = "json",
-        help = "Output format"
-    )]
+    /// Output format.
+    #[arg(short, long, value_enum, default_value = "json")]
     format: Format,
 
-    #[arg(short, long, help = "Use color in the output")]
+    /// Use color in the output.
+    #[arg(short, long)]
     color: Option<bool>,
 
-    #[arg(
-        long,
-        default_value = "profiles.json",
-        help = "Filename of HSM profiles.  Relative to $XDG_CONFIG_HOME/hsmtool."
-    )]
+    /// Filename of HSM profiles.  Relative to $XDG_CONFIG_HOME/hsmtool.
+    #[arg(long, default_value = "profiles.json")]
     profiles: PathBuf,
 
-    #[arg(long, help = "The name of an HSM profile to use")]
+    /// The name of an HSM profile to use.
+    #[arg(long)]
     profile: Option<String>,
 
-    #[arg(long, env = "HSMTOOL_MODULE", help = "Path to a PKCS11 shared library")]
+    /// Path to a PKCS11 shared library.
+    #[arg(long, env = "HSMTOOL_MODULE")]
     module: String,
 
-    #[arg(short, long, env = "HSMTOOL_TOKEN", help = "HSM Token to use")]
+    /// HSM Token to use.
+    #[arg(short, long, env = "HSMTOOL_TOKEN")]
     token: Option<String>,
 
-    #[arg(
-        short,
-        long,
-        env = "HSMTOOL_USER",
-        value_parser = module::parse_user_type,
-        help="User type ('so' or 'user')"
-    )]
+    /// User type ('so' or 'user').
+    #[arg(short, long, env = "HSMTOOL_USER", value_parser = module::parse_user_type)]
     user: Option<UserType>,
 
-    #[arg(short, long, env = "HSMTOOL_PIN", help = "Pin")]
+    /// Pin.
+    #[arg(short, long, env = "HSMTOOL_PIN")]
     pin: Option<String>,
 
-    #[arg(
-        long,
-        default_value = "false",
-        help = "Show JSON encode of the command"
-    )]
+    /// Show JSON encode of the command.
+    #[arg(long, default_value = "false")]
     show_json: bool,
 
     #[command(subcommand)]

--- a/sw/host/opentitanlib/src/backend/chip_whisperer.rs
+++ b/sw/host/opentitanlib/src/backend/chip_whisperer.rs
@@ -12,11 +12,8 @@ use crate::transport::Transport;
 
 #[derive(Debug, Args)]
 pub struct ChipWhispererOpts {
-    #[arg(
-        long,
-        alias = "cw310-uarts",
-        help = "Comma-separated list of Chip Whisperer board UARTs for non-udev environments. List the console uart first."
-    )]
+    /// Comma-separated list of Chip Whisperer board UARTs for non-udev environments. List the console uart first.
+    #[arg(long, alias = "cw310-uarts")]
     pub uarts: Option<String>,
 }
 

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -26,14 +26,18 @@ mod verilator;
 
 #[derive(Debug, Args)]
 pub struct BackendOpts {
-    #[arg(long, default_value = "", help = "Name of the debug interface")]
+    /// Name of the debug interface.
+    #[arg(long, default_value = "")]
     pub interface: String,
 
-    #[arg(long, value_parser = u16::from_str, help = "USB Vendor ID of the interface")]
+    /// USB Vendor ID of the interface.
+    #[arg(long, value_parser = u16::from_str)]
     pub usb_vid: Option<u16>,
-    #[arg(long, value_parser = u16::from_str, help = "USB Product ID of the interface")]
+    /// USB Product ID of the interface.
+    #[arg(long, value_parser = u16::from_str)]
     pub usb_pid: Option<u16>,
-    #[arg(long, help = "USB serial number of the interface")]
+    /// USB serial number of the interface.
+    #[arg(long)]
     pub usb_serial: Option<String>,
 
     #[command(flatten)]
@@ -48,7 +52,8 @@ pub struct BackendOpts {
     #[command(flatten)]
     pub ti50emulator_opts: ti50emulator::Ti50EmulatorOpts,
 
-    #[arg(long, num_args = 1, help = "Configuration files")]
+    /// Configuration files.
+    #[arg(long, num_args = 1)]
     pub conf: Vec<PathBuf>,
 }
 

--- a/sw/host/opentitanlib/src/backend/verilator.rs
+++ b/sw/host/opentitanlib/src/backend/verilator.rs
@@ -25,7 +25,8 @@ pub struct VerilatorOpts {
     #[arg(long, required = false)]
     verilator_args: Vec<String>,
 
-    #[arg(long, value_parser = parse_duration, default_value = "60s", help = "Verilator startup timeout")]
+    /// Verilator startup timeout.
+    #[arg(long, value_parser = parse_duration, default_value = "60s")]
     verilator_timeout: Duration,
 }
 

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -79,30 +79,23 @@ pub struct BootstrapOptions {
     pub uart_params: UartParams,
     #[command(flatten)]
     pub spi_params: SpiParams,
-    #[arg(
-        short,
-        long,
-        value_enum,
-        ignore_case = true,
-        default_value = "eeprom",
-        help = "Bootstrap protocol to use"
-    )]
+    /// Bootstrap protocol to use.
+    #[arg(short, long, value_enum, ignore_case = true, default_value = "eeprom")]
     pub protocol: BootstrapProtocol,
-    #[arg(
-        long,
-        help = "Whether to reset target and clear UART RX buffer after bootstrap. For Chip Whisperer board only."
-    )]
+    /// Whether to reset target and clear UART RX buffer after bootstrap. For Chip Whisperer board only.
+    #[arg(long)]
     pub clear_uart: Option<bool>,
-    #[arg(long, value_parser = parse_duration, default_value = "100ms", help = "Duration of the reset pulse")]
+    /// Duration of the reset pulse.
+    #[arg(long, value_parser = parse_duration, default_value = "100ms")]
     pub reset_delay: Duration,
-    #[arg(
-        long,
-        help = "If set, leave the reset signal asserted after completed bootstrapping."
-    )]
+    /// If set, leave the reset signal asserted after completed bootstrapping.
+    #[arg(long)]
     pub leave_in_reset: bool,
-    #[arg(long, value_parser = parse_duration, help = "Duration of the inter-frame delay")]
+    /// Duration of the inter-frame delay.
+    #[arg(long, value_parser = parse_duration)]
     pub inter_frame_delay: Option<Duration>,
-    #[arg(long, value_parser = parse_duration, help = "Duration of the flash-erase delay")]
+    /// Duration of the flash-erase delay.
+    #[arg(long, value_parser = parse_duration)]
     pub flash_erase_delay: Option<Duration>,
 }
 

--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -16,7 +16,8 @@ pub struct I2cParams {
     #[arg(long, help = "I2C instance", default_value = "0")]
     pub bus: String,
 
-    #[arg(long, help = "I2C bus speed (typically: 100000, 400000, 1000000)")]
+    /// I2C bus speed (typically: 100000, 400000, 1000000).
+    #[arg(long)]
     pub speed: Option<u32>,
 }
 

--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -13,7 +13,8 @@ use crate::impl_serializable_error;
 
 #[derive(Debug, Args)]
 pub struct I2cParams {
-    #[arg(long, help = "I2C instance", default_value = "0")]
+    /// I2C instance.
+    #[arg(long, default_value = "0")]
     pub bus: String,
 
     /// I2C bus speed (typically: 100000, 400000, 1000000).

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -16,19 +16,24 @@ use crate::util::voltage::Voltage;
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
 pub struct SpiParams {
-    #[arg(long, help = "SPI instance")]
+    /// SPI instance.
+    #[arg(long)]
     pub bus: Option<String>,
 
-    #[arg(long, help = "SPI bus speed")]
+    /// SPI bus speed.
+    #[arg(long)]
     pub speed: Option<u32>,
 
-    #[arg(long, help = "SPI chip select pin")]
+    /// SPI chip select pin.
+    #[arg(long)]
     pub chip_select: Option<String>,
 
-    #[arg(long, help = "SPI bus voltage")]
+    /// SPI bus voltage.
+    #[arg(long)]
     pub voltage: Option<Voltage>,
 
-    #[arg(long, help = "SPI polarity/phase mode")]
+    /// SPI polarity/phase mode.
+    #[arg(long)]
     pub mode: Option<TransferMode>,
 }
 

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -16,7 +16,8 @@ use crate::io::console::ConsoleDevice;
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
 pub struct UartParams {
-    #[arg(long, help = "UART instance", default_value = "CONSOLE")]
+    /// UART instance.
+    #[arg(long, default_value = "CONSOLE")]
     uart: String,
 
     /// UART baudrate.

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -19,10 +19,12 @@ pub struct UartParams {
     #[arg(long, help = "UART instance", default_value = "CONSOLE")]
     uart: String,
 
-    #[arg(long, help = "UART baudrate")]
+    /// UART baudrate.
+    #[arg(long)]
     baudrate: Option<u32>,
 
-    #[arg(long, help = "Enable software flow control")]
+    /// Enable software flow control.
+    #[arg(long)]
     flow_control: bool,
 }
 

--- a/sw/host/opentitanlib/src/test_utils/bootstrap.rs
+++ b/sw/host/opentitanlib/src/test_utils/bootstrap.rs
@@ -16,7 +16,8 @@ pub struct Bootstrap {
     #[command(flatten)]
     pub options: BootstrapOptions,
 
-    #[arg(long, help = "RV32 test binary to load")]
+    /// RV32 test binary to load.
+    #[arg(long)]
     pub bootstrap: Option<PathBuf>,
 }
 

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -23,12 +23,8 @@ use crate::io::jtag::JtagParams;
 
 #[derive(Debug, Args)]
 pub struct InitializeTest {
-    #[arg(
-        long,
-        value_parser = PathBuf::from_str,
-        default_value = "config",
-        help = "Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool."
-    )]
+    /// Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool.
+    #[arg(long, value_parser = PathBuf::from_str, default_value = "config")]
     pub rcfile: PathBuf,
 
     #[arg(long, default_value = "off")]

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -14,16 +14,20 @@ use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
 /// Load a bitstream into the FPGA.
 #[derive(Debug, Args)]
 pub struct LoadBitstream {
-    #[arg(long, help = "Whether to clear out any existing bitstream.")]
+    /// Whether to clear out any existing bitstream.
+    #[arg(long)]
     pub clear_bitstream: bool,
 
-    #[arg(long, help = "The bitstream to load for the test")]
+    /// The bitstream to load for the test.
+    #[arg(long)]
     pub bitstream: Option<PathBuf>,
 
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "50ms", help = "Duration of the reset pulse.")]
+    /// Duration of the reset pulse.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "50ms")]
     pub rom_reset_pulse: Duration,
 
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "2s", help = "Duration of ROM detection timeout")]
+    /// Duration of ROM detection timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "2s")]
     pub rom_timeout: Duration,
 }
 

--- a/sw/host/opentitansession/src/main.rs
+++ b/sw/host/opentitansession/src/main.rs
@@ -29,12 +29,8 @@ use opentitanlib::{backend, util};
     about = "A tool for interacting with OpenTitan chips."
 )]
 struct Opts {
-    #[arg(
-        long,
-        value_parser = PathBuf::from_str,
-        default_value = "config",
-        help = "Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool."
-    )]
+    /// Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool.
+    #[arg(long, value_parser = PathBuf::from_str, default_value = "config")]
     rcfile: PathBuf,
 
     #[arg(long, default_value = "off")]
@@ -43,28 +39,20 @@ struct Opts {
     #[command(flatten)]
     backend_opts: backend::BackendOpts,
 
-    #[arg(
-        long,
-        help = "Stop a running session, optionally combine with --listen_port for disambiguation"
-    )]
+    /// Stop a running session, optionally combine with --listen_port for disambiguation.
+    #[arg(long)]
     stop: bool,
 
-    #[arg(
-        long,
-        help = "Optional, defaults to 9900 or nearest higher available port."
-    )]
+    /// Optional, defaults to 9900 or nearest higher available port.
+    #[arg(long)]
     listen_port: Option<u16>,
 
-    #[arg(
-        long,
-        help = "Start session, staying in foreground (do not daemonize).  Session process will terminate if its parent dies."
-    )]
+    /// Start session, staying in foreground (do not daemonize).  Session process will terminate if its parent dies.
+    #[arg(long)]
     foreground: bool,
 
-    #[arg(
-        long,
-        help = "Internal, used to tell the child process to run as a daemon."
-    )]
+    /// Internal, used to tell the child process to run as a daemon.
+    #[arg(long)]
     child: bool,
 }
 

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -20,26 +20,14 @@ use opentitanlib::util::parse_int::ParseInt;
 pub struct BootstrapCommand {
     #[command(flatten)]
     bootstrap_options: BootstrapOptions,
-    #[arg(
-        long,
-        value_parser = usize::from_str,
-        default_value = "1048576",
-        help = "The size of the image to assemble (only valid with mutliple FILE arguments)"
-    )]
+    /// The size of the image to assemble (only valid with mutliple FILE arguments).
+    #[arg(long, value_parser = usize::from_str, default_value = "1048576")]
     size: usize,
-    #[arg(
-        long,
-        action = clap::ArgAction::Set,
-        default_value = "true",
-        help = "Whether or not the assembled image is mirrored (only valid with mutliple FILE arguments)"
-    )]
+    /// Whether or not the assembled image is mirrored (only valid with mutliple FILE arguments).
+    #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     mirror: bool,
-    #[arg(
-        value_name = "FILE",
-        required = true,
-        num_args = 1..,
-        help = "An image to bootstrap or multiple filename@offset specifiers to assemble into a bootstrap image."
-    )]
+    /// An image to bootstrap or multiple filename@offset specifiers to assemble into a bootstrap image.
+    #[arg(value_name = "FILE", required = true, num_args = 1..)]
     filename: Vec<String>,
 }
 

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -20,10 +20,10 @@ use opentitanlib::util::parse_int::ParseInt;
 pub struct BootstrapCommand {
     #[command(flatten)]
     bootstrap_options: BootstrapOptions,
-    /// The size of the image to assemble (only valid with mutliple FILE arguments).
+    /// The size of the image to assemble (only valid with multiple FILE arguments).
     #[arg(long, value_parser = usize::from_str, default_value = "1048576")]
     size: usize,
-    /// Whether or not the assembled image is mirrored (only valid with mutliple FILE arguments).
+    /// Whether or not the assembled image is mirrored (only valid with multiple FILE arguments).
     #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     mirror: bool,
     /// An image to bootstrap or multiple filename@offset specifiers to assemble into a bootstrap image.

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -24,30 +24,34 @@ pub struct Console {
     #[command(flatten)]
     params: UartParams,
 
-    #[arg(short, long, help = "Do not print console start end exit messages.")]
+    /// Do not print console start end exit messages.
+    #[arg(short, long)]
     quiet: bool,
 
-    #[arg(short, long, help = "Log console output to a file")]
+    /// Log console output to a file.
+    #[arg(short, long)]
     logfile: Option<String>,
 
-    #[arg(long, help = "Send a string into the console at startup.")]
+    /// Send a string into the console at startup.
+    #[arg(long)]
     send: Option<String>,
 
-    #[arg(
-        short,
-        long,
-        value_parser = humantime::parse_duration,
-        help = "Duration of ROM detection timeout",
-    )]
+    /// Duration of ROM detection timeout.
+    #[arg(short,
+    long,
+    value_parser = humantime::parse_duration)]
     timeout: Option<Duration>,
 
-    #[arg(long, help = "Print a timestamp on each line of console output.")]
+    /// Print a timestamp on each line of console output.
+    #[arg(long)]
     timestamp: bool,
 
-    #[arg(long, help = "Exit with success if the specified regex is matched.")]
+    /// Exit with success if the specified regex is matched.
+    #[arg(long)]
     exit_success: Option<String>,
 
-    #[arg(long, help = "Exit with failure if the specified regex is matched.")]
+    /// Exit with failure if the specified regex is matched.
+    #[arg(long)]
     exit_failure: Option<String>,
 }
 

--- a/sw/host/opentitantool/src/command/emulator.rs
+++ b/sw/host/opentitantool/src/command/emulator.rs
@@ -42,23 +42,23 @@ impl CommandDispatch for EmuGetState {
 #[derive(Debug, Args)]
 /// Start Emulator instance
 pub struct EmuStart {
-    #[arg(
-        long,
-        help = "Reset all presistent storage (For example: flash, otp, eeprom) to factory state"
-    )]
+    /// Reset all presistent storage (For example: flash, otp, eeprom) to factory state.
+    #[arg(long)]
     pub factory_reset: bool,
-    #[arg(long, help = "Emulator executable file name")]
+    /// Emulator executable file name.
+    #[arg(long)]
     pub emulator_exec: Option<String>,
-    #[arg(
-        long,
-        help = "List of application names that will be provided in flash images"
-    )]
+    /// List of application names that will be provided in flash images.
+    #[arg(long)]
     pub apps_list: Option<Vec<String>>,
-    #[arg(long, help = "List of file paths representing Flash images")]
+    /// List of file paths representing Flash images.
+    #[arg(long)]
     pub flash_list: Option<Vec<PathBuf>>,
-    #[arg(long, help = "Path to file representing Emulator version state")]
+    /// Path to file representing Emulator version state.
+    #[arg(long)]
     pub version_init_state: Option<PathBuf>,
-    #[arg(long, help = "Path to file representing PMU initial state")]
+    /// Path to file representing PMU initial state.
+    #[arg(long)]
     pub pmu_init_state: Option<PathBuf>,
 }
 

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -26,7 +26,7 @@ use opentitanlib::util::voltage::Voltage;
 #[derive(Debug, Args)]
 /// Reads a GPIO pin.
 pub struct GpioRead {
-    #[arg(help = "The GPIO pin to read")]
+    /// The GPIO pin to read.
     pub pin: String,
 }
 
@@ -55,12 +55,10 @@ impl CommandDispatch for GpioRead {
 #[derive(Debug, Args)]
 /// Writes a GPIO pin.
 pub struct GpioWrite {
-    #[arg(help = "The GPIO pin to write")]
+    /// The GPIO pin to write.
     pub pin: String,
-    #[arg(
-        action = clap::ArgAction::Set,
-        help = "The value to write to the pin"
-    )]
+    /// The value to write to the pin.
+    #[arg(action = clap::ArgAction::Set)]
     pub value: bool,
 }
 
@@ -81,9 +79,10 @@ impl CommandDispatch for GpioWrite {
 #[derive(Debug, Args)]
 /// Set the I/O mode of a GPIO pin (Input/OpenDrain/PushPull).
 pub struct GpioSetMode {
-    #[arg(help = "The GPIO pin to modify")]
+    /// The GPIO pin to modify.
     pub pin: String,
-    #[arg(value_enum, ignore_case = true, help = "The I/O mode of the pin")]
+    /// The I/O mode of the pin.
+    #[arg(value_enum, ignore_case = true)]
     pub mode: PinMode,
 }
 
@@ -103,14 +102,10 @@ impl CommandDispatch for GpioSetMode {
 #[derive(Debug, Args)]
 /// Set the I/O weak pull mode of a GPIO pin (PullUp/PullDown/None).
 pub struct GpioSetPullMode {
-    #[arg(help = "The GPIO pin to modify")]
+    /// The GPIO pin to modify.
     pub pin: String,
-    #[arg(
-        value_name = "PULLMODE",
-        value_enum,
-        ignore_case = true,
-        help = "The weak pull mode of the pin"
-    )]
+    /// The weak pull mode of the pin.
+    #[arg(value_name = "PULLMODE", value_enum, ignore_case = true)]
     pub pull_mode: PullMode,
 }
 
@@ -130,23 +125,19 @@ impl CommandDispatch for GpioSetPullMode {
 #[derive(Debug, Args)]
 /// Simultaneously set mode, pull and output value of a GPIO pin.
 pub struct GpioSet {
-    #[arg(help = "The GPIO pin to modify")]
+    /// The GPIO pin to modify.
     pub pin: String,
-    #[arg(long, ignore_case = true, help = "The I/O mode of the pin")]
+    /// The I/O mode of the pin.
+    #[arg(long, ignore_case = true)]
     pub mode: Option<PinMode>,
-    #[arg(
-        long,
-        value_parser = bool::from_str,
-        help = "The value to write to the pin, has effect only in PushPull and OpenDrain modes"
-    )]
+    /// The value to write to the pin, has effect only in PushPull and OpenDrain modes.
+    #[arg(long, value_parser = bool::from_str)]
     pub value: Option<bool>,
-    #[arg(long, ignore_case = true, help = "The weak pull mode of the pin")]
+    /// The weak pull mode of the pin.
+    #[arg(long, ignore_case = true)]
     pub pull: Option<PullMode>,
-    #[arg(
-        long,
-        value_parser = bool::from_str,
-        help = "The analog value to write to the pin in volts, has effect only in AnalogOutput mode"
-    )]
+    /// The analog value to write to the pin in volts, has effect only in AnalogOutput mode.
+    #[arg(long, value_parser = bool::from_str)]
     pub voltage: Option<Voltage>,
 }
 
@@ -172,7 +163,7 @@ impl CommandDispatch for GpioSet {
 #[derive(Debug, Args)]
 /// Reads a GPIO pin.
 pub struct GpioAnalogRead {
-    #[arg(help = "The GPIO pin to read")]
+    /// The GPIO pin to read.
     pub pin: String,
 }
 
@@ -201,12 +192,10 @@ impl CommandDispatch for GpioAnalogRead {
 #[derive(Debug, Args)]
 /// Writes an analog voltage to a GPIO pin.
 pub struct GpioAnalogWrite {
-    #[arg(help = "The GPIO pin to write")]
+    /// The GPIO pin to write.
     pub pin: String,
-    #[arg(
-        value_parser = bool::from_str,
-        help = "The analog value to write to the pin in volts, has effect only in AnalogOutput mode"
-    )]
+    /// The analog value to write to the pin in volts, has effect only in AnalogOutput mode.
+    #[arg(value_parser = bool::from_str)]
     pub volts: f32,
 }
 
@@ -227,7 +216,7 @@ impl CommandDispatch for GpioAnalogWrite {
 #[derive(Debug, Args)]
 /// Apply a configuration-named pin strapping
 pub struct GpioApplyStrapping {
-    #[arg(help = "The pin strapping to apply")]
+    /// The pin strapping to apply.
     pub name: String,
 }
 
@@ -253,7 +242,7 @@ pub enum GpioMonitoringCommand {
 #[derive(Debug, Args)]
 /// Begin logic-analyzer style monitoring of a set of pins.
 pub struct GpioMonitoringStart {
-    #[arg(help = "The list of GPIO pins to monitor (space separated)")]
+    /// The list of GPIO pins to monitor (space separated).
     pub pins: Vec<String>,
 }
 
@@ -309,7 +298,7 @@ impl CommandDispatch for GpioMonitoringStart {
 /// Retrieve logic-analyzer style monitoring events detected so far, on a set of pins.  Optionally
 /// continue monitoring, in which case `monitoring read` must be called again later.
 pub struct GpioMonitoringRead {
-    #[arg(help = "The list of GPIO pins being monitored (space separated)")]
+    /// The list of GPIO pins being monitored (space separated).
     pub pins: Vec<String>,
 
     #[arg(long)]
@@ -374,13 +363,15 @@ impl CommandDispatch for GpioMonitoringRead {
 /// standard VCD format, which can be loaded into e.g. Pulseview (or probably also Saleae
 /// software), to get a logic analyzer view of what transpired.
 pub struct GpioMonitoringVcd {
-    #[arg(help = "The list of GPIO pins to monitor (space separated)")]
+    /// The list of GPIO pins to monitor (space separated).
     pub pins: Vec<String>,
 
-    #[arg(short, long, help = "Output file")]
+    /// Output file.
+    #[arg(short, long)]
     outfile: String,
 
-    #[arg(short, long, help = "Do not print start end exit messages.")]
+    /// Do not print start end exit messages.
+    #[arg(short, long)]
     quiet: bool,
 }
 
@@ -527,7 +518,7 @@ impl CommandDispatch for GpioMonitoringVcd {
 #[derive(Debug, Args)]
 /// Remove a configuration-named pin strapping
 pub struct GpioRemoveStrapping {
-    #[arg(help = "The pin strapping to release")]
+    /// The pin strapping to release.
     pub name: String,
 }
 

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -17,12 +17,8 @@ use opentitanlib::util::parse_int::ParseInt;
 /// Read plain data bytes from a I2C device.
 #[derive(Debug, Args)]
 pub struct I2cRawRead {
-    #[arg(
-        short = 'n',
-        long,
-        value_parser = usize::from_str,
-        help = "Number of bytes to read."
-    )]
+    /// Number of bytes to read.
+    #[arg(short = 'n', long, value_parser = usize::from_str)]
     length: usize,
 }
 
@@ -51,7 +47,8 @@ impl CommandDispatch for I2cRawRead {
 /// Write plain data bytes to a I2C device.
 #[derive(Debug, Args)]
 pub struct I2cRawWrite {
-    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
+    /// Hex data bytes to write.
+    #[arg(short = 'd', long)]
     hexdata: String,
 }
 
@@ -75,14 +72,11 @@ impl CommandDispatch for I2cRawWrite {
 /// Write data bytes to a I2C device, then read back a response.
 #[derive(Debug, Args)]
 pub struct I2cRawWriteRead {
-    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
+    /// Hex data bytes to write.
+    #[arg(short = 'd', long)]
     hexdata: String,
-    #[arg(
-        short = 'n',
-        long,
-        value_parser = usize::from_str,
-        help = "Number of bytes to read."
-    )]
+    /// Number of bytes to read.
+    #[arg(short = 'n', long, value_parser = usize::from_str)]
     length: usize,
 }
 
@@ -147,12 +141,8 @@ pub struct I2cCommand {
     #[command(flatten)]
     params: I2cParams,
 
-    #[arg(
-        short,
-        long,
-        value_parser = u8::from_str,
-        help = "7-bit address of I2C device (0..0x7F)."
-    )]
+    /// 7-bit address of I2C device (0..0x7F).
+    #[arg(short, long, value_parser = u8::from_str)]
     addr: u8,
 
     #[command(subcommand)]

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -100,17 +100,15 @@ pub struct ManifestUpdateCommand {
     /// Filename for an external SPHINCS+ signature file.
     #[arg(short, long)]
     spx_signature: Option<PathBuf>,
-    #[arg(
-        long,
-        help = "Filename for the RSA PKCS8 key corresponding to the signature",
-        long_help = "Passing a private key indicates the key will be used for signing."
-    )]
+    /// Filename for the RSA PKCS8 key corresponding to the signature.
+    ///
+    /// Passing a private key indicates the key will be used for signing.
+    #[arg(long)]
     rsa_key: Option<PathBuf>,
-    #[arg(
-        long,
-        help = "Filename for the SPHINCS+ key corresponding to the signature",
-        long_help = "Passing a private key indicates the key will be used for signing."
-    )]
+    /// Filename for the SPHINCS+ key corresponding to the signature.
+    ///
+    /// Passing a private key indicates the key will be used for signing.
+    #[arg(long)]
     spx_key: Option<PathBuf>,
     /// Filename to write the output to instead of updating the input file.
     #[arg(short, long)]

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -28,30 +28,17 @@ use opentitanlib::util::parse_int::ParseInt;
 /// Bootstrap the target device.
 #[derive(Debug, Args)]
 pub struct AssembleCommand {
-    #[arg(
-        short,
-        long,
-        value_parser = usize::from_str,
-        default_value="1048576",
-        help="The size of the image to assemble"
-    )]
+    /// The size of the image to assemble.
+    #[arg(short, long, value_parser = usize::from_str, default_value="1048576")]
     size: usize,
-    #[arg(
-        short,
-        long,
-        action = clap::ArgAction::Set,
-        default_value = "true",
-        help = "Whether or not the assembled image is mirrored"
-    )]
+    /// Whether or not the assembled image is mirrored.
+    #[arg(short, long, action = clap::ArgAction::Set, default_value = "true")]
     mirror: bool,
-    #[arg(short, long, help = "Filename to write the assembled image to")]
+    /// Filename to write the assembled image to.
+    #[arg(short, long)]
     output: PathBuf,
-    #[arg(
-        value_name = "FILE",
-        required = true,
-        num_args = 1..,
-        help = "One or more filename@offset specifiers to assemble into an image"
-    )]
+    /// One or more filename@offset specifiers to assemble into an image.
+    #[arg(value_name = "FILE", required = true, num_args = 1..)]
     filename: Vec<String>,
 }
 
@@ -77,7 +64,7 @@ impl CommandDispatch for AssembleCommand {
 /// Manifest show command.
 #[derive(Debug, Args)]
 pub struct ManifestShowCommand {
-    #[arg(help = "Filename for the image to display")]
+    /// Filename for the image to display.
     image: PathBuf,
 }
 
@@ -96,29 +83,22 @@ impl CommandDispatch for ManifestShowCommand {
 /// Manifest update command.
 #[derive(Debug, Args)]
 pub struct ManifestUpdateCommand {
-    #[arg(help = "Filename for the image to update")]
+    /// Filename for the image to update.
     image: PathBuf,
-    #[arg(
-        short,
-        long,
-        help = "Filename for an HJSON configuration specifying manifest fields"
-    )]
+    /// Filename for an HJSON configuration specifying manifest fields.
+    #[arg(short, long)]
     manifest: Option<PathBuf>,
-    #[arg(
-        long,
-        help = "Filename for an HJSON configuration specifying manifest extension fields"
-    )]
+    /// Filename for an HJSON configuration specifying manifest extension fields.
+    #[arg(long)]
     manifest_ext: Option<PathBuf>,
-    #[arg(
-        long,
-        action = clap::ArgAction::Set,
-        default_value = "true",
-        help = "Update the length field of the manifest automatically"
-    )]
+    /// Update the length field of the manifest automatically.
+    #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     update_length: bool,
-    #[arg(long, help = "Filename for an external RSA signature file")]
+    /// Filename for an external RSA signature file.
+    #[arg(long)]
     rsa_signature: Option<PathBuf>,
-    #[arg(short, long, help = "Filename for an external SPHINCS+ signature file")]
+    /// Filename for an external SPHINCS+ signature file.
+    #[arg(short, long)]
     spx_signature: Option<PathBuf>,
     #[arg(
         long,
@@ -132,11 +112,8 @@ pub struct ManifestUpdateCommand {
         long_help = "Passing a private key indicates the key will be used for signing."
     )]
     spx_key: Option<PathBuf>,
-    #[arg(
-        short,
-        long,
-        help = "Filename to write the output to instead of updating the input file"
-    )]
+    /// Filename to write the output to instead of updating the input file.
+    #[arg(short, long)]
     output: Option<PathBuf>,
 }
 
@@ -258,9 +235,10 @@ impl CommandDispatch for ManifestUpdateCommand {
 /// Manifest verify command.
 #[derive(Debug, Args)]
 pub struct ManifestVerifyCommand {
-    #[arg(help = "Filename for the image to verify")]
+    /// Filename for the image to verify.
     image: PathBuf,
-    #[arg(short, long, help = "Run verification for SPHINCS+")]
+    /// Run verification for SPHINCS+.
+    #[arg(short, long)]
     spx: bool,
 }
 
@@ -297,9 +275,10 @@ impl CommandDispatch for ManifestVerifyCommand {
 /// Compute digest command.
 #[derive(Debug, Args)]
 pub struct DigestCommand {
-    #[arg(help = "Filename for the image to calculate the digest for")]
+    /// Filename for the image to calculate the digest for.
     image: PathBuf,
-    #[arg(short, long, help = "Filename for an output bin file")]
+    /// Filename for an output bin file.
+    #[arg(short, long)]
     bin: Option<PathBuf>,
 }
 
@@ -332,9 +311,10 @@ impl CommandDispatch for DigestCommand {
 /// Compute spx-message command.
 #[derive(Debug, Args)]
 pub struct SpxMessageCommand {
-    #[arg(help = "Filename for the image to calculate the digest for")]
+    /// Filename for the image to calculate the digest for.
     image: PathBuf,
-    #[arg(short, long, help = "Filename for an output bin file")]
+    /// Filename for an output bin file.
+    #[arg(short, long)]
     output: PathBuf,
 }
 

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -20,19 +20,11 @@ pub struct LoadBitstream {
     #[arg(value_name = "FILE")]
     filename: PathBuf,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "50ms",
-        help = "Duration of the reset pulse."
-    )]
+    /// Duration of the reset pulse.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "50ms")]
     pub rom_reset_pulse: Duration,
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "2s",
-        help = "Duration of ROM detection timeout"
-    )]
+    /// Duration of ROM detection timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "2s")]
     pub rom_timeout: Duration,
 }
 

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -36,12 +36,8 @@ use opentitanlib::app::TransportWrapper;
 #[derive(Debug, Args)]
 /// No Operation.
 pub struct NoOp {
-    #[arg(
-        short = 'd',
-        long,
-        help = "Delay execution",
-        value_parser = humantime::parse_duration
-    )]
+    /// Delay execution.
+    #[arg(short = 'd', long, value_parser = humantime::parse_duration)]
     delay: Option<Duration>,
 }
 

--- a/sw/host/opentitantool/src/command/otp.rs
+++ b/sw/host/opentitantool/src/command/otp.rs
@@ -22,18 +22,13 @@ use opentitanlib::otp::otp_img::{OtpImg, OtpImgItem, OtpImgPartition, OtpImgValu
 /// Generate CRC magic value for alert_handler configuration.
 #[derive(Debug, Args)]
 pub struct AlertDigest {
-    #[arg(help = "OTP memory map file containing alert_handler config in HJSON format")]
+    /// OTP memory map file containing alert_handler config in HJSON format.
     alert_cfg: PathBuf,
-    #[arg(
-        long,
-        help = "Output file to write the new OTP overlay to instead of printing"
-    )]
+    /// Output file to write the new OTP overlay to instead of printing.
+    #[arg(long)]
     output: Option<PathBuf>,
-    #[arg(
-        long,
-        default_value = "OWNER_SW_CFG",
-        help = "Override switch to specify a custom partition"
-    )]
+    /// Override switch to specify a custom partition.
+    #[arg(long, default_value = "OWNER_SW_CFG")]
     partition: String,
 }
 

--- a/sw/host/opentitantool/src/command/rsa.rs
+++ b/sw/host/opentitantool/src/command/rsa.rs
@@ -56,7 +56,7 @@ pub struct RsaKeyInfoInWords {
 /// Show public information of a private or public RSA key
 #[derive(Debug, Args)]
 pub struct RsaKeyShowCommand {
-    #[arg(help = "RSA public or private key file in DER format")]
+    /// RSA public or private key file in DER format.
     der_file: PathBuf,
 }
 
@@ -83,9 +83,9 @@ impl CommandDispatch for RsaKeyShowCommand {
 /// <OUTPUT_DIR>/<BASENAME>.pub.der
 #[derive(Debug, Args)]
 pub struct RsaKeyGenerateCommand {
-    #[arg(help = "Output directory")]
+    /// Output directory.
     output_dir: PathBuf,
-    #[arg(help = "Basename for the generated key pair")]
+    /// Basename for the generated key pair.
     basename: String,
 }
 
@@ -112,9 +112,9 @@ impl CommandDispatch for RsaKeyGenerateCommand {
 /// to a C header that can be used in the ROM or ROM_EXT
 #[derive(Debug, Args)]
 pub struct RsaKeyExportCommand {
-    #[arg(help = "RSA public or private key file in DER format")]
+    /// RSA public or private key file in DER format.
     der_file: PathBuf,
-    #[arg(help = "output header file to generate")]
+    /// output header file to generate.
     output_file: Option<PathBuf>,
 }
 
@@ -256,22 +256,21 @@ pub struct RsaSignResult {
 
 #[derive(Debug, Args)]
 pub struct RsaSignCommand {
-    #[arg(short, long, help = "File containing a SHA256 digest")]
+    /// File containing a SHA256 digest.
+    #[arg(short, long)]
     input: Option<PathBuf>,
-    #[arg(short, long, help = "File name to write the signature to")]
+    /// File name to write the signature to.
+    #[arg(short, long)]
     output: Option<PathBuf>,
 
-    #[arg(
-        value_name = "DER_FILE",
-        value_parser = load_priv_key,
-        help = "RSA private key file in PKCS#1 DER format"
-    )]
+    /// RSA private key file in PKCS#1 DER format.
+    #[arg(value_name = "DER_FILE", value_parser = load_priv_key)]
     private_key: RsaPrivateKey,
+    /// SHA256 digest of the message.
     #[arg(
         value_name = "SHA256_DIGEST",
         value_parser = Sha256Digest::from_str,
-        required_unless_present = "input",
-        help = "SHA256 digest of the message"
+        required_unless_present = "input"
     )]
     digest: Option<Sha256Digest>,
 }
@@ -301,14 +300,13 @@ impl CommandDispatch for RsaSignCommand {
 
 #[derive(Debug, Args)]
 pub struct RsaVerifyCommand {
-    #[arg(value_name = "KEY", help = "Key file in DER format")]
+    /// Key file in DER format.
+    #[arg(value_name = "KEY")]
     der_file: PathBuf,
-    #[arg(
-        value_name = "SHA256_DIGEST",
-        help = "SHA256 digest of the message as a hex string (big-endian), i.e. 0x..."
-    )]
+    /// SHA256 digest of the message as a hex string (big-endian), i.e. 0x...
+    #[arg(value_name = "SHA256_DIGEST")]
     digest: String,
-    #[arg(help = "Signature to be verified as a hex string (big-endian), i.e. 0x...")]
+    /// Signature to be verified as a hex string (big-endian), i.e. 0x...
     signature: String,
 }
 

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -23,18 +23,12 @@ use opentitanlib::transport::ProgressIndicator;
 /// Read and parse an SFDP table.
 #[derive(Debug, Args)]
 pub struct SpiSfdp {
-    #[arg(
-        short,
-        long,
-        help = "Display raw SFDP bytes rather than the parsed struct."
-    )]
+    /// Display raw SFDP bytes rather than the parsed struct.
+    #[arg(short, long)]
     raw: Option<usize>,
 
-    #[arg(
-        short,
-        long,
-        help = "Start reading SFDP at offset.  Only valid with --raw."
-    )]
+    /// Start reading SFDP at offset.  Only valid with --raw.
+    #[arg(short, long)]
     offset: Option<u32>,
 }
 
@@ -99,12 +93,8 @@ impl CommandDispatch for SpiSfdp {
 /// Read the JEDEC ID of a SPI EEPROM.
 #[derive(Debug, Args)]
 pub struct SpiReadId {
-    #[arg(
-        short = 'n',
-        long,
-        default_value = "15",
-        help = "Number of JEDEC ID bytes to read."
-    )]
+    /// Number of JEDEC ID bytes to read.
+    #[arg(short = 'n', long, default_value = "15")]
     length: usize,
 }
 
@@ -131,25 +121,23 @@ impl CommandDispatch for SpiReadId {
 /// Read data from a SPI EEPROM.
 #[derive(Debug, Args)]
 pub struct SpiRead {
-    #[arg(short, long, default_value = "0", help = "Start offset.")]
+    /// Start offset.
+    #[arg(short, long, default_value = "0")]
     start: u32,
-    #[arg(
-        short = 'n',
-        long,
-        default_value = "4096",
-        help = "Number of bytes to read."
-    )]
+    /// Number of bytes to read.
+    #[arg(short = 'n', long, default_value = "4096")]
     length: usize,
+    /// Read mode.
     #[arg(
         short,
         long,
         value_enum,
         ignore_case = true,
-        default_value = "standard",
-        help = "Read mode"
+        default_value = "standard"
     )]
     pub mode: ReadMode,
-    #[arg(long, help = "Hexdump the data.")]
+    /// Hexdump the data.
+    #[arg(long)]
     hexdump: bool,
     #[arg(value_name = "FILE", default_value = "-")]
     filename: PathBuf,
@@ -206,24 +194,22 @@ impl CommandDispatch for SpiRead {
 /// Erase sectors of a SPI EEPROM.
 #[derive(Debug, Args)]
 pub struct SpiErase {
-    #[arg(short, long, required_unless_present = "chip", help = "Start offset.")]
+    /// Start offset.
+    #[arg(short, long, required_unless_present = "chip")]
     start: Option<u32>,
-    #[arg(
-        short = 'n',
-        long,
-        required_unless_present = "chip",
-        help = "Number of bytes to erase."
-    )]
+    /// Number of bytes to erase.
+    #[arg(short = 'n', long, required_unless_present = "chip")]
     length: Option<u32>,
-    #[arg(long, help = "Erase the whole chip.")]
+    /// Erase the whole chip.
+    #[arg(long)]
     chip: bool,
+    /// Erase mode.
     #[arg(
         short,
         long,
         value_enum,
         ignore_case = true,
-        default_value = "standard",
-        help = "Erase mode"
+        default_value = "standard"
     )]
     pub mode: EraseMode,
 }
@@ -276,7 +262,8 @@ impl CommandDispatch for SpiErase {
 /// Program data into a SPI EEPROM.
 #[derive(Debug, Args)]
 pub struct SpiProgram {
-    #[arg(short, long, default_value = "0", help = "Start offset.")]
+    /// Start offset.
+    #[arg(short, long, default_value = "0")]
     start: u32,
     #[arg(value_name = "FILE")]
     filename: PathBuf,
@@ -334,7 +321,8 @@ impl CommandDispatch for SpiTpm {
 /// Read plain data bytes from a SPI device (not necessarily SPI EEPROM/flash).
 #[derive(Debug, Args)]
 pub struct SpiRawRead {
-    #[arg(short = 'n', long, help = "Number of bytes to read.")]
+    /// Number of bytes to read.
+    #[arg(short = 'n', long)]
     length: usize,
 }
 
@@ -363,7 +351,8 @@ impl CommandDispatch for SpiRawRead {
 /// Write plain data bytes to a SPI device (not necessarily SPI EEPROM/flash).
 #[derive(Debug, Args)]
 pub struct SpiRawWrite {
-    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
+    /// Hex data bytes to write.
+    #[arg(short = 'd', long)]
     hexdata: String,
 }
 
@@ -384,10 +373,12 @@ impl CommandDispatch for SpiRawWrite {
 /// Write data bytes to a SPI device then read data (not necessarily SPI EEPROM/flash).
 #[derive(Debug, Args)]
 pub struct SpiRawWriteRead {
-    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
+    /// Hex data bytes to write.
+    #[arg(short = 'd', long)]
     hexdata: String,
 
-    #[arg(short = 'n', long, help = "Number of bytes to read.")]
+    /// Number of bytes to read.
+    #[arg(short = 'n', long)]
     length: usize,
 }
 
@@ -414,7 +405,8 @@ impl CommandDispatch for SpiRawWriteRead {
 /// Simultaneously write and read plain data bytes to a SPI device (not SPI EEPROM/flash).
 #[derive(Debug, Args)]
 pub struct SpiRawTransceive {
-    #[arg(short = 'd', long, help = "Hex data bytes to write.")]
+    /// Hex data bytes to write.
+    #[arg(short = 'd', long)]
     hexdata: String,
 }
 

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -23,7 +23,7 @@ pub struct SpxPublicKeyInfo {
 /// Show public information of a SPHINCS+ public key or key pair.
 #[derive(Debug, Args)]
 pub struct SpxKeyShowCommand {
-    #[arg(help = "SPHINCS+ key file (either just the public key or full keypair)")]
+    /// SPHINCS+ key file (either just the public key or full keypair).
     key_file: PathBuf,
 }
 
@@ -51,9 +51,9 @@ impl CommandDispatch for SpxKeyShowCommand {
 /// <OUTPUT_DIR>/<BASENAME>.pub.key.
 #[derive(Debug, Args)]
 pub struct SpxKeyGenerateCommand {
-    #[arg(help = "Output directory")]
+    /// Output directory.
     output_dir: PathBuf,
-    #[arg(help = "Basename for the generated key pair")]
+    /// Basename for the generated key pair.
     basename: String,
 }
 
@@ -89,12 +89,14 @@ pub struct SpxSignResult {
 
 #[derive(Debug, Args)]
 pub struct SpxSignCommand {
-    #[arg(help = "The filename for the message to sign")]
+    /// The filename for the message to sign.
     message: PathBuf,
 
-    #[arg(value_name = "KEY_FILE", help = "The file contianing SPHICS+ keypair")]
+    /// The file contianing SPHICS+ keypair.
+    #[arg(value_name = "KEY_FILE")]
     keypair: PathBuf,
-    #[arg(short, long, help = "The filename to write the signature to")]
+    /// The filename to write the signature to.
+    #[arg(short, long)]
     output: Option<PathBuf>,
 }
 
@@ -119,11 +121,12 @@ impl CommandDispatch for SpxSignCommand {
 
 #[derive(Debug, Args)]
 pub struct SpxVerifyCommand {
-    #[arg(value_name = "KEY", help = "Key file")]
+    /// Key file.
+    #[arg(value_name = "KEY")]
     key_file: PathBuf,
-    #[arg(help = "Message file to verify the signature against")]
+    /// Message file to verify the signature against.
     message: PathBuf,
-    #[arg(help = "SPHINCS+ signature file to verify")]
+    /// SPHINCS+ signature file to verify.
     signature: PathBuf,
 }
 

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -28,9 +28,10 @@ pub enum StatusCommand {
 #[derive(Debug, Args)]
 /// List all records in an ELF file.
 pub struct ListCommand {
-    #[arg(short, long, help = "Display the raw status create records.")]
+    /// Display the raw status create records.
+    #[arg(short, long)]
     raw_records: bool,
-    #[arg(help = "Filename for the executable to analyze.")]
+    /// Filename for the executable to analyze.
     elf_file: PathBuf,
 }
 
@@ -71,9 +72,10 @@ pub struct LintCommand {
     // Bazel needs any command to create at least one output file, but we want to
     // print to stderr in this case. This option simplies tells the tool to create
     // an empty file to make bazel happy.
-    #[arg(short, long, help = "Create an empty file to make bazel happy.")]
+    /// Create an empty file to make bazel happy.
+    #[arg(short, long)]
     touch: Option<PathBuf>,
-    #[arg(help = "Filenames of the executable to analyze.")]
+    /// Filenames of the executable to analyze.
     elf_files: Vec<PathBuf>,
 }
 
@@ -139,11 +141,8 @@ pub struct DecodeCommand {
         value_parser = u32::from_str,
     )]
     raw_status: u32,
-    #[arg(
-        long,
-        value_name = "ELF_FILE",
-        help = "Filename for the executable to analyze."
-    )]
+    /// Filename for the executable to analyze.
+    #[arg(long, value_name = "ELF_FILE")]
     elf: Option<PathBuf>,
 }
 

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -136,10 +136,8 @@ impl CommandDispatch for LintCommand {
 #[derive(Debug, Args)]
 /// Decode a raw status. Optionally accepts an ELF file to recover the filename.
 pub struct DecodeCommand {
-    #[arg(
-        help = "Raw status to decode (can be in hexadecimal using 0x).",
-        value_parser = u32::from_str,
-    )]
+    /// Raw status to decode (can be in hexadecimal using 0x).
+    #[arg(value_parser = u32::from_str)]
     raw_status: u32,
     /// Filename for the executable to analyze.
     #[arg(long, value_name = "ELF_FILE")]

--- a/sw/host/opentitantool/src/command/tpm.rs
+++ b/sw/host/opentitantool/src/command/tpm.rs
@@ -15,10 +15,12 @@ use opentitanlib::tpm;
 /// Read the value of a given TPM register.
 #[derive(Debug, Args)]
 pub struct TpmReadRegister {
-    #[arg(value_enum, ignore_case = true, help = "The TPM register to inspect")]
+    /// The TPM register to inspect.
+    #[arg(value_enum, ignore_case = true)]
     register: tpm::Register,
 
-    #[arg(long, help = "Number of bytes to read.")]
+    /// Number of bytes to read.
+    #[arg(long)]
     length: Option<usize>,
 }
 
@@ -65,28 +67,29 @@ impl CommandDispatch for TpmReadRegister {
 /// Write to a given TPM register.
 #[derive(Debug, Args)]
 pub struct TpmWriteRegister {
-    #[arg(value_enum, ignore_case = true, help = "The TPM register to modify")]
+    /// The TPM register to modify.
+    #[arg(value_enum, ignore_case = true)]
     register: tpm::Register,
 
+    /// Data to write, specify only one kind.
     #[arg(
         short = 'd',
         long,
-        conflicts_with_all=&["uint32", "uint8"],
-        help = "Data to write, specify only one kind.",
+        conflicts_with_all=&["uint32", "uint8"]
     )]
     hexdata: Option<String>,
+    /// Data to write, specify only one kind.
     #[arg(
         short = 'w',
         long,
-        conflicts_with_all=&["hexdata", "uint8"],
-        help = "Data to write, specify only one kind.",
+        conflicts_with_all=&["hexdata", "uint8"]
     )]
     uint32: Option<u32>,
+    /// Data to write, specify only one kind.
     #[arg(
         short = 'b',
         long,
-        conflicts_with_all=&["hexdata", "uint32"],
-        help = "Data to write, specify only one kind.",
+        conflicts_with_all=&["hexdata", "uint32"]
     )]
     uint8: Option<u8>,
 }
@@ -115,7 +118,8 @@ impl CommandDispatch for TpmWriteRegister {
 /// Write to a given TPM register.
 #[derive(Debug, Args)]
 pub struct TpmExecuteCommand {
-    #[arg(short = 'd', long, help = "Hex encoding of TPM command to execute.")]
+    /// Hex encoding of TPM command to execute.
+    #[arg(short = 'd', long)]
     hexdata: String,
 }
 

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -42,17 +42,12 @@ impl CommandDispatch for TransportInit {
 /// https://docs.google.com/document/d/1ZEH7L5j9-wMw4tkW28-xt6JU5B6hTX0RdZD4h4OZzDo .
 #[derive(Debug, Args)]
 pub struct TransportUpdateFirmware {
-    #[arg(
-        short,
-        long,
-        help = "Local firmware file to use instead of official release"
-    )]
+    /// Local firmware file to use instead of official release.
+    #[arg(short, long)]
     filename: Option<PathBuf>,
 
-    #[arg(
-        long,
-        help = "Update even if transport already reports identical version number"
-    )]
+    /// Update even if transport already reports identical version number.
+    #[arg(long)]
     force: bool,
 }
 
@@ -79,13 +74,10 @@ impl CommandDispatch for TransportUpdateFirmware {
 /// Watch verilator's stdout for a regex or until a timeout is reached.
 #[derive(Debug, Args)]
 pub struct VerilatorWatch {
-    #[arg(help = "Regular expresion to watch for")]
+    /// Regular expresion to watch for.
     regex: String,
-    #[arg(
-        short,
-        long, value_parser=humantime::parse_duration,
-        help = "Duration to watch for the expresion",
-    )]
+    /// Duration to watch for the expresion.
+    #[arg(short, long, value_parser=humantime::parse_duration)]
     timeout: Option<Duration>,
 }
 
@@ -105,7 +97,7 @@ impl CommandDispatch for VerilatorWatch {
 
 #[derive(Debug, Args)]
 pub struct TransportQuery {
-    #[arg(help = "User defined key to look up")]
+    /// User defined key to look up.
     key: String,
 }
 

--- a/sw/host/opentitantool/src/command/update_usr_access.rs
+++ b/sw/host/opentitantool/src/command/update_usr_access.rs
@@ -23,11 +23,8 @@ pub struct UpdateUsrAccess {
     #[arg(value_name = "OUTPUT_FILE")]
     output: PathBuf,
 
-    #[arg(
-        long,
-        value_parser = u32::from_str,
-        help="New USR_ACCESS value, default = crc32"
-    )]
+    /// New USR_ACCESS value, default = crc32.
+    #[arg(long, value_parser = u32::from_str)]
     usr_access: Option<u32>,
 }
 

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -75,38 +75,27 @@ enum Format {
     about = "A tool for interacting with OpenTitan chips."
 )]
 struct Opts {
-    #[arg(
-        long,
-        value_parser = PathBuf::from_str,
-        default_value = "config",
-        help = "Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool."
-    )]
+    /// Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool.
+    #[arg(long, value_parser = PathBuf::from_str, default_value = "config")]
     rcfile: PathBuf,
 
     #[arg(long, default_value = "warn")]
     logging: LevelFilter,
 
-    #[arg(
-        short,
-        long,
-        value_enum,
-        ignore_case = true,
-        default_value = "hjson",
-        help = "Preferred output format"
-    )]
+    /// Preferred output format.
+    #[arg(short, long, value_enum, ignore_case = true, default_value = "hjson")]
     format: Format,
 
-    #[arg(short, long, value_parser = bool::from_str, help = "Use color in the output")]
+    /// Use color in the output.
+    #[arg(short, long, value_parser = bool::from_str)]
     color: Option<bool>,
 
-    #[arg(short, long, help = "Do not print command results")]
+    /// Do not print command results.
+    #[arg(short, long)]
     quiet: bool,
 
-    #[arg(
-        long,
-        num_args = 1,
-        help = "Parse and execute the argument as a command"
-    )]
+    /// Parse and execute the argument as a command.
+    #[arg(long, num_args = 1)]
     exec: Vec<String>,
 
     #[command(flatten)]

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -26,12 +26,8 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -21,19 +21,12 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 
-    #[arg(
-        long,
-        default_value = "0",
-        help = "Name of the debugger's I2C interface"
-    )]
+    /// Name of the debugger's I2C interface.
+    #[arg(long, default_value = "0")]
     i2c: String,
 }
 

--- a/sw/host/tests/chip/power_virus/src/main.rs
+++ b/sw/host/tests/chip/power_virus/src/main.rs
@@ -17,12 +17,8 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
@@ -18,19 +18,12 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-    long,
-    value_parser = humantime::parse_duration,
-    default_value = "600s",
-    help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 
-    #[arg(
-        long,
-        default_value = "BOOTSTRAP",
-        help = "Name of the SPI interface to connect to the OTTF console."
-    )]
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
     console_spi: String,
 }
 

--- a/sw/host/tests/chip/spi_passthru/src/main.rs
+++ b/sw/host/tests/chip/spi_passthru/src/main.rs
@@ -29,19 +29,12 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 
-    #[arg(
-        long,
-        default_value = "BOOTSTRAP",
-        help = "Name of the debugger's SPI interface"
-    )]
+    /// Name of the debugger's SPI interface.
+    #[arg(long, default_value = "BOOTSTRAP")]
     spi: String,
 }
 

--- a/sw/host/tests/manuf/cp_provision_init/src/main.rs
+++ b/sw/host/tests/manuf/cp_provision_init/src/main.rs
@@ -33,12 +33,8 @@ struct Opts {
     #[command(flatten)]
     sram_program: SramProgramParams,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/manuf/manuf_cp_ast_test_execution/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_ast_test_execution/src/main.rs
@@ -28,12 +28,8 @@ struct Opts {
     #[command(flatten)]
     sram_program: SramProgramParams,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -28,20 +28,12 @@ struct Opts {
     #[command(flatten)]
     sram_program: SramProgramParams,
 
-    #[arg(
-        long,
-        value_parser = DifLcCtrlState::parse_lc_state_str,
-        default_value = "prod",
-        help = "LC state to transition to from TEST_UNLOCKED*."
-    )]
+    /// LC state to transition to from TEST_UNLOCKED*.
+    #[arg(long, value_parser = DifLcCtrlState::parse_lc_state_str, default_value = "prod")]
     target_lc_state: DifLcCtrlState,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -27,11 +27,11 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
+    /// LC state to expect the chip to be initialized in.
     #[arg(
         long,
         value_parser = DifLcCtrlState::parse_lc_state_str,
-        default_value = "test_unlocked0",
-        help = "LC state to expect the chip to be initialized in."
+        default_value = "test_unlocked0"
     )]
     initial_lc_state: DifLcCtrlState,
 }

--- a/sw/host/tests/manuf/manuf_scrap/src/main.rs
+++ b/sw/host/tests/manuf/manuf_scrap/src/main.rs
@@ -17,11 +17,11 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
+    /// LC state to expect the chip to be initialized in.
     #[arg(
         long,
         value_parser = DifLcCtrlState::parse_lc_state_str,
-        default_value = "test_unlocked0",
-        help = "LC state to expect the chip to be initialized in."
+        default_value = "test_unlocked0"
     )]
     initial_lc_state: DifLcCtrlState,
 }

--- a/sw/host/tests/manuf/personalize/src/main.rs
+++ b/sw/host/tests/manuf/personalize/src/main.rs
@@ -32,15 +32,12 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "600s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
 
-    #[arg(long, help = "HSM generated ECDH private key DER file.")]
+    /// HSM generated ECDH private key DER file.
+    #[arg(long)]
     hsm_ecdh_sk: PathBuf,
 }
 

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
@@ -19,12 +19,8 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "5s",
-        help = "Bootstrap detection timeout",
-    )]
+    /// Bootstrap detection timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "5s")]
     timeout: Duration,
 }
 

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -26,44 +26,24 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "5s",
-        help = "Bootstrap detection timeout",
-    )]
+    /// Bootstrap detection timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "5s")]
     timeout: Duration,
 
-    #[arg(
-        long,
-        value_parser = usize::from_str,
-        default_value = "12",
-        help = "JEDEC page of manufacturer",
-    )]
+    /// JEDEC page of manufacturer.
+    #[arg(long, value_parser = usize::from_str, default_value = "12")]
     jedec_page: usize,
 
-    #[arg(
-        long,
-        value_parser = u8::from_str,
-        default_value = "0xEF",
-        help = "JEDEC ID of manufacturer",
-    )]
+    /// JEDEC ID of manufacturer.
+    #[arg(long, value_parser = u8::from_str, default_value = "0xEF")]
     jedec_id: u8,
 
-    #[arg(
-        long,
-        value_parser = u8::from_str,
-        default_value = "0x29",
-        help = "JEDEC manufacturer product ID",
-    )]
+    /// JEDEC manufacturer product ID.
+    #[arg(long, value_parser = u8::from_str, default_value = "0x29")]
     jedec_product: u8,
 
-    #[arg(
-        long,
-        value_parser = u32::from_str,
-        default_value = "0x100000",
-        help = "Size of the internal flash",
-    )]
+    /// Size of the internal flash.
+    #[arg(long, value_parser = u32::from_str, default_value = "0x100000")]
     flash_size: u32,
 }
 

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -25,15 +25,12 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "10s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
 
-    #[arg(long, help = "OTP is unprogrammed; be permissive with OTP values")]
+    /// OTP is unprogrammed; be permissive with OTP values.
+    #[arg(long)]
     otp_unprogrammed: bool,
 }
 

--- a/sw/host/tests/rom/sw_strap_value/src/main.rs
+++ b/sw/host/tests/rom/sw_strap_value/src/main.rs
@@ -20,12 +20,8 @@ struct Opts {
     #[command(flatten)]
     init: InitializeTest,
 
-    #[arg(
-        long,
-        value_parser = humantime::parse_duration,
-        default_value = "180s",
-        help = "Console receive timeout",
-    )]
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "180s")]
     timeout: Duration,
 }
 

--- a/sw/host/tpm2_test_server/src/main.rs
+++ b/sw/host/tpm2_test_server/src/main.rs
@@ -49,12 +49,8 @@ struct Opts {
     #[command(flatten)]
     backend_opts: backend::BackendOpts,
 
-    #[arg(
-        short,
-        long,
-        default_value = "9883",
-        help = "TCP port for incoming connections."
-    )]
+    /// TCP port for incoming connections.
+    #[arg(short, long, default_value = "9883")]
     tpm_port: u16,
 }
 


### PR DESCRIPTION
This is done by:
* ```
  ast-grep run --pattern '#[arg($$$META, help = $MSG)]' -l rust -r '/// FIXMSG $MSG
  #[arg($$$META)]'
  ```
* Replace `^\s+#[arg()]\n` with empty string
* Replace `/// FIXMSG (.*)\.$` with `/// $1.`
* Replace `/// FIXMSG (.*)$` with `/// $1.`
* Manually check and fix wrong rewrite and fix formatting issues.