### PR TITLE
[bazel] Rewrite binary & test rules 

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -81,6 +81,9 @@ function outquery_starlark_expr() {
         -all)
             echo "\"\\n\".join([f.path for f in target.files.to_list()])"
             ;;
+        -providers)
+            echo "providers(target)"
+            ;;
         -*)
             echo "\"\\n\".join([f.path for f in target.files.to_list() if \"$q\"[1:] in f.path])"
             ;;

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -5,6 +5,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
+load("//rules/opentitan:defs.bzl", "fpga_cw310", "sim_verilator")
 
 autogen_hjson_header(
     name = "rv_plic_regs",
@@ -28,4 +29,74 @@ filegroup(
         "//hw/top_earlgrey/ip:all_files",
         "//hw/top_earlgrey/sw:all_files",
     ],
+)
+
+fpga_cw310(
+    name = "fpga_cw310",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ] + select({
+        "@//ci:lowrisc_fpga_cw310": ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
+        "//conditions:default": [],
+    }),
+    bitstream = "//hw/bitstream:test_rom",
+    design = "earlgrey",
+    exec_env = "fpga_cw310",
+    lib = "//sw/device/lib/arch:fpga_cw310",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    param = {
+        "interface": "cw310",
+        "exit_success": r"PASS.*\n",
+        "exit_failure": r"(FAIL|FAULT).*\n",
+    },
+    test_cmd = """
+        --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
+fpga_cw310(
+    name = "fpga_cw310_rom_with_fake_keys",
+    testonly = True,
+    base = ":fpga_cw310",
+    exec_env = "fpga_cw310_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+)
+
+sim_verilator(
+    name = "sim_verilator",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface=verilator",
+        "--verilator-bin=$(rootpath //hw:verilator)",
+        "--verilator-rom={rom}",
+        "--verilator-otp={otp}",
+        "--verilator-flash={firmware}",
+    ],
+    data = [
+        "//hw:fusesoc_ignore",
+        "//hw:verilator",
+    ],
+    design = "earlgrey",
+    exec_env = "sim_verilator",
+    lib = "//sw/device/lib/arch:sim_verilator",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    otp = "//hw/ip/otp_ctrl/data:img_rma",
+    param = {
+        "exit_success": r"PASS.*\n",
+        "exit_failure": r"(FAIL|FAULT).*\n",
+    },
+    rom = "//sw/device/lib/testing/test_rom:test_rom_sim_verilator_scr_vmem",
+    test_cmd = """
+        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
 )

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -5,7 +5,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:autogen.bzl", "autogen_hjson_header")
-load("//rules/opentitan:defs.bzl", "fpga_cw310", "sim_verilator")
+load("//rules/opentitan:defs.bzl", "fpga_cw310", "sim_dv", "sim_verilator")
 
 autogen_hjson_header(
     name = "rv_plic_regs",
@@ -99,4 +99,25 @@ sim_verilator(
         --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
+)
+
+sim_dv(
+    name = "sim_dv",
+    testonly = True,
+    args = [
+        "{dvsim_config}",
+    ],
+    data = [
+        "//hw/top_earlgrey/dv:chip_sim_cfg.hjson",
+    ],
+    design = "earlgrey",
+    exec_env = "sim_dv",
+    lib = "//sw/device/lib/arch:sim_dv",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    otp = "//hw/ip/otp_ctrl/data:img_rma",
+    param = {
+        "dvsim_config": "$(location //hw/top_earlgrey/dv:chip_sim_cfg.hjson)",
+    },
+    rom = "//sw/device/lib/testing/test_rom:test_rom_sim_dv_scr_vmem",
+    #extract_sw_logs = "//util/device_sw_utils:extract_sw_logs_db",
 )

--- a/rules/opentitan/BUILD
+++ b/rules/opentitan/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -1,0 +1,341 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load(
+    "@lowrisc_opentitan//rules:rv.bzl",
+    "rv_rule",
+    _OPENTITAN_CPU = "OPENTITAN_CPU",
+    _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
+    _opentitan_transition = "opentitan_transition",
+)
+load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
+load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
+load(
+    "@lowrisc_opentitan//rules/opentitan:transform.bzl",
+    "obj_disassemble",
+    "obj_transform",
+)
+
+# Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
+# to get to them.
+OPENTITAN_CPU = _OPENTITAN_CPU
+OPENTITAN_PLATFORM = _OPENTITAN_PLATFORM
+opentitan_transition = _opentitan_transition
+
+def _expand(ctx, name, items):
+    """Perform location and make_variable expansion on a list of items.
+
+    Args:
+      ctx: The rule context.
+      name: The attribute name (used in error reporting).
+      items: A list of strings on which to perform expansions.
+    Returns:
+      List[str]: The expanded string list.
+    """
+    return [ctx.expand_make_variables(name, ctx.expand_location(item), {}) for item in items]
+
+def ot_binary(ctx, **kwargs):
+    """Compile to a binary executable.
+
+    Args:
+      ctx: The rule context.
+      kwargs: Overrides of values normally retrived from the context object.
+        features: List of features to be enabled.
+        disabled_features: List of disabled/unsupported features.
+        name: Name of the output binary.
+        srcs: Sources to compile this binary.
+        copts: Compiler options.
+        defines: Define values to pass to the compiler.
+        local_defines: Define values to pass to the compiler.
+        includes: Include directories to pass to the compiler.
+        deps: Dependencies for this binary.
+        linker_script: Linker script for this binary.
+        linkopts: Linker options for this binary.
+    Returns:
+      (elf_file, map_file) File objects.
+    """
+    cc_toolchain = find_cc_toolchain(ctx).cc
+    features = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = get_override(ctx, "features", kwargs),
+        unsupported_features = get_override(ctx, "disabled_features", kwargs),
+    )
+
+    compilation_contexts = [
+        dep[CcInfo].compilation_context
+        for dep in get_override(ctx, "attr.deps", kwargs)
+    ]
+    linker_script = get_override(ctx, "attr.linker_script", kwargs)
+    if linker_script:
+        compilation_contexts.append(linker_script[CcInfo].compilation_context)
+
+    name = get_override(ctx, "attr.name", kwargs)
+    cctx, cout = cc_common.compile(
+        name = name,
+        actions = ctx.actions,
+        feature_configuration = features,
+        cc_toolchain = cc_toolchain,
+        compilation_contexts = compilation_contexts,
+        srcs = get_override(ctx, "files.srcs", kwargs),
+        user_compile_flags = ["-ffreestanding"] + _expand(ctx, "copts", get_override(ctx, "attr.copts", kwargs)),
+        defines = _expand(ctx, "defines", get_override(ctx, "attr.defines", kwargs)),
+        local_defines = _expand(ctx, "local_defines", get_override(ctx, "attr.local_defines", kwargs)),
+        quote_includes = _expand(ctx, "includes", get_override(ctx, "attr.includes", kwargs)),
+    )
+
+    linking_contexts = [
+        dep[CcInfo].linking_context
+        for dep in get_override(ctx, "attr.deps", kwargs)
+    ]
+    if linker_script:
+        linking_contexts.append(linker_script[CcInfo].linking_context)
+    mapfile = kwargs.get("mapfile", "{}.map".format(name))
+    mapfile = ctx.actions.declare_file(mapfile)
+    linkopts = [
+        "-Wl,-Map={}".format(mapfile.path),
+        "-nostdlib",
+    ] + _expand(ctx, "linkopts", get_override(ctx, "attr.linkopts", kwargs))
+
+    lout = cc_common.link(
+        name = name + ".elf",
+        actions = ctx.actions,
+        feature_configuration = features,
+        cc_toolchain = cc_toolchain,
+        compilation_outputs = cout,
+        linking_contexts = linking_contexts,
+        user_link_flags = linkopts,
+        additional_outputs = [mapfile],
+    )
+
+    return lout.executable, mapfile
+
+def _as_group_info(name, items):
+    """Prepare a dict of files for OutputGroupInfo.
+
+    Args:
+      name: A prefix for each dictionary key.
+      items: A dict str:File to prepare.
+    Returns:
+      dict
+    """
+    return {
+        "{}_{}".format(name, k): depset([v])
+        for k, v in items.items()
+        if v
+    }
+
+def _binary_name(ctx, exec_env):
+    """Create a binary name according to a naming convention.
+
+    Args:
+      ctx: The rule context.
+      exec_env: An ExecEnvInfo provider.
+    Returns:
+      str: The name.
+    """
+    return ctx.attr.naming_convention.format(
+        name = ctx.attr.name,
+        exec_env = exec_env.exec_env,
+    )
+
+def _build_binary(ctx, exec_env, name, deps):
+    """Build a binary, sign and perform output file transformations.
+    This function is the core of the `opentitan_binary` and `opentitan_test`
+    implementations.
+
+    Args:
+      ctx: The rule context.
+      exec_env: An ExecEnvInfo provider.
+      name: The name of the output artifacts.
+      deps: Dependencies for this binary.
+    Returns:
+      (dict, dict): A dict of output artifacts and a dict of signing artifacts.
+    """
+    elf, mapfile = ot_binary(
+        ctx,
+        name = name,
+        deps = deps,
+        linker_script = get_fallback(ctx, "attr.linker_script", exec_env),
+    )
+    binary = obj_transform(
+        ctx,
+        name = name,
+        suffix = "bin",
+        format = "binary",
+        src = elf,
+    )
+
+    if exec_env.manifest:
+        signed = sign_binary(
+            ctx,
+            bin = binary,
+            rsa_key = exec_env.rsa_key,
+            spx_key = exec_env.spx_key,
+            manifest = exec_env.manifest,
+            # FIXME: will need to supply hsmtool when we add NitroKey signing.
+            _tool = exec_env._opentitantool,
+        )
+    else:
+        signed = {}
+
+    disassembly = obj_disassemble(
+        ctx,
+        name = name,
+        src = elf,
+    )
+
+    provides = exec_env.transform(
+        ctx,
+        exec_env,
+        elf = elf,
+        binary = binary,
+        signed_bin = signed.get("signed"),
+        disassembly = disassembly,
+        mapfile = mapfile,
+    )
+    return provides, signed
+
+def _opentitan_binary(ctx):
+    providers = []
+    default_info = []
+    groups = {}
+    for exec_env in ctx.attr.exec_env:
+        exec_env = exec_env[ExecEnvInfo]
+        name = _binary_name(ctx, exec_env)
+        deps = [exec_env.lib] + ctx.attr.deps
+        provides, signed = _build_binary(ctx, exec_env, name, deps)
+        providers.append(exec_env.create_provider(
+            ctx,
+            exec_env,
+            **provides
+        ))
+        default_info.append(provides["default"])
+        groups.update(_as_group_info(exec_env.exec_env, signed))
+        groups.update(_as_group_info(exec_env.exec_env, provides))
+
+    providers.append(DefaultInfo(files = depset(default_info)))
+    providers.append(OutputGroupInfo(**groups))
+    return providers
+
+common_binary_attrs = {
+    "srcs": attr.label_list(
+        allow_files = True,
+        doc = "The list of C and C++ files that are processed to create the target.",
+    ),
+    "deps": attr.label_list(
+        providers = [CcInfo],
+        doc = "The list of other libraries to be linked in to the binary target.",
+    ),
+    "linker_script": attr.label(
+        providers = [CcInfo],
+        doc = "Linker script for linking this binary",
+    ),
+    "copts": attr.string_list(
+        doc = "Add these options to the C++ compilation command.",
+    ),
+    "defines": attr.string_list(
+        doc = "List of defines to add to the compile line.",
+    ),
+    "local_defines": attr.string_list(
+        doc = "List of defines to add to the compile line.",
+    ),
+    "includes": attr.string_list(
+        doc = "List of include dirs to be added to the compile line.",
+    ),
+    "linkopts": attr.string_list(
+        doc = "Add these flags to the C++ linker command.",
+    ),
+    "naming_convention": attr.string(
+        doc = "Naming convention for binary artifacts.",
+        default = "{name}_{exec_env}",
+    ),
+    "_cleanup_script": attr.label(
+        allow_single_file = True,
+        default = "@//rules/scripts:expand_tabs.sh",
+        doc = "Cleanup script for the disassembly",
+    ),
+}
+
+opentitan_binary = rv_rule(
+    implementation = _opentitan_binary,
+    attrs = dict(common_binary_attrs.items() + {
+        "exec_env": attr.label_list(
+            providers = [ExecEnvInfo],
+            doc = "List of execution environments for this target.",
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    }.items()),
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+)
+
+def _opentitan_test(ctx):
+    exec_env = ctx.attr.exec_env[ExecEnvInfo]
+    # If the test is supplied exactly one file and no deps _and_ that file
+    # is a provider for the current exec_env, then we assume that it's a
+    # pre-built binary.
+    if len(ctx.attr.srcs) == 1 and len(ctx.attr.deps) == 0 and exec_env.get_provider(ctx.attr.srcs[0]):
+        p = exec_env.get_provider(ctx.attr.srcs[0])
+    else:
+        name = _binary_name(ctx, exec_env)
+        deps = [exec_env.lib] + ctx.attr.deps
+        provides, signed = _build_binary(ctx, exec_env, name, deps)
+        p = exec_env.create_provider(
+            ctx,
+            exec_env,
+            **provides
+        )
+
+    executable, runfiles = exec_env.test_dispatch(ctx, exec_env, p)
+    return DefaultInfo(
+        executable = executable,
+        runfiles = ctx.runfiles(files = runfiles),
+    )
+
+opentitan_test = rv_rule(
+    implementation = _opentitan_test,
+    attrs = dict(common_binary_attrs.items() + {
+        "exec_env": attr.label(
+            providers = [ExecEnvInfo],
+            doc = "List of exeuction environments for this target.",
+        ),
+        "test_harness": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+        "rom": attr.label(
+            allow_single_file = True,
+            doc = "ROM image override for this test",
+        ),
+        "otp": attr.label(
+            allow_single_file = True,
+            doc = "OTP image override for this test",
+        ),
+        "bitstream": attr.label(
+            allow_single_file = True,
+            doc = "Bitstream override for this test",
+        ),
+        # Note: an `args` attr exists as an override for exec_env.args.  It is
+        # not listed here because all test rules have an implicit `args`
+        # attribute which is a list of strings subject to location and make
+        # variable substitution.
+        "test_cmd": attr.string(
+            doc = "Test command override for this test",
+        ),
+        "param": attr.string_dict(
+            doc = "Additional parameters for this test",
+        ),
+        "data": attr.label_list(
+            doc = "Additonal dependencies for this test",
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    }.items()),
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+    test = True,
+)

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -15,11 +15,18 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:fpga_cw310.bzl",
+    _cw310_params = "cw310_params",
     _fpga_cw310 = "fpga_cw310",
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:sim_verilator.bzl",
     _sim_verilator = "sim_verilator",
+    _verilator_params = "verilator_params",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:sim_dv.bzl",
+    _dv_params = "dv_params",
+    _sim_dv = "sim_dv",
 )
 
 """Rules to build OpenTitan for the RISC-V target"""
@@ -32,7 +39,33 @@ opentitan_transition = _opentitan_transition
 
 opentitan_binary = _opentitan_binary
 fpga_cw310 = _fpga_cw310
+cw310_params = _cw310_params
+
 sim_verilator = _sim_verilator
+verilator_params = _verilator_params
+
+sim_dv = _sim_dv
+dv_params = _dv_params
+
+# The default set of test environments for Earlgrey.
+EARLGREY_TEST_ENVS = {
+    "//hw/top_earlgrey:fpga_cw310": None,
+    "//hw/top_earlgrey:sim_dv": None,
+    "//hw/top_earlgrey:sim_verilator": None,
+}
+
+def _parameter_name(env, pname):
+    if not pname:
+        (_, suffix) = env.split(":")
+        if "cw310" in suffix:
+            pname = "cw310"
+        elif "verilator" in suffix:
+            pname = "verilator"
+        elif "dv" in suffix:
+            pname = "dv"
+        else:
+            fail("Unable to identify parameter block name:", env)
+    return pname
 
 def opentitan_test(
         name,
@@ -43,16 +76,43 @@ def opentitan_test(
         local_defines = [],
         includes = [],
         linkopts = [],
-        exec_env = []):
-    #args = [],
-    #bitstream = None,
-    #rom = None,
-    #otp = None,
-    #data = [],
-    #param = {},
-    #test_harness = None
+        exec_env = {},
+        cw310 = _cw310_params(),
+        dv = _dv_params(),
+        verilator = _verilator_params(),
+        **kwargs):
+    """Instantiate a test per execution environment.
+
+    Args:
+      name: The base name of the test.  The name will be extended with the name
+            of the execution environment.
+      srcs: The source files (or a binary image) for this test.
+      deps: Dependecies for this test.
+      copts: Compiler options for this test.
+      defines: Compiler defines for this test.
+      local_defines: Compiler defines for this test.
+      includes: Additional compiler include dirs for this test.
+      linkopts: Linker options for this test.
+      exec_env: A dictionary of execution environments.  The keys are labels to
+                execution environments.  The values are the kwargs parameter names
+                of the exec_env override or None.  If None, the default parameter
+                names of `cw310`, `dv` or `verilator` will be guessed.
+      cw310: Execution overrides for a CW310-based test.
+      dv: Execution overrides for a DV-based test.
+      verilator: Execution overrides for a verilator-based test.
+      kwargs: Additional exeuction overrides identified by the `exec_env` dict.
+    """
+    test_parameters = {
+        "cw310": cw310,
+        "dv": dv,
+        "verilator": verilator,
+    }
+    test_parameters.update(kwargs)
+
     all_tests = []
-    for env in exec_env:
+    for (env, pname) in exec_env.items():
+        pname = _parameter_name(env, pname)
+        tparam = test_parameters[pname]
         (_, suffix) = env.split(":")
         test_name = "{}_{}".format(name, suffix)
         all_tests.append(":" + test_name)
@@ -67,7 +127,18 @@ def opentitan_test(
             linkopts = linkopts,
             exec_env = env,
             naming_convention = "{name}",
-            tags = ["local"],
+            # Tagging and timeout info always comes from a param block.
+            tags = tparam.tags,
+            timeout = tparam.timeout,
+            local = tparam.local,
+            # Override parameters in the test rule.
+            test_harness = tparam.test_harness,
+            rom = tparam.rom,
+            otp = tparam.otp,
+            bitstream = tparam.bitstream,
+            test_cmd = tparam.test_cmd,
+            param = tparam.param,
+            data = tparam.data,
         )
     native.test_suite(
         name = name,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -1,0 +1,76 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@lowrisc_opentitan//rules:rv.bzl",
+    _OPENTITAN_CPU = "OPENTITAN_CPU",
+    _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
+    _opentitan_transition = "opentitan_transition",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:cc.bzl",
+    _opentitan_binary = "opentitan_binary",
+    _opentitan_test = "opentitan_test",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:fpga_cw310.bzl",
+    _fpga_cw310 = "fpga_cw310",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:sim_verilator.bzl",
+    _sim_verilator = "sim_verilator",
+)
+
+"""Rules to build OpenTitan for the RISC-V target"""
+
+# Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
+# to get to them.
+OPENTITAN_CPU = _OPENTITAN_CPU
+OPENTITAN_PLATFORM = _OPENTITAN_PLATFORM
+opentitan_transition = _opentitan_transition
+
+opentitan_binary = _opentitan_binary
+fpga_cw310 = _fpga_cw310
+sim_verilator = _sim_verilator
+
+def opentitan_test(
+        name,
+        srcs,
+        deps = [],
+        copts = [],
+        defines = [],
+        local_defines = [],
+        includes = [],
+        linkopts = [],
+        exec_env = []):
+    #args = [],
+    #bitstream = None,
+    #rom = None,
+    #otp = None,
+    #data = [],
+    #param = {},
+    #test_harness = None
+    all_tests = []
+    for env in exec_env:
+        (_, suffix) = env.split(":")
+        test_name = "{}_{}".format(name, suffix)
+        all_tests.append(":" + test_name)
+        _opentitan_test(
+            name = test_name,
+            srcs = srcs,
+            deps = deps,
+            copts = copts,
+            defines = defines,
+            local_defines = local_defines,
+            includes = includes,
+            linkopts = linkopts,
+            exec_env = env,
+            naming_convention = "{name}",
+            tags = ["local"],
+        )
+    native.test_suite(
+        name = name,
+        tests = all_tests,
+        tags = ["manual"],
+    )

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -18,12 +18,12 @@ _FIELDS = {
     "test_cmd": ("attr.test_cmd", False),
     "param": ("attr.param", False),
     "data": ("attr.data", False),
+    #"extract_sw_logs": ("executable.extract_sw_logs", False),
     "_opentitantool": ("executable._opentitantool", True),
 }
 
 ExecEnvInfo = provider(
     doc = "Execution Environment Info",
-    #fields = _FIELDS.keys(),
 )
 
 _unbound = struct(unbound = True)
@@ -71,6 +71,7 @@ def exec_env_as_dict(ctx):
             # If the value doesn't exist in the context object, get the value
             # from the base provider (if present).
             val = getattr(base, field)
+
         if required and not val:
             fail("No value for required field {} in {}".format(field, ctx.attr.name))
         result[field] = val
@@ -146,8 +147,22 @@ def exec_env_common_attrs(**kwargs):
         ),
         "data": attr.label_list(
             default = kwargs.get("data", []),
+            allow_files = True,
             doc = "Additonal dependencies for this environment or test",
         ),
