### PR TITLE
[doc] Add boot log documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -452,6 +452,7 @@
       - [Signoff Test Plan](./sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson)
       - [Shutdown Specification](./sw/device/silicon_creator/rom/doc/shutdown.md)
     - [Manifest Format](./sw/device/silicon_creator/rom_ext/doc/manifest.md)
+    - [Boot Log](./sw/device/silicon_creator/doc/boot_log.md)
   - [Top-Level Tests](./sw/device/tests/README.md)
     - [Manufacturer Test Hooks](./sw/device/tests/closed_source/README.md)
     - [Crypto Library Tests](./sw/device/tests/crypto/README.md)

--- a/sw/device/silicon_creator/doc/boot_log.md
+++ b/sw/device/silicon_creator/doc/boot_log.md
@@ -1,0 +1,15 @@
+# Boot Log
+
+The OpenTitan boot process consists of three stages: `ROM`, `ROM_EXT`, and the first owner boot stage (e.g. `BL0`).
+Both the `ROM_EXT` and `BL0` stages have two slots, A and B, to ensure reliable updates.
+This means that the actual `ROM_EXT` and `BL0` slots executed during boot are determined at runtime.
+
+OpenTitan stores this information in the retention SRAM as a `boot_log_t` struct to make it accessible to later boot stages.
+
+## Field Descriptors
+
+- `digest`: HMAC digest of type `hmac_digest_t` for data integrity.
+- `identifier`: Boot log identifier. The value of this field must be `0x474c4f42` (ASCII: "BOLG").
+- `chip_version`: `scm_revision` field from `chip_info`.
+- `rom_ext_slot`: `ROM_EXT` slot (A or B) used during boot.
+- `bl0_slot`: `BL0` slot (A or B) used during boot.


### PR DESCRIPTION
Following up on https://github.com/lowRISC/opentitan/pull/19496#issuecomment-1701299182, this PR adds the spec for the boot log to the Markdown documentation.