### PR TITLE
[opentitantool] Work around lack of bidirectional SPI

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -916,6 +916,10 @@ impl Target for SpiWrapper {
         Ok(())
     }
 
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        self.underlying_target.supports_bidirectional_transfer()
+    }
+
     fn set_chip_select(&self, chip_select: &Rc<dyn GpioPin>) -> Result<()> {
         *self.my_chip_select.borrow_mut() = Some(Rc::clone(chip_select));
         Ok(())

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -163,6 +163,7 @@ pub struct MaxSizes {
 pub enum Transfer<'rd, 'wr> {
     Read(&'rd mut [u8]),
     Write(&'wr [u8]),
+    // Check supports_bidirectional_transfer before using this.
     Both(&'wr [u8], &'rd mut [u8]),
 }
 
@@ -182,6 +183,9 @@ pub trait Target {
     fn get_max_speed(&self) -> Result<u32>;
     /// Sets the maximum allowed speed of the SPI bus.
     fn set_max_speed(&self, max_speed: u32) -> Result<()>;
+
+    /// Indicates whether `Transfer::Both()` is supported.
+    fn supports_bidirectional_transfer(&self) -> Result<bool>;
 
     /// Sets which pin should be used as Chip Select.  Not supported by most backend transports.
     fn set_chip_select(&self, _: &Rc<dyn gpio::GpioPin>) -> Result<()> {

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -179,6 +179,12 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_max_speed(*value)?;
                         Ok(Response::Spi(SpiResponse::SetMaxSpeed))
                     }
+                    SpiRequest::SupportsBidirectionalTransfer => {
+                        let has_support = instance.supports_bidirectional_transfer()?;
+                        Ok(Response::Spi(SpiResponse::SupportsBidirectionalTransfer {
+                            has_support,
+                        }))
+                    }
                     SpiRequest::SetChipSelect { pin } => {
                         instance.set_chip_select(&self.transport.gpio_pin(pin)?)?;
                         Ok(Response::Spi(SpiResponse::SetChipSelect))

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -147,6 +147,7 @@ pub enum SpiRequest {
     SetMaxSpeed {
         value: u32,
     },
+    SupportsBidirectionalTransfer,
     SetChipSelect {
         pin: String,
     },
@@ -177,6 +178,9 @@ pub enum SpiResponse {
         speed: u32,
     },
     SetMaxSpeed,
+    SupportsBidirectionalTransfer {
+        has_support: bool,
+    },
     SetChipSelect,
     GetMaxTransferCount {
         number: usize,

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/spi.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/spi.rs
@@ -89,6 +89,10 @@ impl<B: Board> Target for Spi<B> {
         Ok(())
     }
 
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Ok(true)
+    }
+
     fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
         Ok(42)

--- a/sw/host/opentitanlib/src/transport/dediprog/spi.rs
+++ b/sw/host/opentitanlib/src/transport/dediprog/spi.rs
@@ -346,6 +346,10 @@ impl Target for DediprogSpi {
         self.set_spi_clock()
     }
 
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Ok(false)
+    }
+
     fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
         Ok(42)

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -83,6 +83,13 @@ impl Target for ProxySpi {
         }
     }
 
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        match self.execute_command(SpiRequest::SupportsBidirectionalTransfer)? {
+            SpiResponse::SupportsBidirectionalTransfer { has_support } => Ok(has_support),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn set_chip_select(&self, pin: &Rc<dyn gpio::GpioPin>) -> Result<()> {
         let Some(pin) = pin.get_internal_pin_name() else {
             bail!(SpiError::InvalidChipSelect)

--- a/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
@@ -42,6 +42,11 @@ impl Target for Ti50Spi {
         Err(TransportError::UnsupportedOperation.into())
     }
 
+    /// Indicates whether `Transfer::Both()` is supported.
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
     /// Returns the maximum number of transfers allowed in a single transaction.
     fn get_max_transfer_count(&self) -> Result<usize> {
         Err(TransportError::UnsupportedOperation.into())

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -99,6 +99,10 @@ impl Target for UltradebugSpi {
         Ok(())
     }
 
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Ok(true)
+    }
+
     fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
         Ok(42)


### PR DESCRIPTION
Strictly speaking, the TPM SPI protocol requires the host to receive while it sends the four-byte request, as the TPM device could send the "ready byte" at the same time as the final byte of the request.

However, the HyperDebug Quad-SPI port does not support simultaneous sending and receiving.

This CL adds ability for Spi trait implementations to advertise whether they support bidirectional transfers, and add workaround code in the TPM logic, which assumes that the TPM device will send the "ready byte" immediately following the fourth and final request byte.