### PR TITLE
[doc] Fix registers in entropy_src documentation

### DIFF
--- a/hw/ip/entropy_src/README.md
+++ b/hw/ip/entropy_src/README.md
@@ -11,9 +11,7 @@
 This document specifies ENTROPY_SRC hardware IP functionality.
 This module conforms to the [Comportable guideline for peripheral functionality.](../../../doc/contributing/hw/comportability/README.md)
 
-
 ## Features
-
 
 - This revision provides an interface to an external physical random noise generator (also referred to as a physical true random number generator.
 The PTRNG external source is a physical true random noise source.
@@ -56,7 +54,7 @@ The repetition count test fails if any sequence of bits continuously asserts the
 The thresholds for these tests should be chosen to achieve a low false-positive rate (&alpha;) given a conservative estimate of the manufacturing tolerances of the PTRNG noise source.
 The combined choice of threshold and window size then determine the false-negative rate (&beta;), or the probability of missing statistical defects at any particular magnitude.
 
-When the IP is disabled by clearing the `ENABLE` bit in [`CONF`](data/entropy_src.hjson#conf), all heath checks are disabled and all counters internal to the health checks are reset.
+When the IP is disabled by clearing the [`MODULE_ENABLE`](./doc/registers.md#MODULE_ENABLE) register, all health checks are disabled and all counters internal to the health checks are reset.
 
 In order to compensate for the fact our tests (like *all* realistic statistical tests) have finite resolution for detecting defects, we conservatively use 2048 bits of PTRNG noise source to construct each 384 bit conditioned entropy sample.
 When passed through the conditioning block, the resultant entropy stream will be full entropy unless the PTRNG noise source has encountered some statistical defect serious enough to reduce the raw min-entropy to a level below 0.375 bits of entropy per output bit.
@@ -88,7 +86,7 @@ Boot-time mode also has the feature that it bypasses the SHA conditioning functi
 For maximal flexibility in normal operation, the conditioning function can also be implemented by firmware.
 When this firmware conditioning feature is activated, data read directly out of the noise source can be reinjected into the entropy pipeline via a TL-UL register after it has been processed by firmware.
 It should be noted that this firmware algorithm must be vetted by NIST to satisfy the requirements for a full-entropy source.
-This feature can also be disabled for security purposes, either by locking the feature via the [`REGEN`](data/entropy_src.hjson#regen) register at boot, or by a write to one-time programmable (OTP) memory.
+This feature can also be disabled for security purposes, either by locking the feature via the [`REGWEN`](./doc/registers.md#regwen) register at boot, or by a write to one-time programmable (OTP) memory.
 
 ## Compatibility
 This IP block does not have any direct hardware compatibility requirements.

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -4,7 +4,7 @@ As already described, this IP block will collect bits of entropy for firmware or
 This revision supports only an external interface for a PTRNG noise source implementation.
 
 The first step is initialization and enabling.
-The PTRNG noise source mode is selected when the `ENABLE` field will be set.
+The PTRNG noise source mode is selected when the [`MODULE_ENABLE`](registers.md#module_enable) field is set.
 After the block is enabled and initialized, entropy bits will be collected up indefinitely until disabled.
 
 
@@ -89,7 +89,7 @@ This drop point will save on conditioner power, and still preserve `esfinal` FIF
 
 The above process will be repeated for as long as entropy bits are to be collected and processed.
 
-At any time, the `ENABLE` field can be cleared to halt the entropy generation (and health check testing).
+At any time, the [`MODULE_ENABLE`](registers.md#module_enable) field can be cleared to halt the entropy generation (and health check testing).
 See the Programmers Guide section for more details on the ENTROPY_SRC block disable sequence.
 
 ## Block Diagram
@@ -105,7 +105,7 @@ After power-up, the ENTROPY_SRC block is disabled.
 For simplicity of initialization, only a single register write is needed to start functional operation of the ENTROPY_SRC block.
 This assumes that proper defaults are chosen for thresholds, sampling rate, and other registers.
 
-For security reasons, a configuration and control register locking function is performed by the [`REGEN`](registers.md#regen) register.
+For security reasons, a configuration and control register locking function is performed by the [`REGWEN`](registers.md#regwen) register.
 Clearing the bit in this register will prevent future modification of the [`CONF`](registers.md#conf) register or other writeable registers by firmware.
 
 ### Entropy Processing

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -25,20 +25,20 @@ The firmware override function has the capability to completely override the har
 In the case of health tests, firmware can turn off one or all of the health tests and perform the tests in firmware.
 A data path is provided in the hardware such that the inbound entropy can be trapped in the observe FIFO.
 Once a pre-determined threshold of entropy has been reached in this FIFO, the firmware can then read the entropy bits out of the FIFO.
-The exact mechanism for this functionality starts with setting the `FW_OV_MODE` field in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register.
+The exact mechanism for this functionality starts with setting the [`FW_OV_MODE`](registers.md#fw_ov_control--fw_ov_mode) field in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register.
 This will enable firmware to monitor post-health test entropy bits by reading from the [`FW_OV_RD_DATA`](registers.md#fw_ov_rd_data) register.
-Firmware can use the [`OBSERVE_FIFO_THRESH`](registers.md#observe_fifo_thresh) and  [`OBSERVE_FIFO_DEPTH`](registers.md#observe_fifo_depth) to determine the state of the OBSERVE FIFO.
+Firmware can use the [`OBSERVE_FIFO_THRESH`](registers.md#observe_fifo_thresh) and [`OBSERVE_FIFO_DEPTH`](registers.md#observe_fifo_depth) to determine the state of the OBSERVE FIFO.
 At this point, firmware can do additional health checks on the entropy.
 Optionally, firmware can do the conditioning function, assuming the hardware is configured to bypass the conditioner block.
-Once firmware has processed the entropy,  it can then write the results back into the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register (pre-conditioner FIFO).
-The `FW_OV_ENTROPY_INSERT` in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register will enable inserting entropy bits back into the entropy flow.
+Once firmware has processed the entropy, it can then write the results back into the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register (pre-conditioner FIFO).
+The [`FW_OV_ENTROPY_INSERT`](registers.md#fw_ov_control--fw_ov_entropy_insert) in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register will enable inserting entropy bits back into the entropy flow.
 The firmware override control fields will be set such that the new entropy will resume normal flow operation.
 
 An additional feature of the firmware override function is to insert entropy bits into the flow and still use the conditioning function in the hardware.
-Setting the `FW_OV_INSERT_START` field in the [`FW_OV_SHA3_START`](registers.md#fw_ov_sha3_start) register will prepare the hardware for this flow.
+Setting the [`FW_OV_INSERT_START`](registers.md#fw_ov_sha3_start--fw_ov_insert_start) field in the [`FW_OV_SHA3_START`](registers.md#fw_ov_sha3_start) register will prepare the hardware for this flow.
 Once this field is set true, the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register can be written with entropy bits.
 The [`FW_OV_WR_FIFO_FULL`](registers.md#fw_ov_wr_fifo_full) register should be monitored after each write to ensure data is not dropped.
-Once all of the data has been written, the `FW_OV_INSERT_START` field should be set to false.
+Once all of the data has been written, the [`FW_OV_INSERT_START`](registers.md#fw_ov_sha3_start--fw_ov_insert_start) field should be set to false.
 The normal SHA3 processing will continue and finally push the conditioned entropy through the module.
 
 Health checks are performed on the input raw data from the PTRNG noise source when in that mode.
@@ -79,10 +79,10 @@ Setting the [`ALERT_THRESHOLD`](registers.md#alert_threshold) register to zero w
 
 Firmware has a path to read entropy from the ENTROPY_SRC block.
 The [`ENTROPY_CONTROL`](registers.md#entropy_control) register allows firmware to set the internal multiplexers to steer entropy data to the [`ENTROPY_DATA`](registers.md#entropy_data) register.
-The control bit `ES_TYPE` sets whether the entropy will come from the conditioning block or be sourced through the bypass path.
+The control bit [`ES_TYPE`](registers.md#entropy_control--es_type) sets whether the entropy will come from the conditioning block or be sourced through the bypass path.
 A status bit will be set that can either be polled or generate an interrupt when the entropy bits are available to be read from the [`ENTROPY_DATA`](registers.md#entropy_data) register.
 The firmware needs to read the [`ENTROPY_DATA`](registers.md#entropy_data) register twelve times in order to cleanly evacuate the 384-bit seed from the hardware path (12 * 32 bits = 384 bits in total).
-The firmware will directly read out of the main entropy FIFO, and when the control bit `ES_ROUTE` is set, no entropy is being passed to the block hardware interface.
+The firmware will directly read out of the main entropy FIFO, and when the control bit [`ES_ROUTE`](registers.md#entropy_control--es_route) is set, no entropy is being passed to the block hardware interface.
 
 If the `esfinal` FIFO fills up, additional entropy that has been health checked will be dropped before entering the conditioner.
 This drop point will save on conditioner power, and still preserve `esfinal` FIFO entropy that has already been collected.
@@ -111,7 +111,7 @@ Clearing the bit in this register will prevent future modification of the [`CONF
 ### Entropy Processing
 
 When enabled, the ENTROPY_SRC block will generate entropy bits continuously.
-The `es_entropy_valid` bit in the `ENTROPY_SRC_INTR_STATE` register will indicate to the firmware when entropy bits can read from the [`ENTROPY_DATA`](registers.md#entropy_data) register.
+The `es_entropy_valid` bit in the [`INTR_STATE`](registers.md#intr_state) register will indicate to the firmware when entropy bits can read from the [`ENTROPY_DATA`](registers.md#entropy_data) register.
 The firmware will do 32-bit register reads of the [`ENTROPY_DATA`](registers.md#entropy_data) register to retrieve the entropy bits.
 Each read will automatically pop an entry from the entropy unpacker block.
 A full twelve 32-bit words need to be read at a time.


### PR DESCRIPTION
This PR fixes some of the names of registers in the entropy_src documentation.

The main two fixes here are:

1. `CONF.ENABLE` was moved to `MODULE_ENABLE` in 51fde5a9830ab1501b01d953c7651c63727a546d.
2. `REGEN` was renamed to `REGWEN` in ef348c9995b53217479ebda6af8f7501042ecb72.

I have also added some convenience links to registers and fields that weren't linked previously.