### PR TITLE
[otbn,dv] Rewrite a line more efficiently in wsr.py

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -244,7 +244,7 @@ class URNDWSR(WSR):
         a_out = a_in ^ b_in ^ d_in
         b_out = a_in ^ b_in ^ c_in
         c_out = a_in ^ ((b_in << 17) & ((1 << 64) - 1)) ^ c_in
-        d_out = self.rol(d_in, 45) ^ self.rol(b_in, 45)
+        d_out = self.rol(d_in ^ b_in, 45)
         assert a_out < (1 << 64)
         assert b_out < (1 << 64)
         assert c_out < (1 << 64)


### PR DESCRIPTION
Since XOR works on each bit independently, we can do the XOR before rotating the inputs by 45 bits. This way, we only have to rotate one thing (the XOR'd value) and the result is somewhat faster. Standalone otbnsim gets a little bit faster (~2.5%) with this change.