### PR TITLE
[usbdev] Fix startup behavior in usb chip sims

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -1144,7 +1144,6 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
     // In the event that the device disconnected, we must start anew in
     // anticipation of a reconnection
     bus_reset(ctx);
-    ctx->driving = set_driving(ctx, d2p, 0, true);  // SE0
     ctx->recovery_time = ctx->tick + 4 * 48;
     return ctx->driving;
   }


### PR DESCRIPTION
Corrects merge of partial bus reset/disconnect behavior from suspend-resume testing. The merged code was sufficient for Verilator t-l sim but failed with the real USB signals of the ASIC chip sim. It's a 'partial' implementation because the full reset/disconnect behavior is interdependent with the sleep/resume behavior of later tests/PRs-to-be.

Background: although the new usbdev_pincfg_test passed in CI, the merge broke the chip_sw_usbdev_dpi test in the nightly regression because the DPI model was unintentionally holding usbdev in reset with its drivers, which are stronger than the ASIC pull up, so the device could not signal its presence.
With this PR the test now passes again.