### PR TITLE
[release] Disable shallow checkout on the release pipeline

### DIFF
--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -39,6 +39,9 @@ jobs:
   steps:
   - checkout: self
     path: opentitan-repo
+    # Disable Azure's default shallow checkout since the bitstream cache uses
+    # the git history
+    fetchDepth: 0
   - bash: |
       tar -C $(Pipeline.Workspace)/opentitan-repo -czf $(Pipeline.Workspace)/opentitan-repo.tar.gz .
     displayName: "Pack up repository"


### PR DESCRIPTION
This PR addresses an error in the Release pipeline where sometimes the bitstream cache may not initialize properly:
```console
ERROR:root:Cannot find a bitstream close to HEAD
(08:40:06) INFO: Repository bitstreams instantiated at:
  /azp/agent/_work/1/s/WORKSPACE:119:16: in <toplevel>
Repository rule bitstreams_repo defined at:
  /azp/agent/_work/1/s/rules/bitstreams.bzl:112:34: in <toplevel>
(08:40:06) ERROR: An error occurred during the fetch of repository 'bitstreams':
   Traceback (most recent call last):
	File "/azp/agent/_work/1/s/rules/bitstreams.bzl", line 85, column 13, in _bitstreams_repo_impl
		fail("Bitstream cache not initialized properly.")
Error in fail: Bitstream cache not initialized properly.
(08:40:06) ERROR: /azp/agent/_work/1/s/WORKSPACE:119:16: fetching bitstreams_repo rule //external:bitstreams: Traceback (most recent call last):
	File "/azp/agent/_work/1/s/rules/bitstreams.bzl", line 85, column 13, in _bitstreams_repo_impl
		fail("Bitstream cache not initialized properly.")
Error in fail: Bitstream cache not initialized properly.
```

If the release pipeline starts before the bitstream has been uploaded to the cache, then it will not be able to find the latest available bitstream without the git history. This PR enables a full fetch rather than just a shallow fetch as described in the [Azure Pipelines docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines#shallow-fetch).