### PR TITLE
[doc] Testplans are now generated as markdown.

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1620,7 +1620,7 @@
             Check that escalation receivers located inside always-on blocks do not auto-escalate
             due to the reverse ping feature while the system is in deep sleep.
 
-            ## Reverse ping timeout calculation
+            **Reverse ping timeout calculation**
 
             The reverse ping timeout calculation is done using the following formula available in
             `prim_esc_receiver`:
@@ -1645,7 +1645,7 @@
             reverse_ping_timeout = 0.175s = (4 * 4 ( 2 * 2 * 2^16)) / 24e6
             ```
 
-            ## Procedure
+            **Procedure**
 
             - On POR reset:
               - Enable all alerts assigning them to ClassA.

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -309,7 +309,7 @@
       name: manuf_ft_provision_rma_token_and_personalization
       desc: '''Provision RMA unlock token.
 
-            ## Provisioning of RMA_UNLOCK_TOKEN
+            **Provisioning of RMA_UNLOCK_TOKEN**
 
             The RMA_UNLOCK_TOKEN is used to take a device from a production ls_state (i.e. DEV,
             PROD) in to RMA state. RMA entry is conditional to flash erase, and it also triggers
@@ -323,15 +323,15 @@
             The manufactuer is expected to maintain the RMA_UNLOCK_TOKEN decryption key in an
             offline HSM.
 
-            ## Personalization
+            **Personalization**
 
             The device is configured with a unique set of secrets, which once provisioned, are
             hidden from software. These secrets are used as the root of the key derivation
             function in the key manager.
 
-            ## Test steps
+            **Test steps**
 
-            ### Prep steps
+            ***Prep steps***
             - Pre-load the OTP state with an image of an individualized device. See
               manuf_ft_sku_individualization for more details.
             - Check expected ls_state and OTP locked partitions (SECRET1, HW_CFG).
@@ -339,7 +339,7 @@
             - Initialize entropy source in FIPS mode. Check health status after setting appropriate
               health test parameters.
 
-            ### Device secrets
+            ***Device secrets***
             - Instantiate the SW CSRNG, and configure it to generate data.
             - Configure the Silicon Creator secret info flash partition.
             - Uninstantiate the SW CSRNG.
@@ -351,14 +351,14 @@
             - Lock SECRET2 OTP partition.
             - Perform reset triggered by software.
 
-            ### RMA provisioning
+            ***RMA provisioning***
             - Instantiate the SW CSRNG, and configure it to generate data.
             - Configure RMA_TOKEN in the OTP partition with data extracted from the CSRNG.
             - Encrypt RMA_TOKEN with asymmetric algorithm (e.g RSA-3072). The encrypted blob will
               be sent to the host in the result status.
             - Uninstantiate the sw CSRNG.
 
-            ### Device Identity
+            ***Device Identity***
 
             The OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN OTP must be configured so that the
             attestation measurement can be provided in the manifest of the test program. This
@@ -375,7 +375,7 @@
             - Configure OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN OTP to switch to attestation mode
               associated with the device SKU.
 
-            ### Result status
+            ***Result status***
             - Send response to host with test result serialized in JSON format. The result must
               include the encrypted RMA_UNLOCK_TOKEN, the DEVICE_ID, the public attestation key
               and its hash.

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -998,10 +998,10 @@
       name: rom_e2e_asm_c_interrupt_handler
       desc: '''Verify that `rom_start.S` configures the ROM C interrupt handler and it triggers shutdown.
 
-            #### Using a ROM_EXT image (preferred)
+            **Using a ROM_EXT image (preferred)**
             See #14274.
 
-            #### Using a debugger
+            **Using a debugger**
             `CREATOR_SW_CFG_ROM_EXEC_EN` should be set to `0` and the chip should in a life cycle
              state where debugging is enabled, i.e. TEST, DEV, or RMA.
 

--- a/util/dvsim/testplanner.py
+++ b/util/dvsim/testplanner.py
@@ -27,7 +27,7 @@ def main():
                         '-o',
                         type=argparse.FileType('w'),
                         default=sys.stdout,
-                        help='output HTML file (without CSS)')
+                        help='output markdown file')
     args = parser.parse_args()
     outfile = args.outfile
 
@@ -36,9 +36,8 @@ def main():
         if args.sim_results:
             outfile.write(
                 testplan.get_sim_results(args.sim_results, fmt="html"))
-
         else:
-            outfile.write(testplan.get_testplan_table("html"))
+            testplan.write_testplan_doc(outfile)
 
         outfile.write('\n')
 

--- a/util/mdbook_testplan.py
+++ b/util/mdbook_testplan.py
@@ -45,7 +45,7 @@ def main() -> None:
                 book_root / chapter["source_path"],
                 repo_top = book_root)
             buffer = io.StringIO()
-            buffer.write(plan.get_testplan_table("html"))
+            plan.write_testplan_doc(buffer)
             chapter["content"] = buffer.getvalue()
 
         testplan_files.add(Path(chapter["source_path"]))


### PR DESCRIPTION
Testplans are now rendered into a markdown document as oppose to a large HTML table.

These HTML tables were unwieldy when viewed from the site or as plain text. The original `pipe` output was not standard markdown.

New version of the [GPIO Testplan](https://opentitan.org/book/hw/ip/gpio/data/gpio_testplan.html):

![image](https://github.com/lowRISC/opentitan/assets/45573837/a191520c-cd05-4019-9fe0-8ca040e82bbf)

Related to https://github.com/lowRISC/opentitan/issues/19078
