### PR TITLE
[opentitantool] Yet another fix to legacy Titan rescue protocol

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -122,7 +122,7 @@ impl Frame {
         while addr < max_addr {
             // Try skipping over 0xffffffff words.
             let nonempty_addr = addr
-                + payload[addr..]
+                + payload[addr..max_addr]
                     .chunks(4)
                     .position(|c| c != [0xff; 4])
                     .unwrap_or(0)


### PR DESCRIPTION
At an earlier time, I modified the rescue protocol to round up the size of the range being flashed to a multiple of a page size.  (After being trimmed for trailing words consisting only of FF.)

Prior to this change, the logic for skipping ranges of FFs "in the middle" of the image needed not worry about going past the end of the range to be flashed, as the last word of the range would always be somthing other than pure FFs.

Now it turns out that ranges of FF bytes extending beyond the end of the section of the image to be flashed can cause `addr` to go beyond `max_addr`, this fix makes sure that if all remaning bytes up to `max_addr` are FFs, then then `unwrap_or(0)` will make sure that the logic does not skip anything, (as this has to be due to padding of the final page.)
