### PR TITLE
[rtl,i2c] Rename FDATA READ field to READB

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -20,7 +20,7 @@
   sw_checklist:       "/sw/device/lib/dif/dif_i2c",
   revisions: [
     {
-      version:            "1.0.0",
+      version:            "1.1.0",
       life_stage:         "L1",
       design_stage:       "D2S",
       verification_stage: "V2",
@@ -233,7 +233,7 @@
           desc: "Issue a STOP condition after this operation"
         }
         { bits: "10"
-          name: "READ"
+          name: "READB"
           desc: "Read BYTE bytes from I2C. (256 if BYTE==0)"
         }
         { bits: "11"

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -209,7 +209,7 @@ I2C Format Data
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "FBYTE", "bits": 8, "attr": ["wo"], "rotate": 0}, {"name": "START", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "STOP", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "READ", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "RCONT", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "NAKOK", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 19}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "FBYTE", "bits": 8, "attr": ["wo"], "rotate": 0}, {"name": "START", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "STOP", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "READB", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "RCONT", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "NAKOK", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 19}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                                                     |
@@ -217,7 +217,7 @@ I2C Format Data
 | 31:13  |        |         |        | Reserved                                                        |
 |   12   |   wo   |   0x0   | NAKOK  | Do not signal an exception if the current byte is not ACK'd     |
 |   11   |   wo   |   0x0   | RCONT  | Do not NACK the last byte read, let the read operation continue |
-|   10   |   wo   |   0x0   | READ   | Read BYTE bytes from I2C. (256 if BYTE==0)                      |
+|   10   |   wo   |   0x0   | READB  | Read BYTE bytes from I2C. (256 if BYTE==0)                      |
 |   9    |   wo   |   0x0   | STOP   | Issue a STOP condition after this operation                     |
 |   8    |   wo   |   0x0   | START  | Issue a START condition before transmitting BYTE.               |
 |  7:0   |   wo   |   0x0   | FBYTE  | Format Byte. Directly transmitted if no flags are set.          |

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -62,27 +62,27 @@ These indicators determine:
 - Which bytes should be followed by a STOP symbol.
 
 The format indicator consists of 13-bits.
