### PR TITLE
[chip-test] SiVal test plan updates for USBDEV

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -278,6 +278,92 @@
       '''
     }
   ],
+  features: [
+    {
+      name: "USBDEV.CONN.VBUS"
+      desc: '''Detection of VBUS/SENSE signal from the host controller, indicating a
+            connection and/or supplying power.
+            '''
+    }
+    {
+      name: "USBDEV.CONN.PULLUP"
+      desc: '''Assertion and removal of pull up resistor indicating Full Speed device
+            presence on the USB.
+            '''
+    }
+    {
+      name: "USBDEV.CONN.REF_PULSE"
+      desc: '''Generation of a reference pulse in response to Start Of Frame packet
+            reception, to synchronize the device clock with that of the host controller.
+            '''
+    }
+    {
+      name: "USBDEV.CONN.PIN_CONFIG"
+      desc: '''Support for different pin configurations; pin flipping, transmission and
+            reception modes.
+            '''
+    }
+    {
+      name: "USBDEV.CONN.RESET"
+      desc: '''usbdev reset and the ability to empty the Av and Rx FIFOs. Required for
+            adapting to polarity of SBU connections on USB-C cables.
+            '''
+    }
+    {
+      name: "USBDEV.TRANSFER.CONTROL_RX"
+      desc: "Reception of packets in Control Transfers from the host controller."
+    }
+    {
+      name: "USBDEV.TRANSFER.CONTROL_TX"
+      desc: "Transmission of response packets in Control Transfers from the host."
+    }
+    {
+      name: "USBDEV.TRANSFER.ENDPOINTS"
+      desc: "Use of multiple endpoints in communication with the host controller."
+    }
+    {
+      name: "USBDEV.TRANSFER.BULK"
+      desc: "Bulk Transfer streams."
+    }
+    {
+      name: "USBDEV.TRANSFER.ISOCHRONOUS"
+      desc: "Support for Isochronous Transfers and Endpoints."
+    }
+    {
+      name: "USBDEV.TRANSFER.CONTROL"
+      desc: '''Support for Control Transfers/Endpoints other than the Default Control Pipe
+            at Endpoint Zero.
+            '''
+    }
+    {
+      name: "USBDEV.TRANSFER.INTERRUPT"
+      desc: "Support for Interrupt Transfers and Endpoints."
+    }
+    {
+      name: "USBDEV.POWER.SUSPEND"
+      desc: "Detection of Suspend request from the host."
+    }
+    {
+      name: "USBDEV.POWER.RESUME"
+      desc: "Detection of Resume Signaling from the host controller."
+    }
+    {
+      name: "USBDEV.POWER.AON"
+      desc: "Handover of the USB to the AON module that handles Wake signaling."
+    }
+    {
+      name: "USBDEV.POWER.WAKE_DISCONNECT",
+      desc: "Wake from Sleep in response to Disconnection."
+    }
+    {
+      name: "USBDEV.POWER.WAKE_RESUME",
+      desc: "Wake from Sleep in response to Resume Signaling."
+    }
+    {
+      name: "USBDEV.POWER.WAKE_BUS_RESET",
+      desc: "Wake from Sleep in response to Bus Reset from host."
+    }
+  ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -29,6 +29,7 @@
     "hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
   ]
 
   testpoints: [
@@ -278,48 +279,6 @@
 
     // USB (pre-verified IP) integration tests:
     {
-      name: chip_sw_usbdev_dpi
-      desc: '''Integration of USBDPI at chip level to test connection and communications.
-
-            - DPI model provides a simulation of a simple USB host; asserts VBUS
-            - SW sets up the USB device, and enables the interface.
-            - DPI detects presence of pull up and VBUS, and initiates communications.
-            - SW receives device address and configuration from DPI model.
-            - A small data packet is transmitted from the device to the DPI model.
-            - DPI model returns a small data packet to the device and SW.
-            - SW checks the content of the received data packet.
-            '''
-      stage: V2
-      tests: ["chip_sw_usbdev_dpi"]
-    }
-    {
-      name: chip_sw_usb_fs_tx_rx
-      desc: '''Verify the transmission of single-ended data over the USB at full speed. As a part of
-            this test, the enablement of USB pullup is also expected to be verified.
-
-            - Set `tx_differential_mode` to single-ended and `rx_differential_mode` to
-              differential. The other modes are not supported in OpenTitan.
-            - configure Link state to `Active`.
-            - Send and receive packets to fill the entire buffer. Ensure all the packets are
-              correct.
-            - Check interrupts (connected, pkt_received, pkt_sent, av_empty, rx_full) are triggered
-              correctly.
-            '''
-      stage: V3
-      tests: ["chip_sw_usbdev_stream"]
-    }
-    {
-      name: chip_sw_usbdev_vbus
-      desc: '''Verify that the USB device can detect the presence of VBUS from the USB host.
-
-            - Set up the pinmux to ensure that the SENSE/VBUS input can reach usbdev.
-            - Check that VBUS is asserted indicating the presence of a connection to the
-              USB host or DPI model.
-            '''
-      stage: V2
-      tests: ["chip_sw_usbdev_vbus"]
-    }
-    {
       name: chip_sw_usb_suspend
       desc: '''Verify that the USB device can detect the presence of VBUS from the USB host.
 
