### PR TITLE
[crypto] Rename uint8_buf to byte_buf.

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -204,7 +204,7 @@ static status_t num_padded_blocks_get(size_t plaintext_len,
  * @param padding Padding mode.
  * @returns Number of AES blocks required.
  */
-static status_t get_block(crypto_const_uint8_buf_t input, aes_padding_t padding,
+static status_t get_block(crypto_const_byte_buf_t input, aes_padding_t padding,
                           size_t index, aes_block_t *block) {
   size_t num_full_blocks = input.len / kAesBlockNumBytes;
 
@@ -244,12 +244,11 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
 }
 
 crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
-                             crypto_uint8_buf_t iv,
-                             block_cipher_mode_t aes_mode,
+                             crypto_byte_buf_t iv, block_cipher_mode_t aes_mode,
                              aes_operation_t aes_operation,
-                             crypto_const_uint8_buf_t cipher_input,
+                             crypto_const_byte_buf_t cipher_input,
                              aes_padding_t aes_padding,
-                             crypto_uint8_buf_t cipher_output) {
+                             crypto_byte_buf_t cipher_output) {
   // Check for NULL pointers in input pointers and data buffers.
   if (key == NULL || (aes_mode != kBlockCipherModeEcb && iv.data == NULL) ||
       cipher_input.data == NULL || cipher_output.data == NULL) {
@@ -464,12 +463,12 @@ status_t aes_gcm_check_tag_length(size_t byte_len, aead_gcm_tag_len_t tag_len) {
 }
 
 crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
-                                         crypto_const_uint8_buf_t plaintext,
-                                         crypto_const_uint8_buf_t iv,
-                                         crypto_const_uint8_buf_t aad,
+                                         crypto_const_byte_buf_t plaintext,
+                                         crypto_const_byte_buf_t iv,
+                                         crypto_const_byte_buf_t aad,
                                          aead_gcm_tag_len_t tag_len,
-                                         crypto_uint8_buf_t *ciphertext,
-                                         crypto_uint8_buf_t *auth_tag) {
+                                         crypto_byte_buf_t *ciphertext,
+                                         crypto_byte_buf_t *auth_tag) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || iv.data == NULL || ciphertext == NULL ||
@@ -507,10 +506,10 @@ crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
 }
 
 crypto_status_t otcrypto_aes_decrypt_gcm(
-    const crypto_blinded_key_t *key, crypto_const_uint8_buf_t ciphertext,
-    crypto_const_uint8_buf_t iv, crypto_const_uint8_buf_t aad,
-    aead_gcm_tag_len_t tag_len, crypto_const_uint8_buf_t auth_tag,
-    crypto_uint8_buf_t *plaintext, hardened_bool_t *success) {
+    const crypto_blinded_key_t *key, crypto_const_byte_buf_t ciphertext,
+    crypto_const_byte_buf_t iv, crypto_const_byte_buf_t aad,
+    aead_gcm_tag_len_t tag_len, crypto_const_byte_buf_t auth_tag,
+    crypto_byte_buf_t *plaintext, hardened_bool_t *success) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
   // buffers.
   if (key == NULL || iv.data == NULL || plaintext == NULL ||
@@ -594,7 +593,7 @@ crypto_status_t otcrypto_gcm_ghash_init(const crypto_blinded_key_t *hash_subkey,
 }
 
 crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
-                                          crypto_const_uint8_buf_t input) {
+                                          crypto_const_byte_buf_t input) {
   if (ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -610,7 +609,7 @@ crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
 }
 
 crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
-                                         crypto_uint8_buf_t digest) {
+                                         crypto_byte_buf_t digest) {
   if (ctx == NULL || digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -631,9 +630,9 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
 }
 
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
-                                      crypto_const_uint8_buf_t icb,
-                                      crypto_const_uint8_buf_t input,
-                                      crypto_uint8_buf_t output) {
+                                      crypto_const_byte_buf_t icb,
+                                      crypto_const_byte_buf_t input,
+                                      crypto_byte_buf_t output) {
   if (key == NULL || icb.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -670,12 +669,12 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
 
 crypto_status_t otcrypto_aes_kwp_encrypt(
     const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_uint8_buf_t *wrapped_key) {
+    const crypto_blinded_key_t *key_kek, crypto_byte_buf_t *wrapped_key) {
   // TODO: AES-KWP is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_uint8_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_byte_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key) {
   // TODO: AES-KWP is not yet implemented.

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -24,7 +24,7 @@
  * @return OK or error.
  */
 static crypto_status_t seed_material_construct(
-    crypto_uint8_buf_t value, entropy_seed_material_t *seed_material) {
+    crypto_byte_buf_t value, entropy_seed_material_t *seed_material) {
   if (value.len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -59,7 +59,7 @@ static crypto_status_t seed_material_construct(
  * @return OK or error.
  */
 static crypto_status_t seed_material_xor(
-    crypto_uint8_buf_t value, entropy_seed_material_t *seed_material) {
+    crypto_byte_buf_t value, entropy_seed_material_t *seed_material) {
   if (value.len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -82,7 +82,7 @@ static crypto_status_t seed_material_xor(
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string) {
+crypto_status_t otcrypto_drbg_instantiate(crypto_byte_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -96,7 +96,7 @@ crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string) {
                                    &seed_material);
 }
 
-crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input) {
+crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -110,7 +110,7 @@ crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input) {
 }
 
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t perso_string) {
+    crypto_byte_buf_t entropy, crypto_byte_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -130,7 +130,7 @@ crypto_status_t otcrypto_drbg_manual_instantiate(
 }
 
 crypto_status_t otcrypto_drbg_manual_reseed(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t additional_input) {
+    crypto_byte_buf_t entropy, crypto_byte_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -149,9 +149,9 @@ crypto_status_t otcrypto_drbg_manual_reseed(
                               &seed_material);
 }
 
-crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
+crypto_status_t otcrypto_drbg_generate(crypto_byte_buf_t additional_input,
                                        size_t output_len,
-                                       crypto_uint8_buf_t *drbg_output) {
+                                       crypto_byte_buf_t *drbg_output) {
   if (output_len == 0) {
     // Nothing to do.
     return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -25,7 +25,7 @@ crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
 }
 
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
-                                    crypto_const_uint8_buf_t input_message,
+                                    crypto_const_byte_buf_t input_message,
                                     const ecc_curve_t *elliptic_curve,
                                     const ecc_signature_t *signature) {
   HARDENED_TRY(otcrypto_ecdsa_sign_async_start(private_key, input_message,
@@ -34,7 +34,7 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
 }
 
 crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
-                                      crypto_const_uint8_buf_t input_message,
+                                      crypto_const_byte_buf_t input_message,
                                       const ecc_signature_t *signature,
                                       const ecc_curve_t *elliptic_curve,
                                       hardened_bool_t *verification_result) {
@@ -69,7 +69,7 @@ crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
 }
 
 crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
-                                      crypto_const_uint8_buf_t input_message,
+                                      crypto_const_byte_buf_t input_message,
                                       eddsa_sign_mode_t sign_mode,
                                       const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
@@ -78,7 +78,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature, hardened_bool_t *verification_result) {
   // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
@@ -354,7 +354,7 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
  */
 static status_t internal_ecdsa_p256_sign_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message) {
+    crypto_const_byte_buf_t input_message) {
   if (private_key->config.hw_backed != kHardenedBoolFalse) {
     // TODO: Implement support for sideloaded keys.
     return OTCRYPTO_NOT_IMPLEMENTED;
@@ -385,7 +385,7 @@ static status_t internal_ecdsa_p256_sign_start(
 
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, const ecc_curve_t *elliptic_curve) {
+    crypto_const_byte_buf_t input_message, const ecc_curve_t *elliptic_curve) {
   if (private_key == NULL || elliptic_curve == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -498,7 +498,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(
  * @return OK or error.
  */
 static status_t internal_ecdsa_p256_verify_start(
-    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    const ecc_public_key_t *public_key, crypto_const_byte_buf_t input_message,
     const ecc_signature_t *signature) {
   // Check the public key size.
   HARDENED_TRY(p256_public_key_length_check(public_key));
@@ -532,7 +532,7 @@ static status_t internal_ecdsa_p256_verify_start(
 }
 
 crypto_status_t otcrypto_ecdsa_verify_async_start(
-    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    const ecc_public_key_t *public_key, crypto_const_byte_buf_t input_message,
     const ecc_signature_t *signature, const ecc_curve_t *elliptic_curve) {
   if (public_key == NULL || elliptic_curve == NULL || signature == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -925,7 +925,7 @@ crypto_status_t otcrypto_ed25519_keygen_async_finalize(
 
 crypto_status_t otcrypto_ed25519_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
@@ -939,7 +939,7 @@ crypto_status_t otcrypto_ed25519_sign_async_finalize(
 
 crypto_status_t otcrypto_ed25519_verify_async_start(
     const crypto_unblinded_key_t *public_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature) {
   // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -174,8 +174,8 @@ static status_t get_digest_size(hash_mode_t hash_mode, size_t *digest_len) {
  * @param[out] digest Output digest.
  */
 OT_WARN_UNUSED_RESULT
-static status_t hmac_sha256(crypto_const_uint8_buf_t message,
-                            crypto_uint8_buf_t *digest) {
+static status_t hmac_sha256(crypto_const_byte_buf_t message,
+                            crypto_byte_buf_t *digest) {
   HARDENED_CHECK_EQ(digest->len, kHmacDigestNumBytes);
 
   // Initialize the hardware.
@@ -192,9 +192,9 @@ static status_t hmac_sha256(crypto_const_uint8_buf_t message,
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
+crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
                               hash_mode_t hash_mode,
-                              crypto_uint8_buf_t *digest) {
+                              crypto_byte_buf_t *digest) {
   if (input_message.data == NULL && input_message.len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -245,12 +245,12 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
+crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
                              xof_mode_t xof_mode,
-                             crypto_const_uint8_buf_t function_name_string,
-                             crypto_const_uint8_buf_t customization_string,
+                             crypto_const_byte_buf_t function_name_string,
+                             crypto_const_byte_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_uint8_buf_t *digest) {
+                             crypto_byte_buf_t *digest) {
   // TODO: (#16410) Add error checks
   if (required_output_len != digest->len) {
     return OTCRYPTO_BAD_ARGS;
@@ -329,7 +329,7 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
 }
 
 crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
-                                     crypto_const_uint8_buf_t input_message) {
+                                     crypto_const_byte_buf_t input_message) {
   if (ctx == NULL || (input_message.data == NULL && input_message.len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -368,7 +368,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
 }
 
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_uint8_buf_t *digest) {
+                                    crypto_byte_buf_t *digest) {
   if (ctx == NULL || digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -11,13 +11,13 @@
 #define MODULE_ID MAKE_MODULE_ID('k', 't', 'r')
 
 crypto_status_t otcrypto_build_unblinded_key(
-    crypto_const_uint8_buf_t plain_key, key_mode_t key_mode,
+    crypto_const_byte_buf_t plain_key, key_mode_t key_mode,
     crypto_unblinded_key_t unblinded_key) {
   // TODO: implement key transport functions.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
-crypto_status_t otcrypto_build_blinded_key(crypto_const_uint8_buf_t plain_key,
+crypto_status_t otcrypto_build_blinded_key(crypto_const_byte_buf_t plain_key,
                                            crypto_blinded_key_t blinded_key) {
   // TODO: implement key transport functions.
   return OTCRYPTO_NOT_IMPLEMENTED;

--- a/sw/device/lib/crypto/impl/keyblob_unittest.cc
+++ b/sw/device/lib/crypto/impl/keyblob_unittest.cc
@@ -23,7 +23,7 @@ constexpr crypto_key_config_t kConfigCtr128 = {
     .key_mode = kKeyModeAesCtr,
     .key_length = 16,
     .hw_backed = kHardenedBoolFalse,
-    .diversification_hw_backed = {.data = NULL, .len = 0},
+    .diversification_hw_backed = {.len = 0, .data = NULL},
     .security_level = kSecurityLevelLow,
 };
 
@@ -34,7 +34,7 @@ constexpr crypto_key_config_t kConfigOddBytes = {
     .key_mode = kKeyModeAesCtr,
     .key_length = 31,
     .hw_backed = kHardenedBoolFalse,
-    .diversification_hw_backed = {.data = NULL, .len = 0},
+    .diversification_hw_backed = {.len = 0, .data = NULL},
     .security_level = kSecurityLevelLow,
 };
 
@@ -45,7 +45,7 @@ constexpr crypto_key_config_t kConfigHuge = {
     .key_mode = kKeyModeAesCtr,
     .key_length = SIZE_MAX,
     .hw_backed = kHardenedBoolFalse,
-    .diversification_hw_backed = {.data = NULL, .len = 0},
+    .diversification_hw_backed = {.len = 0, .data = NULL},
     .security_level = kSecurityLevelLow,
 };
 

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -106,8 +106,8 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
 
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
-                              crypto_const_uint8_buf_t input_message,
-                              crypto_uint8_buf_t *tag) {
+                              crypto_const_byte_buf_t input_message,
+                              crypto_byte_buf_t *tag) {
   // Compute HMAC using the streaming API.
   hmac_context_t ctx;
   HARDENED_TRY(otcrypto_hmac_init(&ctx, key));
@@ -117,11 +117,11 @@ crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
 
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
-                              crypto_const_uint8_buf_t input_message,
+                              crypto_const_byte_buf_t input_message,
                               kmac_mode_t kmac_mode,
-                              crypto_const_uint8_buf_t customization_string,
+                              crypto_const_byte_buf_t customization_string,
                               size_t required_output_len,
-                              crypto_uint8_buf_t *tag) {
+                              crypto_byte_buf_t *tag) {
   // TODO (#16410) Revisit/complete error checks
 
   // Check for null pointers.
@@ -252,7 +252,7 @@ crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
 }
 
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
-                                     crypto_const_uint8_buf_t input_message) {
+                                     crypto_const_byte_buf_t input_message) {
   if (ctx == NULL || (input_message.data == NULL && input_message.len != 0)) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -266,7 +266,7 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
 }
 
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_uint8_buf_t *tag) {
+                                    crypto_byte_buf_t *tag) {
   if (ctx == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -23,20 +23,20 @@ crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
 }
 
 crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
-                                  crypto_const_uint8_buf_t input_message,
+                                  crypto_const_byte_buf_t input_message,
                                   rsa_padding_t padding_mode,
                                   rsa_hash_t hash_mode,
-                                  crypto_uint8_buf_t *signature) {
+                                  crypto_byte_buf_t *signature) {
   HARDENED_TRY(otcrypto_rsa_sign_async_start(rsa_private_key, input_message,
                                              padding_mode, hash_mode));
   return otcrypto_rsa_sign_async_finalize(signature);
 }
 
 crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
-                                    crypto_const_uint8_buf_t input_message,
+                                    crypto_const_byte_buf_t input_message,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
-                                    crypto_const_uint8_buf_t signature,
+                                    crypto_const_byte_buf_t signature,
                                     hardened_bool_t *verification_result) {
   HARDENED_TRY(otcrypto_rsa_verify_async_start(rsa_public_key, signature));
   return otcrypto_rsa_verify_async_finalize(input_message, padding_mode,
@@ -255,7 +255,7 @@ crypto_status_t otcrypto_rsa_keygen_async_finalize(
 
 crypto_status_t otcrypto_rsa_sign_async_start(
     const rsa_private_key_t *rsa_private_key,
-    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    crypto_const_byte_buf_t input_message, rsa_padding_t padding_mode,
     rsa_hash_t hash_mode) {
   // Check the caller-provided private key buffer.
   HARDENED_TRY(private_key_structural_check(rsa_private_key));
@@ -310,8 +310,7 @@ crypto_status_t otcrypto_rsa_sign_async_start(
   return OTCRYPTO_FATAL_ERR;
 }
 
-crypto_status_t otcrypto_rsa_sign_async_finalize(
-    crypto_uint8_buf_t *signature) {
+crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_byte_buf_t *signature) {
   // Check for NULL pointers.
   if (signature == NULL || signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -339,8 +338,7 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(
 }
 
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key,
-    crypto_const_uint8_buf_t signature) {
+    const rsa_public_key_t *rsa_public_key, crypto_const_byte_buf_t signature) {
   // Check the caller-provided public key buffer.
   HARDENED_TRY(public_key_structural_check(rsa_public_key));
 
@@ -399,7 +397,7 @@ crypto_status_t otcrypto_rsa_verify_async_start(
 }
 
 crypto_status_t otcrypto_rsa_verify_async_finalize(
-    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    crypto_const_byte_buf_t input_message, rsa_padding_t padding_mode,
     rsa_hash_t hash_mode, hardened_bool_t *verification_result) {
   // Initialize verification result to false by default.
   *verification_result = kHardenedBoolFalse;

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -156,12 +156,11 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
  * @return The result of the cipher operation.
  */
 crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
-                             crypto_uint8_buf_t iv,
-                             block_cipher_mode_t aes_mode,
+                             crypto_byte_buf_t iv, block_cipher_mode_t aes_mode,
                              aes_operation_t aes_operation,
-                             crypto_const_uint8_buf_t cipher_input,
+                             crypto_const_byte_buf_t cipher_input,
                              aes_padding_t aes_padding,
-                             crypto_uint8_buf_t cipher_output);
+                             crypto_byte_buf_t cipher_output);
 
 /**
  * Performs the AES-GCM authenticated encryption operation.
@@ -188,12 +187,12 @@ crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
  * operation
  */
 crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
-                                         crypto_const_uint8_buf_t plaintext,
-                                         crypto_const_uint8_buf_t iv,
-                                         crypto_const_uint8_buf_t aad,
+                                         crypto_const_byte_buf_t plaintext,
+                                         crypto_const_byte_buf_t iv,
+                                         crypto_const_byte_buf_t aad,
                                          aead_gcm_tag_len_t tag_len,
-                                         crypto_uint8_buf_t *ciphertext,
-                                         crypto_uint8_buf_t *auth_tag);
+                                         crypto_byte_buf_t *ciphertext,
+                                         crypto_byte_buf_t *auth_tag);
 
 /**
  * Performs the AES-GCM authenticated decryption operation.
@@ -223,10 +222,10 @@ crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
  * operation
  */
 crypto_status_t otcrypto_aes_decrypt_gcm(
-    const crypto_blinded_key_t *key, crypto_const_uint8_buf_t ciphertext,
-    crypto_const_uint8_buf_t iv, crypto_const_uint8_buf_t aad,
-    aead_gcm_tag_len_t tag_len, crypto_const_uint8_buf_t auth_tag,
-    crypto_uint8_buf_t *plaintext, hardened_bool_t *success);
+    const crypto_blinded_key_t *key, crypto_const_byte_buf_t ciphertext,
+    crypto_const_byte_buf_t iv, crypto_const_byte_buf_t aad,
+    aead_gcm_tag_len_t tag_len, crypto_const_byte_buf_t auth_tag,
+    crypto_byte_buf_t *plaintext, hardened_bool_t *success);
 
 /**
  * Internal GHASH operation of Galois Counter Mode (GCM).
@@ -266,7 +265,7 @@ crypto_status_t otcrypto_gcm_ghash_init(const crypto_blinded_key_t *hash_subkey,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
-                                          crypto_const_uint8_buf_t input);
+                                          crypto_const_byte_buf_t input);
 
 /**
  * Internal GHASH operation of Galois Counter Mode (GCM).
@@ -286,7 +285,7 @@ crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
-                                         crypto_uint8_buf_t digest);
+                                         crypto_byte_buf_t digest);
 
 /**
  * Internal AES-GCTR operation of AES Galois Counter Mode (AES-GCM).
@@ -307,9 +306,9 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
-                                      crypto_const_uint8_buf_t icb,
-                                      crypto_const_uint8_buf_t input,
-                                      crypto_uint8_buf_t output);
+                                      crypto_const_byte_buf_t icb,
+                                      crypto_const_byte_buf_t input,
+                                      crypto_byte_buf_t output);
 
 /**
  * Performs the AES-KWP authenticated encryption operation.
@@ -329,7 +328,7 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_kwp_encrypt(
     const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_uint8_buf_t *wrapped_key);
+    const crypto_blinded_key_t *key_kek, crypto_byte_buf_t *wrapped_key);
 
 /**
  * Performs the AES-KWP authenticated decryption operation.
@@ -342,7 +341,7 @@ crypto_status_t otcrypto_aes_kwp_encrypt(
  * @param[out] unwrapped_key Pointer to the output unwrapped key struct.
  * @return Result of the aes-kwp decrypt operation.
  */
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_uint8_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_byte_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key);
 

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -74,29 +74,33 @@ typedef enum crypto_status_value {
 } crypto_status_value_t;
 
 /**
- * Struct to handle crypto data buffer with pointer and length.
- * Note: If the crypto_uint8_buf_t is used for output data, it is
- * expected that the user (1) sets the length of the expected output
- * in the `len` field, and (2) allocates the required space for buffer
- * (`len` bytes). If the output length set by the user doesn’t match
- * the generated output length, an error is thrown and code exits.
+ * Struct to hold a fixed-length byte array.
+ *
+ * Note: the caller must (1) allocate sufficient space and (2) set the `len`
+ * field and `data` pointer when `crypto_byte_buf_t` is used for output. The
+ * crypto library will throw an error if `len` doesn't match expectations.
  */
-typedef struct crypto_uint8_buf {
+typedef struct crypto_byte_buf {
+  // Length of the data in bytes.
+  size_t len;
   // Pointer to the data.
   uint8_t *data;
-  // Length of the data in bytes.
-  size_t len;
-} crypto_uint8_buf_t;
+} crypto_byte_buf_t;
 
 /**
- * Struct to handle crypto const data buffer with pointer and length.
+ * Struct to hold a constant fixed-length byte array.
+ *
+ * The const annotations prevent any changes to the byte buffer. It is
+ * necessary to have this structure separate from `crypto_byte_buf_t` because
+ * data pointed to by a struct does not inherit `const`, so `const
+ * crypto_byte_buf_t` would still allow data to change.
  */
-typedef struct crypto_const_uint8_buf {
-  // Pointer to the data.
-  const uint8_t *data;
+typedef struct crypto_const_byte_buf {
   // Length of the data in bytes.
-  size_t len;
-} crypto_const_uint8_buf_t;
+  const size_t len;
+  // Pointer to the data.
+  const uint8_t *const data;
+} crypto_const_byte_buf_t;
 
 /**
  * Enum to denote the key type of the handled key.
@@ -318,7 +322,7 @@ typedef struct crypto_key_config {
   hardened_bool_t hw_backed;
   // Diversification input for key manager (ignored and may be
   // `NULL` if `hw_backed` is false).
-  crypto_const_uint8_buf_t diversification_hw_backed;
+  crypto_const_byte_buf_t diversification_hw_backed;
   // Whether the key should be exportable (if this is true,
   // `hw_backed` must be false).
   hardened_bool_t exportable;

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -25,7 +25,7 @@ extern "C" {
  * @param perso_string Pointer to personalization bitstring.
  * @return Result of the DRBG instantiate operation.
  */
-crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string);
+crypto_status_t otcrypto_drbg_instantiate(crypto_byte_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -36,7 +36,7 @@ crypto_status_t otcrypto_drbg_instantiate(crypto_uint8_buf_t perso_string);
  * @param additional_input Pointer to the additional input for DRBG.
  * @return Result of the DRBG reseed operation.
  */
-crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input);
+crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input);
 
 /**
  * Instantiates the DRBG system.
@@ -53,7 +53,7 @@ crypto_status_t otcrypto_drbg_reseed(crypto_uint8_buf_t additional_input);
  * @return Result of the DRBG manual instantiation.
  */
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t perso_string);
+    crypto_byte_buf_t entropy, crypto_byte_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -65,8 +65,8 @@ crypto_status_t otcrypto_drbg_manual_instantiate(
  * @param additional_input Pointer to the additional input for DRBG.
  * @return Result of the manual DRBG reseed operation.
  */
-crypto_status_t otcrypto_drbg_manual_reseed(
-    crypto_uint8_buf_t entropy, crypto_uint8_buf_t additional_input);
+crypto_status_t otcrypto_drbg_manual_reseed(crypto_byte_buf_t entropy,
+                                            crypto_byte_buf_t additional_input);
 
 /**
  * DRBG function for generating random bits.
@@ -89,9 +89,9 @@ crypto_status_t otcrypto_drbg_manual_reseed(
  * @param[out] drbg_output Pointer to the generated pseudo random bits.
  * @return Result of the DRBG generate operation.
  */
-crypto_status_t otcrypto_drbg_generate(crypto_uint8_buf_t additional_input,
+crypto_status_t otcrypto_drbg_generate(crypto_byte_buf_t additional_input,
                                        size_t output_len,
-                                       crypto_uint8_buf_t *drbg_output);
+                                       crypto_byte_buf_t *drbg_output);
 
 /**
  * Uninstantiates DRBG and clears the context.

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -61,13 +61,13 @@ typedef struct ecc_public_key {
  */
 typedef struct ecc_domain {
   // Prime P (modulus of coordinate finite field).
-  crypto_const_uint8_buf_t p;
+  crypto_const_byte_buf_t p;
   // Coefficient a.
-  crypto_const_uint8_buf_t a;
+  crypto_const_byte_buf_t a;
   // Coefficient b.
-  crypto_const_uint8_buf_t b;
+  crypto_const_byte_buf_t b;
   // q (order of G).
-  crypto_const_uint8_buf_t q;
+  crypto_const_byte_buf_t q;
   // Value of x coordinate of G (basepoint). Same length as p.
   const uint32_t *gx;
   // Value of y coordinate of G (basepoint). Same length as p.
@@ -149,7 +149,7 @@ crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
-                                    crypto_const_uint8_buf_t input_message,
+                                    crypto_const_byte_buf_t input_message,
                                     const ecc_curve_t *elliptic_curve,
                                     const ecc_signature_t *signature);
 
@@ -170,7 +170,7 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
-                                      crypto_const_uint8_buf_t input_message,
+                                      crypto_const_byte_buf_t input_message,
                                       const ecc_signature_t *signature,
                                       const ecc_curve_t *elliptic_curve,
                                       hardened_bool_t *verification_result);
@@ -258,7 +258,7 @@ crypto_status_t otcrypto_ed25519_keygen(crypto_blinded_key_t *private_key,
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
-                                      crypto_const_uint8_buf_t input_message,
+                                      crypto_const_byte_buf_t input_message,
                                       eddsa_sign_mode_t sign_mode,
                                       const ecc_signature_t *signature);
 
@@ -276,7 +276,7 @@ crypto_status_t otcrypto_ed25519_sign(const crypto_blinded_key_t *private_key,
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ed25519_verify(
     const crypto_unblinded_key_t *public_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature, hardened_bool_t *verification_result);
 
 /**
@@ -378,7 +378,7 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, const ecc_curve_t *elliptic_curve);
+    crypto_const_byte_buf_t input_message, const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous ECDSA digital signature generation.
@@ -415,7 +415,7 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_verify_async_start(
-    const ecc_public_key_t *public_key, crypto_const_uint8_buf_t input_message,
+    const ecc_public_key_t *public_key, crypto_const_byte_buf_t input_message,
     const ecc_signature_t *signature, const ecc_curve_t *elliptic_curve);
 
 /**
@@ -574,7 +574,7 @@ crypto_status_t otcrypto_ed25519_keygen_async_finalize(
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ed25519_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature);
 
 /**
@@ -606,7 +606,7 @@ crypto_status_t otcrypto_ed25519_sign_async_finalize(
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ed25519_verify_async_start(
     const crypto_unblinded_key_t *public_key,
-    crypto_const_uint8_buf_t input_message, eddsa_sign_mode_t sign_mode,
+    crypto_const_byte_buf_t input_message, eddsa_sign_mode_t sign_mode,
     const ecc_signature_t *signature);
 
 /**

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -87,9 +87,8 @@ typedef struct hash_context {
  * @param[out] digest Output digest after hashing the input message.
  * @return Result of the hash operation.
  */
-crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
-                              hash_mode_t hash_mode,
-                              crypto_uint8_buf_t *digest);
+crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
+                              hash_mode_t hash_mode, crypto_byte_buf_t *digest);
 
 /**
  * Performs the required extendable output function on the input data.
@@ -116,12 +115,12 @@ crypto_status_t otcrypto_hash(crypto_const_uint8_buf_t input_message,
  * @param[out] digest Output from the extendable output function.
  * @return Result of the xof operation.
  */
-crypto_status_t otcrypto_xof(crypto_const_uint8_buf_t input_message,
+crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
                              xof_mode_t xof_mode,
-                             crypto_const_uint8_buf_t function_name_string,
-                             crypto_const_uint8_buf_t customization_string,
+                             crypto_const_byte_buf_t function_name_string,
+                             crypto_const_byte_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_uint8_buf_t *digest);
+                             crypto_byte_buf_t *digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.
@@ -158,7 +157,7 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
  * @return Result of the hash update operation.
  */
 crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
-                                     crypto_const_uint8_buf_t input_message);
+                                     crypto_const_byte_buf_t input_message);
 
 /**
  * Performs the FINAL operation for a cryptographic hash function.
@@ -179,7 +178,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
  * @return Result of the hash final operation.
  */
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_uint8_buf_t *digest);
+                                    crypto_byte_buf_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -28,7 +28,7 @@ extern "C" {
  * @return Result of the build unblinded key operation.
  */
 crypto_status_t otcrypto_build_unblinded_key(
-    crypto_const_uint8_buf_t plain_key, key_mode_t key_mode,
+    crypto_const_byte_buf_t plain_key, key_mode_t key_mode,
     crypto_unblinded_key_t unblinded_key);
 
 /**
@@ -51,7 +51,7 @@ crypto_status_t otcrypto_build_unblinded_key(
  * @param[out] blinded_key Destination blinded key struct.
  * @return Result of the build blinded key operation.
  */
-crypto_status_t otcrypto_build_blinded_key(crypto_const_uint8_buf_t plain_key,
+crypto_status_t otcrypto_build_blinded_key(crypto_const_byte_buf_t plain_key,
                                            crypto_blinded_key_t blinded_key);
 
 /**

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -73,8 +73,8 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
  * @return The result of the HMAC operation.
  */
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
-                              crypto_const_uint8_buf_t input_message,
-                              crypto_uint8_buf_t *tag);
+                              crypto_const_byte_buf_t input_message,
+                              crypto_byte_buf_t *tag);
 
 /**
  * Performs the KMAC function on the input data.
@@ -98,11 +98,11 @@ crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
  * @return The result of the KMAC operation.
  */
 crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
-                              crypto_const_uint8_buf_t input_message,
+                              crypto_const_byte_buf_t input_message,
                               kmac_mode_t kmac_mode,
-                              crypto_const_uint8_buf_t customization_string,
+                              crypto_const_byte_buf_t customization_string,
                               size_t required_output_len,
-                              crypto_uint8_buf_t *tag);
+                              crypto_byte_buf_t *tag);
 
 /**
  * Performs the INIT operation for HMAC.
@@ -138,7 +138,7 @@ crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
  * @return Result of the HMAC update operation.
  */
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
-                                     crypto_const_uint8_buf_t input_message);
+                                     crypto_const_byte_buf_t input_message);
 
 /**
  * Performs the FINAL operation for HMAC.
@@ -158,7 +158,7 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
  * @return Result of the HMAC final operation.
  */
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_uint8_buf_t *tag);
+                                    crypto_byte_buf_t *tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -128,10 +128,10 @@ crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
  * @return The result of the RSA signature generation.
  */
 crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
-                                  crypto_const_uint8_buf_t input_message,
+                                  crypto_const_byte_buf_t input_message,
                                   rsa_padding_t padding_mode,
                                   rsa_hash_t hash_mode,
-                                  crypto_uint8_buf_t *signature);
+                                  crypto_byte_buf_t *signature);
 
 /**
  * Verifies the authenticity of the input signature.
@@ -149,10 +149,10 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
  * @return Result of the RSA verify operation.
  */
 crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
-                                    crypto_const_uint8_buf_t input_message,
+                                    crypto_const_byte_buf_t input_message,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
-                                    crypto_const_uint8_buf_t signature,
+                                    crypto_const_byte_buf_t signature,
                                     hardened_bool_t *verification_result);
 
 /**
@@ -204,7 +204,7 @@ crypto_status_t otcrypto_rsa_keygen_async_finalize(
  */
 crypto_status_t otcrypto_rsa_sign_async_start(
     const rsa_private_key_t *rsa_private_key,
-    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    crypto_const_byte_buf_t input_message, rsa_padding_t padding_mode,
     rsa_hash_t hash_mode);
 
 /**
@@ -223,7 +223,7 @@ crypto_status_t otcrypto_rsa_sign_async_start(
  * @param[out] signature Pointer to generated signature struct.
  * @return Result of async RSA sign finalize operation.
  */
-crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_uint8_buf_t *signature);
+crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_byte_buf_t *signature);
 
 /**
  * Starts the asynchronous signature verification function.
@@ -236,7 +236,7 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_uint8_buf_t *signature);
  * @return Result of async RSA verify start operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key, crypto_const_uint8_buf_t signature);
+    const rsa_public_key_t *rsa_public_key, crypto_const_byte_buf_t signature);
 
 /**
  * Finalizes the asynchronous signature verification function.
@@ -255,7 +255,7 @@ crypto_status_t otcrypto_rsa_verify_async_start(
  * @return Result of async RSA verify finalize operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_finalize(
-    crypto_const_uint8_buf_t input_message, rsa_padding_t padding_mode,
+    crypto_const_byte_buf_t input_message, rsa_padding_t padding_mode,
     rsa_hash_t hash_mode, hardened_bool_t *verification_result);
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -38,10 +38,10 @@ static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
     .domain_parameter =
         (ecc_domain_t){
-            .p = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
             .gx = NULL,
             .gy = NULL,
             .cofactor = 0u,
@@ -56,7 +56,7 @@ static const crypto_key_config_t kEcdhPrivateKeyConfig = {
     .key_length = kP256ScalarBytes,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelHigh,
 };
 
@@ -67,7 +67,7 @@ static const crypto_key_config_t kRmaUnlockTokenAesKeyConfig = {
     .key_length = kP256CoordBytes,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelHigh,
 };
 
@@ -117,13 +117,13 @@ OT_WARN_UNUSED_RESULT
 static status_t encrypt_rma_unlock_token(
     crypto_blinded_key_t *aes_key, wrapped_rma_unlock_token_t *wrapped_token) {
   // Construct IV, which since we are using ECB mode, is empty.
-  crypto_uint8_buf_t iv = {
+  crypto_byte_buf_t iv = {
       .data = NULL,
       .len = 0,
   };
 
   // Construct plaintext buffer.
-  crypto_const_uint8_buf_t plaintext = {
+  crypto_const_byte_buf_t plaintext = {
       .data = (const unsigned char *)wrapped_token->data,
       .len = kRmaUnlockTokenSizeInBytes,
   };
@@ -131,7 +131,7 @@ static status_t encrypt_rma_unlock_token(
   // Construct ciphertext buffer. (No need for padding since RMA unlock token
   // is 128-bits already.)
   uint32_t ciphertext_data[kRmaUnlockTokenSizeInBytes];
-  crypto_uint8_buf_t ciphertext = {
+  crypto_byte_buf_t ciphertext = {
       .data = (unsigned char *)ciphertext_data,
       .len = kRmaUnlockTokenSizeInBytes,
   };

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -13,19 +13,19 @@
 status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
                                              size_t token_size,
                                              uint64_t *hashed_token) {
-  crypto_const_uint8_buf_t input = {
+  crypto_const_byte_buf_t input = {
       .data = (uint8_t *)raw_token,
       .len = token_size,
   };
-  crypto_const_uint8_buf_t function_name_string = {
+  crypto_const_byte_buf_t function_name_string = {
       .data = (uint8_t *)"",
       .len = 0,
   };
-  crypto_const_uint8_buf_t customization_string = {
+  crypto_const_byte_buf_t customization_string = {
       .data = (uint8_t *)"LC_CTRL",
       .len = 7,
   };
-  crypto_uint8_buf_t output = {
+  crypto_byte_buf_t output = {
       .data = (uint8_t *)hashed_token,
       .len = token_size,
   };

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
@@ -52,11 +52,11 @@ extern const char _chip_info_start[];
 // We hash the ROM using the SHA256 algorithm and print the hash to the console.
 status_t hash_rom(void) {
   uint32_t rom_hash[kSha256HashSizeIn32BitWords];
-  crypto_const_uint8_buf_t input = {
+  crypto_const_byte_buf_t input = {
       .data = (uint8_t *)TOP_EARLGREY_ROM_BASE_ADDR,
       .len = kGoldenRomSizeBytes,
   };
-  crypto_uint8_buf_t output = {
+  crypto_byte_buf_t output = {
       .data = (uint8_t *)rom_hash,
       .len = kSha256HashSizeInBytes,
   };

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -53,7 +53,7 @@ static crypto_key_config_t make_key_config(const aes_test_t *test) {
       .key_length = test->key_len,
       .hw_backed = kHardenedBoolFalse,
       .diversification_hw_backed =
-          (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+          (crypto_const_byte_buf_t){.data = NULL, .len = 0},
       .security_level = kSecurityLevelLow,
   };
 }
@@ -74,13 +74,13 @@ static void encrypt_decrypt_test(const aes_test_t *test) {
   key.checksum = integrity_blinded_checksum(&key);
 
   // Construct IV buffer.
-  crypto_uint8_buf_t iv = {
+  crypto_byte_buf_t iv = {
       .data = (unsigned char *)test->iv,
       .len = kAesBlockBytes,
   };
 
   // Construct plaintext buffer.
-  crypto_const_uint8_buf_t plaintext = {
+  crypto_const_byte_buf_t plaintext = {
       .data = (const unsigned char *)test->plaintext,
       .len = test->plaintext_len,
   };
@@ -93,7 +93,7 @@ static void encrypt_decrypt_test(const aes_test_t *test) {
 
   // Create buffer for ciphertext.
   uint32_t ciphertext_data[padded_len_bytes / sizeof(uint32_t)];
-  crypto_uint8_buf_t ciphertext = {
+  crypto_byte_buf_t ciphertext = {
       .data = (unsigned char *)ciphertext_data,
       .len = padded_len_bytes,
   };
@@ -106,14 +106,14 @@ static void encrypt_decrypt_test(const aes_test_t *test) {
                   ARRAYSIZE(ciphertext_data));
 
   // Create a const buffer for the ciphertext.
-  crypto_const_uint8_buf_t const_ciphertext = {
+  crypto_const_byte_buf_t const_ciphertext = {
       .data = (const unsigned char *)ciphertext_data,
       .len = padded_len_bytes,
   };
 
   // Construct a buffer for the recovered plaintext.
   uint32_t recovered_plaintext_data[ARRAYSIZE(ciphertext_data)];
-  crypto_uint8_buf_t recovered_plaintext = {
+  crypto_byte_buf_t recovered_plaintext = {
       .data = (unsigned char *)recovered_plaintext_data,
       .len = padded_len_bytes,
   };

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -58,7 +58,7 @@ uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
       .key_length = test.key_len * sizeof(uint32_t),
       .hw_backed = kHardenedBoolFalse,
       .diversification_hw_backed =
-          (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+          (crypto_const_byte_buf_t){.data = NULL, .len = 0},
       .security_level = kSecurityLevelLow,
   };
 
@@ -78,27 +78,27 @@ uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
   // Set the checksum.
   key.checksum = integrity_blinded_checksum(&key);
 
-  crypto_const_uint8_buf_t iv = {
+  crypto_const_byte_buf_t iv = {
       .data = test.iv,
       .len = test.iv_len,
   };
-  crypto_const_uint8_buf_t plaintext = {
+  crypto_const_byte_buf_t plaintext = {
       .data = test.plaintext,
       .len = test.plaintext_len,
   };
-  crypto_const_uint8_buf_t aad = {
+  crypto_const_byte_buf_t aad = {
       .data = test.aad,
       .len = test.aad_len,
   };
 
   uint8_t actual_tag_data[test.tag_len];
-  crypto_uint8_buf_t actual_tag = {
+  crypto_byte_buf_t actual_tag = {
       .data = actual_tag_data,
       .len = sizeof(actual_tag_data),
   };
 
   uint8_t actual_ciphertext_data[test.plaintext_len];
-  crypto_uint8_buf_t actual_ciphertext = {
+  crypto_byte_buf_t actual_ciphertext = {
       .data = actual_ciphertext_data,
       .len = sizeof(actual_ciphertext_data),
   };
@@ -131,7 +131,7 @@ uint32_t call_aes_gcm_decrypt(aes_gcm_test_t test, bool tag_valid) {
       .key_length = test.key_len * sizeof(uint32_t),
       .hw_backed = kHardenedBoolFalse,
       .diversification_hw_backed =
-          (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+          (crypto_const_byte_buf_t){.data = NULL, .len = 0},
       .security_level = kSecurityLevelLow,
   };
 
@@ -151,25 +151,25 @@ uint32_t call_aes_gcm_decrypt(aes_gcm_test_t test, bool tag_valid) {
   // Set the checksum.
   key.checksum = integrity_blinded_checksum(&key);
 
-  crypto_const_uint8_buf_t iv = {
+  crypto_const_byte_buf_t iv = {
       .data = test.iv,
       .len = test.iv_len,
   };
-  crypto_const_uint8_buf_t ciphertext = {
+  crypto_const_byte_buf_t ciphertext = {
       .data = test.ciphertext,
       .len = test.plaintext_len,
   };
-  crypto_const_uint8_buf_t aad = {
+  crypto_const_byte_buf_t aad = {
       .data = test.aad,
       .len = test.aad_len,
   };
-  crypto_const_uint8_buf_t tag = {
+  crypto_const_byte_buf_t tag = {
       .data = test.tag,
       .len = test.tag_len,
   };
 
   uint8_t actual_plaintext_data[test.plaintext_len];
-  crypto_uint8_buf_t actual_plaintext = {
+  crypto_byte_buf_t actual_plaintext = {
       .data = actual_plaintext_data,
       .len = sizeof(actual_plaintext_data),
   };

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -25,7 +25,7 @@ static uint32_t kExpOutput[16] = {
     0x771c619b, 0xdf82ab22, 0x80b1dc2f, 0x2581f391, 0x64f7ac0c, 0x510494b3,
     0xa43c41b7, 0xdb17514c, 0x87b107ae, 0x793e01c5,
 };
-static const crypto_uint8_buf_t kEmptyBuffer = {
+static const crypto_byte_buf_t kEmptyBuffer = {
     .data = NULL,
     .len = 0,
 };
@@ -40,7 +40,7 @@ static status_t entropy_complex_init_test(void) {
 }
 
 static status_t kat_test(void) {
-  crypto_uint8_buf_t entropy = {
+  crypto_byte_buf_t entropy = {
       .data = (unsigned char *)kTestSeed,
       .len = sizeof(kTestSeed),
   };
@@ -49,7 +49,7 @@ static status_t kat_test(void) {
   TRY(otcrypto_drbg_manual_instantiate(entropy, /*perso_string=*/kEmptyBuffer));
 
   uint32_t actual_output_words[ARRAYSIZE(kExpOutput)];
-  crypto_uint8_buf_t actual_output = {
+  crypto_byte_buf_t actual_output = {
       .data = (unsigned char *)actual_output_words,
       .len = sizeof(actual_output_words),
   };

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -16,10 +16,10 @@ static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
     .domain_parameter =
         (ecc_domain_t){
-            .p = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
             .gx = NULL,
             .gy = NULL,
             .cofactor = 0u,
@@ -34,7 +34,7 @@ static const crypto_key_config_t kEcdhPrivateKeyConfig = {
     .key_length = kP256ScalarBytes,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelLow,
 };
 
@@ -47,7 +47,7 @@ static const crypto_key_config_t kEcdhSharedKeyConfig = {
     .key_length = kP256CoordBytes,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelLow,
 };
 

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -19,10 +19,10 @@ static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
     .domain_parameter =
         (ecc_domain_t){
-            .p = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
             .gx = NULL,
             .gy = NULL,
             .cofactor = 0u,
@@ -36,7 +36,7 @@ static const crypto_key_config_t kPrivateKeyConfig = {
     .key_length = 258 / 8,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelLow,
 };
 
@@ -75,7 +75,7 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
       otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
 
   // Package message in a cryptolib-style struct.
-  crypto_const_uint8_buf_t message = {
+  crypto_const_byte_buf_t message = {
       .len = sizeof(kMessage) - 1,
       .data = (unsigned char *)&kMessage,
   };

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -55,8 +55,7 @@ static const uint32_t kTestMask[ARRAYSIZE(kLongTestKey)] = {
  * @return Result (OK or error).
  */
 static status_t run_test(const uint32_t *key, size_t key_len,
-                         crypto_const_uint8_buf_t msg,
-                         const uint32_t *exp_tag) {
+                         crypto_const_byte_buf_t msg, const uint32_t *exp_tag) {
   // Construct blinded key.
   crypto_key_config_t config = {
       .version = kCryptoLibVersion1,
@@ -79,7 +78,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
   blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
-  crypto_uint8_buf_t tag_buf = {
+  crypto_byte_buf_t tag_buf = {
       .data = (unsigned char *)act_tag,
       .len = sizeof(act_tag),
   };
@@ -97,7 +96,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
  */
 static status_t simple_test(void) {
   const char plaintext[] = "Test message.";
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };
@@ -119,7 +118,7 @@ static status_t empty_test(void) {
       0xbb5c42a9, 0x0e3ad140, 0x61679107, 0xa34a6cc0,
       0x53306979, 0xfa8a5061, 0xbc8b2ee6, 0xa499c0a5,
   };
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = NULL,
       .len = 0,
   };
@@ -134,7 +133,7 @@ static status_t empty_test(void) {
  */
 static status_t short_key_test(void) {
   const char plaintext[] = "Test message.";
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };
@@ -153,7 +152,7 @@ static status_t short_key_test(void) {
  */
 static status_t long_key_test(void) {
   const char plaintext[] = "Test message.";
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };

--- a/sw/device/tests/crypto/kmac_verify_functest.c
+++ b/sw/device/tests/crypto/kmac_verify_functest.c
@@ -29,7 +29,7 @@ bool test_main(void) {
              current_test_vector->vector_identifier);
 
     uint8_t digest[current_test_vector->digest.len];
-    crypto_uint8_buf_t digest_buf = {
+    crypto_byte_buf_t digest_buf = {
         .data = digest,
         .len = current_test_vector->digest.len,
     };

--- a/sw/device/tests/crypto/kmac_verify_testvectors.h.tpl
+++ b/sw/device/tests/crypto/kmac_verify_testvectors.h.tpl
@@ -33,10 +33,10 @@ typedef struct kmac_test_vector {
   hash_mode_t hash_mode;
   kmac_mode_t mac_mode;
   crypto_blinded_key_t key;
-  crypto_const_uint8_buf_t input_msg;
-  crypto_const_uint8_buf_t func_name;
-  crypto_const_uint8_buf_t cust_str;
-  crypto_const_uint8_buf_t digest;
+  crypto_const_byte_buf_t input_msg;
+  crypto_const_byte_buf_t func_name;
+  crypto_const_byte_buf_t cust_str;
+  crypto_const_byte_buf_t digest;
 } kmac_test_vector_t;
 
 static size_t nist_kmac_nr_of_vectors = ${len(tests)};

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -32,7 +32,7 @@ static const crypto_key_config_t kRsaPrivateKeyConfig = {
     .key_length = kRsa2048NumBytes,
     .hw_backed = kHardenedBoolFalse,
     .diversification_hw_backed =
-        (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+        (crypto_const_byte_buf_t){.data = NULL, .len = 0},
     .security_level = kSecurityLevelLow,
 };
 
@@ -97,17 +97,17 @@ status_t keygen_then_sign_test(void) {
   }
   TRY_CHECK(d_large_enough);
 
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .len = kTestMessageLen,
       .data = kTestMessage,
   };
 
   uint32_t sig[kRsa2048NumWords];
-  crypto_uint8_buf_t sig_buf = {
+  crypto_byte_buf_t sig_buf = {
       .data = (unsigned char *)sig,
       .len = kRsa2048NumBytes,
   };
-  crypto_const_uint8_buf_t const_sig_buf = {
+  crypto_const_byte_buf_t const_sig_buf = {
       .data = (unsigned char *)sig,
       .len = kRsa2048NumBytes,
   };

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -119,7 +119,7 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .key_length = kRsa2048NumBytes,
       .hw_backed = kHardenedBoolFalse,
       .diversification_hw_backed =
-          (crypto_const_uint8_buf_t){.data = NULL, .len = 0},
+          (crypto_const_byte_buf_t){.data = NULL, .len = 0},
       .security_level = kSecurityLevelLow,
   };
 
@@ -137,12 +137,12 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
   private_key.n.checksum = integrity_unblinded_checksum(&private_key.n);
   private_key.d.checksum = integrity_blinded_checksum(&private_key.d);
 
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = msg,
       .len = msg_len,
   };
 
-  crypto_uint8_buf_t sig_buf = {
+  crypto_byte_buf_t sig_buf = {
       .data = (unsigned char *)sig,
       .len = kRsa2048NumBytes,
   };
@@ -196,12 +196,12 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
   public_key.n.checksum = integrity_unblinded_checksum(&public_key.n);
   public_key.e.checksum = integrity_unblinded_checksum(&public_key.e);
 
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = msg,
       .len = msg_len,
   };
 
-  crypto_const_uint8_buf_t sig_buf = {
+  crypto_const_byte_buf_t sig_buf = {
       .data = (unsigned char *)sig,
       .len = kRsa2048NumBytes,
   };

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -53,10 +53,10 @@ static const uint8_t kExactBlockExpDigest[] = {
  * @param msg Input message.
  * @param exp_digest Expected digest (256 bits).
  */
-static status_t run_test(crypto_const_uint8_buf_t msg,
+static status_t run_test(crypto_const_byte_buf_t msg,
                          const uint32_t *exp_digest) {
   uint32_t act_digest[kHmacDigestNumWords];
-  crypto_uint8_buf_t digest_buf = {
+  crypto_byte_buf_t digest_buf = {
       .data = (unsigned char *)act_digest,
       .len = sizeof(act_digest),
   };
@@ -73,7 +73,7 @@ static status_t run_test(crypto_const_uint8_buf_t msg,
  */
 static status_t simple_test(void) {
   const char plaintext[] = "Test message.";
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };
@@ -95,7 +95,7 @@ static status_t empty_test(void) {
       0x7852b855, 0xa495991b, 0x649b934c, 0x27ae41e4,
       0x996fb924, 0x9afbf4c8, 0x98fc1c14, 0xe3b0c442,
   };
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = NULL,
       .len = 0,
   };
@@ -109,14 +109,14 @@ static status_t one_update_streaming_test(void) {
   hash_context_t ctx;
   TRY(otcrypto_hash_init(&ctx, kHashModeSha256));
 
-  crypto_const_uint8_buf_t msg_buf = {
+  crypto_const_byte_buf_t msg_buf = {
       .data = kExactBlockMessage,
       .len = kExactBlockMessageLen,
   };
   TRY(otcrypto_hash_update(&ctx, msg_buf));
 
   uint8_t act_digest[ARRAYSIZE(kExactBlockExpDigest)];
-  crypto_uint8_buf_t digest_buf = {
+  crypto_byte_buf_t digest_buf = {
       .data = act_digest,
       .len = sizeof(act_digest),
   };
@@ -139,7 +139,7 @@ static status_t multiple_update_streaming_test(void) {
   size_t update_size = 0;
   while (len > 0) {
     update_size = len <= update_size ? len : update_size;
-    crypto_const_uint8_buf_t msg_buf = {
+    crypto_const_byte_buf_t msg_buf = {
         .data = next,
         .len = update_size,
     };
@@ -149,7 +149,7 @@ static status_t multiple_update_streaming_test(void) {
     TRY(otcrypto_hash_update(&ctx, msg_buf));
   }
   uint8_t act_digest[ARRAYSIZE(kTwoBlockExpDigest)];
-  crypto_uint8_buf_t digest_buf = {
+  crypto_byte_buf_t digest_buf = {
       .data = act_digest,
       .len = sizeof(act_digest),
   };

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -40,14 +40,14 @@ static const uint8_t kTwoBlockExpDigest[] = {
 status_t sha384_test(const unsigned char *msg, const size_t msg_len,
                      const uint8_t *expected_digest) {
   // Construct a buffer for the message.
-  crypto_const_uint8_buf_t input_message = {
+  crypto_const_byte_buf_t input_message = {
       .data = msg,
       .len = msg_len,
   };
 
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[384 / 8];
-  crypto_uint8_buf_t actual_digest = {
+  crypto_byte_buf_t actual_digest = {
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
@@ -72,7 +72,7 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
   while (msg_len > 0) {
     // Construct a buffer for the next update.
     size_t len = (msg_len <= 5) ? msg_len : 5;
-    crypto_const_uint8_buf_t input_message = {
+    crypto_const_byte_buf_t input_message = {
         .data = msg,
         .len = len,
     };
@@ -83,7 +83,7 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[384 / 8];
-  crypto_uint8_buf_t actual_digest = {
+  crypto_byte_buf_t actual_digest = {
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -45,14 +45,14 @@ static const uint8_t kTwoBlockExpDigest[] = {
 status_t sha512_test(const unsigned char *msg, const size_t msg_len,
                      const uint8_t *expected_digest) {
   // Construct a buffer for the message.
-  crypto_const_uint8_buf_t input_message = {
+  crypto_const_byte_buf_t input_message = {
       .data = msg,
       .len = msg_len,
   };
 
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[512 / 8];
-  crypto_uint8_buf_t actual_digest = {
+  crypto_byte_buf_t actual_digest = {
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };
@@ -77,7 +77,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
   while (msg_len > 0) {
     // Construct a buffer for the next update.
     size_t len = (msg_len <= 5) ? msg_len : 5;
-    crypto_const_uint8_buf_t input_message = {
+    crypto_const_byte_buf_t input_message = {
         .data = msg,
         .len = len,
     };
@@ -88,7 +88,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint8_t actual_digest_data[512 / 8];
-  crypto_uint8_buf_t actual_digest = {
+  crypto_byte_buf_t actual_digest = {
       .data = (unsigned char *)actual_digest_data,
       .len = sizeof(actual_digest_data),
   };


### PR DESCRIPTION
This is a little nicer to read and analogous to `word_buf`, which I am about to introduce in an upcoming PR (see #19549). 
Also lightly edit the docstring and insert some `const`s to prevent the pointer or size from changing underneath constant byte buffers.

Everything outside of `datatypes.h` is the work of `sed` and `clang-format`.

CC @y-srini for visibility on API changes.