### PR TITLE
[ci] [DO NOT MERGE] Try build opentitantool in airgapped environment

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -26,6 +26,7 @@ sudo ip netns exec airgapped sudo -u "$USER" bash -c \
   export BAZEL_PYTHON_WHEELS_REPO=$(pwd)/bazel-airgapped/ot_python_wheels;
   TARGET_PATTERN_FILE=\$(mktemp)
   echo //sw/device/silicon_creator/rom:rom_with_fake_keys > \"\${TARGET_PATTERN_FILE}\"
+  echo //sw/host/opentitantool > \"\${TARGET_PATTERN_FILE}\"
   bazel-airgapped/bazel cquery \
     --distdir=$(pwd)/bazel-airgapped/bazel-distdir \
     --repository_cache=$(pwd)/bazel-airgapped/bazel-cache \


### PR DESCRIPTION
This is an experimental PR to test out the airgapped environment by trying to build opentitanlib.

Currently, only `rom_with_fake_keys` is built in the environment, and we want to know if Rust crates are present there.

This is the run we're interested in FYI:
https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=128771&view=logs&j=62754bfd-1e07-590e-4563-63d5dff44c03