### PR TITLE
[ci] OTBN crypto test job cleanups

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -404,7 +404,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool:
     vmImage: ubuntu-20.04
-  timeoutInMinutes: 180
+  timeoutInMinutes: 60
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,8 +408,18 @@ jobs:
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
+  - task: DownloadSecureFile@1
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    name: bazelCacheGcpKey
+    inputs:
+      secureFile: "bazel_cache_gcp_key.json"
+  - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    displayName: GCP key path
+    # Set the remote cache GCP key path
   - bash: |
       ci/bazelisk.sh test //sw/otbn/crypto/...
+    displayName: Execute tests
 
 - job: chip_earlgrey_cw310
   displayName: CW310's Earl Grey Bitstream


### PR DESCRIPTION
This is a followup to #19619 to clean up a few things on the new OTBN crypto test job:
- Reduce the timeout to 60 minutes (the expected completion time is 41 minutes)
- Enable uploading results to the Bazel remote cache