### PR TITLE
[opentitantool] Allow configuration of I2C address

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -227,6 +227,18 @@
       "alias_of": "QSPI"
     }
   ],
+  "i2c": [
+    {
+      "name": "DEFAULT",
+      "alias_of": "I2C1"
+    },
+    {
+      "name": "TPM",
+      "bits_per_sec": 100000,
+      "address": 0x50,
+      "alias_of": "I2C1"
+    }
+  ],
   "uarts": [
     {
       "name": "console",

--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -125,10 +125,12 @@ pub struct SpiConfiguration {
 }
 
 /// Configuration of a particular I2C bus.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Default, Deserialize, Clone, Debug)]
 pub struct I2cConfiguration {
     /// The user-visible name of the I2C bus.
     pub name: String,
+    /// I2C address of the "default" device on the bus.
+    pub address: Option<u8>,
     /// Data communication rate in bits/second.
     pub bits_per_sec: Option<u32>,
     /// Name of the I2C bus as defined by the transport.

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -214,7 +214,7 @@ pub enum I2cRequest {
         value: u32,
     },
     RunTransaction {
-        address: u8,
+        address: Option<u8>,
         transaction: Vec<I2cTransferRequest>,
     },
 }

--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -273,12 +273,11 @@ impl Driver for SpiDriver {
 /// Implementation of the low level interface via Google I2C protocol.
 pub struct I2cDriver {
     i2c: Rc<dyn i2c::Bus>,
-    addr: u8,
 }
 
 impl I2cDriver {
-    pub fn new(i2c: Rc<dyn i2c::Bus>, addr: u8) -> Self {
-        Self { i2c, addr }
+    pub fn new(i2c: Rc<dyn i2c::Bus>) -> Self {
+        Self { i2c }
     }
 
     /// Numerical TPM register address as used in Google I2C protocol.
@@ -301,7 +300,7 @@ impl Driver for I2cDriver {
         let res = loop {
             count += 1;
             let res = self.i2c.run_transaction(
-                self.addr,
+                None, /* default addr */
                 &mut [
                     i2c::Transfer::Write(&[Self::addr(register).unwrap()]),
                     i2c::Transfer::Read(data),
@@ -336,8 +335,10 @@ impl Driver for I2cDriver {
     fn write_register(&self, register: Register, data: &[u8]) -> Result<()> {
         let mut buffer = vec![Self::addr(register).unwrap()];
         buffer.extend_from_slice(data);
-        self.i2c
-            .run_transaction(self.addr, &mut [i2c::Transfer::Write(&buffer)])?;
+        self.i2c.run_transaction(
+            None, /* default addr */
+            &mut [i2c::Transfer::Write(&buffer)],
+        )?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, ensure, Result};
+use std::cell::Cell;
 use std::cmp;
 use std::rc::Rc;
 use zerocopy::{AsBytes, FromBytes};
@@ -17,6 +18,7 @@ pub struct HyperdebugI2cBus {
     bus_idx: u8,
     max_write_size: usize,
     max_read_size: usize,
+    default_addr: Cell<Option<u8>>,
 }
 
 const USB_MAX_SIZE: usize = 64;
@@ -82,6 +84,7 @@ impl HyperdebugI2cBus {
             bus_idx: idx,
             max_read_size: 0x8000,
             max_write_size: 0x1000,
+            default_addr: Cell::new(None),
         })
     }
 
@@ -200,7 +203,15 @@ impl Bus for HyperdebugI2cBus {
             .cmd_no_output(&format!("i2c set speed {} {}", &self.bus_idx, max_speed))
     }
 
-    fn run_transaction(&self, addr: u8, mut transaction: &mut [Transfer]) -> Result<()> {
+    fn set_default_address(&self, addr: u8) -> Result<()> {
+        self.default_addr.set(Some(addr));
+        Ok(())
+    }
+
+    fn run_transaction(&self, addr: Option<u8>, mut transaction: &mut [Transfer]) -> Result<()> {
+        let addr = addr
+            .or(self.default_addr.get())
+            .ok_or(I2cError::MissingAddress)?;
         while !transaction.is_empty() {
             match transaction {
                 [Transfer::Write(wbuf), Transfer::Read(rbuf), ..] => {

--- a/sw/host/opentitanlib/src/transport/ioexpander/sx1503.rs
+++ b/sw/host/opentitanlib/src/transport/ioexpander/sx1503.rs
@@ -75,7 +75,7 @@ impl Sx1503 {
     fn read_register(&self, addr: Sx1503Registers) -> Result<u8> {
         let mut val: u8 = 0;
         self.i2c_bus.run_transaction(
-            self.i2c_addr,
+            Some(self.i2c_addr),
             &mut [
                 i2c::Transfer::Write(&[addr as u8]),
                 i2c::Transfer::Read(std::slice::from_mut(&mut val)),
@@ -86,7 +86,7 @@ impl Sx1503 {
 
     fn write_register(&self, addr: Sx1503Registers, data: u8) -> Result<()> {
         self.i2c_bus.run_transaction(
-            self.i2c_addr,
+            Some(self.i2c_addr),
             &mut [i2c::Transfer::Write(&[addr as u8, data])],
         )?;
         Ok(())

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -59,7 +59,7 @@ fn test_read_transaction(opts: &Opts, transport: &TransportWrapper, address: u8)
     let txn = I2cTransaction::new(b"Hello");
     let mut result = vec![0u8; txn.length as usize];
     let rx_result = txn.execute_read(&*uart, || {
-        i2c.run_transaction(address, &mut [Transfer::Read(&mut result)])
+        i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut result)])
     })?;
     assert_eq!(result.as_slice(), txn.data.as_slice());
     assert_eq!(rx_result.address, address);
@@ -72,7 +72,7 @@ fn test_write_transaction(opts: &Opts, transport: &TransportWrapper, address: u8
     let i2c = transport.i2c(&opts.i2c)?;
     log::info!("Testing write transaction at I2C address {address:02x}");
     let result = I2cTransaction::execute_write(&*uart, TestCommand::I2cWriteTransaction, || {
-        i2c.run_transaction(address, &mut [Transfer::Write(b"Hello World")])
+        i2c.run_transaction(Some(address), &mut [Transfer::Write(b"Hello World")])
     })?;
     let len = result.length as usize;
     assert_eq!(&result.data[0..len], b"Hello World");
@@ -91,7 +91,7 @@ fn test_write_transaction_slow(
     log::info!("Testing slow write transaction at I2C address {address:02x}");
     let result =
         I2cTransaction::execute_write(&*uart, TestCommand::I2cWriteTransactionSlow, || {
-            i2c.run_transaction(address, &mut [Transfer::Write(GETTYSBURG.as_bytes())])
+            i2c.run_transaction(Some(address), &mut [Transfer::Write(GETTYSBURG.as_bytes())])
         })?;
     let len = result.length as usize;
     assert_eq!(&result.data[0..len], GETTYSBURG.as_bytes());
@@ -107,7 +107,7 @@ fn test_wakeup_normal_sleep(opts: &Opts, transport: &TransportWrapper, address: 
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
-    let result = i2c.run_transaction(address, &mut [Transfer::Read(&mut buf)]);
+    let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
     Status::recv(&*uart, Duration::from_secs(5), false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");
@@ -121,7 +121,7 @@ fn test_wakeup_deep_sleep(opts: &Opts, transport: &TransportWrapper, address: u8
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
-    let result = i2c.run_transaction(address, &mut [Transfer::Read(&mut buf)]);
+    let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
     Status::recv(&*uart, Duration::from_secs(5), false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");

--- a/sw/host/tpm2_test_server/src/main.rs
+++ b/sw/host/tpm2_test_server/src/main.rs
@@ -10,7 +10,6 @@ use opentitanlib::backend;
 use opentitanlib::io::i2c::I2cParams;
 use opentitanlib::io::spi::SpiParams;
 use opentitanlib::tpm::{Driver, I2cDriver, SpiDriver};
-use opentitanlib::util::parse_int::ParseInt;
 use std::net::{SocketAddr, TcpListener};
 
 mod interface;
@@ -24,13 +23,6 @@ pub enum TpmBus {
     I2C {
         #[command(flatten)]
         params: I2cParams,
-        #[arg(
-            short,
-            long,
-            help = "7 bit I2C device address.",
-            value_parser = u8::from_str
-        )]
-        address: u8,
     },
 }
 
@@ -83,12 +75,12 @@ pub fn main() -> std::io::Result<()> {
     let transport = backend::create(&options.backend_opts).unwrap();
     let bus: Box<dyn Driver> = match options.bus {
         TpmBus::Spi { params } => {
-            let spi = params.create(&transport, "").unwrap();
+            let spi = params.create(&transport, "TPM").unwrap();
             Box::new(SpiDriver::new(spi))
         }
-        TpmBus::I2C { params, address } => {
-            let i2c = params.create(&transport).unwrap();
-            Box::new(I2cDriver::new(i2c, address))
+        TpmBus::I2C { params } => {
+            let i2c = params.create(&transport, "TPM").unwrap();
+            Box::new(I2cDriver::new(i2c))
         }
     };
     bus.init().unwrap();


### PR DESCRIPTION
With this change, OpenTitanTool is able to use I2C addresses from configuration files:
```
"i2c": [
  {
    "name": "TPM",
    "bits_per_sec": 400000,
    "address": 0x50,
    "alias_of": "I2C1"
  }
],
```

This is in addition to being able to specify on command line: `opentitantool i2c --bus=I2C0 --addr=0x50 raw-write --hexdata="1234"`

The above `--addr` flag has become part of the `I2cParams`, meaning that several commands that previously declared their own `addr` field next to a "flattened" `I2cParams` now need only the `I2cParams`.

With this change, the bus/address of I2C behaves substantially similar to bus/chip_select for SPI, in that a "bus alias" can optionally carry additional information about a particular target to be addressed.