### PR TITLE
[otbn,dv] Allow URND to change over time in standalonesim.py

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -38,9 +38,6 @@ class StandaloneSim(OTBNSim):
             if self.state.ext_regs.read('RND_REQ', True):
                 self.state.wsrs.RND.set_unsigned(next(_TEST_RND_DATA), False,
                                                  False)
-            # If there's a URND request, respond immediately.
-            if not self.state.wsrs.URND.running:
-                self.state.wsrs.URND.set_seed(_TEST_URND_DATA)
 
             self.step(verbose)
             insn_count += 1


### PR DESCRIPTION
The code that we're deleting checked whether the URND PRNG was running (always true, once execution has started) and then set its value to a static seed on every cycle.

This makes more sense for RND (on the lines above), where the Python model doesn't have a model value to satisfy the request, but the logic doesn't make so much sense for URND.