### PR TITLE
[dv] Iterate over a shorter list of CSRs in shadow reg errors test

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -47,12 +47,22 @@ virtual task run_shadow_reg_errors(int num_times, bit en_csr_rw_seq = 0);
   end
 
   for (int trans = 1; trans <= num_times; trans++) begin
-    `uvm_info(`gfn, $sformatf("Running shadow reg error test iteration %0d/%0d", trans,
-                              num_times), UVM_LOW)
+    // Iterate over shadowed CSRs, corrupting them in turn and checking that we get errors. The
+    // easiest thing to write would be a loop over all the CSRs, but that takes longer if you have
+    // lots of CSRs (obviously) and we don't want to time out on a single test run.
+    //
+    // Instead, we do the first 50 (if there are that many) in the shuffled list. If there are lots
+    // of CSRs, we can run more seeds to ensure we try them all.
+    int max_idx = shadowed_csrs.size() - 1;
+    if (max_idx > 49)
+      max_idx = 49;
+
+    `uvm_info(`gfn, $sformatf("Running shadow reg error test iteration %0d/%0d. max_idx=%0d",
+                              trans, num_times, max_idx), UVM_LOW)
 
     shadowed_csrs.shuffle();
 
-    foreach (shadowed_csrs[i]) begin
+    for (int i = 0; i < max_idx; i++) begin
       `uvm_info(`gfn, $sformatf("mycsr: %s    en_csr_rw_seq:%d",
                 shadowed_csrs[i].get_name(), en_csr_rw_seq), UVM_HIGH);
 


### PR DESCRIPTION
This test sequence times out (in simulated time) some of the time in our nightlies. In particular, this happens for alert_handler at the moment.

The problem turns out to be that the test iterates over all the CSRs and pokes them in turn. We don't really expect any inter-CSR interactions, so this is just a quick way to get through everything in "one test". Unfortunately, alert_handler has 182 CSRs and this takes a while. In local testing, I think we're taking about 3ms of simulated time per CSR. With 182 CSRs, that's ~546ms, which is more than the 500ms default timeout in uvm-phase.svh!

This patch switches the code to iterate over a shorter list of CSRs. If we have a block with lots of CSRs, we'll need to run the test more times (in parallel!) to get the coverage we expect, but that should be less brittle than the current approach.