### PR TITLE
[release] Avoid fetching from the bitstream cache when building the release

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//rules:splice.bzl", "bitstream_splice")
 load("//rules:otp.bzl", "get_otp_images")
 load("//rules:const.bzl", "KEY_AUTHENTICITY")
@@ -175,5 +176,21 @@ pkg_tar(
     mode = "0444",
     package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug",
     strip_prefix = "/hw/bitstream/chip_earlgrey_cw310_hyperdebug_cached_fragment",
+    tags = ["manual"],
+)
+
+# Packaging rule for spliced bitstreams
+pkg_files(
+    name = "package",
+    testonly = True,
+    srcs = [
+        ":rom_with_{}_keys".format(authenticity)
+        for authenticity in KEY_AUTHENTICITY
+    ] + [
+        ":rom_with_{}_keys_otp_{}".format(authenticity, otp_name)
+        for (otp_name, _) in get_otp_images()
+        for authenticity in KEY_AUTHENTICITY
+    ],
+    prefix = "earlgrey/fpga_cw310/standard",
     tags = ["manual"],
 )

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -8,7 +8,6 @@ load("//rules:const.bzl", "KEY_AUTHENTICITY")
 load("//rules:fusesoc.bzl", "fusesoc_build")
 load("//rules:otp.bzl", "get_otp_images")
 load("//rules:splice.bzl", "bitstream_splice")
-load("//rules:const.bzl", "KEY_AUTHENTICITY")
 load("//rules:bitstreams.bzl", "bitstream_manifest_fragment")
 
 package(default_visibility = ["//visibility:public"])
@@ -258,15 +257,9 @@ pkg_files(
     name = "standard",
     testonly = True,
     srcs = [
-        ":fpga_cw310_rom_with_fake_keys",
-        ":fpga_cw310_rom_with_real_keys",
         ":fpga_cw310_test_rom",
         ":otp_mmi",
         ":rom_mmi",
-    ] + [
-        ":fpga_cw310_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)
-        for (otp_name, _) in get_otp_images()
-        for authenticity in KEY_AUTHENTICITY
     ],
     prefix = "earlgrey/fpga_cw310/standard",
     tags = ["manual"],

--- a/release/BUILD
+++ b/release/BUILD
@@ -12,6 +12,7 @@ pkg_tar(
     testonly = True,
     srcs = [
         "//hw:package",
+        "//hw/bitstream:package",
         "//hw/bitstream/vivado:package",
         "//hw/ip/otp_ctrl/data:package",
         "//sw/device/examples/hello_world:package",

--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -73,10 +73,10 @@ jobs:
       # --jobs=1 is necessary due to resource constraints on the build machine.
       # Running multiple Vivado and Verilator build jobs simultaneously can
       # cause Synthesis failures
-      ci/bazelisk.sh build release --jobs=1
+      ci/bazelisk.sh build release --jobs=1 --define bitstream=vivado
 
       # Set the package-path variable for the artifact-publishing step
-      PKG_PATH=$(./bazelisk.sh outquery //release:opentitan)
+      PKG_PATH=$(./bazelisk.sh outquery //release:opentitan --define bitstream=vivado)
       echo $PKG_PATH
       echo "##vso[task.setvariable variable=pkg_path]$PKG_PATH"
     displayName: "Build Bazel release package"


### PR DESCRIPTION
This PR addresses an error in the Release pipeline where sometimes the bitstream cache may not initialize properly:
```console
ERROR:root:Cannot find a bitstream close to HEAD
(08:40:06) INFO: Repository bitstreams instantiated at:
  /azp/agent/_work/1/s/WORKSPACE:119:16: in <toplevel>
Repository rule bitstreams_repo defined at:
  /azp/agent/_work/1/s/rules/bitstreams.bzl:112:34: in <toplevel>
(08:40:06) ERROR: An error occurred during the fetch of repository 'bitstreams':
   Traceback (most recent call last):
	File "/azp/agent/_work/1/s/rules/bitstreams.bzl", line 85, column 13, in _bitstreams_repo_impl
		fail("Bitstream cache not initialized properly.")
Error in fail: Bitstream cache not initialized properly.
(08:40:06) ERROR: /azp/agent/_work/1/s/WORKSPACE:119:16: fetching bitstreams_repo rule //external:bitstreams: Traceback (most recent call last):
	File "/azp/agent/_work/1/s/rules/bitstreams.bzl", line 85, column 13, in _bitstreams_repo_impl
		fail("Bitstream cache not initialized properly.")
Error in fail: Bitstream cache not initialized properly.
```
Because we rebuild the bitstream for the release anyway, we should avoid setting up the bitstream cache.