### PR TITLE
[bazel,dvsim] Prevent dvsim from (trying to) copy irrelevant files

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -121,7 +121,10 @@ ifneq (${sw_images},)
 				$${bazel_cquery} \
 				--ui_event_filters=-info \
 				--noshow_progress \
-				--output=starlark); do \
+				--output=starlark \
+				`# Bazel 6 cquery outputs repository targets in canonical format (@//blabla) whereas bazel 5 does not, ` \
+				`# so we use a custom starlark printer to remove in leading @ when needed.` \
+				--starlark:expr='str(target.label)[1:] if str(target.label).startswith("@//") else target.label'); do \
 				if [[ $$dep == //hw/ip/otp_ctrl/data* ]] || \
 				  ([[ $$dep != //hw* ]] && [[ $$dep != //util* ]] && [[ $$dep != //sw/host* ]]); then \
 					for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} $${dep} \


### PR DESCRIPTION
See #19553 for details. Due to a bazel change between verions 5 and 6, bazel cquery will print fully qualified paths like @//sw/device/...
for the repository instead of just //sw/device/... This breaks the filtering done when copying file and will make dvsim copy way too many files, or even try to copy files that are not there.
This commit fixes the issue by using a custom priting function for the query that removes the @ for path starting with @//.