### PR TITLE
[flash_ctrl,dv] fix cs reg fail

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -172,6 +172,8 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_start_op(flash_op);
     flash_ctrl_write(flash_op_data, poll_fifo_status);
     wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+    // Add guard time between previous alert detection complete and set the next expected alert
+    cfg.clk_rst_vif.wait_clks(100);
 
     expect_alert          = 1;
     cfg.scb_h.expected_alert["recov_err"].expected = 1;

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -183,6 +183,7 @@
     {
       name: flash_ctrl_invalid_op
       uvm_test_seq: flash_ctrl_invalid_op_vseq
+      run_opts: ["+fast_rcvr_recov_err"]
       reseed: 20
     }
     {


### PR DESCRIPTION
All error tests using for loop have potential issue with alert agent random response delay.
The issue is while current alert thread waiting for hand shake to finish, another alert comes in or set_exp_alert is called. This will start the next alert thread and overlaped with previous alert thread. Using fast_rcvr knob can reduce the chance but not a complete solution. As this failure, sometimes it is required to explicit guard time before two back to back alert monitoring thread.