### PR TITLE
[opentitanlib] Improve UART autodetection

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -194,6 +194,7 @@ rust_library(
         "src/util/unknown.rs",
         "src/util/usb.rs",
         "src/util/usr_access.rs",
+        "src/util/tty.rs",
         "src/util/vmem/mod.rs",
         "src/util/vmem/parser.rs",
         "src/util/voltage.rs",

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Result};
+
+use crate::util::tty::{scan_usb_ttys, UsbTty};
+
 pub trait Board {
     const VENDOR_ID: u16 = 0x2b3e;
     const PRODUCT_ID: u16;
@@ -19,6 +23,29 @@ pub trait Board {
     const PIN_SW_STRAP2: &'static str;
     const PIN_TAP_STRAP0: &'static str;
     const PIN_TAP_STRAP1: &'static str;
+
+    /// Auto-detect UARTs for this board (if possible).
+    fn auto_detect_uarts(serial_number: &str) -> Result<Vec<String>>;
+}
+
+/// Helper function: return a list of serial port name of the
+/// serial ports exported by the SAM3X with a given serial number.
+/// Ports are returned by increasing interface number.
+fn find_sam3x_uarts(ttys: &[UsbTty], serial_number: &str) -> Result<Vec<UsbTty>> {
+    let mut ports: Vec<UsbTty> = ttys
+        .iter()
+        .filter(|tty| tty.serial_number == Some(serial_number.to_string()))
+        .cloned()
+        .collect();
+    ensure!(
+        ports.len() == 2,
+        "The SAM3x has two serial ports but {} were found",
+        ports.len()
+    );
+    // Sort by interface number.
+    ports.sort_by(|a, b| a.interface.cmp(&b.interface));
+    // Only keep the serial port name.
+    Ok(ports)
 }
 
 pub struct Cw310 {}
@@ -39,6 +66,24 @@ impl Board for Cw310 {
     const PIN_SW_STRAP2: &'static str = "USB_A17";
     const PIN_TAP_STRAP0: &'static str = "USB_A18";
     const PIN_TAP_STRAP1: &'static str = "USB_A19";
+
+    fn auto_detect_uarts(serial_number: &str) -> Result<Vec<String>> {
+        // Per the documentation [1], the default CW310/SAM3X firmware exposes
+        // two serial interfaces with two interfaces:
+        // - interface 0: pins AB22/AA24, this corresponds to OT UART2 [2]
+        // - interface 1: pins AA22/W24, this corresponds to OT UART0 [2]
+        // The opentitanlib app expects the console UART (UART0) to be at index 0. [3]
+        //
+        // [1] https://rtfm.newae.com/Targets/CW310%20Bergen%20Board/
+        // [2] https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/data/pins_cw310.xdc
+        // [3] https://github.com/lowRISC/opentitan/blob/master/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+
+        let ttys = scan_usb_ttys()?;
+        let mut ports = find_sam3x_uarts(&ttys, serial_number)?;
+        // Reverse ports
+        ports.reverse();
+        Ok(ports.into_iter().map(|tty| tty.port_name).collect())
+    }
 }
 
 pub struct Cw340 {}
@@ -59,4 +104,49 @@ impl Board for Cw340 {
     const PIN_SW_STRAP2: &'static str = "PC21";
     const PIN_TAP_STRAP0: &'static str = "PB13";
     const PIN_TAP_STRAP1: &'static str = "PB12";
+
+    fn auto_detect_uarts(serial_number: &str) -> Result<Vec<String>> {
+        const USE_FTDI_FOR_SERIAL: bool = true;
+        const FTDI_CW340_VID: u16 = 0x0403;
+        const FTDI_CW340_PID: u16 = 0x6011;
+        const FTDI_CW340_UART0_INTF: u8 = 2;
+        const FTDI_CW340_UART2_INTF: u8 = 3;
+
+        let mut ttys = scan_usb_ttys()?;
+        let sam_ports = find_sam3x_uarts(&ttys, serial_number)?;
+
+        // The CW340 has jumpers to route the UARTs to the SAM3x, to the FTDI or the HD.
+        if USE_FTDI_FOR_SERIAL {
+            // When routed to the FTDI, UART0 is routed to port C and UART2 to port D [1]
+            // so we need to find all ttys that correspond to the FTDI and use interfaces
+            // 2 and 3. In order to find the FTDI, we know the USB VID and PID and that they
+            // are under the some USB hub on the board. Unfortunately, the FTDI does not
+            // come programmed with a serial number which is quite harder.
+            //
+            // [1] https://raw.githubusercontent.com/newaetech/cw340-luna-board/main/docs/NPCA-CW340-LUNABOARD-05.PDF
+
+            assert!(!sam_ports.is_empty()); // Should always be true since find_sam3x_uarts() already checks
+            let bus = sam_ports[0].bus;
+            let mut parent_ports = sam_ports[0].ports.clone();
+            parent_ports.pop(); // remove last port to get to the parent
+                                // Now only keep devices that match a given VID&PID and share a parent.
+                                // Also only keep interfaces 2 and 3.
+            ttys.retain(|tty| {
+                tty.vid == FTDI_CW340_VID
+                    && tty.pid == FTDI_CW340_PID
+                    && tty.bus == bus
+                    && !tty.ports.is_empty()
+                    && tty.ports[0..tty.ports.len() - 1] == parent_ports
+                    && (tty.interface == FTDI_CW340_UART0_INTF
+                        || tty.interface == FTDI_CW340_UART2_INTF)
+            });
+            ttys.sort_by(|a, b| a.interface.cmp(&b.interface));
+
+            Ok(ttys.into_iter().map(|tty| tty.port_name).collect())
+        } else {
+            // When routed to the SAM3x,the configuration is similar to the CW310 but
+            // the not inverted: interface 0 corresponds to UART0, and interface 1 to UART 2.
+            Ok(sam_ports.into_iter().map(|tty| tty.port_name).collect())
+        }
+    }
 }

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use serde_annotate::Annotate;
-use serialport::SerialPortType;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
@@ -14,7 +13,7 @@ use std::rc::Rc;
 use crate::io::gpio::GpioPin;
 use crate::io::jtag::{Jtag, JtagParams};
 use crate::io::spi::Target;
-use crate::io::uart::{Uart, UartError};
+use crate::io::uart::Uart;
 use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
 use crate::transport::common::uart::SerialPortUart;
 use crate::transport::{
@@ -39,7 +38,7 @@ struct Inner {
 
 pub struct ChipWhisperer<B: Board> {
     pub(crate) device: Rc<RefCell<usb::Backend<B>>>,
-    uart_override: Vec<String>,
+    uart: Vec<String>,
     inner: RefCell<Inner>,
 }
 
@@ -50,11 +49,19 @@ impl<B: Board> ChipWhisperer<B> {
         usb_serial: Option<&str>,
         uart_override: &[&str],
     ) -> anyhow::Result<Self> {
+        let dev = usb::Backend::new(usb_vid, usb_pid, usb_serial)?;
+        let uarts =
+            B::auto_detect_uarts(dev.get_serial_number()).context("Could not auto-detect UARTs")?;
+        log::info!("Auto-detected UARTS: {:?}", uarts);
+        let uarts = if uart_override.is_empty() {
+            uarts
+        } else {
+            log::info!("UARTS overridde: {:?}", uarts);
+            uart_override.iter().map(|s| s.to_string()).collect()
+        };
         let board = ChipWhisperer {
-            device: Rc::new(RefCell::new(usb::Backend::new(
-                usb_vid, usb_pid, usb_serial,
-            )?)),
-            uart_override: uart_override.iter().map(|s| s.to_string()).collect(),
+            device: Rc::new(RefCell::new(dev)),
+            uart: uarts,
             inner: RefCell::default(),
         };
         board.init_pin_directions()?;
@@ -89,36 +96,12 @@ impl<B: Board> ChipWhisperer<B> {
     }
 
     fn open_uart(&self, instance: u32) -> Result<SerialPortUart> {
-        if self.uart_override.is_empty() {
-            let usb = self.device.borrow();
-            let serial_number = usb.get_serial_number();
-
-            let mut ports = serialport::available_ports()
-                .map_err(|e| UartError::EnumerationError(e.to_string()))?;
-            ports.retain(|port| {
-                if let SerialPortType::UsbPort(info) = &port.port_type {
-                    if info.serial_number.as_deref() == Some(serial_number) {
-                        return true;
-                    }
-                }
-                false
-            });
-            // The CW board seems to have the last port connected as OpenTitan UART 0.
-            // Reverse the sort order so the last port will be instance 0.
-            ports.sort_by(|a, b| b.port_name.cmp(&a.port_name));
-
-            let port = ports.get(instance as usize).ok_or_else(|| {
-                TransportError::InvalidInstance(TransportInterfaceType::Uart, instance.to_string())
-            })?;
-            SerialPortUart::open(&port.port_name)
-        } else {
-            let instance = instance as usize;
-            ensure!(
-                instance < self.uart_override.len(),
-                TransportError::InvalidInstance(TransportInterfaceType::Uart, instance.to_string())
-            );
-            SerialPortUart::open(&self.uart_override[instance])
-        }
+        let instance = instance as usize;
+        ensure!(
+            instance < self.uart.len(),
+            TransportError::InvalidInstance(TransportInterfaceType::Uart, instance.to_string())
+        );
+        SerialPortUart::open(&self.uart[instance])
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/usb.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/usb.rs
@@ -137,6 +137,16 @@ impl<B: Board> Backend<B> {
         self.usb.get_serial_number()
     }
 
+    /// Get the USB bus number.
+    pub fn bus_number(&self) -> u8 {
+        self.usb.bus_number()
+    }
+
+    /// Get the USB port numbers to the root hub.
+    pub fn port_numbers(&self) -> Result<Vec<u8>> {
+        self.usb.port_numbers()
+    }
+
     /// Get the firmware build date as a string.
     pub fn get_firmware_build_date(&self) -> Result<String> {
         let mut buf = [0u8; 100];

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -13,6 +13,7 @@ pub mod present;
 pub mod printer;
 pub mod rom_detect;
 pub mod status;
+pub mod tty;
 pub mod unknown;
 pub mod usb;
 pub mod usr_access;

--- a/sw/host/opentitanlib/src/util/tty.rs
+++ b/sw/host/opentitanlib/src/util/tty.rs
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This utility handles the discovery of TTY device. It does not use serialport
+// at the moment because this code needs to work in non-udev environment and
+// make as little assumptions are possible. This code also works for USB devices.
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use regex::Regex;
+
+/// A discovered USB TTY.
+#[derive(Debug, Clone)]
+pub struct UsbTty {
+    pub port_name: String,             // Name of the port, e.g. ttyACM0.
+    pub vid: u16,                      // USB vendor ID.
+    pub pid: u16,                      // USB vendor ID.
+    pub serial_number: Option<String>, // USB serial number (if any).
+    pub interface: u8,                 // USB Interface number.
+    pub config: u8,                    // USB configuration number.
+    pub bus: u8,                       // USB bus number.
+    pub ports: Vec<u8>,                // USB port numbers.
+}
+
+/// Path to the linux sysfs USB device tree.
+pub const SYSFS_USB_PATH: &str = "/sys/bus/usb/devices";
+
+pub fn scan_usb_ttys() -> Result<Vec<UsbTty>> {
+    // The devices directory looks something like this (see https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-bus-usb):
+    //
+    // ```plain
+    // 3-6/         # USB device
+    // |- 3-6:1.0/  # USB Interface
+    // |- 3-6:1.1/  # USB Interface
+    // |- 3-6:1.2/  # USB Interface
+    // |- 3-6:1.3/  # USB Interface
+    // |- 3-6:1.3/  # USB Interface
+    // |- power/    # Other device stuff...
+    // |- idVendor  # USB vendor ID
+    // |- idProduct # USB product ID
+    // |- ...
+    //
+    // 4-2/         # USB device
+    // |- 4-2:1.0/  # USB Interface
+    // |- ...
+    // ...
+    // ```
+    //
+    // Note that devices under several hubs have a more complex path like 3-1.4.3 which is more generally
+    // of the form <bus>-<port1>[.<portX>]*
+    // And the interface are numbered as <config>.<interface>
+    let mut list = Vec::new();
+
+    // Regex for a full usb path: <bus>-<port1>[.<portX>]*:<cfg>.<intf>
+    let usb_re = Regex::new(
+        r"^(?<bus>[0-9]+)-(?<ports>[0-9]+(?:\.[0-9]+)*):(?<cfg>[0-9]+)\.(?<intf>[0-9]+)$",
+    )
+    .context("Could not build regex to match interfaces")?;
+
+    for dev in fs::read_dir(SYSFS_USB_PATH).context("Cannot find USB device in sysfs")? {
+        let dirent = dev?;
+        let dev_path = dirent.path();
+        let dev_name = dirent
+            .file_name()
+            .to_str()
+            .context("Cannot convert filename to string")?
+            .to_string();
+        // Only consider devices.
+        if !dev_path.is_dir() || dev_name.contains(':') {
+            continue;
+        }
+        // Read VID, PID and serial.
+        let vid = u16::from_str_radix(fs::read_to_string(dev_path.join("idVendor"))?.trim(), 16)?;
+        let pid = u16::from_str_radix(fs::read_to_string(dev_path.join("idProduct"))?.trim(), 16)?;
+        let serial_number_path = dev_path.join("serial");
+        let serial_number = if serial_number_path.exists() {
+            Some(fs::read_to_string(serial_number_path)?.trim().to_string())
+        } else {
+            None
+        };
+
+        // List interfaces.
+        for iface in dev_path.read_dir()? {
+            let iface_dirent = iface?;
+            let iface_name = iface_dirent
+                .file_name()
+                .to_str()
+                .context("sysfs filename is not in UTF9")?
+                .to_string();
+            let captures = match usb_re.captures(&iface_name) {
+                None => {
+                    // Not an interface directory.
+                    continue;
+                }
+                Some(captures) => captures,
+            };
+            let bus = captures["bus"].parse::<u8>()?;
+            let ports = captures["ports"]
+                .split('.')
+                .map(|x| x.parse::<u8>().context("sysfs usb ports is invalid"))
+                .collect::<Result<Vec<_>>>()?;
+            let config = captures["cfg"].parse::<u8>()?;
+            let interface = captures["intf"].parse::<u8>()?;
+            // Look for a TTY in this directory.
+            let port_name = match find_tty_in_usb_dir(&iface_dirent.path())? {
+                None => continue,
+                Some(port_name) => port_name,
+            };
+
+            list.push(UsbTty {
+                port_name: format!("/dev/{}", port_name),
+                vid,
+                pid,
+                serial_number: serial_number.clone(),
+                interface,
+                config,
+                bus,
+                ports,
+            })
+        }
+    }
+
+    Ok(list)
+}
+
+fn find_the_tty(path: &Path) -> Result<Option<String>> {
+    // Expect a single device under tty/ so return the first entry.
+    let child = path
+        .read_dir()
+        .context("Cannot list tty directory in sysfs")?
+        .next()
+        .context("The tty directory in sysfs is empty!")?;
+    let filename = child?.file_name();
+    Ok(Some(filename.to_str().context("bad")?.to_string()))
+}
+
+fn find_tty_in_usb_dir(path: &Path) -> Result<Option<String>> {
+    // There seems to be an inconsistency in the naming of tty directories
+    // under USB interface: cdcacn creates a device `tty/ttyACMx` but ftdi_sio
+    // creates `ttyUSBx/tty/ttyUSBx`.
+
+    let the_tty = path.join("tty");
+    if the_tty.exists() {
+        return find_the_tty(&the_tty);
+    }
+
+    for child in path.read_dir()? {
+        let child_path = child?.path();
+        let the_tty = child_path.join("tty");
+        if the_tty.exists() {
+            return find_the_tty(&the_tty);
+        }
+    }
+    Ok(None)
+}


### PR DESCRIPTION
With this PR, opentitanlib can now correctly autodetect UARTs, even when several devices are plugged and even in non-udev environment. To achieve that, I had to write a routine to list TTYs from scratch only using sysfs. The code is inspired by work from Jorge and @jwnrt . This makes the autodetection code linux specific which is a downside of this approach. UARTs can still be overriden from the CLI.

This is not necessarily the final form of this PR, maybe some code can be refactored in the hyperdebug backend as well. Comments are welcome.