### PR TITLE
[bazel] Add support for the CW340

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -657,7 +657,31 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
+
+- job: execute_rom_fpga_tests_cw340
+  displayName: CW340 ROM Tests
+  pool: FPGA CW340
+  timeoutInMinutes: 60
+  dependsOn:
+    - chip_earlgrey_cw340
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw340', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw340
+        - sw_build
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-tests.sh cw340 cw340_rom_with_fake_keys,cw340_rom_with_real_keys,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -522,7 +522,7 @@ jobs:
   # Build CW340 variant of the Earl Grey toplevel design using Vivado
   dependsOn:
     - lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'), eq(variables['Build.SourceBranchName'], 'master'))
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public-eda
   timeoutInMinutes: 150
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -633,7 +633,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh cw310_test_rom,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 cw310_test_rom,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
@@ -681,7 +681,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-cw310-tests.sh manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -14,3 +14,10 @@ config_setting(
         "cw310": "lowrisc",
     },
 )
+
+config_setting(
+    name = "lowrisc_fpga_cw340",
+    define_values = {
+        "cw340": "lowrisc",
+    },
+)

--- a/hw/bitstream/cw340/BUILD
+++ b/hw/bitstream/cw340/BUILD
@@ -1,0 +1,100 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:splice.bzl", "bitstream_splice")
+load("//rules:otp.bzl", "get_otp_images")
+
+# We do not have a signed CW340 ROM yet.
+KEY_AUTHENTICITY = [
+    "fake",
+]
+
+package(default_visibility = ["//visibility:public"])
+
+[
+    bitstream_splice(
+        name = "fpga_cw340_rom_with_{}_keys".format(authenticity),
+        testonly = True,
+        src = "//hw/bitstream/vivado:fpga_cw340_test_rom",
+        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw340_scr_vmem".format(authenticity),
+        meminfo = "//hw/bitstream/vivado:fpga_cw340_rom_mmi",
+        tags = ["manual"],
+        visibility = ["//visibility:private"],
+    )
+    for authenticity in KEY_AUTHENTICITY
+]
+
+bitstream_splice(
+    name = "gcp_spliced_test_rom",
+    testonly = True,
+    src = "@bitstreams//:chip_earlgrey_cw340_bitstream",
+    data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw340_scr_vmem",
+    meminfo = "@bitstreams//:chip_earlgrey_cw340_rom_mmi",
+    tags = ["manual"],
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+
+[
+    bitstream_splice(
+        name = "gcp_spliced_rom_with_{}_keys".format(authenticity),
+        testonly = True,
+        src = "@bitstreams//:chip_earlgrey_cw340_bitstream",
+        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw340_scr_vmem".format(authenticity),
+        meminfo = "@bitstreams//:chip_earlgrey_cw340_rom_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+        visibility = ["//visibility:private"],
+    )
+    for authenticity in KEY_AUTHENTICITY
+]
+
+filegroup(
+    name = "test_rom",
+    testonly = True,
+    srcs = select({
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_test_rom"],
+        "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_test_rom"],
+        "//conditions:default": [":gcp_spliced_test_rom"],
+    }),
+    tags = ["manual"],
+)
+
+[
+    filegroup(
+        name = "rom_with_{}_keys".format(authenticity),
+        testonly = True,
+        srcs = select({
+            "//hw/bitstream:bitstream_skip": ["skip.bit"],
+            "//hw/bitstream:bitstream_vivado": [":fpga_cw340_rom_with_{}_keys".format(authenticity)],
+            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
+            "//conditions:default": [":gcp_spliced_rom_with_fake_keys"],
+        }),
+        tags = ["manual"],
+    )
+    for authenticity in KEY_AUTHENTICITY
+]
+
+filegroup(
+    name = "rom_mmi",
+    testonly = True,
+    srcs = select({
+        "//hw/bitstream:bitstream_skip": ["skip.bit"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_rom_mmi"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_rom_mmi"],
+    }),
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "otp_mmi",
+    testonly = True,
+    srcs = select({
+        "//hw/bitstream:bitstream_skip": ["skip.bit"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_otp_mmi"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_otp_mmi"],
+    }),
+    tags = ["manual"],
+)

--- a/hw/bitstream/hyperdebug/BUILD
+++ b/hw/bitstream/hyperdebug/BUILD
@@ -27,8 +27,8 @@ filegroup(
         srcs = select({
             "//hw/bitstream:bitstream_skip": ["skip.bit"],
             "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_with_{}_keys".format(authenticity)],
-            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_fake_keys".format(authenticity)],
-            "//conditions:default": [":gcp_spliced_rom_with_fake_keys"],
+            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
+            "//conditions:default": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
         }),
         tags = ["manual"],
     )

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -185,6 +185,30 @@ fusesoc_build(
     target = "synth",
 )
 
