### PR TITLE
[edn/dv] csrng commands check

### DIFF
--- a/hw/ip/csrng/rtl/csrng_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_pkg.sv
@@ -45,6 +45,15 @@ package csrng_pkg;
     GENU = 3'h7
   } acmd_e;
 
+  typedef struct packed {
+    logic [7:0]       resv;
+    logic [11:0]      glen;
+    logic [3:0]       flag0;
+    logic [3:0]       clen;
+    logic             gap; // acmd is defined as 4 bits wide but only 3 are used
+    acmd_e            acmd;
+  } csrng_cmd_t;
+
 
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 3 -m 15 -n 8 \

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -70,6 +70,33 @@
       package: "edn_pkg",
     }
   ],
+  // Keep the following parameters in line with the literal values defined in the corresponding registers below
+  param_list: [
+    { name:    "EdnBootInsCmdResval",
+      type:    "logic [31:0]",
+      default: "32'h901",
+      desc:    "Reset value for the boot_ins_cmd register.",
+      local:   "true",
+    },
+    { name:    "EdnBootGenCmdResval",
+      type:    "logic [31:0]",
+      default: "32'hfff003",
+      desc:    "Reset value for the boot_gen_cmd register.",
+      local:   "true",
+    },
+    { name:    "CtrlResval",
+      type:    "logic [31:0]",
+      default: "32'h9999",
+      desc:    "Reset value for the ctrl register.",
+      local:   "true",
+    },
+    { name:    "MaxNumReqsBetweenReseedsResval",
+      type:    "logic [31:0]",
+      default: "32'h0",
+      desc:    "Reset value for the max_num_reqs_between_reseeds register.",
+      local:   "true",
+    },
+  ],
   countermeasures: [
     { name: "CONFIG.REGWEN"
       desc: "Registers are protected from writes."

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -158,6 +158,7 @@
                 entropy complex may only be enabled and disabled in a specific order, see
                 Programmers Guide for details.
                 '''
+          // keep this in line with the resval parameters above
           resval: false
         },
         { bits: "7:4",
@@ -169,6 +170,7 @@
                 The purpose of this feature is to request entropy as fast as possible after reset,
                 and during chip boot-time.
                 '''
+          // keep this in line with the resval parameters above
           resval: false
         },
         { bits: "11:8",
@@ -186,6 +188,7 @@
                 The !!GENERATE_CMD, !!RESEED_CMD, and !!MAX_NUM_REQS_BETWEEN_RESEEDS registers must
                 set up before the !!SW_CMD_REQ register command is issued.
                 '''
+          // keep this in line with the resval parameters above
           resval: false
         },
         { bits: "15:12",
@@ -197,6 +200,7 @@
                 set to the reset state by software before any further commands can be issued to
                 these FIFOs.
                 '''
+          // keep this in line with the resval parameters above
           resval: false
         },
       ]
@@ -213,6 +217,7 @@
           desc: '''
                 This field is used as the value for Instantiate command at boot time.
                 '''
+         // keep this in line with the resval parameters above
          resval: 0x0000_0901
         }
       ]
@@ -229,6 +234,7 @@
           desc: '''
                 This field is used as the value for generate command at boot time.
                 '''
+         // keep this in line with the resval parameters above
          resval: 0x00ff_f003
        }
       ]

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -26,6 +26,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   uint   reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
 
   bit abort_sw_cmd = 0;
+  bit backdoor_disable = 1'b0;
 
   // Knobs & Weights
   uint   enable_pct, boot_req_mode_pct, auto_req_mode_pct, cmd_fifo_rst_pct,

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -23,7 +23,31 @@ class edn_scoreboard extends cip_base_scoreboard #(
   uvm_tlm_analysis_fifo#(bit) rsp_sts_fifo;
 
   // local queues to hold incoming packets pending comparison
