### PR TITLE
[otbn] Cherry-pick LC signal handling fixes - Part 1

### DIFF
--- a/hw/ip/otbn/doc/interfaces.md
+++ b/hw/ip/otbn/doc/interfaces.md
@@ -95,3 +95,13 @@ To maintain its security properties, OTBN requires the following configuration f
   For performance reasons, requests on this EDN connection should be answered quickly.
 * `edn_rnd` must provide AIS31-compliant class PTG.3 random numbers.
   The randomness from this interface is made available through the `RND` WSR and intended to be used for key generation.
+
+### Life Cycle Controller (LC_CTRL)
+
+OTBN has three LC_CTRL connections: one for triggering life cycle escalation requests (`lc_escalate_en`) and two for handling RMA entry (`lc_rma_req/ack`).
+
+As LC_CTRL might sit in a different clock domain and since all these connections are using multi-bit signals, OTBN might observe staggered signal transitions due to the clock domain crossings.
+To avoid spurious life cycle escalations and to enable reliable RMA entry, it should be ensured that:
+
+* The `lc_escalate_en` and `lc_rma_req` inputs are stably driven to `lc_ctrl_pkg::Off` before releasing the reset of OTBN.
+* When triggering RMA entry, the `lc_rma_req` input switches from `lc_ctrl_pkg::Off` to `lc_ctrl_pkg::On` exactly once, and then remains `On` until OTBN signals completion of the secure wipe operation with the `lc_rma_ack` output switching to `lc_ctrl_pkg::On`.

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -382,7 +382,6 @@ interface otbn_trace_if
   controller_bad_int_t controller_bad_int_i, controller_bad_int_d, controller_bad_int_q;
   missed_gnt_t missed_gnt_i, missed_gnt_d, missed_gnt_q;
   logic scramble_state_err_i, scramble_state_err_d, scramble_state_err_q;
-  logic ext_mubi_err_i, ext_mubi_err_d, ext_mubi_err_q;
   logic urnd_all_zero_d, urnd_all_zero_q;
   logic insn_addr_err_d, insn_addr_err_q;
   logic rf_base_spurious_we_err_d, rf_base_spurious_we_err_q;
@@ -395,7 +394,6 @@ interface otbn_trace_if
   assign start_stop_bad_int_d = (locking_o) ? '0 : (start_stop_bad_int_q | start_stop_bad_int_i);
   assign controller_bad_int_d = (locking_o) ? '0 : (controller_bad_int_q | controller_bad_int_i);
   assign scramble_state_err_d = (locking_o) ? '0 : (scramble_state_err_q | scramble_state_err_i);
-  assign ext_mubi_err_d = (locking_o) ? '0 : (ext_mubi_err_q| ext_mubi_err_i);
   assign rf_base_spurious_we_err_d = (locking_o) ? '0 :
    (rf_base_spurious_we_err_q | rf_base_spurious_we_err);
   assign rf_bignum_spurious_we_err_d = (locking_o) ? '0 :
@@ -403,7 +401,6 @@ interface otbn_trace_if
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      ext_mubi_err_q <= '0;
       missed_gnt_q <= '0;
       predec_err_q <= '0;
       urnd_all_zero_q <= '0;
@@ -414,7 +411,6 @@ interface otbn_trace_if
       rf_bignum_spurious_we_err_q <= '0;
       rf_base_spurious_we_err_q <= '0;
     end else begin
-      ext_mubi_err_q <= ext_mubi_err_d;
       missed_gnt_q <= missed_gnt_d;
       predec_err_q <= predec_err_d;
       urnd_all_zero_q <= urnd_all_zero_d;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -633,8 +633,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                          otbn_pkg::controller_bad_int_t controller_bad_int,
                          otbn_pkg::start_stop_bad_int_t start_stop_bad_int,
                          logic rf_base_spurious_we_err,
-                         logic rf_bignum_spurious_we_err,
-                         logic ext_mubi_err);
+                         logic rf_bignum_spurious_we_err);
 
     `DEF_SEEN_CP(alu_bignum_predec_err, predec_err.alu_bignum_err)
     `DEF_SEEN_CP(mac_bignum_predec_err, predec_err.mac_bignum_err)
@@ -666,7 +665,6 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_SEEN_CP(scramble_state_err_cp, scramble_state_err)
     `DEF_SEEN_CP(rf_base_spurious_we_err_cp, rf_base_spurious_we_err)
     `DEF_SEEN_CP(rf_bignum_spurious_we_err_cp, rf_bignum_spurious_we_err)
-    `DEF_SEEN_CP(ext_mubi_err_cp, ext_mubi_err)
 
   endgroup
 
@@ -2251,8 +2249,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                                  cfg.trace_vif.controller_bad_int_q,
                                  cfg.trace_vif.start_stop_bad_int_q,
                                  cfg.trace_vif.rf_base_spurious_we_err_q,
-                                 cfg.trace_vif.rf_bignum_spurious_we_err_q,
-                                 cfg.trace_vif.ext_mubi_err_q);
+                                 cfg.trace_vif.rf_bignum_spurious_we_err_q);
 
     internal_intg_err_cg.sample(cfg.trace_vif.internal_intg_err_q);
   endfunction

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -133,7 +133,6 @@ module tb;
   ) i_otbn_trace_if (.*);
 
   assign dut.u_otbn_core.i_otbn_trace_if.scramble_state_err_i = dut.otbn_scramble_state_error;
-  assign dut.u_otbn_core.i_otbn_trace_if.ext_mubi_err_i = dut.mubi_err;
   assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.imem_gnt_missed_err = dut.imem_missed_gnt;
   assign dut.u_otbn_core.i_otbn_trace_if.missed_gnt_i.dmem_gnt_missed_err = dut.dmem_missed_gnt;
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -176,7 +176,6 @@ module otbn_top_sim (
   bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   assign u_otbn_core.i_otbn_trace_if.scramble_state_err_i = '0;
-  assign u_otbn_core.i_otbn_trace_if.ext_mubi_err_i = '0;
   assign u_otbn_core.i_otbn_trace_if.missed_gnt_i = '0;
 
   // Convert from core_err_bits_t to err_bits_t


### PR DESCRIPTION
This PR cherry-picks the first part of the fixes making OTBN compatible with the LC_CTRL spec. In particular, this PR changes the interpretation of the `lc_escalate_en_i` input signal (remove the detection of invalid values on this signal, consistently use `lc_tx_test_true_loose()`). This is related to https://github.com/lowRISC/opentitan/issues/19050.

The second part of the fix cannot be carried over yet as we first need to modify LC_CTRL itself to have two parallel RMA request interfaces for flash_ctrl and OTBN. See #19136.