-That is of one single format byte (entered into the format FIFO through [`FDATA.FBYTE`](registers.md#fdata)), and five 1-bit flags (entered into the format FIFO through registers [`FDATA.READ`](registers.md#fdata), [`FDATA.RCONT`](registers.md#fdata), [`FDATA.START`](registers.md#fdata), [`FDATA.STOP`](registers.md#fdata) and [`FDATA.NAKOK`](registers.md#fdata))
+That is of one single format byte (entered into the format FIFO through [`FDATA.FBYTE`](registers.md#fdata)), and five 1-bit flags (entered into the format FIFO through registers [`FDATA.READB`](registers.md#fdata), [`FDATA.RCONT`](registers.md#fdata), [`FDATA.START`](registers.md#fdata), [`FDATA.STOP`](registers.md#fdata) and [`FDATA.NAKOK`](registers.md#fdata))
 
 The I2C reads each format indicator from the head of FMT_FIFO, and processes them in turn.
 If none of the flags are set for the format indicator, the I2C FSM simply transmits the format byte onto the SCL and SDA pins according to the specification, waits for acknowledgement, and then proceeds to the next format indicator.
 The format flags modulate the behavior as follows.
-- READ (corresponds to [`FDATA.READ`](registers.md#fdata)):
+- READB (corresponds to [`FDATA.READB`](registers.md#fdata)):
 Signifies the format byte ([`FDATA.FBYTE`](registers.md#fdata)) should be treated as an unsigned number, R, and prompts the state machine to read R bytes from the target device.
 Bytes read from the bus are inserted into the RX FIFO where they can be accessed by software.
 A value of 0 is treated as a read of 256 bytes.
 To read a larger byte stream, multiple 256-byte reads can be chained together using the RCONT flag.
-- RCONT (corresponds to FIFO inputs [`FDATA.RCONT`](registers.md#fdata), only used with READ):
+- RCONT (corresponds to FIFO inputs [`FDATA.RCONT`](registers.md#fdata), only used with READB):
     - If RCONT is set, the format byte represents part of a longer sequence of reads, allowing for reads to be chained indefinitely.
     - The RCONT flag indicates the final byte returned with the current read should be responded to with an ACK, allowing the target to continue sending data.
     (Note that the first R-1 bytes read will still be acknowledged regardless of whether RCONT is asserted or not.)
-- START (corresponds to [`FDATA.START`](registers.md#fdata), Ignored when used with READ):
+- START (corresponds to [`FDATA.START`](registers.md#fdata), Ignored when used with READB):
 Issue a START condition before transmitting the format byte on the bus.
 This flag may also be used to issue a repeated start condition.
 - STOP (corresponds to [`FDATA.STOP`](registers.md#fdata)):
 Issue a STOP signal after processing this current entry in the FMT FIFO.
-Note that this flag is not compatible with (READ & RCONT), and will cause bus conflicts.
-- NAKOK (corresponds to [`FDATA.NAKOK`](registers.md#fdata), Not compatible with READ):
+Note that this flag is not compatible with (READB & RCONT), and will cause bus conflicts.
+- NAKOK (corresponds to [`FDATA.NAKOK`](registers.md#fdata), Not compatible with READB):
 Typically every byte transmitted must also receive an ACK signal, and the IP will raise an exception if no ACK is received.
 However, there are some I2C commands which do not require an ACK.
 In those cases this flag should be asserted with FBYTE indicating no ACK is expected and no interrupt should be raised if the ACK is not received.

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -274,7 +274,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             fbyte = get_field_val(ral.fdata.fbyte, item.a_data);
             start = bit'(get_field_val(ral.fdata.start, item.a_data));
             stop  = bit'(get_field_val(ral.fdata.stop, item.a_data));
-            read  = bit'(get_field_val(ral.fdata.read, item.a_data));
+            read  = bit'(get_field_val(ral.fdata.readb, item.a_data));
             rcont = bit'(get_field_val(ral.fdata.rcont, item.a_data));
             nakok = bit'(get_field_val(ral.fdata.nakok, item.a_data));
             if (cfg.en_cov) begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -431,7 +431,7 @@ class i2c_base_vseq extends cip_base_vseq #(
 
     ral.fdata.nakok.set(item.nakok);
     ral.fdata.rcont.set(item.rcont);
-    ral.fdata.read.set(item.read);
+    ral.fdata.readb.set(item.read);
     ral.fdata.stop.set(item.stop);
     ral.fdata.start.set(item.start);
     ral.fdata.fbyte.set(item.fbyte);

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -263,13 +263,13 @@ module i2c_core import i2c_pkg::*;
   assign fmt_fifo_wvalid     = reg2hw.fdata.fbyte.qe &
                                reg2hw.fdata.start.qe &
                                reg2hw.fdata.stop.qe  &
-                               reg2hw.fdata.read.qe  &
+                               reg2hw.fdata.readb.qe  &
                                reg2hw.fdata.rcont.qe &
                                reg2hw.fdata.nakok.qe;
   assign fmt_fifo_wdata[7:0] = reg2hw.fdata.fbyte.q;
   assign fmt_fifo_wdata[8]   = reg2hw.fdata.start.q;
   assign fmt_fifo_wdata[9]   = reg2hw.fdata.stop.q;
-  assign fmt_fifo_wdata[10]  = reg2hw.fdata.read.q;
+  assign fmt_fifo_wdata[10]  = reg2hw.fdata.readb.q;
   assign fmt_fifo_wdata[11]  = reg2hw.fdata.rcont.q;
   assign fmt_fifo_wdata[12]  = reg2hw.fdata.nakok.q;
 

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -214,7 +214,7 @@ package i2c_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } read;
+    } readb;
     struct packed {
       logic        q;
       logic        qe;

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -226,7 +226,7 @@ module i2c_reg_top (
   logic [7:0] fdata_fbyte_wd;
   logic fdata_start_wd;
   logic fdata_stop_wd;
-  logic fdata_read_wd;
+  logic fdata_readb_wd;
   logic fdata_rcont_wd;
   logic fdata_nakok_wd;
   logic fifo_ctrl_we;
@@ -1728,19 +1728,19 @@ module i2c_reg_top (
   );
   assign reg2hw.fdata.stop.qe = fdata_qe;
 
-  //   F[read]: 10:10
+  //   F[readb]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_fdata_read (
+  ) u_fdata_readb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (fdata_we),
-    .wd     (fdata_read_wd),
+    .wd     (fdata_readb_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1748,13 +1748,13 @@ module i2c_reg_top (
 
     // to internal hardware
     .qe     (fdata_flds_we[3]),
-    .q      (reg2hw.fdata.read.q),
+    .q      (reg2hw.fdata.readb.q),
     .ds     (),
 
     // to register interface (read)
     .qs     ()
   );
-  assign reg2hw.fdata.read.qe = fdata_qe;
+  assign reg2hw.fdata.readb.qe = fdata_qe;
 
   //   F[rcont]: 11:11
   prim_subreg #(
@@ -2884,7 +2884,7 @@ module i2c_reg_top (
 
   assign fdata_stop_wd = reg_wdata[9];
 
-  assign fdata_read_wd = reg_wdata[10];
+  assign fdata_readb_wd = reg_wdata[10];
 
   assign fdata_rcont_wd = reg_wdata[11];
 

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -477,7 +477,7 @@ dif_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
   fmt_byte = bitfield_field32_write(fmt_byte, I2C_FDATA_FBYTE_FIELD, byte);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_START_BIT, flags.start);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_STOP_BIT, flags.stop);
-  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READ_BIT, flags.read);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READB_BIT, flags.read);
   fmt_byte =
       bitfield_bit32_write(fmt_byte, I2C_FDATA_RCONT_BIT, flags.read_cont);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_NAKOK_BIT,

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -684,7 +684,7 @@ TEST_F(FifoTest, WriteRaw) {
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x00},
-                                           {I2C_FDATA_READ_BIT, 0x1},
+                                           {I2C_FDATA_READB_BIT, 0x1},
                                            {I2C_FDATA_RCONT_BIT, 0x1},
                                        });
   EXPECT_DIF_OK(dif_i2c_write_byte_raw(&i2c_, 0x00,
@@ -695,7 +695,7 @@ TEST_F(FifoTest, WriteRaw) {
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x77},
-                                           {I2C_FDATA_READ_BIT, 0x1},
+                                           {I2C_FDATA_READB_BIT, 0x1},
                                        });
   EXPECT_DIF_OK(dif_i2c_write_byte_raw(&i2c_, 0x77,
                                        {


### PR DESCRIPTION
The name READ shadows the uvm_reg_field read() member function in the ral generated package.

This renaming should not affect the real hardware, only the programming model.