### PR TITLE
[Usbdev]usbdev_osc_test_vseq

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_if.sv
@@ -1,54 +1,46 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
 interface usb20_if (
-  input clk_i,
-  input rst_ni,
-
+  input clk, 
+  input rst,
   output wire usb_vbus,
-  inout wire usb_p,
-  inout wire usb_n
+  inout wire usb_Dp,
+  inout wire usb_Dn
 );
 
-  // This interface presently serves just to connect/disconnect the USB DPI
-  // model to/from the ASIC pins. In time it may be extended to support a DV
-  // block-level USB 2.0 agent.
+	// Data Inputs pins
+	logic usb_dp_i;
+	logic usb_dn_i;
+	logic usb_rx_d_i;
+	// Data Outputs pins
+	logic usb_dp_o;
+	logic usb_dp_en_o;
+	logic usb_dn_o;
+	logic usb_dn_en_o;
+	logic usb_tx_se0_o;
+	logic usb_tx_d_o;
 
-  // Clock and reset not presently required
-  wire unused_clk = clk_i;
-  wire unused_rst_n = rst_ni;
+	// Non-data pins
+	logic usb_sense_i;          // indicates the presence of VBUS from Host
+	logic usb_dp_pullup_o ;
+	logic usb_dn_pullup_o ;
+	logic usb_rx_enable_o;
+	logic usb_tx_use_d_se0_o;
+        
 
-  // Nomenclature notes:
-  //   dp (or p) and dn (or n) are the two signals of the differential USB
-  //   d2p means device to DPI
-  //   p2d means DPI to device
+        
+	assign usb_sense_i = usb_vbus;
 
-  // VBUS/SENSE output from DPI
-  wire usb_sense_p2d;
-  // DPI driver enables
-  wire usb_dp_en_p2d;
-  wire usb_dn_en_p2d;
-  // DPI driver outputs
-  wire usb_dp_p2d;
-  wire usb_dn_p2d;
+	assign usb_dp_i = usb_Dp;
+	assign usb_dn_i = usb_Dn;
+	
+	assign usb_Dp = usb_dp_en_o ? usb_dp_o : 1'bz;
+	assign usb_Dn = usb_dn_en_o ? usb_dn_o : 1'bz;	
 
-  // Are our drivers connected?
-  bit connected = 0;
+ clocking cb@(posedge clk);
+ 
+ endclocking
 
-  // Enable/disable the output drivers
-  function automatic void enable_driver(bit enabled);
-    connected = enabled;
-  endfunction
-
-  assign usb_vbus = connected ? usb_sense_p2d : 1'bZ;
-
-  // Weak pull downs so that we can detect the presence of the device, and we
-  // also prevent Z triggering 'X assertions' in usbdev
-  assign (weak0, weak1) usb_p = connected ? 1'b0 : 1'bZ;
-  assign (weak0, weak1) usb_n = connected ? 1'b0 : 1'bZ;
-  // Tri-stated output drivers
-  assign (strong0, strong1) usb_p = (connected & usb_dp_en_p2d) ? usb_dp_p2d : 1'bZ;
-  assign (strong0, strong1) usb_n = (connected & usb_dn_en_p2d) ? usb_dn_p2d : 1'bZ;
 
 endinterface

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_osc_test_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_osc_test_vseq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// csr reset and read/write test vseq
+class usbdev_osc_test_vseq extends usbdev_common_vseq;
+  `uvm_object_utils(usbdev_osc_test_vseq)
+
+  `uvm_object_new
+
+  task body();
+    uvm_reg_data_t data;
+    csr_wr(.ptr(ral.phy_config.tx_osc_test_mode), .value(1));
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 200));
+
+  endtask : body
+
+endclass //: usbdev_osc_test_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -6,3 +6,4 @@
 `include "usbdev_common_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
 `include "usbdev_smoke_vseq.sv"
+`include "usbdev_osc_test_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_osc_test_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -12,6 +12,8 @@ module tb;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
+  `include "cip_macros.svh"
+
 
   wire aon_clk, aon_rst_n;
   wire usb_clk, usb_rst_n;
@@ -33,8 +35,10 @@ module tb;
   wire intr_rx_pid_err;
   wire intr_rx_bitstuff_err;
   wire intr_frame;
-
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  wire usb_vbus;
+  wire usb_Dp;
+  wire usb_Dn;
 
   // interfaces
   clk_rst_if aon_clk_rst_if(.clk(aon_clk), .rst_n(aon_rst_n));
