### PR TITLE
[opentitantool] Allow config control of all spi pins 

### DIFF
--- a/sw/host/opentitanlib/src/app/config/structs.rs
+++ b/sw/host/opentitanlib/src/app/config/structs.rs
@@ -120,6 +120,12 @@ pub struct SpiConfiguration {
     pub bits_per_word: Option<u32>,
     /// Data communication rate in bits/second.
     pub bits_per_sec: Option<u32>,
+    /// Which GPIO pin should be used for clock.
+    pub serial_clock: Option<String>,
+    /// Which GPIO pin should be used for signal from debugger to OpenTitan.
+    pub host_out_device_in: Option<String>,
+    /// Which GPIO pin should be used for signal from OpenTitan to debugger.
+    pub host_in_device_out: Option<String>,
     /// Which GPIO pin should be used for chip select.
     pub chip_select: Option<String>,
     /// Name of the SPI controller as defined by the transport.

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -158,6 +158,9 @@ impl PinConfiguration {
 pub struct SpiConfiguration {
     pub underlying_instance: String,
     pub mode: Option<TransferMode>,
+    pub serial_clock: Option<String>,
+    pub host_out_device_in: Option<String>,
+    pub host_in_device_out: Option<String>,
     pub chip_select: Option<String>,
     pub bits_per_word: Option<u32>,
     pub bits_per_sec: Option<u32>,
@@ -267,6 +270,9 @@ impl TransportWrapperBuilder {
         merge_field(&mut entry.mode, &spi_conf.mode)?;
         merge_field(&mut entry.bits_per_word, &spi_conf.bits_per_word)?;
         merge_field(&mut entry.bits_per_sec, &spi_conf.bits_per_sec)?;
+        merge_field(&mut entry.serial_clock, &spi_conf.serial_clock)?;
+        merge_field(&mut entry.host_out_device_in, &spi_conf.host_out_device_in)?;
+        merge_field(&mut entry.host_in_device_out, &spi_conf.host_in_device_out)?;
         merge_field(&mut entry.chip_select, &spi_conf.chip_select)?;
         merge_field(&mut entry.alias_of, &spi_conf.alias_of)?;
         Ok(())

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -148,8 +148,11 @@ pub enum SpiRequest {
         value: u32,
     },
     SupportsBidirectionalTransfer,
-    SetChipSelect {
-        pin: String,
+    SetPins {
+        serial_clock: Option<String>,
+        host_out_device_in: Option<String>,
+        host_in_device_out: Option<String>,
+        chip_select: Option<String>,
     },
     GetMaxTransferCount,
     GetMaxTransferSizes,
@@ -181,7 +184,7 @@ pub enum SpiResponse {
     SupportsBidirectionalTransfer {
         has_support: bool,
     },
-    SetChipSelect,
+    SetPins,
     GetMaxTransferCount {
         number: usize,
     },

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -634,13 +634,24 @@ impl Target for HyperdebugSpiTarget {
         Ok((self.feature_bitmap & FEATURE_BIT_FULL_DUPLEX) != 0)
     }
 
-    fn set_chip_select(&self, pin: &Rc<dyn GpioPin>) -> Result<()> {
-        self.inner.cmd_no_output(&format!(
-            "spi set cs {} {}",
-            &self.target_idx,
-            pin.get_internal_pin_name()
-                .ok_or(SpiError::InvalidChipSelect)?
-        ))
+    fn set_pins(
+        &self,
+        serial_clock: Option<&Rc<dyn GpioPin>>,
+        host_out_device_in: Option<&Rc<dyn GpioPin>>,
+        host_in_device_out: Option<&Rc<dyn GpioPin>>,
+        chip_select: Option<&Rc<dyn GpioPin>>,
+    ) -> Result<()> {
+        if serial_clock.is_some() || host_out_device_in.is_some() || host_in_device_out.is_some() {
+            bail!(SpiError::InvalidPin);
+        }
+        if let Some(pin) = chip_select {
+            self.inner.cmd_no_output(&format!(
+                "spi set cs {} {}",
+                &self.target_idx,
+                pin.get_internal_pin_name().ok_or(SpiError::InvalidPin)?
+            ))?;
+        }
+        Ok(())
     }
 
     fn get_max_transfer_count(&self) -> Result<usize> {


### PR DESCRIPTION
This change allows all four pins of SPI ports to be controlled from json configuration files.  Depending on backend transport, explicitly specifying pins may not be supported, or may be supported only for some pins (chip select).

This change does not yet add Sam3X driver support.