+filegroup(
+    name = "fpga_cw340_test_rom",
+    testonly = True,
+    srcs = [":fpga_cw340"],
+    output_group = "bitstream",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "fpga_cw340_rom_mmi",
+    testonly = True,
+    srcs = [":fpga_cw340"],
+    output_group = "rom_mmi",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "fpga_cw340_otp_mmi",
+    testonly = True,
+    srcs = [":fpga_cw340"],
+    output_group = "otp_mmi",
+    tags = ["manual"],
+)
+
 # Bitstream cache manifest fragment targets
 bitstream_manifest_fragment(
     name = "earlgrey_cw310_manifest",

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -45,6 +45,7 @@ PER_DEVICE_DEPS = {
     "sim_dv": ["@//sw/device/lib/arch:sim_dv"],
     "fpga_cw305": ["@//sw/device/lib/arch:fpga_cw305"],
     "fpga_cw310": ["@//sw/device/lib/arch:fpga_cw310"],
+    "fpga_cw340": ["@//sw/device/lib/arch:fpga_cw340"],
 }
 
 def create_key_(name, label, hw_lc_states):

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -43,12 +43,14 @@ FPGA_TARGETS = [
     for rom in _ROMS
     if (fpga, rom) not in _BLACKLIST_TARGETS
 ]
-FPGA_TARGETS_WITH_REAL_KEYS = [
-    _fpga_target(fpga, "rom_with_real_keys")
-    for fpga in _FPGAS
-    if (fpga, "rom_with_real_keys") not in _BLACKLIST_TARGETS
+FPGA_DEFAULT_TARGETS = [
+    _fpga_target("cw310", "rom_with_fake_keys"),
+    _fpga_target("cw310", "test_rom"),
 ]
 VALID_TARGETS = ["dv", "verilator"] + FPGA_TARGETS
+
+# By default, only build CW310 targets to avoid overloading the CI
+DEFAULT_TARGETS = ["dv", "verilator"] + FPGA_DEFAULT_TARGETS
 
 OTTF_SUCCESS_MSG = r"PASS.*\n"
 OTTF_FAILURE_MSG = r"(FAIL|FAULT).*\n"
@@ -326,7 +328,7 @@ def cw340_params(
 
 def opentitan_functest(
         name,
-        targets = sets.to_list(sets.difference(sets.make(VALID_TARGETS), sets.make(FPGA_TARGETS_WITH_REAL_KEYS))),
+        targets = DEFAULT_TARGETS,
         args = [],
         data = [],
         test_in_rom = False,

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -35,6 +35,17 @@ cc_library(
 )
 
 cc_library(
+    name = "fpga_cw340",
+    srcs = ["device_fpga_cw340.c"],
+    deps = [
+        ":device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:rom_print",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+    ],
+)
+
+cc_library(
     name = "sim_dv",
     srcs = ["device_sim_dv.c"],
     deps = [

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -56,6 +56,11 @@ typedef enum device_type {
    * development board with SCA capability, containing a Xilinx FPGA.
    */
   kDeviceFpgaCw305 = 3,
+  /**
+   * Represents the "ChipWhisperer CW340 FPGA" device, i.e., the particular
+   * FPGA board blessed for OpenTitan development, containing a Xilinx FPGA.
+   */
+  kDeviceFpgaCw340 = 4,
 } device_type_t;
 
 /**

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/rom_print.h"
+
+/**
+ * @file
+ * @brief Device-specific symbol definitions for the ChipWhisperer CW310 device.
+ */
+
+const device_type_t kDeviceType = kDeviceFpgaCw340;
+
+const uint64_t kClockFreqCpuMhz = 24;
+
+const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
+
+uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
+
+const uint64_t kClockFreqHiSpeedPeripheralHz = 24 * 1000 * 1000;  // 24MHz
+
+const uint64_t kClockFreqPeripheralHz = 6 * 1000 * 1000;  // 6MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
+
+const uint64_t kClockFreqAonHz = 250 * 1000;  // 250kHz
+
+const uint64_t kUartBaudrate = 115200;
+
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
+const uint32_t kUartTxFifoCpuCycles =
+    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+
+const uint32_t kAstCheckPollCpuCycles =
+    CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
+
+const uintptr_t kDeviceTestStatusAddress = 0;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+const bool kJitterEnabled = false;
+
+void device_fpga_version_print(void) {
+  // This value is guaranteed to be zero on all non-FPGA implementations.
+  uint32_t fpga = ibex_fpga_version();
+  // The cast to unsigned int stops GCC from complaining about uint32_t
+  // being a `long unsigned int` while the %x specifier takes `unsigned int`.
+  OT_DISCARD(rom_printf("ROM:%x\r\n", (unsigned int)fpga));
+}

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -9,6 +9,7 @@ load(
     "OPENTITANTOOL_OPENOCD_TEST_CMDS",
     "ROM_BOOT_FAILURE_MSG",
     "cw310_params",
+    "cw340_params",
     "dv_params",
     "opentitan_functest",
     "verilator_params",
@@ -948,6 +949,14 @@ opentitan_functest(
 opentitan_functest(
     name = "example_test_from_flash",
     srcs = ["example_test_from_flash.c"],
+    targets = [
+        "dv",
+        "verilator",
+        "cw310_test_rom",
+        "cw310_rom_with_fake_keys",
+        "cw340_test_rom",
+        "cw340_rom_with_fake_keys",
+    ],
     deps = [
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -2309,6 +2318,9 @@ opentitan_functest(
     cw310 = cw310_params(
         exit_failure = ROM_BOOT_FAILURE_MSG,
     ),
+    cw340 = cw340_params(
+        exit_failure = ROM_BOOT_FAILURE_MSG,
+    ),
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
     ),
@@ -2316,6 +2328,7 @@ opentitan_functest(
     signed = True,
     targets = [
         "cw310_rom_with_fake_keys",
+        "cw340_rom_with_fake_keys",
         "verilator",
         "dv",
     ],


### PR DESCRIPTION
TODO, this is a work in progrss. I was able to make it work on fred after fixing the tty devices permissions and running
```
bazel test --test_output=streamed --cache_test_results=no //sw/device/tests:example_test_from_flash_cw340_rom_with_fake_keys --test_arg=--uarts=/dev/ttyUSB2,/dev/ttyACM0
```