### PR TITLE
[crypto] Introduce word-aligned buffers for cryptolib.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -79,8 +79,17 @@ Callers who do not wish to use `status_t` infrastructure may compare to these va
 
 ### Data buffers
 
+The cryptolib uses byte buffers for data that may not be 32-bit aligned, such as message inputs to hash functions.
+
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_byte_buf }}
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_const_byte_buf }}
+
+The cryptolib uses word buffers to enforce alignment where either the data is guaranteed to be aligned or where it is especially helpful for implementation reasons.
+Since most OpenTitan hardware interfaces expect aligned data, this is important sometimes for security and simplicity.
+Word buffers can be safely interpreted as byte streams by the caller; the bytes are arranged so that on a little-endian processor like Ibex, they will read as the correct byte-stream even if the specification calls for big-endian.
+
+{{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_word32_buf }}
+{{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_const_word32_buf }}
 
 ### Key data structures
 

--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -80,7 +80,7 @@ status_t kmac_hwip_default_configure(void);
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_sha3_224(const uint8_t *message, size_t message_len,
-                       uint8_t *digest);
+                       uint32_t *digest);
 
 /**
  * Compute SHA-3-256 in one-shot.
@@ -95,7 +95,7 @@ status_t kmac_sha3_224(const uint8_t *message, size_t message_len,
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_sha3_256(const uint8_t *message, size_t message_len,
-                       uint8_t *digest);
+                       uint32_t *digest);
 
 /**
  * Compute SHA-3-384 in one-shot.
@@ -110,7 +110,7 @@ status_t kmac_sha3_256(const uint8_t *message, size_t message_len,
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_sha3_384(const uint8_t *message, size_t message_len,
-                       uint8_t *digest);
+                       uint32_t *digest);
 
 /**
  * Compute SHA-3-512 in one-shot.
@@ -125,44 +125,44 @@ status_t kmac_sha3_384(const uint8_t *message, size_t message_len,
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_sha3_512(const uint8_t *message, size_t message_len,
-                       uint8_t *digest);
+                       uint32_t *digest);
 
 /**
  * Compute SHAKE-128 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
  * @param message_len The input message length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_shake_128(const uint8_t *message, size_t message_len,
-                        uint8_t *digest, size_t digest_len);
+                        uint32_t *digest, size_t digest_len);
 
 /**
  * Compute SHAKE-256 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
  * @param message_len The input message length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_shake_256(const uint8_t *message, size_t message_len,
-                        uint8_t *digest, size_t digest_len);
+                        uint32_t *digest, size_t digest_len);
 
 /**
  * Compute CSHAKE-128 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
@@ -172,19 +172,19 @@ status_t kmac_shake_256(const uint8_t *message, size_t message_len,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_cshake_128(const uint8_t *message, size_t message_len,
                          const unsigned char *func_name, size_t func_name_len,
                          const unsigned char *cust_str, size_t cust_str_len,
-                         uint8_t *digest, size_t digest_len);
+                         uint32_t *digest, size_t digest_len);
 
 /**
  * Compute CSHAKE-256 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
@@ -194,19 +194,19 @@ status_t kmac_cshake_128(const uint8_t *message, size_t message_len,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_cshake_256(const uint8_t *message, size_t message_len,
                          const unsigned char *func_name, size_t func_name_len,
                          const unsigned char *cust_str, size_t cust_str_len,
-                         uint8_t *digest, size_t digest_len);
+                         uint32_t *digest, size_t digest_len);
 
 /**
  * Compute KMAC-128 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
@@ -214,18 +214,19 @@ status_t kmac_cshake_256(const uint8_t *message, size_t message_len,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
                        size_t message_len, const unsigned char *cust_str,
-                       size_t cust_str_len, uint8_t *digest, size_t digest_len);
+                       size_t cust_str_len, uint32_t *digest,
+                       size_t digest_len);
 
 /**
  * Compute KMAC-256 in one-shot.
  *
- * The caller must ensure that `digest_len` bytes are allocated at the location
+ * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
  * @param message The input message.
@@ -233,13 +234,14 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
  * @param cust_str The customization string.
  * @param cust_str_len The customization string length in bytes.
  * @param[out] digest Output buffer for the result.
- * @param digest_len Requested digest length in bytes.
+ * @param digest_len Requested digest length in 32-bit words.
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
 status_t kmac_kmac_256(kmac_blinded_key_t *key, const uint8_t *message,
                        size_t message_len, const unsigned char *cust_str,
-                       size_t cust_str_len, uint8_t *digest, size_t digest_len);
+                       size_t cust_str_len, uint32_t *digest,
+                       size_t digest_len);
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -244,7 +244,8 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
 }
 
 crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
-                             crypto_word_buf_t iv, block_cipher_mode_t aes_mode,
+                             crypto_word32_buf_t iv,
+                             block_cipher_mode_t aes_mode,
                              aes_operation_t aes_operation,
                              crypto_const_byte_buf_t cipher_input,
                              aes_padding_t aes_padding,
@@ -467,7 +468,7 @@ status_t aes_gcm_check_tag_length(size_t byte_len, aead_gcm_tag_len_t tag_len) {
 
 crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
                                          crypto_const_byte_buf_t plaintext,
-                                         crypto_const_word_buf_t iv,
+                                         crypto_const_word32_buf_t iv,
                                          crypto_const_byte_buf_t aad,
                                          aead_gcm_tag_len_t tag_len,
                                          crypto_byte_buf_t *ciphertext,
@@ -510,7 +511,7 @@ crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
 
 crypto_status_t otcrypto_aes_decrypt_gcm(
     const crypto_blinded_key_t *key, crypto_const_byte_buf_t ciphertext,
-    crypto_const_word_buf_t iv, crypto_const_byte_buf_t aad,
+    crypto_const_word32_buf_t iv, crypto_const_byte_buf_t aad,
     aead_gcm_tag_len_t tag_len, crypto_const_byte_buf_t auth_tag,
     crypto_byte_buf_t *plaintext, hardened_bool_t *success) {
   // Check for NULL pointers in input pointers and required-nonzero-length data
@@ -612,7 +613,7 @@ crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
 }
 
 crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
-                                         crypto_word_buf_t digest) {
+                                         crypto_word32_buf_t digest) {
   if (ctx == NULL || digest.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -629,7 +630,7 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
 }
 
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
-                                      crypto_const_word_buf_t icb,
+                                      crypto_const_word32_buf_t icb,
                                       crypto_const_byte_buf_t input,
                                       crypto_byte_buf_t output) {
   if (key == NULL || icb.data == NULL) {
@@ -667,12 +668,12 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
 
 crypto_status_t otcrypto_aes_kwp_encrypt(
     const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_word_buf_t *wrapped_key) {
+    const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key) {
   // TODO: AES-KWP is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word32_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key) {
   // TODO: AES-KWP is not yet implemented.

--- a/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
+++ b/sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h
@@ -28,7 +28,7 @@ extern "C" {
  * This implementation does not support short tags.
  *
  * @param key AES key
- * @param iv_len length of IV in bytes
+ * @param iv_len length of IV in 32-bit words
  * @param iv IV value (may be NULL if iv_len is 0)
  * @param plaintext_len length of plaintext in bytes
  * @param plaintext plaintext value (may be NULL if plaintext_len is 0)
@@ -42,7 +42,7 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
-                         const uint8_t *iv, const size_t plaintext_len,
+                         const uint32_t *iv, const size_t plaintext_len,
                          const uint8_t *plaintext, const size_t aad_len,
                          const uint8_t *aad, const size_t tag_len, uint8_t *tag,
                          uint8_t *ciphertext);
@@ -66,7 +66,7 @@ status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
  * `success`.
  *
  * @param key AES key
- * @param iv_len length of IV in bytes
+ * @param iv_len length of IV in 32-bit words
  * @param iv IV value (may be NULL if iv_len is 0)
  * @param ciphertext_len length of ciphertext in bytes
  * @param ciphertext plaintext value (may be NULL if ciphertext_len is 0)
@@ -80,7 +80,7 @@ status_t aes_gcm_encrypt(const aes_key_t key, const size_t iv_len,
  */
 OT_WARN_UNUSED_RESULT
 status_t aes_gcm_decrypt(const aes_key_t key, const size_t iv_len,
-                         const uint8_t *iv, const size_t ciphertext_len,
+                         const uint32_t *iv, const size_t ciphertext_len,
                          const uint8_t *ciphertext, const size_t aad_len,
                          const uint8_t *aad, const size_t tag_len,
                          const uint8_t *tag, uint8_t *plaintext,

--- a/sw/device/lib/crypto/impl/hash.c
+++ b/sw/device/lib/crypto/impl/hash.c
@@ -183,7 +183,7 @@ static status_t check_digest_len(hash_mode_t hash_mode, size_t digest_len) {
  */
 OT_WARN_UNUSED_RESULT
 static status_t hmac_sha256(crypto_const_byte_buf_t message,
-                            crypto_word_buf_t *digest) {
+                            crypto_word32_buf_t *digest) {
   HARDENED_CHECK_EQ(digest->len, kHmacDigestNumWords);
 
   // Initialize the hardware.
@@ -202,7 +202,7 @@ static status_t hmac_sha256(crypto_const_byte_buf_t message,
 
 crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
                               hash_mode_t hash_mode,
-                              crypto_word_buf_t *digest) {
+                              crypto_word32_buf_t *digest) {
   if (input_message.data == NULL && input_message.len != 0) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -254,7 +254,7 @@ crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
                              crypto_const_byte_buf_t function_name_string,
                              crypto_const_byte_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_word_buf_t *digest) {
+                             crypto_word32_buf_t *digest) {
   // TODO: (#16410) Add error checks
 
   // Check that the output lengths match.
@@ -375,7 +375,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
 }
 
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_word_buf_t *digest) {
+                                    crypto_word32_buf_t *digest) {
   if (ctx == NULL || digest == NULL || digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -107,7 +107,7 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_byte_buf_t input_message,
-                              crypto_word_buf_t *tag) {
+                              crypto_word32_buf_t *tag) {
   // Compute HMAC using the streaming API.
   hmac_context_t ctx;
   HARDENED_TRY(otcrypto_hmac_init(&ctx, key));
@@ -121,7 +121,7 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
                               kmac_mode_t kmac_mode,
                               crypto_const_byte_buf_t customization_string,
                               size_t required_output_len,
-                              crypto_word_buf_t *tag) {
+                              crypto_word32_buf_t *tag) {
   // TODO (#16410) Revisit/complete error checks
 
   // Check for null pointers.
@@ -272,7 +272,7 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
 }
 
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_word_buf_t *tag) {
+                                    crypto_word32_buf_t *tag) {
   if (ctx == NULL || tag == NULL || tag->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -26,7 +26,7 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
                                   crypto_const_byte_buf_t input_message,
                                   rsa_padding_t padding_mode,
                                   rsa_hash_t hash_mode,
-                                  crypto_word_buf_t *signature) {
+                                  crypto_word32_buf_t *signature) {
   HARDENED_TRY(otcrypto_rsa_sign_async_start(rsa_private_key, input_message,
                                              padding_mode, hash_mode));
   return otcrypto_rsa_sign_async_finalize(signature);
@@ -36,7 +36,7 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
                                     crypto_const_byte_buf_t input_message,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
-                                    crypto_const_word_buf_t signature,
+                                    crypto_const_word32_buf_t signature,
                                     hardened_bool_t *verification_result) {
   HARDENED_TRY(otcrypto_rsa_verify_async_start(rsa_public_key, signature));
   return otcrypto_rsa_verify_async_finalize(input_message, padding_mode,
@@ -310,7 +310,8 @@ crypto_status_t otcrypto_rsa_sign_async_start(
   return OTCRYPTO_FATAL_ERR;
 }
 
-crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_word_buf_t *signature) {
+crypto_status_t otcrypto_rsa_sign_async_finalize(
+    crypto_word32_buf_t *signature) {
   // Check for NULL pointers.
   if (signature == NULL || signature->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -337,7 +338,8 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_word_buf_t *signature) {
 }
 
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key, crypto_const_word_buf_t signature) {
+    const rsa_public_key_t *rsa_public_key,
+    crypto_const_word32_buf_t signature) {
   // Check the caller-provided public key buffer.
   HARDENED_TRY(public_key_structural_check(rsa_public_key));
 

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -86,19 +86,19 @@ static status_t digest_info_write(const uint8_t *message,
   size_t digest_words = 0;
   switch (hash_mode) {
     case kRsaSignatureHashSha256:
-      HARDENED_TRY(sha256(message, message_len, (unsigned char *)encoding));
+      HARDENED_TRY(sha256(message, message_len, encoding));
       memcpy(encoding + kSha256DigestWords, &kSha256DigestIdentifier,
              sizeof(kSha256DigestIdentifier));
       digest_words = kSha256DigestWords;
       break;
     case kRsaSignatureHashSha384:
-      HARDENED_TRY(sha384(message, message_len, (unsigned char *)encoding));
+      HARDENED_TRY(sha384(message, message_len, encoding));
       memcpy(encoding + kSha384DigestWords, &kSha384DigestIdentifier,
              sizeof(kSha384DigestIdentifier));
       digest_words = kSha384DigestWords;
       break;
     case kRsaSignatureHashSha512:
-      HARDENED_TRY(sha512(message, message_len, (unsigned char *)encoding));
+      HARDENED_TRY(sha512(message, message_len, encoding));
       memcpy(encoding + kSha512DigestWords, &kSha512DigestIdentifier,
              sizeof(kSha512DigestIdentifier));
       digest_words = kSha512DigestWords;

--- a/sw/device/lib/crypto/impl/sha2/sha256.h
+++ b/sw/device/lib/crypto/impl/sha2/sha256.h
@@ -90,7 +90,7 @@ typedef struct sha256_state {
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha256(const uint8_t *msg, const size_t msg_len, uint8_t *digest);
+status_t sha256(const uint8_t *msg, const size_t msg_len, uint32_t *digest);
 
 /**
  * Set up a SHA-256 hash computation.
@@ -141,7 +141,7 @@ status_t sha256_update(sha256_state_t *state, const uint8_t *msg,
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha256_final(sha256_state_t *state, uint8_t *digest);
+status_t sha256_final(sha256_state_t *state, uint32_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/sha2/sha512.c
+++ b/sw/device/lib/crypto/impl/sha2/sha512.c
@@ -359,13 +359,12 @@ static void state_shred(sha512_state_t *state) {
  * @param state Context object.
  * @param[out] digest Destination buffer for digest.
  */
-static void sha512_digest_get(sha512_state_t *state, uint8_t *digest) {
+static void sha512_digest_get(sha512_state_t *state, uint32_t *digest) {
   // Reverse the bytes in each word to match FIPS 180-4.
   for (size_t i = 0; i < kSha512StateWords; i++) {
     state->H[i] = __builtin_bswap32(state->H[i]);
   }
-  // TODO(#17711): this can be `hardened_memcpy` if `digest` is aligned.
-  memcpy(digest, state->H, kSha512DigestBytes);
+  hardened_memcpy(digest, state->H, kSha512DigestWords);
 }
 
 /**
@@ -377,16 +376,15 @@ static void sha512_digest_get(sha512_state_t *state, uint8_t *digest) {
  * @param state Context object.
  * @param[out] digest Destination buffer for digest.
  */
-static void sha384_digest_get(sha512_state_t *state, uint8_t *digest) {
+static void sha384_digest_get(sha512_state_t *state, uint32_t *digest) {
   // Reverse the bytes in each word to match FIPS 180-4.
   for (size_t i = 0; i < kSha512StateWords; i++) {
     state->H[i] = __builtin_bswap32(state->H[i]);
   }
-  // TODO(#17711): this can be `hardened_memcpy` if `digest` is aligned.
-  memcpy(digest, state->H, kSha384DigestBytes);
+  hardened_memcpy(digest, state->H, kSha384DigestWords);
 }
 
-status_t sha512_final(sha512_state_t *state, uint8_t *digest) {
+status_t sha512_final(sha512_state_t *state, uint32_t *digest) {
   // Construct padding.
   HARDENED_TRY(process_message(state, NULL, 0, kHardenedBoolTrue));
 
@@ -396,7 +394,7 @@ status_t sha512_final(sha512_state_t *state, uint8_t *digest) {
   return OTCRYPTO_OK;
 }
 
-status_t sha512(const uint8_t *msg, const size_t msg_len, uint8_t *digest) {
+status_t sha512(const uint8_t *msg, const size_t msg_len, uint32_t *digest) {
   sha512_state_t state;
   sha512_init(&state);
 
@@ -413,7 +411,7 @@ status_t sha384_update(sha384_state_t *state, const uint8_t *msg,
   return sha512_update(state, msg, msg_len);
 }
 
-status_t sha384_final(sha384_state_t *state, uint8_t *digest) {
+status_t sha384_final(sha384_state_t *state, uint32_t *digest) {
   // Construct padding.
   HARDENED_TRY(process_message(state, NULL, 0, kHardenedBoolTrue));
 
@@ -423,7 +421,7 @@ status_t sha384_final(sha384_state_t *state, uint8_t *digest) {
   return OTCRYPTO_OK;
 }
 
-status_t sha384(const uint8_t *msg, const size_t msg_len, uint8_t *digest) {
+status_t sha384(const uint8_t *msg, const size_t msg_len, uint32_t *digest) {
   sha384_state_t state;
   sha384_init(&state);
 

--- a/sw/device/lib/crypto/impl/sha2/sha512.h
+++ b/sw/device/lib/crypto/impl/sha2/sha512.h
@@ -129,7 +129,7 @@ typedef sha512_state_t sha384_state_t;
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha384(const uint8_t *msg, const size_t msg_len, uint8_t *digest);
+status_t sha384(const uint8_t *msg, const size_t msg_len, uint32_t *digest);
 
 /**
  * Set up a SHA-384 hash computation.
@@ -180,7 +180,7 @@ status_t sha384_update(sha384_state_t *state, const uint8_t *msg,
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha384_final(sha384_state_t *state, uint8_t *digest);
+status_t sha384_final(sha384_state_t *state, uint32_t *digest);
 
 /**
  * One-shot SHA-512 hash computation.
@@ -193,7 +193,7 @@ status_t sha384_final(sha384_state_t *state, uint8_t *digest);
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha512(const uint8_t *msg, const size_t msg_len, uint8_t *digest);
+status_t sha512(const uint8_t *msg, const size_t msg_len, uint32_t *digest);
 
 /**
  * Set up a SHA-512 hash computation.
@@ -244,7 +244,7 @@ status_t sha512_update(sha512_state_t *state, const uint8_t *msg,
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t sha512_final(sha512_state_t *state, uint8_t *digest);
+status_t sha512_final(sha512_state_t *state, uint32_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -135,11 +135,10 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
  * The input data in the `cipher_input` is first padded using the
  * `aes_padding` scheme and the output is copied to `cipher_output`.
  *
- * The caller should allocate space for the `cipher_output` buffer,
- * which should have the length returned by
- * `otcrypto_aes_padded_plaintext_length`, and set the length of expected
- * output in the `len` field of the output. If the user-set length and the
- * expected length do not match, an error message will be returned.
+ * The caller should allocate space for the `cipher_output` buffer, which is
+ * given in bytes by `otcrypto_aes_padded_plaintext_length`, and set the number
+ * of bytes allocated in the `len` field of the output.  If the user-set length
+ * and the expected length do not match, an error message will be returned.
  *
  * Note that, during decryption, the padding mode is ignored. This function
  * will NOT check the padding or return an error if the padding is invalid,
@@ -156,7 +155,7 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
  * @return The result of the cipher operation.
  */
 crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
-                             crypto_byte_buf_t iv, block_cipher_mode_t aes_mode,
+                             crypto_word_buf_t iv, block_cipher_mode_t aes_mode,
                              aes_operation_t aes_operation,
                              crypto_const_byte_buf_t cipher_input,
                              aes_padding_t aes_padding,
@@ -188,7 +187,7 @@ crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
                                          crypto_const_byte_buf_t plaintext,
-                                         crypto_const_byte_buf_t iv,
+                                         crypto_const_word_buf_t iv,
                                          crypto_const_byte_buf_t aad,
                                          aead_gcm_tag_len_t tag_len,
                                          crypto_byte_buf_t *ciphertext,
@@ -223,7 +222,7 @@ crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_decrypt_gcm(
     const crypto_blinded_key_t *key, crypto_const_byte_buf_t ciphertext,
-    crypto_const_byte_buf_t iv, crypto_const_byte_buf_t aad,
+    crypto_const_word_buf_t iv, crypto_const_byte_buf_t aad,
     aead_gcm_tag_len_t tag_len, crypto_const_byte_buf_t auth_tag,
     crypto_byte_buf_t *plaintext, hardened_bool_t *success);
 
@@ -285,7 +284,7 @@ crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
-                                         crypto_byte_buf_t digest);
+                                         crypto_word_buf_t digest);
 
 /**
  * Internal AES-GCTR operation of AES Galois Counter Mode (AES-GCM).
@@ -306,7 +305,7 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
-                                      crypto_const_byte_buf_t icb,
+                                      crypto_const_word_buf_t icb,
                                       crypto_const_byte_buf_t input,
                                       crypto_byte_buf_t output);
 
@@ -328,7 +327,7 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_kwp_encrypt(
     const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_byte_buf_t *wrapped_key);
+    const crypto_blinded_key_t *key_kek, crypto_word_buf_t *wrapped_key);
 
 /**
  * Performs the AES-KWP authenticated decryption operation.
@@ -341,7 +340,7 @@ crypto_status_t otcrypto_aes_kwp_encrypt(
  * @param[out] unwrapped_key Pointer to the output unwrapped key struct.
  * @return Result of the aes-kwp decrypt operation.
  */
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_byte_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key);
 

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -155,7 +155,8 @@ crypto_status_t otcrypto_aes_padded_plaintext_length(size_t plaintext_len,
  * @return The result of the cipher operation.
  */
 crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
-                             crypto_word_buf_t iv, block_cipher_mode_t aes_mode,
+                             crypto_word32_buf_t iv,
+                             block_cipher_mode_t aes_mode,
                              aes_operation_t aes_operation,
                              crypto_const_byte_buf_t cipher_input,
                              aes_padding_t aes_padding,
@@ -187,7 +188,7 @@ crypto_status_t otcrypto_aes(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
                                          crypto_const_byte_buf_t plaintext,
-                                         crypto_const_word_buf_t iv,
+                                         crypto_const_word32_buf_t iv,
                                          crypto_const_byte_buf_t aad,
                                          aead_gcm_tag_len_t tag_len,
                                          crypto_byte_buf_t *ciphertext,
@@ -222,7 +223,7 @@ crypto_status_t otcrypto_aes_encrypt_gcm(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_decrypt_gcm(
     const crypto_blinded_key_t *key, crypto_const_byte_buf_t ciphertext,
-    crypto_const_word_buf_t iv, crypto_const_byte_buf_t aad,
+    crypto_const_word32_buf_t iv, crypto_const_byte_buf_t aad,
     aead_gcm_tag_len_t tag_len, crypto_const_byte_buf_t auth_tag,
     crypto_byte_buf_t *plaintext, hardened_bool_t *success);
 
@@ -284,7 +285,7 @@ crypto_status_t otcrypto_gcm_ghash_update(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
-                                         crypto_word_buf_t digest);
+                                         crypto_word32_buf_t digest);
 
 /**
  * Internal AES-GCTR operation of AES Galois Counter Mode (AES-GCM).
@@ -305,7 +306,7 @@ crypto_status_t otcrypto_gcm_ghash_final(gcm_ghash_context_t *ctx,
  * @return Result of the operation.
  */
 crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
-                                      crypto_const_word_buf_t icb,
+                                      crypto_const_word32_buf_t icb,
                                       crypto_const_byte_buf_t input,
                                       crypto_byte_buf_t output);
 
@@ -327,7 +328,7 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
  */
 crypto_status_t otcrypto_aes_kwp_encrypt(
     const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_word_buf_t *wrapped_key);
+    const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key);
 
 /**
  * Performs the AES-KWP authenticated decryption operation.
@@ -340,7 +341,7 @@ crypto_status_t otcrypto_aes_kwp_encrypt(
  * @param[out] unwrapped_key Pointer to the output unwrapped key struct.
  * @return Result of the aes-kwp decrypt operation.
  */
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word32_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key);
 

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -106,30 +106,30 @@ typedef struct crypto_const_byte_buf {
  * Struct to hold a fixed-length word array.
  *
  * Note: the caller must (1) allocate sufficient space and (2) set the `len`
- * field and `data` pointer when `crypto_word_buf_t` is used for output. The
+ * field and `data` pointer when `crypto_word32_buf_t` is used for output. The
  * crypto library will throw an error if `len` doesn't match expectations.
  */
-typedef struct crypto_word_buf {
+typedef struct crypto_word32_buf {
   // Length of the data in words.
   size_t len;
   // Pointer to the data.
   uint32_t *data;
-} crypto_word_buf_t;
+} crypto_word32_buf_t;
 
 /**
  * Struct to hold a constant fixed-length word array.
  *
  * The const annotations prevent any changes to the word buffer. It is
- * necessary to have this structure separate from `crypto_word_buf_t` because
+ * necessary to have this structure separate from `crypto_word32_buf_t` because
  * data pointed to by a struct does not inherit `const`, so `const
- * crypto_word_buf_t` would still allow data to change.
+ * crypto_word32_buf_t` would still allow data to change.
  */
-typedef struct crypto_const_word_buf {
+typedef struct crypto_const_word32_buf {
   // Length of the data in words.
   const size_t len;
   // Pointer to the data.
   const uint32_t *const data;
-} crypto_const_word_buf_t;
+} crypto_const_word32_buf_t;
 
 /**
  * Enum to denote the key type of the handled key.

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -103,6 +103,35 @@ typedef struct crypto_const_byte_buf {
 } crypto_const_byte_buf_t;
 
 /**
+ * Struct to hold a fixed-length word array.
+ *
+ * Note: the caller must (1) allocate sufficient space and (2) set the `len`
+ * field and `data` pointer when `crypto_word_buf_t` is used for output. The
+ * crypto library will throw an error if `len` doesn't match expectations.
+ */
+typedef struct crypto_word_buf {
+  // Length of the data in words.
+  size_t len;
+  // Pointer to the data.
+  uint32_t *data;
+} crypto_word_buf_t;
+
+/**
+ * Struct to hold a constant fixed-length word array.
+ *
+ * The const annotations prevent any changes to the word buffer. It is
+ * necessary to have this structure separate from `crypto_word_buf_t` because
+ * data pointed to by a struct does not inherit `const`, so `const
+ * crypto_word_buf_t` would still allow data to change.
+ */
+typedef struct crypto_const_word_buf {
+  // Length of the data in words.
+  const size_t len;
+  // Pointer to the data.
+  const uint32_t *const data;
+} crypto_const_word_buf_t;
+
+/**
  * Enum to denote the key type of the handled key.
  *
  * Values are hardened.

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -88,7 +88,7 @@ typedef struct hash_context {
  * @return Result of the hash operation.
  */
 crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
-                              hash_mode_t hash_mode, crypto_byte_buf_t *digest);
+                              hash_mode_t hash_mode, crypto_word_buf_t *digest);
 
 /**
  * Performs the required extendable output function on the input data.
@@ -101,11 +101,11 @@ crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
  * are ignored when the `xof_mode` is set to kHashModeSha3Shake128 or
  * kHashModeSha3Shake256.
  *
- * The caller should allocate space for the `digest` buffer,
- * (expected length same as `required_output_len`), and set the length
- * of expected output in the `len` field of `digest`. If the user-set
- * length and the output length does not match, an error message will
- * be returned.
+ * The caller should allocate space for the `digest` buffer, with a word-length
+ * long enough to hold `required_output_len`, and set the `len` field of
+ * `digest` to the word-length of the allocated buffer. If the `len` field of
+ * digest does not match `required_output_len`, the function will return an
+ * error.
  *
  * @param input_message Input message for extendable output function.
  * @param xof_mode Required extendable output function.
@@ -120,7 +120,7 @@ crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
                              crypto_const_byte_buf_t function_name_string,
                              crypto_const_byte_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_byte_buf_t *digest);
+                             crypto_word_buf_t *digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.
@@ -178,7 +178,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
  * @return Result of the hash final operation.
  */
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_byte_buf_t *digest);
+                                    crypto_word_buf_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -88,7 +88,8 @@ typedef struct hash_context {
  * @return Result of the hash operation.
  */
 crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
-                              hash_mode_t hash_mode, crypto_word_buf_t *digest);
+                              hash_mode_t hash_mode,
+                              crypto_word32_buf_t *digest);
 
 /**
  * Performs the required extendable output function on the input data.
@@ -120,7 +121,7 @@ crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
                              crypto_const_byte_buf_t function_name_string,
                              crypto_const_byte_buf_t customization_string,
                              size_t required_output_len,
-                             crypto_word_buf_t *digest);
+                             crypto_word32_buf_t *digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.
@@ -178,7 +179,7 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
  * @return Result of the hash final operation.
  */
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_word_buf_t *digest);
+                                    crypto_word32_buf_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -74,7 +74,7 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
  */
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_byte_buf_t input_message,
-                              crypto_word_buf_t *tag);
+                              crypto_word32_buf_t *tag);
 
 /**
  * Performs the KMAC function on the input data.
@@ -103,7 +103,7 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
                               kmac_mode_t kmac_mode,
                               crypto_const_byte_buf_t customization_string,
                               size_t required_output_len,
-                              crypto_word_buf_t *tag);
+                              crypto_word32_buf_t *tag);
 
 /**
  * Performs the INIT operation for HMAC.
@@ -159,7 +159,7 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
  * @return Result of the HMAC final operation.
  */
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_word_buf_t *tag);
+                                    crypto_word32_buf_t *tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -64,8 +64,8 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
  * This function computes the HMAC-SHA256 function on the `input_message`
  * using the `key` and returns a `tag`.
  *
- * The caller should allocate 32 bytes of space for the `tag` buffer and set
- * its `len` field to 32.
+ * The caller should allocate 32 bytes (8 32-bit words) of space for the `tag`
+ * buffer and set its `len` field to 8.
  *
  * @param key Pointer to the blinded key struct with key shares.
  * @param input_message Input message to be hashed.
@@ -74,7 +74,7 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
  */
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_byte_buf_t input_message,
-                              crypto_byte_buf_t *tag);
+                              crypto_word_buf_t *tag);
 
 /**
  * Performs the KMAC function on the input data.
@@ -84,10 +84,11 @@ crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
  * through `customization_string` parameter. If no customization is desired it
  * can be empty.
  *
- * The caller should allocate `required_output_len` bytes for the `tag` buffer
- * and set the `len` field of `tag` to `required_output_len`. If the user-set
- * length and the output length does not match, an error message will be
- * returned.
+ * The caller should allocate enough space in the `tag` buffer to hold
+ * `required_output_len` bytes, rounded up to the nearest word, and then set
+ * the `len` field of `tag` to the word length. If the word length is not long
+ * enough to hold `required_output_len` bytes, then the function will return an
+ * error.
  *
  * @param key Pointer to the blinded key struct with key shares.
  * @param input_message Input message to be hashed.
@@ -102,7 +103,7 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
                               kmac_mode_t kmac_mode,
                               crypto_const_byte_buf_t customization_string,
                               size_t required_output_len,
-                              crypto_byte_buf_t *tag);
+                              crypto_word_buf_t *tag);
 
 /**
  * Performs the INIT operation for HMAC.
@@ -149,16 +150,16 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
  * #otcrypto_hmac_update should be called before calling this function.
  *
  * The caller should allocate space for the `tag` buffer, (expected length is
- * 32 bytes for HMAC), and set the length of expected output in the `len` field
- * of `tag`. If the user-set length and the output length does not match, an
- * error message will be returned.
+ * 32 bytes = 8 32-bit words for HMAC), and set the length of expected output
+ * in the `len` field of `tag`. If the user-set length and the output length
+ * does not match, an error message will be returned.
  *
  * @param ctx Pointer to the generic HMAC context struct.
  * @param[out] tag Output authentication tag.
  * @return Result of the HMAC final operation.
  */
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
-                                    crypto_byte_buf_t *tag);
+                                    crypto_word_buf_t *tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -131,7 +131,7 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
                                   crypto_const_byte_buf_t input_message,
                                   rsa_padding_t padding_mode,
                                   rsa_hash_t hash_mode,
-                                  crypto_byte_buf_t *signature);
+                                  crypto_word_buf_t *signature);
 
 /**
  * Verifies the authenticity of the input signature.
@@ -152,7 +152,7 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
                                     crypto_const_byte_buf_t input_message,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
-                                    crypto_const_byte_buf_t signature,
+                                    crypto_const_word_buf_t signature,
                                     hardened_bool_t *verification_result);
 
 /**
@@ -223,7 +223,7 @@ crypto_status_t otcrypto_rsa_sign_async_start(
  * @param[out] signature Pointer to generated signature struct.
  * @return Result of async RSA sign finalize operation.
  */
-crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_byte_buf_t *signature);
+crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_word_buf_t *signature);
 
 /**
  * Starts the asynchronous signature verification function.
@@ -236,7 +236,7 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_byte_buf_t *signature);
  * @return Result of async RSA verify start operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key, crypto_const_byte_buf_t signature);
+    const rsa_public_key_t *rsa_public_key, crypto_const_word_buf_t signature);
 
 /**
  * Finalizes the asynchronous signature verification function.

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -131,7 +131,7 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
                                   crypto_const_byte_buf_t input_message,
                                   rsa_padding_t padding_mode,
                                   rsa_hash_t hash_mode,
-                                  crypto_word_buf_t *signature);
+                                  crypto_word32_buf_t *signature);
 
 /**
  * Verifies the authenticity of the input signature.
@@ -152,7 +152,7 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
                                     crypto_const_byte_buf_t input_message,
                                     rsa_padding_t padding_mode,
                                     rsa_hash_t hash_mode,
-                                    crypto_const_word_buf_t signature,
+                                    crypto_const_word32_buf_t signature,
                                     hardened_bool_t *verification_result);
 
 /**
@@ -223,7 +223,8 @@ crypto_status_t otcrypto_rsa_sign_async_start(
  * @param[out] signature Pointer to generated signature struct.
  * @return Result of async RSA sign finalize operation.
  */
-crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_word_buf_t *signature);
+crypto_status_t otcrypto_rsa_sign_async_finalize(
+    crypto_word32_buf_t *signature);
 
 /**
  * Starts the asynchronous signature verification function.
@@ -236,7 +237,8 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(crypto_word_buf_t *signature);
  * @return Result of async RSA verify start operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key, crypto_const_word_buf_t signature);
+    const rsa_public_key_t *rsa_public_key,
+    crypto_const_word32_buf_t signature);
 
 /**
  * Finalizes the asynchronous signature verification function.

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -117,7 +117,7 @@ OT_WARN_UNUSED_RESULT
 static status_t encrypt_rma_unlock_token(
     crypto_blinded_key_t *aes_key, wrapped_rma_unlock_token_t *wrapped_token) {
   // Construct IV, which since we are using ECB mode, is empty.
-  crypto_byte_buf_t iv = {
+  crypto_word_buf_t iv = {
       .data = NULL,
       .len = 0,
   };

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -117,7 +117,7 @@ OT_WARN_UNUSED_RESULT
 static status_t encrypt_rma_unlock_token(
     crypto_blinded_key_t *aes_key, wrapped_rma_unlock_token_t *wrapped_token) {
   // Construct IV, which since we are using ECB mode, is empty.
-  crypto_word_buf_t iv = {
+  crypto_word32_buf_t iv = {
       .data = NULL,
       .len = 0,
   };

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -11,27 +11,40 @@
 #include "sw/device/lib/crypto/include/hash.h"
 
 status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
-                                             size_t token_size,
+                                             size_t token_size_bytes,
                                              uint64_t *hashed_token) {
   crypto_const_byte_buf_t input = {
-      .data = (uint8_t *)raw_token,
-      .len = token_size,
+      .data = (unsigned char *)raw_token,
+      .len = token_size_bytes,
   };
   crypto_const_byte_buf_t function_name_string = {
-      .data = (uint8_t *)"",
+      .data = (unsigned char *)"",
       .len = 0,
   };
   crypto_const_byte_buf_t customization_string = {
-      .data = (uint8_t *)"LC_CTRL",
+      .data = (unsigned char *)"LC_CTRL",
       .len = 7,
   };
-  crypto_byte_buf_t output = {
-      .data = (uint8_t *)hashed_token,
-      .len = token_size,
+
+  // Create a temporary uint32_t buffer and copy the result from there to the
+  // uint64_t buffer.
+  // TODO(#16556): this is a workaround to avoid violating strict-aliasing; if
+  // we pass -fno-strict-aliasing, then we can cast `hashed_token` to `uint32_t
+  // *` instead.
+  size_t token_num_words = token_size_bytes / sizeof(uint32_t);
+  if (token_size_bytes % sizeof(uint32_t) != 0) {
+    token_num_words++;
+  }
+  uint32_t token_data[token_num_words];
+  memset(token_data, 0, sizeof(token_data));
+  crypto_word_buf_t output = {
+      .data = token_data,
+      .len = token_num_words,
   };
 
   TRY(otcrypto_xof(input, kXofModeSha3Cshake128, function_name_string,
-                   customization_string, token_size, &output));
+                   customization_string, token_size_bytes, &output));
+  memcpy(hashed_token, token_data, sizeof(token_data));
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -37,7 +37,7 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
   }
   uint32_t token_data[token_num_words];
   memset(token_data, 0, sizeof(token_data));
-  crypto_word_buf_t output = {
+  crypto_word32_buf_t output = {
       .data = token_data,
       .len = token_num_words,
   };

--- a/sw/device/silicon_creator/manuf/lib/util.h
+++ b/sw/device/silicon_creator/manuf/lib/util.h
@@ -21,13 +21,13 @@
  * “” and customization string “LC_CTRL”".
  *
  * @param raw_token The raw token to be hashed.
- * @param token_size The expected hashed token size in bytes.
+ * @param token_size_bytes The expected hashed token size in bytes.
  * @param[out] hashed_token The hashed token.
  * @return Result of the hash operation.
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
-                                             size_t token_size,
+                                             size_t token_size_bytes,
                                              uint64_t *hashed_token);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
@@ -56,9 +56,9 @@ status_t hash_rom(void) {
       .data = (uint8_t *)TOP_EARLGREY_ROM_BASE_ADDR,
       .len = kGoldenRomSizeBytes,
   };
-  crypto_byte_buf_t output = {
-      .data = (uint8_t *)rom_hash,
-      .len = kSha256HashSizeInBytes,
+  crypto_word_buf_t output = {
+      .data = rom_hash,
+      .len = ARRAYSIZE(rom_hash),
   };
 
   TRY(otcrypto_hash(input, kHashModeSha256, &output));

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
@@ -56,7 +56,7 @@ status_t hash_rom(void) {
       .data = (uint8_t *)TOP_EARLGREY_ROM_BASE_ADDR,
       .len = kGoldenRomSizeBytes,
   };
-  crypto_word_buf_t output = {
+  crypto_word32_buf_t output = {
       .data = rom_hash,
       .len = ARRAYSIZE(rom_hash),
   };

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -79,7 +79,7 @@ static void encrypt_decrypt_test(const aes_test_t *test) {
   // Construct non-constant version of IV buffer.
   uint32_t iv_data[kAesBlockWords];
   memcpy(iv_data, test->iv, kAesBlockBytes);
-  crypto_word_buf_t iv = {
+  crypto_word32_buf_t iv = {
       .data = iv_data,
       .len = kAesBlockWords,
   };

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -81,7 +81,7 @@ uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
   size_t iv_num_words = (test.iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t iv_data[iv_num_words];
   memcpy(iv_data, test.iv, test.iv_len);
-  crypto_const_word_buf_t iv = {
+  crypto_const_word32_buf_t iv = {
       .data = iv_data,
       .len = iv_num_words,
   };
@@ -157,7 +157,7 @@ uint32_t call_aes_gcm_decrypt(aes_gcm_test_t test, bool tag_valid) {
   size_t iv_num_words = (test.iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t iv_data[iv_num_words];
   memcpy(iv_data, test.iv, test.iv_len);
-  crypto_const_word_buf_t iv = {
+  crypto_const_word32_buf_t iv = {
       .data = iv_data,
       .len = iv_num_words,
   };

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -78,9 +78,12 @@ uint32_t call_aes_gcm_encrypt(aes_gcm_test_t test) {
   // Set the checksum.
   key.checksum = integrity_blinded_checksum(&key);
 
-  crypto_const_byte_buf_t iv = {
-      .data = test.iv,
-      .len = test.iv_len,
+  size_t iv_num_words = (test.iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t iv_data[iv_num_words];
+  memcpy(iv_data, test.iv, test.iv_len);
+  crypto_const_word_buf_t iv = {
+      .data = iv_data,
+      .len = iv_num_words,
   };
   crypto_const_byte_buf_t plaintext = {
       .data = test.plaintext,
@@ -151,9 +154,12 @@ uint32_t call_aes_gcm_decrypt(aes_gcm_test_t test, bool tag_valid) {
   // Set the checksum.
   key.checksum = integrity_blinded_checksum(&key);
 
-  crypto_const_byte_buf_t iv = {
-      .data = test.iv,
-      .len = test.iv_len,
+  size_t iv_num_words = (test.iv_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t iv_data[iv_num_words];
+  memcpy(iv_data, test.iv, test.iv_len);
+  crypto_const_word_buf_t iv = {
+      .data = iv_data,
+      .len = iv_num_words,
   };
   crypto_const_byte_buf_t ciphertext = {
       .data = test.ciphertext,

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -78,7 +78,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
   blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
-  crypto_word_buf_t tag_buf = {
+  crypto_word32_buf_t tag_buf = {
       .data = act_tag,
       .len = ARRAYSIZE(act_tag),
   };

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -78,9 +78,9 @@ static status_t run_test(const uint32_t *key, size_t key_len,
   blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
 
   uint32_t act_tag[kTagLenWords];
-  crypto_byte_buf_t tag_buf = {
-      .data = (unsigned char *)act_tag,
-      .len = sizeof(act_tag),
+  crypto_word_buf_t tag_buf = {
+      .data = act_tag,
+      .len = ARRAYSIZE(act_tag),
   };
 
   TRY(otcrypto_hmac(&blinded_key, msg, &tag_buf));

--- a/sw/device/tests/crypto/kmac_verify_functest.c
+++ b/sw/device/tests/crypto/kmac_verify_functest.c
@@ -28,10 +28,15 @@ bool test_main(void) {
     LOG_INFO("loop counter = %d, vector identifier: %s", i,
              current_test_vector->vector_identifier);
 
-    uint8_t digest[current_test_vector->digest.len];
-    crypto_byte_buf_t digest_buf = {
+    size_t digest_len_words =
+        current_test_vector->digest.len / sizeof(uint32_t);
+    if (current_test_vector->digest.len % sizeof(uint32_t) != 0) {
+      digest_len_words++;
+    }
+    uint32_t digest[digest_len_words];
+    crypto_word_buf_t digest_buf = {
         .data = digest,
-        .len = current_test_vector->digest.len,
+        .len = digest_len_words,
     };
 
     crypto_status_t err_status;
@@ -58,7 +63,8 @@ bool test_main(void) {
     }
 
     CHECK_STATUS_OK(err_status);
-    CHECK_ARRAYS_EQ(digest_buf.data, current_test_vector->digest.data,
+    CHECK_ARRAYS_EQ((unsigned char *)digest_buf.data,
+                    current_test_vector->digest.data,
                     current_test_vector->digest.len);
   }
 

--- a/sw/device/tests/crypto/kmac_verify_functest.c
+++ b/sw/device/tests/crypto/kmac_verify_functest.c
@@ -34,7 +34,7 @@ bool test_main(void) {
       digest_len_words++;
     }
     uint32_t digest[digest_len_words];
-    crypto_word_buf_t digest_buf = {
+    crypto_word32_buf_t digest_buf = {
         .data = digest,
         .len = digest_len_words,
     };

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -103,11 +103,11 @@ status_t keygen_then_sign_test(void) {
   };
 
   uint32_t sig[kRsa2048NumWords];
-  crypto_word_buf_t sig_buf = {
+  crypto_word32_buf_t sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };
-  crypto_const_word_buf_t const_sig_buf = {
+  crypto_const_word32_buf_t const_sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -103,13 +103,13 @@ status_t keygen_then_sign_test(void) {
   };
 
   uint32_t sig[kRsa2048NumWords];
-  crypto_byte_buf_t sig_buf = {
-      .data = (unsigned char *)sig,
-      .len = kRsa2048NumBytes,
+  crypto_word_buf_t sig_buf = {
+      .data = sig,
+      .len = kRsa2048NumWords,
   };
-  crypto_const_byte_buf_t const_sig_buf = {
-      .data = (unsigned char *)sig,
-      .len = kRsa2048NumBytes,
+  crypto_const_word_buf_t const_sig_buf = {
+      .data = sig,
+      .len = kRsa2048NumWords,
   };
 
   // Generate a signature.

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -142,7 +142,7 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .len = msg_len,
   };
 
-  crypto_word_buf_t sig_buf = {
+  crypto_word32_buf_t sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };
@@ -201,7 +201,7 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
       .len = msg_len,
   };
 
-  crypto_const_word_buf_t sig_buf = {
+  crypto_const_word32_buf_t sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -142,9 +142,9 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .len = msg_len,
   };
 
-  crypto_byte_buf_t sig_buf = {
-      .data = (unsigned char *)sig,
-      .len = kRsa2048NumBytes,
+  crypto_word_buf_t sig_buf = {
+      .data = sig,
+      .len = kRsa2048NumWords,
   };
 
   return otcrypto_rsa_sign(&private_key, msg_buf, padding_mode, hash_mode,
@@ -201,9 +201,9 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
       .len = msg_len,
   };
 
-  crypto_const_byte_buf_t sig_buf = {
-      .data = (unsigned char *)sig,
-      .len = kRsa2048NumBytes,
+  crypto_const_word_buf_t sig_buf = {
+      .data = sig,
+      .len = kRsa2048NumWords,
   };
 
   return otcrypto_rsa_verify(&public_key, msg_buf, padding_mode, hash_mode,

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -56,7 +56,7 @@ static const uint8_t kExactBlockExpDigest[] = {
 static status_t run_test(crypto_const_byte_buf_t msg,
                          const uint32_t *exp_digest) {
   uint32_t act_digest[kHmacDigestNumWords];
-  crypto_word_buf_t digest_buf = {
+  crypto_word32_buf_t digest_buf = {
       .data = act_digest,
       .len = kHmacDigestNumWords,
   };
@@ -118,7 +118,7 @@ static status_t one_update_streaming_test(void) {
   size_t digest_num_words =
       (sizeof(kExactBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t act_digest[digest_num_words];
-  crypto_word_buf_t digest_buf = {
+  crypto_word32_buf_t digest_buf = {
       .data = act_digest,
       .len = digest_num_words,
   };
@@ -153,7 +153,7 @@ static status_t multiple_update_streaming_test(void) {
   size_t digest_num_words =
       (sizeof(kTwoBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t act_digest[digest_num_words];
-  crypto_word_buf_t digest_buf = {
+  crypto_word32_buf_t digest_buf = {
       .data = act_digest,
       .len = digest_num_words,
   };

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -56,9 +56,9 @@ static const uint8_t kExactBlockExpDigest[] = {
 static status_t run_test(crypto_const_byte_buf_t msg,
                          const uint32_t *exp_digest) {
   uint32_t act_digest[kHmacDigestNumWords];
-  crypto_byte_buf_t digest_buf = {
-      .data = (unsigned char *)act_digest,
-      .len = sizeof(act_digest),
+  crypto_word_buf_t digest_buf = {
+      .data = act_digest,
+      .len = kHmacDigestNumWords,
   };
   TRY(otcrypto_hash(msg, kHashModeSha256, &digest_buf));
   TRY_CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
@@ -115,14 +115,16 @@ static status_t one_update_streaming_test(void) {
   };
   TRY(otcrypto_hash_update(&ctx, msg_buf));
 
-  uint8_t act_digest[ARRAYSIZE(kExactBlockExpDigest)];
-  crypto_byte_buf_t digest_buf = {
+  size_t digest_num_words =
+      (sizeof(kExactBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t act_digest[digest_num_words];
+  crypto_word_buf_t digest_buf = {
       .data = act_digest,
-      .len = sizeof(act_digest),
+      .len = digest_num_words,
   };
   TRY(otcrypto_hash_final(&ctx, &digest_buf));
-  TRY_CHECK_ARRAYS_EQ(act_digest, kExactBlockExpDigest,
-                      ARRAYSIZE(kExactBlockExpDigest));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kExactBlockExpDigest,
+                      sizeof(kExactBlockExpDigest));
   return OK_STATUS();
 }
 
@@ -148,14 +150,16 @@ static status_t multiple_update_streaming_test(void) {
     update_size++;
     TRY(otcrypto_hash_update(&ctx, msg_buf));
   }
-  uint8_t act_digest[ARRAYSIZE(kTwoBlockExpDigest)];
-  crypto_byte_buf_t digest_buf = {
+  size_t digest_num_words =
+      (sizeof(kTwoBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t act_digest[digest_num_words];
+  crypto_word_buf_t digest_buf = {
       .data = act_digest,
-      .len = sizeof(act_digest),
+      .len = digest_num_words,
   };
   TRY(otcrypto_hash_final(&ctx, &digest_buf));
-  TRY_CHECK_ARRAYS_EQ(act_digest, kTwoBlockExpDigest,
-                      ARRAYSIZE(kTwoBlockExpDigest));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kTwoBlockExpDigest,
+                      sizeof(kTwoBlockExpDigest));
   return OK_STATUS();
 }
 

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -47,7 +47,7 @@ status_t sha384_test(const unsigned char *msg, const size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[384 / 32];
-  crypto_word_buf_t actual_digest = {
+  crypto_word32_buf_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
   };
@@ -83,7 +83,7 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[384 / 32];
-  crypto_word_buf_t actual_digest = {
+  crypto_word32_buf_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
   };

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -46,16 +46,16 @@ status_t sha384_test(const unsigned char *msg, const size_t msg_len,
   };
 
   // Allocate space for the computed digest.
-  uint8_t actual_digest_data[384 / 8];
-  crypto_byte_buf_t actual_digest = {
-      .data = (unsigned char *)actual_digest_data,
-      .len = sizeof(actual_digest_data),
+  uint32_t actual_digest_data[384 / 32];
+  crypto_word_buf_t actual_digest = {
+      .data = actual_digest_data,
+      .len = ARRAYSIZE(actual_digest_data),
   };
   TRY(otcrypto_hash(input_message, kHashModeSha384, &actual_digest));
 
   // Check that the expected and actual digests match.
-  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-                      ARRAYSIZE(actual_digest_data));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
+                      sizeof(actual_digest_data));
 
   return OTCRYPTO_OK;
 }
@@ -82,16 +82,16 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
   }
 
   // Allocate space for the computed digest.
-  uint8_t actual_digest_data[384 / 8];
-  crypto_byte_buf_t actual_digest = {
-      .data = (unsigned char *)actual_digest_data,
-      .len = sizeof(actual_digest_data),
+  uint32_t actual_digest_data[384 / 32];
+  crypto_word_buf_t actual_digest = {
+      .data = actual_digest_data,
+      .len = ARRAYSIZE(actual_digest_data),
   };
   TRY(otcrypto_hash_final(&ctx, &actual_digest));
 
   // Check that the expected and actual digests match.
-  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-                      ARRAYSIZE(actual_digest_data));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
+                      sizeof(actual_digest_data));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -52,7 +52,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[512 / 32];
-  crypto_word_buf_t actual_digest = {
+  crypto_word32_buf_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
   };
@@ -88,7 +88,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[512 / 32];
-  crypto_word_buf_t actual_digest = {
+  crypto_word32_buf_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
   };

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -51,16 +51,16 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
   };
 
   // Allocate space for the computed digest.
-  uint8_t actual_digest_data[512 / 8];
-  crypto_byte_buf_t actual_digest = {
-      .data = (unsigned char *)actual_digest_data,
-      .len = sizeof(actual_digest_data),
+  uint32_t actual_digest_data[512 / 32];
+  crypto_word_buf_t actual_digest = {
+      .data = actual_digest_data,
+      .len = ARRAYSIZE(actual_digest_data),
   };
   TRY(otcrypto_hash(input_message, kHashModeSha512, &actual_digest));
 
   // Check that the expected and actual digests match.
-  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-                      ARRAYSIZE(actual_digest_data));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
+                      sizeof(actual_digest_data));
 
   return OTCRYPTO_OK;
 }
@@ -87,16 +87,16 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
   }
 
   // Allocate space for the computed digest.
-  uint8_t actual_digest_data[512 / 8];
-  crypto_byte_buf_t actual_digest = {
-      .data = (unsigned char *)actual_digest_data,
-      .len = sizeof(actual_digest_data),
+  uint32_t actual_digest_data[512 / 32];
+  crypto_word_buf_t actual_digest = {
+      .data = actual_digest_data,
+      .len = ARRAYSIZE(actual_digest_data),
   };
   TRY(otcrypto_hash_final(&ctx, &actual_digest));
 
   // Check that the expected and actual digests match.
-  TRY_CHECK_ARRAYS_EQ(actual_digest_data, expected_digest,
-                      ARRAYSIZE(actual_digest_data));
+  TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
+                      sizeof(actual_digest_data));
 
   return OTCRYPTO_OK;
 }


### PR DESCRIPTION
Introduces a datatype called `crypto_word32_buf` that is analogous to `crypto_byte_buf` and holds aligned data, which is easier and safer to handle when interfacing with the hardware. Word buffers then replace byte buffers for most things: signatures, DRBG output values, AES initialization vectors, hash function digests, and MAC tags. Byte buffers remain for freeform "message" inputs, for example hash function inputs and message inputs for signatures.

See https://github.com/lowRISC/opentitan/issues/19549 for discussion.