### PR TITLE
[SiVal] Test plan updates for `lc_ctrl`

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -435,11 +435,97 @@
       default: "1'b0"
     },
   ] // inter_signal_list
+  features: [
+    {
+      name: "LC_CTRL.STATE.RAW"
+      desc: '''Initial state. No functions other than transition to `TEST_UNLOCKED0` are available.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.TEST_UNLOCKED"
+      desc: '''State used for manufacturing and production testing. CPU execution and all debug
+            functionality is enabled in this state. The key manager (`keymgr`) is disabled.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.TEST_LOCKED"
+      desc: '''This state is logically equivalent to `RAW`, where only transitions to
+            `TEST_UNLOCKED` states are available. The transition requires a test unlock token which
+            needs to be provisioned in the `TEST_UNLOCKED0` state.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.DEV"
+      desc: '''This state is used to develop provisioning and mission mode software. It can also
+            be used to debug software via `rv_dm`. All other debug functionality is disabled. The
+            key manager (`keymgr`) is enabled. This is a mutually exclusive state to `PROD` and
+            `PROD_END`.
 
-  /////////////////////
-  // Countermeasures //
-  /////////////////////
+            Entry into `DEV` from any `TEST_UNLOCKED` state requires a valid test exit token which
+            needs to be provisioned in a `TEST_UNLOCKED` state.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.PROD"
+      desc: '''This state state is used both for provisioning and mission mode. CPU execution and
+            all debug functionality is disabled. The key manager (`keymgr`) is enabled. This is a
+            mutually exclusive state to `DEV` and `PROD_END`.
 
+            Entry into `PROD` from any `TEST_UNLOCKED` state requires a valid test exit token which
+            needs to be provisioned in a `TEST_UNLOCKED` state.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.PROD_END"
+      desc: '''This state is used both for provisioning and mission mode. This state is logically
+            equivalent to `PROD`, with the only difference being that transitions from this state
+            to `RMA` are not allowed.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.RMA"
+      desc: '''This state is logically equivalent to `TEST_UNLOCKED`. It can be entered from any
+            mission mode state (`DEV`, `PROD` and `PROD_END`) states using an authentication
+            token provisioned at manufacturing time by the Silicon Creator.
+            '''
+    }
+    {
+      name: "LC_CTRL.STATE.SCRAP"
+      desc: '''This state is logically equivalent to `RAW` state, with the following exceptions:
+            1) `SCRAP` is a final state; and, 2) Life cycle JTAG interface is disabled upon
+            successful entry into this state.
+            '''
+    }
+    {
+      name: "LC_CTRL.ACCESS.JTAG"
+      desc: '''Lifecycle controller CSRs are accessible via a dedicated JTAG interface, supporting
+            manufacturing life cycle transitions and RMA flows. The CSRs support a hardware mutex
+            to arbitrate access through the JTAG interface versus from the TL-UL bus.
+            '''
+    }
+    {
+      name: "LC_CTRL.ACCESS.EXT_CLK"
+      desc: '''The lifecycle controller supports switching to an external clock source via a CSR
+            interface.
+            '''
+    }
+    {
+      name: "LC_CTRL.AUTHENTICATED_TRANSITIONS"
+      desc: '''The following transitions require an user provided token, which is verified against
+            a pre-hashed image stored in OTP: 1) Transition from `RAW` into `TEST_UNLOCKED0` state,
+            2) Transition from any `TEST_LOCKED` state into a `TEST_UNLOCKED` state, 3) Transition
+            from any `TEST_UNLOCKED` state into `PROD`, `DEV` or `PROD_END` states; or 4)
+            Transition into `RMA` state.
+            '''
+    }
+    {
+      name: "LC_CTRL.LOGICAL_SCRAP"
+      desc: '''The lifecycle controller supports escalating to a logical scrap state as part of
+            alert escalations. The life cycle can be reverted to the configured state by
+            performing a hard reset.
+            '''
+    }
+  ]
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -21,6 +21,7 @@
     // IP block specific top level test plans.
     "hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson",
   ]
 
@@ -575,7 +576,7 @@
 
     //////////////////////////////////////////////////////////////////////////////////////
     // System Peripherals                                                               //
