### PR TITLE
[flash_ctrl,dv] fix closed source regression

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -6,12 +6,16 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
   `uvm_object_utils(flash_ctrl_phy_arb_redun_vseq)
   `uvm_object_new
 
+  constraint ctrl_num_c {
+    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:16] :/ 1};
+  }
+
   task run_error_event();
     int delay;
     string path = {"tb.dut.u_eflash.gen_flash_cores[0].",
                    "u_core.u_host_arb.gen_input_bufs[1].u_req_buf.out_o[1:0]"};
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = cfg.seq_cfg.long_fatal_err_delay;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
 
     // unit 100 ns;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_path_intg_vseq.sv
@@ -25,16 +25,15 @@ class flash_ctrl_rd_path_intg_vseq extends flash_ctrl_legacy_base_vseq;
       //  hw/ip/flash_ctrl/rtl/flash_phy_rd.sv;drc=8046c2896fa50aaf3a186a7ce8c0570db9f99eaf;l=481)
       // Enable ecc for all regions
       flash_otf_region_cfg(.scr_mode(OTFCfgTrue), .ecc_mode(OTFCfgTrue));
-      // Set path to subset of both upperword [63:32] and lowerword[31:0]
-      path1 = {"tb.dut.u_eflash.gen_flash_cores[0].u_core",
-               ".u_rd.gen_bufs[0].u_rd_buf.data_i[35:28]"};
-      path2 = {"tb.dut.u_eflash.gen_flash_cores[1].u_core",
-               ".u_rd.gen_bufs[0].u_rd_buf.data_i[35:28]"};
-
       cfg.clk_rst_vif.wait_clks(10);
-
-      `DV_CHECK(uvm_hdl_force(path1, $urandom()))
-      `DV_CHECK(uvm_hdl_force(path2, $urandom()))
+      for (int k = 0; k < 4; k++) begin
+        path1 = $sformatf({"tb.dut.u_eflash.gen_flash_cores[0].u_core",
+                           ".u_rd.gen_bufs[%0d].u_rd_buf.data_i[35:28]"}, k);
+        path2 = $sformatf({"tb.dut.u_eflash.gen_flash_cores[1].u_core",
+                           ".u_rd.gen_bufs[%0d].u_rd_buf.data_i[35:28]"}, k);
+        `DV_CHECK(uvm_hdl_force(path1, $urandom()))
+        `DV_CHECK(uvm_hdl_force(path2, $urandom()))
+      end
       cfg.scb_h.expected_alert["fatal_err"].expected = 1;
       cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
       cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;


### PR DESCRIPTION
Following tests are fixed. See commit message for detail

- flash_ctrl_phy_arb_redun
- flash_ctrl_rd_intg