### PR TITLE
[tests/usbdev] Introduce usbdev test timeouts

### DIFF
--- a/sw/device/lib/testing/usb_testutils_controlep.h
+++ b/sw/device/lib/testing/usb_testutils_controlep.h
@@ -94,6 +94,17 @@ status_t usb_testutils_controlep_init(usb_testutils_controlep_ctx_t *ctctx,
                                       const uint8_t *test_dscr,
                                       size_t test_dscr_len);
 
+/**
+ * Wait until the device configuration has been set by the host.
+ *
+ * @param ctctx uninitialized context for this instance.
+ * @param ctx initialized context for usbdev driver.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t usb_testutils_controlep_config_wait(
+    usb_testutils_controlep_ctx_t *ctctx, usb_testutils_ctx_t *ctx);
+
 /***********************************************************************/
 /* Below this point are macros used to construct the USB configuration */
 /* descriptor. Use them to initialize a uint8_t array for cfg_dscr     */

--- a/sw/device/lib/testing/usb_testutils_diags.h
+++ b/sw/device/lib/testing/usb_testutils_diags.h
@@ -4,6 +4,9 @@
 
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_DIAGS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_USB_TESTUTILS_DIAGS_H_
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/runtime/print.h"
+
 // Diagnostic, testing and performance measurements utilities for verification
 // of usbdev and development of the usb_testutils support software; the
 // requirements of this software are peculiar in that the USBDPI model used in
@@ -21,6 +24,15 @@
 // Used for tracing what is going on. This may impact timing which is critical
 // when simulating with the USB DPI module.
 #define USBUTILS_ENABLE_TRC 0
+
+// Prompt the user for intervention if we're not running in simulation;
+// logging within simulation can be time-consuming and induce failures.
+#define USBUTILS_USER_PROMPT(...)                                            \
+  do {                                                                       \
+    if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) { \
+      LOG_INFO(__VA_ARGS__);                                                 \
+    }                                                                        \
+  } while (false)
 
 #if USBUTILS_ENABLE_TRC
 // May be useful on FPGA CW310

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -114,7 +114,7 @@ static usb_testutils_streams_ctx_t stream_test;
  *   (Note that this substantially alters the timing of interactions with the
  * DPI model and will increase the simulation time)
  */
-static bool verbose = false;
+static const bool kVerbose = false;
 
 /*
  * These switches may be modified manually to experimentally measure the
@@ -122,29 +122,29 @@ static bool verbose = false;
  *
  * Are we sending data?
  */
-static bool sending = true;
+static const bool kSending = true;
 
 /**
  * Are we generating a valid byte sequence?
  */
-static bool generating = true;
+static const bool kGenerating = true;
 
 /**
  * Retrying is meaningless for this test since we have only Isochronous streams.
  */
-static bool retrying = false;
+static const bool kRetrying = false;
 
 /**
  * Are we expecting to receive data?
  */
-static bool recving = true;
+static const bool kRecving = true;
 
 /**
  * Send only maximal length packets?
  * (important for performance measurements on the USB, but obviously undesirable
  *  for testing reliability/function)
  */
