### PR TITLE
[ci] Fix the documentation build job in CI.

### DIFF
--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -6,7 +6,7 @@
 # Build docs and tell the Azure runner to upload any doxygen warnings
 
 set -e
-util/site/build-docs.sh || {
+util/site/build-docs.sh build-local || {
   echo -n "##vso[task.logissue type=error]"
   echo "Documentation build failed."
   exit 1


### PR DESCRIPTION
The CI command to render documentation omitted an argument, so the CI job always just printed usage advice and exited "successfully", meaning it would miss changes that broke documentation builds.

See https://github.com/lowRISC/opentitan/pull/19633#issuecomment-1711479976