### PR TITLE
[otbn,dv] Cleanups of wsr.py in otbnsim

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -210,8 +210,8 @@ class URNDWSR(WSR):
         super().__init__(name)
         seed = [0x84ddfadaf7e1134d, 0x70aa1c59de6197ff,
                 0x25a4fe335d095f1e, 0x2cba89acbe4a07e9]
-        self.state = [seed, 4 * [0], 4 * [0], 4 * [0], 4 * [0]]
-        self.out = 4 * [0]
+        self._state = [seed, 4 * [0], 4 * [0], 4 * [0], 4 * [0]]
+        self._out = 4 * [0]
         self._next_value = None  # type: Optional[int]
         self._value = None  # type: Optional[int]
         self.running = False
@@ -254,7 +254,7 @@ class URNDWSR(WSR):
     def set_seed(self, value: List[int]) -> None:
         assert len(value) == 4
         self.running = True
-        self.state[0] = value
+        self._state[0] = value
         # Step immediately to update the internal state with the new seed
         self.step()
 
@@ -264,13 +264,13 @@ class URNDWSR(WSR):
             mid = 4 * [0]
             nv = 0
             for i in range(4):
-                st_i = self.state[i]
-                self.state[i + 1] = self.state_update(st_i)
+                st_i = self._state[i]
+                self._state[i + 1] = self.state_update(st_i)
                 mid[i] = (st_i[3] + st_i[0]) & mask64
-                self.out[i] = (self.rol(mid[i], 23) + st_i[3]) & mask64
-                nv |= self.out[i] << (64 * i)
+                self._out[i] = (self.rol(mid[i], 23) + st_i[3]) & mask64
+                nv |= self._out[i] << (64 * i)
             self._next_value = nv
-            self.state[0] = self.state[4]
+            self._state[0] = self._state[4]
 
     def commit(self) -> None:
         if self._next_value is not None:

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -264,11 +264,10 @@ class URNDWSR(WSR):
             nv = 0
             for i in range(4):
                 st_i = self._state[i]
-                self._state[i + 1] = self.state_update(st_i)
+                self._state[(i + 1) & 3] = self.state_update(st_i)
                 mid[i] = (st_i[3] + st_i[0]) & mask64
                 nv |= ((self.rol(mid[i], 23) + st_i[3]) & mask64) << (64 * i)
             self._next_value = nv
-            self._state[0] = self._state[4]
 
     def commit(self) -> None:
         if self._next_value is not None:

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -211,7 +211,6 @@ class URNDWSR(WSR):
         seed = [0x84ddfadaf7e1134d, 0x70aa1c59de6197ff,
                 0x25a4fe335d095f1e, 0x2cba89acbe4a07e9]
         self._state = [seed, 4 * [0], 4 * [0], 4 * [0], 4 * [0]]
-        self._out = 4 * [0]
         self._next_value = None  # type: Optional[int]
         self._value = None  # type: Optional[int]
         self.running = False
@@ -267,8 +266,7 @@ class URNDWSR(WSR):
                 st_i = self._state[i]
                 self._state[i + 1] = self.state_update(st_i)
                 mid[i] = (st_i[3] + st_i[0]) & mask64
-                self._out[i] = (self.rol(mid[i], 23) + st_i[3]) & mask64
-                nv |= self._out[i] << (64 * i)
+                nv |= ((self.rol(mid[i], 23) + st_i[3]) & mask64) << (64 * i)
             self._next_value = nv
             self._state[0] = self._state[4]
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -63,12 +63,10 @@ class WSR:
     def commit(self) -> None:
         '''Commit pending changes'''
         self._pending_write = False
-        return
 
     def abort(self) -> None:
         '''Abort pending changes'''
         self._pending_write = False
-        return
 
     def changes(self) -> Sequence[Trace]:
         '''Return list of pending architectural changes'''

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -273,9 +273,6 @@ class URNDWSR(WSR):
         if self._next_value is not None:
             self._value = self._next_value
 
-    def abort(self) -> None:
-        self._next_value = 0
-
     def changes(self) -> List[TraceWSR]:
         return ([])
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -209,8 +209,8 @@ class URNDWSR(WSR):
         seed = [0x84ddfadaf7e1134d, 0x70aa1c59de6197ff,
                 0x25a4fe335d095f1e, 0x2cba89acbe4a07e9]
         self._state = [seed, 4 * [0], 4 * [0], 4 * [0], 4 * [0]]
-        self._next_value = None  # type: Optional[int]
-        self._value = None  # type: Optional[int]
+        self._next_value = 0
+        self._value = 0
         self.running = False
 
     def rol(self, n: int, d: int) -> int:
@@ -229,7 +229,6 @@ class URNDWSR(WSR):
         self.running = False
 
     def read_unsigned(self) -> int:
-        assert self._value is not None
         return self._value
 
     def state_update(self, data_in: List[int]) -> List[int]:
@@ -268,8 +267,7 @@ class URNDWSR(WSR):
             self._next_value = nv
 
     def commit(self) -> None:
-        if self._next_value is not None:
-            self._value = self._next_value
+        self._value = self._next_value
 
     def changes(self) -> List[TraceWSR]:
         return ([])

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -270,7 +270,9 @@ class URNDWSR(WSR):
         self._value = self._next_value
 
     def changes(self) -> List[TraceWSR]:
-        return ([])
+        # Our URND model doesn't track (or report) changes to its internal
+        # state.
+        raise NotImplementedError
 
 
 class KeyTrace(Trace):
@@ -425,7 +427,6 @@ class WSRFile:
         ret = []  # type: List[Trace]
         ret += self.MOD.changes()
         ret += self.RND.changes()
-        ret += self.URND.changes()
         ret += self.ACC.changes()
         ret += self.KeyS0.changes()
         ret += self.KeyS1.changes()


### PR DESCRIPTION
Minor cleanups to `wsr.py`, the code that represents WSRs in otbnsim. There shouldn't be any functional change, but the code is a bit easier to understand and it runs (very marginally) faster.