### PR TITLE
[opentitantool] `opentitantool console` prints status to stderr

### DIFF
--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -85,10 +85,6 @@ impl CommandDispatch for Console {
             ..Default::default()
         };
 
-        if !self.quiet {
-            println!("Starting interactive console");
-            println!("[CTRL+C] to exit.\n");
-        }
         let status = {
             // Put the terminal into raw mode.  The tty guard will restore the
             // console settings when it goes out of scope.
@@ -111,10 +107,14 @@ impl CommandDispatch for Console {
                 log::info!("Sending: {:?}", send);
                 uart.write(send.as_bytes())?;
             }
+            if !self.quiet {
+                eprintln!("Starting interactive console");
+                eprintln!("[CTRL+C] to exit.\n");
+            }
             console.interact(&*uart, Some(&mut stdin), Some(&mut stdout))?
         };
         if !self.quiet {
-            println!("\n\nExiting interactive console.");
+            eprintln!("\n\nExiting interactive console.");
         }
 
         match status {


### PR DESCRIPTION
The automated test systems used at Google will routinely start `opentitantool console` as a sub-process to pipe data back and forth. When such a sub-process is started, it would be ideal that the parent could wait long enough to be able to "see" error output such as "could not open /dev/ttyUSB6: permission denied", or any other error that happens in the setup phase.

This CL makes sure that the "Starting interactive console" message is printed after every bit of initialization has been successful, and switches to printing the aforementioned message on standard error instead of standard out..

Doing so allows the process that starts 'opentitantool console` as a sub process, to monitor stderr of the sub-process until either it closes (and the sub-process then exits with an error code), or until it sees "Starting interactive console".  And the stdout of the sub process will be reserved for only the actual passthough data.