### PR TITLE
[SiVal] I2C test plan

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -105,6 +105,68 @@
       default: "64",
     }
   ],
+  features: [
+    { name: "I2C.MODE.HOST",
+      desc: '''
+            The I2C block can be configued in host mode.
+            '''
+    },
+    { name: "I2C.MODE.TARGET",
+      desc: '''
+            The I2C block can be configured in target mode.
+            '''
+    },
+    { name: "I2C.SPEED.STANDARD",
+      desc: '''
+            Standard-mode of 100 kbaud is supported.
+            '''
+    },
+    { name: "I2C.SPEED.FAST",
+      desc: '''
+            Fast-mode of 400 kbaud is supported.
+            '''
+    },
+    { name: "I2C.SPEED.FASTPLUS",
+      desc: '''
+            Fast-mode Plus of 1 Mbaud is supported.
+            '''
+    },
+    { name: "I2C.OVERRIDE",
+      desc: '''
+            Software can override the values of SCL and SDA.
+            '''
+    },
+    { name: "I2C.OPERATION.READ",
+      desc: '''
+            Hosts can read from targets.
+            '''
+    },
+    { name: "I2C.OPERATION.WRITE",
+      desc: '''
+            Hosts can write to targets.
+            '''
+    },
+    { name: "I2C.PROTOCOL.CLOCKSTRETCHING",
+      desc: '''
+            Clock stretching is a way for a target to buy time.
+            There are three scenarios when clock stretching occurs:
+            - After an address read.
+            - During a write.
+            - During a read.
+            '''
+    },
+    { name: "I2C.PROTOCOL.NACK",
+      desc: '''
+            Whenever a byte is sent, it must be accompanied by an acknowledgement (ack), unless NAKOK is high.
+            When no ack is received, this is a nack.
+            '''
+    },
+    { name: "I2C.PROTOCOL.REPEATEDSTART",
+      desc: '''
+            Instead of doing a stop and then a start to start the next transaction, a host can choose to perform a repeated start to begin a new transaction without stopping the previous one.
+            '''
+    },
+  ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -20,6 +20,7 @@
 
     // IP block specific top level test plans.
     "hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson"
     "hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson",
   ]
