### PR TITLE
[dv/rom/lc] Add some delay after reset in lc_raw_unlock_vseq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_raw_unlock_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_raw_unlock_vseq.sv
@@ -70,6 +70,9 @@ class chip_sw_lc_raw_unlock_vseq extends chip_sw_base_vseq;
     jtag_lc_state_transition(DecLcStRaw, DecLcStTestUnlocked0);
     // Complete state transition
     apply_reset();
+    // Needed to add extra delay between the reset and the JTAG read of the lc_ctrl status
+    // register.
+    #(10us);
     wait_lc_ready();
 
     // After reset, clock bypass back to 'off'.


### PR DESCRIPTION
Add some delay between reset and waiting for lc_ready in chip_sw_lc_raw_unlock_vseq.
Without the delay there are some seeds in which the clocks are slower and the jtag reading of the status register in the lc_ctrl are failing.