@@ -42,8 +46,7 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(usb_clk), .rst_n(usb_rst_n));
-  usb20_if usb20_if();
-
+  usb20_if usb20_if(.clk(usb_clk), .rst(usb_rst_n), .usb_vbus(usb_vbus), .usb_Dp(usb_Dp), .usb_Dn(usb_Dn));
  `DV_ALERT_IF_CONNECT(usb_clk, usb_rst_n)
 
   // dut
@@ -61,26 +64,24 @@ module tb;
 
     // USB Interface
     // TOOD: need to hook up an interface
-    .cio_usb_dp_i           (1'b1),
-    .cio_usb_dn_i           (1'b0),
-    .usb_rx_d_i             (1'b0),
-    .cio_usb_dp_o           (),
-    .cio_usb_dp_en_o        (),
-    .cio_usb_dn_o           (),
-    .cio_usb_dn_en_o        (),
-    .usb_tx_d_o             (),
-    .usb_tx_se0_o           (),
+    .cio_usb_dp_i           (usb20_if.usb_dp_i            ),
+    .cio_usb_dn_i           (usb20_if.usb_dn_i            ),
+    .usb_rx_d_i             (usb20_if.usb_rx_d_i          ),
+    .cio_usb_dp_o           (usb20_if.usb_dp_o            ),
+    .cio_usb_dp_en_o        (usb20_if.usb_dp_en_o         ),
+    .cio_usb_dn_o           (usb20_if.usb_dn_o            ),
+    .cio_usb_dn_en_o        (usb20_if.usb_dn_en_o         ),
+    .usb_tx_d_o             (usb20_if.usb_tx_d_o          ),
+    .usb_tx_se0_o           (usb20_if.usb_tx_se0_o        ),
 
-    .cio_sense_i            (1'b0),
-    .usb_dp_pullup_o        (),
-    .usb_dn_pullup_o        (),
-    .usb_rx_enable_o        (),
-    .usb_tx_use_d_se0_o     (),
-
+    .cio_sense_i            (usb20_if.usb_sense_i         ),
+    .usb_dp_pullup_o        (usb20_if.usb_dp_pullup_o     ),
+    .usb_dn_pullup_o        (usb20_if.usb_dn_pullup_o     ),
+    .usb_rx_enable_o        (usb20_if.usb_rx_enable_o     ),
+    .usb_tx_use_d_se0_o     (usb20_if.usb_tx_use_d_se0_o  ),
     // Direct pinmux aon detect connections
     .usb_aon_suspend_req_o  (),
     .usb_aon_wake_ack_o     (),
-
     // Events and debug info from wakeup module
     .usb_aon_bus_reset_i          ('0),
     .usb_aon_sense_lost_i         ('0),
@@ -96,7 +97,7 @@ module tb;
     // Interrupts
     .intr_pkt_received_o    (intr_pkt_received    ),
     .intr_pkt_sent_o        (intr_pkt_sent        ),
-    .intr_powered_o         (intr_powered       ),
+    .intr_powered_o         (intr_powered         ),
     .intr_disconnected_o    (intr_disconnected    ),
     .intr_host_lost_o       (intr_host_lost       ),
     .intr_link_reset_o      (intr_link_reset      ),
@@ -131,8 +132,11 @@ module tb;
   assign interrupts[IntrRxPidErr]       = intr_rx_pid_err;
   assign interrupts[IntrRxBitstuffErr]  = intr_rx_bitstuff_err;
   assign interrupts[IntrFrame]          = intr_frame;
+  assign usb_vbus = 1'b1;
 
   initial begin
+  
+   
     // drive clk and rst_n from clk_if
     aon_clk_rst_if.set_active();
     usb_clk_rst_if.set_active();
@@ -145,5 +149,7 @@ module tb;
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
+
+
 
 endmodule

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -60,6 +60,10 @@
       name: usbdev_smoke
       uvm_test_seq: usbdev_smoke_vseq
     }
+    {
+      name: usbdev_osc_test
+      uvm_test_seq: usbdev_osc_test_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This particular test, known as "phy_config_tx_osc_test_mode," provides the flexibility to enable or disable the dut oscillator test mode. When enabled, the device consistently transmits a J/K pattern, which are useful in assessing the USB clock.

@jdonjdon 