### PR TITLE
[kmac, doc] Update `MSG_FIFO` description

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -1010,9 +1010,11 @@
         byte-write: "true"
         desc: '''Message FIFO.
 
-              Any write to this window will be appended to the FIFO. Only lower
-              2 bits `[1:0]` of the address matter to writes within the window
-              in order to handle with sub-word writes.
+              Any write operation to this window will be appended to MSG_FIFO. SW can
+              simply write bytes/words to any address within this address range.
+              Ordering and packing of the incoming bytes/words are handled
+              internally. Therefore, the least significant 12 bits of the address
+              are ignored.
               '''
       }
     } // W: MSG_FIFO

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -787,9 +787,11 @@ this memory space.
 ## MSG_FIFO
 Message FIFO.
 
-Any write to this window will be appended to the FIFO. Only lower
-2 bits `[1:0]` of the address matter to writes within the window
-in order to handle with sub-word writes.
+Any write operation to this window will be appended to MSG_FIFO. SW can
+simply write bytes/words to any address within this address range.
+Ordering and packing of the incoming bytes/words are handled
+internally. Therefore, the least significant 12 bits of the address
+are ignored.
 
 - Word Aligned Offset Range: `0x800`to`0xffc`
 - Size (words): `512`


### PR DESCRIPTION
Spawned from the thread https://github.com/lowRISC/opentitan/pull/19554#discussion_r1314309770.

The description of `MSG_FIFO` states that when writing bytes/words to it, SW can ignore the word addresses but should correctly provide the least significant 2 bits of the address, so that MSG_FIFO can recognize the position of a byte within word. I think this is incorrect (a test by @jadephilipoom also points to this direction).

What really happens is that, even if SW ignores the least significant 2 bits of the address and directly writes a byte, its alignment is internally corrected by prim_packer primitive inside MSG_FIFO. As prim_packer is receiving input bytes (in order to accumulate them to word, and then release), it only takes the masking bits that come from TL-UL transaction into account. prim_packer keeps track of previously written bytes/words and uses this information to correctly align the position of the incoming byte within words.

In short, SW can always simply write to the beginning address of MSG_FIFO, and ignore the address calculation details. Even if SW switched arbitrarily between bytes/half-words/words while writing to a fixed address in MSG_FIFO range, it would work.

Therefore this PR updates the doc.