### PR TITLE
[prim_onehot,cov] Fix coverage when AddrCheck == 0

### DIFF
--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -5,7 +5,13 @@
 // Generic countermeasure interface for hardened onehot_check
 //
 // This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
-// control inject_fault and restore_fault
+// control inject_fault and restore_fault.
+//
+// This interface is parameterized, and the AddrCheck parameter can be 0 or 1 in some instances.
+// For the instances with AddrCheck == 0 we end up with a coverage hole, so in order to
+// avoid this there are two derived classes from prim_onehot_check_if_proxy that differ
+// in their embedded covergroups.
+
 interface prim_onehot_check_if #(
   parameter int unsigned AddrWidth   = 5,
   parameter int unsigned OneHotWidth = 2 ** AddrWidth,
@@ -43,32 +49,13 @@ interface prim_onehot_check_if #(
     logic [AddrWidth-1:0]   addr_orig_value;
     logic                   en_orig_value;
 
-    covergroup onehot_fault_cg (string name) with function sample(
-          onehot_fault_type_e onehot_fault_type);
-      option.name = name;
-      option.per_instance = 1;
-
-      cp_onehot_fault: coverpoint onehot_fault_type {
-        option.weight = AddrWidth > 1;  // set to 0 to disable it if it's not supported
-        option.at_least = AddrWidth > 1; // If 0, we expect 0 hits.
-        bins hit = {OnehotFault};
-      }
-      cp_onehot_enable_fault: coverpoint onehot_fault_type {
-        option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = EnableCheck; // If 0, we expect 0 hits.
-        bins hit = {OnehotEnableFault};
-      }
-      cp_onehot_addr_fault: coverpoint onehot_fault_type {
-        option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
-        option.at_least = AddrCheck; // If 0, we expect 0 hits.
-        bins hit = {OnehotAddrFault};
-      }
-    endgroup
-
     function new(string name = "");
       super.new(name);
-      if (sec_cm_pkg::en_sec_cm_cov) onehot_fault_cg = new(msg_id);
     endfunction : new
+
+    virtual function sample_cov(onehot_fault_type_e onehot_fault_type);
+      `uvm_fatal(msg_id, "sample_cov in base class")
+    endfunction
 
     virtual task inject_fault();
       onehot_fault_type_e                   onehot_fault_type;
@@ -86,7 +73,7 @@ interface prim_onehot_check_if #(
                                          !AddrCheck -> onehot_fault_type != OnehotAddrFault;
                                          !EnableCheck -> onehot_fault_type != OnehotEnableFault;)
 
-      if (sec_cm_pkg::en_sec_cm_cov) onehot_fault_cg.sample(onehot_fault_type);
+      if (sec_cm_pkg::en_sec_cm_cov) sample_cov(onehot_fault_type);
       case (onehot_fault_type)
         OnehotFault: begin
           success = std::randomize(en_force_value, oh_force_value, addr_force_value) with {
@@ -147,7 +134,70 @@ interface prim_onehot_check_if #(
       `DV_CHECK(uvm_hdl_deposit(oh_signal_forced, oh_orig_value))
       `DV_CHECK(uvm_hdl_deposit(addr_signal_forced, addr_orig_value))
     endtask
-  endclass
+  endclass : prim_onehot_check_if_proxy
+
+  class prim_onehot_check_with_addr_fault_if_proxy extends prim_onehot_check_if_proxy;
+
+    covergroup onehot_with_addr_fault_cg (string name) with function sample(
+          onehot_fault_type_e onehot_fault_type);
+      option.name = name;
+      option.per_instance = 1;
+
+      cp_onehot_fault: coverpoint onehot_fault_type {
+        option.weight = AddrWidth > 1;  // set to 0 to disable it if it's not supported
+        bins hit = {OnehotFault};
+      }
+      cp_onehot_enable_fault: coverpoint onehot_fault_type {
+        option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
+        bins hit = {OnehotEnableFault};
+      }
+      cp_onehot_addr_fault: coverpoint onehot_fault_type {
+        option.weight = AddrCheck;  // set to 0 to disable it if it's not supported
+        bins hit = {OnehotAddrFault};
+      }
+    endgroup
+
+    virtual function sample_cov(onehot_fault_type_e onehot_fault_type);
+      onehot_with_addr_fault_cg.sample(onehot_fault_type);
+    endfunction
+
+    function new(string name = "");
+      super.new(name);
+      if (sec_cm_pkg::en_sec_cm_cov) begin
+        onehot_with_addr_fault_cg = new(msg_id);
+      end
+    endfunction
+  endclass : prim_onehot_check_with_addr_fault_if_proxy
+
+  class prim_onehot_check_without_addr_fault_if_proxy extends prim_onehot_check_if_proxy;
+
+    covergroup onehot_without_addr_fault_cg (string name) with function sample(
+          onehot_fault_type_e onehot_fault_type);
+      option.name = name;
+      option.per_instance = 1;
+
+      cp_onehot_fault: coverpoint onehot_fault_type {
+        option.weight = AddrWidth > 1;  // set to 0 to disable it if it's not supported
+        bins hit = {OnehotFault};
+      }
+      cp_onehot_enable_fault: coverpoint onehot_fault_type {
+        option.weight = EnableCheck;  // set to 0 to disable it if it's not supported
+        bins hit = {OnehotEnableFault};
+      }
+    endgroup
+
+    virtual function sample_cov(onehot_fault_type_e onehot_fault_type);
+      `DV_CHECK_NE(onehot_fault_type, OnehotAddrFault)
+      onehot_without_addr_fault_cg.sample(onehot_fault_type);
+    endfunction
+
+    function new(string name = "");
+      super.new(name);
+      if (sec_cm_pkg::en_sec_cm_cov) begin
+        onehot_without_addr_fault_cg = new(msg_id);
+      end
+    endfunction
+  endclass : prim_onehot_check_without_addr_fault_if_proxy
 
   prim_onehot_check_if_proxy if_proxy;
 
@@ -156,7 +206,15 @@ interface prim_onehot_check_if #(
     `DV_CHECK_FATAL(uvm_hdl_check_path(oh_signal_forced),, msg_id)
 
     // Store the proxy object for TB to use
-    if_proxy = new("if_proxy");
+    if (AddrCheck) begin
+      prim_onehot_check_with_addr_fault_if_proxy with_addr_fault_if_proxy;
+      with_addr_fault_if_proxy = new("if_proxy");
+      if_proxy = with_addr_fault_if_proxy;
+    end else begin
+      prim_onehot_check_without_addr_fault_if_proxy without_addr_fault_if_proxy;
+      without_addr_fault_if_proxy = new("if_proxy");
+      if_proxy = without_addr_fault_if_proxy;
+    end
     if_proxy.sec_cm_type = sec_cm_pkg::SecCmPrimOnehot;
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);


### PR DESCRIPTION
The prim_onehot_check_if_proxy class can be instantiated when AddrCheck is either on or off. When it is off it should result in no coverage holes for the cp_onehot_addr_fault coverpoint. The previous implementation set option.at_least to zero in this case, which caused a runtime warning. This implementation creates two derived classes from prim_onehot_check_if_proxy, one that is equivalent to the prior class for AddrCheck == 1, and one whose embedded covergroup does not have cp_onehot_addr_fault for AddrCheck == 0.

This removes the option.at_least setting, thus a problematic warning.