### PR TITLE
[dif, spi_host] Fix deadlock when the send size is larger than the FIFO

### DIFF
--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -341,29 +341,25 @@ static void issue_dummy(const dif_spi_host_t *spi_host,
 static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,
                                      dif_spi_host_segment_t *segment,
                                      bool last_segment) {
-  size_t length;
-  dif_spi_host_width_t width;
-  dif_spi_host_direction_t direction;
-
   switch (segment->type) {
     case kDifSpiHostSegmentTypeTx:
-      width = segment->tx.width;
-      length = segment->tx.length;
-      direction = kDifSpiHostDirectionTx;
+      write_command_reg(spi_host, (uint16_t)segment->tx.length,
+                        segment->tx.width, kDifSpiHostDirectionTx,
+                        last_segment);
       spi_host_fifo_write_alias(spi_host, segment->tx.buf,
                                 (uint16_t)segment->tx.length);
       break;
     case kDifSpiHostSegmentTypeBidirectional:
-      width = segment->bidir.width;
-      length = segment->bidir.length;
-      direction = kDifSpiHostDirectionBidirectional;
+      write_command_reg(spi_host, (uint16_t)segment->bidir.length,
+                        segment->bidir.width, kDifSpiHostDirectionBidirectional,
+                        last_segment);
       spi_host_fifo_write_alias(spi_host, segment->bidir.txbuf,
                                 (uint16_t)segment->bidir.length);
       break;
     case kDifSpiHostSegmentTypeRx:
-      width = segment->rx.width;
-      length = segment->rx.length;
-      direction = kDifSpiHostDirectionRx;
+      write_command_reg(spi_host, (uint16_t)segment->rx.length,
+                        segment->rx.width, kDifSpiHostDirectionRx,
+                        last_segment);
       break;
     default:
       // Programming error (within this file).  We should never get here.
@@ -371,7 +367,6 @@ static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,
       // represent a data transfer.
       return kDifBadArg;
   }
-  write_command_reg(spi_host, (uint16_t)length, width, direction, last_segment);
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -365,9 +365,9 @@ TEST_F(TransactionTest, TransmitDual) {
 
   EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
   EXPECT_READY(true);
-  EXPECT_CALL(fifo_, write(&spi_host_, buf, sizeof(buf)));
   EXPECT_COMMAND_REG(/*length=*/sizeof(buf), /*width=*/kDifSpiHostWidthDual,
                      /*direction=*/kDifSpiHostDirectionTx, /*last=*/true);
+  EXPECT_CALL(fifo_, write(&spi_host_, buf, sizeof(buf)));
 
   EXPECT_DIF_OK(dif_spi_host_transaction(&spi_host_, 0, &segment, 1));
 }
@@ -403,10 +403,10 @@ TEST_F(TransactionTest, Transceive) {
 
   EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
   EXPECT_READY(true);
-  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
   EXPECT_COMMAND_REG(
       /*length=*/sizeof(txbuf), /*width=*/kDifSpiHostWidthStandard,
       /*direction=*/kDifSpiHostDirectionBidirectional, /*last=*/true);
+  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
   EXPECT_CALL(fifo_, read(&spi_host_, rxbuf, sizeof(rxbuf)));
 
   EXPECT_DIF_OK(dif_spi_host_transaction(&spi_host_, 0, &segment, 1));
@@ -429,9 +429,9 @@ TEST_F(TransactionTest, MultiSegmentTxRx) {
 
   EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
   EXPECT_READY(true);
-  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
   EXPECT_COMMAND_REG(/*length=*/sizeof(txbuf), /*width=*/kDifSpiHostWidthDual,
                      /*direction=*/kDifSpiHostDirectionTx, /*last=*/false);
+  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
   EXPECT_READY(true);
   EXPECT_COMMAND_REG(/*length=*/sizeof(rxbuf), /*width=*/kDifSpiHostWidthDual,
                      /*direction=*/kDifSpiHostDirectionRx, /*last=*/true);


### PR DESCRIPTION
 This PR put the transaction in the CMD_FIFO before the data is put in the TX_FIFO, this allows transactions lager than the FIFO size, otherwise, the DIF would deadlock during the FIFO feeding.