### PR TITLE
[crypto] Add a key manager driver and basic tests.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -39,6 +39,41 @@ opentitan_functest(
 )
 
 cc_library(
+    name = "keymgr",
+    srcs = ["keymgr.c"],
+    hdrs = [
+        "keymgr.h",
+    ],
+    deps = [
+        ":entropy",
+        "//hw/ip/keymgr/data:keymgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/runtime:hart",
+    ],
+)
+
+opentitan_functest(
+    name = "keymgr_test",
+    srcs = ["keymgr_test.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":keymgr",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+cc_library(
     name = "kmac",
     srcs = ["kmac.c"],
     hdrs = [

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -1,0 +1,252 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/keymgr.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/hart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "keymgr_regs.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('d', 'k', 'r')
+
+enum {
+  kBaseAddr = TOP_EARLGREY_KEYMGR_BASE_ADDR,
+};
+static_assert(kKeymgrSaltNumWords == KEYMGR_SALT_MULTIREG_COUNT,
+              "Number of salt registers does not match.");
+static_assert(kKeymgrOutputShareNumWords ==
+                  KEYMGR_SW_SHARE0_OUTPUT_MULTIREG_COUNT,
+              "Number of output share 0 registers does not match.");
+static_assert(kKeymgrOutputShareNumWords ==
+                  KEYMGR_SW_SHARE1_OUTPUT_MULTIREG_COUNT,
+              "Number of output share 1 registers does not match.");
+
+/**
+ * Fails if the keymgr is not idle.
+ *
+ * @return OK if the key manager is idle, OTCRYPTO_RECOV_ERR otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t keymgr_is_idle(void) {
+  uint32_t reg = abs_mmio_read32(kBaseAddr + KEYMGR_OP_STATUS_REG_OFFSET);
+  uint32_t status = bitfield_field32_read(reg, KEYMGR_OP_STATUS_STATUS_FIELD);
+  if (launder32(status) == KEYMGR_OP_STATUS_STATUS_VALUE_IDLE) {
+    HARDENED_CHECK_EQ(status, KEYMGR_OP_STATUS_STATUS_VALUE_IDLE);
+    return OTCRYPTO_OK;
+  }
+  return OTCRYPTO_RECOV_ERR;
+}
+
+/**
+ * Set diversification input and start the key manager operation.
+ *
+ * Ensure the key manager is idle before calling this function.
+ *
+ * @param diversification Diversification input for the key derivation.
+ */
+static void keymgr_start(keymgr_diversification_t diversification) {
+  // Set the version.
+  abs_mmio_write32(kBaseAddr + KEYMGR_KEY_VERSION_REG_OFFSET,
+                   diversification.version);
+  // Set the salt.
+  for (size_t i = 0; i < kKeymgrSaltNumWords; i++) {
+    abs_mmio_write32(
+        kBaseAddr + KEYMGR_SALT_0_REG_OFFSET + (i * sizeof(uint32_t)),
+        diversification.salt[i]);
+  }
+
+  // Issue the start command.
+  abs_mmio_write32(kBaseAddr + KEYMGR_START_REG_OFFSET,
+                   1 << KEYMGR_START_EN_BIT);
+}
+
+/**
+ * Wait for the key manager to finish an operation.
+ *
+ * Polls the key manager until it is no longer busy. If the operation completed
+ * successfully or the key manager was already idle, returns OTCRYPTO_OK. If
+ * there was an error during the operation, reads and clears the error code
+ * and returns OTCRYPTO_RECOV_ERR; the operation can be retried afterwards.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t keymgr_wait_until_done(void) {
+  // Poll the OP_STATUS register until it is something other than "WIP".
+  uint32_t reg;
+  uint32_t status;
+  do {
+    reg = abs_mmio_read32(kBaseAddr + KEYMGR_OP_STATUS_REG_OFFSET);
+    status = bitfield_field32_read(reg, KEYMGR_OP_STATUS_STATUS_FIELD);
+  } while (status == KEYMGR_OP_STATUS_STATUS_VALUE_WIP);
+
+  // Clear OP_STATUS by writing back the value we read.
+  abs_mmio_write32(kBaseAddr + KEYMGR_OP_STATUS_REG_OFFSET, reg);
+
+  // Check if the key manager reported errors. If it is already idle or
+  // completed an operation successfully, return an OK status. No other
+  // statuses (e.g. WIP) should be possible.
+  switch (status) {
+    case KEYMGR_OP_STATUS_STATUS_VALUE_IDLE:
+      return OTCRYPTO_OK;
+    case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
+      return OTCRYPTO_OK;
+    case KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR: {
+      // Clear the ERR_CODE register before returning.
+      uint32_t err_code =
+          abs_mmio_read32(kBaseAddr + KEYMGR_ERR_CODE_REG_OFFSET);
+      abs_mmio_write32(kBaseAddr + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
+      return OTCRYPTO_RECOV_ERR;
+    }
+  }
+
+  // Should be unreachable.
+  HARDENED_TRAP();
+  return OTCRYPTO_FATAL_ERR;
+}
+
+/**
+ * Set the control register of the key manager.
+ *
+ * The CDI select bit is always set to false for this driver (i.e. Sealing
+ * CDI). The driver does not support attestation CDI.
+ *
+ * @param dest (NONE, AES, OTBN, or KMAC)
+ * @param operation (GENERATE_SW or GENERATE_HW)
+ */
+#define WRITE_CTRL(dest, operation)                                            \
+  do {                                                                         \
+    uint32_t ctrl =                                                            \
+        bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,      \
+                               KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_##dest); \
+    ctrl = bitfield_bit32_write(ctrl, KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT,     \
+                                false);                                        \
+    ctrl = bitfield_field32_write(                                             \
+        ctrl, KEYMGR_CONTROL_SHADOWED_OPERATION_FIELD,                         \
+        KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_##operation##_OUTPUT);         \
+    abs_mmio_write32_shadowed(kBaseAddr + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,  \
+                              ctrl);                                           \
+  } while (false);
+
+status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
+                                keymgr_output_t *key) {
+  HARDENED_TRY(keymgr_is_idle());
+
+  // Set the control register to generate a software-visible key.
+  WRITE_CTRL(NONE, GENERATE_SW);
+
+  // Start the operation and wait for it to complete.
+  keymgr_start(diversification);
+  HARDENED_TRY(keymgr_wait_until_done());
+
+  // Collect output.
+  // TODO: for SCA hardening, randomize the order of these reads.
+  for (size_t i = 0; i < kKeymgrOutputShareNumWords; i++) {
+    key->share0[i] =
+        abs_mmio_read32(kBaseAddr + KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET +
+                        (i * sizeof(uint32_t)));
+  }
+  for (size_t i = 0; i < kKeymgrOutputShareNumWords; i++) {
+    key->share1[i] =
+        abs_mmio_read32(kBaseAddr + KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET +
+                        (i * sizeof(uint32_t)));
+  }
+
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_generate_key_aes(keymgr_diversification_t diversification) {
+  HARDENED_TRY(keymgr_is_idle());
+
+  // Set the control register to generate an AES key.
+  WRITE_CTRL(AES, GENERATE_HW);
+
+  // Start the operation and wait for it to complete.
+  keymgr_start(diversification);
+  return keymgr_wait_until_done();
+}
+
+status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
+  HARDENED_TRY(keymgr_is_idle());
+
+  // Set the control register to generate a KMAC key.
+  WRITE_CTRL(KMAC, GENERATE_HW);
+
+  // Start the operation and wait for it to complete.
+  keymgr_start(diversification);
+  return keymgr_wait_until_done();
+}
+
+status_t keymgr_generate_key_otbn(keymgr_diversification_t diversification) {
+  HARDENED_TRY(keymgr_is_idle());
+
+  // Set the control register to generate an OTBN key.
+  WRITE_CTRL(OTBN, GENERATE_HW);
+
+  // Start the operation and wait for it to complete.
+  keymgr_start(diversification);
+  return keymgr_wait_until_done();
+}
+
+/**
+ * Clear the requested sideload slot.
+ *
+ * The `slot` parameter should be one of:
+ *   - KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_AES
+ *   - KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_KMAC
+ *   - KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_OTBN
+ *
+ * @param slot Value to write to the SIDELOAD_CLEAR register.
+ */
+static status_t keymgr_sideload_clear(uint32_t slot) {
+  HARDENED_TRY(keymgr_is_idle());
+
+  // Ensure that the entropy complex has been initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  // Set SIDELOAD_CLEAR to begin continuously clearing the requested slot.
+  abs_mmio_write32(
+      kBaseAddr + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+      bitfield_field32_write(0, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD, slot));
+
+  // Read back the value (hardening measure).
+  uint32_t sideload_clear =
+      abs_mmio_read32(kBaseAddr + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
+  if (bitfield_field32_read(sideload_clear, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD) !=
+      slot) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  // Spin for 100 microseconds.
+  // TODO: this value seems to work for tests, but it would be good to run a
+  // more principled analysis.
+  busy_spin_micros(100);
+
+  // Stop continuous clearing.
+  abs_mmio_write32(
+      kBaseAddr + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
+      bitfield_field32_write(0, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD,
+                             KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_NONE));
+
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_sideload_clear_aes(void) {
+  return keymgr_sideload_clear(KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_AES);
+}
+
+status_t keymgr_sideload_clear_kmac(void) {
+  return keymgr_sideload_clear(KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_KMAC);
+}
+
+status_t keymgr_sideload_clear_otbn(void) {
+  return keymgr_sideload_clear(KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_OTBN);
+}

--- a/sw/device/lib/crypto/drivers/keymgr.h
+++ b/sw/device/lib/crypto/drivers/keymgr.h
@@ -1,0 +1,131 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Number of 32-bit words for the salt.
+   */
+  kKeymgrSaltNumWords = 8,
+  /**
+   * Number of 32-bit words for each output key share.
+   */
+  kKeymgrOutputShareNumWords = 8,
+};
+
+/**
+ * Data used to differentiate a generated keymgr key.
+ */
+typedef struct keymgr_diversification {
+  /**
+   * Salt value to use for key generation.
+   */
+  uint32_t salt[kKeymgrSaltNumWords];
+  /**
+   * Version for key generation (anti-rollback protection).
+   */
+  uint32_t version;
+} keymgr_diversification_t;
+
+/**
+ * Generated key from keymgr.
+ *
+ * The output key material is 256 bits, generated in two shares.
+ */
+typedef struct keymgr_output {
+  uint32_t share0[kKeymgrOutputShareNumWords];
+  uint32_t share1[kKeymgrOutputShareNumWords];
+} keymgr_output_t;
+
+/**
+ * Derive a key manager key that is visible to software.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @param[out] key Destination key struct.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_generate_key_sw(const keymgr_diversification_t diversification,
+                                keymgr_output_t *key);
+
+/**
+ * Derive a key manager key for the AES block.
+ *
+ * Calls the key manager to sideload a key into the AES hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_generate_key_aes(
+    const keymgr_diversification_t diversification);
+
+/**
+ * Derive a key manager key for the KMAC block.
+ *
+ * Calls the key manager to sideload a key into the KMAC hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_generate_key_kmac(
+    const keymgr_diversification_t diversification);
+
+/**
+ * Derive a key manager key for the OTBN block.
+ *
+ * Calls the key manager to sideload a key into the OTBN hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_generate_key_otbn(
+    const keymgr_diversification_t diversification);
+
+/**
+ * Clear the sideloaded AES key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_sideload_clear_aes(void);
+
+/**
+ * Clear the sideloaded KMAC key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_sideload_clear_kmac(void);
+
+/**
+ * Clear the sideloaded OTBN key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_sideload_clear_otbn(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_H_

--- a/sw/device/lib/crypto/drivers/keymgr_test.c
+++ b/sw/device/lib/crypto/drivers/keymgr_test.c
@@ -1,0 +1,206 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/keymgr.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+// Key diversification data for testing
+static const keymgr_diversification_t kTestDiversification = {
+    .salt =
+        {
+            0x00112233,
+            0x44556677,
+            0x8899aabb,
+            0xccddeeff,
+            0x00010203,
+            0x04050607,
+            0x08090a0b,
+            0x0c0d0e0f,
+        },
+    .version = 0x9,
+};
+
+/**
+ * Setup keymgr and entropy complex.
+ *
+ * Run this test before any others.
+ */
+status_t test_setup(void) {
+  // Initialize the key manager and advance to OwnerRootKey state.
+  dif_keymgr_t keymgr;
+  dif_kmac_t kmac;
+  TRY(keymgr_testutils_startup(&keymgr, &kmac));
+  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
+
+  // Initialize entropy complex, which the key manager uses to clear sideloaded
+  // keys. The `keymgr_testutils_startup` function restarts the device, so this
+  // should happen afterwards.
+  return entropy_complex_init();
+}
+
+/**
+ * Test generating a single software-visible key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without performing any validation on the key.
+ */
+status_t sw_single_key_test(void) {
+  keymgr_output_t key;
+  return keymgr_generate_key_sw(kTestDiversification, &key);
+}
+
+/**
+ * Test generating a single sideloaded AES key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t aes_basic_test(void) {
+  return keymgr_generate_key_aes(kTestDiversification);
+}
+
+/**
+ * Test generating a single sideloaded KMAC key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t kmac_basic_test(void) {
+  return keymgr_generate_key_kmac(kTestDiversification);
+}
+
+/**
+ * Test generating a single sideloaded OTBN key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t otbn_basic_test(void) {
+  return keymgr_generate_key_otbn(kTestDiversification);
+}
+
+/**
+ * Check whether two key manager output values are equivalent.
+ *
+ * Unmasks both keys and compares their unmasked values; masking should not
+ * affect this comparison.
+ *
+ * @param key1 First key manager output.
+ * @param key2 Second key manager output.
+ * @return true if the keys are equivalent, false otherwise.
+ */
+static bool output_equiv(keymgr_output_t key1, keymgr_output_t key2) {
+  for (size_t i = 0; i < kKeymgrOutputShareNumWords; i++) {
+    uint32_t word1 = key1.share0[i] ^ key1.share1[i];
+    uint32_t word2 = key2.share0[i] ^ key2.share1[i];
+    if (word1 != word2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Test generating software-visible keys with different salts.
+ *
+ * Different salts should produce different keys; the same salt should produce
+ * the same key but with different masking.
+ */
+status_t sw_keys_change_salt_test(void) {
+  // Copy the test data into a mutable structure.
+  keymgr_diversification_t div;
+  memcpy(div.salt, kTestDiversification.salt, sizeof(div.salt));
+  div.version = kTestDiversification.version;
+
+  // Generate a key.
+  keymgr_output_t key1;
+  TRY(keymgr_generate_key_sw(div, &key1));
+
+  // Change the salt and generate the key again.
+  div.salt[0]++;
+  keymgr_output_t key2;
+  TRY(keymgr_generate_key_sw(div, &key2));
+
+  // Check that the keys are distinct.
+  TRY_CHECK(!output_equiv(key1, key2));
+
+  // Change the salt back to its original value and generate a third time.
+  div.salt[0]--;
+  keymgr_output_t key3;
+  TRY(keymgr_generate_key_sw(div, &key3));
+
+  // Check that the key is the equivalent to the first key when unmasked.
+  TRY_CHECK(output_equiv(key1, key3));
+
+  // Check that the masking on the equivalent keys is different.
+  TRY_CHECK_ARRAYS_NE(key1.share0, key2.share0, sizeof(key1.share0));
+
+  return OK_STATUS();
+}
+
+/**
+ * Test generating software-visible keys with different versions.
+ *
+ * Different versions should produce different keys; the same version should
+ * produce the same key but with different masking.
+ */
+status_t sw_keys_change_version_test(void) {
+  // Copy the test data into a mutable structure.
+  keymgr_diversification_t div;
+  memcpy(div.salt, kTestDiversification.salt, sizeof(div.salt));
+  div.version = kTestDiversification.version;
+
+  // Generate a key.
+  keymgr_output_t key1;
+  TRY(keymgr_generate_key_sw(div, &key1));
+
+  // Change the version and generate the key again.
+  div.version++;
+  keymgr_output_t key2;
+  TRY(keymgr_generate_key_sw(div, &key2));
+
+  // Check that the keys are distinct.
+  TRY_CHECK(!output_equiv(key1, key2));
+
+  // Change the version back to its original value and generate a third time.
+  div.version--;
+  keymgr_output_t key3;
+  TRY(keymgr_generate_key_sw(div, &key3));
+
+  // Check that the key is the equivalent to the first key when unmasked.
+  TRY_CHECK(output_equiv(key1, key3));
+
+  // Check that the masking on the equivalent keys is different.
+  TRY_CHECK_ARRAYS_NE(key1.share0, key2.share0, sizeof(key1.share0));
+
+  return OK_STATUS();
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  static status_t result;
+
+  EXECUTE_TEST(result, test_setup);
+  EXECUTE_TEST(result, sw_single_key_test);
+  EXECUTE_TEST(result, sw_keys_change_salt_test);
+  EXECUTE_TEST(result, sw_keys_change_version_test);
+  EXECUTE_TEST(result, aes_basic_test);
+  EXECUTE_TEST(result, kmac_basic_test);
+  EXECUTE_TEST(result, otbn_basic_test);
+
+  return status_ok(result);
+}

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -13,7 +13,7 @@
 #include "kmac_regs.h"  // Generated.
 
 // Module ID for status codes.
-#define MODULE_ID MAKE_MODULE_ID('d', 'k', 'm')
+#define MODULE_ID MAKE_MODULE_ID('d', 'k', 'c')
 
 /**
  * Security strength values.

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -50,6 +50,26 @@ static const dif_keymgr_state_params_t kOwnerIntParams = {
 };
 
 /**
+ * Software binding value for advancing to owner root key state.
+ *
+ * Values were randomly generated.
+ */
+static const dif_keymgr_state_params_t kOwnerRootKeyParams = {
+    .binding_value =
+        {
+            0xd8a812ea,
+            0xb6ebe129,
+            0x217773d4,
+            0x35b37c77,
+            0xec8298be,
+            0x1f7dec77,
+            0x1803199e,
+            0xa02ad81d,
+        },
+    .max_key_version = 0xaa,
+};
+
+/**
  * Struct to hold the creator or owner secrets for the key manager.
  */
 typedef struct keymgr_testutils_secret {


### PR DESCRIPTION
- Adds a cryptolib driver for the key manager.
    - The cryptolib never needs to advance the keymgr state, so the driver only has the capability to generate/clear keys
- Adds a test for the basic functionality of the driver
    - I'll merge follow-up PRs with functional tests for each sideloaded block that actually use and clear the keys, but since these tests will involve specific details of each block it makes sense to me for them to be separate and live under `sw/device/tests/crypto` instead of with the driver.
