### PR TITLE
[base_hexdump] Protect base_hexdump calls in DV

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -687,6 +687,10 @@ size_t base_snhexdump_with(char *out, size_t out_len, base_hexdump_fmt_t fmt,
 
 size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
                           const char *buf, size_t len) {
+  if (out.sink == NULL) {
+    out.sink = &base_dev_null;
+  }
+
   size_t bytes_written = 0;
   size_t bytes_per_line = fmt.bytes_per_word * fmt.words_per_line;
 

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -93,7 +93,7 @@ typedef struct buffer_sink {
  * Note that for logging in DV, the following script updates the format
  * specifiers supported in C above and changes them to match the SystemVerilog
  * language semantics: util/device_sw_utils/extract_sw_logs.py
- * It also makes fixes as needed for custom speficiers such as %!s.
+ * It also makes fixes as needed for custom specifiers such as %!s.
  *
  * @param format the format spec.
  * @param ... values to interpolate in the format spec.


### PR DESCRIPTION
Introduce check for NULL sink function and safely suppress output as per other base_ stdout functions, rather than branching to address zero in chip simulation.
The other base_ functions already included protection against the fact that in DV simulation the base_set_stdout() function has never been invoked. It seems that base_hexdump() and related function were overlooked.
Also noticed a typo.