@@ -347,59 +306,6 @@
       tests: []
     }
     {
-      name: chip_sw_usbdev_pullup
-      desc: '''Verify that the USB device can assert the pull up to indicate its presence.
-
-            - This test extends from `chip_sw_usbdev_vbus` by checking that the DP line of
-              the USB is deasserted after VBUS detection.
-            - Enable the interface by asserting the pull up.
-            - Check that the DP line rises by reading from the `phy_pins_sense` register.
-            - Host/DPI model detects the presence of a Full Speed device.
-            - Deassert the pull up.
-            - Check that the DP line falls again.
-            - For those targets which can apply a pull up to either line, repeat the above
-              for the DN line using the usbdev pin-flipping feature.
-            - No other communication with the host, so indicating Low Speed is harmless.
-            '''
-      stage: V2
-      tests: ["chip_sw_usbdev_pullup"]
-    }
-    {
-      name: chip_usb_sof
-      desc: '''Verify that USB can detect SOF and respond with `usb_ref_pulse_o` and
-            `usb_ref_val_o`.
-
-            - Configure to enable `usb_ref_disable`.
-            - Send a frame with the same frame number as the USB device to trigger `frame`
-              interrupt.
-            - Ensure `usb_ref_pulse_o` and `usb_ref_val_o` behave correctly.
-            - Stop sending any frame and check the `host_lost` interrupt. Ensure `use_ref_*` behave
-              correctly.
-            '''
-      stage: V3
-      tests: []
-    }
-    {
-      name: chip_sw_usbdev_setup_rx
-      desc: '''Verify that the USB device can receive the SETUP stage of a Control Transfer
-            from the host/DPI model.
-
-            - This test extends from `chip_sw_usbdev_pullup` by checking that the device
-              can receive packets from the host/DPI model.
-            - Set `tx_differential_mode` to single-ended and `rx_differential_mode` to
-              differential. The other modes are not supported in OpenTitan Earl Grey.
-            - Upon detection of the usbdev asserting its pull up on the DP line,
-              indicating the presence of a Full Speed device, the first communication
-              attempt from the host/DPI model will be a SETUP token packet.
-            - Software shall receive the SETUP DATA packet following the token packet.
-            - The properties but not contents of this packet shall be verified;
-              This makes the test robust against alternative host behaviors, since the
-              first Control Transfer to be sent upon connection is unspecified.
-            '''
-      stage: V2
-      tests: ["chip_sw_usbdev_setuprx"]
-    }
-    {
       name: chip_usb_wake_debug
       desc: '''Verify that `usb_state_debug_i` can be read from the CSR.
 
@@ -408,20 +314,6 @@
             '''
       stage: V3
       tests: []
-    }
-    {
-      name: chip_sw_usbdev_pincfg
-      desc: '''Verify that the USB device can operate in all pin configurations.
-
-            - This test extends from `chip_sw_usbdev_dpi`
-            - Cycles the device through each of the supported bus modes/pin configurations.
-            - Checks that the DPI model can set up the device with a given pin configuration,
-              before resetting the device and advancing to the next pin configuration.
-            - Exercises all permutations of (i) pinflipping on/off, (ii) single-ended transmission
-              on/off, and (iii) external differential receiver yes/no
-            '''
-      stage: V2
-      tests: ["chip_sw_usbdev_pincfg"]
     }
 
     // PINMUX & PADRING (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -1,0 +1,277 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_usbdev
