### PR TITLE
[usbdpi] Fix SYNC generation

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -1425,8 +1425,9 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
         } else {
           ctx->state = ST_IDLE;
         }
+      } else {
+        ctx->bit <<= 1;
       }
-      ctx->bit <<= 1;
       break;
 
     case ST_GET:


### PR DESCRIPTION
Fix SYNC signal generation on SETUP and OUT DATA packets. Non-initial SYNC omitted the first K state and usbdev coped because it responds to the final 6 bits of the SYNC signal rather than requiring detection of the full 8 bits.*

Previous SYNC signal at start of DATA transaction/packet shows [J]KJKJKJKK at the position of the red marker:
![DPIsyncInvalid](https://github.com/lowRISC/opentitan/assets/117650394/795b3c56-b3ae-46ae-b507-68634ad606ca)

Note that the first 'J' is transmitted but since the bus is already in the Idle/J state, there is no transition.
The invalid signal results from advancing the `bit` number even when transitioning from ST_EOP to S_SYNC

The above signals show three distinct packets, separated by the driver output enable on the bottom row. The packets are Start Of Frame (SOF), SETUP and DATA. The invalid SYNC generation occurs on any DATA packet being transmitted by the USBDPI model, ie. all packets following SETUP token packets or OUT token packets.


Corrected behavior with the full 8-bit SYNC signal KJKJKJKK:
![DPIsyncFixed](https://github.com/lowRISC/opentitan/assets/117650394/518c553c-741f-487c-befd-bd3dd00aa969)

Reference (from logic analyzer displaying traffic from real host controller):
![USB_SYNC_Trace](https://github.com/lowRISC/opentitan/assets/117650394/39ce6291-d4d6-45db-bf4e-d4094e5af3c3)


* Since this makes the usbdev slightly more robust against transmission/synchronization issues, there could be an argument for introducing generation of invalid SYNC signals as a special test case, in the same way that the DPI model currently has some limited capacity to generate other invalid data including PID errors and Bit Stuffing violations.