-  bit[FIPS_ENDPOINT_BUS_WIDTH - 1:0]   endpoint_data_q[$];
+  bit [FIPS_ENDPOINT_BUS_WIDTH - 1:0] endpoint_data_q[$];
+
+  // queues/variables holding commands for comparison at the CSRNG output
+  csrng_pkg::csrng_cmd_t sw_cmd_req_q[$];
+  csrng_pkg::csrng_cmd_t reseed_cmd_q[$];
+  csrng_pkg::csrng_cmd_t generate_cmd_q[$];
+
+  csrng_pkg::csrng_cmd_t sw_cmd_req_comp = edn_reg_pkg::EDN_SW_CMD_REQ_RESVAL;
+  csrng_pkg::csrng_cmd_t boot_ins_cmd_comp = edn_reg_pkg::EdnBootInsCmdResval;
+  csrng_pkg::csrng_cmd_t boot_gen_cmd_comp = edn_reg_pkg::EdnBootGenCmdResval;
+  csrng_pkg::csrng_cmd_t reseed_cmd_comp = edn_reg_pkg::EDN_RESEED_CMD_RESVAL;
+  csrng_pkg::csrng_cmd_t generate_cmd_comp = edn_reg_pkg::EDN_GENERATE_CMD_RESVAL;
+
+  // indicator bit, 1'b1 if EDN was instantiated 1'b0 elsewise
+  bit instantiated = 1'b0;
+  // indicator bit, 1'b1 if in boot_req_mode and generate cmd has already been sent
+  bit boot_gen_cmd_sent = 1'b0;
+  // counter to keep track of additional data
+  int clen_cntr = 0;
+  // EDN previous and current ctrl state
+  edn_reg_pkg::edn_reg2hw_ctrl_reg_t edn_ctrl_pre = edn_reg_pkg::CtrlResval;
+  edn_reg_pkg::edn_reg2hw_ctrl_reg_t edn_ctrl = edn_reg_pkg::CtrlResval;
+  // MAX_NUM_REQS_BETWEEN_RESEEDS state and ctr
+  bit [31:0] max_num_reqs_between_reseeds = edn_reg_pkg::MaxNumReqsBetweenReseedsResval;
+  bit [31:0] reqs_between_reseeds_ctr     = edn_reg_pkg::MaxNumReqsBetweenReseedsResval;
 
   // Sample interrupt pins at read data phase. This is used to compare with intr_state read value.
   bit [NumEdnIntr-1:0] intr_pins;
@@ -54,6 +78,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
     super.run_phase(phase);
 
     fork
+      process_cs_cmd_fifo();
       process_genbits_fifo();
       process_rsp_sts_fifo();
     join_none
@@ -79,6 +104,11 @@ class edn_scoreboard extends cip_base_scoreboard #(
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
+    // bools to determine whether sm is done and FIFOs need to be reset
+    bit auto_req_mode_turned_off;
+    bit boot_req_mode_turned_off;
+    bit main_sm_done;
+
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
@@ -86,6 +116,10 @@ class edn_scoreboard extends cip_base_scoreboard #(
     end
     else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+
+    if (csr.get_name() == "ctrl") begin
+      edn_ctrl_pre = edn_ctrl;
     end
 
     // if incoming access is a write to a valid csr, then make updates right away
@@ -127,23 +161,83 @@ class edn_scoreboard extends cip_base_scoreboard #(
         end
       end
       "ctrl": begin
