### PR TITLE
[doc] Add entries to glossary

### DIFF
--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -214,7 +214,7 @@ Position-Independent Code.
 
 Pin Multiplexer.
 
-### PKI
+#### PKI
 
 Public Key Infrastructure.
 
@@ -222,7 +222,7 @@ Public Key Infrastructure.
 
 Physical Memory Protection.
 
-### POR
+#### POR
 
 Power-On Reset.
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -38,6 +38,10 @@ Comportable (hardware) Intellectual Property.
 
 See the [comportability specification](./contributing/hw/comportability/README.md).
 
+#### CP
+
+Circuit Probe.
+
 #### CRC
 
 Cyclic Redundancy Check.
@@ -137,6 +141,10 @@ Field Programmable Gate Array.
 #### FPV
 
 Formal Property Verification.
+
+#### FT
+
+Final Test.
 
 #### GF2
 

--- a/hw/ip/entropy_src/README.md
+++ b/hw/ip/entropy_src/README.md
@@ -13,7 +13,7 @@ This module conforms to the [Comportable guideline for peripheral functionality.
 
 ## Features
 
-- This revision provides an interface to an external physical random noise generator (also referred to as a physical true random number generator.
+- This revision provides an interface to an external physical random noise generator (also referred to as a physical true random number generator or PTRNG).
 The PTRNG external source is a physical true random noise source.
 A noise source and its relation to an entropy source are defined by [SP 800-90B.](https://csrc.nist.gov/publications/detail/sp/800-90b/final)
 - A set of registers is provided for firmware to obtain entropy bits.

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -1,7 +1,7 @@
 # Theory of Operation
 
 As already described, this IP block will collect bits of entropy for firmware or hardware consumption.
-This revision supports only an external interface for a PTRNG noise source implementation.
+This revision supports only an external interface for a PTRNG (Physical True Random Number Generator) noise source implementation.
 
 The first step is initialization and enabling.
 The PTRNG noise source mode is selected when the [`MODULE_ENABLE`](registers.md#module_enable) field is set.


### PR DESCRIPTION
This PR adds a few more acronym entries to the glossary and fixes some Markdown headings that were set at the wrong level.

* CP and FT: Circuit Probe and Final Test.
* ~~PTRNG: Physical True Random Number Generator.~~
  * This acronym does not seem very widely known.
  * Instead, I have made its expansion clearer in the entropy_src documentation.
  * Is a PTRNG synonymous with a TRNG (True Random Number Generator)? Maybe we should replace.

I would like to give actual descriptions of CP and FT but don't fully understand what they mean. If anybody can help suggest some description text, that would be greatly appreciated!