### PR TITLE
[ci] Move OTBN sim tests to nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,12 +219,14 @@ jobs:
       #   shallow exclusion; tests deeper under //hw will still be found.
       # * It excludes targets that depend on bitstream_splice rules, since the
       #   environment does not have access to Vivado.
+      # * OTBN simulator tests are excluded as they take a long time to run.
       export GCP_BAZEL_CACHE_KEY=$(bazelCacheGcpKeyPath)
       TARGET_PATTERN_FILE=$(mktemp)
       echo //... > "${TARGET_PATTERN_FILE}"
       echo -//quality/... >> "${TARGET_PATTERN_FILE}"
       echo -//third_party/riscv-compliance/... >> "${TARGET_PATTERN_FILE}"
       echo -//hw:all >> "${TARGET_PATTERN_FILE}"
+      echo -//sw/otbn/crypto/tests:all >> "${TARGET_PATTERN_FILE}"
       ./bazelisk.sh cquery \
         --noinclude_aspects \
         --output=starlark \

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -88,3 +88,23 @@ jobs:
         $(bash ./bazelisk.sh query 'attr("tags", "[\[ ]bob[,\]]", attr("tags", "[\[ ]cw310[,\]]", tests(//...)))')
     displayName: "Run all the SPI and I2C Tests with BoB"
   - template: ../ci/publish-bazel-test-results.yml
+
+- job: otbn_sim
+  displayName: "OTBN Simulator Tests"
+  timeoutInMinutes: 180
+  dependsOn: checkout
+  pool: ci-public
+  steps:
+  - template: ../ci/checkout-template.yml
+  - template: ../ci/install-package-dependencies.yml
+  - bash: |
+      set -x
+      ci/bazelisk.sh test \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --define bitstream=gcp_splice \
+        --test_tag_filters=-broken \
+        --build_tests_only \
+        --test_output=errors \
+        //sw/otbn/crypto/tests:all
+    displayName: "Run all OTBN simulator crypto tests"
+  - template: ../ci/publish-bazel-test-results.yml


### PR DESCRIPTION
Experimental PR to move OTBN simulator tests to the nightly CI as these need a long running time.

This moves the tests found in a certain BUILD file, not specifically those which take a long time or which use the OTBN simulator.

I would like a more robust way of deciding which tests run in CI and which run in nightly, but this is beyond my Bazel and CI knowledge.