### PR TITLE
align reseed cntr resval with MAX_NUM_REQS_BETWEEN_RESEEDS resval

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -676,7 +676,7 @@ module edn_core import edn_pkg::*;
   // SEC_CM: CTR.REDUN
   prim_count #(
     .Width(RegWidth),
-    .ResetValue({RegWidth{1'b1}})
+    .ResetValue(edn_reg_pkg::MaxNumReqsBetweenReseedsResval)
   ) u_prim_count_max_reqs_cntr (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
There is a discrepancy between the reset values of the EDN MAX_NUM_REQS_BETWEEN_RESEEDS register (32'b0) and the auto request mode counter ('1) that counts the number of generate commands between reseeds.

The scoreboard counts the number of generates between reseeds and compares it to the value in the register. If the number of generates is larger than the value of MAX_NUM_REQS_BETWEEN_RESEEDS an error occurs. The counter value is updated every time a value is written to the register. However, if the value is never updated, in the scoreboard's view the number of allowed generates is 0 and from the counter's view its '1. This leads to the issue that the scoreboard throws an error even though there is nothing wrong.

In this PR I update the default value of the counter to 0. This gets rid of the above issue. Alternatives would have been to set the reset value of the register to '1 or to add some functionality to update the counter each time the EDN is enabled.
This PR fixes the issue mentioned in #19656 