### PR TITLE
[ast] Reword some pgd/pok blocks in AST

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
@@ -24,20 +24,15 @@ assign gen_supp_a = 1'b1;
 ////////////////////////////////////////
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
-logic init_start;
-
 initial begin
-  init_start = 1'b1; #1;
-  init_start = 1'b0;
-end
-
-always @( * ) begin
-  if ( init_start ) begin
-    vcaon_pok_o <= 1'b0;
-  end else if ( !init_start && gen_supp_a ) begin
-    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_RDLY) gen_supp_a;
-  end else if ( !init_start && !gen_supp_a ) begin
-    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_FDLY) gen_supp_a;
+  #1; // Wait until the assignment to gen_supp_a has happened above
+  vcaon_pok_o = 1'b0;
+  if (gen_supp_a) begin
+    #(ast_bhv_pkg::VCAON_POK_RDLY);
+    vcaon_pok_o = 1'b1;
+  end else begin
+    #(ast_bhv_pkg::VCAON_POK_FDLY);
+    vcaon_pok_o = 1'b0;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
@@ -24,22 +24,15 @@ assign gen_supp_a = 1'b1;
 ////////////////////////////////////////
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
-logic init_start;
-
 initial begin
-  init_start = 1'b1; #1;
-  init_start = 1'b0;
-end
-
-always (* xprop_off *) @( * ) begin
-  if ( init_start ) begin
-    vcc_pok_o <= 1'b0;
-  end
-  if ( !init_start && gen_supp_a ) begin
-    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_RDLY) gen_supp_a;
-  end
-  if ( !init_start && !gen_supp_a ) begin
-    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_FDLY) gen_supp_a;
+  #1; // Wait until the assignment to gen_supp_a has happened above
+  vcc_pok_o = 1'b0;
+  if (gen_supp_a) begin
+    #(ast_bhv_pkg::VCC_POK_RDLY);
+    vcc_pok_o = 1'b1;
+  end else begin
+    #(ast_bhv_pkg::VCC_POK_FDLY);
+    vcc_pok_o = 1'b0;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
@@ -24,20 +24,15 @@ assign gen_supp_a = 1'b1;
 ////////////////////////////////////////
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
-logic init_start;
-
 initial begin
-  init_start = 1'b1; #1;
-  init_start = 1'b0;
-end
-
-always @( * ) begin
-  if ( init_start ) begin
-    vcmain_pok_o <= 1'b0;
-  end else if ( !init_start && gen_supp_a ) begin
-    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_RDLY) gen_supp_a;
-  end else if ( !init_start && !gen_supp_a ) begin
-    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_FDLY) gen_supp_a;
+  #1; // Wait until the assignment to gen_supp_a has happened above
+  vcmain_pok_o = 1'b0;
+  if (gen_supp_a) begin
+    #(ast_bhv_pkg::VCMAIN_POK_RDLY);
+    vcmain_pok_o = 1'b1;
+  end else begin
+    #(ast_bhv_pkg::VCMAIN_POK_FDLY);
+    vcmain_pok_o = 1'b0;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
@@ -24,22 +24,15 @@ assign gen_supp_a = 1'b1;
 ////////////////////////////////////////
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
-logic init_start;
-
 initial begin
-  init_start = 1'b1; #1;
-  init_start = 1'b0;
-end
-
-always (* xprop_off *) @( * ) begin
-  if ( init_start ) begin
-    vio_pok_o <= 1'b0;
-  end
-  if ( !init_start && gen_supp_a ) begin
-    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_RDLY) gen_supp_a;
-  end
-  if ( !init_start && !gen_supp_a ) begin
-    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_FDLY) gen_supp_a;
+  #1; // Wait until the assignment to gen_supp_a has happened above
+  vio_pok_o = 1'b0;
+  if (gen_supp_a) begin
+    #(ast_bhv_pkg::VIO_POK_RDLY);
+    vio_pok_o = 1'b1;
+  end else begin
+    #(ast_bhv_pkg::VIO_POK_FDLY);
+    vio_pok_o = 1'b0;
   end
 end
 `else


### PR DESCRIPTION
This code is in an ifndef synthesis block and works by asserting a
signal (e.g. vcc_pok_o) shortly after the start of time, using a
"#RDLY" delay to get the timing right.

Using "always @*" to structure this causes Verible to warn because of
its "always-comb" lint rule. There's no real reason to use this style
here (and the code goes back to the initial AST import in 9ee56b2 from
2020).

Make the ordering more explicit, and stick everything in the same
initial block: it should be easier to understand and does the same
thing.

Fixes #19556.