-static bool max_packets = false;
+static const bool kMaxPackets = false;
 
 /**
  * Number of streams to be created
@@ -191,12 +191,12 @@ bool test_main(void) {
       kTopEarlgreyPinmuxInselIoc7));
 
   // Construct the test/stream flags to be used
-  test_flags = (sending ? kUsbdevStreamFlagRetrieve : 0U) |
-               (generating ? kUsbdevStreamFlagCheck : 0U) |
-               (retrying ? kUsbdevStreamFlagRetry : 0U) |
-               (recving ? kUsbdevStreamFlagSend : 0U) |
-               // Note: the 'max_packets' test flag is not required by the DPI
-               (max_packets ? kUsbdevStreamFlagMaxPackets : 0U);
+  test_flags = (kSending ? kUsbdevStreamFlagRetrieve : 0U) |
+               (kGenerating ? kUsbdevStreamFlagCheck : 0U) |
+               (kRetrying ? kUsbdevStreamFlagRetry : 0U) |
+               (kRecving ? kUsbdevStreamFlagSend : 0U) |
+               // Note: the 'max packets' test flag is not required by the DPI
+               (kMaxPackets ? kUsbdevStreamFlagMaxPackets : 0U);
 
   // Initialize the test descriptor
   // Note: the 'max packets' test flag is not required by the DPI model
@@ -217,9 +217,10 @@ bool test_main(void) {
       &usbdev_control, ctx->usbdev, 0, config_descriptors,
       sizeof(config_descriptors), test_descriptor, sizeof(test_descriptor)));
 
-  while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
-    CHECK_STATUS_OK(usb_testutils_poll(ctx->usbdev));
-  }
+  // Proceed only when the device has been configured; this allows host-side
+  // software to establish communication.
+  CHECK_STATUS_OK(
+      usb_testutils_controlep_config_wait(&usbdev_control, &usbdev));
 
   // Describe the transfer type of each stream;
   // Note: make all of the streams Isochronous streams for now, but later we
@@ -231,11 +232,9 @@ bool test_main(void) {
 
   // Initialise the state of the streams
   CHECK_STATUS_OK(usb_testutils_streams_init(
-      ctx, nstreams, xfr_types, transfer_bytes, test_flags, verbose));
+      ctx, nstreams, xfr_types, transfer_bytes, test_flags, kVerbose));
 
-  if (verbose) {
-    LOG_INFO("Commencing data transfer...");
-  }
+  USBUTILS_USER_PROMPT("Start host-side streaming software");
 
   // Streaming loop; most of the work is done by the usb_testutils_streams base
   //   code and we don't need to specialize its behavior for this test.
@@ -262,11 +261,11 @@ bool test_main(void) {
 
   // Note: since Isochronous streams are susceptible to packet loss we can only
   // perform a lower bounds check on the transmitted and received byte counts.
-  if (sending) {
+  if (kSending) {
     CHECK(tx_bytes >= nstreams * transfer_bytes,
           "Unexpected count of byte(s) sent to USB host");
   }
-  if (recving) {
+  if (kRecving) {
     CHECK(rx_bytes >= nstreams * transfer_bytes,
           "Unexpected count of byte(s) received from USB host");
   }

--- a/sw/device/tests/usbdev_pincfg_test.c
+++ b/sw/device/tests/usbdev_pincfg_test.c
@@ -6,7 +6,7 @@
 //
 // For each of the pin/bus configurations in turn, this test runs the USB test
 // software, device and DPI model through all of the initial communications to
-// set up the device and select a confgiguration.
+// set up the device and select a configuration.
 //
 // It is necessary to perform a complete reset of the usbdev hardware block
 // before starting the next test because the DIF keeps the 'Available buffers'
@@ -179,14 +179,8 @@ bool test_main(void) {
 
     // Configuration shall have been selected only after the host/DPI model has
     // successfully concluded the SET_CONFIGURATION control transfer
-    const uint32_t kTimeoutUsecs = 30 * 1000000;
-    ibex_timeout_t timeout = ibex_timeout_init(kTimeoutUsecs);
-    while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured &&
-           !ibex_timeout_check(&timeout)) {
-      CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
-    }
-    // Check that we were configured, implying that communication is working.
-    CHECK(usbdev_control.device_state == kUsbTestutilsDeviceConfigured);
+    CHECK_STATUS_OK(
+        usb_testutils_controlep_config_wait(&usbdev_control, &usbdev));
 
     if (kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator) {
       // TODO: We shall probably want simply to drop the connection and control

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -137,7 +137,7 @@ static usb_testutils_streams_ctx_t stream_test;
  *   (Note that this substantially alters the timing of interactions with the
  * DPI model and will increase the simulation time)
  */
-static bool verbose = false;
+static const bool kVerbose = false;
 
 /*
  * These switches may be modified manually to experimentally measure the
@@ -145,30 +145,30 @@ static bool verbose = false;
  *
  * Are we sending data?
  */
-static bool sending = true;
+static const bool kSending = true;
 
 /**
  * Are we generating a valid byte sequence?
  */
-static bool generating = true;
+static const bool kGenerating = true;
 
 /**
  * Do we want the host to retry transmissions? (DPI model only; we cannot
  * instruct a physical host to fake delivery failure/packet corruption etc)
  */
-static bool retrying = true;
+static const bool kRetrying = true;
 
 /**
  * Are we expecting to receive data?
  */
-static bool recving = true;
+static const bool kRecving = true;
 
 /**
  * Send only maximal length packets?
  * (important for performance measurements on the USB, but obviously undesirable
  *  for testing reliability/function)
  */