+        // update current ctrl state
+        edn_ctrl.edn_enable.q = `gmv(ral.ctrl.edn_enable);
+        edn_ctrl.auto_req_mode.q = `gmv(ral.ctrl.auto_req_mode);
+        edn_ctrl.boot_req_mode.q = `gmv(ral.ctrl.boot_req_mode);
+        edn_ctrl.cmd_fifo_rst.q = `gmv(ral.ctrl.cmd_fifo_rst);
+
+        // If EDN was disabled and is now enabled, reset the kept state
+        if ( write && (edn_ctrl.edn_enable.q == MuBi4True) &&
+            ( (edn_ctrl_pre.edn_enable.q == MuBi4False) || (cfg.backdoor_disable) ) ) begin
+          cfg.backdoor_disable = 1'b0;
+          instantiated = 1'b0;
+          boot_gen_cmd_sent = 1'b0;
+          clen_cntr = 0;
+          sw_cmd_req_q.delete();
+          // currently FIFOs aren't cleared when EDN is disabled.
+          // TODO(#19653): Uncomment or delete based on decision in that issue
+          // reseed_cmd_q.delete();
+          // generate_cmd_q.delete();
+        end
+
+        // currently BootDone state can only be left if EDN is disabled.
+        // TODO(#19655): Uncomment or delete based on decision in that issue
+        // If boot_gen_mode is left reset boot_gen_cmd_sent
+        // if (write && (edn_ctrl_pre.boot_req_mode.q == MuBi4True)
+        //    && (edn_ctrl.boot_req_mode.q == MuBi4False)) begin
+        //   boot_gen_cmd_sent = 1'b0;
+        // end
+
+        // determine if the main state machine is done
+        auto_req_mode_turned_off = (edn_ctrl_pre.auto_req_mode.q == MuBi4True) &&
+                                   (edn_ctrl.auto_req_mode.q == MuBi4False);
+        boot_req_mode_turned_off = (edn_ctrl_pre.boot_req_mode.q == MuBi4True) &&
+                                   (edn_ctrl.boot_req_mode.q == MuBi4False);
+        main_sm_done = (edn_ctrl.edn_enable.q == MuBi4True) &&
+                       (auto_req_mode_turned_off || boot_req_mode_turned_off);
+
+        // Clear reseed & generate queues if cmd_fifo_rst is true or if main_sm_done_pulse is high
+        if ( write && ( (edn_ctrl.cmd_fifo_rst.q == MuBi4True) || main_sm_done ) ) begin
+          reseed_cmd_q.delete();
+          generate_cmd_q.delete();
+        end
+
       end
       "sw_cmd_req": begin
+        if (addr_phase_write) begin
+          sw_cmd_req_q.push_back(item.a_data);
+        end
       end
       "sw_cmd_sts": begin
         do_read_check = 1'b0;
       end
       "boot_ins_cmd": begin
+        if (addr_phase_write) begin
+          boot_ins_cmd_comp = item.a_data;
+        end
       end
       "boot_gen_cmd": begin
+        if (addr_phase_write) begin
+          boot_gen_cmd_comp = item.a_data;
+        end
       end
       "sum_sts": begin
       end
       "generate_cmd": begin
+        if (addr_phase_write) begin
+          generate_cmd_q.push_back(item.a_data);
+        end
       end
       "reseed_cmd": begin
+        if (addr_phase_write) begin
+          reseed_cmd_q.push_back(item.a_data);
+        end
       end
       "max_num_reqs_between_reseeds": begin
+        if (addr_phase_write) begin
+          max_num_reqs_between_reseeds = item.a_data;
+        end
       end
       "recov_alert_sts": begin
       end
@@ -166,6 +260,253 @@ class edn_scoreboard extends cip_base_scoreboard #(
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
     end
