### PR TITLE
[bazel] Update the binary/test rules for building ROMs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -351,9 +351,12 @@ jobs:
   - bash: |
       . util/build_consts.sh
       mkdir -p "$BIN_DIR/sw/device/lib/testing/test_rom"
-      cp $(ci/scripts/target-location.sh //sw/device/lib/testing/test_rom:test_rom_fpga_cw305_vmem) \
+      cp $(ci/scripts/target-location.sh \
+          //sw/device/lib/testing/test_rom:test_rom_fpga_cw305 \
+          --features=-rv32_bitmanip \
+          --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_) \
         "$BIN_DIR/sw/device/lib/testing/test_rom"
-    displayName: Copy test_rom_fpga_cw305_vmem to $BIN_DIR
+    displayName: Copy test_rom_fpga_cw305 to $BIN_DIR
   - template: ci/upload-artifacts-template.yml
     parameters:
       includePatterns:

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -122,14 +122,15 @@ ifneq (${sw_images},)
 				--ui_event_filters=-info \
 				--noshow_progress \
 				--output=label_kind | cut -f1 -d' '); \
-			if [[ $${kind} == "opentitan_test" ]]; then \
+			if [[ $${kind} == "opentitan_test" || \
+					$${bazel_label} == "//sw/device/lib/testing/test_rom:test_rom_sim_dv" ]]; then \
 				for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
 					$${bazel_label} \
 					--ui_event_filters=-info \
 					--noshow_progress \
 					--output=starlark \
 					`# An opentitan_test rule has all of its needed files in its runfiles.` \
-					--starlark:expr='"\n".join([f.path for f in target.default_runfiles.files.to_list()])'); do \
+					--starlark:expr='"\n".join([f.path for f in target.data_runfiles.files.to_list()])'); do \
 						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
 						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -9,6 +9,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
+    "fpga_cw305",
     "fpga_cw310",
     "fpga_cw340",
     "sim_dv",
@@ -88,6 +89,23 @@ fpga_cw310(
     exec_env = "fpga_cw310_rom_with_fake_keys",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+)
+
+###########################################################################
+# FPGA CW305 Environments
+#
+# TODO(opentitan#19493): Determine whether the `fpga_cw310` infrastructure
+# should become a more generic `fpga_chipwhisperer` infrastruture able to
+# handle multiple CW-type boards.
+###########################################################################
+fpga_cw305(
+    name = "fpga_cw305",
+    design = "earlgrey",
+    exec_env = "fpga_cw305",
+    lib = "//sw/device/lib/arch:fpga_cw305",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
+    test_cmd = "testing-not-supported",
 )
 
 ###########################################################################

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -10,6 +10,7 @@ load(
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
     "fpga_cw310",
+    "fpga_cw340",
     "sim_dv",
     "sim_verilator",
 )
@@ -47,6 +48,7 @@ fpga_cw310(
     exec_env = "fpga_cw310",
     lib = "//sw/device/lib/arch:fpga_cw310",
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
     test_cmd = "testing-not-supported",
 )
 
@@ -89,6 +91,50 @@ fpga_cw310(
 )
 
 ###########################################################################