-static bool max_packets = false;
+static const bool kMaxPackets = false;
 
 /**
  * Number of streams to be created
@@ -215,12 +215,12 @@ bool test_main(void) {
       kTopEarlgreyPinmuxInselIoc7));
 
   // Construct the test/stream flags to be used
-  test_flags = (sending ? kUsbdevStreamFlagRetrieve : 0U) |
-               (generating ? kUsbdevStreamFlagCheck : 0U) |
-               (retrying ? kUsbdevStreamFlagRetry : 0U) |
-               (recving ? kUsbdevStreamFlagSend : 0U) |
-               // Note: the 'max_packets' test flag is not required by the DPI
-               (max_packets ? kUsbdevStreamFlagMaxPackets : 0U);
+  test_flags = (kSending ? kUsbdevStreamFlagRetrieve : 0U) |
+               (kGenerating ? kUsbdevStreamFlagCheck : 0U) |
+               (kRetrying ? kUsbdevStreamFlagRetry : 0U) |
+               (kRecving ? kUsbdevStreamFlagSend : 0U) |
+               // Note: the 'max packets' test flag is not required by the DPI
+               (kMaxPackets ? kUsbdevStreamFlagMaxPackets : 0U);
 
   // Initialize the test descriptor
   // Note: the 'max packets' test flag is not required by the DPI model
@@ -241,9 +241,10 @@ bool test_main(void) {
       &usbdev_control, ctx->usbdev, 0, config_descriptors,
       sizeof(config_descriptors), test_descriptor, sizeof(test_descriptor)));
 
-  while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
-    CHECK_STATUS_OK(usb_testutils_poll(ctx->usbdev));
-  }
+  // Proceed only when the device has been configured; this allows host-side
+  // software to establish communication.
+  CHECK_STATUS_OK(
+      usb_testutils_controlep_config_wait(&usbdev_control, &usbdev));
 
   // Describe the transfer type of each stream;
   // Note: for now we support only Bulk Transfer streams but this should change
@@ -255,11 +256,9 @@ bool test_main(void) {
 
   // Initialise the state of the streams
   CHECK_STATUS_OK(usb_testutils_streams_init(
-      ctx, nstreams, xfr_types, transfer_bytes, test_flags, verbose));
+      ctx, nstreams, xfr_types, transfer_bytes, test_flags, kVerbose));
 
-  if (verbose) {
-    LOG_INFO("Commencing data transfer...");
-  }
+  USBUTILS_USER_PROMPT("Start host-side streaming software");
 
   // Streaming loop; most of the work is done by the usb_testutils_streams base
   //   code and we don't need to specialize its behavior for this test.
@@ -284,11 +283,11 @@ bool test_main(void) {
   LOG_INFO("USB sent 0x%x byte(s), received and checked 0x%x byte(s)", tx_bytes,
            rx_bytes);
 
-  if (sending) {
+  if (kSending) {
     CHECK(tx_bytes == nstreams * transfer_bytes,
           "Unexpected count of byte(s) sent to USB host");
   }
-  if (recving) {
+  if (kRecving) {
     CHECK(rx_bytes == nstreams * transfer_bytes,
           "Unexpected count of byte(s) received from USB host");
   }

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -26,6 +26,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/usb_testutils.h"
 #include "sw/device/lib/testing/usb_testutils_controlep.h"
+#include "sw/device/lib/testing/usb_testutils_diags.h"
 #include "sw/device/lib/testing/usb_testutils_simpleserial.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
@@ -119,13 +120,14 @@ bool test_main(void) {
 
   // Proceed only when the device has been configured; this allows host-side
   // software to establish communication.
-  while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
-    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
-  }
+  CHECK_STATUS_OK(
+      usb_testutils_controlep_config_wait(&usbdev_control, &usbdev));
 
   // Set up a serial port.
   CHECK_STATUS_OK(usb_testutils_simpleserial_init(&simple_serial, &usbdev, 1U,
                                                   usb_receipt_callback));
+
+  USBUTILS_USER_PROMPT("Echo characters now...eg. 'cat /dev/ttyUSB0'");
 
   // Send a "Hi!Hi!" sign on message.
   for (int idx = 0; idx < kExpectedUsbCharsRecved; idx++) {


### PR DESCRIPTION
Time out much more promptly in simulation if the configuration is not set by the DPI host; if a change breaks connectivity or communications, regression tests should not continue idling until the test is aborted.

This PR uses this timeout functionality in place of the previous indefinite loop for each of the existing tests.

Include a couple of helpful prompts for the user when these tests are run on the FPGA. (Do not issue the prompt in simulation, because logging over UART can induce test failures because of the CPU time consumed.)