+        # FIXME(cfrantz): This should work, but when we try to use this executable
+        # in the opentitan_{binary,test} rules, the runfiles aren't present.
+        # Somehow, bazel ends up building only the py_binary launcher script but
+        # doesn't construct the runfiles directory.  If we place this label in the
+        # opentitan_{binary,test} attrs, then the runfiles get created.
+        #
+        # Talk to the bazel team and determine whether or not this is a bazel bug.
+        #"extract_sw_logs": attr.label(
+        #    #default = kwargs.get("extract_sw_logs"),
+        #    default = "//util/device_sw_utils:extract_sw_logs_db",
+        #    executable = True,
+        #    cfg = "exec",
+        #),
         "_opentitantool": attr.label(
             default = "//sw/host/opentitantool:opentitantool",
             executable = True,

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -1,0 +1,156 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# ExecEnvInfo provider fields and whether the field is required.
+_FIELDS = {
+    "design": ("attr.design", True),
+    "exec_env": ("attr.exec_env", False),
+    "lib": ("attr.lib", True),
+    "linker_script": ("attr.linker_script", False),
+    "rsa_key": ("attr.rsa_key", False),
+    "spx_key": ("attr.spx_key", False),
+    "manifest": ("file.manifest", False),
+    "rom": ("file.rom", False),
+    "otp": ("file.otp", False),
+    "bitstream": ("file.bitstream", False),
+    "args": ("attr.args", False),
+    "test_cmd": ("attr.test_cmd", False),
+    "param": ("attr.param", False),
+    "data": ("attr.data", False),
+    "_opentitantool": ("executable._opentitantool", True),
+}
+
+ExecEnvInfo = provider(
+    doc = "Execution Environment Info",
+    #fields = _FIELDS.keys(),
+)
+
+_unbound = struct(unbound = True)
+
+def getattr_path(obj, path, defval = _unbound):
+    """Gets a named item from an object hierarchy.
+
+    This function is like `getattr`, but it walks an object path instead of
+    retrieving a single item.
+
+    Args:
+      obj: The root of an object hierarchy.
+      path: An object path to the desired attribute (e.g. attr.srcs).
+      defval: An optional default value if the item is not found.
+    Returns:
+      The requested object or defval.
+    """
+    path = path.split(".")
+    item = path.pop(-1)
+    for p in path:
+        obj = getattr(obj, p, None)
+    val = getattr(obj, item, defval)
+    if val == _unbound:
+        fail("Item '{}' not found in object".format(path))
+    return val
+
+def exec_env_as_dict(ctx):
+    """Initialize provider fields, possibly inheriting from a base provider.
+
+    This function will return a dict of ExecEnvInfo provider fields, preferring
+    the values in the `ctx` object and falling back to the base provider (if given).
+
+    Args:
+      ctx: The rule context.
+    Returns:
+      dict: A dict of items to initialize in the ExecEnvInfo provider.
+    """
+    base = ctx.attr.base
+    if base:
+        base = base[ExecEnvInfo]
+    result = {}
+    for field, (path, required) in _FIELDS.items():
+        val = getattr_path(ctx, path)
+        if not val and base:
+            # If the value doesn't exist in the context object, get the value
+            # from the base provider (if present).
+            val = getattr(base, field)
+        if required and not val:
+            fail("No value for required field {} in {}".format(field, ctx.attr.name))
+        result[field] = val
+    return result
+
+def exec_env_common_attrs(**kwargs):
+    """Common attributes for rules creating ExecEnvInfo providers."""
+    return {
+        "base": attr.label(
+            default = kwargs.get("base"),
+            providers = [ExecEnvInfo],
+            doc = "Base execution environment used to initialize this environment",
+        ),
+        "design": attr.string(
+            default = kwargs.get("design", ""),
+            doc = "Top-level hardware design name (e.g. `earlgrey`)",
+        ),
+        "exec_env": attr.string(
+            default = kwargs.get("exec_env", "{name}"),
+            doc = "Name of the execution environment (e.g. `fpga_cw310`)",
+        ),
+        "lib": attr.label(
+            default = kwargs.get("lib"),
+            providers = [CcInfo],
+            doc = "Library providing environment-specific constants",
+        ),
+        "linker_script": attr.label(
+            default = kwargs.get("linker_script"),
+            providers = [CcInfo],
+            doc = "Library providing the environment-specific linker script",
+        ),
+        "rsa_key": attr.label_keyed_string_dict(
+            default = kwargs.get("rsa_key", {}),
+            allow_files = True,
+            doc = "RSA key to sign images",
+        ),
+        "spx_key": attr.label_keyed_string_dict(
+            default = kwargs.get("spx_key", {}),
+            allow_files = True,
+            doc = "SPX key to sign images",
+        ),
+        "manifest": attr.label(
+            default = kwargs.get("manifest"),
+            allow_single_file = True,
+            doc = "Manifest used when signing images",
+        ),
+        "rom": attr.label(
+            default = kwargs.get("rom"),
+            allow_single_file = True,
+            doc = "ROM image to use in this environment",
+        ),
+        "otp": attr.label(
+            default = kwargs.get("otp"),
+            allow_single_file = True,
+            doc = "OTP image to use in this environment",
+        ),
+        "bitstream": attr.label(
+            default = kwargs.get("bitstream"),
+            allow_single_file = True,
+            doc = "Bitstream to use in this environment",
+        ),
+        "args": attr.string_list(
+            default = kwargs.get("args", []),
+            doc = "Pre-test_cmd arguments in this environment",
+        ),
+        "test_cmd": attr.string(
+            default = kwargs.get("test_cmd", ""),
+            doc = "Command to execute a test in this environment",
+        ),
+        "param": attr.string_dict(
+            default = kwargs.get("param", {}),
+            doc = "Additional parameters for this environment or test",
+        ),
+        "data": attr.label_list(
+            default = kwargs.get("data", []),
+            doc = "Additonal dependencies for this environment or test",
+        ),
+        "_opentitantool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = "exec",
+        ),
+    }

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -1,0 +1,144 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "Cw310BinaryInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
+load(
+    "//rules/opentitan:exec_env.bzl",
+    "ExecEnvInfo",
+    "exec_env_as_dict",
+    "exec_env_common_attrs",
+)
+
+_TEST_SCRIPT = """#!/bin/bash
+set -e
+
+echo Invoking test: {test_harness} {args} {test_cmd}
+RUST_BACKTRACE=1 {test_harness} {args} {test_cmd}
+"""
+
+def _transform(ctx, exec_env, elf, binary, signed_bin, disassembly, mapfile):
+    """Transform binaries into the preferred forms for fpga_cw310.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      elf: The compiled elf program.
+      binary: The raw binary of the compiled program.
+      signed_bin: The signed binary (if available).
+      disassembly: A disassembly listing.
+      mapfile: The linker-created mapfile.
+    Returns:
+      dict: A dict of fields to create in the provider.
+    """
+
+    # The CW310 environment doesn't need any transformations; just
+    # return the files as a dictionary.
+    default = signed_bin if signed_bin else binary
+    return {
+        "elf": elf,
+        "binary": binary,
+        "default": default,
+        "signed_bin": signed_bin,
+        "disassembly": disassembly,
+        "mapfile": mapfile,
+    }
+
+def _create_provider(ctx, exec_env, **kwargs):
+    """Create a provider for this exec_env."""
+    return Cw310BinaryInfo(**kwargs)
+
+def _get_provider(item):
+    """Given an attr from a rule, return the Cw310BinaryInfo provider if preseent.
+
+    Args:
+      item: a label that may have a provider attached.
+    Returns:
+      Cw310BinaryInfo or None
+    """
+    if Cw310BinaryInfo in item:
+        return item[Cw310BinaryInfo]
+    return None
+
+def _test_dispatch(ctx, exec_env, provider):
+    """Dispatch a test for the fpga_cw310 environment.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      provider: A label with a Cw310BinaryInfo provider attached.
+    Returns:
+      (File, List[File]) The test script and needed runfiles.
+    """
+
+    # If there is no explicitly specified test_harness, then the harness is opentitantool.
+    test_harness = ctx.executable.test_harness
+    if test_harness == None:
+        test_harness = exec_env._opentitantool
+
+    # Get the files we'll need to run the test.
+    bitstream = get_fallback(ctx, "file.bitstream", exec_env)
+    otp = get_fallback(ctx, "file.otp", exec_env)
+    rom = get_fallback(ctx, "file.rom", exec_env)
+    data_labels = ctx.attr.data + exec_env.data
+    data_files = get_files(data_labels)
+    if bitstream:
+        data_files.append(bitstream)
+    if rom:
+        data_files.append(rom)
+    if otp:
+        data_files.append(otp)
+    data_files.append(provider.default)
+    data_files.append(test_harness)
+
+    # Construct a param dictionary from the provided dict and some extra file references.
+    param = dict(get_fallback(ctx, "attr.param", exec_env))
+    if bitstream and "bitstream" not in param:
+        param["bitstream"] = bitstream.short_path
+    if rom and "rom" not in param:
+        param["rom"] = rom.short_path
+    if otp and "otp" not in param:
+        param["otp"] = otp.short_path
+    if "firmware" not in param:
+        param["firmware"] = provider.default.short_path
+
+    # FIXME: maybe splice a bitstream here
+
+    # Perform all relevant substitutions on the test_cmd.
+    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
+    test_cmd = test_cmd.replace("\n", " ").format(**param)
+    test_cmd = ctx.expand_location(test_cmd, data_labels)
+
+    # Get the pre-test_cmd args.
+    args = get_fallback(ctx, "attr.args", exec_env)
+    args = " ".join(args).format(**param)
+    args = ctx.expand_location(args, data_labels)
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+    ctx.actions.write(
+        script,
+        _TEST_SCRIPT.format(
+            test_harness = test_harness.short_path,
+            args = args,
+            test_cmd = test_cmd,
+        ),
+        is_executable = True,
+    )
+    return script, data_files
+
+def _fpga_cw310(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        get_provider = _get_provider,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        create_provider = _create_provider,
+        **fields
+    )
+
+fpga_cw310 = rule(
+    implementation = _fpga_cw310,
+    attrs = exec_env_common_attrs(),
+)

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Providers and helper functions associated with all execution environments.
+
+Cw310BinaryInfo = provider(
+    doc = "CW310 Binary Info",
+)
+
+SimDvBinaryInfo = provider(
+    doc = "Dv Binary Info",
+)
+
+SimVerilatorBinaryInfo = provider(
+    doc = "Verilator Binary Info",
+)
+
+ALL_BINARY_PROVIDERS = [
+    Cw310BinaryInfo,
+    SimDvBinaryInfo,
+    SimVerilatorBinaryInfo,
+]
+
+def get_binary_files(attrs):
+    """Get the list of binary files associated with a list of labels.
+
+    Args:
+      attrs: a list of labels with BinaryInfo or DefaultInfo providers.
+    Returns:
+      List[File]: the files associated with the labels.
+    """
+    files = []
+    for attr in attrs:
+        found_files = False
+        for p in ALL_BINARY_PROVIDERS:
+            if p in attr:
+                found_files = True
+                files.append(attr[p].binary)
+
+        if not found_files and DefaultInfo in attr:
+            found_files = True
+            files.extend(attr[DefaultInfo].files.to_list())
+        if not found_files:
+            print("No file providers in ", attr)
+    return files

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -1,0 +1,141 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "SimVerilatorBinaryInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files", "get_override")
+load(
+    "//rules/opentitan:exec_env.bzl",
+    "ExecEnvInfo",
+    "exec_env_as_dict",
+    "exec_env_common_attrs",
+)
+load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "convert_to_vmem")
+
+_TEST_SCRIPT = """#!/bin/bash
+set -e
+
+echo Invoking test: {test_harness} {args} {test_cmd}
+RUST_BACKTRACE=1 {test_harness} {args} {test_cmd}
+"""
+
+def _transform(ctx, exec_env, elf, binary, signed_bin, disassembly, mapfile):
+    """Transform binaries into the preferred forms for sim_verilator.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      elf: The compiled elf program.
+      binary: The raw binary of the compiled program.
+      signed_bin: The signed binary (if available).
+      disassembly: A disassembly listing.
+      mapfile: The linker-created mapfile.
+    Returns:
+      dict: A dict of fields to create in the provider.
+    """
+    default = signed_bin if signed_bin else binary
+    vmem = convert_to_vmem(
+        ctx,
+        src = default,
+        word_size = 64,
+    )
+    return {
+        "elf": elf,
+        "binary": binary,
+        "default": vmem,
+        "signed_bin": signed_bin,
+        "disassembly": disassembly,
+        "mapfile": mapfile,
+        "vmem": vmem,
+    }
+
+def _create_provider(ctx, exec_env, **kwargs):
+    """Create a provider for this exec_env."""
+    return SimVerilatorBinaryInfo(**kwargs)
+
+def _get_provider(item):
+    """Given an attr from a rule, return the SimVerilatorBinaryInfo provider if preseent.
+
+    Args:
+      item: a label that may have a provider attached.
+    Returns:
+      SimVerilatorBinaryInfo or None
+    """
+    if SimVerilatorBinaryInfo in item:
+        return item[SimVerilatorBinaryInfo]
+    return None
+
+def _test_dispatch(ctx, exec_env, provider):
+    """Dispatch a test for the sim_verilator environment.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      provider: A label with a SimVerilatorBinaryInfo provider attached.
+    Returns:
+      (File, List[File]) The test script and needed runfiles.
+    """
+
+    # If there is no explicitly specified test_harness, then the harness is opentitantool.
+    test_harness = ctx.executable.test_harness
+    if test_harness == None:
+        test_harness = exec_env._opentitantool
+
+    # Get the files we'll need to run the test.
+    otp = get_fallback(ctx, "file.otp", exec_env)
+    rom = get_fallback(ctx, "file.rom", exec_env)
+    data_labels = ctx.attr.data + exec_env.data
+    data_files = get_files(data_labels)
+    if rom:
+        data_files.append(rom)
+    if otp:
+        data_files.append(otp)
+    data_files.append(provider.default)
+    data_files.append(test_harness)
+
+    # Construct a param dictionary from the provided dict and some extra file references.
+    param = dict(get_fallback(ctx, "attr.param", exec_env))
+    if rom and "rom" not in param:
+        param["rom"] = rom.short_path
+    if otp and "otp" not in param:
+        param["otp"] = otp.short_path
+    if "firmware" not in param:
+        param["firmware"] = provider.default.short_path
+
+    # Perform all relevant substitutions on the test_cmd.
+    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
+    test_cmd = test_cmd.replace("\n", " ").format(**param)
+    test_cmd = ctx.expand_location(test_cmd, data_labels)
+
+    # Get the pre-test_cmd args.
+    args = get_fallback(ctx, "attr.args", exec_env)
+    args = " ".join(args).format(**param)
+    args = ctx.expand_location(args, data_labels)
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+    ctx.actions.write(
+        script,
+        _TEST_SCRIPT.format(
+            test_harness = test_harness.short_path,
+            args = args,
+            test_cmd = test_cmd,
+        ),
+        is_executable = True,
+    )
+    return script, data_files
+
+def _sim_verilator(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        get_provider = _get_provider,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        create_provider = _create_provider,
+        **fields
+    )
+
+sim_verilator = rule(
+    implementation = _sim_verilator,
+    attrs = exec_env_common_attrs(),
+)

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -1,0 +1,137 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_override")
+
+def obj_transform(ctx, **kwargs):
+    """Transform an object file via objcopy.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` and `suffix`
+                 if not specified.
+        src: The src File object.
+        format: The objcopy output-format.
+    Returns:
+      The transformed File.
+    """
+    cc_toolchain = find_cc_toolchain(ctx).cc
+    output = kwargs.get("output")
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        suffix = get_override(ctx, "attr.suffix", kwargs)
+        output = "{}.{}".format(name, suffix)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "attr.src", kwargs)
+    out_format = get_override(ctx, "attr.format", kwargs)
+
+    ctx.actions.run(
+        outputs = [output],
+        inputs = [src] + cc_toolchain.all_files.to_list(),
+        arguments = [
+            "--output-target",
+            out_format,
+            src.path,
+            output.path,
+        ],
+        executable = cc_toolchain.objcopy_executable,
+    )
+    return output
+
+def obj_disassemble(ctx, **kwargs):
+    """Disassemble an input file.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` if not
+                specified.
+        src: The src File object.
+    Returns:
+      The disassembled File.
+    """
+    cc_toolchain = find_cc_toolchain(ctx).cc
+    output = kwargs.get("output")
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        output = "{}.dis".format(name)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "attr.src", kwargs)
+    cleanup_script = get_override(ctx, "file._cleanup_script", kwargs)
+
+    ctx.actions.run_shell(
+        tools = [cleanup_script],
+        outputs = [output],
+        inputs = [src] + cc_toolchain.all_files.to_list(),
+        arguments = [
+            cc_toolchain.objdump_executable,
+            src.path,
+            cleanup_script.path,
+            output.path,
+        ],
+        execution_requirements = {
+            "no-sandbox": "",
+        },
+        command = "$1 -wx --disassemble --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | $3 > $4",
+    )
+    return output
+
+def convert_to_vmem(ctx, **kwargs):
+    """Transform a binary to a VMEM file.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` and `suffix`
+                 if not specified.
+        src: The src File object.
+        format: The objcopy output-format.
+    Returns:
+      The transformed File.
+    """
+    output = kwargs.get("output")
+    word_size = get_override(ctx, "attr.word_size", kwargs)
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        output = "{}.{}.vmem".format(name, word_size)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "attr.src", kwargs)
+
+    ctx.actions.run(
+        outputs = [output],
+        inputs = [src],
+        arguments = [
+            src.path,
+            "--binary",
+            # Reverse the endianness of every word.
+            "--offset",
+            "0x0",
+            "--byte-swap",
+            str(word_size // 8),
+            # Pad to word alignment
+            "--fill",
+            "0xff",
+            "-within",
+            src.path,
+            "-binary",
+            "-range-pad",
+            str(word_size // 8),
+            # Output a VMEM file with specified word size
+            "--output",
+            output.path,
+            "--vmem",
+            str(word_size),
+        ],
+        # This this executable is expected to be installed (as required by the
+        # srecord package in apt-requirements.txt).
+        executable = "srec_cat",
+        use_default_shell_env = True,
+    )
+    return output

--- a/rules/opentitan/util.bzl
+++ b/rules/opentitan/util.bzl
@@ -1,0 +1,53 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def get_override(obj, item, overrides):
+    """Get an item from obj unless it exists in overrides.
+
+    Args:
+      obj: The object holding the item.
+      item: An object path to the desired item (ie: `attr.srcs`).
+      overrides: A dict that may contain an override named by the last
+                 component of the item path (ie: `srcs`).
+    """
+    items = item.split(".")
+    item = items[-1]
+    if item in overrides:
+        return overrides.get(item)
+    for i in items:
+        obj = getattr(obj, i)
+    return obj
+
+def get_fallback(obj, item, fallback):
+    """Get an item from obj and fall back to `fallback` if falsy.
+
+    Args:
+      obj: The object holding the item.
+      item: An object path to the desired item (ie: `attr.srcs`).
+      fallback: An object that contains a fallback value named by the last
+                component of the item path (ie: `srcs`).
+    """
+    items = item.split(".")
+    item = items[-1]
+    for i in items:
+        obj = getattr(obj, i)
+    if obj:
+        return obj
+    return getattr(fallback, item)
+
+def get_files(attrs):
+    """Get the list of files associated with a list of labels.
+
+    Args:
+      attrs: a list of labels with DefaultInfo providers.
+    Returns:
+      List[File]: the files associated with the labels.
+    """
+    files = []
+    for attr in attrs:
+        if DefaultInfo in attr:
+            files.extend(attr[DefaultInfo].files.to_list())
+        else:
+            print("No DefaultInfo in ", attr)
+    return files

--- a/signing/examples/BUILD
+++ b/signing/examples/BUILD
@@ -9,8 +9,9 @@ package(default_visibility = ["//visibility:public"])
 
 offline_presigning_artifacts(
     name = "presigning",
+    testonly = True,
     srcs = [
-        "//sw/device/examples/hello_world:hello_world_bin",
+        "//sw/device/examples/hello_world",
     ],
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     # To sign with real keys, replace the rsa_key with the label of a real
@@ -25,6 +26,7 @@ offline_presigning_artifacts(
 
 pkg_tar(
     name = "digests",
+    testonly = True,
     srcs = [":presigning"],
     mode = "0644",
     tags = ["manual"],
@@ -36,6 +38,7 @@ pkg_tar(
 # to the binaries to test the offline signing flow without an HSM operation.
 offline_fake_rsa_sign(
     name = "fake",
+    testonly = True,
     srcs = [":presigning"],
     rsa_key = {
         "//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "fake_test_key_0",
@@ -45,6 +48,7 @@ offline_fake_rsa_sign(
 
 offline_signature_attach(
     name = "signed",
+    testonly = True,
     srcs = [
         ":presigning",
     ],

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -2,22 +2,24 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_flash_binary")
 load("//rules:exclude_files.bzl", "exclude_files")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//visibility:public"])
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "hello_world",
-    srcs = [
-        "hello_world.c",
-    ],
+    testonly = True,
+    srcs = ["hello_world.c"],
     copts = [
-        "-nostdlib",
-        "-ffreestanding",
         # Disable the date-time warning only for the hello world program.
         "-Wno-date-time",
+    ],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_verilator",
     ],
     deps = [
         ":hello_world_lib",

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -19,6 +19,7 @@ opentitan_binary(
     ],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv",
         "//hw/top_earlgrey:sim_verilator",
     ],
     deps = [

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -4,7 +4,7 @@
 
 load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
-load("//rules/opentitan:defs.bzl", "opentitan_test")
+load("//rules/opentitan:defs.bzl", "EARLGREY_TEST_ENVS", "opentitan_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -210,10 +210,7 @@ cc_test(
 opentitan_test(
     name = "hmac_functest",
     srcs = ["hmac_functest.c"],
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:sim_verilator",
-    ],
+    exec_env = EARLGREY_TEST_ENVS,
     deps = [
         ":hmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
+load("//rules/opentitan:defs.bzl", "opentitan_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -206,9 +207,13 @@ cc_test(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "hmac_functest",
     srcs = ["hmac_functest.c"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_verilator",
+    ],
     deps = [
         ":hmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
1. Create rules for describing the target execution environments for
   OpenTitan code, including "arch" libraries, linker scripts, signing
   keys and test dispatch information.
2. Create a new `opentitan_binary` rule that can build and link C
   programs for a set of execution environments.  Emit providers
   specific to each environment.
3. Createa new `opentitan_test` rule that can dispatch a test on a
   given execution environment.  Like `cc_test`, the opentitan rule
   can compile and link the test program before dispatch.
4. Create an `opentitan_test` macro that, given a list of execution
   environments, creates a rule per exec_env.

# Note
This is still a work in progress.  Draft pull request to collect some early feedback.