### PR TITLE
[silicon_creator] Lock rom_ext flash region

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -629,6 +629,32 @@ void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
                                  /*en=*/kMultiBitBool4True);
 }
 
+void flash_ctrl_data_region_lock(flash_ctrl_region_index_t region) {
+#define FLASH_CTRL_MP_REGION_CFG_REGWEN_WRITE_(region_macro_arg)                                   \
+  case ((region_macro_arg)): {                                                                     \
+    uint32_t region_cfg = bitfield_field32_write(                                                  \
+        0,                                                                                         \
+        (bitfield_field32_t){                                                                      \
+            .mask = UINT32_MAX,                                                                    \
+            .index =                                                                               \
+                FLASH_CTRL_REGION_CFG_REGWEN_##region_macro_arg##_REGION_##region_macro_arg##_BIT, \
+        },                                                                                         \
+        true);                                                                                     \
+    sec_mmio_write32(                                                                              \
+        kBase + FLASH_CTRL_REGION_CFG_REGWEN_##region_macro_arg##_REG_OFFSET,                      \
+        region_cfg);                                                                               \
+    return;                                                                                        \
+  }
+
+  switch (launder32(region)) {
+    FLASH_CTRL_MP_REGIONS(FLASH_CTRL_MP_REGION_CFG_REGWEN_WRITE_)
+    default:
+      OT_UNREACHABLE();
+  }
+
+#undef FLASH_CTRL_MP_REGION_CFG_REGWEN_WRITE_
+}
+
 void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
                              flash_ctrl_cfg_t cfg) {
   SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgSet, 1);

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -96,6 +96,13 @@ typedef enum flash_ctrl_partition {
 // clang-format on
 
 /**
+ * Table of flash data memory protection regions.
+ */
+enum {
+  kFlashCtrlDataRegionActiveRomExt = 0,
+};
+
+/**
  * A struct for storing base, config write-enable register, and config register
  * addresses of an info page.
  */
@@ -481,6 +488,17 @@ void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
                                     uint32_t page_offset, uint32_t num_pages,
                                     flash_ctrl_perms_t perms,
                                     flash_ctrl_cfg_t cfg);
+
+/**
+ * Lock the configuration for a region of pages.
+ *
+ * Based on the `region` parameter, this function sets the
+ * `REGION_CFG_REGWEN_${region}.REGION` field, locking the region and preventing
+ * it from being reconfigured until the next reset.
+ *
+ * @param region The index of the region to lock.
+ */
+void flash_ctrl_data_region_lock(flash_ctrl_region_index_t region);
 
 /**
  * Sets configuration settings for an info page.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -883,5 +883,37 @@ TEST_P(DataRegionProtectTestSuite, ProtectRegionReadWriteEraseEnabled) {
       });
 }
 
+class DataRegionLockTestSuite : public testing::TestWithParam<size_t> {
+ protected:
+  static const size_t kNumMemoryProtectionRegions = 8;
+  static constexpr size_t
+      kFlashCtrlRegionCfgRegwenOffset[kNumMemoryProtectionRegions]{
+          FLASH_CTRL_REGION_CFG_REGWEN_0_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_1_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_2_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_3_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_4_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_5_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_6_REG_OFFSET,
+          FLASH_CTRL_REGION_CFG_REGWEN_7_REG_OFFSET,
+      };
+
+  static constexpr uint32_t kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR;
+
+  rom_test::MockSecMmio sec_mmio_;
+};
+
+constexpr size_t DataRegionLockTestSuite::kFlashCtrlRegionCfgRegwenOffset[];
+
+INSTANTIATE_TEST_SUITE_P(DataRegionLockTestInstance, DataRegionLockTestSuite,
+                         testing::Values(0, 1, 2, 3, 4, 5, 6, 7));
+
+TEST_P(DataRegionLockTestSuite, RegionLockTest) {
+  size_t region = GetParam();
+  EXPECT_CALL(sec_mmio_,
+              Write32(kBase + kFlashCtrlRegionCfgRegwenOffset[region], 0x1u));
+  flash_ctrl_data_region_lock(region);
+}
+
 }  // namespace
 }  // namespace flash_ctrl_unittest

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -152,6 +152,8 @@ enum module_ {
   \
   X(kErrorRomExtBootFailed,           ERROR_(1, kModuleRomExt, kFailedPrecondition)), \
   \
+  X(kErrorRomExtBadOffsetLen,         ERROR_(2, kModuleRomExt, kInternal)), \
+  \
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorRomExtInterrupt,            ERROR_(0, kModuleRomExtInterrupt, kUnknown)), \
   \

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -204,6 +204,7 @@ cc_library(
         ":rom_ext_boot_policy_ptrs",
         ":rom_ext_epmp",
         ":sigverify_keys",
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",


### PR DESCRIPTION
As part of rom_ext lockdown, set the active rom_ext flash slot to read only to prevent owner code from modifying it.

Pushing this in draft stage until the following have been addressed:
- [ ] Organize the locked data regions in a similar way to how info pages are organized
- [ ] Ensure the locked region is consistent with the actual location of rom_ext in flash