+# FPGA CW340 Environments
+#
+# TODO(opentitan#19493): Determine whether the `fpga_cw310` infrastructure
+# should become a more generic `fpga_chipwhisperer` infrastruture able to
+# handle multiple CW-type boards.
+###########################################################################
+fpga_cw340(
+    name = "fpga_cw340",
+    design = "earlgrey",
+    exec_env = "fpga_cw340",
+    lib = "//sw/device/lib/arch:fpga_cw340",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
+    test_cmd = "testing-not-supported",
+)
+
+fpga_cw340(
+    name = "fpga_cw340_test_rom",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ] + select({
+        "@//ci:lowrisc_fpga_cw340": ["--uarts=/dev/ttyACM_CW340_1,/dev/ttyACM_CW340_0"],
+        "//conditions:default": [],
+    }),
+    base = ":fpga_cw340",
+    bitstream = "//hw/bitstream:test_rom",
+    exec_env = "fpga_cw340_test_rom",
+    param = {
+        "interface": "cw340",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    test_cmd = """
+        --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
+###########################################################################
 # Sim Verilator Environments
 #
 # The sim_verilator_base target is only meant to be used for building ROMs
@@ -101,6 +147,7 @@ sim_verilator(
     lib = "//sw/device/lib/arch:sim_verilator",
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
     test_cmd = "testing-not-supported",
 )
 
@@ -126,7 +173,7 @@ sim_verilator(
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
-    rom = "//sw/device/lib/testing/test_rom:test_rom_sim_verilator_scr_vmem",
+    rom = "//sw/device/lib/testing/test_rom:test_rom",
     test_cmd = """
         --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
@@ -143,9 +190,15 @@ sim_dv(
     name = "sim_dv_base",
     design = "earlgrey",
     exec_env = "sim_dv",
+    extract_sw_logs = "//util/device_sw_utils:extract_sw_logs_db",
+    flash_scramble_tool = "//util/design:gen-flash-img",
     lib = "//sw/device/lib/arch:sim_dv",
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
+    otp_data_perm = "//hw/ip/otp_ctrl/data:data_perm",
+    otp_mmap = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
+    otp_seed = "//hw/ip/otp_ctrl/data:otp_seed",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
 )
 
 sim_dv(
@@ -159,16 +212,8 @@ sim_dv(
         "//hw/top_earlgrey/dv:chip_sim_cfg.hjson",
     ],
     exec_env = "sim_dv",
-    extract_sw_logs = "//util/device_sw_utils:extract_sw_logs_db",
-    flash_scramble_tool = "//util/design:gen-flash-img",
-    lib = "//sw/device/lib/arch:sim_dv",
-    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    otp = "//hw/ip/otp_ctrl/data:img_rma",
-    otp_data_perm = "//hw/ip/otp_ctrl/data:data_perm",
-    otp_mmap = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
-    otp_seed = "//hw/ip/otp_ctrl/data:otp_seed",
     param = {
         "dvsim_config": "$(location //hw/top_earlgrey/dv:chip_sim_cfg.hjson)",
     },
-    rom = "//sw/device/lib/testing/test_rom:test_rom_sim_dv_scr_vmem",
+    rom = "//sw/device/lib/testing/test_rom:test_rom",
 )

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -228,6 +228,12 @@ def _opentitan_binary(ctx):
         # the DefaultInfo provider.
         if "logs" in provides:
             default_info.extend(provides["logs"])
+
+        # FIXME(cfrantz): Special case: The englishbreakfast verilator model
+        # requires a non-scrambled ROM image.
+        if provides.get("rom32"):
+            default_info.append(provides["rom32"])
+
         groups.update(_as_group_info(exec_env.exec_env, signed))
         groups.update(_as_group_info(exec_env.exec_env, provides))
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -221,11 +221,7 @@ def _opentitan_binary(ctx):
         name = _binary_name(ctx, exec_env)
         deps = ctx.attr.deps + [exec_env.lib]
         provides, signed = _build_binary(ctx, exec_env, name, deps)
-        providers.append(exec_env.create_provider(
-            ctx,
-            exec_env,
-            **provides
-        ))
+        providers.append(exec_env.provider(**provides))
         default_info.append(provides["default"])
 
         # FIXME(cfrantz): logs are a special case and get added into
@@ -316,17 +312,13 @@ def _opentitan_test(ctx):
     # If the test is supplied exactly one file and no deps _and_ that file
     # is a provider for the current exec_env, then we assume that it's a
     # pre-built binary.
-    if len(ctx.attr.srcs) == 1 and len(ctx.attr.deps) == 0 and exec_env.get_provider(ctx.attr.srcs[0]):
-        p = exec_env.get_provider(ctx.attr.srcs[0])
+    if len(ctx.attr.srcs) == 1 and len(ctx.attr.deps) == 0 and exec_env.provider in ctx.attr.srcs[0]:
+        p = ctx.attr.srcs[0][exec_env.provider]
     else:
         name = _binary_name(ctx, exec_env)
         deps = ctx.attr.deps + [exec_env.lib]
         provides, signed = _build_binary(ctx, exec_env, name, deps)
-        p = exec_env.create_provider(
-            ctx,
-            exec_env,
-            **provides
-        )
+        p = exec_env.provider(**provides)
 
     executable, runfiles = exec_env.test_dispatch(ctx, exec_env, p)
     return DefaultInfo(

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -17,6 +17,7 @@ load(
     "@lowrisc_opentitan//rules/opentitan:fpga_cw310.bzl",
     _cw310_params = "cw310_params",
     _fpga_cw310 = "fpga_cw310",
+    _fpga_cw340 = "fpga_cw340",
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:sim_verilator.bzl",
@@ -39,6 +40,7 @@ opentitan_transition = _opentitan_transition
 
 opentitan_binary = _opentitan_binary
 fpga_cw310 = _fpga_cw310
+fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 
 sim_verilator = _sim_verilator

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -16,6 +16,7 @@ load(
 load(
     "@lowrisc_opentitan//rules/opentitan:fpga_cw310.bzl",
     _cw310_params = "cw310_params",
+    _fpga_cw305 = "fpga_cw305",
     _fpga_cw310 = "fpga_cw310",
     _fpga_cw340 = "fpga_cw340",
 )
@@ -40,6 +41,7 @@ opentitan_transition = _opentitan_transition
 
 opentitan_binary = _opentitan_binary
 fpga_cw310 = _fpga_cw310
+fpga_cw305 = _fpga_cw305
 fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -95,12 +95,14 @@ def _hacky_tags(env):
 def opentitan_test(
         name,
         srcs,
+        kind = "flash",
         deps = [],
         copts = [],
         defines = [],
         local_defines = [],
         includes = [],
         linkopts = [],
+        linker_script = None,
         exec_env = {},
         cw310 = _cw310_params(),
         dv = _dv_params(),
@@ -112,11 +114,13 @@ def opentitan_test(
       name: The base name of the test.  The name will be extended with the name
             of the execution environment.
       srcs: The source files (or a binary image) for this test.
+      kind: The kind of test (flash, ram, rom).
       deps: Dependecies for this test.
       copts: Compiler options for this test.
       defines: Compiler defines for this test.
       local_defines: Compiler defines for this test.
       includes: Additional compiler include dirs for this test.
+      linker_script: Linker script for this test.
       linkopts: Linker options for this test.
       exec_env: A dictionary of execution environments.  The keys are labels to
                 execution environments.  The values are the kwargs parameter names
@@ -145,11 +149,13 @@ def opentitan_test(
         _opentitan_test(
             name = test_name,
             srcs = srcs,
+            kind = kind,
             deps = deps,
             copts = copts,
             defines = defines,
             local_defines = local_defines,
             includes = includes,
+            linker_script = linker_script,
             linkopts = linkopts,
             exec_env = env,
             naming_convention = "{name}",

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -11,7 +11,7 @@ _FIELDS = {
     "rsa_key": ("attr.rsa_key", False),
     "spx_key": ("attr.spx_key", False),
     "manifest": ("file.manifest", False),
-    "rom": ("file.rom", False),
+    "rom": ("attr.rom", False),
     "otp": ("file.otp", False),
     "bitstream": ("file.bitstream", False),
     "args": ("attr.args", False),
@@ -23,6 +23,7 @@ _FIELDS = {
     "otp_seed": ("attr.otp_seed", False),
     "otp_data_perm": ("attr.otp_data_perm", False),
     "flash_scramble_tool": ("attr.flash_scramble_tool", False),
+    "rom_scramble_config": ("file.rom_scramble_config", False),
     "_opentitantool": ("executable._opentitantool", True),
 }
 
@@ -124,7 +125,7 @@ def exec_env_common_attrs(**kwargs):
         ),
         "rom": attr.label(
             default = kwargs.get("rom"),
-            allow_single_file = True,
+            allow_files = True,
             doc = "ROM image to use in this environment",
         ),
         "otp": attr.label(
@@ -176,6 +177,17 @@ def exec_env_common_attrs(**kwargs):
             default = kwargs.get("flash_scramble_tool"),
             executable = True,
             cfg = "exec",
+        ),
+        "rom_scramble_tool": attr.label(
+            doc = "ROM scrambling tool.",
+            default = "//hw/ip/rom_ctrl/util:scramble_image",
+            executable = True,
+            cfg = "exec",
+        ),
+        "rom_scramble_config": attr.label(
+            default = kwargs.get("rom_scramble_config", None),
+            doc = "ROM scrambling config for this environment",
+            allow_single_file = True,
         ),
         "_opentitantool": attr.label(
             default = "//sw/host/opentitantool:opentitantool",

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "Cw310BinaryInfo", "get_one_binary_file")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "Cw310BinaryInfo", "Cw340BinaryInfo", "get_one_binary_file")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
 load(
     "//rules/opentitan:exec_env.bzl",
@@ -64,22 +64,6 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "mapfile": mapfile,
     }
 
-def _create_provider(ctx, exec_env, **kwargs):
-    """Create a provider for this exec_env."""
-    return Cw310BinaryInfo(**kwargs)
-
-def _get_provider(item):
-    """Given an attr from a rule, return the Cw310BinaryInfo provider if preseent.
-
-    Args:
-      item: a label that may have a provider attached.
-    Returns:
-      Cw310BinaryInfo or None
-    """
-    if Cw310BinaryInfo in item:
-        return item[Cw310BinaryInfo]
-    return None
-
 def _test_dispatch(ctx, exec_env, provider):
     """Dispatch a test for the fpga_cw310 environment.
 
@@ -107,7 +91,7 @@ def _test_dispatch(ctx, exec_env, provider):
     if bitstream:
         data_files.append(bitstream)
     if rom:
-        rom = get_one_binary_file(rom, field = "rom", providers = [Cw310BinaryInfo])
+        rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
         data_files.append(rom)
     if otp:
         data_files.append(otp)
@@ -155,15 +139,28 @@ def _test_dispatch(ctx, exec_env, provider):
 def _fpga_cw310(ctx):
     fields = exec_env_as_dict(ctx)
     return ExecEnvInfo(
-        get_provider = _get_provider,
+        provider = Cw310BinaryInfo,
         test_dispatch = _test_dispatch,
         transform = _transform,
-        create_provider = _create_provider,
         **fields
     )
 
 fpga_cw310 = rule(
     implementation = _fpga_cw310,
+    attrs = exec_env_common_attrs(),
+)
+
+def _fpga_cw340(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        provider = Cw340BinaryInfo,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        **fields
+    )
+
+fpga_cw340 = rule(
+    implementation = _fpga_cw340,
     attrs = exec_env_common_attrs(),
 )
 

--- a/rules/opentitan/legacy.bzl
+++ b/rules/opentitan/legacy.bzl
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def legacy_rom_targets(target, suffixes):
+    """Create filegroups for legacy ROM rule target names.
+
+    Creates the `<name>_rom` and `<name>_scr_vmem` targets required by the
+    `opentitan_functest` macro.
+
+    Args:
+      target: The name of the new `opentitan_binary` ROM target.
+      targets: The suffix names to use when creating filegroups.
+    """
+    for suffix in suffixes:
+        native.filegroup(
+            name = "{}_{}".format(target, suffix),
+            srcs = [":{}".format(target)],
+            output_group = "{}_rom".format(suffix),
+        )
+        native.alias(
+            name = "{}_{}_scr_vmem".format(target, suffix),
+            actual = ":{}_{}".format(target, suffix),
+        )

--- a/rules/opentitan/legacy.bzl
+++ b/rules/opentitan/legacy.bzl
@@ -16,7 +16,10 @@ def legacy_rom_targets(target, suffixes):
         native.filegroup(
             name = "{}_{}".format(target, suffix),
             srcs = [":{}".format(target)],
-            output_group = "{}_rom".format(suffix),
+            output_group = select({
+                "//sw/device:is_english_breakfast": "{}_rom32".format(suffix),
+                "//conditions:default": "{}_rom".format(suffix),
+            }),
         )
         native.alias(
             name = "{}_{}_scr_vmem".format(target, suffix),

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -8,6 +8,10 @@ Cw310BinaryInfo = provider(
     doc = "CW310 Binary Info",
 )
 
+Cw305BinaryInfo = provider(
+    doc = "CW305 Binary Info",
+)
+
 Cw340BinaryInfo = provider(
     doc = "CW340 Binary Info",
 )

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -8,6 +8,10 @@ Cw310BinaryInfo = provider(
     doc = "CW310 Binary Info",
 )
 
+Cw340BinaryInfo = provider(
+    doc = "CW340 Binary Info",
+)
+
 SimDvBinaryInfo = provider(
     doc = "Dv Binary Info",
 )
@@ -18,6 +22,7 @@ SimVerilatorBinaryInfo = provider(
 
 ALL_BINARY_PROVIDERS = [
     Cw310BinaryInfo,
+    Cw340BinaryInfo,
     SimDvBinaryInfo,
     SimVerilatorBinaryInfo,
 ]

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -22,21 +22,23 @@ ALL_BINARY_PROVIDERS = [
     SimVerilatorBinaryInfo,
 ]
 
-def get_binary_files(attrs):
+def get_binary_files(attrs, field = "binary", providers = ALL_BINARY_PROVIDERS):
     """Get the list of binary files associated with a list of labels.
 
     Args:
       attrs: a list of labels with BinaryInfo or DefaultInfo providers.
+      field: the name of the provider field contaning files.
+      providers: the set of providers to inspect.
     Returns:
       List[File]: the files associated with the labels.
     """
     files = []
     for attr in attrs:
         found_files = False
-        for p in ALL_BINARY_PROVIDERS:
+        for p in providers:
             if p in attr:
                 found_files = True
-                files.append(attr[p].binary)
+                files.append(getattr(attr[p], field))
 
         if not found_files and DefaultInfo in attr:
             found_files = True
@@ -44,3 +46,18 @@ def get_binary_files(attrs):
         if not found_files:
             print("No file providers in ", attr)
     return files
+
+def get_one_binary_file(attr, field = "binary", providers = ALL_BINARY_PROVIDERS):
+    """Get exactly one binary file associated with a label.
+
+    Args:
+      attr: a label with BinaryInfo or DefaultInfo providers.
+      field: the name of the provider field contaning files.
+      providers: the set of providers to inspect.
+    Returns:
+      File: the files associated with the label.
+    """
+    files = get_binary_files([attr], field, providers)
+    if len(files) != 1:
+        fail("Expected only one binary file in", attr)
+    return files[0]

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -95,22 +95,6 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "vmem": vmem,
     }
 
-def _create_provider(ctx, exec_env, **kwargs):
-    """Create a provider for this exec_env."""
-    return SimDvBinaryInfo(**kwargs)
-
-def _get_provider(item):
-    """Given an attr from a rule, return the SimDvBinaryInfo provider if preseent.
-
-    Args:
-      item: a label that may have a provider attached.
-    Returns:
-      SimDvBinaryInfo or None
-    """
-    if SimDvBinaryInfo in item:
-        return item[SimDvBinaryInfo]
-    return None
-
 def _test_dispatch(ctx, exec_env, provider):
     """Dispatch a test for the sim_dv environment.
 
@@ -133,7 +117,7 @@ def _test_dispatch(ctx, exec_env, provider):
     data_labels = ctx.attr.data + exec_env.data
     data_files = get_files(data_labels)
     if rom:
-        rom = get_one_binary_file(rom, field = "rom", providers = [SimDvBinaryInfo])
+        rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
         data_files.append(rom)
     if otp:
         data_files.append(otp)
@@ -179,10 +163,9 @@ def _test_dispatch(ctx, exec_env, provider):
 def _sim_dv(ctx):
     fields = exec_env_as_dict(ctx)
     return ExecEnvInfo(
-        get_provider = _get_provider,
+        provider = SimDvBinaryInfo,
         test_dispatch = _test_dispatch,
         transform = _transform,
-        create_provider = _create_provider,
         **fields
     )
 

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -72,22 +72,6 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "vmem": vmem,
     }
 
-def _create_provider(ctx, exec_env, **kwargs):
-    """Create a provider for this exec_env."""
-    return SimVerilatorBinaryInfo(**kwargs)
-
-def _get_provider(item):
-    """Given an attr from a rule, return the SimVerilatorBinaryInfo provider if preseent.
-
-    Args:
-      item: a label that may have a provider attached.
-    Returns:
-      SimVerilatorBinaryInfo or None
-    """
-    if SimVerilatorBinaryInfo in item:
-        return item[SimVerilatorBinaryInfo]
-    return None
-
 def _test_dispatch(ctx, exec_env, provider):
     """Dispatch a test for the sim_verilator environment.
 
@@ -110,7 +94,7 @@ def _test_dispatch(ctx, exec_env, provider):
     data_labels = ctx.attr.data + exec_env.data
     data_files = get_files(data_labels)
     if rom:
-        rom = get_one_binary_file(rom, field = "rom", providers = [SimVerilatorBinaryInfo])
+        rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
         data_files.append(rom)
     if otp:
         data_files.append(otp)
@@ -163,10 +147,9 @@ def _test_dispatch(ctx, exec_env, provider):
 def _sim_verilator(ctx):
     fields = exec_env_as_dict(ctx)
     return ExecEnvInfo(
-        get_provider = _get_provider,
+        provider = SimVerilatorBinaryInfo,
         test_dispatch = _test_dispatch,
         transform = _transform,
-        create_provider = _create_provider,
         **fields
     )
 

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -47,6 +47,15 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
         )
+
+        # The englishbreakfast verilator model does not understand ROM
+        # scrambling, so we also create a non-scrambled VMEM file.
+        rom32 = convert_to_vmem(
+            ctx,
+            name = name,
+            src = binary,
+            word_size = 32,
+        )
         default = rom
         vmem = rom
     elif ctx.attr.kind == "flash":
@@ -58,6 +67,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         )
         default = vmem
         rom = None
+        rom32 = None
     else:
         fail("Not implemented: kind ==", ctx.attr.kind)
 
@@ -70,6 +80,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "disassembly": disassembly,
         "mapfile": mapfile,
         "vmem": vmem,
+        "rom32": rom32,
     }
 
 def _test_dispatch(ctx, exec_env, provider):

--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -233,3 +233,41 @@ def extract_software_logs(ctx, **kwargs):
         executable = tool,
     )
     return (output_logs, output_rodata)
+
+def convert_to_scrambled_rom_vmem(ctx, **kwargs):
+    """Transform a binary to a VMEM file.
+
+    Args:
+      ctx: The context object for this rule.
+      kwargs: Overrides of values normally retrived from the context object.
+        output: The name of the output file.  Constructed from `name` and `suffix`
+                 if not specified.
+        src: The src File object.
+        rom_scramble_config: The scrambling config.
+        rom_scramble_tool: The scrambling tool.
+    Returns:
+      The transformed File.
+    """
+    output = kwargs.get("output")
+    if not output:
+        name = get_override(ctx, "attr.name", kwargs)
+        suffix = get_override(ctx, "attr.suffix", kwargs)
+        output = "{}.{}".format(name, suffix)
+
+    output = ctx.actions.declare_file(output)
+    src = get_override(ctx, "attr.src", kwargs)
+
+    config = get_override(ctx, "file.rom_scramble_config", kwargs)
+    tool = get_override(ctx, "executable.rom_scramble_tool", kwargs)
+
+    ctx.actions.run(
+        outputs = [output],
+        inputs = [src, tool, config],
+        arguments = [
+            config.path,
+            src.path,
+            output.path,
+        ],
+        executable = tool,
+    )
+    return output

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -2,8 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_rom_binary")
-load("//rules:opentitan_test.bzl", "opentitan_functest")
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
+    "OPENTITAN_CPU",
+    "opentitan_binary",
+    "opentitan_test",
+)
+load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
 load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:linker.bzl", "ld_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
@@ -20,12 +26,31 @@ ld_library(
     ],
 )
 
-opentitan_rom_binary(
+opentitan_binary(
     name = "test_rom",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    kind = "rom",
+    linker_script = ":linker_script",
     deps = [
-        ":linker_script",
         ":test_rom_lib",
     ],
+)
+
+# Create the legacy ROM target names so that existing opentitan_functest and
+# splicing rules can find the test_rom VMEM files.
+legacy_rom_targets(
+    suffixes = [
+        "fpga_cw310",
+        "fpga_cw340",
+        "sim_dv",
+        "sim_verilator",
+    ],
+    target = "test_rom",
 )
 
 # TODO(#12905): Use a slightly hollowed out version of the silicon_creator bootstrap
@@ -154,9 +179,14 @@ cc_library(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "test_rom_test",
     srcs = ["test_rom_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -30,6 +30,7 @@ opentitan_binary(
     name = "test_rom",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
@@ -46,6 +47,7 @@ opentitan_binary(
 legacy_rom_targets(
     suffixes = [
         "fpga_cw310",
+        "fpga_cw305",
         "fpga_cw340",
         "sim_dv",
         "sim_verilator",

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_test")
 load("//rules:opentitan.bzl", "OPENTITAN_CPU", "OPENTITAN_PLATFORM", "elf_to_scrambled_rom_vmem", "opentitan_rom_binary")
 load("//rules:exclude_files.bzl", "exclude_files")
 load("//rules:linker.bzl", "ld_library")
@@ -237,22 +238,26 @@ cc_library(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_epmp_test",
     srcs = [
         "rom_epmp_test.c",
     ],
-    linkopts = [
-        "-Wl,--defsym=rom_test=1",
-    ],
-    # This test doesn't use the OTTF.
-    targets = ["verilator"],  # Can only run in verilator right now.
+    # This test doesn't use the OTTF and can only run in verilator right now.
+    #
     # This test is designed to run and complete entirely in the ROM boot stage.
-    # Setting the `test_in_rom` flag makes the `opentitan_functest` rule aware
+    # Setting `kind = "rom"` makes the `opentitan_test` rule aware
     # of this, and instructs it to load the test image into ROM (rather than
     # loading the default test ROM, or any other ROM that may be specified via
     # Verilator or CW310 params).
-    test_in_rom = True,
+    exec_env = {
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    kind = "rom",
+    linker_script = ":linker_script",
+    linkopts = [
+        "-Wl,--defsym=rom_test=1",
+    ],
     deps = [
         ":rom_without_keys",
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",


### PR DESCRIPTION
1. Add a `kind` attribute to the binary and test rules to indicate
   whether the target is for flash, ram or rom.
2. Plumb flash scrambling support into the exec_env and binary rules.
3. Update the `rom` attribute in the exec environments and binary rules.
   Allow the label to be any provider.
4. Implement flash and rom paths for fpga_cw310 and sim_{dv,verilator}.
4a. When building, apply the scrambling transform to the ROM binary.
4b. When testing, retrieve the supplied ROM and substitute it into the
    test flow.  Currently, only verilator can run ROM tests.
5. Build the `test_rom` with the new rules.
6. Update the `rom_epmp_test` to the new rules.

This PR depends on #19650 and #19697.  You need only review the last 3 commits.