+  endtask
+
+  task process_cs_cmd_fifo();
+    cs_cmd_item_t cs_cmd_item;
+    csrng_pkg::csrng_cmd_t cs_cmd;
+    csrng_pkg::acmd_e acmd_cur; // store current acmd to determine where additional data comes from
+
+    instantiated = 1'b0;
+    clen_cntr = 0;
+    reqs_between_reseeds_ctr = 32'b0;
+
+    forever begin
+      cs_cmd_fifo.get(cs_cmd_item);
+      cs_cmd = cs_cmd_item.h_data[csrng_pkg::CSRNG_CMD_WIDTH-1:0];
+
+      // Check if EDN is enabled
+      if ( (edn_ctrl.edn_enable.q == MuBi4False) ||
+           (cfg.backdoor_disable == 1'b1) ) begin
+        `uvm_error(`gfn, $sformatf("No commands can be issued if EDN is disabled. cmd: 0x%h",
+            cs_cmd))
+
+      // If cs_cmd contains a command
+      end else if(clen_cntr == 0) begin
+        clen_cntr = cs_cmd.clen;
+        acmd_cur = cs_cmd.acmd;
+
+        case (acmd_cur)
+          csrng_pkg::INS: begin
+            if (instantiated == 1'b1) begin
+              `uvm_error(`gfn,
+                  $sformatf({"Instantiate command not allowed for instantiated CSRNG instance.",
+                    " cmd: 0x%h"}, cs_cmd))
+            end else begin
+
+              instantiated = 1'b1;
+              // If EDN is in boot_req_mode and boot sequence is not done
+              if ( (edn_ctrl.boot_req_mode.q == MuBi4True) && (boot_gen_cmd_sent == 1'b0) ) begin
+                if (cs_cmd != boot_ins_cmd_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Instantiate command 0x%h in boot_req_mode",
+                      " has to match the value in boot_ins_cmd register 0x%h."},
+                      cs_cmd, boot_ins_cmd_comp))
+                end
+
+              // If EDN is in auto_req_mode
+              end else if (edn_ctrl.auto_req_mode.q == MuBi4True) begin
+                sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+                if (cs_cmd != sw_cmd_req_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Instantiate command 0x%h in auto_req_mode",
+                      " has to match the value from sw_cmd_req register 0x%h."},
+                      cs_cmd, sw_cmd_req_comp))
+                end
+
+              // If EDN is in sw mode or boot_gen command has been sent
+              end else begin
+                sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+                if (cs_cmd != sw_cmd_req_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Instantiate command 0x%h in sw mode",
+                      " has to match the value from sw_cmd_req register 0x%h."},
+                      cs_cmd, sw_cmd_req_comp))
+                end
+
+              end
+            end
+          end
+          csrng_pkg::RES: begin
+            if (instantiated == 1'b0) begin
+              `uvm_error(`gfn, $sformatf({"Reseed command not allowed without instantiated",
+                  " CSRNG instance. cmd: 0x%h"}, cs_cmd))
+
+            end else begin
+              // If EDN is in boot_req_mode and boot sequence is not done
+              if ( (edn_ctrl.boot_req_mode.q == MuBi4True) && (boot_gen_cmd_sent == 1'b0) ) begin
+                `uvm_error(`gfn, $sformatf({"Reseed command not allowed in boot_req_mode.",
+                    " cmd: 0x%h"}, cs_cmd))
+
+              // If EDN is in auto_req_mode
+              end else if (edn_ctrl.auto_req_mode.q == MuBi4True) begin
+                reseed_cmd_comp = reseed_cmd_q.pop_front();
+                reseed_cmd_q.push_back(reseed_cmd_comp);
+                reqs_between_reseeds_ctr = 32'b0;
+                if (cs_cmd != reseed_cmd_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Reseed command 0x%h in auto_req_mode",
+                      " has to match the value in reseed fifo 0x%h."}, cs_cmd, reseed_cmd_comp))
+                end
+
+              // If EDN is in sw mode or boot_gen command has been sent
+              end else begin
+                sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+                if (cs_cmd != sw_cmd_req_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Reseed command 0x%h in sw mode has to match",
+                      " the value from sw_cmd_req register 0x%h."}, cs_cmd, sw_cmd_req_comp))
+                end
+
+              end
+            end
+          end
+          csrng_pkg::GEN: begin
+            if (instantiated == 1'b0) begin
+              `uvm_error(`gfn, $sformatf({"Generate command not allowed without instantiated",
+                  " CSRNG instance. cmd: 0x%h"}, cs_cmd))
+
+            end else begin
+              // If EDN is in boot_req_mode and boot sequence is not done
+              if ( (edn_ctrl.boot_req_mode.q == MuBi4True) && (boot_gen_cmd_sent == 1'b0) ) begin
+                if (cs_cmd != boot_gen_cmd_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Generate command 0x%h in boot_req_mode",
+                      " has to match the value in boot_gen_cmd register 0x%h."},
+                      cs_cmd, boot_gen_cmd_comp))
+                end
+
+                boot_gen_cmd_sent = 1'b1;
+
+              // If EDN is in auto_req_mode
+              end else if (edn_ctrl.auto_req_mode.q == MuBi4True) begin
+                generate_cmd_comp = generate_cmd_q.pop_front();
+                generate_cmd_q.push_back(generate_cmd_comp);
+
+                if (cs_cmd != generate_cmd_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Generate command 0x%h in auto_req_mode",
+                      " has to match the value in generate fifo 0x%h."},
+                      cs_cmd, generate_cmd_comp))
+
+                end else if (reqs_between_reseeds_ctr >= max_num_reqs_between_reseeds) begin
+                  `uvm_error(`gfn, $sformatf({"Maximum number of request between reseeds",
+                      " in auto_req_mode 0x%h exceeded."}, max_num_reqs_between_reseeds))
+                end
+
+                reqs_between_reseeds_ctr++;
+
+              // If EDN is in sw mode or boot_gen command has been sent
+              end else begin
+                sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+                if (cs_cmd != sw_cmd_req_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Generate command 0x%h in sw mode has to match",
+                      " the value from sw_cmd_req register 0x%h."}, cs_cmd, sw_cmd_req_comp))
+                end
+
+              end
+            end
+          end
+          csrng_pkg::UPD: begin
+            if (instantiated == 1'b0) begin
+              `uvm_error(`gfn, $sformatf({"Update command not allowed without instantiated CSRNG",
+                  " instance. cmd: 0x%h"}, cs_cmd))
+
+            end else begin
+              // If EDN is in boot_req_mode and boot sequence is not done
+              if ( (edn_ctrl.boot_req_mode.q == MuBi4True) && (boot_gen_cmd_sent == 1'b0) ) begin
+                `uvm_error(`gfn, $sformatf({"Update command not allowed in boot_req_mode.",
+                    " cmd: 0x%h"}, cs_cmd))
+
+              // If EDN is in auto_req_mode
+              end else if (edn_ctrl.auto_req_mode.q == MuBi4True) begin
+                `uvm_error(`gfn, $sformatf({"Update command not allowed in auto_req_mode.",
+                    " cmd: 0x%h"}, cs_cmd))
+
+              // If EDN is in sw mode or boot_gen command has been sent
+              end else begin
+                sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+                if (cs_cmd != sw_cmd_req_comp) begin
+                  `uvm_error(`gfn, $sformatf({"Update command 0x%h in sw mode has to match",
+                      " the value from sw_cmd_req register 0x%h."}, cs_cmd, sw_cmd_req_comp))
+                end
+
+              end
+            end
+          end
+          csrng_pkg::UNI: begin
+            if (instantiated == 1'b0) begin
+              `uvm_error(`gfn, $sformatf({"Uninstantiate command not allowed without",
+                  " instantiated CSRNG instance. cmd: 0x%h"}, cs_cmd))
+
+            end else if (clen_cntr != 0) begin
+              `uvm_error(`gfn, $sformatf("clen must be 0 for uninstantiate command. cmd: 0x%h",
+                  cs_cmd))
+
+            end else if ((edn_ctrl.auto_req_mode.q == MuBi4False) &&
+                         (edn_ctrl.boot_req_mode.q == MuBi4False)) begin
+              sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+              if (cs_cmd != sw_cmd_req_comp) begin
+                `uvm_error(`gfn, $sformatf({"Uninstantiate command 0x%h in sw mode has to match",
+                    " the value from sw_cmd_req register 0x%h."}, cs_cmd, sw_cmd_req_comp))
+              end
+            end
+            instantiated = 1'b0;
+          end
+          default: begin
+            `uvm_error(`gfn, $sformatf("Invalid application command. cmd: 0x%h", cs_cmd))
+          end
+        endcase
+
+      // Else cs_cmd contains additional data
+      end else begin
+        // Decrease additional data counter
+        clen_cntr--;
+
+        // Determine which fifo to compare the additional data with
+        // If the EDN is in boot_req_mode and boot sequence is not done
+        // no additional data is allowed
+        if ( (edn_ctrl.boot_req_mode.q == MuBi4True) && (boot_gen_cmd_sent == 1'b0) ) begin
+          `uvm_error(`gfn, $sformatf({"Additional data not allowed in boot_req_mode",
+              " if boot is not complete. cmd: 0x%h"}, cs_cmd))
+
+        // If the EDN is in auto_req_mode
+        // determine whether the additional data comes from a reseed or a generate cmd.
+        end else if (edn_ctrl.auto_req_mode.q == MuBi4True) begin
+          case (acmd_cur)
+            csrng_pkg::INS: begin
+              sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+              if (cs_cmd != sw_cmd_req_comp) begin
+                `uvm_error(`gfn, $sformatf({"Additional data 0x%h in auto_req_mode has to match",
+                    " the value from sw_cmd_req register 0x%h."}, cs_cmd, sw_cmd_req_comp))
+              end
+            end
+            csrng_pkg::RES: begin
+              reseed_cmd_comp = reseed_cmd_q.pop_front();
+              reseed_cmd_q.push_back(reseed_cmd_comp);
+              if (cs_cmd != reseed_cmd_comp) begin
+                `uvm_error(`gfn, $sformatf({"Additional data 0x%h in auto_req_mode has to match",
+                    " the value in reseed fifo 0x%h."}, cs_cmd, reseed_cmd_comp))
+              end
+            end
+            csrng_pkg::GEN: begin
+              generate_cmd_comp = generate_cmd_q.pop_front();
+              generate_cmd_q.push_back(generate_cmd_comp);
+              if (cs_cmd != generate_cmd_comp) begin
+                `uvm_error(`gfn, $sformatf({"Additional data 0x%h in auto_req_mode has to match",
+                    " the value in generate fifo 0x%h."}, cs_cmd, generate_cmd_comp))
+              end
+            end
+            default: begin
+              `uvm_error(`gfn, $sformatf({"Only additional data for reseed and generate accepted",
+                  " in auto_req_mode. cmd: 0x%h"}, cs_cmd))
+            end
+          endcase
+
+        // Else the EDN must be in sw mode and the additional data must come from sw_cmd_req
+        end else begin
+          sw_cmd_req_comp = sw_cmd_req_q.pop_front();
+          if (cs_cmd != sw_cmd_req_comp) begin
+            `uvm_error(`gfn, $sformatf({"Additional data 0x%h in sw mode has to match",
+                " the value in sw fifo 0x%h."}, cs_cmd, sw_cmd_req_comp))
+          end
+        end
+      end
+    end
+
   endtask
 
   task process_genbits_fifo();

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -42,7 +42,13 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
 
     // Write EDN's control CSR.
     ctrl_val = {MuBi4False, MuBi4True, MuBi4False, MuBi4False};
