### PR TITLE
[test_rom] align clk jitter enablement between test ROM and ROM

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -130,23 +130,14 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `uvm_info(`gfn, "cpu_init completed", UVM_MEDIUM)
   endtask
 
-  // The jitter enable mechanism is different from test_rom and rom right now.
-  // That's why below there is both a symbol overwrite and an otp backdoor load.
-  // Once test_rom and rom are consistent in this area, the symbol backdoor load
-  // can be removed.
   task config_jitter();
     bit en_jitter;
     void'($value$plusargs("en_jitter=%0d", en_jitter));
+    // ROM blindly copies from OTP, backdoor load a true or false value.
     if (en_jitter) begin
-      // enable for test_rom
-      bit [7:0] en_jitter_arr[] = {1};
-      sw_symbol_backdoor_overwrite("kJitterEnabled", en_jitter_arr, SwTypeRom);
-
-      // enable for rom
       cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgJitterEnOffset,
                                        prim_mubi_pkg::MuBi4True);
     end else begin
-      // rom blindly copies from otp, backdoor load a false value
       cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgJitterEnOffset,
                                        prim_mubi_pkg::MuBi4False);
     end

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -175,11 +175,6 @@ extern const uintptr_t kDeviceTestStatusAddress;
 extern const uintptr_t kDeviceLogBypassUartAddress;
 
 /**
- * A knob to set jitter_enable in clkmgr.
- */
-extern const bool kJitterEnabled;
-
-/**
  * A platform-specific function to convert microseconds to cpu cycles.
  *
  * This is primarily used for spin waits that use the cpu cycle counters.

--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -43,8 +43,6 @@ const uintptr_t kDeviceTestStatusAddress = 0;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
-const bool kJitterEnabled = false;
-
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -45,8 +45,6 @@ const uintptr_t kDeviceTestStatusAddress = 0;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
-const bool kJitterEnabled = false;
-
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -51,6 +51,4 @@ const uintptr_t kDeviceLogBypassUartAddress =
     TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
     RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET + 0x04;
 
-const bool kJitterEnabled = false;
-
 void device_fpga_version_print(void) {}

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -56,6 +56,4 @@ const uintptr_t kDeviceTestStatusAddress =
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
 
-const bool kJitterEnabled = false;
-
 void device_fpga_version_print(void) {}

--- a/sw/device/lib/testing/test_rom/test_rom.c
+++ b/sw/device/lib/testing/test_rom/test_rom.c
@@ -8,7 +8,6 @@
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
-#include "sw/device/lib/dif/dif_clkmgr.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
@@ -50,7 +49,6 @@ extern char _rom_ext_virtual_size[];
  */
 typedef void ottf_entry_point(void);
 
-static dif_clkmgr_t clkmgr;
 static dif_flash_ctrl_state_t flash_ctrl;
 static dif_pinmux_t pinmux;
 static dif_rstmgr_t rstmgr;
@@ -184,17 +182,6 @@ bool rom_test_main(void) {
   CHECK_DIF_OK(dif_rv_core_ibex_read_fpga_info(&ibex, &fpga));
   if (fpga != 0) {
     LOG_INFO("TestROM:%08x", fpga);
-  }
-
-  // Enable clock jitter if requested.
-  // The kJitterEnabled symbol defaults to false across all hardware platforms.
-  // However, in DV simulation, it may be overridden via a backdoor write with
-  // the plusarg: `+en_jitter=1`.
-  if (kJitterEnabled) {
-    CHECK_DIF_OK(dif_clkmgr_init(
-        mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
-    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
-    LOG_INFO("Jitter is enabled");
   }
 
   if (bootstrap_requested() == kHardenedBoolTrue) {

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -6,6 +6,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits_asm.h"
 #include "ast_regs.h"
+#include "clkmgr_regs.h"
 #include "csrng_regs.h"
 #include "edn_regs.h"
 #include "entropy_src_regs.h"
@@ -168,6 +169,13 @@ _start:
   srli t0, t0, SENSOR_CTRL_STATUS_AST_INIT_DONE_BIT // no-op as bit index is currently 0
   andi t0, t0, 0x1
   beqz t0, .L_ast_done_loop
+
+  // Enable jittery clock if enabled in OTP.
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_JITTER_EN_OFFSET(a0)
+  li   a0, TOP_EARLGREY_CLKMGR_AON_BASE_ADDR
+  sw   t0, CLKMGR_JITTER_ENABLE_REG_OFFSET(a0)
 
 .L_ast_init_skip:
   // The following sequence enables the minimum level of entropy required to


### PR DESCRIPTION
The test ROM now reads the jittery clk enablement field from OTP to perfrom the enablement, same as the ROM. This fixes #19580.