### PR TITLE
Minor refactor in otbn_start_stop_control

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -440,7 +440,7 @@ interface otbn_trace_if
   assign start_stop_bad_int_i.mubi_rma_err = u_otbn_start_stop_control.mubi_err_d &&
     prim_mubi_pkg::mubi4_test_invalid(u_otbn_start_stop_control.rma_ack_q);
   assign start_stop_bad_int_i.mubi_urnd_err = u_otbn_start_stop_control.mubi_err_d &&
-    prim_mubi_pkg::mubi4_test_invalid(u_otbn_start_stop_control.wipe_after_urnd_refresh_q);
+    prim_mubi_pkg::mubi4_test_invalid(u_otbn_start_stop_control.first_wipe_phase_done_q);
 
   assign controller_bad_int_i.loop_hw_cnt_err =
     (|u_otbn_controller.u_otbn_loop_controller.loop_counter_err);

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -191,22 +191,22 @@ module otbn_start_stop_control
         end
       end
       OtbnStartStopStateHalt: begin
-        if (stop && !rma_request) begin
-          state_d = OtbnStartStopStateLocked;
-        end else if (start_i || rma_request) begin
+        if (rma_request) begin
           ispr_init_o   = 1'b1;
           state_reset_o = 1'b1;
-          if (rma_request) begin
-            // Do not reseed URND before secure wipe for RMA, as the entropy complex may not be able
-            // to provide entropy at this point.
-            state_d = OtbnStartStopSecureWipeWdrUrnd;
-            // As we don't reseed URND, there's no point in doing two rounds of wiping, so we
-            // pretend that the first round is already the second round.
-            wipe_after_urnd_refresh_d = MuBi4True;
-          end else begin // start_i
-            urnd_reseed_req_o = ~SecSkipUrndReseedAtStart;
-            state_d           = OtbnStartStopStateUrndRefresh;
-          end
+          // Do not reseed URND before secure wipe for RMA, as the entropy complex may not be able
+          // to provide entropy at this point.
+          state_d = OtbnStartStopSecureWipeWdrUrnd;
+          // As we don't reseed URND, there's no point in doing two rounds of wiping, so we
+          // pretend that the first round is already the second round.
+          wipe_after_urnd_refresh_d = MuBi4True;
+        end else if (stop) begin
+          state_d = OtbnStartStopStateLocked;
+        end else if (start_i) begin
+          ispr_init_o       = 1'b1;
+          state_reset_o     = 1'b1;
+          urnd_reseed_req_o = ~SecSkipUrndReseedAtStart;
+          state_d           = OtbnStartStopStateUrndRefresh;
         end
       end
       OtbnStartStopStateUrndRefresh: begin


### PR DESCRIPTION
I spent a bit of time trying to understand how this code worked, in order to get the (currently broken) otbn_escalate tests working again. It was hard! I think these commits make the code slightly easier to understand, and they are not intended to change the meaning of the code. There is a bit of text in each commit's commit message to explain what's going on.