-    if (!backdoor) wait_no_outstanding_access();
+
+    if (!backdoor) begin
+      wait_no_outstanding_access();
+    end else begin
+      cfg.backdoor_disable = 1'b1; // Notify scoreboard of backdoor disable
+    end
+
     csr_wr(.ptr(ral.ctrl), .value(ctrl_val), .backdoor(backdoor), .predict(backdoor));
 
     // Let CSRNG agent know that EDN is disabled.

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_vseq.sv
@@ -56,6 +56,7 @@ class edn_disable_vseq extends edn_base_vseq;
         // boot_req_mode to Mubi4False, so I hardcode this ctrl_val for now.
         ctrl_val = {MuBi4False, MuBi4False, MuBi4True, MuBi4False};
         csr_wr(.ptr(ral.ctrl), .value(ctrl_val), .backdoor(1));
+        cfg.backdoor_disable = 1'b1; // Notify scoreboard of backdoor disable
         cfg.edn_vif.drive_edn_disable(1);
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 50));
         // Enable edn

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -129,6 +129,10 @@ class edn_genbits_vseq extends edn_base_vseq;
             (p_sequencer.endpoint_sequencer_h[endpoint_q[extra_requester]]);
       end
     end
+
+    // uninstantiate CSRNG instance
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::UNI));
+
   endtask
 
 endclass

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -7,6 +7,10 @@
 package edn_reg_pkg;
 
   // Param list
+  parameter logic [31:0] EdnBootInsCmdResval = 32'h901;
+  parameter logic [31:0] EdnBootGenCmdResval = 32'hfff003;
+  parameter logic [31:0] CtrlResval = 32'h9999;
+  parameter logic [31:0] MaxNumReqsBetweenReseedsResval = 32'h0;
   parameter int NumAlerts = 2;
 
   // Address widths within the block


### PR DESCRIPTION
Before this PR no checking of the command interface of the CSRNG block was done.  This PR adds DV checks on the commands issued to the CSRNG block.

This PR resolves #17087