-    // XBAR, RV_DM, RV_TIMER, AON_TIMER, PLIC, CLK/RST/PWR MGR, ALERT_HANDLER, LC_CTRL, //
+    // XBAR, RV_DM, RV_TIMER, AON_TIMER, PLIC, CLK/RST/PWR MGR, ALERT_HANDLER,          //
     // ADC_CTRL, SYSRST_CTRL                                                            //
     //////////////////////////////////////////////////////////////////////////////////////
 
@@ -1666,176 +1667,6 @@
       stage: V2
       tests: ["chip_sw_alert_handler_reverse_ping_in_deep_sleep"]
     }
-
-    // LC_CTRL (pre-verified IP) integration tests:
-    {
-      name: chip_sw_lc_ctrl_alert_handler_escalation
-      desc: '''Verify that the escalation signals from the alert handler are connected to LC ctrl.
-
-            - Trigger an alert to initiate the escalations.
-            - Check that the escalation signals are connected to the LC ctrl:
-              - First escalation has no effect on the LC ctrl.  Read LC_STATE CSR to confirm
-                this is the case.
-              - Second escalation should cause the `lc_escalation_en` output to be asserted and for
-                the LC_STATE to transition to scrap state.  Confirm by reading the LC_STATE CSR
-              - Verify that all decoded outputs except for escalate_en are
-                disabled. X-ref'ed with the respective IP tests that consume these signals.
-
-            X-ref'ed with chip_sw_lc_ctrl_broadcast test, which verifies the connectivity of the LC
-            decoded outputs to other IPs.
-            X-ref'ed with alert_handler's escalation test.
-            '''
-      stage: V2
-      tests: ["chip_sw_alert_handler_escalation"]
-    }
-    {
-      name: chip_sw_lc_ctrl_jtag_access
-      desc: '''Verify enable to access LC ctrl via JTAG.
-
-            Using the JTAG agent, write and read LC ctrl CSRs, verify the read value for
-            correctness.
-            '''
-      stage: V2
-      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
-    }
-    {
-      name: chip_sw_lc_ctrl_otp_hw_cfg
-      desc: '''Verify the device_ID and ID_state CSRs.
-
-            - Preload the hw_cfg partition in OTP ctrl with random data.
-            - Read the device ID and the ID state CSRs to verify their correctness.
-            - Reset the chip and repeat the first 2 steps to verify a different set of values.
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
-    }
-    {
-      name: chip_sw_lc_ctrl_init
-      desc: '''Verify the LC ctrl initialization on power up.
-
-            Verify that the chip powers up correctly on POR.
-            - The pwrmgr initiates a handshake with OTP ctrl and later, with LC ctrl in subsequent
-              FSM states. Ensure that the whole power up sequence does not hang.
-            - Verify with connectivity assertion checks, the handshake signals are connected.
-            - Ensure that no interrupts or alerts are triggered.
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_transition"]
-    }
-    {
-      name: chip_sw_lc_ctrl_transitions
-      desc: '''Verify the LC ctrl can transit from one state to another valid state with the
-            correct tokens.
-
-            - Preload OTP image with a LC state and required tokens to transfer to next state.
-            - Initiate an LC ctrl state transition via SW if CPU is enabled, or via JTAG interface
-              if CPU is disable.
-            - Ensure that the LC program request is received by the OTP ctrl.
-            - Verify the updated data output from OTP ctrl to LC ctrl is correct.
-            - Ensure that there is no background or otp_init error.
-            - Verify that the LC ctrl has transitioned to the programmed state after a reboot.
-            Re-randomize the lc_transition tokens and repeat the sequence above.
-
-            X-ref'ed chip_sw_otp_ctrl_program.
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_transition"]
-    }
-    {
-      name: chip_sw_lc_ctrl_kmac_req
-      desc: '''Verify the token requested from KMAC.
-
-            - For conditional transition, the LC ctrl will send out a token request to KMAC.
-            - Verify that the KMAC returns a hashed token, which should match one of the
-              transition token CSRs.
-
-            X-ref'ed with chip_kmac_lc_req.
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_transition"]
-    }
-    {
-      name: chip_sw_lc_ctrl_key_div
-      desc: '''Verify the keymgr div output to keymgr.
-
-            - Verify in different LC states, LC ctrl outputs the correct `key_div_o` to keymgr.
-            - Verify that the keymgr uses the given `key_div_o` value to compute the keys.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_key_derivation_prod"]
-    }
-    {
-      name: chip_sw_lc_ctrl_broadcast
-      desc: '''Verify broadcast signals from lc_ctrl.
-
-            - Preload the LC partition in the otp_ctrl with the following states: RMA, DEV,
-              TEST_LOCKED[N] & SCRAP.
-            - Verify that the following broadcast signals are having the right effect in the
-              respective IPs that consume them:
-              - lc_dft_en_o: impacts pinmux, pwrmgr, otp_ctrl, AST
-              - lc_hw_debug_en_o: impacts pinmux, pwrmgr, sram_ctrl (main and ret) & the rv_dm
-              - lc_keymgr_en_o: impacts keymgr
-              - lc_clk_byp_req_o: impacts clkmgr (handshake with lc_clk_byp_ack_i)
-              - lc_flash_rma_req_o: impacts flash_ctrl (handshake with lc_flash_ram_ack_i)
-              - lc_flash_rma_seed_o: impacts flash_ctrl
-              - lc_check_byp_en_o: impacts otp_ctrl
-              - lc_creator_seed_sw_rw_en_o: impacts flash_ctrl & otp_ctrl
-              - lc_owner_seed_sw_rw_en_o: impacts flash_ctrl
-              - lc_iso_part_sw_rd_en_o: impacts flash_ctrl
-              - lc_iso_part_sw_wr_en_o: impacts flash_ctrl
-              - lc_seed_hw_rd_en_o: impacts flash_ctrl & otp_ctrl
-            - These outputs are enabled per the
-              [life cycle architecture spec](doc/security/specs/device_life_cycle/README.md#architecture).
-
-            X-ref'ed with the respective IP tests that consume these signals.
-
-            Note that the following signals are already verified with connectivity tests and SVAs:
-              - lc_dft_en_o (AST connection)
-              - lc_cpu_en_o (rv_core_ibex)
-              - lc_nvm_debug_en_o (flash_ctrl)
-              - lc_escalate_en_o (multiple)
-            '''
-      stage: V2
-      tests: [
-        "chip_prim_tl_access",                         // lc_dft_en_o: otp_ctrl
-        "chip_tap_straps_dev",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_prod",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_rma",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_sw_rom_ctrl_integrity_check",            // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_sram_ctrl_execution_main",            // lc_hw_debug_en_o: sram_ctrl main
-        "chip_rv_dm_lc_disabled"                       // lc_hw_debug_en_o: rv_dm
-        "chip_sw_keymgr_key_derivation",               // lc_keymgr_en_o: keymgr
-        "chip_sw_clkmgr_external_clk_src_for_lc",      // lc_clk_byp_req_o: clkmgr
-        "chip_sw_flash_rma_unlocked",                  // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
-        "chip_sw_lc_ctrl_transition",                  // lc_check_byp_en_o: otp_ctrl
-        "chip_sw_flash_ctrl_lc_rw_en",                 // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
-        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",  // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_dev",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_prod",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_rma",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-      ]
-    }
-    {
-      name: chip_sw_lc_ctrl_kmac_error
-      desc: '''
-            Verify the effect of KMAC returning an error during the hash generation of LC tokens.
-
-            - Follow the steps in `chip_sw_lc_ctrl_kmac_req` test.
-            - While the KMAC is actively computing the digest, glitch the KMAC app sparse FSM to
-              trigger a fault.
-            - Verify that KMAC returns an error signal to the LC controller.
-            - TBD
-            '''
-      stage: V3
-      tests: []
-    }
-
 
     // SYSRST_CTRL (pre-verified IP) integration tests:
     {
@@ -3232,86 +3063,6 @@
              '''
       stage: V2
       tests: ["rom_e2e_smoke"]
-    }
-    {
-      name: chip_lc_scrap
-      desc: '''Ensure it is possible to enter scrap state from every legal life cycle state.
-
-            -  Request transition to SCRAP state using the JTAG interface.
-            -  It should be possible to transition from every legal state using external clock.
-            -  Where it is allowed, transition using internal clocks should also be checked.
-            -  After transition, verify that the device is in SCRAP state through LC read.
-            -  Verify while in SCRAP state:
-               - RV JTAG interface is unavailable.
-               - Ibex is not executing.
-               - RV_DM is unreachable by the stub CPU.
-
-            - X-ref'd with manuf_scrap from the manufacturing testplan.
-            - X-ref'd with chip_lc_test_locked.
-            - X-ref'd with chip_tap_strap_sampling
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_rand_to_scrap",
-              "chip_sw_lc_ctrl_raw_to_scrap",
-              "chip_sw_lc_ctrl_rma_to_scrap",
-              "chip_sw_lc_ctrl_test_locked0_to_scrap"]
-    }
-    {
-      name: chip_lc_test_locked
-      desc: '''Transition from TEST_UNLOCKED to TEST_LOCKED using LC JTAG interface.
-
-            -  Check in TEST_UNLOCKED RV JTAG interface is available.
-            -  Verify When in TEST_LOCKED state:
-               - RV JTAG interface is unavailable.
-               - Ibex is not executing.
-               - RV_DM is unreachable by the stub CPU.
-
-            - X-ref'd with manuf_cp_test_lock from the manufacturing testplan.
-            - X-ref'd with chip_lc_scrap.
-            - X-ref'd with chip_tap_strap_sampling
-            - X-ref'd with chip_sw_lc_walkthrough
-            - X-ref'd with chip_rv_dm_lc_disabled
-            '''
-      stage: V2
-      tests: ["chip_sw_lc_walkthrough_testunlocks",
-              "chip_rv_dm_lc_disabled"]
-    }
-    {
-      name: chip_sw_lc_walkthrough
-      desc: '''Walk through the life cycle stages from RAW state and reseting the chip each time.
-
-             - Pre-load OTP image with RAW lc_state.
-             - Initiate the LC transition to one of the test unlock state.
-             - Program test_unlock_token, test_exit_token, rma_unlock_token into OTP partitions.
-             - Move forward to next valid LC states via JTAG interface or SW interface if CPU is
-               enabled.
-             Verify that the features that should indeed be disabled are indeed disabled.
-             '''
-      stage: V2
-      tests: ["chip_sw_lc_walkthrough_dev",
-              "chip_sw_lc_walkthrough_prod",
-              "chip_sw_lc_walkthrough_prodend",
-              "chip_sw_lc_walkthrough_rma",
-              "chip_sw_lc_walkthrough_testunlocks"]
-    }
-    {
-      name: chip_sw_lc_ctrl_volatile_raw_unlock
-      desc: '''Configure VOLATILE_RAW_UNLOCK via LC TAP interface and enable CPU execution.
-
-             - Pre-load OTP image with RAW lc_state.
-             - Initiate the LC transition to test_unlocked0 state using the
-               VOLATILE_RAW_UNLOCK mode of operation.
-             - As part of the transition to test_unlocked0, switch the TAP interface to rv_dm.
-             - Enable ROM execution via rv_dm, and perform POR.
-             - Initiate a second transition to test_unlocked0 using VOLATILE_RAW_UNLOCK.
-             - Verify that the CPU is able to execute.
-
-             Test ext_clk injection before enabling ROM execution.
-             '''
-      stage: V2
-      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock",
-              "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz",
-              "rom_volatile_raw_unlock"]
     }
     {
       name: chip_sw_rom_raw_unlock

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -1,0 +1,347 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_hmac
+  testpoints: [
+    // LC_CTRL integration tests
+    {
+      name: chip_sw_lc_ctrl_alert_handler_escalation
+      desc: '''Verify that the escalation signals from the alert handler are connected to LC ctrl.
+
+            - Trigger an alert to initiate the escalations.
+            - Check that the escalation signals are connected to the LC ctrl:
+              - First escalation has no effect on the LC ctrl.  Read LC_STATE CSR to confirm
+                this is the case.
+              - Second escalation should cause the `lc_escalation_en` output to be asserted and for
+                the LC_STATE to transition to scrap state.  Confirm by reading the LC_STATE CSR
+              - Verify that all decoded outputs except for escalate_en are
+                disabled. X-ref'ed with the respective IP tests that consume these signals.
+
+            In silicon and FPGA test targets, verify that the device debug interfaces are not
+            accessible when testing in `TEST_UNLOCKED`, `DEV` or `RMA` states.
+
+            X-ref'ed with chip_sw_lc_ctrl_broadcast test, which verifies the connectivity of the LC
+            decoded outputs to other IPs.
+            X-ref'ed with alert_handler's escalation test.
+            '''
+      features: ["LC_CTRL.LOGICAL_SCRAP"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV3
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_alert_handler_escalation"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_jtag_access
+      desc: '''Verify enable to access LC ctrl via JTAG.
+
+            Using the JTAG agent, write and read LC ctrl CSRs, verify the read value for
+            correctness. Repeat test with clk_ext configuration.
+            '''
+      features: ["LC_CTRL.ACCESS.JTAG", "LC_CTRL.ACCESS.EXT_CLK"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_otp_hw_cfg
+      desc: '''Verify the device_ID and ID_state CSRs.
+
+            - Preload the hw_cfg partition in OTP ctrl with random data.
+            - Read the device ID and the ID state CSRs to verify their correctness.
+            - Reset the chip and repeat the first 2 steps to verify a different set of values.
+
+            In silicon and FPGA targets, verify that the DeviceID read via JTAG matches the
+            value read from Ibex.
+            '''
+      features: ["LC_CTRL.ACCESS.JTAG"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_init
+      desc: '''Verify the LC ctrl initialization on power up.
+
+            Verify that the chip powers up correctly on POR.
+            - The pwrmgr initiates a handshake with OTP ctrl and later, with LC ctrl in subsequent
+              FSM states. Ensure that the whole power up sequence does not hang.
+            - Verify with connectivity assertion checks, the handshake signals are connected.
+            - Ensure that no interrupts or alerts are triggered.
+            '''
+      stage: V2
+      tests: ["chip_sw_lc_ctrl_transition"]
+    }
+    {
+      name: chip_sw_lc_ctrl_transitions
+      desc: '''Verify the LC ctrl can transit from one state to another valid state with the
+            correct tokens.
+
+            - Preload OTP image with a LC state and required tokens to transfer to next state.
+            - Initiate an LC ctrl state transition via SW if CPU is enabled, or via JTAG interface
+              if CPU is disable.
+            - Ensure that the LC program request is received by the OTP ctrl.
+            - Verify the updated data output from OTP ctrl to LC ctrl is correct.
+            - Ensure that there is no background or otp_init error.
+            - Verify that the LC ctrl has transitioned to the programmed state after a reboot.
+            Re-randomize the lc_transition tokens and repeat the sequence above.
+
+            X-ref'ed chip_sw_otp_ctrl_program.
+            X-ref'ed manuf_cp_unlock_raw
+            X-ref'ed manuf_cp_test_lock
+            X-ref'ed manuf_ft_exit_token
+            '''
+      features: [
+        "LC_CTRL.AUTHENTICATED_TRANSITIONS"
+        "LC_CTRL.STATE.RAW",
+        "LC_CTRL.STATE.TEST_UNLOCKED",
+        "LC_CTRL.STATE.TEST_LOCKED",
+      ]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV1
+      otp_mutate: true
+      lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED"]
+      tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_kmac_req
+      desc: '''Verify the token requested from KMAC.
+
+            - For conditional transition, the LC ctrl will send out a token request to KMAC.
+            - Verify that the KMAC returns a hashed token, which should match one of the
+              transition token CSRs.
+
+            X-ref'ed with chip_kmac_lc_req.
+            X-ref'ed manuf_cp_unlock_raw
+            X-ref'ed manuf_cp_test_lock
+            X-ref'ed manuf_ft_exit_token
+            X-ref'ed manuf_rma_entry
+            '''
+      features: ["LC_CTRL.AUTHENTICATED_TRANSITIONS"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV1
+      otp_mutate: true
+      lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED", "DEV", "PROD", "PROD_END"]
+      tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_key_div
+      desc: '''Verify the keymgr div output to keymgr.
+
+            - Verify in different LC states, LC ctrl outputs the correct `key_div_o` to keymgr.
+            - Verify that the keymgr uses the given `key_div_o` value to compute the keys.
+            '''
+      stage: V2
+      tests: ["chip_sw_keymgr_key_derivation_prod"]
+    }
+    {
+      name: chip_sw_lc_ctrl_broadcast
+      desc: '''Verify broadcast signals from lc_ctrl.
+
+            - Preload the LC partition in the otp_ctrl with the following states: RMA, DEV,
+              TEST_LOCKED[N] & SCRAP.
+            - Verify that the following broadcast signals are having the right effect in the
+              respective IPs that consume them:
+              - lc_dft_en_o: impacts pinmux, pwrmgr, otp_ctrl, AST
+              - lc_hw_debug_en_o: impacts pinmux, pwrmgr, sram_ctrl (main and ret) & the rv_dm
+              - lc_keymgr_en_o: impacts keymgr
+              - lc_clk_byp_req_o: impacts clkmgr (handshake with lc_clk_byp_ack_i)
+              - lc_flash_rma_req_o: impacts flash_ctrl (handshake with lc_flash_ram_ack_i)
+              - lc_flash_rma_seed_o: impacts flash_ctrl
+              - lc_check_byp_en_o: impacts otp_ctrl
+              - lc_creator_seed_sw_rw_en_o: impacts flash_ctrl & otp_ctrl
+              - lc_owner_seed_sw_rw_en_o: impacts flash_ctrl
+              - lc_iso_part_sw_rd_en_o: impacts flash_ctrl
+              - lc_iso_part_sw_wr_en_o: impacts flash_ctrl
+              - lc_seed_hw_rd_en_o: impacts flash_ctrl & otp_ctrl
+            - These outputs are enabled per the
+              [life cycle architecture spec](doc/security/specs/device_life_cycle/README.md#architecture).
+
+            X-ref'ed with the respective IP tests that consume these signals.
+
+            Note that the following signals are already verified with connectivity tests and SVAs:
+              - lc_dft_en_o (AST connection)
+              - lc_cpu_en_o (rv_core_ibex)
+              - lc_nvm_debug_en_o (flash_ctrl)
+              - lc_escalate_en_o (multiple)
+            '''
+      stage: V2
+      tests: [
+        "chip_prim_tl_access",                         // lc_dft_en_o: otp_ctrl
+        "chip_tap_straps_dev",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_prod",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_tap_straps_rma",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
+        "chip_sw_rom_ctrl_integrity_check",            // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",            // lc_hw_debug_en_o: clkmgr
+        "chip_sw_sram_ctrl_execution_main",            // lc_hw_debug_en_o: sram_ctrl main
+        "chip_rv_dm_lc_disabled"                       // lc_hw_debug_en_o: rv_dm
+        "chip_sw_keymgr_key_derivation",               // lc_keymgr_en_o: keymgr
+        "chip_sw_clkmgr_external_clk_src_for_lc",      // lc_clk_byp_req_o: clkmgr
+        "chip_sw_flash_rma_unlocked",                  // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
+        "chip_sw_lc_ctrl_transition",                  // lc_check_byp_en_o: otp_ctrl
+        "chip_sw_flash_ctrl_lc_rw_en",                 // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
+        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",  // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_dev",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_prod",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+        "chip_sw_otp_ctrl_lc_signals_rma",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
+      ]
+    }
+    {
+      name: chip_sw_lc_ctrl_kmac_error
+      desc: '''
+            Verify the effect of KMAC returning an error during the hash generation of LC tokens.
+
+            - Follow the steps in `chip_sw_lc_ctrl_kmac_req` test.
+            - While the KMAC is actively computing the digest, glitch the KMAC app sparse FSM to
+              trigger a fault.
+            - Verify that KMAC returns an error signal to the LC controller.
+            - TBD
+            '''
+      stage: V3
+      tests: []
+    }
+    {
+      name: chip_lc_scrap
+      desc: '''Ensure it is possible to enter scrap state from every legal life cycle state.
+
+            -  Request transition to SCRAP state using the JTAG interface.
+            -  It should be possible to transition from every legal state using external clock.
+            -  Where it is allowed, transition using internal clocks should also be checked.
+            -  After transition, verify that the device is in SCRAP state through LC read.
+            -  Verify while in SCRAP state:
+               - RV JTAG interface is unavailable.
+               - Ibex is not executing.
+               - RV_DM is unreachable by the stub CPU.
+
+            - X-ref'd with manuf_scrap from the manufacturing testplan.
+            - X-ref'd with chip_lc_test_locked.
+            - X-ref'd with chip_tap_strap_sampling
+            '''
+      features: ["LC_CTRL.STATE.SCRAP"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV3
+      otp_mutate: true
+      lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_lc_ctrl_rand_to_scrap",
+              "chip_sw_lc_ctrl_raw_to_scrap",
+              "chip_sw_lc_ctrl_rma_to_scrap",
+              "chip_sw_lc_ctrl_test_locked0_to_scrap"]
+      bazel: []
+    }
+    {
+      name: chip_lc_test_locked
+      desc: '''Transition from TEST_UNLOCKED to TEST_LOCKED using LC JTAG interface.
+
+            -  Check in TEST_UNLOCKED RV JTAG interface is available.
+            -  Verify When in TEST_LOCKED state:
+               - RV JTAG interface is unavailable.
+               - Ibex is not executing.
+               - RV_DM is unreachable by the stub CPU.
+
+            - X-ref'd with manuf_cp_test_lock from the manufacturing testplan.
+            - X-ref'd with chip_lc_scrap.
+            - X-ref'd with chip_tap_strap_sampling
+            - X-ref'd with chip_sw_lc_walkthrough
+            - X-ref'd with chip_rv_dm_lc_disabled
+            '''
+      features: ["LC_CTRL.STATE.TEST_LOCKED"]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV3
+      otp_mutate: true
+      lc_states: ["TEST_UNLOCKED"]
+      tests: ["chip_sw_lc_walkthrough_testunlocks",
+              "chip_rv_dm_lc_disabled"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_walkthrough
+      desc: '''Walk through the life cycle stages from RAW state and reseting the chip each time.
+
+             - Pre-load OTP image with RAW lc_state.
+             - Initiate the LC transition to one of the test unlock state.
+             - Program test_unlock_token, test_exit_token, rma_unlock_token into OTP partitions.
+             - Move forward to next valid LC states via JTAG interface or SW interface if CPU is
+               enabled.
+             Verify that the features that should indeed be disabled are indeed disabled.
+             '''
+      stage: V2
+      tests: ["chip_sw_lc_walkthrough_dev",
+              "chip_sw_lc_walkthrough_prod",
+              "chip_sw_lc_walkthrough_prodend",
+              "chip_sw_lc_walkthrough_rma",
+              "chip_sw_lc_walkthrough_testunlocks"]
+    }
+    {
+      name: chip_sw_lc_ctrl_volatile_raw_unlock
+      desc: '''Configure VOLATILE_RAW_UNLOCK via LC TAP interface and enable CPU execution.
+
+             - Pre-load OTP image with RAW lc_state.
+             - Initiate the LC transition to test_unlocked0 state using the
+               VOLATILE_RAW_UNLOCK mode of operation.
+             - As part of the transition to test_unlocked0, switch the TAP interface to rv_dm.
+             - Enable ROM execution via rv_dm, and perform POR.
+             - Initiate a second transition to test_unlocked0 using VOLATILE_RAW_UNLOCK.
+             - Verify that the CPU is able to execute.
+
+             Test ext_clk injection before enabling ROM execution.
+             '''
+      features: [
+        "LC_CTRL.STATE.RAW",
+        "LC_CTRL.STATE.TEST_UNLOCKED",
+        "LC_CTRL.ACCESS.JTAG",
+        "LC_CTRL.ACCESS.EXT_CLK",
+        "LC_CTRL.AUTHENTICATED_TRANSITIONS",
+      ]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V2
+      si_stage: SV1
+      lc_states: ["RAW"]
+      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock",
+              "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz",
+              "rom_volatile_raw_unlock"]
+      bazel: []
+    }
+    {
+      name: chip_sw_lc_ctrl_debug_access
+      desc: '''Verify debug access for each lifecycle state.
+
+             For each lifecycle state verify the debug and CPU access to make sure it matches the
+             specification.
+             '''
+      features: [
+        "LC_CTRL.STATE.RAW",
+        "LC_CTRL.STATE.TEST_UNLOCKED",
+        "LC_CTRL.STATE.TEST_LOCKED",
+        "LC_CTRL.STATE.DEV",
+        "LC_CTRL.STATE.PROD",
+        "LC_CTRL.STATE.PROD_END",
+        "LC_CTRL.STATE.RMA",
+        "LC_CTRL.STATE.SCRAP",
+      ]
+      tags: ["dv", "fpga", "silicon"]
+      stage: V3
+      si_stage: SV2
+      tests: []
+      bazel: []
+    }
+  ]
+}


### PR DESCRIPTION
1. Added list of features to the lc_ctrl specification.
2. Moved lc_ctrl chip tests to chip_lc_ctrl_testplan.hjson
3. Added `si_stage: SV*` test cases to cover functionality enumerated in the list of features.
4. Updated the pre-silicon test cases with relevant `SV*` labels.