### PR TITLE
[reggen] Add support for multi-bit regwen signals

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -1306,7 +1306,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1333,7 +1334,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1401,7 +1403,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_en_ctl_adc_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1427,7 +1430,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_en_ctl_oneshot_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1455,7 +1459,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_pd_ctl_lp_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1481,7 +1486,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h7)
+    .RESVAL  (4'h7),
+    .Mubi    (1'b0)
   ) u_adc_pd_ctl_pwrup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1507,7 +1513,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (24'h640)
+    .RESVAL  (24'h640),
+    .Mubi    (1'b0)
   ) u_adc_pd_ctl_wakeup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1534,7 +1541,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h4)
+    .RESVAL  (8'h4),
+    .Mubi    (1'b0)
   ) u_adc_lp_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1561,7 +1569,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h9b)
+    .RESVAL  (16'h9b),
+    .Mubi    (1'b0)
   ) u_adc_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1588,7 +1597,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_fsm_rst (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1617,7 +1627,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1643,7 +1654,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1669,7 +1681,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1695,7 +1708,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1724,7 +1738,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1750,7 +1765,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1776,7 +1792,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1802,7 +1819,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1831,7 +1849,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1857,7 +1876,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1883,7 +1903,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1909,7 +1930,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1938,7 +1960,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1964,7 +1987,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1990,7 +2014,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2016,7 +2041,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2045,7 +2071,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2071,7 +2098,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2097,7 +2125,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2123,7 +2152,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2152,7 +2182,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2178,7 +2209,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2204,7 +2236,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2230,7 +2263,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2259,7 +2293,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2285,7 +2320,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2311,7 +2347,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2337,7 +2374,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2366,7 +2404,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2392,7 +2431,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2418,7 +2458,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2444,7 +2485,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn0_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2473,7 +2515,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2499,7 +2542,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2525,7 +2569,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2551,7 +2596,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2580,7 +2626,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2606,7 +2653,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2632,7 +2680,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2658,7 +2707,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2687,7 +2737,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2713,7 +2764,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2739,7 +2791,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2765,7 +2818,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2794,7 +2848,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2820,7 +2875,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2846,7 +2902,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2872,7 +2929,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2901,7 +2959,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2927,7 +2986,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2953,7 +3013,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2979,7 +3040,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3008,7 +3070,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3034,7 +3097,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3060,7 +3124,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3086,7 +3151,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3115,7 +3181,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3141,7 +3208,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3167,7 +3235,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3193,7 +3262,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3222,7 +3292,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3248,7 +3319,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3274,7 +3346,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3300,7 +3373,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn1_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3331,7 +3405,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_0_adc_chn_value_ext_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3357,7 +3432,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_0_adc_chn_value_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3383,7 +3459,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_0_adc_chn_value_intr_ext_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3409,7 +3486,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_0_adc_chn_value_intr_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3440,7 +3518,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_1_adc_chn_value_ext_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3466,7 +3545,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_1_adc_chn_value_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3492,7 +3572,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_1_adc_chn_value_intr_ext_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3518,7 +3599,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_adc_chn_val_1_adc_chn_value_intr_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3545,7 +3627,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_adc_wakeup_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3574,7 +3657,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_filter_status (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3601,7 +3685,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_adc_intr_ctl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3629,7 +3714,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_adc_intr_status_filter_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3655,7 +3741,8 @@ module adc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_adc_intr_status_oneshot (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -709,7 +709,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_in_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -749,7 +750,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_in_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +791,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_in_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -829,7 +832,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_in_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1030,7 +1034,8 @@ module aes_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ctrl_aux_shadowed_key_touch_forces_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1070,8 @@ module aes_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_aux_shadowed_force_masks (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1101,7 +1107,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ctrl_aux_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1129,7 +1136,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_trigger_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1155,7 +1163,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_trigger_key_iv_data_in_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1181,7 +1190,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_trigger_data_out_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1207,7 +1217,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_trigger_prng_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1235,7 +1246,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1273,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_stall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1300,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_output_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1313,7 +1327,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_output_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1339,7 +1354,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_input_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1365,7 +1381,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_alert_recov_ctrl_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1391,7 +1408,8 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_alert_fatal_fault (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -518,7 +518,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -544,7 +545,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h0)
+    .RESVAL  (12'h0),
+    .Mubi    (1'b0)
   ) u_wkup_ctrl_prescaler (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -571,7 +573,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_wkup_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -600,7 +603,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_wkup_count (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -627,7 +631,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wdog_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +663,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wdog_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -684,7 +690,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wdog_ctrl_pause_in_sleep (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -714,7 +721,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_wdog_bark_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -744,7 +752,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_wdog_bite_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -773,7 +782,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_wdog_count (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -801,7 +811,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_wkup_timer_expired (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -827,7 +838,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_wdog_timer_bark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -893,7 +905,8 @@ module aon_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -143,7 +143,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_fixed_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -169,7 +170,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_usb_48mhz_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -197,7 +199,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -223,7 +226,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -251,7 +255,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -277,7 +282,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -227,7 +227,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -253,7 +254,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -279,7 +281,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -305,7 +308,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -333,7 +337,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -359,7 +364,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -385,7 +391,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -411,7 +418,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +552,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -575,7 +584,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -601,7 +611,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_sw_app_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -627,7 +638,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_read_int_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -665,7 +677,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_cmd_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -694,7 +707,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -720,7 +734,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -806,7 +821,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_int_state_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -850,7 +866,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_hw_exc_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -878,7 +895,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +922,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_sw_app_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -930,7 +949,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_read_int_state_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -956,7 +976,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_acmd_flag0_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -982,7 +1003,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_cs_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1008,7 +1030,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_cs_main_sm_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1036,7 +1059,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_cmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1062,7 +1086,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_genbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1088,7 +1113,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_cmdreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1114,7 +1140,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_rcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1140,7 +1167,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_keyvrc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1166,7 +1194,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_updreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1192,7 +1221,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_bencreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1218,7 +1248,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_bencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1244,7 +1275,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_pdata_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1270,7 +1302,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_final_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1329,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_gbencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1322,7 +1356,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_grcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1348,7 +1383,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_ggenreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1374,7 +1410,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_gadstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1400,7 +1437,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_ggenbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1426,7 +1464,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_blkenc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1452,7 +1491,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_cmd_stage_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1478,7 +1518,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1504,7 +1545,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_drbg_gen_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1530,7 +1572,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_drbg_updbe_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1556,7 +1599,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_drbg_updob_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1626,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_aes_cipher_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1653,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_cmd_gen_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1634,7 +1680,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1660,7 +1707,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1686,7 +1734,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1727,7 +1776,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1755,7 +1805,8 @@ module csrng_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h4e)
+    .RESVAL  (8'h4e),
+    .Mubi    (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -200,7 +200,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -226,7 +227,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +256,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -280,7 +283,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -381,7 +385,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -412,7 +417,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_edn_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +444,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_boot_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -464,7 +471,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_auto_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -490,7 +498,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_ctrl_cmd_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -517,7 +526,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h901)
+    .RESVAL  (32'h901),
+    .Mubi    (1'b0)
   ) u_boot_ins_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +554,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hfff003)
+    .RESVAL  (32'hfff003),
+    .Mubi    (1'b0)
   ) u_boot_gen_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -592,7 +603,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -618,7 +630,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -696,7 +709,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_max_num_reqs_between_reseeds (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -725,7 +739,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_edn_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -751,7 +766,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_boot_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -777,7 +793,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_auto_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -803,7 +820,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_cmd_fifo_rst_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -829,7 +847,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_edn_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -857,7 +876,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_rescmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -883,7 +903,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_gencmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -909,7 +930,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_output_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -935,7 +957,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_edn_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -961,7 +984,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_edn_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -987,7 +1011,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_edn_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1013,7 +1038,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1039,7 +1065,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1092,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1103,7 +1131,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1160,8 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (9'h185)
+    .RESVAL  (9'h185),
+    .Mubi    (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -387,7 +387,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -413,7 +414,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -439,7 +441,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -465,7 +468,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +497,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -519,7 +524,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -545,7 +551,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +578,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +712,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_me_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +740,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_regupd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -758,7 +768,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -802,7 +813,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_module_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -833,7 +845,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_conf_fips_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -859,7 +872,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_conf_entropy_data_reg_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -885,7 +899,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_conf_threshold_scope (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -911,7 +926,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_conf_rng_bit_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -937,7 +953,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_conf_rng_bit_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -968,7 +985,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_entropy_control_es_route (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +1012,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_entropy_control_es_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1041,7 +1060,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h200)
+    .RESVAL  (16'h200),
+    .Mubi    (1'b0)
   ) u_health_test_windows_fips_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1067,7 +1087,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h60)
+    .RESVAL  (16'h60),
+    .Mubi    (1'b0)
   ) u_health_test_windows_bypass_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1890,7 +1911,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h2)
+    .RESVAL  (16'h2),
+    .Mubi    (1'b0)
   ) u_alert_threshold_alert_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1916,7 +1938,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'hfffd)
+    .RESVAL  (16'hfffd),
+    .Mubi    (1'b0)
   ) u_alert_threshold_alert_threshold_inv (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2102,7 +2125,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_fw_ov_control_fw_ov_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2128,7 +2152,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_fw_ov_control_fw_ov_entropy_insert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2155,7 +2180,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_fw_ov_sha3_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2198,7 +2224,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fw_ov_rd_fifo_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2264,7 +2291,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h20)
+    .RESVAL  (7'h20),
+    .Mubi    (1'b0)
   ) u_observe_fifo_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2430,7 +2458,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_fips_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2456,7 +2485,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_entropy_data_reg_en_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2482,7 +2512,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_module_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2508,7 +2539,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_threshold_scope_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2534,7 +2566,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_rng_bit_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2560,7 +2593,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_fw_ov_sha3_start_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2586,7 +2620,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_fw_ov_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2612,7 +2647,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_fw_ov_entropy_insert_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2638,7 +2674,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_route_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2664,7 +2701,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_type_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2690,7 +2728,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_main_sm_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2716,7 +2755,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2742,7 +2782,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_thresh_cfg_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2768,7 +2809,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_fw_ov_wr_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2836,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_sts_es_fw_ov_disable_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2822,7 +2865,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_esrng_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2848,7 +2892,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_observe_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2874,7 +2919,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sfifo_esfinal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2900,7 +2946,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_es_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2926,7 +2973,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_es_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2952,7 +3000,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_es_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2978,7 +3027,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sha3_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3004,7 +3054,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_sha3_rst_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3030,7 +3081,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3056,7 +3108,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3082,7 +3135,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3120,7 +3174,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3148,7 +3203,8 @@ module entropy_src_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (9'hf5)
+    .RESVAL  (9'hf5),
+    .Mubi    (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1027,7 +1027,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1054,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1081,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1108,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1135,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1157,7 +1162,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1185,7 +1191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1263,7 +1272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1299,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1315,7 +1326,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1528,7 +1540,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1555,7 +1568,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1596,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1644,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1655,7 +1671,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1681,7 +1698,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1707,7 +1725,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1733,7 +1752,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1759,7 +1779,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1785,7 +1806,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h0)
+    .RESVAL  (12'h0),
+    .Mubi    (1'b0)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1815,7 +1837,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1846,7 +1869,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1872,7 +1896,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1899,7 +1924,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1927,7 +1953,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1955,7 +1982,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1983,7 +2011,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2011,7 +2040,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2039,7 +2069,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2098,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2127,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2123,7 +2156,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2155,7 +2189,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2181,7 +2216,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2207,7 +2243,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2233,7 +2270,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2259,7 +2297,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2285,7 +2324,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2311,7 +2351,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2343,7 +2384,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2369,7 +2411,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2395,7 +2438,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2421,7 +2465,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2447,7 +2492,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2519,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2499,7 +2546,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2531,7 +2579,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2557,7 +2606,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2583,7 +2633,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2609,7 +2660,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2635,7 +2687,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2661,7 +2714,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2687,7 +2741,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2719,7 +2774,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2745,7 +2801,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2771,7 +2828,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2797,7 +2855,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2823,7 +2882,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2849,7 +2909,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2875,7 +2936,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2907,7 +2969,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2933,7 +2996,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2959,7 +3023,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3050,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3011,7 +3077,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3037,7 +3104,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3063,7 +3131,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3095,7 +3164,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3121,7 +3191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3147,7 +3218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3173,7 +3245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3199,7 +3272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3225,7 +3299,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3251,7 +3326,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3283,7 +3359,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3309,7 +3386,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3335,7 +3413,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3361,7 +3440,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3387,7 +3467,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3413,7 +3494,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3439,7 +3521,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3471,7 +3554,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3497,7 +3581,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3523,7 +3608,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3549,7 +3635,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3575,7 +3662,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3601,7 +3689,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3627,7 +3716,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3659,7 +3749,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3685,7 +3776,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3717,7 +3809,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3743,7 +3836,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3775,7 +3869,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3801,7 +3896,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3833,7 +3929,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3859,7 +3956,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3891,7 +3989,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3917,7 +4016,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3949,7 +4049,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3975,7 +4076,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4007,7 +4109,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4033,7 +4136,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4065,7 +4169,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4091,7 +4196,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4119,7 +4225,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4145,7 +4252,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4171,7 +4279,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4197,7 +4306,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4223,7 +4333,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4249,7 +4360,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4277,7 +4389,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4305,7 +4418,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4333,7 +4447,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4361,7 +4476,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4389,7 +4505,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4417,7 +4534,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4445,7 +4563,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4592,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4501,7 +4621,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4650,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4561,7 +4683,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4587,7 +4710,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4613,7 +4737,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4639,7 +4764,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4665,7 +4791,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4691,7 +4818,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4717,7 +4845,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4749,7 +4878,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4775,7 +4905,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4801,7 +4932,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4827,7 +4959,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4853,7 +4986,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4879,7 +5013,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4905,7 +5040,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4937,7 +5073,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4963,7 +5100,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4989,7 +5127,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5015,7 +5154,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5041,7 +5181,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5067,7 +5208,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5093,7 +5235,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5125,7 +5268,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5295,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5177,7 +5322,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5349,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5229,7 +5376,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5255,7 +5403,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5281,7 +5430,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5313,7 +5463,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5339,7 +5490,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5365,7 +5517,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5391,7 +5544,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5417,7 +5571,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5443,7 +5598,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5469,7 +5625,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5501,7 +5658,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5527,7 +5685,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5553,7 +5712,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5579,7 +5739,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5605,7 +5766,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5631,7 +5793,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5657,7 +5820,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5689,7 +5853,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5715,7 +5880,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5741,7 +5907,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5767,7 +5934,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5793,7 +5961,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5819,7 +5988,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5845,7 +6015,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5877,7 +6048,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5903,7 +6075,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5929,7 +6102,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5955,7 +6129,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5981,7 +6156,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6007,7 +6183,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6033,7 +6210,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6065,7 +6243,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6270,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6117,7 +6297,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6143,7 +6324,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6169,7 +6351,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6195,7 +6378,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6221,7 +6405,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6253,7 +6438,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6279,7 +6465,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6305,7 +6492,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6331,7 +6519,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6357,7 +6546,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6383,7 +6573,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6409,7 +6600,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6437,7 +6629,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6469,7 +6662,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6495,7 +6689,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6521,7 +6716,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6547,7 +6743,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6573,7 +6770,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6599,7 +6797,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6625,7 +6824,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6653,7 +6853,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6681,7 +6882,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6713,7 +6915,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6739,7 +6942,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6765,7 +6969,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6791,7 +6996,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6817,7 +7023,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6843,7 +7050,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6869,7 +7077,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +7110,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6927,7 +7137,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6953,7 +7164,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6979,7 +7191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7005,7 +7218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7031,7 +7245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7057,7 +7272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7085,7 +7301,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7113,7 +7330,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7141,7 +7359,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7169,7 +7388,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7197,7 +7417,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7225,7 +7446,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7253,7 +7475,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7281,7 +7504,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7309,7 +7533,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7337,7 +7562,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7369,7 +7595,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7395,7 +7622,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7421,7 +7649,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7447,7 +7676,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7473,7 +7703,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7499,7 +7730,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7525,7 +7757,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7557,7 +7790,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7583,7 +7817,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7609,7 +7844,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7635,7 +7871,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7661,7 +7898,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7687,7 +7925,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7713,7 +7952,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7745,7 +7985,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7771,7 +8012,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7797,7 +8039,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7823,7 +8066,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7849,7 +8093,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7875,7 +8120,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7901,7 +8147,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7933,7 +8180,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7959,7 +8207,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7985,7 +8234,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8011,7 +8261,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8037,7 +8288,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8063,7 +8315,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8089,7 +8342,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8121,7 +8375,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8147,7 +8402,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8173,7 +8429,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8199,7 +8456,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8225,7 +8483,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8251,7 +8510,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8277,7 +8537,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8309,7 +8570,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8335,7 +8597,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8361,7 +8624,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8387,7 +8651,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8413,7 +8678,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8439,7 +8705,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8465,7 +8732,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8497,7 +8765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8523,7 +8792,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8549,7 +8819,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8575,7 +8846,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8601,7 +8873,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8900,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8653,7 +8927,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8685,7 +8960,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8987,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8737,7 +9014,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8763,7 +9041,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8789,7 +9068,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8815,7 +9095,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8841,7 +9122,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8873,7 +9155,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8899,7 +9182,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8925,7 +9209,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8951,7 +9236,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8977,7 +9263,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9003,7 +9290,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9029,7 +9317,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9061,7 +9350,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9087,7 +9377,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9113,7 +9404,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9139,7 +9431,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9165,7 +9458,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9191,7 +9485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9217,7 +9512,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9245,7 +9541,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9277,7 +9574,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9303,7 +9601,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9329,7 +9628,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9355,7 +9655,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9381,7 +9682,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9407,7 +9709,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9433,7 +9736,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9461,7 +9765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9489,7 +9794,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9521,7 +9827,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9854,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9573,7 +9881,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9599,7 +9908,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9625,7 +9935,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9651,7 +9962,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9677,7 +9989,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9709,7 +10022,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9735,7 +10049,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9761,7 +10076,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9787,7 +10103,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9813,7 +10130,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9839,7 +10157,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9865,7 +10184,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9893,7 +10213,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9919,7 +10240,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9946,7 +10268,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9978,7 +10301,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10013,7 +10337,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10050,7 +10375,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10076,7 +10402,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10104,7 +10431,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10130,7 +10458,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10156,7 +10485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10182,7 +10512,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10208,7 +10539,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10234,7 +10566,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10278,7 +10611,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10304,7 +10638,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10330,7 +10665,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10356,7 +10692,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10382,7 +10719,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10408,7 +10746,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10434,7 +10773,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10460,7 +10800,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10488,7 +10829,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10514,7 +10856,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10540,7 +10883,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10566,7 +10910,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10592,7 +10937,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10618,7 +10964,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10644,7 +10991,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10670,7 +11018,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10696,7 +11045,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10724,7 +11074,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10750,7 +11101,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10776,7 +11128,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10802,7 +11155,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10828,7 +11182,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10854,7 +11209,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10880,7 +11236,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10906,7 +11263,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10932,7 +11290,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10958,7 +11317,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10984,7 +11344,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11010,7 +11371,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11037,7 +11399,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11066,7 +11429,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11092,7 +11456,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11120,7 +11485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11148,7 +11514,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11176,7 +11543,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11202,7 +11570,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11230,7 +11599,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11256,7 +11626,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11282,7 +11653,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11309,7 +11681,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11337,7 +11710,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'hf)
+    .RESVAL  (5'hf),
+    .Mubi    (1'b0)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11363,7 +11737,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'hf)
+    .RESVAL  (5'hf),
+    .Mubi    (1'b0)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11390,7 +11765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -272,7 +272,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -303,7 +304,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -329,7 +331,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -357,7 +360,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -383,7 +387,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -409,7 +414,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -435,7 +441,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -461,7 +468,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -487,7 +495,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +522,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -539,7 +549,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -570,7 +581,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -596,7 +608,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -622,7 +635,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -648,7 +662,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -674,7 +689,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -700,7 +716,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -726,7 +743,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +770,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -778,7 +797,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -804,7 +824,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -835,7 +856,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -861,7 +883,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +910,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +937,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -944,7 +969,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -970,7 +996,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -996,7 +1023,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1022,7 +1050,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1077,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1109,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1136,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1163,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1157,7 +1190,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1217,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1209,7 +1244,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1235,7 +1271,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1298,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1325,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1318,7 +1357,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1344,7 +1384,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1374,7 +1415,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1404,7 +1446,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1434,7 +1477,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1464,7 +1508,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1494,7 +1539,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1525,7 +1571,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1598,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1630,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1657,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1639,7 +1689,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1665,7 +1716,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1696,7 +1748,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1722,7 +1775,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1753,7 +1807,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1779,7 +1834,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1809,7 +1865,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1839,7 +1896,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1867,7 +1925,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1952,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1919,7 +1979,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -186,7 +186,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -213,7 +214,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -280,7 +282,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -495,7 +498,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -522,7 +526,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -549,7 +554,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -576,7 +582,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -603,7 +610,8 @@ module gpio_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -254,7 +254,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -280,7 +281,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -306,7 +308,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -334,7 +337,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -360,7 +364,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -386,7 +391,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -639,7 +645,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -990,7 +997,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_msg_length_lower (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1017,7 +1025,8 @@ module hmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_msg_length_upper (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -307,7 +307,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -333,7 +334,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -359,7 +361,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_fmt_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -385,7 +388,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -411,7 +415,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_nak (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -437,7 +442,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -463,7 +469,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -489,7 +496,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -515,7 +523,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -541,7 +550,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -567,7 +577,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +604,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_tx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +631,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_acq_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +658,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -671,7 +685,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -699,7 +714,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -725,7 +741,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -751,7 +768,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_fmt_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -777,7 +795,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -803,7 +822,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_nak (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -829,7 +849,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -855,7 +876,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -881,7 +903,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -907,7 +930,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -933,7 +957,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -959,7 +984,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -985,7 +1011,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_tx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1011,7 +1038,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_acq_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1065,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1063,7 +1092,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1356,7 +1386,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_enablehost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1382,7 +1413,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_enabletarget (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1408,7 +1440,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1615,7 +1648,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_fdata_fbyte (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1642,7 +1676,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fdata_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1669,7 +1704,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fdata_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1696,7 +1732,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fdata_read (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1723,7 +1760,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fdata_rcont (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1750,7 +1788,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fdata_nakok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1790,7 +1829,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1817,7 +1857,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_fmtrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1844,7 +1885,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_rxilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1871,7 +1913,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_fmtilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1898,7 +1941,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_acqrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1925,7 +1969,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2016,7 +2061,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ovrd_txovrden (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2042,7 +2088,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ovrd_sclval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2068,7 +2115,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ovrd_sdaval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2128,7 +2176,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing0_thigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2154,7 +2203,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing0_tlow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2182,7 +2232,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing1_t_r (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2208,7 +2259,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing1_t_f (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2236,7 +2288,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing2_tsu_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2262,7 +2315,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing2_thd_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2290,7 +2344,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing3_tsu_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2316,7 +2371,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing3_thd_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2344,7 +2400,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing4_tsu_sto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2370,7 +2427,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_timing4_t_buf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2398,7 +2456,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (31),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (31'h0)
+    .RESVAL  (31'h0),
+    .Mubi    (1'b0)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2424,7 +2483,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2452,7 +2512,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_target_id_address0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2478,7 +2539,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_target_id_mask0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2504,7 +2566,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_target_id_address1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2530,7 +2593,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_target_id_mask1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2600,7 +2664,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_txdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2628,7 +2693,8 @@ module i2c_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_host_timeout_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -370,7 +370,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -397,7 +398,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -500,7 +502,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -531,7 +534,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h1)
+    .RESVAL  (3'h1),
+    .Mubi    (1'b0)
   ) u_control_shadowed_operation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -566,7 +570,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_shadowed_cdi_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -601,7 +606,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_control_shadowed_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -640,7 +646,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_sideload_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +674,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_reseed_interval_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -698,7 +706,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h100)
+    .RESVAL  (16'h100),
+    .Mubi    (1'b0)
   ) u_reseed_interval_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -758,7 +767,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +799,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -820,7 +831,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -851,7 +863,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -882,7 +895,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +927,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -944,7 +959,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -975,7 +991,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sealing_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1006,7 +1023,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1055,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1068,7 +1087,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1099,7 +1119,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1130,7 +1151,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1183,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1192,7 +1215,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1223,7 +1247,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_attest_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1254,7 +1279,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1285,7 +1311,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1316,7 +1343,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1347,7 +1375,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1378,7 +1407,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1409,7 +1439,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1440,7 +1471,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1471,7 +1503,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_salt_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1502,7 +1535,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1529,7 +1563,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_max_creator_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1560,7 +1595,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_max_creator_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1596,7 +1632,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_max_owner_int_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1627,7 +1664,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1)
+    .RESVAL  (32'h1),
+    .Mubi    (1'b0)
   ) u_max_owner_int_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1663,7 +1701,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_max_owner_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1694,7 +1733,8 @@ module keymgr_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_max_owner_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1731,7 +1771,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1759,7 +1800,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1787,7 +1829,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1815,7 +1858,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1843,7 +1887,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1871,7 +1916,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1899,7 +1945,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1927,7 +1974,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share0_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1955,7 +2003,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1983,7 +2032,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2011,7 +2061,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2039,7 +2090,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2119,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2148,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2123,7 +2177,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2151,7 +2206,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_sw_share1_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2178,7 +2234,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_working_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2205,7 +2262,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_op_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2233,7 +2291,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_invalid_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2259,7 +2318,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_invalid_kmac_input (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2285,7 +2345,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_invalid_shadow_update (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2313,7 +2374,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2339,7 +2401,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_kmac_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2365,7 +2428,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2391,7 +2455,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_kmac_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2417,7 +2482,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_kmac_out (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2443,7 +2509,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_regfile_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2469,7 +2536,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_shadow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2495,7 +2563,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_ctrl_fsm_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2521,7 +2590,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_ctrl_fsm_chk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2547,7 +2617,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_ctrl_fsm_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2573,7 +2644,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_reseed_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2599,7 +2671,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_side_ctrl_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2625,7 +2698,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_side_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2651,7 +2725,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_key_ecc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2679,7 +2754,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_creator_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2705,7 +2781,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_owner_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2731,7 +2808,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_dev_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2757,7 +2835,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_health_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2783,7 +2862,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2809,7 +2889,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2835,7 +2916,8 @@ module keymgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_debug_invalid_digest (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -395,7 +395,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +422,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -447,7 +449,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -475,7 +478,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -501,7 +505,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -527,7 +532,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -675,7 +681,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_kmac_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -711,7 +718,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_kstrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +755,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -783,7 +792,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_msg_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -819,7 +829,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_state_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -855,7 +866,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_sideload (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -891,7 +903,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_entropy_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -927,7 +940,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_entropy_fast_process (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -963,7 +977,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_msg_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -999,7 +1014,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_entropy_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1035,7 +1051,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_err_processed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1088,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_shadowed_en_unsupported_modestrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1305,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_entropy_period_prescaler (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1313,7 +1332,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_entropy_period_wait_timer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1340,7 +1360,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_entropy_refresh_hash_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1371,7 +1392,8 @@ module kmac_reg_top (
   prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_entropy_refresh_threshold_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2283,7 +2305,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_key_len (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2314,7 +2337,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2345,7 +2369,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2376,7 +2401,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2407,7 +2433,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2438,7 +2465,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2469,7 +2497,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2500,7 +2529,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2531,7 +2561,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2562,7 +2593,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2593,7 +2625,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2624,7 +2657,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prefix_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2651,7 +2685,8 @@ module kmac_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -469,7 +469,8 @@ module lc_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_claim_transition_if_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -250,7 +250,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -277,7 +278,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -401,7 +403,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h4)
+    .RESVAL  (8'h4),
+    .Mubi    (1'b0)
   ) u_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -690,7 +693,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_imem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -716,7 +720,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_dmem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -742,7 +747,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_reg_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +774,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_bus_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -794,7 +801,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_bad_internal_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -820,7 +828,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_illegal_bus_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -846,7 +855,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_lifecycle_escalation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -872,7 +882,8 @@ module otbn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_fatal_software (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -302,7 +302,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -328,7 +329,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -356,7 +358,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -382,7 +385,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1016,7 +1020,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (11'h0)
+    .RESVAL  (11'h0),
+    .Mubi    (1'b0)
   ) u_direct_access_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1047,7 +1052,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_direct_access_wdata_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1078,7 +1084,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_direct_access_wdata_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1139,7 +1146,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1206,7 +1214,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_check_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1236,7 +1245,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_check_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1266,7 +1276,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_integrity_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1307,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_consistency_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1326,7 +1338,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_vendor_test_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1356,7 +1369,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1386,7 +1400,8 @@ module otp_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -202,7 +202,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -228,7 +229,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +256,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -280,7 +283,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -306,7 +310,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (11'h0)
+    .RESVAL  (11'h0),
+    .Mubi    (1'b0)
   ) u_csr0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -334,7 +339,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -360,7 +366,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -386,7 +393,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -412,7 +420,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +447,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -465,7 +475,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +504,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -519,7 +531,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -545,7 +558,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +585,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -597,7 +612,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -623,7 +639,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +666,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -675,7 +693,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -701,7 +720,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -729,7 +749,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -755,7 +776,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -781,7 +803,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -807,7 +830,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -835,7 +859,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -861,7 +886,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +913,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +940,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -939,7 +967,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +994,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -991,7 +1021,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1019,7 +1050,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1045,7 +1077,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1104,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1097,7 +1131,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1125,7 +1160,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1151,7 +1187,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1177,7 +1214,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1203,7 +1241,8 @@ module otp_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -182,7 +182,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -208,7 +209,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -236,7 +238,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -262,7 +265,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -347,7 +351,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_enable_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -373,7 +378,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_enable_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +405,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_polarity_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -425,7 +432,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_polarity_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -452,7 +460,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prediv_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -479,7 +488,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_prediv_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -507,7 +517,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_ch0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -535,7 +546,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_ch0_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -563,7 +575,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_ch1_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -591,7 +604,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_data_ch1_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +633,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_size_len_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +660,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_size_reps_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -671,7 +687,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_size_len_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -697,7 +714,8 @@ module pattgen_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_size_reps_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -3343,7 +3343,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3371,7 +3372,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3399,7 +3401,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3427,7 +3430,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3455,7 +3459,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3483,7 +3488,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3511,7 +3517,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3539,7 +3546,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3567,7 +3575,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3595,7 +3604,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3623,7 +3633,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3651,7 +3662,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3679,7 +3691,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3707,7 +3720,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3735,7 +3749,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3763,7 +3778,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3791,7 +3807,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3819,7 +3836,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3847,7 +3865,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3875,7 +3894,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3903,7 +3923,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3931,7 +3952,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3959,7 +3981,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3987,7 +4010,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4015,7 +4039,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4043,7 +4068,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4071,7 +4097,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4099,7 +4126,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4127,7 +4155,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4155,7 +4184,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4183,7 +4213,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4211,7 +4242,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4239,7 +4271,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4270,7 +4303,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4301,7 +4335,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4332,7 +4367,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4399,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4394,7 +4431,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4425,7 +4463,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4456,7 +4495,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4487,7 +4527,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4518,7 +4559,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4549,7 +4591,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4623,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4611,7 +4655,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4642,7 +4687,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4673,7 +4719,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4704,7 +4751,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4735,7 +4783,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4766,7 +4815,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4797,7 +4847,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4828,7 +4879,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4859,7 +4911,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4890,7 +4943,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4921,7 +4975,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4952,7 +5007,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4983,7 +5039,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5014,7 +5071,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5045,7 +5103,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5076,7 +5135,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5107,7 +5167,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5138,7 +5199,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5169,7 +5231,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5200,7 +5263,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5231,7 +5295,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5262,7 +5327,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5290,7 +5356,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5318,7 +5385,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5346,7 +5414,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5374,7 +5443,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5402,7 +5472,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5430,7 +5501,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5458,7 +5530,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5486,7 +5559,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5514,7 +5588,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5542,7 +5617,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5570,7 +5646,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5598,7 +5675,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5626,7 +5704,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5654,7 +5733,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5762,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5710,7 +5791,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5738,7 +5820,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5766,7 +5849,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5794,7 +5878,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5822,7 +5907,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5850,7 +5936,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5878,7 +5965,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5906,7 +5994,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5934,7 +6023,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5962,7 +6052,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5990,7 +6081,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6018,7 +6110,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6046,7 +6139,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6074,7 +6168,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6102,7 +6197,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6130,7 +6226,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6158,7 +6255,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6189,7 +6287,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6220,7 +6319,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6251,7 +6351,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6282,7 +6383,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6313,7 +6415,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6344,7 +6447,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6375,7 +6479,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6406,7 +6511,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6437,7 +6543,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6468,7 +6575,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6499,7 +6607,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6530,7 +6639,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6561,7 +6671,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6592,7 +6703,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6623,7 +6735,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6654,7 +6767,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6685,7 +6799,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6716,7 +6831,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6747,7 +6863,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6778,7 +6895,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6809,7 +6927,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6840,7 +6959,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6871,7 +6991,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6902,7 +7023,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6933,7 +7055,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6964,7 +7087,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6995,7 +7119,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7026,7 +7151,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7057,7 +7183,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7088,7 +7215,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7119,7 +7247,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7150,7 +7279,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h2)
+    .RESVAL  (6'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7178,7 +7308,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7206,7 +7337,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7234,7 +7366,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7262,7 +7395,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7290,7 +7424,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7318,7 +7453,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7346,7 +7482,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7374,7 +7511,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7402,7 +7540,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7430,7 +7569,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7458,7 +7598,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7486,7 +7627,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7514,7 +7656,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7542,7 +7685,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7570,7 +7714,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7598,7 +7743,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7626,7 +7772,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7654,7 +7801,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7682,7 +7830,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7710,7 +7859,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7738,7 +7888,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7766,7 +7917,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7794,7 +7946,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7822,7 +7975,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7850,7 +8004,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7878,7 +8033,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7906,7 +8062,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7934,7 +8091,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7962,7 +8120,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7990,7 +8149,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8018,7 +8178,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8046,7 +8207,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12970,7 +13132,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12998,7 +13161,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13026,7 +13190,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13054,7 +13219,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13082,7 +13248,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13110,7 +13277,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13138,7 +13306,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13166,7 +13335,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13194,7 +13364,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13222,7 +13393,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13250,7 +13422,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13278,7 +13451,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13306,7 +13480,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13334,7 +13509,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13362,7 +13538,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13390,7 +13567,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15867,7 +16045,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15893,7 +16072,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15919,7 +16099,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15945,7 +16126,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15971,7 +16153,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15997,7 +16180,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16023,7 +16207,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16049,7 +16234,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16075,7 +16261,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16101,7 +16288,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16127,7 +16315,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16153,7 +16342,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16179,7 +16369,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16205,7 +16396,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16231,7 +16423,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16257,7 +16450,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16283,7 +16477,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16309,7 +16504,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16335,7 +16531,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16361,7 +16558,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16387,7 +16585,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16413,7 +16612,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16439,7 +16639,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16465,7 +16666,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16491,7 +16693,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16517,7 +16720,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16543,7 +16747,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16569,7 +16774,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16595,7 +16801,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16621,7 +16828,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16647,7 +16855,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16673,7 +16882,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16701,7 +16911,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16729,7 +16940,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16757,7 +16969,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16785,7 +16998,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16813,7 +17027,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16841,7 +17056,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16869,7 +17085,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16897,7 +17114,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16925,7 +17143,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16953,7 +17172,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16981,7 +17201,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17009,7 +17230,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17037,7 +17259,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17065,7 +17288,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17093,7 +17317,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17121,7 +17346,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17149,7 +17375,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17177,7 +17404,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17205,7 +17433,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17233,7 +17462,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17261,7 +17491,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17289,7 +17520,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17317,7 +17549,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17345,7 +17578,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17373,7 +17607,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17401,7 +17636,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17429,7 +17665,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17457,7 +17694,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17485,7 +17723,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17513,7 +17752,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17541,7 +17781,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17569,7 +17810,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17600,7 +17842,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17631,7 +17874,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17662,7 +17906,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17693,7 +17938,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17724,7 +17970,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17755,7 +18002,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17786,7 +18034,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17817,7 +18066,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17848,7 +18098,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17879,7 +18130,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17910,7 +18162,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17941,7 +18194,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17972,7 +18226,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18003,7 +18258,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18034,7 +18290,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18065,7 +18322,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18096,7 +18354,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18127,7 +18386,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18158,7 +18418,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18189,7 +18450,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18220,7 +18482,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18251,7 +18514,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18282,7 +18546,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18313,7 +18578,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18344,7 +18610,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18375,7 +18642,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18406,7 +18674,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18437,7 +18706,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18468,7 +18738,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18499,7 +18770,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18530,7 +18802,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18561,7 +18834,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18592,7 +18866,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18623,7 +18898,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18654,7 +18930,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18685,7 +18962,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18716,7 +18994,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18747,7 +19026,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18778,7 +19058,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18809,7 +19090,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18840,7 +19122,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18871,7 +19154,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18902,7 +19186,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18933,7 +19218,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18964,7 +19250,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18995,7 +19282,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19026,7 +19314,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19057,7 +19346,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19088,7 +19378,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19119,7 +19410,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19150,7 +19442,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19181,7 +19474,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19212,7 +19506,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19243,7 +19538,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19274,7 +19570,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19305,7 +19602,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19336,7 +19634,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19367,7 +19666,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19398,7 +19698,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19429,7 +19730,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19460,7 +19762,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19491,7 +19794,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19522,7 +19826,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19553,7 +19858,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19582,7 +19888,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19608,7 +19915,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19634,7 +19942,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19660,7 +19969,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19686,7 +19996,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19712,7 +20023,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19738,7 +20050,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19764,7 +20077,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19790,7 +20104,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19816,7 +20131,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19842,7 +20158,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19868,7 +20185,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19894,7 +20212,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19920,7 +20239,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19946,7 +20266,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19972,7 +20293,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20000,7 +20322,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20028,7 +20351,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20056,7 +20380,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20084,7 +20409,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20112,7 +20438,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20140,7 +20467,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20168,7 +20496,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20196,7 +20525,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20224,7 +20554,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20252,7 +20583,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20280,7 +20612,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20308,7 +20641,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20336,7 +20670,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20364,7 +20699,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20392,7 +20728,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20420,7 +20757,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20451,7 +20789,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20482,7 +20821,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20513,7 +20853,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20544,7 +20885,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20575,7 +20917,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20606,7 +20949,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20637,7 +20981,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20668,7 +21013,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20699,7 +21045,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20730,7 +21077,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20761,7 +21109,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20792,7 +21141,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20823,7 +21173,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20854,7 +21205,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20885,7 +21237,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20916,7 +21269,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20947,7 +21301,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20978,7 +21333,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21009,7 +21365,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21040,7 +21397,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21071,7 +21429,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21102,7 +21461,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21133,7 +21493,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21164,7 +21525,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21195,7 +21557,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21226,7 +21589,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21257,7 +21621,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21288,7 +21653,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21319,7 +21685,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21350,7 +21717,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21381,7 +21749,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21412,7 +21781,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21440,7 +21810,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21468,7 +21839,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21496,7 +21868,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21524,7 +21897,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21552,7 +21926,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21580,7 +21955,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21608,7 +21984,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21636,7 +22013,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21668,7 +22046,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21700,7 +22079,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21732,7 +22112,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21764,7 +22145,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21796,7 +22178,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21828,7 +22211,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21860,7 +22244,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21892,7 +22277,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21924,7 +22310,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21950,7 +22337,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -21976,7 +22364,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22008,7 +22397,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22034,7 +22424,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22060,7 +22451,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22092,7 +22484,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22118,7 +22511,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22144,7 +22538,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22176,7 +22571,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22202,7 +22598,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22228,7 +22625,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22260,7 +22658,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22286,7 +22685,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22312,7 +22712,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22344,7 +22745,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22370,7 +22772,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22396,7 +22799,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22428,7 +22832,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22454,7 +22859,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22480,7 +22886,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22512,7 +22919,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22538,7 +22946,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22564,7 +22973,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22596,7 +23006,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22628,7 +23039,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22660,7 +23072,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22692,7 +23105,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22724,7 +23138,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22756,7 +23171,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22788,7 +23204,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22820,7 +23237,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -22851,7 +23269,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22882,7 +23301,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22913,7 +23333,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22944,7 +23365,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22975,7 +23397,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23006,7 +23429,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23037,7 +23461,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23068,7 +23493,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23099,7 +23525,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23125,7 +23552,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23151,7 +23579,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23177,7 +23606,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23203,7 +23633,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23229,7 +23660,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23255,7 +23687,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -23281,7 +23714,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/ip/prim/lint/prim_subreg.waiver
+++ b/hw/ip/prim/lint/prim_subreg.waiver
@@ -4,3 +4,6 @@
 
 waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
       -comment "for RO wd is not used"
+
+waive -rules {PARAM_NOT_USED} -location {prim_subreg_shadow.sv} -regexp {Mubi} \
+      -comment "Mubi is not yet supported in prim_subreg_shadow."

--- a/hw/ip/prim/prim_subreg.core
+++ b/hw/ip/prim/prim_subreg.core
@@ -18,6 +18,7 @@ filesets:
     file_type: systemVerilogSource
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:mubi
 
   files_verilator_waiver:
     depend:

--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -9,7 +9,8 @@ module prim_subreg
 #(
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
-  parameter logic [DW-1:0] RESVAL   = '0    // reset value
+  parameter logic [DW-1:0] RESVAL   = '0 ,   // reset value
+  parameter bit            Mubi     = 1'b0
 ) (
   input clk_i,
   input rst_ni,
@@ -39,7 +40,8 @@ module prim_subreg
 
   prim_subreg_arb #(
     .DW       ( DW       ),
-    .SwAccess ( SwAccess )
+    .SwAccess ( SwAccess ),
+    .Mubi     ( Mubi     )
   ) wr_en_data_arb (
     .we,
     .wd,

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -11,7 +11,8 @@ module prim_subreg_shadow
 #(
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
-  parameter logic [DW-1:0] RESVAL   = '0    // reset value
+  parameter logic [DW-1:0] RESVAL   = '0,    // reset value
+  parameter bit            Mubi     = 1'b0
 ) (
   input clk_i,
   input rst_ni,
@@ -186,5 +187,8 @@ module prim_subreg_shadow
   assign qe = committed_qe;
   assign q  = committed_q;
   assign qs = committed_qs;
+
+  // prim_subreg_shadow does not support multi-bit software access yet
+  `ASSERT_NEVER(MubiIsNotYetSupported_A, Mubi)
 
 endmodule

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1112,7 +1112,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1154,7 +1155,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (27),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (27'h8000)
+    .RESVAL  (27'h8000),
+    .Mubi    (1'b0)
   ) u_cfg_clk_div (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1181,7 +1183,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h7)
+    .RESVAL  (4'h7),
+    .Mubi    (1'b0)
   ) u_cfg_dc_resn (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1208,7 +1211,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_cntr_en (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1252,7 +1256,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1279,7 +1284,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1306,7 +1312,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1333,7 +1340,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1360,7 +1368,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1387,7 +1396,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_en_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1431,7 +1441,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1458,7 +1469,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1485,7 +1497,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1512,7 +1525,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1539,7 +1553,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1566,7 +1581,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_invert_invert_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1610,7 +1626,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_0_phase_delay_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1637,7 +1654,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_0_htbt_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1664,7 +1682,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_0_blink_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1708,7 +1727,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_1_phase_delay_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1735,7 +1755,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_1_htbt_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1762,7 +1783,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_1_blink_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1806,7 +1828,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_2_phase_delay_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1833,7 +1856,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_2_htbt_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1860,7 +1884,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_2_blink_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1904,7 +1929,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_3_phase_delay_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1931,7 +1957,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_3_htbt_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1958,7 +1985,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_3_blink_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2002,7 +2030,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_4_phase_delay_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2029,7 +2058,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_4_htbt_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2056,7 +2086,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_4_blink_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2100,7 +2131,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_5_phase_delay_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2127,7 +2159,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_5_htbt_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2154,7 +2187,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pwm_param_5_blink_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2198,7 +2232,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_0_a_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2225,7 +2260,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_0_b_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2269,7 +2305,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_1_a_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2296,7 +2333,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_1_b_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2340,7 +2378,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_2_a_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2367,7 +2406,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_2_b_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2411,7 +2451,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_3_a_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2438,7 +2479,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_3_b_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2482,7 +2524,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_4_a_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2509,7 +2552,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_4_b_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2553,7 +2597,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_5_a_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2580,7 +2625,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7fff)
+    .RESVAL  (16'h7fff),
+    .Mubi    (1'b0)
   ) u_duty_cycle_5_b_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2624,7 +2670,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_0_x_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2651,7 +2698,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_0_y_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2695,7 +2743,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_1_x_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2722,7 +2771,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_1_y_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2766,7 +2816,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_2_x_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2793,7 +2844,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_2_y_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2837,7 +2889,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_3_x_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2864,7 +2917,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_3_y_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2908,7 +2962,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_4_x_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2935,7 +2990,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_4_y_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2979,7 +3035,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_5_x_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3006,7 +3063,8 @@ module pwm_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_blink_param_5_y_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -181,7 +181,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -208,7 +209,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -275,7 +277,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -301,7 +304,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -327,7 +331,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -353,7 +358,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -379,7 +385,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -405,7 +412,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -443,7 +451,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -471,7 +480,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +512,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -530,7 +541,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -557,7 +569,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -588,7 +601,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -616,7 +630,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -643,7 +658,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -171,7 +171,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_checker_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -197,7 +198,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_cause_integrity_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -225,7 +227,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -253,7 +256,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +285,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +314,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +343,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -365,7 +372,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -393,7 +401,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +430,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +459,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +488,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -505,7 +517,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -533,7 +546,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -561,7 +575,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -589,7 +604,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -617,7 +633,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +662,8 @@ module rom_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exp_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -164,7 +164,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -191,7 +192,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -218,7 +220,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_ndm_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -245,7 +248,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -274,7 +278,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -301,7 +306,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -363,7 +369,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -389,7 +396,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -333,7 +333,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_sw_recov_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -360,7 +361,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_sw_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -388,7 +390,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ibus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -416,7 +419,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ibus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -447,7 +451,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ibus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -478,7 +483,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ibus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -509,7 +515,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_ibus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -540,7 +547,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_ibus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +579,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_ibus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -602,7 +611,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_ibus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -630,7 +640,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dbus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +669,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dbus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -689,7 +701,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dbus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -720,7 +733,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dbus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -751,7 +765,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dbus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -782,7 +797,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dbus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -813,7 +829,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dbus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -844,7 +861,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dbus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -872,7 +890,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_nmi_enable_alert_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -898,7 +917,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_nmi_enable_wdog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +946,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_nmi_state_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -952,7 +973,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_nmi_state_wdog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -980,7 +1002,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1006,7 +1029,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_status_fatal_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1032,7 +1056,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_status_fatal_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1058,7 +1083,8 @@ module rv_core_ibex_cfg_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_status_recov_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
@@ -468,7 +468,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_halted (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -495,7 +496,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_going (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -522,7 +524,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_resuming (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -549,7 +552,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_exception (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -576,7 +580,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_whereto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -604,7 +609,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -632,7 +638,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +667,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -688,7 +696,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -716,7 +725,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -744,7 +754,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -772,7 +783,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -800,7 +812,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -828,7 +841,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -856,7 +870,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_abstractcmd_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -884,7 +899,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -912,7 +928,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -940,7 +957,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -968,7 +986,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -996,7 +1015,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1024,7 +1044,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1052,7 +1073,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1080,7 +1102,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_program_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1108,7 +1131,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dataaddr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1136,7 +1160,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_dataaddr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1164,7 +1189,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1192,7 +1218,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1220,7 +1247,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1248,7 +1276,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1276,7 +1305,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1304,7 +1334,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1332,7 +1363,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1360,7 +1392,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1388,7 +1421,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1416,7 +1450,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1444,7 +1479,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1472,7 +1508,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1500,7 +1537,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1528,7 +1566,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1556,7 +1595,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1584,7 +1624,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1612,7 +1653,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1640,7 +1682,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1668,7 +1711,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1696,7 +1740,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1724,7 +1769,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1752,7 +1798,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1780,7 +1827,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1808,7 +1856,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1836,7 +1885,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1864,7 +1914,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1892,7 +1943,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1920,7 +1972,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1948,7 +2001,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1976,7 +2030,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2004,7 +2059,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2032,7 +2088,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2060,7 +2117,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2088,7 +2146,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2116,7 +2175,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2144,7 +2204,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2172,7 +2233,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2200,7 +2262,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2228,7 +2291,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2256,7 +2320,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2284,7 +2349,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2312,7 +2378,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2340,7 +2407,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2368,7 +2436,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2396,7 +2465,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2424,7 +2494,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2452,7 +2523,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2480,7 +2552,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2508,7 +2581,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2536,7 +2610,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2564,7 +2639,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2592,7 +2668,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2620,7 +2697,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2648,7 +2726,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2676,7 +2755,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2704,7 +2784,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2732,7 +2813,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2760,7 +2842,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2788,7 +2871,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2816,7 +2900,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2844,7 +2929,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2872,7 +2958,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2900,7 +2987,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2928,7 +3016,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +3045,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2984,7 +3074,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3012,7 +3103,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3040,7 +3132,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3068,7 +3161,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3096,7 +3190,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3124,7 +3219,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3152,7 +3248,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3180,7 +3277,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3208,7 +3306,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3236,7 +3335,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3264,7 +3364,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3292,7 +3393,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3320,7 +3422,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3348,7 +3451,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3376,7 +3480,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3404,7 +3509,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3432,7 +3538,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3460,7 +3567,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3488,7 +3596,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3516,7 +3625,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3544,7 +3654,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3572,7 +3683,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3600,7 +3712,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3628,7 +3741,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3656,7 +3770,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3684,7 +3799,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3712,7 +3828,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3740,7 +3857,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3768,7 +3886,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3796,7 +3915,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3824,7 +3944,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3852,7 +3973,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3880,7 +4002,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3908,7 +4031,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3936,7 +4060,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3964,7 +4089,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3992,7 +4118,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4020,7 +4147,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4048,7 +4176,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4076,7 +4205,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4104,7 +4234,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4132,7 +4263,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4160,7 +4292,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4188,7 +4321,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4216,7 +4350,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4244,7 +4379,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4272,7 +4408,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4300,7 +4437,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4328,7 +4466,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4356,7 +4495,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4384,7 +4524,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4412,7 +4553,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4440,7 +4582,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4468,7 +4611,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4496,7 +4640,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4524,7 +4669,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4552,7 +4698,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4727,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4608,7 +4756,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4636,7 +4785,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4664,7 +4814,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4692,7 +4843,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4720,7 +4872,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4748,7 +4901,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4776,7 +4930,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4804,7 +4959,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4832,7 +4988,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4860,7 +5017,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4888,7 +5046,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4916,7 +5075,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4944,7 +5104,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4972,7 +5133,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5000,7 +5162,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5028,7 +5191,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5056,7 +5220,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5084,7 +5249,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5112,7 +5278,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5140,7 +5307,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5168,7 +5336,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5196,7 +5365,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5224,7 +5394,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5252,7 +5423,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5280,7 +5452,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5481,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5336,7 +5510,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5364,7 +5539,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5568,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5420,7 +5597,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5448,7 +5626,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5476,7 +5655,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5504,7 +5684,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5532,7 +5713,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5560,7 +5742,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5588,7 +5771,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5616,7 +5800,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5644,7 +5829,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5672,7 +5858,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5700,7 +5887,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5728,7 +5916,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5756,7 +5945,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5784,7 +5974,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5812,7 +6003,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5840,7 +6032,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5868,7 +6061,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5896,7 +6090,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5924,7 +6119,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5952,7 +6148,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5980,7 +6177,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6008,7 +6206,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6036,7 +6235,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6064,7 +6264,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6092,7 +6293,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6120,7 +6322,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6148,7 +6351,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6176,7 +6380,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6204,7 +6409,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6232,7 +6438,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6260,7 +6467,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6288,7 +6496,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6316,7 +6525,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6344,7 +6554,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6372,7 +6583,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6400,7 +6612,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6428,7 +6641,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6456,7 +6670,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6484,7 +6699,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6512,7 +6728,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6540,7 +6757,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6568,7 +6786,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6596,7 +6815,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6624,7 +6844,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6652,7 +6873,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6680,7 +6902,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6708,7 +6931,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6736,7 +6960,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6764,7 +6989,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6792,7 +7018,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6820,7 +7047,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6848,7 +7076,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6876,7 +7105,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6904,7 +7134,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6932,7 +7163,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6960,7 +7192,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6988,7 +7221,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7016,7 +7250,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7044,7 +7279,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7072,7 +7308,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7100,7 +7337,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7128,7 +7366,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7156,7 +7395,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7184,7 +7424,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7212,7 +7453,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7240,7 +7482,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7268,7 +7511,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7296,7 +7540,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7324,7 +7569,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7352,7 +7598,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7380,7 +7627,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7408,7 +7656,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7436,7 +7685,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7464,7 +7714,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7492,7 +7743,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7520,7 +7772,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7548,7 +7801,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7576,7 +7830,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7604,7 +7859,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7632,7 +7888,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7660,7 +7917,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7688,7 +7946,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7716,7 +7975,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7744,7 +8004,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7772,7 +8033,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7800,7 +8062,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7828,7 +8091,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7856,7 +8120,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7884,7 +8149,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7912,7 +8178,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7940,7 +8207,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7968,7 +8236,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7996,7 +8265,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8024,7 +8294,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8052,7 +8323,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8080,7 +8352,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8108,7 +8381,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8136,7 +8410,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8164,7 +8439,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8192,7 +8468,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8220,7 +8497,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8248,7 +8526,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8276,7 +8555,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8304,7 +8584,8 @@ module rv_dm_mem_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_flags_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -181,7 +181,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -209,7 +210,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -237,7 +239,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -286,7 +289,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h0)
+    .RESVAL  (12'h0),
+    .Mubi    (1'b0)
   ) u_cfg0_prescale (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -312,7 +316,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h1)
+    .RESVAL  (8'h1),
+    .Mubi    (1'b0)
   ) u_cfg0_step (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -339,7 +344,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_timer_v_lower0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -366,7 +372,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_timer_v_upper0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +411,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hffffffff)
+    .RESVAL  (32'hffffffff),
+    .Mubi    (1'b0)
   ) u_compare_lower0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -443,7 +451,8 @@ module rv_timer_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hffffffff)
+    .RESVAL  (32'hffffffff),
+    .Mubi    (1'b0)
   ) u_compare_upper0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1558,7 +1558,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1584,7 +1585,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1610,7 +1612,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1636,7 +1639,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_rx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1662,7 +1666,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1688,7 +1693,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_generic_tx_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1714,7 +1720,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1740,7 +1747,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1766,7 +1774,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1792,7 +1801,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1818,7 +1828,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1844,7 +1855,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1872,7 +1884,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1898,7 +1911,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1924,7 +1938,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1950,7 +1965,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_rx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1976,7 +1992,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2002,7 +2019,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_generic_tx_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2028,7 +2046,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2054,7 +2073,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2080,7 +2100,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2106,7 +2127,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2132,7 +2154,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2158,7 +2181,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2403,7 +2427,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2429,7 +2454,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h1),
+    .Mubi    (1'b0)
   ) u_control_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2455,7 +2481,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_rst_txfifo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2481,7 +2508,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_rst_rxfifo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2507,7 +2535,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_control_sram_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2535,7 +2564,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_cpol (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2561,7 +2591,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_cpha (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2587,7 +2618,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_tx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2613,7 +2645,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_rx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2639,7 +2672,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h7f)
+    .RESVAL  (8'h7f),
+    .Mubi    (1'b0)
   ) u_cfg_timer_v (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2665,7 +2699,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_addr_4b_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2691,7 +2726,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_mailbox_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2719,7 +2755,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h80)
+    .RESVAL  (16'h80),
+    .Mubi    (1'b0)
   ) u_fifo_level_rxlvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2745,7 +2782,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_fifo_level_txlvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2912,7 +2950,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_rxf_ptr_rptr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2938,7 +2977,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_rxf_ptr_wptr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2966,7 +3006,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_txf_ptr_rptr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2992,7 +3033,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_txf_ptr_wptr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3020,7 +3062,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_rxf_addr_base (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3046,7 +3089,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h1fc)
+    .RESVAL  (16'h1fc),
+    .Mubi    (1'b0)
   ) u_rxf_addr_limit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3074,7 +3118,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h200)
+    .RESVAL  (16'h200),
+    .Mubi    (1'b0)
   ) u_txf_addr_base (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3100,7 +3145,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h3fc)
+    .RESVAL  (16'h3fc),
+    .Mubi    (1'b0)
   ) u_txf_addr_limit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3128,7 +3174,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intercept_en_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3154,7 +3201,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intercept_en_jedec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3180,7 +3228,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intercept_en_sfdp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3206,7 +3255,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intercept_en_mbx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3287,7 +3337,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h7f)
+    .RESVAL  (8'h7f),
+    .Mubi    (1'b0)
   ) u_jedec_cc_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3313,7 +3364,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_jedec_cc_num_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3341,7 +3393,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_jedec_id_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3367,7 +3420,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_jedec_id_mf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3394,7 +3448,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_read_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3421,7 +3476,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_mailbox_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3449,7 +3505,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_upload_status_cmdfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3475,7 +3532,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_upload_status_cmdfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3501,7 +3559,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_upload_status_addrfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3527,7 +3586,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_upload_status_addrfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3555,7 +3615,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_upload_status2_payload_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3581,7 +3642,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_upload_status2_payload_start_idx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3642,7 +3704,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3668,7 +3731,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3694,7 +3758,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3720,7 +3785,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3746,7 +3812,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3772,7 +3839,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3798,7 +3866,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3824,7 +3893,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3850,7 +3920,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3876,7 +3947,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3902,7 +3974,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3928,7 +4001,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3954,7 +4028,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3980,7 +4055,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4006,7 +4082,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4032,7 +4109,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4058,7 +4136,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4084,7 +4163,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4110,7 +4190,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4136,7 +4217,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4162,7 +4244,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4188,7 +4271,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4214,7 +4298,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4240,7 +4325,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4266,7 +4352,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4292,7 +4379,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4318,7 +4406,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4344,7 +4433,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4370,7 +4460,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4396,7 +4487,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4422,7 +4514,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4448,7 +4541,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_0_filter_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4477,7 +4571,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4503,7 +4598,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4625,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4555,7 +4652,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4581,7 +4679,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4607,7 +4706,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4733,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4659,7 +4760,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4685,7 +4787,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4711,7 +4814,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4737,7 +4841,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4763,7 +4868,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4789,7 +4895,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4815,7 +4922,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4841,7 +4949,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4867,7 +4976,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4893,7 +5003,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4919,7 +5030,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4945,7 +5057,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4971,7 +5084,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4997,7 +5111,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5023,7 +5138,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5049,7 +5165,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5075,7 +5192,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5101,7 +5219,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5127,7 +5246,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5153,7 +5273,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5179,7 +5300,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5205,7 +5327,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5231,7 +5354,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5257,7 +5381,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5283,7 +5408,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_1_filter_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5312,7 +5438,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5338,7 +5465,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5364,7 +5492,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5390,7 +5519,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5416,7 +5546,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5442,7 +5573,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5468,7 +5600,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5494,7 +5627,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5520,7 +5654,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5546,7 +5681,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5572,7 +5708,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5598,7 +5735,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5624,7 +5762,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5650,7 +5789,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5676,7 +5816,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5702,7 +5843,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5728,7 +5870,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5754,7 +5897,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5780,7 +5924,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5806,7 +5951,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5832,7 +5978,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5858,7 +6005,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5884,7 +6032,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5910,7 +6059,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5936,7 +6086,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5962,7 +6113,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5988,7 +6140,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6014,7 +6167,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6040,7 +6194,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6066,7 +6221,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6092,7 +6248,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6118,7 +6275,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_2_filter_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6147,7 +6305,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6173,7 +6332,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6199,7 +6359,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6225,7 +6386,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6251,7 +6413,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6277,7 +6440,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6303,7 +6467,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6329,7 +6494,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6355,7 +6521,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6381,7 +6548,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6407,7 +6575,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6433,7 +6602,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6459,7 +6629,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6485,7 +6656,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6511,7 +6683,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6537,7 +6710,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6563,7 +6737,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6589,7 +6764,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6615,7 +6791,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6641,7 +6818,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6667,7 +6845,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6693,7 +6872,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6719,7 +6899,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6745,7 +6926,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6771,7 +6953,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6797,7 +6980,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6823,7 +7007,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6849,7 +7034,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6875,7 +7061,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +7088,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6927,7 +7115,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6953,7 +7142,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_3_filter_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6982,7 +7172,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7008,7 +7199,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7034,7 +7226,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7060,7 +7253,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7086,7 +7280,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7112,7 +7307,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7138,7 +7334,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7164,7 +7361,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7190,7 +7388,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7216,7 +7415,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7242,7 +7442,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7268,7 +7469,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7294,7 +7496,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7320,7 +7523,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7346,7 +7550,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7372,7 +7577,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7398,7 +7604,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7424,7 +7631,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7450,7 +7658,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7476,7 +7685,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7502,7 +7712,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7528,7 +7739,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7554,7 +7766,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7580,7 +7793,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7606,7 +7820,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7632,7 +7847,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7658,7 +7874,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7684,7 +7901,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7710,7 +7928,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7736,7 +7955,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7762,7 +7982,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7788,7 +8009,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_4_filter_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7817,7 +8039,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7843,7 +8066,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7869,7 +8093,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7895,7 +8120,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7921,7 +8147,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7947,7 +8174,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7973,7 +8201,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7999,7 +8228,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8025,7 +8255,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8051,7 +8282,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8077,7 +8309,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8103,7 +8336,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8129,7 +8363,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8155,7 +8390,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8181,7 +8417,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8207,7 +8444,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8233,7 +8471,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8259,7 +8498,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8285,7 +8525,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8311,7 +8552,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8337,7 +8579,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8363,7 +8606,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8389,7 +8633,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8415,7 +8660,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8441,7 +8687,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8467,7 +8714,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8493,7 +8741,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8519,7 +8768,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8545,7 +8795,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8571,7 +8822,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8597,7 +8849,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8623,7 +8876,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_5_filter_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8652,7 +8906,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8678,7 +8933,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8704,7 +8960,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8730,7 +8987,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8756,7 +9014,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8782,7 +9041,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8808,7 +9068,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8834,7 +9095,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8860,7 +9122,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8886,7 +9149,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8912,7 +9176,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8938,7 +9203,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8964,7 +9230,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8990,7 +9257,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9016,7 +9284,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9042,7 +9311,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9068,7 +9338,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9094,7 +9365,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9120,7 +9392,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9146,7 +9419,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9172,7 +9446,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9198,7 +9473,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9224,7 +9500,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9250,7 +9527,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9276,7 +9554,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9302,7 +9581,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9328,7 +9608,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9354,7 +9635,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9380,7 +9662,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9406,7 +9689,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9432,7 +9716,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9458,7 +9743,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_6_filter_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9487,7 +9773,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9513,7 +9800,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9539,7 +9827,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9565,7 +9854,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9591,7 +9881,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9617,7 +9908,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9643,7 +9935,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9669,7 +9962,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9695,7 +9989,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9721,7 +10016,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9747,7 +10043,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9773,7 +10070,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9799,7 +10097,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9825,7 +10124,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9851,7 +10151,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9877,7 +10178,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9903,7 +10205,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9929,7 +10232,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9955,7 +10259,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9981,7 +10286,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10007,7 +10313,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10033,7 +10340,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10059,7 +10367,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10085,7 +10394,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10111,7 +10421,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10137,7 +10448,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10163,7 +10475,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10189,7 +10502,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10215,7 +10529,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10241,7 +10556,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10267,7 +10583,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10293,7 +10610,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_filter_7_filter_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10320,7 +10638,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_addr_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10347,7 +10666,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_addr_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10374,7 +10694,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_payload_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10401,7 +10722,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_payload_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10430,7 +10752,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_opcode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10456,7 +10779,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_addr_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10482,7 +10806,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_addr_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10508,7 +10833,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_mbyte_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10534,7 +10860,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_dummy_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10560,7 +10887,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_dummy_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10586,7 +10914,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_payload_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10612,7 +10941,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_payload_dir_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10638,7 +10968,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_payload_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10664,7 +10995,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_upload_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10690,7 +11022,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_busy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10716,7 +11049,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_0_valid_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10745,7 +11079,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_opcode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10771,7 +11106,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_addr_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10797,7 +11133,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_addr_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10823,7 +11160,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_mbyte_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10849,7 +11187,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_dummy_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10875,7 +11214,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_dummy_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10901,7 +11241,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_payload_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10927,7 +11268,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_payload_dir_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10953,7 +11295,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_payload_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10979,7 +11322,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_upload_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11005,7 +11349,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_busy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11031,7 +11376,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_1_valid_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11060,7 +11406,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_opcode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11086,7 +11433,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_addr_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11112,7 +11460,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_addr_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11138,7 +11487,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_mbyte_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11164,7 +11514,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_dummy_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11190,7 +11541,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_dummy_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11216,7 +11568,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_payload_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11242,7 +11595,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_payload_dir_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11268,7 +11622,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_payload_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11294,7 +11649,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_upload_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11320,7 +11676,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_busy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11346,7 +11703,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_2_valid_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11375,7 +11733,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_opcode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11401,7 +11760,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_addr_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11427,7 +11787,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_addr_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11453,7 +11814,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_mbyte_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11479,7 +11841,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_dummy_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11505,7 +11868,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_dummy_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11531,7 +11895,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_payload_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11557,7 +11922,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_payload_dir_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11583,7 +11949,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_payload_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11609,7 +11976,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_upload_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11635,7 +12003,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_busy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11661,7 +12030,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_3_valid_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11690,7 +12060,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_opcode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11716,7 +12087,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_addr_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11742,7 +12114,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_addr_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11768,7 +12141,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_mbyte_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11794,7 +12168,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_dummy_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11820,7 +12195,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_dummy_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11846,7 +12222,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_payload_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11872,7 +12249,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_payload_dir_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11898,7 +12276,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_payload_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11924,7 +12303,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_upload_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11950,7 +12330,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_busy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11976,7 +12357,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_4_valid_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12005,7 +12387,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_opcode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12031,7 +12414,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_addr_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12057,7 +12441,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_addr_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12083,7 +12468,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_mbyte_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12109,7 +12495,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_dummy_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12135,7 +12522,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_dummy_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12161,7 +12549,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_payload_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12187,7 +12576,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_payload_dir_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12213,7 +12603,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_payload_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12239,7 +12630,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_upload_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12265,7 +12657,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_busy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12291,7 +12684,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_5_valid_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12320,7 +12714,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_opcode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12346,7 +12741,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_addr_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12372,7 +12768,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_addr_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12398,7 +12795,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_mbyte_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12424,7 +12822,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_dummy_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12450,7 +12849,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_dummy_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12476,7 +12876,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_payload_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12502,7 +12903,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_payload_dir_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12528,7 +12930,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_payload_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12554,7 +12957,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_upload_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12580,7 +12984,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_busy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12606,7 +13011,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_6_valid_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12635,7 +13041,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_opcode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12661,7 +13068,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_addr_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12687,7 +13095,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_addr_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12713,7 +13122,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_mbyte_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12739,7 +13149,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_dummy_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12765,7 +13176,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_dummy_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12791,7 +13203,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_payload_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12817,7 +13230,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_payload_dir_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12843,7 +13257,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_payload_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12869,7 +13284,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_upload_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12895,7 +13311,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_busy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12921,7 +13338,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_7_valid_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12950,7 +13368,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_opcode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12976,7 +13395,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_addr_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13002,7 +13422,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_addr_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13028,7 +13449,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_mbyte_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13054,7 +13476,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_dummy_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13080,7 +13503,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_dummy_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13106,7 +13530,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_payload_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13132,7 +13557,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_payload_dir_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13158,7 +13584,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_payload_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13184,7 +13611,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_upload_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13210,7 +13638,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_busy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13236,7 +13665,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_8_valid_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13265,7 +13695,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_opcode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13291,7 +13722,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_addr_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13317,7 +13749,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_addr_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13343,7 +13776,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_mbyte_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13369,7 +13803,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_dummy_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13395,7 +13830,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_dummy_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13421,7 +13857,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_payload_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13447,7 +13884,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_payload_dir_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13473,7 +13911,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_payload_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13499,7 +13938,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_upload_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13525,7 +13965,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_busy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13551,7 +13992,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_9_valid_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13580,7 +14022,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_opcode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13606,7 +14049,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_addr_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13632,7 +14076,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_addr_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13658,7 +14103,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_mbyte_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13684,7 +14130,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_dummy_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13710,7 +14157,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_dummy_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13736,7 +14184,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_payload_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13762,7 +14211,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_payload_dir_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13788,7 +14238,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_payload_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13814,7 +14265,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_upload_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13840,7 +14292,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_busy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13866,7 +14319,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_10_valid_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13895,7 +14349,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_opcode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13921,7 +14376,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_addr_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13947,7 +14403,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_addr_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13973,7 +14430,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_mbyte_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13999,7 +14457,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_dummy_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14025,7 +14484,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_dummy_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14051,7 +14511,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_payload_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14077,7 +14538,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_payload_dir_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14103,7 +14565,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_payload_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14129,7 +14592,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_upload_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14155,7 +14619,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_busy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14181,7 +14646,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_11_valid_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14210,7 +14676,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_opcode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14236,7 +14703,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_addr_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14262,7 +14730,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_addr_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14288,7 +14757,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_mbyte_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14314,7 +14784,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_dummy_size_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14340,7 +14811,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_dummy_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14366,7 +14838,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_payload_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14392,7 +14865,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_payload_dir_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14418,7 +14892,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_payload_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14444,7 +14919,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_upload_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14470,7 +14946,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_busy_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14496,7 +14973,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_12_valid_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14525,7 +15003,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_opcode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14551,7 +15030,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_addr_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14577,7 +15057,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_addr_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14603,7 +15084,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_mbyte_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14629,7 +15111,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_dummy_size_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14655,7 +15138,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_dummy_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14681,7 +15165,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_payload_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14707,7 +15192,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_payload_dir_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14733,7 +15219,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_payload_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14759,7 +15246,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_upload_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14785,7 +15273,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_busy_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14811,7 +15300,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_13_valid_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14840,7 +15330,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_opcode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14866,7 +15357,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_addr_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14892,7 +15384,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_addr_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14918,7 +15411,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_mbyte_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14944,7 +15438,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_dummy_size_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14970,7 +15465,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_dummy_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14996,7 +15492,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_payload_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15022,7 +15519,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_payload_dir_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15048,7 +15546,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_payload_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15074,7 +15573,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_upload_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15100,7 +15600,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_busy_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15126,7 +15627,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_14_valid_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15155,7 +15657,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_opcode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15181,7 +15684,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_addr_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15207,7 +15711,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_addr_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15233,7 +15738,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_mbyte_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15259,7 +15765,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_dummy_size_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15285,7 +15792,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_dummy_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15311,7 +15819,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_payload_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15337,7 +15846,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_payload_dir_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15363,7 +15873,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_payload_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15389,7 +15900,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_upload_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15415,7 +15927,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_busy_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15441,7 +15954,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_15_valid_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15470,7 +15984,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_opcode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15496,7 +16011,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_addr_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15522,7 +16038,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_addr_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15548,7 +16065,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_mbyte_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15574,7 +16092,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_dummy_size_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15600,7 +16119,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_dummy_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15626,7 +16146,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_payload_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15652,7 +16173,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_payload_dir_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15678,7 +16200,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_payload_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15704,7 +16227,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_upload_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15730,7 +16254,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_busy_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15756,7 +16281,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_16_valid_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15785,7 +16311,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_opcode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15811,7 +16338,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_addr_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15837,7 +16365,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_addr_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15863,7 +16392,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_mbyte_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15889,7 +16419,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_dummy_size_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15915,7 +16446,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_dummy_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15941,7 +16473,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_payload_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15967,7 +16500,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_payload_dir_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15993,7 +16527,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_payload_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16019,7 +16554,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_upload_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16045,7 +16581,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_busy_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16071,7 +16608,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_17_valid_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16100,7 +16638,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_opcode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16126,7 +16665,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_addr_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16152,7 +16692,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_addr_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16178,7 +16719,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_mbyte_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16204,7 +16746,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_dummy_size_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16230,7 +16773,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_dummy_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16256,7 +16800,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_payload_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16282,7 +16827,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_payload_dir_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16308,7 +16854,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_payload_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16334,7 +16881,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_upload_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16360,7 +16908,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_busy_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16386,7 +16935,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_18_valid_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16415,7 +16965,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_opcode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16441,7 +16992,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_addr_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16467,7 +17019,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_addr_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16493,7 +17046,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_mbyte_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16519,7 +17073,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_dummy_size_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16545,7 +17100,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_dummy_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16571,7 +17127,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_payload_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16597,7 +17154,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_payload_dir_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16623,7 +17181,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_payload_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16649,7 +17208,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_upload_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16675,7 +17235,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_busy_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16701,7 +17262,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_19_valid_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16730,7 +17292,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_opcode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16756,7 +17319,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_addr_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16782,7 +17346,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_addr_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16808,7 +17373,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_mbyte_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16834,7 +17400,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_dummy_size_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16860,7 +17427,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_dummy_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16886,7 +17454,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_payload_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16912,7 +17481,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_payload_dir_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16938,7 +17508,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_payload_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16964,7 +17535,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_upload_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16990,7 +17562,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_busy_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17016,7 +17589,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_20_valid_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17045,7 +17619,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_opcode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17071,7 +17646,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_addr_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17097,7 +17673,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_addr_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17123,7 +17700,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_mbyte_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17149,7 +17727,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_dummy_size_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17175,7 +17754,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_dummy_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17201,7 +17781,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_payload_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17227,7 +17808,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_payload_dir_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17253,7 +17835,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_payload_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17279,7 +17862,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_upload_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17305,7 +17889,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_busy_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17331,7 +17916,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_21_valid_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17360,7 +17946,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_opcode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17386,7 +17973,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_addr_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17412,7 +18000,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_addr_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17438,7 +18027,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_mbyte_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17464,7 +18054,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_dummy_size_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17490,7 +18081,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_dummy_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17516,7 +18108,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_payload_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17542,7 +18135,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_payload_dir_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17568,7 +18162,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_payload_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17594,7 +18189,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_upload_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17620,7 +18216,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_busy_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17646,7 +18243,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_22_valid_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17675,7 +18273,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_opcode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17701,7 +18300,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_addr_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17727,7 +18327,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_addr_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17753,7 +18354,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_mbyte_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17779,7 +18381,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h7)
+    .RESVAL  (3'h7),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_dummy_size_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17805,7 +18408,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_dummy_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17831,7 +18435,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_payload_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17857,7 +18462,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_payload_dir_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17883,7 +18489,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_payload_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17909,7 +18516,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_upload_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17935,7 +18543,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_busy_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17961,7 +18570,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_23_valid_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17989,7 +18599,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_en4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18015,7 +18626,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_en4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18043,7 +18655,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_ex4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18069,7 +18682,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_ex4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18097,7 +18711,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_wren_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18123,7 +18738,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_wren_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18151,7 +18767,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_wrdi_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18177,7 +18794,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cmd_info_wrdi_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18205,7 +18823,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cap_rev (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18231,7 +18850,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_tpm_cap_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18257,7 +18877,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h6)
+    .RESVAL  (3'h6),
+    .Mubi    (1'b0)
   ) u_tpm_cap_max_wr_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18283,7 +18904,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h6)
+    .RESVAL  (3'h6),
+    .Mubi    (1'b0)
   ) u_tpm_cap_max_rd_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18311,7 +18933,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cfg_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18337,7 +18960,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cfg_tpm_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18363,7 +18987,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cfg_hw_reg_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18389,7 +19014,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cfg_tpm_reg_chk_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18415,7 +19041,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_cfg_invalid_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18443,7 +19070,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_tpm_status_cmdaddr_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18469,7 +19097,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_tpm_status_wrfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18498,7 +19127,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_access_0_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18524,7 +19154,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_access_0_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18550,7 +19181,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_access_0_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18576,7 +19208,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_access_0_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18604,7 +19237,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18631,7 +19265,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_tpm_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18658,7 +19293,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_tpm_intf_capability (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18685,7 +19321,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_tpm_int_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18712,7 +19349,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_int_vector (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18739,7 +19377,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_tpm_int_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18767,7 +19406,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_tpm_did_vid_vid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18793,7 +19433,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_tpm_did_vid_did (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18820,7 +19461,8 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_tpm_rid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -283,7 +283,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +310,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +339,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -363,7 +366,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -448,7 +452,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h7f)
+    .RESVAL  (8'h7f),
+    .Mubi    (1'b0)
   ) u_control_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -474,7 +479,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_control_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -500,7 +506,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_output_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -526,7 +533,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_sw_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -552,7 +560,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_spien (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -580,7 +589,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_status_txqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -606,7 +616,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_status_rxqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -632,7 +643,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_status_cmdqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +670,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -684,7 +697,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_byteorder (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -710,7 +724,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rxstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -736,7 +751,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rxempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -762,7 +778,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -788,7 +805,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -814,7 +832,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_txstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -840,7 +859,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -866,7 +886,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_txfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -892,7 +913,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -918,7 +940,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -947,7 +970,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_configopts_clkdiv_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +997,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_configopts_csnidle_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -999,7 +1024,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_configopts_csntrail_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1025,7 +1051,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_configopts_csnlead_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1078,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configopts_fullcyc_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1077,7 +1105,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configopts_cpha_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1103,7 +1132,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configopts_cpol_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1130,7 +1160,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1227,7 +1258,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_error_enable_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1253,7 +1285,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_error_enable_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1279,7 +1312,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_error_enable_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1305,7 +1339,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_error_enable_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1331,7 +1366,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_error_enable_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1359,7 +1395,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1385,7 +1422,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1411,7 +1449,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1476,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1463,7 +1503,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1489,7 +1530,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_error_status_accessinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1517,7 +1559,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1543,7 +1586,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1569,7 +1613,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1595,7 +1640,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1621,7 +1667,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1647,7 +1694,8 @@ module spi_host_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_event_enable_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -171,7 +171,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_bus_integ_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -197,7 +198,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_init_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -223,7 +225,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_escalated (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -249,7 +252,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_scr_key_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -275,7 +279,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_scr_key_seed_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -301,7 +306,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -328,7 +334,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_exec_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -358,7 +365,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -385,7 +393,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -427,7 +436,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_renew_scr_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -454,7 +464,8 @@ module sram_ctrl_regs_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -1992,7 +1992,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2019,7 +2020,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2086,7 +2088,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2116,7 +2119,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7d0)
+    .RESVAL  (16'h7d0),
+    .Mubi    (1'b0)
   ) u_ec_rst_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2147,7 +2151,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h1f40)
+    .RESVAL  (16'h1f40),
+    .Mubi    (1'b0)
   ) u_ulp_ac_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2178,7 +2183,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h1f40)
+    .RESVAL  (16'h1f40),
+    .Mubi    (1'b0)
   ) u_ulp_lid_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2209,7 +2215,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h1f40)
+    .RESVAL  (16'h1f40),
+    .Mubi    (1'b0)
   ) u_ulp_pwrb_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2236,7 +2243,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ulp_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2265,7 +2273,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ulp_status (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2294,7 +2303,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_status (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2325,7 +2335,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key0_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2351,7 +2362,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2377,7 +2389,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key1_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2403,7 +2416,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2429,7 +2443,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key2_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2455,7 +2470,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2481,7 +2497,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_pwrb_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2507,7 +2524,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2533,7 +2551,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_ac_present (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2559,7 +2578,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2585,7 +2605,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_lid_open (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2611,7 +2632,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_invert_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2642,7 +2664,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2668,7 +2691,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_ec_rst_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2694,7 +2718,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_pwrb_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2720,7 +2745,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key0_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2746,7 +2772,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key1_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2772,7 +2799,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key2_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2798,7 +2826,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_z3_wakeup_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2824,7 +2853,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_flash_wp_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2850,7 +2880,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2876,7 +2907,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_ec_rst_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2902,7 +2934,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_pwrb_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2928,7 +2961,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key0_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2954,7 +2988,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key1_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2980,7 +3015,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_key2_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3006,7 +3042,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_z3_wakeup_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3032,7 +3069,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_allowed_ctl_flash_wp_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3060,7 +3098,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3086,7 +3125,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3112,7 +3152,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3138,7 +3179,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3164,7 +3206,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3190,7 +3233,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3216,7 +3260,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3242,7 +3287,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_pin_out_ctl_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3270,7 +3316,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3296,7 +3343,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3322,7 +3370,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3348,7 +3397,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3374,7 +3424,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3400,7 +3451,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3426,7 +3478,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3452,7 +3505,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_out_value_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3480,7 +3534,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_pwrb_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3506,7 +3561,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_key0_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3532,7 +3588,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_key1_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3558,7 +3615,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_key2_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3584,7 +3642,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_lid_open (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3610,7 +3669,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_ac_present (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3636,7 +3696,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_ec_rst_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3662,7 +3723,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_pin_in_value_flash_wp_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3693,7 +3755,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_pwrb_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3719,7 +3782,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key0_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3745,7 +3809,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key1_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3771,7 +3836,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key2_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3797,7 +3863,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_ac_present_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3823,7 +3890,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_ec_rst_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3849,7 +3917,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_flash_wp_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3875,7 +3944,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_pwrb_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3901,7 +3971,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key0_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3927,7 +3998,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key1_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3953,7 +4025,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_key2_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3979,7 +4052,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_ac_present_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4005,7 +4079,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_ec_rst_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4031,7 +4106,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_ctl_flash_wp_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4062,7 +4138,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7d0)
+    .RESVAL  (16'h7d0),
+    .Mubi    (1'b0)
   ) u_key_intr_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4094,7 +4171,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h7d0)
+    .RESVAL  (16'h7d0),
+    .Mubi    (1'b0)
   ) u_auto_block_debounce_ctl_debounce_timer (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4120,7 +4198,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_debounce_ctl_auto_block_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4152,7 +4231,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key0_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4178,7 +4258,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key1_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4204,7 +4285,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key2_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4230,7 +4312,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key0_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4256,7 +4339,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key1_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4282,7 +4366,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_auto_block_out_ctl_key2_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4314,7 +4399,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4340,7 +4426,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4366,7 +4453,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4392,7 +4480,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4418,7 +4507,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4450,7 +4540,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4476,7 +4567,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4502,7 +4594,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4528,7 +4621,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4554,7 +4648,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4586,7 +4681,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4612,7 +4708,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4638,7 +4735,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4664,7 +4762,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4690,7 +4789,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4722,7 +4822,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4748,7 +4849,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4774,7 +4876,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4800,7 +4903,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4826,7 +4930,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4857,7 +4962,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4888,7 +4994,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4919,7 +5026,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4950,7 +5058,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_pre_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4982,7 +5091,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5008,7 +5118,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5034,7 +5145,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5060,7 +5172,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5086,7 +5199,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5118,7 +5232,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5144,7 +5259,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5170,7 +5286,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5196,7 +5313,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5222,7 +5340,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5254,7 +5373,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5280,7 +5400,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5306,7 +5427,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5332,7 +5454,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5358,7 +5481,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5390,7 +5514,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5416,7 +5541,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5442,7 +5568,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5468,7 +5595,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5494,7 +5622,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5525,7 +5654,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5556,7 +5686,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5587,7 +5718,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5618,7 +5750,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_com_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5650,7 +5783,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_0_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5676,7 +5810,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_0_interrupt_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5702,7 +5837,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_0_ec_rst_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5728,7 +5864,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_0_rst_req_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5760,7 +5897,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_1_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5786,7 +5924,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_1_interrupt_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5812,7 +5951,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_1_ec_rst_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5838,7 +5978,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_1_rst_req_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5870,7 +6011,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_2_bat_disable_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5896,7 +6038,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_2_interrupt_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5922,7 +6065,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_2_ec_rst_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5948,7 +6092,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_2_rst_req_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5980,7 +6125,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_3_bat_disable_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6006,7 +6152,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_3_interrupt_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6032,7 +6179,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_3_ec_rst_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6058,7 +6206,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_com_out_ctl_3_rst_req_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6088,7 +6237,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_combo_intr_status_combo0_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6114,7 +6264,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_combo_intr_status_combo1_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6140,7 +6291,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_combo_intr_status_combo2_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6166,7 +6318,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_combo_intr_status_combo3_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6196,7 +6349,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_pwrb_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6222,7 +6376,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key0_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6248,7 +6403,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key1_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6274,7 +6430,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key2_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6300,7 +6457,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_ac_present_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6326,7 +6484,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_ec_rst_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6352,7 +6511,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_flash_wp_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6378,7 +6538,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_pwrb_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6404,7 +6565,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key0_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6430,7 +6592,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key1_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6456,7 +6619,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_key2_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6482,7 +6646,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_ac_present_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6508,7 +6673,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_ec_rst_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6534,7 +6700,8 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_key_intr_status_flash_wp_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -209,7 +209,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hbc614e)
+    .RESVAL  (32'hbc614e),
+    .Mubi    (1'b0)
   ) u_rwtype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -237,7 +238,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_rwtype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -263,7 +265,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rwtype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -289,7 +292,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_rwtype1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -315,7 +319,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h64)
+    .RESVAL  (8'h64),
+    .Mubi    (1'b0)
   ) u_rwtype1_field15_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -342,7 +347,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h4000400)
+    .RESVAL  (32'h4000400),
+    .Mubi    (1'b0)
   ) u_rwtype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +376,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'hcc55)
+    .RESVAL  (16'hcc55),
+    .Mubi    (1'b0)
   ) u_rwtype3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -396,7 +403,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'hee66)
+    .RESVAL  (16'hee66),
+    .Mubi    (1'b0)
   ) u_rwtype3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -424,7 +432,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h4000)
+    .RESVAL  (16'h4000),
+    .Mubi    (1'b0)
   ) u_rwtype4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -450,7 +459,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h8000)
+    .RESVAL  (16'h8000),
+    .Mubi    (1'b0)
   ) u_rwtype4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +487,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h11111111)
+    .RESVAL  (32'h11111111),
+    .Mubi    (1'b0)
   ) u_rotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -504,7 +515,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (32'hbbccddee)
+    .RESVAL  (32'hbbccddee),
+    .Mubi    (1'b0)
   ) u_w1ctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -532,7 +544,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (16'heeee)
+    .RESVAL  (16'heeee),
+    .Mubi    (1'b0)
   ) u_w1ctype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +571,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (16'h7777)
+    .RESVAL  (16'h7777),
+    .Mubi    (1'b0)
   ) u_w1ctype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -585,7 +599,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (32'haa775566)
+    .RESVAL  (32'haa775566),
+    .Mubi    (1'b0)
   ) u_w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -612,7 +627,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (32'h11224488)
+    .RESVAL  (32'h11224488),
+    .Mubi    (1'b0)
   ) u_w1stype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -639,7 +655,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (32'hfec8137f)
+    .RESVAL  (32'hfec8137f),
+    .Mubi    (1'b0)
   ) u_w0ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -666,7 +683,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (32'haa775566)
+    .RESVAL  (32'haa775566),
+    .Mubi    (1'b0)
   ) u_r0w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -693,7 +711,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
-    .RESVAL  (32'h77443399)
+    .RESVAL  (32'h77443399),
+    .Mubi    (1'b0)
   ) u_rctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -720,7 +739,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (32'h11223344)
+    .RESVAL  (32'h11223344),
+    .Mubi    (1'b0)
   ) u_wotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -748,7 +768,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'h1),
+    .Mubi    (1'b0)
   ) u_mixtype0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +795,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h2)
+    .RESVAL  (4'h2),
+    .Mubi    (1'b0)
   ) u_mixtype0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -800,7 +822,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h3)
+    .RESVAL  (4'h3),
+    .Mubi    (1'b0)
   ) u_mixtype0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +849,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h4)
+    .RESVAL  (4'h4),
+    .Mubi    (1'b0)
   ) u_mixtype0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -852,7 +876,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (4'h5)
+    .RESVAL  (4'h5),
+    .Mubi    (1'b0)
   ) u_mixtype0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -878,7 +903,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (4'h6)
+    .RESVAL  (4'h6),
+    .Mubi    (1'b0)
   ) u_mixtype0_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +930,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h7)
+    .RESVAL  (4'h7),
+    .Mubi    (1'b0)
   ) u_mixtype0_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -930,7 +957,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (4'h8)
+    .RESVAL  (4'h8),
+    .Mubi    (1'b0)
   ) u_mixtype0_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -968,7 +996,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hbabababa)
+    .RESVAL  (32'hbabababa),
+    .Mubi    (1'b0)
   ) u_rwtype5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1046,7 +1075,8 @@ module trial1_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hf6f6f6f6)
+    .RESVAL  (32'hf6f6f6f6),
+    .Mubi    (1'b0)
   ) u_rwtype7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -228,7 +228,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +255,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -280,7 +282,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -306,7 +309,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -332,7 +336,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -358,7 +363,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -384,7 +390,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -410,7 +417,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +446,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -464,7 +473,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -490,7 +500,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -516,7 +527,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +554,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -568,7 +581,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -594,7 +608,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -620,7 +635,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -801,7 +817,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_tx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -827,7 +844,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_rx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +871,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_nf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -879,7 +898,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_slpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -905,7 +925,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -931,7 +952,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_parity_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -957,7 +979,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_parity_odd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -983,7 +1006,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_rxblvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1009,7 +1033,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_ctrl_nco (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1155,7 +1180,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1195,7 +1221,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1249,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1249,7 +1277,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_rxilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1276,7 +1305,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_fifo_ctrl_txilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1337,7 +1367,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ovrd_txen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1363,7 +1394,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ovrd_txval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1407,7 +1439,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (24'h0)
+    .RESVAL  (24'h0),
+    .Mubi    (1'b0)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1433,7 +1466,8 @@ module uart_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -796,7 +796,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +823,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -848,7 +850,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -874,7 +877,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -900,7 +904,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +931,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -952,7 +958,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -978,7 +985,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_av_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1004,7 +1012,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1030,7 +1039,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1056,7 +1066,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1082,7 +1093,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1108,7 +1120,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1134,7 +1147,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1160,7 +1174,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1186,7 +1201,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1212,7 +1228,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1240,7 +1257,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1266,7 +1284,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1292,7 +1311,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1318,7 +1338,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1344,7 +1365,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1370,7 +1392,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1396,7 +1419,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1422,7 +1446,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_av_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1473,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1474,7 +1500,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1500,7 +1527,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1526,7 +1554,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1552,7 +1581,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1578,7 +1608,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1604,7 +1635,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1630,7 +1662,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1656,7 +1689,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1992,7 +2026,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_usbctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2018,7 +2053,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_usbctrl_resume_link_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2045,7 +2081,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_usbctrl_device_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2074,7 +2111,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2100,7 +2138,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2126,7 +2165,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2152,7 +2192,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2178,7 +2219,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2204,7 +2246,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2230,7 +2273,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2256,7 +2300,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2282,7 +2327,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2308,7 +2354,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2334,7 +2381,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2360,7 +2408,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_out_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2389,7 +2438,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2415,7 +2465,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2441,7 +2492,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2467,7 +2519,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2493,7 +2546,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2519,7 +2573,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2545,7 +2600,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2571,7 +2627,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2597,7 +2654,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2623,7 +2681,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2649,7 +2708,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2675,7 +2735,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ep_in_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2835,7 +2896,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_avbuffer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2927,7 +2989,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2953,7 +3016,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2979,7 +3043,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3005,7 +3070,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3031,7 +3097,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3057,7 +3124,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3083,7 +3151,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3109,7 +3178,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3135,7 +3205,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3161,7 +3232,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3187,7 +3259,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3213,7 +3286,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_setup_setup_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3242,7 +3316,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3268,7 +3343,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3294,7 +3370,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3320,7 +3397,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3346,7 +3424,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3372,7 +3451,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3398,7 +3478,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3424,7 +3505,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3450,7 +3532,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3476,7 +3559,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3502,7 +3586,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3528,7 +3613,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_rxenable_out_out_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3557,7 +3643,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3583,7 +3670,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3609,7 +3697,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3635,7 +3724,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3661,7 +3751,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3687,7 +3778,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3713,7 +3805,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3739,7 +3832,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3765,7 +3859,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3791,7 +3886,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3817,7 +3913,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3843,7 +3940,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_set_nak_out_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3872,7 +3970,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3898,7 +3997,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3924,7 +4024,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3950,7 +4051,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3976,7 +4078,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4002,7 +4105,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4028,7 +4132,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4054,7 +4159,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4080,7 +4186,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4106,7 +4213,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4132,7 +4240,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4158,7 +4267,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_sent_sent_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4187,7 +4297,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4213,7 +4324,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4239,7 +4351,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4265,7 +4378,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4291,7 +4405,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4317,7 +4432,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4343,7 +4459,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4369,7 +4486,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4395,7 +4513,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4421,7 +4540,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4447,7 +4567,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4594,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4502,7 +4624,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4528,7 +4651,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4554,7 +4678,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4705,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4606,7 +4732,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4632,7 +4759,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4658,7 +4786,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4684,7 +4813,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4710,7 +4840,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4736,7 +4867,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4762,7 +4894,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4788,7 +4921,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4817,7 +4951,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_0_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4843,7 +4978,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4869,7 +5005,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_0_pend_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4895,7 +5032,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_0_rdy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4924,7 +5062,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_1_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4950,7 +5089,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4976,7 +5116,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_1_pend_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5002,7 +5143,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_1_rdy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5031,7 +5173,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_2_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5057,7 +5200,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5083,7 +5227,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_2_pend_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5109,7 +5254,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_2_rdy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5138,7 +5284,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_3_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5164,7 +5311,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5190,7 +5338,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_3_pend_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5216,7 +5365,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_3_rdy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5245,7 +5395,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_4_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5271,7 +5422,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5297,7 +5449,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_4_pend_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5476,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_4_rdy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5352,7 +5506,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_5_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5378,7 +5533,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5404,7 +5560,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_5_pend_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5430,7 +5587,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_5_rdy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5459,7 +5617,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_6_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5485,7 +5644,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5511,7 +5671,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_6_pend_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5537,7 +5698,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_6_rdy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5728,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_7_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5592,7 +5755,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5618,7 +5782,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_7_pend_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5644,7 +5809,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_7_rdy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5673,7 +5839,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_8_buffer_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5699,7 +5866,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_8_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5725,7 +5893,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_8_pend_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5751,7 +5920,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_8_rdy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5780,7 +5950,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_9_buffer_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5806,7 +5977,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_9_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5832,7 +6004,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_9_pend_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5858,7 +6031,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_9_rdy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5887,7 +6061,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_10_buffer_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5913,7 +6088,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_10_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5939,7 +6115,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_10_pend_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5965,7 +6142,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_10_rdy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5994,7 +6172,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_configin_11_buffer_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6020,7 +6199,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h0)
+    .RESVAL  (7'h0),
+    .Mubi    (1'b0)
   ) u_configin_11_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6046,7 +6226,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_11_pend_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6072,7 +6253,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_configin_11_rdy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6101,7 +6283,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6127,7 +6310,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6153,7 +6337,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6179,7 +6364,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6205,7 +6391,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6231,7 +6418,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6257,7 +6445,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6283,7 +6472,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6309,7 +6499,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6335,7 +6526,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6361,7 +6553,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6387,7 +6580,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_out_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6416,7 +6610,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6442,7 +6637,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6468,7 +6664,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6494,7 +6691,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6520,7 +6718,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6546,7 +6745,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6572,7 +6772,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6598,7 +6799,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6624,7 +6826,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6650,7 +6853,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6676,7 +6880,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6702,7 +6907,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_in_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6742,7 +6948,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6769,7 +6976,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6796,7 +7004,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6823,7 +7032,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6850,7 +7060,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6877,7 +7088,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6904,7 +7116,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6931,7 +7144,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6958,7 +7172,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6985,7 +7200,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7012,7 +7228,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7039,7 +7256,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_data_toggle_clear_clear_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7205,7 +7423,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_dp_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7231,7 +7450,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_dn_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7257,7 +7477,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_d_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7283,7 +7504,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_se0_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7309,7 +7531,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_oe_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7335,7 +7558,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_rx_enable_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7361,7 +7585,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_dp_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7387,7 +7612,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_dn_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7413,7 +7639,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_pins_drive_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7441,7 +7668,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_config_use_diff_rcvr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7467,7 +7695,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_config_tx_use_d_se0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7493,7 +7722,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_phy_config_eop_single_bit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7519,7 +7749,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_config_pinflip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7545,7 +7776,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_config_usb_ref_disable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7571,7 +7803,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_config_tx_osc_test_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7638,7 +7871,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_events_module_active (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -7664,7 +7898,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_events_disconnected (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -7690,7 +7925,8 @@ module usbdev_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_events_bus_reset (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -255,7 +255,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -282,7 +283,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h1)
+    .RESVAL  (32'h1),
+    .Mubi    (1'b0)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +311,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h2)
+    .RESVAL  (32'h2),
+    .Mubi    (1'b0)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -336,7 +339,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h3)
+    .RESVAL  (32'h3),
+    .Mubi    (1'b0)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -363,7 +367,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h4)
+    .RESVAL  (32'h4),
+    .Mubi    (1'b0)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -390,7 +395,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h5)
+    .RESVAL  (32'h5),
+    .Mubi    (1'b0)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -417,7 +423,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h6)
+    .RESVAL  (32'h6),
+    .Mubi    (1'b0)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -444,7 +451,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h7)
+    .RESVAL  (32'h7),
+    .Mubi    (1'b0)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -471,7 +479,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h8)
+    .RESVAL  (32'h8),
+    .Mubi    (1'b0)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -498,7 +507,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h9)
+    .RESVAL  (32'h9),
+    .Mubi    (1'b0)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -525,7 +535,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'ha)
+    .RESVAL  (32'ha),
+    .Mubi    (1'b0)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -552,7 +563,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hb)
+    .RESVAL  (32'hb),
+    .Mubi    (1'b0)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -579,7 +591,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hc)
+    .RESVAL  (32'hc),
+    .Mubi    (1'b0)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -606,7 +619,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hd)
+    .RESVAL  (32'hd),
+    .Mubi    (1'b0)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -633,7 +647,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'he)
+    .RESVAL  (32'he),
+    .Mubi    (1'b0)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +675,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'hf)
+    .RESVAL  (32'hf),
+    .Mubi    (1'b0)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -687,7 +703,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h10)
+    .RESVAL  (32'h10),
+    .Mubi    (1'b0)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -714,7 +731,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h11)
+    .RESVAL  (32'h11),
+    .Mubi    (1'b0)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +759,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h12)
+    .RESVAL  (32'h12),
+    .Mubi    (1'b0)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +787,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h13)
+    .RESVAL  (32'h13),
+    .Mubi    (1'b0)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +815,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h14)
+    .RESVAL  (32'h14),
+    .Mubi    (1'b0)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +843,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h15)
+    .RESVAL  (32'h15),
+    .Mubi    (1'b0)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -849,7 +871,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h16)
+    .RESVAL  (32'h16),
+    .Mubi    (1'b0)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -876,7 +899,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h17)
+    .RESVAL  (32'h17),
+    .Mubi    (1'b0)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -903,7 +927,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h18)
+    .RESVAL  (32'h18),
+    .Mubi    (1'b0)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -930,7 +955,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h19)
+    .RESVAL  (32'h19),
+    .Mubi    (1'b0)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -957,7 +983,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1a)
+    .RESVAL  (32'h1a),
+    .Mubi    (1'b0)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +1011,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1b)
+    .RESVAL  (32'h1b),
+    .Mubi    (1'b0)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1011,7 +1039,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h1c)
+    .RESVAL  (32'h1c),
+    .Mubi    (1'b0)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1038,7 +1067,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1d)
+    .RESVAL  (32'h1d),
+    .Mubi    (1'b0)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1095,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1e)
+    .RESVAL  (32'h1e),
+    .Mubi    (1'b0)
   ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1092,7 +1123,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h1f)
+    .RESVAL  (32'h1f),
+    .Mubi    (1'b0)
   ) u_rega31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1119,7 +1151,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h20)
+    .RESVAL  (32'h20),
+    .Mubi    (1'b0)
   ) u_rega32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1146,7 +1179,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h21)
+    .RESVAL  (32'h21),
+    .Mubi    (1'b0)
   ) u_rega33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1173,7 +1207,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h22)
+    .RESVAL  (32'h22),
+    .Mubi    (1'b0)
   ) u_rega34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1200,7 +1235,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h23)
+    .RESVAL  (32'h23),
+    .Mubi    (1'b0)
   ) u_rega35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1227,7 +1263,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h24)
+    .RESVAL  (32'h24),
+    .Mubi    (1'b0)
   ) u_rega36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1254,7 +1291,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h25)
+    .RESVAL  (32'h25),
+    .Mubi    (1'b0)
   ) u_rega37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1302,7 +1340,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1330,7 +1369,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1358,7 +1398,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1386,7 +1427,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1414,7 +1456,8 @@ module ast_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -738,7 +738,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -769,7 +770,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +797,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -838,7 +841,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -865,7 +869,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -893,7 +898,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -919,7 +925,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -945,7 +952,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_io_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -971,7 +979,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -999,7 +1008,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1025,7 +1035,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1062,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1077,7 +1089,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_clk_main_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1118,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1145,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1157,7 +1172,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1199,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_clk_hints_status_clk_main_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1210,7 +1227,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1242,7 +1260,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_io_meas_ctrl_en (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1297,7 +1316,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1ea)
+    .RESVAL  (10'h1ea),
+    .Mubi    (1'b0)
   ) u_io_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1355,7 +1375,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1d6)
+    .RESVAL  (10'h1d6),
+    .Mubi    (1'b0)
   ) u_io_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1397,7 +1418,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_io_div2_meas_ctrl_en (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1452,7 +1474,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'hfa)
+    .RESVAL  (9'hfa),
+    .Mubi    (1'b0)
   ) u_io_div2_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1510,7 +1533,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'he6)
+    .RESVAL  (9'he6),
+    .Mubi    (1'b0)
   ) u_io_div2_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1552,7 +1576,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_io_div4_meas_ctrl_en (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1607,7 +1632,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h82)
+    .RESVAL  (8'h82),
+    .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1665,7 +1691,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h6e)
+    .RESVAL  (8'h6e),
+    .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1707,7 +1734,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_main_meas_ctrl_en (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1762,7 +1790,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1fe)
+    .RESVAL  (10'h1fe),
+    .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1820,7 +1849,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1ea)
+    .RESVAL  (10'h1ea),
+    .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1861,7 +1891,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_usb_meas_ctrl_en (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1916,7 +1947,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'hfa)
+    .RESVAL  (9'hfa),
+    .Mubi    (1'b0)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1974,7 +2006,8 @@ module clkmgr_reg_top (
   prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'he6)
+    .RESVAL  (9'he6),
+    .Mubi    (1'b0)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -2011,7 +2044,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2037,7 +2071,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2063,7 +2098,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_div2_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2089,7 +2125,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2115,7 +2152,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2141,7 +2179,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2167,7 +2206,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2193,7 +2233,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_div2_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2219,7 +2260,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2245,7 +2287,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2271,7 +2314,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2299,7 +2343,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2325,7 +2370,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2351,7 +2397,8 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -1027,7 +1027,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1054,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1081,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1108,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1135,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1157,7 +1162,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1185,7 +1191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1263,7 +1272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1299,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1315,7 +1326,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1528,7 +1540,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1555,7 +1568,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1596,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1644,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1655,7 +1671,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1681,7 +1698,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1707,7 +1725,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1733,7 +1752,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1759,7 +1779,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1785,7 +1806,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h0)
+    .RESVAL  (12'h0),
+    .Mubi    (1'b0)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1815,7 +1837,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1846,7 +1869,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1872,7 +1896,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1899,7 +1924,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1927,7 +1953,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1955,7 +1982,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1983,7 +2011,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2011,7 +2040,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2039,7 +2069,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2098,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2127,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2123,7 +2156,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2155,7 +2189,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2181,7 +2216,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2207,7 +2243,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2233,7 +2270,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2259,7 +2297,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2285,7 +2324,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2311,7 +2351,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2343,7 +2384,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2369,7 +2411,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2395,7 +2438,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2421,7 +2465,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2447,7 +2492,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2519,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2499,7 +2546,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2531,7 +2579,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2557,7 +2606,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2583,7 +2633,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2609,7 +2660,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2635,7 +2687,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2661,7 +2714,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2687,7 +2741,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2719,7 +2774,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2745,7 +2801,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2771,7 +2828,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2797,7 +2855,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2823,7 +2882,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2849,7 +2909,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2875,7 +2936,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2907,7 +2969,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2933,7 +2996,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2959,7 +3023,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3050,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3011,7 +3077,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3037,7 +3104,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3063,7 +3131,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3095,7 +3164,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3121,7 +3191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3147,7 +3218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3173,7 +3245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3199,7 +3272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3225,7 +3299,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3251,7 +3326,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3283,7 +3359,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3309,7 +3386,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3335,7 +3413,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3361,7 +3440,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3387,7 +3467,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3413,7 +3494,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3439,7 +3521,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3471,7 +3554,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3497,7 +3581,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3523,7 +3608,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3549,7 +3635,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3575,7 +3662,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3601,7 +3689,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3627,7 +3716,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3659,7 +3749,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3685,7 +3776,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3717,7 +3809,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3743,7 +3836,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3775,7 +3869,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3801,7 +3896,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3833,7 +3929,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3859,7 +3956,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3891,7 +3989,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3917,7 +4016,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3949,7 +4049,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3975,7 +4076,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4007,7 +4109,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4033,7 +4136,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4065,7 +4169,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4091,7 +4196,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4119,7 +4225,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4145,7 +4252,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4171,7 +4279,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4197,7 +4306,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4223,7 +4333,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4249,7 +4360,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4277,7 +4389,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4305,7 +4418,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4333,7 +4447,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4361,7 +4476,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4389,7 +4505,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4417,7 +4534,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4445,7 +4563,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4592,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4501,7 +4621,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4650,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4561,7 +4683,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4587,7 +4710,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4613,7 +4737,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4639,7 +4764,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4665,7 +4791,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4691,7 +4818,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4717,7 +4845,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4749,7 +4878,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4775,7 +4905,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4801,7 +4932,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4827,7 +4959,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4853,7 +4986,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4879,7 +5013,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4905,7 +5040,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4937,7 +5073,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4963,7 +5100,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4989,7 +5127,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5015,7 +5154,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5041,7 +5181,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5067,7 +5208,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5093,7 +5235,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5125,7 +5268,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5295,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5177,7 +5322,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5349,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5229,7 +5376,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5255,7 +5403,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5281,7 +5430,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5313,7 +5463,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5339,7 +5490,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5365,7 +5517,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5391,7 +5544,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5417,7 +5571,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5443,7 +5598,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5469,7 +5625,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5501,7 +5658,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5527,7 +5685,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5553,7 +5712,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5579,7 +5739,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5605,7 +5766,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5631,7 +5793,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5657,7 +5820,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5689,7 +5853,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5715,7 +5880,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5741,7 +5907,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5767,7 +5934,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5793,7 +5961,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5819,7 +5988,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5845,7 +6015,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5877,7 +6048,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5903,7 +6075,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5929,7 +6102,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5955,7 +6129,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5981,7 +6156,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6007,7 +6183,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6033,7 +6210,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6065,7 +6243,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6270,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6117,7 +6297,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6143,7 +6324,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6169,7 +6351,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6195,7 +6378,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6221,7 +6405,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6253,7 +6438,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6279,7 +6465,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6305,7 +6492,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6331,7 +6519,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6357,7 +6546,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6383,7 +6573,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6409,7 +6600,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6437,7 +6629,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6469,7 +6662,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6495,7 +6689,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6521,7 +6716,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6547,7 +6743,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6573,7 +6770,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6599,7 +6797,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6625,7 +6824,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6653,7 +6853,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6681,7 +6882,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6713,7 +6915,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6739,7 +6942,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6765,7 +6969,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6791,7 +6996,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6817,7 +7023,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6843,7 +7050,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6869,7 +7077,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +7110,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6927,7 +7137,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6953,7 +7164,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6979,7 +7191,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7005,7 +7218,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7031,7 +7245,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7057,7 +7272,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7085,7 +7301,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7113,7 +7330,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7141,7 +7359,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7169,7 +7388,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7197,7 +7417,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7225,7 +7446,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7253,7 +7475,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7281,7 +7504,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7309,7 +7533,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7337,7 +7562,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7369,7 +7595,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7395,7 +7622,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7421,7 +7649,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7447,7 +7676,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7473,7 +7703,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7499,7 +7730,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7525,7 +7757,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7557,7 +7790,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7583,7 +7817,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7609,7 +7844,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7635,7 +7871,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7661,7 +7898,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7687,7 +7925,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7713,7 +7952,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7745,7 +7985,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7771,7 +8012,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7797,7 +8039,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7823,7 +8066,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7849,7 +8093,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7875,7 +8120,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7901,7 +8147,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7933,7 +8180,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7959,7 +8207,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7985,7 +8234,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8011,7 +8261,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8037,7 +8288,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8063,7 +8315,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8089,7 +8342,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8121,7 +8375,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8147,7 +8402,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8173,7 +8429,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8199,7 +8456,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8225,7 +8483,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8251,7 +8510,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8277,7 +8537,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8309,7 +8570,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8335,7 +8597,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8361,7 +8624,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8387,7 +8651,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8413,7 +8678,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8439,7 +8705,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8465,7 +8732,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8497,7 +8765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8523,7 +8792,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8549,7 +8819,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8575,7 +8846,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8601,7 +8873,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8900,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8653,7 +8927,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8685,7 +8960,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8987,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8737,7 +9014,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8763,7 +9041,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8789,7 +9068,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8815,7 +9095,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8841,7 +9122,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8873,7 +9155,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8899,7 +9182,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8925,7 +9209,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8951,7 +9236,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8977,7 +9263,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9003,7 +9290,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9029,7 +9317,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9061,7 +9350,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9087,7 +9377,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9113,7 +9404,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9139,7 +9431,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9165,7 +9458,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9191,7 +9485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9217,7 +9512,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9245,7 +9541,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9277,7 +9574,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9303,7 +9601,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9329,7 +9628,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9355,7 +9655,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9381,7 +9682,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9407,7 +9709,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9433,7 +9736,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9461,7 +9765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9489,7 +9794,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9521,7 +9827,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9854,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9573,7 +9881,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9599,7 +9908,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9625,7 +9935,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9651,7 +9962,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9677,7 +9989,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9709,7 +10022,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9735,7 +10049,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9761,7 +10076,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9787,7 +10103,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9813,7 +10130,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9839,7 +10157,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9865,7 +10184,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9893,7 +10213,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9919,7 +10240,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9946,7 +10268,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9978,7 +10301,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10013,7 +10337,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10050,7 +10375,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10076,7 +10402,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10104,7 +10431,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10130,7 +10458,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10156,7 +10485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10182,7 +10512,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10208,7 +10539,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10234,7 +10566,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10278,7 +10611,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10304,7 +10638,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10330,7 +10665,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10356,7 +10692,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10382,7 +10719,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10408,7 +10746,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10434,7 +10773,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10460,7 +10800,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10488,7 +10829,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10514,7 +10856,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10540,7 +10883,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10566,7 +10910,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10592,7 +10937,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10618,7 +10964,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10644,7 +10991,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10670,7 +11018,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10696,7 +11045,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10724,7 +11074,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10750,7 +11101,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10776,7 +11128,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10802,7 +11155,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10828,7 +11182,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10854,7 +11209,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10880,7 +11236,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10906,7 +11263,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10932,7 +11290,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10958,7 +11317,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10984,7 +11344,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11010,7 +11371,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11037,7 +11399,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11066,7 +11429,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11092,7 +11456,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11120,7 +11485,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11148,7 +11514,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11176,7 +11543,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11202,7 +11570,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11230,7 +11599,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11256,7 +11626,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11282,7 +11653,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11309,7 +11681,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11337,7 +11710,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'hf)
+    .RESVAL  (5'hf),
+    .Mubi    (1'b0)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11363,7 +11737,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'hf)
+    .RESVAL  (5'hf),
+    .Mubi    (1'b0)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11390,7 +11765,8 @@ module flash_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
@@ -272,7 +272,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -303,7 +304,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -329,7 +331,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -357,7 +360,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -383,7 +387,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -409,7 +414,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -435,7 +441,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -461,7 +468,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -487,7 +495,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +522,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -539,7 +549,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -570,7 +581,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -596,7 +608,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -622,7 +635,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -648,7 +662,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -674,7 +689,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -700,7 +716,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -726,7 +743,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +770,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -778,7 +797,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -804,7 +824,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -835,7 +856,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -861,7 +883,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +910,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +937,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -944,7 +969,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -970,7 +996,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -996,7 +1023,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1022,7 +1050,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1077,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1109,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1136,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1163,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1157,7 +1190,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1217,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1209,7 +1244,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1235,7 +1271,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1298,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1325,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1318,7 +1357,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1344,7 +1384,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h0)
+    .RESVAL  (9'h0),
+    .Mubi    (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1374,7 +1415,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1404,7 +1446,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1434,7 +1477,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1464,7 +1508,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1494,7 +1539,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h0)
+    .RESVAL  (10'h0),
+    .Mubi    (1'b0)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1525,7 +1571,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (20'h0)
+    .RESVAL  (20'h0),
+    .Mubi    (1'b0)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1598,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1630,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1657,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1639,7 +1689,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1665,7 +1716,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1696,7 +1748,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1722,7 +1775,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1753,7 +1807,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1779,7 +1834,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1809,7 +1865,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1839,7 +1896,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1867,7 +1925,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1952,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1919,7 +1979,8 @@ module flash_ctrl_prim_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -4088,7 +4088,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4116,7 +4117,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4144,7 +4146,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4172,7 +4175,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4200,7 +4204,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4228,7 +4233,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4256,7 +4262,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4284,7 +4291,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4312,7 +4320,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4340,7 +4349,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4368,7 +4378,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4396,7 +4407,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4424,7 +4436,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4452,7 +4465,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4480,7 +4494,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4508,7 +4523,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4536,7 +4552,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4564,7 +4581,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4592,7 +4610,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4620,7 +4639,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4648,7 +4668,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4676,7 +4697,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4704,7 +4726,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4732,7 +4755,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4760,7 +4784,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4788,7 +4813,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4816,7 +4842,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4844,7 +4871,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4872,7 +4900,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4900,7 +4929,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4928,7 +4958,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4956,7 +4987,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4984,7 +5016,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5012,7 +5045,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5040,7 +5074,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5068,7 +5103,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5096,7 +5132,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5124,7 +5161,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5152,7 +5190,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5180,7 +5219,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5208,7 +5248,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5236,7 +5277,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5264,7 +5306,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5292,7 +5335,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5320,7 +5364,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5348,7 +5393,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5376,7 +5422,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5404,7 +5451,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5432,7 +5480,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5460,7 +5509,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5488,7 +5538,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5516,7 +5567,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5544,7 +5596,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5572,7 +5625,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5600,7 +5654,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5628,7 +5683,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5656,7 +5712,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5687,7 +5744,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5718,7 +5776,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5749,7 +5808,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5780,7 +5840,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5811,7 +5872,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5842,7 +5904,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5873,7 +5936,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5904,7 +5968,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5935,7 +6000,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5966,7 +6032,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5997,7 +6064,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6028,7 +6096,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6059,7 +6128,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6090,7 +6160,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6121,7 +6192,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6152,7 +6224,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6183,7 +6256,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6214,7 +6288,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6245,7 +6320,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6276,7 +6352,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6307,7 +6384,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6338,7 +6416,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6369,7 +6448,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6400,7 +6480,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6431,7 +6512,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6462,7 +6544,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6493,7 +6576,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6524,7 +6608,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6555,7 +6640,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6586,7 +6672,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6617,7 +6704,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6648,7 +6736,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6679,7 +6768,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6710,7 +6800,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6741,7 +6832,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6772,7 +6864,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6803,7 +6896,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6834,7 +6928,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6865,7 +6960,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6896,7 +6992,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6927,7 +7024,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6958,7 +7056,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6989,7 +7088,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7120,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7152,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7082,7 +7184,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7113,7 +7216,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7144,7 +7248,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7175,7 +7280,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7206,7 +7312,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7237,7 +7344,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7268,7 +7376,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7299,7 +7408,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7330,7 +7440,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7361,7 +7472,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7392,7 +7504,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7423,7 +7536,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_mio_periph_insel_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7451,7 +7565,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7479,7 +7594,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7507,7 +7623,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7535,7 +7652,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7563,7 +7681,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7591,7 +7710,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7619,7 +7739,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7647,7 +7768,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7675,7 +7797,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7703,7 +7826,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7731,7 +7855,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7759,7 +7884,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7787,7 +7913,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7815,7 +7942,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7843,7 +7971,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7871,7 +8000,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7899,7 +8029,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7927,7 +8058,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7955,7 +8087,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7983,7 +8116,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8011,7 +8145,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8039,7 +8174,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8067,7 +8203,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8095,7 +8232,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8123,7 +8261,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8151,7 +8290,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8179,7 +8319,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8207,7 +8348,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8235,7 +8377,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8263,7 +8406,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8291,7 +8435,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8319,7 +8464,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8347,7 +8493,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8375,7 +8522,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8403,7 +8551,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8431,7 +8580,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8459,7 +8609,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8487,7 +8638,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8515,7 +8667,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8543,7 +8696,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8571,7 +8725,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8599,7 +8754,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8783,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8655,7 +8812,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8683,7 +8841,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8870,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8739,7 +8899,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_outsel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8770,7 +8931,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8801,7 +8963,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8832,7 +8995,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8863,7 +9027,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8894,7 +9059,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8925,7 +9091,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8956,7 +9123,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8987,7 +9155,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9018,7 +9187,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9049,7 +9219,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9080,7 +9251,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9111,7 +9283,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9142,7 +9315,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9173,7 +9347,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9204,7 +9379,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9235,7 +9411,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9266,7 +9443,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9297,7 +9475,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9328,7 +9507,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9359,7 +9539,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9390,7 +9571,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9421,7 +9603,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9452,7 +9635,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9483,7 +9667,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9514,7 +9699,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9545,7 +9731,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9576,7 +9763,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9607,7 +9795,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9638,7 +9827,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9669,7 +9859,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9700,7 +9891,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9731,7 +9923,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9762,7 +9955,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9793,7 +9987,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9824,7 +10019,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9855,7 +10051,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9886,7 +10083,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9917,7 +10115,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9948,7 +10147,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9979,7 +10179,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10010,7 +10211,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10041,7 +10243,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10072,7 +10275,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10103,7 +10307,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10134,7 +10339,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10165,7 +10371,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10196,7 +10403,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h2)
+    .RESVAL  (7'h2),
+    .Mubi    (1'b0)
   ) u_mio_outsel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10224,7 +10432,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10252,7 +10461,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10280,7 +10490,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10308,7 +10519,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10336,7 +10548,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10364,7 +10577,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10392,7 +10606,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10420,7 +10635,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10448,7 +10664,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10476,7 +10693,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10504,7 +10722,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10532,7 +10751,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10560,7 +10780,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10588,7 +10809,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10616,7 +10838,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10644,7 +10867,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10672,7 +10896,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10700,7 +10925,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10728,7 +10954,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10756,7 +10983,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10784,7 +11012,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10812,7 +11041,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10840,7 +11070,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10868,7 +11099,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10896,7 +11128,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10924,7 +11157,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10952,7 +11186,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10980,7 +11215,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11008,7 +11244,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11036,7 +11273,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11064,7 +11302,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11092,7 +11331,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11120,7 +11360,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11148,7 +11389,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11176,7 +11418,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11204,7 +11447,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11232,7 +11476,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11260,7 +11505,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11288,7 +11534,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11316,7 +11563,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11344,7 +11592,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11372,7 +11621,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11400,7 +11650,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11428,7 +11679,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11456,7 +11708,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11484,7 +11737,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11512,7 +11766,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18731,7 +18986,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18759,7 +19015,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18787,7 +19044,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18815,7 +19073,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18843,7 +19102,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18871,7 +19131,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18899,7 +19160,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18927,7 +19189,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18955,7 +19218,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18983,7 +19247,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19011,7 +19276,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19039,7 +19305,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19067,7 +19334,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19095,7 +19363,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19123,7 +19392,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19151,7 +19421,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21628,7 +21899,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21654,7 +21926,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21680,7 +21953,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21706,7 +21980,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21732,7 +22007,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21758,7 +22034,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21784,7 +22061,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21810,7 +22088,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21836,7 +22115,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21862,7 +22142,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21888,7 +22169,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21914,7 +22196,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21940,7 +22223,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21966,7 +22250,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21992,7 +22277,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22018,7 +22304,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22044,7 +22331,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22070,7 +22358,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22096,7 +22385,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22122,7 +22412,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22148,7 +22439,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22174,7 +22466,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22200,7 +22493,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22226,7 +22520,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22252,7 +22547,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22278,7 +22574,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22304,7 +22601,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22330,7 +22628,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22356,7 +22655,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22382,7 +22682,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22408,7 +22709,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22434,7 +22736,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22463,7 +22766,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22489,7 +22793,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22515,7 +22820,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22541,7 +22847,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22567,7 +22874,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22593,7 +22901,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22619,7 +22928,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22645,7 +22955,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22671,7 +22982,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22697,7 +23009,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22723,7 +23036,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22749,7 +23063,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22775,7 +23090,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22801,7 +23117,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22827,7 +23144,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22855,7 +23173,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22883,7 +23202,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22911,7 +23231,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22939,7 +23260,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22967,7 +23289,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22995,7 +23318,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23023,7 +23347,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23051,7 +23376,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23079,7 +23405,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23107,7 +23434,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23135,7 +23463,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23163,7 +23492,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23191,7 +23521,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23219,7 +23550,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23247,7 +23579,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23275,7 +23608,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23303,7 +23637,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23331,7 +23666,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23359,7 +23695,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23387,7 +23724,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23415,7 +23753,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23443,7 +23782,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23471,7 +23811,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23499,7 +23840,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23527,7 +23869,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23555,7 +23898,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23583,7 +23927,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23611,7 +23956,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23639,7 +23985,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23667,7 +24014,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23695,7 +24043,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23723,7 +24072,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23751,7 +24101,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23779,7 +24130,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23807,7 +24159,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23835,7 +24188,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23863,7 +24217,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23891,7 +24246,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23919,7 +24275,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23947,7 +24304,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23975,7 +24333,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24003,7 +24362,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24031,7 +24391,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24059,7 +24420,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24087,7 +24449,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24115,7 +24478,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24143,7 +24507,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24174,7 +24539,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24205,7 +24571,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24236,7 +24603,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24267,7 +24635,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24298,7 +24667,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24329,7 +24699,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24360,7 +24731,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24391,7 +24763,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24422,7 +24795,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24453,7 +24827,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24484,7 +24859,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24515,7 +24891,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24546,7 +24923,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24577,7 +24955,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24608,7 +24987,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24639,7 +25019,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24670,7 +25051,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24701,7 +25083,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24732,7 +25115,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24763,7 +25147,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24794,7 +25179,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24825,7 +25211,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24856,7 +25243,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24887,7 +25275,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24918,7 +25307,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24949,7 +25339,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24980,7 +25371,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25011,7 +25403,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25042,7 +25435,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25073,7 +25467,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25104,7 +25499,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25135,7 +25531,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25166,7 +25563,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25197,7 +25595,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25228,7 +25627,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25259,7 +25659,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25290,7 +25691,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25321,7 +25723,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25352,7 +25755,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25383,7 +25787,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25414,7 +25819,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25445,7 +25851,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25476,7 +25883,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25507,7 +25915,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25538,7 +25947,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25569,7 +25979,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25600,7 +26011,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25631,7 +26043,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25662,7 +26075,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25693,7 +26107,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25724,7 +26139,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25755,7 +26171,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25786,7 +26203,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25817,7 +26235,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25848,7 +26267,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25879,7 +26299,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25910,7 +26331,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25941,7 +26363,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25972,7 +26395,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26003,7 +26427,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26034,7 +26459,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26065,7 +26491,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26096,7 +26523,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26127,7 +26555,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26158,7 +26587,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26189,7 +26619,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26220,7 +26651,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26251,7 +26683,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26282,7 +26715,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26313,7 +26747,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26344,7 +26779,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26375,7 +26811,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26406,7 +26843,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26437,7 +26875,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26468,7 +26907,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26499,7 +26939,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26530,7 +26971,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26561,7 +27003,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26592,7 +27035,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26623,7 +27067,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26654,7 +27099,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26685,7 +27131,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26716,7 +27163,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26747,7 +27195,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26778,7 +27227,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26809,7 +27259,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26840,7 +27291,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26871,7 +27323,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26902,7 +27355,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26933,7 +27387,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26964,7 +27419,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26995,7 +27451,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27026,7 +27483,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27057,7 +27515,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_mio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27086,7 +27545,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27112,7 +27572,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27138,7 +27599,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27164,7 +27626,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27190,7 +27653,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27216,7 +27680,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27242,7 +27707,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27268,7 +27734,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27294,7 +27761,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27320,7 +27788,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27346,7 +27815,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27372,7 +27842,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27398,7 +27869,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27424,7 +27896,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27450,7 +27923,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27476,7 +27950,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_status_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27504,7 +27979,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27532,7 +28008,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27560,7 +28037,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27588,7 +28066,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27616,7 +28095,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27644,7 +28124,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27672,7 +28153,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27700,7 +28182,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27728,7 +28211,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27756,7 +28240,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27784,7 +28269,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27812,7 +28298,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27840,7 +28327,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27868,7 +28356,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27896,7 +28385,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27924,7 +28414,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27955,7 +28446,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27986,7 +28478,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28017,7 +28510,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28048,7 +28542,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28079,7 +28574,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28110,7 +28606,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28141,7 +28638,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28172,7 +28670,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28203,7 +28702,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28234,7 +28734,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28265,7 +28766,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28296,7 +28798,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28327,7 +28830,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28358,7 +28862,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28389,7 +28894,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28420,7 +28926,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28451,7 +28958,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28482,7 +28990,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28513,7 +29022,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28544,7 +29054,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28575,7 +29086,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28606,7 +29118,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28637,7 +29150,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28668,7 +29182,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28699,7 +29214,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28730,7 +29246,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28761,7 +29278,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28792,7 +29310,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28823,7 +29342,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28854,7 +29374,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28885,7 +29406,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28916,7 +29438,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28944,7 +29467,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28972,7 +29496,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29000,7 +29525,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29028,7 +29554,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29056,7 +29583,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29084,7 +29612,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29112,7 +29641,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29140,7 +29670,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29172,7 +29703,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29204,7 +29736,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29236,7 +29769,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29268,7 +29802,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29300,7 +29835,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29332,7 +29868,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29364,7 +29901,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29396,7 +29934,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29428,7 +29967,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29454,7 +29994,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29480,7 +30021,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29512,7 +30054,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29538,7 +30081,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29564,7 +30108,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29596,7 +30141,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29622,7 +30168,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29648,7 +30195,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29680,7 +30228,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29706,7 +30255,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29732,7 +30282,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29764,7 +30315,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29790,7 +30342,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29816,7 +30369,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29848,7 +30402,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29874,7 +30429,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29900,7 +30456,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29932,7 +30489,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29958,7 +30516,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29984,7 +30543,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30016,7 +30576,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30042,7 +30603,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30068,7 +30630,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30100,7 +30663,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30132,7 +30696,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30164,7 +30729,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30196,7 +30762,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30228,7 +30795,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30260,7 +30828,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30292,7 +30861,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30324,7 +30894,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30355,7 +30926,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30386,7 +30958,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30417,7 +30990,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30448,7 +31022,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30479,7 +31054,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30510,7 +31086,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30541,7 +31118,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30572,7 +31150,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0)
+    .RESVAL  (6'h0),
+    .Mubi    (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30603,7 +31182,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30629,7 +31209,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30655,7 +31236,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30681,7 +31263,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30707,7 +31290,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30733,7 +31317,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30759,7 +31344,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30785,7 +31371,8 @@ module pinmux_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wkup_cause_cause_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -209,7 +209,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -236,7 +237,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -323,7 +325,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -349,7 +352,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -375,7 +379,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -401,7 +406,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -427,7 +433,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -453,7 +460,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -491,7 +499,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -519,7 +528,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -551,7 +561,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -577,7 +588,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -603,7 +615,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -629,7 +642,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -655,7 +669,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -681,7 +696,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wakeup_en_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -710,7 +726,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -736,7 +753,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -762,7 +780,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -788,7 +807,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -814,7 +834,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -840,7 +861,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_status_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -867,7 +889,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -899,7 +922,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +949,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -954,7 +979,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -980,7 +1006,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1007,7 +1034,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1034,7 +1062,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1115,7 +1144,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1142,7 +1172,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1169,7 +1200,8 @@ module pwrmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -261,7 +261,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h9)
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -289,7 +290,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -316,7 +318,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -343,7 +346,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -370,7 +374,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (5'h0)
+    .RESVAL  (5'h0),
+    .Mubi    (1'b0)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -398,7 +403,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -429,7 +435,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -456,7 +463,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -516,7 +524,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -547,7 +556,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -574,7 +584,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0)
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -635,7 +646,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -663,7 +675,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +704,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +733,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +762,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -775,7 +791,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -803,7 +820,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -831,7 +849,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -862,7 +881,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -893,7 +913,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -924,7 +945,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -955,7 +977,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -986,7 +1009,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1017,7 +1041,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1073,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1105,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_sw_rst_ctrl_n_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1134,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1133,7 +1161,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1159,7 +1188,8 @@ module rstmgr_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -233,7 +233,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -259,7 +260,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -287,7 +289,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -313,7 +316,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -414,7 +418,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -443,7 +448,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -469,7 +475,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -495,7 +502,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -521,7 +529,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -547,7 +556,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -573,7 +583,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -599,7 +610,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -625,7 +637,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -651,7 +664,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +691,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +718,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_trig_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -735,7 +751,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -761,7 +778,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -787,7 +805,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -813,7 +832,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -839,7 +859,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -865,7 +886,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -891,7 +913,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -917,7 +940,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -943,7 +967,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -969,7 +994,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -995,7 +1021,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_en_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1024,7 +1051,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1050,7 +1078,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1076,7 +1105,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1102,7 +1132,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1128,7 +1159,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1154,7 +1186,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1180,7 +1213,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1206,7 +1240,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1232,7 +1267,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1258,7 +1294,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1284,7 +1321,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_recov_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1313,7 +1351,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1339,7 +1378,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1365,7 +1405,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1391,7 +1432,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1417,7 +1459,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1443,7 +1486,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1469,7 +1513,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1495,7 +1540,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1521,7 +1567,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1547,7 +1594,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1621,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1599,7 +1648,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_fatal_alert_val_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1627,7 +1677,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_status_ast_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1653,7 +1704,8 @@ module sensor_ctrl_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_status_io_pok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1877,7 +1877,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1903,7 +1904,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1929,7 +1931,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1955,7 +1958,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_state_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1983,7 +1987,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2009,7 +2014,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2035,7 +2041,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2061,7 +2068,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_intr_enable_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2157,7 +2165,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_ping_timer_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2187,7 +2196,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h100)
+    .RESVAL  (16'h100),
+    .Mubi    (1'b0)
   ) u_ping_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2226,7 +2236,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ping_timer_en_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2263,7 +2274,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2291,7 +2303,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2319,7 +2332,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2347,7 +2361,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2375,7 +2390,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2403,7 +2419,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2431,7 +2448,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2459,7 +2477,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2487,7 +2506,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2515,7 +2535,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2543,7 +2564,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2571,7 +2593,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2599,7 +2622,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2627,7 +2651,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2655,7 +2680,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2683,7 +2709,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2711,7 +2738,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2739,7 +2767,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2767,7 +2796,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2795,7 +2825,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2823,7 +2854,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2851,7 +2883,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2879,7 +2912,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2907,7 +2941,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2935,7 +2970,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2963,7 +2999,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2991,7 +3028,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3019,7 +3057,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3047,7 +3086,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3075,7 +3115,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3103,7 +3144,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3131,7 +3173,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3159,7 +3202,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3187,7 +3231,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3215,7 +3260,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3243,7 +3289,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3271,7 +3318,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3299,7 +3347,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3327,7 +3376,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3355,7 +3405,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3383,7 +3434,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3411,7 +3463,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3439,7 +3492,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3467,7 +3521,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3495,7 +3550,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3523,7 +3579,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3551,7 +3608,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3579,7 +3637,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3607,7 +3666,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3635,7 +3695,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3663,7 +3724,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3691,7 +3753,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3719,7 +3782,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3747,7 +3811,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3775,7 +3840,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3803,7 +3869,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3831,7 +3898,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3859,7 +3927,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3887,7 +3956,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3915,7 +3985,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3943,7 +4014,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3971,7 +4043,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3999,7 +4072,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4027,7 +4101,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4055,7 +4130,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_alert_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4086,7 +4162,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4126,7 +4203,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4166,7 +4244,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4206,7 +4285,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4246,7 +4326,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4286,7 +4367,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4326,7 +4408,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4366,7 +4449,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4406,7 +4490,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4446,7 +4531,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4486,7 +4572,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4526,7 +4613,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4566,7 +4654,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4606,7 +4695,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4646,7 +4736,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4686,7 +4777,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4726,7 +4818,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4766,7 +4859,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4806,7 +4900,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4846,7 +4941,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4886,7 +4982,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4926,7 +5023,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4966,7 +5064,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5006,7 +5105,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5046,7 +5146,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5086,7 +5187,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5126,7 +5228,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5166,7 +5269,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5206,7 +5310,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5246,7 +5351,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5286,7 +5392,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5326,7 +5433,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5366,7 +5474,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5406,7 +5515,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5446,7 +5556,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5486,7 +5597,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5526,7 +5638,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5679,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5606,7 +5720,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5646,7 +5761,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5686,7 +5802,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5726,7 +5843,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5766,7 +5884,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5806,7 +5925,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5846,7 +5966,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5886,7 +6007,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5926,7 +6048,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5966,7 +6089,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6006,7 +6130,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6046,7 +6171,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6086,7 +6212,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6126,7 +6253,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6166,7 +6294,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6206,7 +6335,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6246,7 +6376,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6286,7 +6417,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6326,7 +6458,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6366,7 +6499,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6406,7 +6540,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6446,7 +6581,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6486,7 +6622,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6526,7 +6663,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6566,7 +6704,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6606,7 +6745,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6646,7 +6786,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_en_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6686,7 +6827,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6726,7 +6868,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6766,7 +6909,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6806,7 +6950,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6846,7 +6991,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6886,7 +7032,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6926,7 +7073,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6966,7 +7114,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7006,7 +7155,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7046,7 +7196,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7086,7 +7237,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7126,7 +7278,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7166,7 +7319,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7206,7 +7360,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7246,7 +7401,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7286,7 +7442,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7326,7 +7483,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7366,7 +7524,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7406,7 +7565,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7446,7 +7606,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7486,7 +7647,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7526,7 +7688,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7566,7 +7729,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7606,7 +7770,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7646,7 +7811,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7686,7 +7852,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7726,7 +7893,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7766,7 +7934,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7806,7 +7975,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7846,7 +8016,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7886,7 +8057,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7926,7 +8098,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7966,7 +8139,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8006,7 +8180,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8046,7 +8221,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8086,7 +8262,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8126,7 +8303,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8166,7 +8344,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8206,7 +8385,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8246,7 +8426,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8286,7 +8467,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8326,7 +8508,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8366,7 +8549,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8406,7 +8590,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8446,7 +8631,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8486,7 +8672,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8526,7 +8713,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8566,7 +8754,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8606,7 +8795,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8646,7 +8836,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8686,7 +8877,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8726,7 +8918,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8766,7 +8959,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8806,7 +9000,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8846,7 +9041,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8886,7 +9082,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8926,7 +9123,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8966,7 +9164,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9006,7 +9205,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9046,7 +9246,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9086,7 +9287,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9126,7 +9328,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9166,7 +9369,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9206,7 +9410,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9246,7 +9451,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_alert_class_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9283,7 +9489,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9311,7 +9518,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9339,7 +9547,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9367,7 +9576,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9395,7 +9605,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9423,7 +9634,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9451,7 +9663,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9479,7 +9692,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9507,7 +9721,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9535,7 +9750,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9563,7 +9779,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9591,7 +9808,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9619,7 +9837,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9647,7 +9866,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9675,7 +9895,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9703,7 +9924,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9731,7 +9953,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9759,7 +9982,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9787,7 +10011,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9815,7 +10040,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9843,7 +10069,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9871,7 +10098,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9899,7 +10127,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9927,7 +10156,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9955,7 +10185,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9983,7 +10214,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10011,7 +10243,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10039,7 +10272,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10067,7 +10301,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10095,7 +10330,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10123,7 +10359,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10151,7 +10388,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10179,7 +10417,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10207,7 +10446,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10235,7 +10475,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10263,7 +10504,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10291,7 +10533,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10319,7 +10562,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10347,7 +10591,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10375,7 +10620,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10403,7 +10649,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10431,7 +10678,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10459,7 +10707,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10487,7 +10736,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10515,7 +10765,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10543,7 +10794,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10571,7 +10823,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10599,7 +10852,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10627,7 +10881,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10655,7 +10910,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10683,7 +10939,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10711,7 +10968,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10739,7 +10997,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10767,7 +11026,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10795,7 +11055,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10823,7 +11084,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10851,7 +11113,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10879,7 +11142,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10907,7 +11171,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10935,7 +11200,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10963,7 +11229,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10991,7 +11258,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11019,7 +11287,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11047,7 +11316,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11075,7 +11345,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_alert_cause_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11103,7 +11374,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11131,7 +11403,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11159,7 +11432,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11187,7 +11461,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11215,7 +11490,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11243,7 +11519,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11271,7 +11548,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_loc_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11302,7 +11580,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11342,7 +11621,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11382,7 +11662,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11422,7 +11703,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11462,7 +11744,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11502,7 +11785,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11542,7 +11826,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11583,7 +11868,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11624,7 +11910,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11665,7 +11952,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11706,7 +11994,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11747,7 +12036,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11788,7 +12078,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11829,7 +12120,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11866,7 +12158,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11894,7 +12187,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11922,7 +12216,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11950,7 +12245,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11978,7 +12274,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12006,7 +12303,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12034,7 +12332,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_loc_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12061,7 +12360,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12092,7 +12392,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12127,7 +12428,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12162,7 +12464,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12197,7 +12500,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12232,7 +12536,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12267,7 +12572,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12302,7 +12608,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12337,7 +12644,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h1),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12372,7 +12680,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12407,7 +12716,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h3)
+    .RESVAL  (2'h3),
+    .Mubi    (1'b0)
   ) u_classa_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12443,7 +12753,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classa_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12484,7 +12795,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classa_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12540,7 +12852,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_classa_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12579,7 +12892,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classa_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12619,7 +12933,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classa_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12658,7 +12973,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classa_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12697,7 +13013,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classa_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12736,7 +13053,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classa_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12775,7 +13093,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classa_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12843,7 +13162,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12874,7 +13194,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12909,7 +13230,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12944,7 +13266,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12979,7 +13302,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13014,7 +13338,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13049,7 +13374,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13084,7 +13410,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13119,7 +13446,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h1),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13154,7 +13482,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13189,7 +13518,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h3)
+    .RESVAL  (2'h3),
+    .Mubi    (1'b0)
   ) u_classb_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13225,7 +13555,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classb_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13266,7 +13597,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classb_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13322,7 +13654,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_classb_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13361,7 +13694,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classb_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13401,7 +13735,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classb_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13440,7 +13775,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classb_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13479,7 +13815,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classb_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13518,7 +13855,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classb_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13557,7 +13895,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classb_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13625,7 +13964,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13656,7 +13996,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13691,7 +14032,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13726,7 +14068,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13761,7 +14104,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13796,7 +14140,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13831,7 +14176,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13866,7 +14212,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13901,7 +14248,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h1),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13936,7 +14284,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13971,7 +14320,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h3)
+    .RESVAL  (2'h3),
+    .Mubi    (1'b0)
   ) u_classc_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14007,7 +14357,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classc_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14048,7 +14399,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classc_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14104,7 +14456,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_classc_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14143,7 +14496,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classc_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14183,7 +14537,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classc_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14222,7 +14577,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classc_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14261,7 +14617,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classc_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14300,7 +14657,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classc_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14339,7 +14697,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classc_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14407,7 +14766,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14438,7 +14798,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14473,7 +14834,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14508,7 +14870,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14543,7 +14906,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14578,7 +14942,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14613,7 +14978,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14648,7 +15014,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14683,7 +15050,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
+    .RESVAL  (2'h1),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14718,7 +15086,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h2)
+    .RESVAL  (2'h2),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14753,7 +15122,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h3)
+    .RESVAL  (2'h3),
+    .Mubi    (1'b0)
   ) u_classd_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14789,7 +15159,8 @@ module alert_handler_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
   ) u_classd_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14830,7 +15201,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_classd_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14886,7 +15258,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h0),
+    .Mubi    (1'b0)
   ) u_classd_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14925,7 +15298,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classd_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14965,7 +15339,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_classd_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15004,7 +15379,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classd_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15043,7 +15419,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classd_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15082,7 +15459,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classd_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15121,7 +15499,8 @@ module alert_handler_reg_top (
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
   ) u_classd_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1258,7 +1258,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1285,7 +1286,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1312,7 +1314,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1339,7 +1342,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1366,7 +1370,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1393,7 +1398,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1420,7 +1426,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1447,7 +1454,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1474,7 +1482,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1501,7 +1510,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1528,7 +1538,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1555,7 +1566,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1594,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1609,7 +1622,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1636,7 +1650,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1663,7 +1678,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1690,7 +1706,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1717,7 +1734,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1744,7 +1762,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1771,7 +1790,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1798,7 +1818,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1825,7 +1846,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1852,7 +1874,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1879,7 +1902,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1906,7 +1930,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1933,7 +1958,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1960,7 +1986,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1987,7 +2014,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2014,7 +2042,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2041,7 +2070,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2068,7 +2098,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2126,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2122,7 +2154,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2149,7 +2182,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2176,7 +2210,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2203,7 +2238,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2230,7 +2266,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2257,7 +2294,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2284,7 +2322,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2311,7 +2350,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2338,7 +2378,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2365,7 +2406,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2392,7 +2434,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2419,7 +2462,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2446,7 +2490,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2518,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2500,7 +2546,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2527,7 +2574,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2554,7 +2602,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2581,7 +2630,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2608,7 +2658,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2635,7 +2686,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2662,7 +2714,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2689,7 +2742,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2716,7 +2770,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2743,7 +2798,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2770,7 +2826,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2797,7 +2854,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2824,7 +2882,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2851,7 +2910,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2878,7 +2938,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2905,7 +2966,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2932,7 +2994,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2959,7 +3022,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2986,7 +3050,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3013,7 +3078,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3040,7 +3106,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3067,7 +3134,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3094,7 +3162,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3121,7 +3190,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3148,7 +3218,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3175,7 +3246,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3202,7 +3274,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3229,7 +3302,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3256,7 +3330,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3283,7 +3358,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3310,7 +3386,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3337,7 +3414,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3364,7 +3442,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3391,7 +3470,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3418,7 +3498,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3445,7 +3526,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3472,7 +3554,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3499,7 +3582,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3526,7 +3610,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3553,7 +3638,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3580,7 +3666,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3607,7 +3694,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3634,7 +3722,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3661,7 +3750,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3688,7 +3778,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3715,7 +3806,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3742,7 +3834,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3769,7 +3862,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3796,7 +3890,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3823,7 +3918,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3850,7 +3946,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3877,7 +3974,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3904,7 +4002,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3931,7 +4030,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3958,7 +4058,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3985,7 +4086,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4012,7 +4114,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4039,7 +4142,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4066,7 +4170,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4093,7 +4198,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4120,7 +4226,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4254,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4282,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4201,7 +4310,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4228,7 +4338,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4255,7 +4366,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4282,7 +4394,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4309,7 +4422,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4336,7 +4450,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4478,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4390,7 +4506,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4417,7 +4534,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4562,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4471,7 +4590,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4498,7 +4618,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4525,7 +4646,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4552,7 +4674,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4579,7 +4702,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4606,7 +4730,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4758,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4660,7 +4786,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4687,7 +4814,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4714,7 +4842,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4741,7 +4870,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4768,7 +4898,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4795,7 +4926,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4822,7 +4954,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4849,7 +4982,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4876,7 +5010,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4903,7 +5038,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4930,7 +5066,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4957,7 +5094,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4984,7 +5122,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5011,7 +5150,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5038,7 +5178,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5065,7 +5206,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5092,7 +5234,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5119,7 +5262,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5146,7 +5290,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5173,7 +5318,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5200,7 +5346,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5227,7 +5374,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5254,7 +5402,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5281,7 +5430,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5458,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5335,7 +5486,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5362,7 +5514,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5389,7 +5542,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5416,7 +5570,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5443,7 +5598,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5470,7 +5626,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5497,7 +5654,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5524,7 +5682,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5551,7 +5710,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5578,7 +5738,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5605,7 +5766,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5632,7 +5794,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5659,7 +5822,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5686,7 +5850,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5713,7 +5878,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5740,7 +5906,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5767,7 +5934,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5794,7 +5962,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5821,7 +5990,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5848,7 +6018,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5875,7 +6046,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5902,7 +6074,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5929,7 +6102,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5956,7 +6130,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5983,7 +6158,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6010,7 +6186,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6037,7 +6214,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6064,7 +6242,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6270,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6118,7 +6298,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6145,7 +6326,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6172,7 +6354,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6199,7 +6382,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6226,7 +6410,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_prio184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6255,7 +6440,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6281,7 +6467,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6307,7 +6494,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6333,7 +6521,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6359,7 +6548,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6385,7 +6575,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6411,7 +6602,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6437,7 +6629,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6463,7 +6656,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6489,7 +6683,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6515,7 +6710,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6541,7 +6737,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6567,7 +6764,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6593,7 +6791,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6619,7 +6818,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6645,7 +6845,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6671,7 +6872,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6697,7 +6899,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6723,7 +6926,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6749,7 +6953,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6775,7 +6980,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6801,7 +7007,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6827,7 +7034,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6853,7 +7061,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6879,7 +7088,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6905,7 +7115,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6931,7 +7142,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6957,7 +7169,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6983,7 +7196,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7009,7 +7223,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7035,7 +7250,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7061,7 +7277,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7090,7 +7307,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7116,7 +7334,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7142,7 +7361,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7168,7 +7388,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7194,7 +7415,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7220,7 +7442,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7246,7 +7469,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7272,7 +7496,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7298,7 +7523,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7324,7 +7550,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7350,7 +7577,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7376,7 +7604,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7402,7 +7631,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7428,7 +7658,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7454,7 +7685,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7480,7 +7712,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7506,7 +7739,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7532,7 +7766,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7558,7 +7793,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7584,7 +7820,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7610,7 +7847,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7636,7 +7874,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7662,7 +7901,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7688,7 +7928,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7714,7 +7955,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7740,7 +7982,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7766,7 +8009,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7792,7 +8036,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7818,7 +8063,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7844,7 +8090,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7870,7 +8117,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7896,7 +8144,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7925,7 +8174,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7951,7 +8201,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7977,7 +8228,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8003,7 +8255,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8029,7 +8282,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8055,7 +8309,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8081,7 +8336,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8107,7 +8363,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8133,7 +8390,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8159,7 +8417,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8185,7 +8444,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8211,7 +8471,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8237,7 +8498,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8263,7 +8525,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8289,7 +8552,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8315,7 +8579,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8341,7 +8606,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8367,7 +8633,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8393,7 +8660,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8419,7 +8687,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8445,7 +8714,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8471,7 +8741,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8497,7 +8768,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8523,7 +8795,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8549,7 +8822,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8575,7 +8849,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8601,7 +8876,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8903,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8653,7 +8930,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8679,7 +8957,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8705,7 +8984,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8731,7 +9011,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_2_p_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8760,7 +9041,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8786,7 +9068,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8812,7 +9095,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8838,7 +9122,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8864,7 +9149,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8890,7 +9176,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8916,7 +9203,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8942,7 +9230,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8968,7 +9257,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8994,7 +9284,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9020,7 +9311,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9046,7 +9338,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9072,7 +9365,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9098,7 +9392,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9124,7 +9419,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9150,7 +9446,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9176,7 +9473,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9202,7 +9500,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9228,7 +9527,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9254,7 +9554,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9280,7 +9581,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9306,7 +9608,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9332,7 +9635,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9358,7 +9662,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9384,7 +9689,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9410,7 +9716,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9436,7 +9743,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9462,7 +9770,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9488,7 +9797,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9514,7 +9824,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9540,7 +9851,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9566,7 +9878,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_3_p_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9595,7 +9908,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9621,7 +9935,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9647,7 +9962,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9673,7 +9989,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9699,7 +10016,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9725,7 +10043,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9751,7 +10070,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9777,7 +10097,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9803,7 +10124,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9829,7 +10151,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9855,7 +10178,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9881,7 +10205,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9907,7 +10232,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9933,7 +10259,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9959,7 +10286,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9985,7 +10313,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10011,7 +10340,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10037,7 +10367,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10063,7 +10394,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10089,7 +10421,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10115,7 +10448,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10141,7 +10475,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10167,7 +10502,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10193,7 +10529,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10219,7 +10556,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10245,7 +10583,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10271,7 +10610,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10297,7 +10637,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10323,7 +10664,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10349,7 +10691,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10375,7 +10718,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10401,7 +10745,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_4_p_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10430,7 +10775,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10456,7 +10802,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10482,7 +10829,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10508,7 +10856,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10534,7 +10883,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10560,7 +10910,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10586,7 +10937,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10612,7 +10964,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10638,7 +10991,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10664,7 +11018,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10690,7 +11045,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10716,7 +11072,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10742,7 +11099,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10768,7 +11126,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10794,7 +11153,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10820,7 +11180,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10846,7 +11207,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10872,7 +11234,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10898,7 +11261,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10924,7 +11288,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10950,7 +11315,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10976,7 +11342,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11002,7 +11369,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11028,7 +11396,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11054,7 +11423,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ip_5_p_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11083,7 +11453,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11109,7 +11480,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11135,7 +11507,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11161,7 +11534,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11187,7 +11561,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11213,7 +11588,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11239,7 +11615,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11265,7 +11642,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11291,7 +11669,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11317,7 +11696,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11343,7 +11723,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11369,7 +11750,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11395,7 +11777,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11421,7 +11804,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11447,7 +11831,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11473,7 +11858,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11499,7 +11885,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11525,7 +11912,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11551,7 +11939,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11577,7 +11966,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11603,7 +11993,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11629,7 +12020,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11655,7 +12047,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11681,7 +12074,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11707,7 +12101,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11733,7 +12128,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11759,7 +12155,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11785,7 +12182,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11811,7 +12209,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11837,7 +12236,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11863,7 +12263,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11889,7 +12290,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11918,7 +12320,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11944,7 +12347,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11970,7 +12374,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11996,7 +12401,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12022,7 +12428,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12048,7 +12455,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12074,7 +12482,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12100,7 +12509,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12126,7 +12536,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12152,7 +12563,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12178,7 +12590,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12204,7 +12617,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12230,7 +12644,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12256,7 +12671,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12282,7 +12698,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12308,7 +12725,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12334,7 +12752,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12360,7 +12779,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12386,7 +12806,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12412,7 +12833,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12438,7 +12860,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12464,7 +12887,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12490,7 +12914,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12516,7 +12941,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12542,7 +12968,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12568,7 +12995,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12594,7 +13022,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12620,7 +13049,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12646,7 +13076,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12672,7 +13103,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12698,7 +13130,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12724,7 +13157,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12753,7 +13187,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12779,7 +13214,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12805,7 +13241,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12831,7 +13268,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12857,7 +13295,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12883,7 +13322,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12909,7 +13349,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12935,7 +13376,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12961,7 +13403,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12987,7 +13430,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13013,7 +13457,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13039,7 +13484,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13065,7 +13511,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13091,7 +13538,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13117,7 +13565,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13143,7 +13592,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13169,7 +13619,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13195,7 +13646,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13221,7 +13673,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13247,7 +13700,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13273,7 +13727,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13299,7 +13754,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13325,7 +13781,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13351,7 +13808,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13377,7 +13835,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13403,7 +13862,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13429,7 +13889,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13455,7 +13916,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13481,7 +13943,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13507,7 +13970,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13533,7 +13997,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13559,7 +14024,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_2_e_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13588,7 +14054,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13614,7 +14081,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13640,7 +14108,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13666,7 +14135,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13692,7 +14162,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13718,7 +14189,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13744,7 +14216,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13770,7 +14243,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13796,7 +14270,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13822,7 +14297,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13848,7 +14324,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13874,7 +14351,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13900,7 +14378,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13926,7 +14405,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13952,7 +14432,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13978,7 +14459,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14004,7 +14486,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14030,7 +14513,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14056,7 +14540,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14082,7 +14567,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14108,7 +14594,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14134,7 +14621,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14160,7 +14648,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14186,7 +14675,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14212,7 +14702,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14238,7 +14729,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14264,7 +14756,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14290,7 +14783,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14316,7 +14810,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14342,7 +14837,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14368,7 +14864,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14394,7 +14891,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_3_e_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14423,7 +14921,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14449,7 +14948,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14475,7 +14975,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14501,7 +15002,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14527,7 +15029,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14553,7 +15056,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14579,7 +15083,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14605,7 +15110,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14631,7 +15137,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14657,7 +15164,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14683,7 +15191,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14709,7 +15218,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14735,7 +15245,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14761,7 +15272,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14787,7 +15299,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14813,7 +15326,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14839,7 +15353,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14865,7 +15380,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14891,7 +15407,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14917,7 +15434,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14943,7 +15461,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14969,7 +15488,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14995,7 +15515,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15021,7 +15542,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15047,7 +15569,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15073,7 +15596,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15099,7 +15623,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15125,7 +15650,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15151,7 +15677,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15177,7 +15704,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15203,7 +15731,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15229,7 +15758,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_4_e_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15258,7 +15788,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15284,7 +15815,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15310,7 +15842,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15336,7 +15869,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15362,7 +15896,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15388,7 +15923,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15414,7 +15950,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15440,7 +15977,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15466,7 +16004,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15492,7 +16031,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15518,7 +16058,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15544,7 +16085,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15570,7 +16112,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15596,7 +16139,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15622,7 +16166,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15648,7 +16193,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15674,7 +16220,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15700,7 +16247,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15726,7 +16274,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15752,7 +16301,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15778,7 +16328,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15804,7 +16355,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15830,7 +16382,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15856,7 +16409,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15882,7 +16436,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_ie0_5_e_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15909,7 +16464,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15956,7 +16512,8 @@ module rv_plic_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -288,15 +288,16 @@ multireg | optional | group | group defining registers generated from a base ins
 
 
 Registers can protect themselves from software writes by using the
-register attribute regwen. When not an emptry string (the default
+register attribute regwen. When not an empty string (the default
 value), regwen indicates that another register must be true in order
-to allow writes to this register.  This is useful for the prevention
+to allow writes to this register. This is useful for the prevention
 of software modification.  The register-enable register (call it
-REGWEN) must be one bit in width, and should default to 1 and be rw1c
-for preferred security control.  This allows all writes to proceed
+REGWEN) must be either one bit or 4 bit in width to support a FI-protected
+multi-bit REGWEN. The default value should be true and be rw1c for
+preferred security control. This allows all writes to proceed
 until at some point software disables future modifications by clearing
 REGWEN. An error is reported if REGWEN does not exist, contains more
-than one bit, is not `rw1c` or does not default to 1. One REGWEN can
+than one bit, is not `rw1c` or does not default to true. One REGWEN can
 protect multiple registers. The REGWEN register must precede those
 registers that refer to it in the .hjson register list. An example:
 

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -164,15 +164,16 @@ for things that are not registers (for example access to a buffer ram).
 regwen_intro = """
 
 Registers can protect themselves from software writes by using the
-register attribute regwen. When not an emptry string (the default
+register attribute regwen. When not an empty string (the default
 value), regwen indicates that another register must be true in order
-to allow writes to this register.  This is useful for the prevention
+to allow writes to this register. This is useful for the prevention
 of software modification.  The register-enable register (call it
-REGWEN) must be one bit in width, and should default to 1 and be rw1c
-for preferred security control.  This allows all writes to proceed
+REGWEN) must be either one bit or 4 bit in width to support a FI-protected
+multi-bit REGWEN. The default value should be true and be rw1c for
+preferred security control. This allows all writes to proceed
 until at some point software disables future modifications by clearing
 REGWEN. An error is reported if REGWEN does not exist, contains more
-than one bit, is not `rw1c` or does not default to 1. One REGWEN can
+than one bit, is not `rw1c` or does not default to true. One REGWEN can
 protect multiple registers. The REGWEN register must precede those
 registers that refer to it in the .hjson register list. An example:
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -942,6 +942,11 @@ ${bits.msb}\
     else:
       q_expr = ''
 
+    if field.mubi:
+      mubi_expr = "1'b1"
+    else:
+      mubi_expr = "1'b0"
+    
     # when async, the outputs are aggregated first by the cdc module
     async_suffix = '_int' if reg.async_clk else ''
     qs_expr = f'{clk_base_name}{finst_name}_qs{async_suffix}' if field.swaccess.allows_read() else ''
@@ -1010,7 +1015,8 @@ ${bits.msb}\
   ${subreg_block} #(
     .DW      (${field.bits.width()}),
     .SwAccess(prim_subreg_pkg::SwAccess${field.swaccess.value[1].name.upper()}),
-    .RESVAL  (${resval_expr})
+    .RESVAL  (${resval_expr}),
+    .Mubi    (${mubi_expr})
   ) u_${finst_name} (
       % if reg.sync_clk:
     // sync clock and reset required for this register

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -255,7 +255,7 @@ module ${mod_name} (
 % else:
   always_ff @(posedge ${reg_clk_expr} or negedge ${reg_rst_expr}) begin
     if (!${reg_rst_expr}) begin
-% endif    
+% endif
       err_q <= '0;
     end else if (intg_err || reg_we_err) begin
       err_q <= 1'b1;
@@ -601,6 +601,9 @@ ${reg_hdr}
     we_expr = f'{we_signal} & {clk_base_name}{sr_name}_regwen'
   elif sr.regwen:
     we_expr = f'{we_signal} & {sr.regwen.lower()}_qs'
+    for reg in regs_flat:
+      if reg.name == sr.regwen and reg.fields[0].mubi:
+        we_expr = f'{we_signal} & prim_mubi_pkg::mubi4_test_true_strict({sr.regwen.lower()}_qs)'
   else:
     we_expr = we_signal
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -604,7 +604,7 @@ ${reg_hdr}
     for reg in regs_flat:
       if reg.name == sr.regwen and reg.fields[0].mubi:
         we_expr = f'''{we_signal} &
-          prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t\'({sr.regwen.lower()}_qs))'''
+          prim_mubi_pkg::mubi{reg.fields[0].bits.width()}_test_true_strict(prim_mubi_pkg::mubi{reg.fields[0].bits.width()}_t\'({sr.regwen.lower()}_qs))'''
   else:
     we_expr = we_signal
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -603,7 +603,8 @@ ${reg_hdr}
     we_expr = f'{we_signal} & {sr.regwen.lower()}_qs'
     for reg in regs_flat:
       if reg.name == sr.regwen and reg.fields[0].mubi:
-        we_expr = f'{we_signal} & prim_mubi_pkg::mubi4_test_true_strict({sr.regwen.lower()}_qs)'
+        we_expr = f'''{we_signal} &
+          prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t\'({sr.regwen.lower()}_qs))'''
   else:
     we_expr = we_signal
 

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -560,10 +560,10 @@ class Register(RegBase):
 
         wen_fld = self.fields[0]
         if wen_fld.mubi:
-            if wen_fld.bits.width() != 4:
-                raise ValueError('One or more registers use {} as a multi-bit'
-                                 'write-enable so its field should be 4 bit wide, '
-                                 'not {}.'
+            if wen_fld.bits.width() % 4:
+                raise ValueError('One or more registers use {} as a multi-bit '
+                                 'write-enable so its field bit-width should '
+                                 'be a multiple of 4, not {}.'
                                  .format(self.name, wen_fld.bits.width()))
         else:
             if wen_fld.bits.width() != 1:


### PR DESCRIPTION
This PR cherry-picks the the commits for multibit regwen support from the OT-integrated repository to ensure it does not create regressions on earlgrey.

Related to https://github.com/lowRISC/opentitan-integrated/pull/379