### PR TITLE
[ci] Split the 'SW build & test' job into build and test jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,9 +173,9 @@ jobs:
     displayName: Verible FPV (Verilog lint)
 
 - job: sw_build
-  displayName: Earl Grey SW Build & Test
-  # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 210
+  displayName: Earl Grey SW Build
+  # Build software tests for the Earl Grey toplevel design
+  timeoutInMinutes: 120
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public
@@ -190,10 +190,10 @@ jobs:
     name: bazelCacheGcpKey
     inputs:
       secureFile: "bazel_cache_gcp_key.json"
+    # Set the remote cache GCP key path
   - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
     condition: eq(variables['Build.SourceBranchName'], 'master')
     displayName: GCP key path
-    # Set the remote cache GCP key path
   - bash: |
       set -x -e
       # Check the entire build graph for conflicts in loading or analysis
@@ -202,8 +202,8 @@ jobs:
       ci/scripts/test-empty-bitstream-cache.sh
       # Now redo with the real bitstream cache included.
       ci/bazelisk.sh build --nobuild //...
-      # This command builds all software and runs all unit tests that run on the
-      # host, with a few exceptions:
+
+      # This command selects the unit tests to be built:
       # * It excludes //quality because that's the purview of `slow_lints`.
       # * It excludes //sw/otbn/crypto because that's tested in `otbn_crypto_tests`.
       # * It excludes the tests from //third_party/riscv-compliance because
@@ -228,19 +228,14 @@ jobs:
         --define DISABLE_VERILATOR_BUILD=true \
         -- "rdeps(//..., kind(bitstream_splice, //...))" \
         >> "${TARGET_PATTERN_FILE}"
+
+      # Build all unit tests and their dependencies.
       ci/bazelisk.sh build \
         --build_tests_only=false \
         --define DISABLE_VERILATOR_BUILD=true \
         --test_tag_filters=-broken,-cw310,-verilator,-dv \
         --target_pattern_file="${TARGET_PATTERN_FILE}"
-      ci/bazelisk.sh test \
-        --build_tests_only=false \
-        --test_output=errors \
-        --define DISABLE_VERILATOR_BUILD=true \
-        --test_tag_filters=-broken,-cw310,-verilator,-dv \
-        --target_pattern_file="${TARGET_PATTERN_FILE}"
-    displayName: Build & test SW
-  - template: ci/publish-bazel-test-results.yml
+    displayName: Build SW
   - bash: |
       set -x -e
       . util/build_consts.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,7 +215,7 @@ jobs:
       # * It excludes targets that depend on bitstream_splice rules, since the
       #   environment does not have access to Vivado.
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
-      TARGET_PATTERN_FILE=$(mktemp)
+      TARGET_PATTERN_FILE=target_pattern.txt
       echo //... > "${TARGET_PATTERN_FILE}"
       echo -//quality/... >> "${TARGET_PATTERN_FILE}"
       echo -//sw/otbn/crypto/... >> "${TARGET_PATTERN_FILE}"
@@ -236,6 +236,8 @@ jobs:
         --test_tag_filters=-broken,-cw310,-verilator,-dv \
         --target_pattern_file="${TARGET_PATTERN_FILE}"
     displayName: Build SW
+  - publish: target_pattern.txt
+    artifact: target_pattern_file
   - bash: |
       set -x -e
       . util/build_consts.sh
@@ -252,6 +254,39 @@ jobs:
     parameters:
       includePatterns:
         - "/sw/***"
+
+- job: sw_test
+  displayName: Earl Grey SW Test
+  timeoutInMinutes: 120
+  dependsOn: sw_build
+  pool: ci-public
+  variables:
+    - name: bazelCacheGcpKeyPath
+      value: ''
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - task: DownloadSecureFile@1
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    name: bazelCacheGcpKey
+    inputs:
+      secureFile: "bazel_cache_gcp_key.json"
+    # Set the remote cache GCP key path
+  - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    displayName: GCP key path
+  - download: current
+    artifact: target_pattern_file
+  - bash: |
+      TARGET_PATTERN_FILE="$(Pipeline.Workspace)/target_pattern_file/target_pattern.txt"
+      ci/bazelisk.sh test \
+        --build_tests_only=false \
+        --test_output=errors \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --test_tag_filters=-broken,-cw310,-verilator,-dv \
+        --target_pattern_file="${TARGET_PATTERN_FILE}"
+    displayName: Build & test SW
+  - template: ci/publish-bazel-test-results.yml
 
 - job: chip_englishbreakfast_verilator
   displayName: Verilated English Breakfast (Build)


### PR DESCRIPTION
This PR attempts to cut down total CI length by splitting the "SW build and test" into "build" and "test" jobs to shorten the critical path.

Here's a Gantt chart of a typical CI run before this PR:

![23-09-01_14:42:14](https://github.com/lowRISC/opentitan/assets/105280833/e9186c78-547c-4756-af3e-85af3946623f)

You can see that "software build & test" (SWB&T) takes the longest and is a dependency of the three FPGA tests (and a short packaging test).

The FPGA jobs only depend on the software _build_, not the test part. This PR split the build & test job so that the FPGA tests can start just after the build has finished.