### PR TITLE
[sival] Fix a missing end-quote in flash_ctrl testplan.

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -591,7 +591,7 @@
     }
     {
       name: "FLASH_CTRL.INIT.ROOT_SEEDS"
-      desc: "After the scrambling keys are requested, the flash controller reads root seeds from secret partitions and provides them to the key manager.
+      desc: "After the scrambling keys are requested, the flash controller reads root seeds from secret partitions and provides them to the key manager."
     }
     {
       name: "FLASH_CTRL.INIT.SCRAMBLING_KEYS"


### PR DESCRIPTION
I was getting build errors from `flash_ctrl_regs.h` (I think they're also happening on `master`, which has been failing CI since Friday) and followed the error message to this line from https://github.com/lowRISC/opentitan/pull/19636 . Adding a quotation mark seems to fix the issue for me!