### PR TITLE
[bazel] update rules_rust to add patch for specifying `ld` location

### DIFF
--- a/doc/contributing/bazel_notes.md
+++ b/doc/contributing/bazel_notes.md
@@ -371,8 +371,11 @@ Specifically, when the rustc compiler is invoked, it uses the LLVM linker that i
 This means bazel cannot ensure it is installed at a specific location, and instead just uses whatever is available on the host machine.
 The issue above points out that rustc expects the linker to be located in the same directory as `gcc`, so if on the host machine this statement is untrue, there can be build issues.
 
-To resolve this problem:
+To resolve this problem, you can either:
 1. Install the LLVM linker with, e.g., `sudo apt install lld`.
 2. Symlink `lld` to where `gcc` is installed.
 
-This workaround will be needed until the rust issue is resolved.
+or,
+1. add the build flag `--@rules_rust//:extra_rustc_toolchain_dirs=/path/to/somewhere/else` to your `.bazelrc-site` file to specify a different location on your system where host toolchain tools may be found.
+
+Either of these workarounds will be needed until the `rules_rust` issue is resolved.

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -95,9 +95,9 @@ def rust_repos(rules_rust = None, safe_ftdi = None, serde_annotate = None):
     http_archive_or_local(
         name = "rules_rust",
         local = rules_rust,
-        sha256 = "a5cd81f9ffbe4dfff73767ecc1f5469d17f4f819fd4bc6b482fd775c6b08b11f",
-        strip_prefix = "rules_rust-rebase-20230822_01",
-        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/rebase-20230822_01.tar.gz",
+        sha256 = "e85891dd6bb24e877a9622c09f028b9e11c0f4df69db4735194eb1d8dc7ae917",
+        strip_prefix = "rules_rust-rebase-20230822_02",
+        url = "https://github.com/lowRISC/rules_rust/archive/refs/tags/rebase-20230822_02.tar.gz",
     )
 
     http_archive_or_local(


### PR DESCRIPTION
This updates rules_rust to make use of a new [patch](https://github.com/lowRISC/rules_rust/commit/545f431ebd1d477ff5a5699665de8b29331c67f2) that was added in the lowRISC fork of rules_rust that enables a workaround for https://github.com/lowRISC/opentitan/issues/12448.

The workaround provides a command line build flag
`--@rules_rust//:extra_rustc_toolchain_dirs=/path/to/somewhere/else` that you can add to your `.bazelrc` file to specify a different location on your system where host toolchain tools may be found.