### PR TITLE
[opentitantool] Remove fallbacks for ancient HyperDebug firmware

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -268,7 +268,7 @@ impl UpdateProtocol for Legacy {
             std::thread::sleep(self.inter_frame_delay);
 
             // Write the frame and read back the ack of a previously transmitted frame.
-            progress.progress(frame.header.flash_offset as usize);
+            progress.progress(frame.header.flash_offset as usize - Frame::FLASH_BASE_ADDRESS);
             let mut response = [0u8; std::mem::size_of::<Frame>()];
             spi.run_transaction(&mut [Transfer::Both(frame.as_bytes(), &mut response)])?;
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -115,36 +115,35 @@ impl GpioPin for HyperdebugGpioPin {
                 return Err(GpioError::UnsupportedPinVoltage(v).into());
             }
         }
-        self.inner
-            .cmd_no_output(&format!(
-                "gpio multiset {} {} {} {} {}",
-                &self.pinname,
-                match value {
-                    Some(false) => "0",
-                    Some(true) => "1",
-                    None => "-",
-                },
-                match mode {
-                    Some(PinMode::Input) => "input",
-                    Some(PinMode::OpenDrain) => "opendrain",
-                    Some(PinMode::PushPull) => "pushpull",
-                    Some(PinMode::AnalogInput) => "adc",
-                    Some(PinMode::AnalogOutput) => "dac",
-                    Some(PinMode::Alternate) => "alternate",
-                    None => "-",
-                },
-                match pull {
-                    Some(PullMode::None) => "none",
-                    Some(PullMode::PullUp) => "up",
-                    Some(PullMode::PullDown) => "down",
-                    None => "-",
-                },
-                if let Some(v) = volts {
-                    format!("{}", (v * 1000.0) as u32)
-                } else {
-                    "-".to_string()
-                },
-            ))
+        self.inner.cmd_no_output(&format!(
+            "gpio multiset {} {} {} {} {}",
+            &self.pinname,
+            match value {
+                Some(false) => "0",
+                Some(true) => "1",
+                None => "-",
+            },
+            match mode {
+                Some(PinMode::Input) => "input",
+                Some(PinMode::OpenDrain) => "opendrain",
+                Some(PinMode::PushPull) => "pushpull",
+                Some(PinMode::AnalogInput) => "adc",
+                Some(PinMode::AnalogOutput) => "dac",
+                Some(PinMode::Alternate) => "alternate",
+                None => "-",
+            },
+            match pull {
+                Some(PullMode::None) => "none",
+                Some(PullMode::PullUp) => "up",
+                Some(PullMode::PullDown) => "down",
+                None => "-",
+            },
+            if let Some(v) = volts {
+                format!("{}", (v * 1000.0) as u32)
+            } else {
+                "-".to_string()
+            },
+        ))
     }
 
     fn get_internal_pin_name(&self) -> Option<&str> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -145,23 +145,6 @@ impl GpioPin for HyperdebugGpioPin {
                     "-".to_string()
                 },
             ))
-            .or_else(|_| {
-                // HyperDebug firmware does not support atomically setting all three, fall back to
-                // separate commands.
-                if let Some(mode) = mode {
-                    self.set_mode(mode)?;
-                }
-                if let Some(pull) = pull {
-                    self.set_pull_mode(pull)?;
-                }
-                if let Some(value) = value {
-                    self.write(value)?;
-                }
-                if let Some(volts) = volts {
-                    self.analog_write(volts)?;
-                }
-                Ok(())
-            })
     }
 
     fn get_internal_pin_name(&self) -> Option<&str> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -626,13 +626,11 @@ impl Target for HyperdebugSpiTarget {
 
     fn get_max_speed(&self) -> Result<u32> {
         let mut buf = String::new();
-        let captures = self
-            .inner
-            .cmd_one_line_output_match(
-                &format!("spi info {}", &self.target_idx),
-                &super::SPI_REGEX,
-                &mut buf,
-            )?;
+        let captures = self.inner.cmd_one_line_output_match(
+            &format!("spi info {}", &self.target_idx),
+            &super::SPI_REGEX,
+            &mut buf,
+        )?;
         Ok(captures.get(3).unwrap().as_str().parse().unwrap())
     }
     fn set_max_speed(&self, frequency: u32) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -626,30 +626,18 @@ impl Target for HyperdebugSpiTarget {
 
     fn get_max_speed(&self) -> Result<u32> {
         let mut buf = String::new();
-        let mut buf2 = String::new();
         let captures = self
             .inner
             .cmd_one_line_output_match(
                 &format!("spi info {}", &self.target_idx),
                 &super::SPI_REGEX,
                 &mut buf,
-            )
-            .or_else(|_| {
-                self.inner.cmd_one_line_output_match(
-                    &format!("spiget {}", &self.target_idx),
-                    &super::SPI_REGEX,
-                    &mut buf2,
-                )
-            })?;
+            )?;
         Ok(captures.get(3).unwrap().as_str().parse().unwrap())
     }
     fn set_max_speed(&self, frequency: u32) -> Result<()> {
         self.inner
             .cmd_no_output(&format!("spi set speed {} {}", &self.target_idx, frequency))
-            .or_else(|_| {
-                self.inner
-                    .cmd_no_output(&format!("spisetspeed {} {}", &self.target_idx, frequency))
-            })
     }
 
     fn set_chip_select(&self, pin: &Rc<dyn GpioPin>) -> Result<()> {


### PR DESCRIPTION
OpenTitanTool now ships with "official" HyperDebug firmware, is able to upgrade the device, and warns if used with non-official firmware.

Given the above, I do not think that we need to keep carrying fallback code meant for cases in which opentitantool is working with older HyperDebug firmware, which does not understand newly added commands.

Also, a small fix to the legacy SPI bootstrap protocol progress bar.  The flash offset was not properly taken into account when using "start address" of the current block as measure of progress.