@@ -267,44 +268,6 @@
             '''
       stage: V2
       tests: ["chip_sw_spi_host_tx_rx"]
-    }
-
-    // I2C (pre-verified IP) integration tests:
-    {
-      name: chip_sw_i2c_host_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C host interface.
-
-            - Program the I2C to be in host mode.
-            - The SW test writes a known payload over the chip's I2C host interface, which is
-              received by the testbench.
-            - The testbench then loops this data back to the chip's I2C host and exercises the
-              read interface.
-            - SW validates the reception of FMT watermark and trans complete interrupts.
-            - SW validates that the data read matches the original data written.
-            - Verify the virtual / true open drain capability.
-
-            Verify all instances of I2C in the chip.
-            '''
-      stage: V2
-      tests: ["chip_sw_i2c_host_tx_rx",
-              "chip_sw_i2c_host_tx_rx_idx1",
-              "chip_sw_i2c_host_tx_rx_idx2"]
-    }
-    {
-      name: chip_sw_i2c_device_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C device interface.
-
-            - Program the I2C to be in device mode.
-            - The testbench writes a known payload over the chip's I2C device interface, which is
-              received and verified by the SW test for correctness.
-            - The testbench reads and verifies a known payload over the chip's I2C device interface,
-            - SW validates the reception of tx empty and trans complete interrupts.
-            - Verify the virtual / true open drain capability.
-
-            Verify all instances of I2C in the chip.
-            '''
-      stage: V2
-      tests: ["chip_sw_i2c_device_tx_rx"]
     }
 
     // USB (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -19,8 +19,13 @@
             - Verify the virtual / true open drain capability.
 
             Verify all instances of I2C in the chip.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
             '''
+      features: ["I2C.MODE.HOST", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
+      si_stage: SV2
       tests: ["chip_sw_i2c_host_tx_rx",
               "chip_sw_i2c_host_tx_rx_idx1",
               "chip_sw_i2c_host_tx_rx_idx2"]
@@ -37,9 +42,119 @@
             - Verify the virtual / true open drain capability.
 
             Verify all instances of I2C in the chip.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
             '''
+      features: ["I2C.MODE.TARGET", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
+      si_stage: SV2
       tests: ["chip_sw_i2c_device_tx_rx"]
+    }
+    {
+      name: chip_sw_i2c_speed
+      desc: '''Verify the transmission speed of data over the chip's I2C interfaces.
+
+            Run the following for standard, fast and fast plus speeds:
+            - Program the I2C to be in the appropriate mode (host/target).
+            - For hosts, the SW test writes a known payload over the chip's I2C host interface.
+              It should then receive back that payload plus one.
+              The test checks whether the payload is sent at the appropriate baud-rate.
+            - For targets, the test sends data at the appropriate baud-rate and checks whether an ack is received.
+              The test should also do a read request.
+
+            Verify all instances of I2C in the chip.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
+            - To check the baud rate the test bench should time the packets and average this time out over multiple runs.
+            Then check whether these timings match the appropriate baud-rate within an acceptable range:
+            Fast-mode should be faster than standard-mode and fast-mode plus should be faster than fast-mode.
+            '''
+      features: ["I2C.MODE.HOST", "I2C.MODE.TARGET", "I2C.SPEED.STANDARD", "I2C.SPEED.FAST", "I2C.SPEED.FASTPLUS"]
+      stage: V3
+      si_stage: SV2
+      tests: []
+    }
+    {
+      name: chip_sw_i2c_override
+      desc: '''Verify overriding SDA and SCL on I2C interfaces.
+
+            For all I2C host mode instances:
+            - Software cycles through all SDA/SCL combinations with long delays.
+            - Test monitors the SDA/SCL lines and checks whether it receives the values in the expected order and delay.
+
+            Verify all instances of I2C in the chip.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
+            '''
+      features: ["I2C.MODE.HOST", "I2C.OVERRIDE"]
+      stage: V3
+      si_stage: SV2
+      tests: []
+    }
+    {
+      name: chip_sw_i2c_clockstretching
+      desc: '''Verify clock stretching on I2C interfaces.
+
+            For all I2C host mode instances:
+            - Do a read and make target stretch after reading an address.
+            - Do a write and make the target stretch during that write.
+            - Do a read and make the target stretch during that read.
+
+            For all I2C target mode instances:
+            - Have a queue of 10 I2C transactions where the data increments by one.
+            - The test bench host tries to send these transactions one after the other without pausing.
+            - On the chip, the Ibex waits to receive the first transaction, then it goes to sleep for 1 second and refuses to pull transactions out of the ACQ FIFO, which should cause clock stretching to happen.
+            - Afterwards Ibex repeats the reading transaction and sleeping for 1 second.
+            - The Ibex checks that it receives 10 transactions total and that the data in each of the transactions are incremented by one. After that, it sends back a transactions with the data value of the final transaction.
+            - The test bench checks that the transaction received from the chip has the same data value as the final packet sent.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
+            '''
+      features: ["I2C.MODE.HOST", "I2C.PROTOCOL.CLOCKSTRETCHING"]
+      stage: V3
+      si_stage: SV2
+      tests: []
+    }
+    {
+      name: chip_sw_i2c_nack
+      desc: '''Verify correct behavior of nack detection.
+
+            For all I2C host mode instances:
+            - Program the I2C to be in host mode.
+            - Fail to send an acknowledgement after the address.
+            - Fail to send an acknowledgment after a random data byte.
+
+            The host mode should successfully detect this nack and raise the appropriate interrupt.
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
+            '''
+      features: ["I2C.MODE.HOST", "I2C.PROTOCOL.NACK"]
+      stage: V3
+      si_stage: SV2
+      tests: []
+    }
+    {
+      name: chip_sw_i2c_repeatedstart
+      desc: '''Verify correct behavior of repeated start.
+
+            For all I2C target mode instances:
+            - Program the I2C to be in target mode.
+            - Start a transaction, but fail to send a stop.
+            - Send a repeated start with a specific data value and stop the transaction as usual.
+            - Perform a read from the I2C device and check that the target sends back the data val
+
+            Notes for silicon targets:
+            - The testbench in this case will be a device that physically toggles/inspects the appropriate SCL and SDA lines.
+            '''
+      features: ["I2C.MODE.TARGET", "I2C.PROTOCOL.REPEATEDSTART"]
+      stage: V3
+      si_stage: SV2
+      tests: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_i2c
+  testpoints: [
+    // I2C (pre-verified IP) integration tests:
+    {
+      name: chip_sw_i2c_host_tx_rx
+      desc: '''Verify the transmission of data over the chip's I2C host interface.
+
+            - Program the I2C to be in host mode.
+            - The SW test writes a known payload over the chip's I2C host interface, which is
+              received by the testbench.
+            - The testbench then loops this data back to the chip's I2C host and exercises the
+              read interface.
+            - SW validates the reception of FMT watermark and trans complete interrupts.
+            - SW validates that the data read matches the original data written.
+            - Verify the virtual / true open drain capability.
+
+            Verify all instances of I2C in the chip.
+            '''
+      stage: V2
+      tests: ["chip_sw_i2c_host_tx_rx",
+              "chip_sw_i2c_host_tx_rx_idx1",
+              "chip_sw_i2c_host_tx_rx_idx2"]
+    }
+    {
+      name: chip_sw_i2c_device_tx_rx
+      desc: '''Verify the transmission of data over the chip's I2C device interface.
+
+            - Program the I2C to be in device mode.
+            - The testbench writes a known payload over the chip's I2C device interface, which is
+              received and verified by the SW test for correctness.
+            - The testbench reads and verifies a known payload over the chip's I2C device interface,
+            - SW validates the reception of tx empty and trans complete interrupts.
+            - Verify the virtual / true open drain capability.
+
+            Verify all instances of I2C in the chip.
+            '''
+      stage: V2
+      tests: ["chip_sw_i2c_device_tx_rx"]
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_kmac
+  name: chip_keymgr
   testpoints: [
     // KEYMGR integration tests
     {


### PR DESCRIPTION
This is an initial version of the I2C silicon validation test plan. It takes inspiration from the counterpart in key manager: https://github.com/lowRISC/opentitan/pull/19521

I tried to create enough tests so that all of I2C's features are covered, but it would probably be good to get the input of more people here. Alternatively, we can merge this as a base version and iterate over it with future PRs.