### PR TITLE
[crypto] Separate SHAKE/cSHAKE interface.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -134,7 +134,8 @@ Data structures for key types and modes help the cryptolib recognize and prevent
 #### Hash data structures
 
 {{#header-snippet sw/device/lib/crypto/include/hash.h hash_mode }}
-{{#header-snippet sw/device/lib/crypto/include/hash.h xof_mode }}
+{{#header-snippet sw/device/lib/crypto/include/hash.h xof_cshake_mode }}
+{{#header-snippet sw/device/lib/crypto/include/hash.h xof_shake_mode }}
 
 #### Key derivation data structures
 
@@ -239,8 +240,8 @@ The supported hash modes are SHA256, SHA384, SHA512, SHA3-224, SHA3-256, SHA3-38
 The cryptolib supports the SHAKE and cSHAKE extendable-output functions, which can produce a varaible-sized digest.
 To avoid locking up the KMAC block, only a one-shot mode is supported.
 
-<!-- TODO: fix header to have shake/cshake! -->
-{{#header-snippet sw/device/lib/crypto/include/hash.h otcrypto_xof }}
+{{#header-snippet sw/device/lib/crypto/include/hash.h otcrypto_xof_shake }}
+{{#header-snippet sw/device/lib/crypto/include/hash.h otcrypto_xof_cshake }}
 
 ### Streaming mode
 

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -42,20 +42,28 @@ typedef enum hash_mode {
 } hash_mode_t;
 
 /**
- * Enum to define the supported extendable-output functions.
+ * Enum to define the supported SHAKE (extendable-output) functions.
  *
  * Values are hardened.
  */
-typedef enum xof_mode {
+typedef enum xof_shake_mode {
   // Shake128 mode.
-  kXofModeSha3Shake128 = 0x9bd,
+  kXofShakeModeShake128 = 0x9bd,
   // Shake256 mode.
-  kXofModeSha3Shake256 = 0x758,
+  kXofShakeModeShake256 = 0x758,
+} xof_shake_mode_t;
+
+/**
+ * Enum to define the supported CSHAKE (extendable-output) functions.
+ *
+ * Values are hardened.
+ */
+typedef enum xof_cshake_mode {
   // cShake128 mode.
-  kXofModeSha3Cshake128 = 0xbd3,
+  kXofCshakeModeCshake128 = 0xbd3,
   // cShake256 mode.
-  kXofModeSha3Cshake256 = 0x0fa,
-} xof_mode_t;
+  kXofCshakeModeCshake256 = 0x0fa,
+} xof_cshake_mode_t;
 
 /**
  * Generic hash context.
@@ -92,15 +100,7 @@ crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
                               crypto_word32_buf_t *digest);
 
 /**
- * Performs the required extendable output function on the input data.
- *
- * The `function_name_string` is used by NIST to define functions
- * based on cSHAKE. When no function other than cSHAKE is desired; it
- * can be empty. The `customization_string` is used to define a
- * variant of the cSHAKE function. If no customization is desired it
- * can be empty. The `function_name_string` and `customization_string`
- * are ignored when the `xof_mode` is set to kHashModeSha3Shake128 or
- * kHashModeSha3Shake256.
+ * Performs the SHAKE extendable output function (XOF) on input data.
  *
  * The caller should allocate space for the `digest` buffer, with a word-length
  * long enough to hold `required_output_len`, and set the `len` field of
@@ -109,19 +109,44 @@ crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
  * error.
  *
  * @param input_message Input message for extendable output function.
- * @param xof_mode Required extendable output function.
+ * @param shake_mode Required extendable output function.
+ * @param required_output_len Required output length, in bytes.
+ * @param[out] digest Output from the extendable output function.
+ * @return Result of the xof operation.
+ */
+crypto_status_t otcrypto_xof_shake(crypto_const_byte_buf_t input_message,
+                                   xof_shake_mode_t shake_mode,
+                                   size_t required_output_len,
+                                   crypto_word32_buf_t *digest);
+
+/**
+ * Performs the CSHAKE extendable output function (XOF) on input data.
+ *
+ * The `function_name_string` is used by NIST to define functions
+ * based on cSHAKE. When no function other than cSHAKE is desired; it
+ * can be empty. The `customization_string` is used to define a
+ * variant of the cSHAKE function. If no customization is desired it
+ * can be empty.
+ *
+ * The caller should allocate space for the `digest` buffer,
+ * (expected length same as `required_output_len`), and set the length
+ * of expected output in the `len` field of `digest`. If the user-set
+ * length and the output length does not match, an error message will
+ * be returned.
+ *
+ * @param input_message Input message for extendable output function.
+ * @param cshake_mode Required extendable output function.
  * @param function_name_string NIST Function name string.
  * @param customization_string Customization string for cSHAKE.
  * @param required_output_len Required output length, in bytes.
  * @param[out] digest Output from the extendable output function.
  * @return Result of the xof operation.
  */
-crypto_status_t otcrypto_xof(crypto_const_byte_buf_t input_message,
-                             xof_mode_t xof_mode,
-                             crypto_const_byte_buf_t function_name_string,
-                             crypto_const_byte_buf_t customization_string,
-                             size_t required_output_len,
-                             crypto_word32_buf_t *digest);
+crypto_status_t otcrypto_xof_cshake(
+    crypto_const_byte_buf_t input_message, xof_cshake_mode_t cshake_mode,
+    crypto_const_byte_buf_t function_name_string,
+    crypto_const_byte_buf_t customization_string, size_t required_output_len,
+    crypto_word32_buf_t *digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -42,8 +42,8 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
       .len = token_num_words,
   };
 
-  TRY(otcrypto_xof(input, kXofModeSha3Cshake128, function_name_string,
-                   customization_string, token_size_bytes, &output));
+  TRY(otcrypto_xof_cshake(input, kXofCshakeModeCshake128, function_name_string,
+                          customization_string, token_size_bytes, &output));
   memcpy(hashed_token, token_data, sizeof(token_data));
 
   return OK_STATUS();

--- a/sw/device/tests/crypto/kmac_set_testvectors.py
+++ b/sw/device/tests/crypto/kmac_set_testvectors.py
@@ -78,19 +78,15 @@ def main() -> int:
 
         # Correctly determine `hash_mode`, `xof_mode` or `mac_mode`
         if t["operation"] == "SHAKE":
-            t["xof_mode"] = "kXofModeSha3Shake" + str(t["security_str"])
-            t["test_operation"] = "kKmacTestOperationXOF"
+            t["test_operation"] = "kKmacTestOperationShake"
         elif t["operation"] == "CSHAKE":
-            t["xof_mode"] = "kXofModeSha3Cshake" + str(t["security_str"])
-            t["test_operation"] = "kKmacTestOperationXOF"
+            t["test_operation"] = "kKmacTestOperationCshake"
         elif t["operation"] == "SHA3":
-            t["hash_mode"] = "kHashModeSha3_" + str(t["security_str"])
-            t["test_operation"] = "kKmacTestOperationHASH"
+            t["test_operation"] = "kKmacTestOperationSha3"
         elif t["operation"] == "KMAC":
-            t["mac_mode"] = "kMacModeKmac" + str(t["security_str"])
-            t["test_operation"] = "kKmacTestOperationMAC"
+            t["test_operation"] = "kKmacTestOperationKmac"
         else:
-            raise ValueError("Bad `operation`, `security_str` pair.")
+            raise ValueError(f"Bad `operation`: {t['operation']}")
 
     args.headerfile.write(Template(args.template.read()).render(tests=testvecs))
     args.headerfile.close()

--- a/sw/device/tests/crypto/kmac_testvectors.h.tpl
+++ b/sw/device/tests/crypto/kmac_testvectors.h.tpl
@@ -20,18 +20,17 @@ extern "C" {
  * call through cryptolib API.
  */
 typedef enum kmac_test_operation_t {
-  kKmacTestOperationXOF,
-  kKmacTestOperationHASH,
-  kKmacTestOperationMAC,
+  kKmacTestOperationCshake,
+  kKmacTestOperationShake,
+  kKmacTestOperationSha3,
+  kKmacTestOperationKmac,
 } kmac_test_operation_t;
 
 // This struct allows us to neatly pack SHA-3/SHAKE/cSHAKE/KMAC vectors
 typedef struct kmac_test_vector {
   char* vector_identifier;
   kmac_test_operation_t test_operation;
-  xof_mode_t xof_mode;
-  hash_mode_t hash_mode;
-  kmac_mode_t mac_mode;
+  size_t security_strength;
   crypto_blinded_key_t key;
   crypto_const_byte_buf_t input_msg;
   crypto_const_byte_buf_t func_name;
@@ -44,13 +43,7 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
     {
         .vector_identifier = "${t["vector_identifier"]}",
         .test_operation = ${t["test_operation"]},
-  % if "xof_mode" in t:
-        .xof_mode = ${t["xof_mode"]},
-  % elif "hash_mode" in t:
-        .hash_mode = ${t["hash_mode"]},
-  % elif "mac_mode" in t:
-        .mac_mode = ${t["mac_mode"]},
-  % endif
+        .security_strength = ${t["security_str"]},
   % if "key" in t:
         .key = {
             .config = {
@@ -65,7 +58,7 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
       % endfor
             },
         },
-   % endif  
+   % endif
         .input_msg = {
   % if "input_msg" in t:
             .data = (uint8_t[]){
@@ -90,7 +83,7 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
             .len = ${len(t["func_name"])},
   % else:
             .data = NULL,
-            .len = 0,        
+            .len = 0,
   % endif
         },
         .cust_str = {
@@ -103,7 +96,7 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
             .len = ${len(t["cust_str"])},
   % else:
             .data = NULL,
-            .len = 0,        
+            .len = 0,
   % endif
         },
         .digest = {
@@ -112,7 +105,7 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
                 ${', '.join(t["digest"][i:i + 8])},
       % endfor
             },
-            .len = ${len(t["digest"])},     
+            .len = ${len(t["digest"])},
         },
     },
 % endfor


### PR DESCRIPTION
Separate the SHAKE and cSHAKE interfaces in the cryptolib.

Since the two take a different set of arguments, we agreed several months ago to separate them in the cryptolib API, but the change hasn't actually happened until now.

Part of https://github.com/lowRISC/opentitan/issues/19549