### PR TITLE
[opentitantool] Add JTAG support to HyperDebug backend

### DIFF
--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -5,15 +5,11 @@
 OPENTITANTOOL_OPENOCD_DATA_DEPS = [
     "//third_party/openocd:jtag_olimex_cfg",
     "//third_party/openocd:openocd_bin",
-    "//util/openocd/target:lowrisc-earlgrey.cfg",
-    "//util/openocd/target:lowrisc-earlgrey-lc.cfg",
 ]
 
 OPENTITANTOOL_OPENOCD_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
     --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_olimex_cfg)"
-    --openocd-riscv-target-config="$(rootpath //util/openocd/target:lowrisc-earlgrey.cfg)"
-    --openocd-lc-target-config="$(rootpath //util/openocd/target:lowrisc-earlgrey-lc.cfg)"
     --clear-bitstream
     --bitstream={bitstream}
     --elf={firmware}

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -67,14 +67,10 @@ DEFAULT_TEST_FAILURE_MSG = "({})|({})".format(
 OPENTITANTOOL_OPENOCD_TEST_CMDS = [
     "--openocd=\"$(rootpath //third_party/openocd:openocd_bin)\"",
     "--openocd-adapter-config=\"$(rootpath //third_party/openocd:jtag_olimex_cfg)\"",
-    "--openocd-riscv-target-config=\"$(rootpath //util/openocd/target:lowrisc-earlgrey.cfg)\"",
-    "--openocd-lc-target-config=\"$(rootpath //util/openocd/target:lowrisc-earlgrey-lc.cfg)\"",
 ]
 OPENTITANTOOL_OPENOCD_DATA_DEPS = [
     "//third_party/openocd:jtag_olimex_cfg",
     "//third_party/openocd:openocd_bin",
-    "//util/openocd/target:lowrisc-earlgrey.cfg",
-    "//util/openocd/target:lowrisc-earlgrey-lc.cfg",
 ]
 
 # This constant holds a dictionary of slot-specific linker script dependencies

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -69,8 +69,6 @@ _MANUF_LC_TRANSITION_TEST_CMDS = [
     "--bitstream=\"$(rootpath {bitstream})\"",
     "--openocd=\"$(rootpath //third_party/openocd:openocd_bin)\"",
     "--openocd-adapter-config=\"$(rootpath //third_party/openocd:jtag_olimex_cfg)\"",
-    "--openocd-riscv-target-config=\"$(rootpath //util/openocd/target:lowrisc-earlgrey.cfg)\"",
-    "--openocd-lc-target-config=\"$(rootpath //util/openocd/target:lowrisc-earlgrey-lc.cfg)\"",
 ]
 
 _MANUF_LC_TRANSITION_TEST_CMDS_WBOOTSTRAP = _MANUF_LC_TRANSITION_TEST_CMDS + [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2830,6 +2830,34 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "openocd_hyperdebug_test",
+    srcs = ["example_test_from_flash.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
+        interface = "hyper310",
+        test_cmds = [
+            "--bitstream=\"$(rootpath {bitstream})\"",
+            "--bootstrap=\"$(rootpath {flash})\"",
+        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+    ),
+    cw340 = cw340_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
+        interface = "hyper340",
+        test_cmds = [
+            "--bitstream=\"$(rootpath {bitstream})\"",
+            "--bootstrap=\"$(rootpath {flash})\"",
+        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+    ),
+    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+    targets = ["cw310_rom_with_fake_keys"],
+    test_harness = "//sw/host/tests/chip/jtag:openocd_test",
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "spi_device_ottf_console_test",
     srcs = ["spi_device_ottf_console_test.c"],
     cw310 = cw310_params(

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -213,6 +213,8 @@ rust_library(
         ":pinmux_config",
         ":spi_passthru",
         "@hyperdebug_firmware//:hyperdebug/ec.bin",
+        "//util/openocd/target:lowrisc-earlgrey.cfg",
+        "//util/openocd/target:lowrisc-earlgrey-lc.cfg",
     ],
     crate_features = [
         "include_hyperdebug_firmware",
@@ -231,6 +233,8 @@ rust_library(
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
+        "openocd_riscv_target_cfg": "$(location //util/openocd/target:lowrisc-earlgrey.cfg)",
+        "openocd_lc_target_cfg": "$(location //util/openocd/target:lowrisc-earlgrey-lc.cfg)",
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -213,6 +213,7 @@ rust_library(
         ":pinmux_config",
         ":spi_passthru",
         "@hyperdebug_firmware//:hyperdebug/ec.bin",
+        "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
         "//util/openocd/target:lowrisc-earlgrey.cfg",
         "//util/openocd/target:lowrisc-earlgrey-lc.cfg",
     ],
@@ -235,6 +236,7 @@ rust_library(
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
         "openocd_riscv_target_cfg": "$(location //util/openocd/target:lowrisc-earlgrey.cfg)",
         "openocd_lc_target_cfg": "$(location //util/openocd/target:lowrisc-earlgrey-lc.cfg)",
+        "openocd_cmsis_dap_adapter_cfg": "$(location //third_party/openocd:jtag_cmsis_dap_adapter_cfg)",
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",

--- a/sw/host/opentitanlib/src/backend/chip_whisperer.rs
+++ b/sw/host/opentitanlib/src/backend/chip_whisperer.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use clap::Args;
+use std::path::PathBuf;
 
 use crate::backend::BackendOpts;
 use crate::transport::chip_whisperer::board::Board;
@@ -15,6 +16,11 @@ pub struct ChipWhispererOpts {
     /// Comma-separated list of Chip Whisperer board UARTs for non-udev environments. List the console uart first.
     #[arg(long, alias = "cw310-uarts")]
     pub uarts: Option<String>,
+
+    /// Path to OpenOCD JTAG adapter config file to use (usually Olimex, but could be another
+    /// adapter).
+    #[arg(long)]
+    pub openocd_adapter_config: Option<PathBuf>,
 }
 
 pub fn create<B: Board + 'static>(args: &BackendOpts) -> Result<Box<dyn Transport>> {
@@ -30,5 +36,6 @@ pub fn create<B: Board + 'static>(args: &BackendOpts) -> Result<Box<dyn Transpor
         args.usb_pid,
         args.usb_serial.as_deref(),
         &uarts,
+        args.opts.openocd_adapter_config.clone(),
     )?))
 }

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -21,18 +21,6 @@ pub struct JtagParams {
     #[arg(long, default_value = "openocd")]
     pub openocd: PathBuf,
 
-    /// Path to OpenOCD JTAG adapter config file.
-    #[arg(long)]
-    pub openocd_adapter_config: Option<String>,
-
-    /// Path to OpenOCD JTAG target config file for the RISC-V TAP.
-    #[arg(long)]
-    pub openocd_riscv_target_config: Option<String>,
-
-    /// Path to OpenOCD JTAG target config file for the LC TAP.
-    #[arg(long)]
-    pub openocd_lc_target_config: Option<String>,
-
     /// Port used to start and connect to OpenOCD over.
     #[arg(long, default_value = "6666")]
     pub openocd_port: u16,

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -628,7 +628,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
     fn jtag(&self, opts: &JtagParams) -> Result<Rc<dyn Jtag>> {
         let mut jtag = self.inner.jtag.borrow_mut();
         if jtag.is_none() {
-            jtag.replace(Rc::new(OpenOcdServer::new(opts)?));
+            jtag.replace(Rc::new(OpenOcdServer::new(None, None, opts)?));
         }
         Ok(Rc::clone(jtag.as_ref().unwrap()))
     }
@@ -734,7 +734,7 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
 
         // First, try to establish a connection to the native Chip Whisperer interface
         // which we will use for bitstream loading.
-        let board = ChipWhisperer::<B>::new(None, None, None, &[])?;
+        let board = ChipWhisperer::<B>::new(None, None, None, &[], None)?;
 
         // The transport does not provide name resolution for the IO interface
         // names, so: console=UART2 and RESET=CN10_29 on the Hyp+CW310.
@@ -754,7 +754,7 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
         Ok(())
     }
     fn clear_bitstream(_clear: &ClearBitstream) -> Result<()> {
-        let board = ChipWhisperer::<B>::new(None, None, None, &[])?;
+        let board = ChipWhisperer::<B>::new(None, None, None, &[], None)?;
         let usb = board.device.borrow();
         usb.spi1_enable(false)?;
         usb.clear_bitstream()?;

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230911_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "695600f7466839a16214b4a39a9be3a5802a158dc89de9862a31390e56f0bec4",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230922_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "b9171be8e8d9d2327670f1a058408535d0332579be59f367e040915acb4e1f35",
         build_file = "@//third_party/hyperdebug:BUILD",
     )

--- a/third_party/openocd/BUILD
+++ b/third_party/openocd/BUILD
@@ -40,6 +40,12 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "jtag_cmsis_dap_adapter_cfg",
+    srcs = ["@openocd//:tcl/interface/cmsis-dap.cfg"],
+    visibility = ["//visibility:public"],
+)
+
 configure_make(
     name = "build_openocd",
     # Speed up the build with multiple jobs, but set an upper bound to constrain


### PR DESCRIPTION
HyperDebug now supports the CMSIS-DAP protocol which OpenOCD already has a transport driver for.  With this change, the HyperDebug backend driver is able to start up OpenOCD with appropriate parameters to have it connect to the same HyperDebug.