### PR TITLE
[rust] migrate from is-terminal to `std::io::IsTerminal`

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -58,7 +58,6 @@ rust_library(
         "@crate_index//:directories",
         "@crate_index//:hex",
         "@crate_index//:indexmap",
-        "@crate_index//:is-terminal",
         "@crate_index//:log",
         "@crate_index//:num_enum",
         "@crate_index//:once_cell",

--- a/sw/host/hsmtool/src/commands/mod.rs
+++ b/sw/host/hsmtool/src/commands/mod.rs
@@ -4,10 +4,10 @@
 
 use anyhow::Result;
 use cryptoki::session::Session;
-use is_terminal::IsTerminal;
 use serde::{Deserialize, Serialize};
 use serde_annotate::{Annotate, ColorProfile};
 use std::any::Any;
+use std::io::IsTerminal;
 
 use crate::module::Module;
 use crate::util::attribute::AttrData;

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -54,7 +54,6 @@ rust_binary(
         "@crate_index//:erased-serde",
         "@crate_index//:hex",
         "@crate_index//:humantime",
-        "@crate_index//:is-terminal",
         "@crate_index//:log",
         "@crate_index//:mio",
         "@crate_index//:mio-signals",

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -4,12 +4,12 @@
 
 use anyhow::{anyhow, Result};
 use clap::Args;
-use is_terminal::IsTerminal;
 use raw_tty::TtyModeGuard;
 use regex::Regex;
 use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::File;
+use std::io::IsTerminal;
 use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -4,12 +4,12 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use is_terminal::IsTerminal;
 use raw_tty::TtyModeGuard;
 use serde_annotate::Annotate;
 use std::any::Any;
 use std::borrow::Borrow;
 use std::fs::File;
+use std::io::IsTerminal;
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
 use std::rc::Rc;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -6,13 +6,13 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use directories::ProjectDirs;
-use is_terminal::IsTerminal;
 use log::LevelFilter;
 use serde_annotate::Annotate;
 use serde_annotate::ColorProfile;
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsString;
 use std::io::ErrorKind;
+use std::io::IsTerminal;
 use std::iter::{IntoIterator, Iterator};
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "humantime-serde",
  "indexmap 2.0.0",
  "indicatif",
- "is-terminal",
  "libftdi1-sys",
  "log",
  "mdbook",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -31,7 +31,6 @@ hex = "0.4.3"
 humantime = "2.1.0"
 humantime-serde = "1.1"
 indicatif = "0.17.6"
-is-terminal = "0.4"
 log = "0.4"
 memoffset = "0.9.0"
 mio = { version = "0.8.8", features = ["os-poll", "net", "os-ext"] }

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -164,12 +164,6 @@ alias(
 )
 
 alias(
-    name = "is-terminal",
-    actual = "@crate_index__is-terminal-0.4.9//:is_terminal",
-    tags = ["manual"],
-)
-
-alias(
     name = "libftdi1-sys",
     actual = "@crate_index__libftdi1-sys-1.1.2//:libftdi1_sys",
     tags = ["manual"],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -318,7 +318,6 @@ _NORMAL_DEPENDENCIES = {
             "humantime-serde": "@crate_index__humantime-serde-1.1.1//:humantime_serde",
             "indexmap": "@crate_index__indexmap-2.0.0//:indexmap",
             "indicatif": "@crate_index__indicatif-0.17.6//:indicatif",
-            "is-terminal": "@crate_index__is-terminal-0.4.9//:is_terminal",
             "libftdi1-sys": "@crate_index__libftdi1-sys-1.1.2//:libftdi1_sys",
             "log": "@crate_index__log-0.4.20//:log",
             "mdbook": "@crate_index__mdbook-0.4.34//:mdbook",

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -13,7 +13,7 @@ def rust_deps():
         # upstream `rules_rust`.
         #include_rustc_srcs = False,
         edition = "2021",
-        versions = ["1.67.0", "nightly/2023-07-30"],
+        versions = ["1.71.1", "nightly/2023-07-30"],
         extra_target_triples = [
             "riscv32imc-unknown-none-elf",
         ],

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -157,7 +157,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @ninja_1.10.2_linux//... \
     @cmake-3.22.2-linux-x86_64//... \
     @rustfmt_nightly-2023-07-13__x86_64-unknown-linux-gnu_tools//... \
-    @rust_analyzer_1.67.0_tools//... \
+    @rust_analyzer_1.71.1_tools//... \
     @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//... \
     @rust_linux_x86_64__riscv32imc-unknown-none-elf__nightly_tools//...
   cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \


### PR DESCRIPTION
Update the stable compiler version to 1.71 given that out nightly compiler is already newer than that. This gives us the ability to use `std::io::IsTerminal` to replace the crate.