### PR TITLE
Remove erroneous UNIMP fill of .bss section

### DIFF
--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -112,7 +112,7 @@ _rom_interrupt_vector_c:
    * ROM shadow stack.
    */
   .section .bss
-  .balignl 4, UNIMP
+  .balignl 4
   .global _rom_shadow_stack
   .type _rom_shadow_stack, @object
 _rom_shadow_stack:


### PR DESCRIPTION
The fill value of .balign is ignored for .bss. Binutils will warn about
using a non-zero fill value. Clang's integrated assembler won't complain
but it has a debug assertion that will trip in debug builds of the toolchain.
