### PR TITLE
[crypto] Fix an endianness mismatch in the HMAC driver.

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_3072_verify.c
@@ -84,8 +84,12 @@ status_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
   hmac_digest_t digest;
   hmac_final(&digest);
 
-  // Copy the message digest into the least significant end of the result.
-  memcpy(result->data, digest.digest, sizeof(digest.digest));
+  // Copy the message digest into the least significant end of the result,
+  // reversing the order of bytes to get little-endian form.
+  for (size_t i = 0; i < kSha256DigestNumWords; i++) {
+    result->data[i] =
+        __builtin_bswap32(digest.digest[kSha256DigestNumWords - 1 - i]);
+  }
 
   // Set remainder of 0x00 || T section
   result->data[kSha256DigestNumWords] = 0x05000420;

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -4013,11 +4013,10 @@ opentitan_flash_binary(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device/lib/base:status",
-        "//sw/device/lib/crypto/impl:hash",
-        "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:chip_info",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )
 

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -77,9 +77,9 @@ static status_t simple_test(void) {
       .data = (unsigned char *)plaintext,
       .len = sizeof(plaintext) - 1,
   };
-  const uint32_t exp_digest[kHmacDigestNumWords] = {
-      0x20b50917, 0xdc72a118, 0xd13b02ca, 0x4bc0a4ca,
-      0x807ce588, 0x43e1f083, 0x966ee07c, 0xb2da997a,
+  const uint32_t exp_digest[] = {
+      0x7a99dab2, 0x7ce06e96, 0x83f0e143, 0x88e57c80,
+      0xcaa4c04b, 0xca023bd1, 0x18a172dc, 0x1709b520,
   };
   return run_test(msg_buf, exp_digest);
 }
@@ -91,9 +91,9 @@ static status_t simple_test(void) {
  *   = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  */
 static status_t empty_test(void) {
-  const uint32_t exp_digest[kHmacDigestNumWords] = {
-      0x7852b855, 0xa495991b, 0x649b934c, 0x27ae41e4,
-      0x996fb924, 0x9afbf4c8, 0x98fc1c14, 0xe3b0c442,
+  const uint32_t exp_digest[] = {
+      0x42c4b0e3, 0x141cfc98, 0xc8f4fb9a, 0x24b96f99,
+      0xe441ae27, 0x4c939b64, 0x1b9995a4, 0x55b85278,
   };
   crypto_const_byte_buf_t msg_buf = {
       .data = NULL,


### PR DESCRIPTION
The HMAC driver previously returned the SHA-256 digest in little-endian order, which is what it does for ROM. However, for cryptolib, we treat the digest more like a raw data buffer, and for that we want the direct byte stream to adhere to the SHA-256 specification. That means we need to use big-endian order within words.

@timothytrippel I switched the `rom_self_hash_test` to use the `silicon_creator` driver instead, since that's what we actually use at boot anyway. ROM has absolutely everything in little-endian, so I think it's consistent to keep that driver little-endian even though it differs from what cryptolib will now do.