+  testpoints: [
+    // USBDEV integration tests
+    {
+      name: chip_sw_usbdev_vbus
+      desc: '''Verify that the USB device can detect the presence of VBUS from the USB host.
+
+            - Set up the pinmux to ensure that the SENSE/VBUS input can reach usbdev
+            - Check that VBUS is asserted indicating the presence of a connection to the
+              USB host or DPI model.
+            '''
+      features: ["USBDEV.CONN.VBUS"]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_vbus"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_pullup
+      desc: '''Verify that the USB device can assert the pull up to indicate its presence.
+
+            - This test extends from `chip_sw_usbdev_vbus` by checking that the DP line of
+              the USB is deasserted after VBUS detection.
+            - Enable the interface by asserting the pull up.
+            - Check that the DP line rises by reading from the `phy_pins_sense` register.
+            - Host/DPI model detects the presence of a Full Speed device.
+            - Deassert the pull up.
+            - Check that the DP line falls again.
+            - For those targets which can apply a pull up to either line, repeat the above
+              for the DN line using the usbdev pin-flipping feature.
+            - No other communication with the host, so indicating Low Speed is harmless.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_pullup"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_sof
+      desc: '''Verify that the USB device can detect SOF and respond with `usb_ref_pulse_o`
+            and `usb_ref_val_o`.
+
+            - This test extends from `chip_sw_usbdev_pullup` by connecting to the host/DPI
+              model and awaiting the Start Of Frame token packets that signal the bus frames.
+            - SOF packets serve as a 'heartbeat' from the host and allow the device to keep
+              its clock frequency calibrated.
+            - Configure the device to enable the `usb_ref_val_o` and `usb_ref_pulse_o` outputs.
+            - Monitor the bus to check that the host/DPI SOF signal is not lost for a number
+              of bus frames.
+            - Ascertain that the reference pulse is being used to adjust the usb clock
+              frequency appropriately.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: []
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_setup_rx
+      desc: '''Verify that the USB device can receive the SETUP stage of a Control Transfer
+            from the host/DPI model.
+
+            - This test extends from `chip_sw_usbdev_pullup` by checking that the device
+              can receive packets from the host/DPI model.
+            - Set `tx_differential_mode` to single-ended and `rx_differential_mode` to
+              differential. The other modes are not supported in OpenTitan Earl Grey.
+            - Upon detection of the usbdev asserting its pull up on the DP line,
+              indicating the presence of a Full Speed device, the first communication
+              attempt from the host/DPI model will be a SETUP token packet.
+            - Software shall receive the SETUP DATA packet following the token packet.
+            - The properties but not contents of this packet shall be verified;
+              This makes the test robust against alternative host behaviors, since the
+              first Control Transfer to be sent upon connection is unspecified.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_setuprx"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_config_host
+      desc: '''Verify that the USB device can be configured by the host/DPI.
+
+            - This test extends from `chip_sw_usbdev_setup_rx` by using the usb_testutils
+              software layer to receive, decode and respond to Control Transfers.
+            - Software/usbdev receives GET_DESCRIPTOR requests and SET_ADDRESS control
+              transfer from the host controller/USB device driver software,
+              assigning an address on the USB and configuring the device via a
+              SET_CONFIGURATION control transfer.
+            - The device should present two serial ports (as /dev/ttyUSBn on a Linux
+              host).
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: []
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_pincfg
+      desc: '''Verify that the USB device can operate in all pin configurations.
+
+            - This test extends from `chip_sw_usbdev_config_host` by testing all pin
+              configurations.
+            - Cycles the device through each of the supported bus modes/pin configurations.
+            - Checks that the host/DPI model can set up the device with a given pin configuration,
+              before resetting the device and advancing to the next pin configuration.
+            - Exercises all available permutations of (i) pinflipping on/off, (ii) single-ended
+              transmission on/off, and (iii) external differential receiver yes/no.
+            - Targets differ in which modes/pin configurations are supported.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+        "USBDEV.CONN.PIN_CONFIG",
+        "USBDEV.CONN.RESET",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_pincfg"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_tx_rx
+      desc: '''Verify operation of simple Bulk Transfers to/from host/DPI model.
+
+            - DPI model provides a simulation of a simple USB host; asserts VBUS
+            - SW sets up the USB device, and enables the interface.
+            - Host/DPI detects presence of pull up and VBUS, and initiates communications.
+            - SW receives device address and configuration from host/DPI model.
+            - A small data packet is transmitted from the device to the host/DPI model.
+            - Host/DPI model returns a small data packet to the device and SW.
+            - SW checks the content of the received data packet.
+            - With a physical host this just requires character echo in response to
+              a serial connection (eg. `cat /dev/ttyUSB0`).
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+        "USBDEV.TRANSFER.ENDPOINTS",
+        "USBDEV.TRANSFER.BULK",
+      ]
+      stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_dpi"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_stream
+      desc: '''Verify the transmission of randomized Bulk Transfer stream data
+            to/from host/DPI model.
+
+            - This test extends from `chip_sw_usbdev_tx_rx`.
+            - All endpoints in use simultaneously.
+            - Randomized packet contents and length; LFSR-generated data at
+              device is combined with host LFSR-generated byte stream.
+            - Checking of both byte streams when returned to the device.
+            - Randomized retrying when using the DPI model.
+            - With a physical host this requires the `usbdev/stream_test` host-
+              side test application.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+        "USBDEV.TRANSFER.ENDPOINTS",
+        "USBDEV.TRANSFER.BULK",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: ["chip_sw_usbdev_stream"]
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_iso
+      desc: '''Verify the transmission of randomized Isochronous Transfer stream
+            data to/from host/DPI model.
+
+            - This test extends from `chip_sw_usbdev_stream`.
+            - Maximal endpoints in use simultaneously (limited by bandwidth).
+            - Randomized packet contents and length; LFSR-generated data at
+              device is combined with host LFSR-generated byte stream.
+            - Checking of both byte streams when returned to the device.
+            - Expectation of and recovery from packet-dropping, prioritizing
+              guaranteed service over reliability.
+            - With a physical host this requires the `usbdev/stream_test` host-
+              side test application.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+        "USBDEV.TRANSFER.ENDPOINTS",
+        "USBDEV.TRANSFER.ISOCHRONOUS",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: []
+      bazel: []
+    }
+    {
+      name: chip_sw_usbdev_mixed
+      desc: '''Verify the transmission of randomized Control, Interrupt, Bulk and
+            Isochronous Transfer stream data to/from host/DPI model.
+
+            - This test extends from `chip_sw_usbdev_iso` by adding Control
+              Endpoints and Interrupt endpoints alongside the Isochronous and
+              Bulk Endpoints.
+            - Streaming occurs simultaneously to all endpoints of all types.
+            - With a physical host this requires the `usbdev/stream_test` host-
+              side test application.
+            '''
+      features: [
+        "USBDEV.CONN.VBUS",
+        "USBDEV.CONN.PULLUP",
+        "USBDEV.CONN.REF_PULSE",
+        "USBDEV.TRANSFER.CONTROL_RX",
+        "USBDEV.TRANSFER.CONTROL_TX",
+        "USBDEV.TRANSFER.ENDPOINTS",
+        "USBDEV.TRANSFER.ISOCHRONOUS",
+        "USBDEV.TRANSFER.CONTROL",
+        "USBDEV.TRANSFER.INTERRUPT",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      tests: []
+      bazel: []
+    }
+    // This test list does not yet cover Suspend, Resume, Sleep and Wake
+    // functionality.
+  ]
+}


### PR DESCRIPTION
Added list of usbdev features.
List usbdev chip-level tests available for SiVal.

Note:
A number of these tests are not yet available, pending merging into the repository but they can be included soon.
For now, tests related to Suspend, Resume, Sleep and Wake are not included in this SiVal test list although they cover important functionality. These tests still require completion.
This PR does however list the features/functionality that they shall cover.

Describes/depends on new tests in PR #19672 and PR #19673.
