### PR TITLE
[crypto] Add support for HMAC-SHA384 and HMAC-SHA512.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -183,10 +183,12 @@ cc_library(
         "//sw/device/lib/crypto/include:mac.h",
     ],
     deps = [
+        ":hash",
         ":integrity",
         ":keyblob",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/impl/sha2:sha256",
+        "//sw/device/lib/crypto/impl/sha2:sha512",
     ],
 )

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -9,93 +9,12 @@
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/sha2/sha256.h"
+#include "sw/device/lib/crypto/impl/sha2/sha512.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/hash.h"
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('m', 'a', 'c')
-
-/**
- * Ensure that the hmac context is large enough.
- *
- * The HMAC context should hold one SHA-256 message block and a SHA-256 state
- * object.
- */
-static_assert(
-    sizeof(hmac_context_t) == kSha256MessageBlockBytes + sizeof(sha256_state_t),
-    "hmac_context_t must be the same size as a key block and a SHA-256 state");
-/**
- * Ensure that the SHA-256 state struct is suitable for `hardened_memcpy()`.
- */
-static_assert(sizeof(sha256_state_t) % sizeof(uint32_t) == 0,
-              "Size of sha256_state_t must be a multiple of the word size for "
-              "`hardened_memcpy()`");
-
-enum {
-  /**
-   * Word-offset of the key block within the HMAC context object.
-   */
-  kHmacContextKeyBlockWordOffset = 0,
-  /**
-   * Word-offset of the SHA-256 state within the HMAC context object.
-   */
-  kHmacContextSha256StateWordOffset = kSha256MessageBlockWords,
-};
-
-/**
- * Save a SHA-256 state to an HMAC context.
- *
- * @param[out] ctx HMAC context to copy to.
- * @param state SHA-256 state object.
- * @param k0 Key block.
- */
-static void sha256_state_save(hmac_context_t *restrict ctx,
-                              const sha256_state_t *restrict state) {
-  // As per the `hardened_memcpy()` documentation, it
-  // is OK to cast to `uint32_t *` here as long as `state` is word-aligned,
-  // which it must be because all its fields are.
-  uint32_t *dest = ctx->data + kHmacContextSha256StateWordOffset;
-  hardened_memcpy(dest, (uint32_t *)state,
-                  sizeof(sha256_state_t) / sizeof(uint32_t));
-}
-
-/**
- * Restore a SHA-256 state from an HMAC context.
- *
- * @param ctx HMAC context to restore from.
- * @param[out] state Destination SHA-256 state object.
- */
-static void sha256_state_restore(const hmac_context_t *restrict ctx,
-                                 sha256_state_t *restrict state) {
-  // As per the `hardened_memcpy()` documentation, it is OK to cast to
-  // `uint32_t *` here as long as `state` is word-aligned, which it must be
-  // because all its fields are.
-  const uint32_t *src = ctx->data + kHmacContextSha256StateWordOffset;
-  hardened_memcpy((uint32_t *)state, src,
-                  sizeof(sha256_state_t) / sizeof(uint32_t));
-}
-/**
- * Save the key block to an HMAC context.
- *
- * @param[out] ctx HMAC context to copy to.
- * @param k0 Key block to save.
- */
-static void key_block_save(hmac_context_t *restrict ctx,
-                           const uint32_t *restrict k0) {
-  uint32_t *dest = ctx->data + kHmacContextKeyBlockWordOffset;
-  hardened_memcpy(dest, k0, kSha256MessageBlockWords);
-}
-
-/**
- * Restore a key block from an HMAC context.
- *
- * @param ctx HMAC context to restore from.
- * @param[out] k0 Destination key block buffer.
- */
-static void key_block_restore(const hmac_context_t *restrict ctx,
-                              uint32_t *restrict k0) {
-  const uint32_t *src = ctx->data + kHmacContextKeyBlockWordOffset;
-  hardened_memcpy(k0, src, kSha256MessageBlockWords);
-}
 
 crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
   // TODO: Implement KMAC sideloaded key generation once we have a keymgr
@@ -107,10 +26,10 @@ crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key) {
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_byte_buf_t input_message,
-                              crypto_word32_buf_t *tag) {
+                              hash_mode_t hash_mode, crypto_word32_buf_t *tag) {
   // Compute HMAC using the streaming API.
   hmac_context_t ctx;
-  HARDENED_TRY(otcrypto_hmac_init(&ctx, key));
+  HARDENED_TRY(otcrypto_hmac_init(&ctx, key, hash_mode));
   HARDENED_TRY(otcrypto_hmac_update(&ctx, input_message));
   return otcrypto_hmac_final(&ctx, tag);
 }
@@ -194,20 +113,54 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
 }
 
 crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
-                                   const crypto_blinded_key_t *key) {
+                                   const crypto_blinded_key_t *key,
+                                   hash_mode_t hash_mode) {
   if (ctx == NULL || key == NULL || key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-
   if (key->config.hw_backed != kHardenedBoolFalse) {
-    // TODO(#15590): Add support for sideloaded keys.
+    // TODO(#15590): Add support for sideloaded keys via a custom OTBN program.
+    return OTCRYPTO_NOT_IMPLEMENTED;
+  }
+  if (key->config.security_level != kSecurityLevelLow) {
+    // TODO: Harden SHA2 implementations.
     return OTCRYPTO_NOT_IMPLEMENTED;
   }
 
-  // Key mode must be HMAC-SHA256.
-  if (key->config.key_mode != kKeyModeHmacSha256) {
-    return OTCRYPTO_BAD_ARGS;
+  // Ensure the key is for HMAC and the hash function matches, and remember the
+  // digest and message block sizes.
+  size_t digest_words = 0;
+  size_t message_block_words = 0;
+  switch (key->config.key_mode) {
+    case kKeyModeHmacSha256:
+      if (hash_mode != kHashModeSha256) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      digest_words = kSha256DigestWords;
+      message_block_words = kSha256MessageBlockWords;
+      break;
+    case kKeyModeHmacSha384:
+      if (hash_mode != kHashModeSha384) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      digest_words = kSha384DigestWords;
+      // Since SHA-512 and SHA-384 have the same core, they use the same
+      // message block size.
+      message_block_words = kSha512MessageBlockWords;
+      break;
+    case kKeyModeHmacSha512:
+      if (hash_mode != kHashModeSha512) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      digest_words = kSha512DigestWords;
+      message_block_words = kSha512MessageBlockWords;
+      break;
+    default:
+      return OTCRYPTO_BAD_ARGS;
   }
+  HARDENED_CHECK_NE(digest_words, 0);
+  HARDENED_CHECK_NE(message_block_words, 0);
+  HARDENED_CHECK_LE(digest_words, message_block_words);
 
   // Check the integrity of the key.
   if (integrity_blinded_key_check(key) != kHardenedBoolTrue) {
@@ -219,55 +172,83 @@ crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
   uint32_t *share1;
   HARDENED_TRY(keyblob_to_shares(key, &share0, &share1));
 
-  // TODO: Once we have hardened SHA-256, do not unmask the key here.
+  // TODO: Once we have hardened SHA2, do not unmask the key here.
   uint32_t unmasked_key[keyblob_share_num_words(key->config)];
   for (size_t i = 0; i < keyblob_share_num_words(key->config); i++) {
     unmasked_key[i] = share0[i] ^ share1[i];
   }
 
   // Initialize the key block, K0. See FIPS 198-1, section 4.
-  uint32_t k0[kSha256MessageBlockWords] = {0};
-  if (key->config.key_length <= kSha256MessageBlockBytes) {
-    // If the key fits into the SHA-256 block size, we just need to copy it
+  uint32_t k0[message_block_words];
+  memset(k0, 0, sizeof(k0));
+  if (key->config.key_length < (digest_words * sizeof(uint32_t))) {
+    // Key is too short.
+    return OTCRYPTO_BAD_ARGS;
+  } else if (key->config.key_length <= message_block_words * sizeof(uint32_t)) {
+    // If the key fits into the message block size, we just need to copy it
     // into the first part of K0.
     hardened_memcpy(k0, unmasked_key, ARRAYSIZE(unmasked_key));
+    // If the key size isn't a multiple of the word size, zero the last few
+    // bytes.
+    size_t offset = key->config.key_length % sizeof(uint32_t);
+    if (offset != 0) {
+      unsigned char *k0_bytes = (unsigned char *)k0;
+      size_t num_zero_bytes = sizeof(uint32_t) - offset;
+      unsigned char *dest = k0_bytes + (sizeof(unmasked_key) - num_zero_bytes);
+      memset(dest, 0, num_zero_bytes);
+    }
   } else {
-    // If the key is longer than the SHA-256 block size, we need to hash it
-    // and write the digest into the start of K0.
-    HARDENED_TRY(
-        sha256((unsigned char *)unmasked_key, key->config.key_length, k0));
+    // If the key is longer than the hash function block size, we need to hash
+    // it and write the digest into the start of K0.
+    crypto_word32_buf_t key_digest = {
+        .len = digest_words,
+        .data = k0,
+    };
+    HARDENED_TRY(otcrypto_hash(
+        (crypto_const_byte_buf_t){
+            .len = key->config.key_length,
+            .data = (unsigned char *)unmasked_key,
+        },
+        hash_mode, &key_digest));
   }
 
-  // Compute SHA256(K0 ^ ipad).
-  uint32_t inner_block[kSha256MessageBlockWords];
-  for (size_t i = 0; i < kSha256MessageBlockWords; i++) {
+  // Compute (K0 ^ ipad).
+  uint32_t inner_block[message_block_words];
+  for (size_t i = 0; i < message_block_words; i++) {
     inner_block[i] = k0[i] ^ 0x36363636;
   }
 
-  // Start computing SHA256(K0 ^ ipad) || message).
-  sha256_state_t sha256_ctx;
-  sha256_init(&sha256_ctx);
-  HARDENED_TRY(sha256_update(&sha256_ctx, (unsigned char *)inner_block,
-                             sizeof(inner_block)));
+  // Compute (K0 ^ opad).
+  uint32_t outer_block[message_block_words];
+  for (size_t i = 0; i < message_block_words; i++) {
+    outer_block[i] = k0[i] ^ 0x5c5c5c5c;
+  }
 
-  // Save the key block and SHA-256 state.
-  key_block_save(ctx, k0);
-  sha256_state_save(ctx, &sha256_ctx);
+  // Start computing inner hash = H(K0 ^ ipad) || message).
+  HARDENED_TRY(otcrypto_hash_init(&ctx->inner, hash_mode));
+  HARDENED_TRY(otcrypto_hash_update(
+      &ctx->inner,
+      (crypto_const_byte_buf_t){.len = sizeof(inner_block),
+                                .data = (unsigned char *)inner_block}));
+
+  // Start computing outer hash = H(K0 ^ opad || inner).
+  HARDENED_TRY(otcrypto_hash_init(&ctx->outer, hash_mode));
+  HARDENED_TRY(otcrypto_hash_update(
+      &ctx->outer,
+      (crypto_const_byte_buf_t){.len = sizeof(outer_block),
+                                .data = (unsigned char *)outer_block}));
 
   return OTCRYPTO_OK;
 }
 
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
                                      crypto_const_byte_buf_t input_message) {
-  if (ctx == NULL || (input_message.data == NULL && input_message.len != 0)) {
+  if (ctx == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  sha256_state_t sha256_ctx;
-  sha256_state_restore(ctx, &sha256_ctx);
-  HARDENED_TRY(
-      sha256_update(&sha256_ctx, input_message.data, input_message.len));
-  sha256_state_save(ctx, &sha256_ctx);
+  // Append the message to the inner block.
+  HARDENED_TRY(otcrypto_hash_update(&ctx->inner, input_message));
   return OTCRYPTO_OK;
 }
 
@@ -277,36 +258,17 @@ crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (tag->len != kSha256DigestWords) {
-    return OTCRYPTO_BAD_ARGS;
-  }
+  // Finalize the computation of the inner hash = H(K0 ^ ipad || message) and
+  // store it in `tag` temporarily.
+  HARDENED_TRY(otcrypto_hash_final(&ctx->inner, tag));
 
-  // Restore the SHA-256 state from the context.
-  sha256_state_t sha256_ctx;
-  sha256_state_restore(ctx, &sha256_ctx);
-
-  // Finalize the computation of SHA256(K0 ^ ipad || message).
-  uint32_t inner_digest[kSha256DigestWords];
-  HARDENED_TRY(sha256_final(&sha256_ctx, inner_digest));
-
-  // Restore the key block K0 from the context.
-  uint32_t k0[kSha256MessageBlockWords];
-  key_block_restore(ctx, k0);
-
-  // Compute K0 ^ opad.
-  uint32_t outer_block[kSha256MessageBlockWords];
-  for (size_t i = 0; i < kSha256MessageBlockWords; i++) {
-    outer_block[i] = k0[i] ^ 0x5c5c5c5c;
-  }
-
-  // Start a new hash computation to get the final tag: SHA256(K0 ^ opad ||
-  // SHA256(K0 ^ ipad || message))
-  sha256_init(&sha256_ctx);
-  HARDENED_TRY(sha256_update(&sha256_ctx, (unsigned char *)outer_block,
-                             sizeof(outer_block)));
-  HARDENED_TRY(sha256_update(&sha256_ctx, (unsigned char *)inner_digest,
-                             sizeof(inner_digest)));
-  HARDENED_TRY(sha256_final(&sha256_ctx, tag->data));
+  // Finalize the computation of the outer hash
+  //    = H(K0 ^ opad || H(K0 ^ ipad || message)).
+  HARDENED_TRY(otcrypto_hash_update(
+      &ctx->outer,
+      (crypto_const_byte_buf_t){.len = sizeof(uint32_t) * tag->len,
+                                .data = (unsigned char *)tag->data}));
+  HARDENED_TRY(otcrypto_hash_final(&ctx->outer, tag));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -233,12 +233,10 @@ crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
 
   // Start computing outer hash = H(K0 ^ opad || inner).
   HARDENED_TRY(otcrypto_hash_init(&ctx->outer, hash_mode));
-  HARDENED_TRY(otcrypto_hash_update(
+  return otcrypto_hash_update(
       &ctx->outer,
       (crypto_const_byte_buf_t){.len = sizeof(outer_block),
-                                .data = (unsigned char *)outer_block}));
-
-  return OTCRYPTO_OK;
+                                .data = (unsigned char *)outer_block});
 }
 
 crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
@@ -248,8 +246,7 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
   }
 
   // Append the message to the inner block.
-  HARDENED_TRY(otcrypto_hash_update(&ctx->inner, input_message));
-  return OTCRYPTO_OK;
+  return otcrypto_hash_update(&ctx->inner, input_message);
 }
 
 crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
@@ -268,7 +265,5 @@ crypto_status_t otcrypto_hmac_final(hmac_context_t *const ctx,
       &ctx->outer,
       (crypto_const_byte_buf_t){.len = sizeof(uint32_t) * tag->len,
                                 .data = (unsigned char *)tag->data}));
-  HARDENED_TRY(otcrypto_hash_final(&ctx->outer, tag));
-
-  return OTCRYPTO_OK;
+  return otcrypto_hash_final(&ctx->outer, tag);
 }

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -186,7 +186,11 @@ typedef enum aes_key_mode {
  */
 typedef enum hmac_key_mode {
   // Mode HMAC SHA256.
-  kHmacKeyModeSha256 = 0xc1d,
+  kHmacKeyModeSha256 = 0x7fd,
+  // Mode HMAC SHA384.
+  kHmacKeyModeSha384 = 0x43b,
+  // Mode HMAC SHA512.
+  kHmacKeyModeSha512 = 0x7a2,
 } hmac_key_mode_t;
 
 /**
@@ -279,6 +283,10 @@ typedef enum key_mode {
   kKeyModeAesKwp = kKeyTypeAes << 16 | kAesKeyModeKwp,
   // Key is intended for HMAC SHA256 mode.
   kKeyModeHmacSha256 = kKeyTypeHmac << 16 | kHmacKeyModeSha256,
+  // Key is intended for HMAC SHA384 mode.
+  kKeyModeHmacSha384 = kKeyTypeHmac << 16 | kHmacKeyModeSha384,
+  // Key is intended for HMAC SHA512 mode.
+  kKeyModeHmacSha512 = kKeyTypeHmac << 16 | kHmacKeyModeSha512,
   // Key is intended for KMAC128 mode.
   kKeyModeKmac128 = kKeyTypeKmac << 16 | kKmacKeyModeKmac128,
   // Key is intended for KMAC256 mode.

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_
 
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/hash.h"
 
 /**
  * @file
@@ -37,8 +38,8 @@ typedef enum kmac_mode {
  * with #otcrypto_hmac_init.
  */
 typedef struct hmac_context {
-  // Context for the hmac operation.
-  uint32_t data[42];
+  hash_context_t inner;
+  hash_context_t outer;
 } hmac_context_t;
 
 /**
@@ -59,22 +60,26 @@ typedef struct hmac_context {
 crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
 
 /**
- * Performs the HMAC-SHA256 function on the input data.
+ * Performs the HMAC function on the input data.
  *
- * This function computes the HMAC-SHA256 function on the `input_message`
- * using the `key` and returns a `tag`.
+ * This function computes the HMAC function on the `input_message` using the
+ * `key` and returns a `tag`. The key should be at least as long as the digest
+ * for the chosen hash function.. Only `kHashModeSha256`, `kHashModeSha384` and
+ * `kHashModeSha512` are supported. Other modes (e.g. SHA-3) are not supported
+ * and will result in errors.
  *
  * The caller should allocate 32 bytes (8 32-bit words) of space for the `tag`
  * buffer and set its `len` field to 8.
  *
  * @param key Pointer to the blinded key struct with key shares.
  * @param input_message Input message to be hashed.
+ * @param hash_mode Hash function to use.
  * @param[out] tag Output authentication tag.
  * @return The result of the HMAC operation.
  */
 crypto_status_t otcrypto_hmac(const crypto_blinded_key_t *key,
                               crypto_const_byte_buf_t input_message,
-                              crypto_word32_buf_t *tag);
+                              hash_mode_t hash_mode, crypto_word32_buf_t *tag);
 
 /**
  * Performs the KMAC function on the input data.
@@ -108,10 +113,10 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
 /**
  * Performs the INIT operation for HMAC.
  *
- * Initializes the generic HMAC context. The required HMAC mode is selected
- * through the `hmac_mode` parameter. The structure of HMAC context and how it
- * populates the required fields based on the HMAC mode are internal to the
- * specific HMAC implementation.
+ * Initializes the HMAC context. The key should be at least as long as the
+ * digest for the chosen hash function. Only `kHashModeSha256`,
+ * `kHashModeSha384` and `kHashModeSha512` are supported. Other modes (e.g.
+ * SHA-3) are not supported and will result in errors.
  *
  * The HMAC streaming API supports only the `kMacModeHmacSha256` mode.  Other
  * modes are not supported and an error would be returned. The interface is
@@ -119,10 +124,12 @@ crypto_status_t otcrypto_kmac(const crypto_blinded_key_t *key,
  *
  * @param ctx Pointer to the generic HMAC context struct.
  * @param key Pointer to the blinded HMAC key struct.
+ * @param hash_mode Hash function to use.
  * @return Result of the HMAC init operation.
  */
 crypto_status_t otcrypto_hmac_init(hmac_context_t *ctx,
-                                   const crypto_blinded_key_t *key);
+                                   const crypto_blinded_key_t *key,
+                                   hash_mode_t hash_mode);
 
 /**
  * Performs the UPDATE operation for HMAC.
@@ -149,8 +156,8 @@ crypto_status_t otcrypto_hmac_update(hmac_context_t *const ctx,
  *
  * #otcrypto_hmac_update should be called before calling this function.
  *
- * The caller should allocate space for the `tag` buffer, (expected length is
- * 32 bytes = 8 32-bit words for HMAC), and set the length of expected output
+ * The caller should allocate space for the `tag` buffer, (the length should
+ * match the hash function digest size), and set the length of expected output
  * in the `len` field of `tag`. If the user-set length and the output length
  * does not match, an error message will be returned.
  *

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -319,6 +319,20 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "hmac_sha384_functest",
+    srcs = ["hmac_sha384_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 py_binary(
     name = "rsa_3072_verify_set_testvectors",
     srcs = ["rsa_3072_verify_set_testvectors.py"],

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -326,7 +326,19 @@ opentitan_functest(
         timeout = "long",
     ),
     deps = [
-        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
+    name = "hmac_sha512_functest",
+    srcs = ["hmac_sha512_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
         "//sw/device/lib/crypto/impl:mac",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -306,8 +306,8 @@ py_binary(
 )
 
 opentitan_functest(
-    name = "hmac_functest",
-    srcs = ["hmac_functest.c"],
+    name = "hmac_sha256_functest",
+    srcs = ["hmac_sha256_functest.c"],
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -24,11 +24,6 @@ static const uint32_t kBasicTestKey[] = {
     0xc3687ba2, 0xea6d3619, 0xb0916bf2, 0x347a2f71,
 };
 
-// Short test key, 32 bits (big endian) = 0x1bff10ea
-static const uint32_t kShortTestKey[] = {
-    0xea10ff1b,
-};
-
 // Long test key, 544 bits (big endian) =
 // 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243
 static const uint32_t kLongTestKey[] = {
@@ -82,7 +77,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .len = ARRAYSIZE(act_tag),
   };
 
-  TRY(otcrypto_hmac(&blinded_key, msg, &tag_buf));
+  TRY(otcrypto_hmac(&blinded_key, msg, kHashModeSha256, &tag_buf));
   TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
   return OK_STATUS();
 }
@@ -125,25 +120,6 @@ static status_t empty_test(void) {
 }
 
 /**
- * Test using a short key.
- *
- * HMAC-SHA256(kShortTestKey, 'Test message.')
- *   = 0x3f08885633d7caa1728f798c49110ed8c8020f74ba6de7d0b549935b87eb3ef1
- */
-static status_t short_key_test(void) {
-  const char plaintext[] = "Test message.";
-  crypto_const_byte_buf_t msg_buf = {
-      .data = (unsigned char *)plaintext,
-      .len = sizeof(plaintext) - 1,
-  };
-  const uint32_t exp_tag[] = {
-      0x5688083f, 0xa1cad733, 0x8c798f72, 0xd80e1149,
-      0x740f02c8, 0xd0e76dba, 0x5b9349b5, 0xf13eeb87,
-  };
-  return run_test(kShortTestKey, sizeof(kShortTestKey), msg_buf, exp_tag);
-}
-
-/**
  * Test using a long key.
  *
  * HMAC-SHA256(kLongTestKey, 'Test message.')
@@ -171,7 +147,6 @@ bool test_main(void) {
   test_result = OK_STATUS();
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
-  EXECUTE_TEST(test_result, short_key_test);
   EXECUTE_TEST(test_result, long_key_test);
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -1,0 +1,160 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /**
+   * HMAC-SHA384 tag length (384 bits) in words.
+   */
+  kTagLenWords = 384 / 32,
+};
+
+// Randomly generated 384-bit test key (big endian) =
+// 0x7751ae57bc0ba74f9d5cba1a458d9543342c70fe102f5e2fb339c2500f5610f132276a7cb87d39cde522efea6ba18dd1
+static const uint32_t kBasicTestKey[] = {
+    0x57ae5177, 0x4fa70bbc, 0x1aba5c9d, 0x43958d45, 0xfe702c34, 0x2f5e2f10,
+    0x50c239b3, 0xf110560f, 0x7c6a2732, 0xcd397db8, 0xeaef22e5, 0xd18da16b};
+
+// Test key longer than the message block size, 1088 bits (big endian) =
+// 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243
+static const uint32_t kLongTestKey[] = {
+    0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514,
+    0x1b1a1918, 0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c,
+    0x33323130, 0x37363534, 0x3b3a3938, 0x3f3e3d3c, 0x43424140, 0x03020100,
+    0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514, 0x1b1a1918,
+    0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c, 0x33323130,
+    0x37363534, 0x3b3a3938, 0x3f3e3d3c, 0x43424140,
+};
+
+// Random value for masking, as large as the longest test key. This value
+// should not affect the result.
+static const uint32_t kTestMask[ARRAYSIZE(kLongTestKey)] = {
+    0x8cb847c3, 0xc6d34f36, 0x72edbf7b, 0x9bc0317f, 0x8f003c7f, 0x1d7ba049,
+    0xfd463b63, 0xbb720c44, 0x784c215e, 0xeb101d65, 0x35beb911, 0xab481345,
+    0xa7ebc3e3, 0x04b2a1b9, 0x764a9630, 0x78b8f9c5, 0x3f2a1d8e, 0x8cb847c3,
+    0xc6d34f36, 0x72edbf7b, 0x9bc0317f, 0x8f003c7f, 0x1d7ba049, 0xfd463b63,
+    0xbb720c44, 0x784c215e, 0xeb101d65, 0x35beb911, 0xab481345, 0xa7ebc3e3,
+    0x04b2a1b9, 0x764a9630, 0x78b8f9c5, 0x3f2a1d8e,
+};
+
+/**
+ * Call the `otcrypto_mac` API and check the resulting tag.
+ *
+ * @param key Key material.
+ * @param key_num_words Key length in bytes.
+ * @param msg Input message.
+ * @param exp_tag Expected tag.
+ * @return Result (OK or error).
+ */
+static status_t run_test(const uint32_t *key, size_t key_len,
+                         crypto_const_byte_buf_t msg, const uint32_t *exp_tag) {
+  // Construct blinded key.
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = kKeyModeHmacSha384,
+      .key_length = key_len,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kSecurityLevelLow,
+  };
+
+  uint32_t keyblob[keyblob_num_words(config)];
+  TRY(keyblob_from_key_and_mask(key, kTestMask, config, keyblob));
+  crypto_blinded_key_t blinded_key = {
+      .config = config,
+      .keyblob = keyblob,
+      .keyblob_length = sizeof(keyblob),
+      .checksum = 0,
+  };
+  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+
+  uint32_t act_tag[kTagLenWords];
+  crypto_word32_buf_t tag_buf = {
+      .data = act_tag,
+      .len = ARRAYSIZE(act_tag),
+  };
+
+  TRY(otcrypto_hmac(&blinded_key, msg, kHashModeSha384, &tag_buf));
+  TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
+  return OK_STATUS();
+}
+
+/**
+ * Simple test with a short message.
+ *
+ * HMAC-SHA384(kBasicTestKey, 'Test message.')
+ *   =
+ * 0x2fba69e09ba15197aff88d3768aaee009cb6895763c31dcdf1d0146d4e4462d01a3c68ed42e6cee1e67b4ba48bdd1805
+ */
+static status_t simple_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_byte_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0xe069ba2f, 0x9751a19b, 0x378df8af, 0x00eeaa68, 0x5789b69c, 0xcd1dc363,
+      0x6d14d0f1, 0xd062444e, 0xed683c1a, 0xe1cee642, 0xa44b7be6, 0x0518dd8b,
+  };
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test with an empty message.
+ *
+ * HMAC-SHA384(kBasicTestKey, '')
+ * =
+ * 0xb69271e94f5f5da40337cdb2f2d3412b6d568b7b51a86f7109f8454f3c34276cf44a5b98997ce3ab8f59170b6e1f71f9
+ */
+static status_t empty_test(void) {
+  const uint32_t exp_tag[] = {
+      0xe97192b6, 0xa45d5f4f, 0xb2cd3703, 0x2b41d3f2, 0x7b8b566d, 0x716fa851,
+      0x4f45f809, 0x6c27343c, 0x985b4af4, 0xabe37c99, 0x0b17598f, 0xf9711f6e,
+  };
+  crypto_const_byte_buf_t msg_buf = {
+      .data = NULL,
+      .len = 0,
+  };
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test using a long key.
+ *
+ * HMAC-SHA384(kLongTestKey, 'Test message.')
+ *   =
+ * 0xaacc6a2d9aadee928c78467c02a881b00afc8a6b004d09cf05b8a492651a5f5cf8d4bc988598b2bd3154f07239b48dc0
+ */
+static status_t long_key_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_byte_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0x2d6accaa, 0x92eead9a, 0x7c46788c, 0xb081a802, 0x6b8afc0a, 0xcf094d00,
+      0x92a4b805, 0x5c5f1a65, 0x98bcd4f8, 0xbdb29885, 0x72f05431, 0xc08db439,
+  };
+  return run_test(kLongTestKey, sizeof(kLongTestKey), msg_buf, exp_tag);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Holds the test result.
+static volatile status_t test_result;
+
+bool test_main(void) {
+  test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, empty_test);
+  EXECUTE_TEST(test_result, simple_test);
+  EXECUTE_TEST(test_result, long_key_test);
+  return status_ok(test_result);
+}

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -1,0 +1,169 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /**
+   * HMAC-SHA512 tag length (512 bits) in words.
+   */
+  kTagLenWords = 512 / 32,
+};
+
+// Randomly generated 512-bit test key (big endian) =
+// 0xba79877bb2027c689bef5c69567ca099977928d90a82c05c5d18c39967d4099f64b9f8d7dd192cd6e5902fb599fb601a6879ecb0fdb081bf1b75a4c1ed8865a4
+static const uint32_t kBasicTestKey[] = {
+    0x7b8779ba, 0x687c02b2, 0x695cef9b, 0x99a07c56, 0xd9287997, 0x5cc0820a,
+    0x99c3185d, 0x9f09d467, 0xd7f8b964, 0xd62c19dd, 0xb52f90e5, 0x1a60fb99,
+    0xb0ec7968, 0xbf81b0fd, 0xc1a4751b, 0xa46588ed,
+
+};
+
+// Test key longer than the message block size, 1088 bits (big endian) =
+// 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243
+static const uint32_t kLongTestKey[] = {
+    0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514,
+    0x1b1a1918, 0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c,
+    0x33323130, 0x37363534, 0x3b3a3938, 0x3f3e3d3c, 0x43424140, 0x03020100,
+    0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514, 0x1b1a1918,
+    0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c, 0x33323130,
+    0x37363534, 0x3b3a3938, 0x3f3e3d3c, 0x43424140,
+};
+
+// Random value for masking, as large as the longest test key. This value
+// should not affect the result.
+static const uint32_t kTestMask[ARRAYSIZE(kLongTestKey)] = {
+    0x8cb847c3, 0xc6d34f36, 0x72edbf7b, 0x9bc0317f, 0x8f003c7f, 0x1d7ba049,
+    0xfd463b63, 0xbb720c44, 0x784c215e, 0xeb101d65, 0x35beb911, 0xab481345,
+    0xa7ebc3e3, 0x04b2a1b9, 0x764a9630, 0x78b8f9c5, 0x3f2a1d8e, 0x8cb847c3,
+    0xc6d34f36, 0x72edbf7b, 0x9bc0317f, 0x8f003c7f, 0x1d7ba049, 0xfd463b63,
+    0xbb720c44, 0x784c215e, 0xeb101d65, 0x35beb911, 0xab481345, 0xa7ebc3e3,
+    0x04b2a1b9, 0x764a9630, 0x78b8f9c5, 0x3f2a1d8e,
+};
+
+/**
+ * Call the `otcrypto_mac` API and check the resulting tag.
+ *
+ * @param key Key material.
+ * @param key_num_words Key length in bytes.
+ * @param msg Input message.
+ * @param exp_tag Expected tag.
+ * @return Result (OK or error).
+ */
+static status_t run_test(const uint32_t *key, size_t key_len,
+                         crypto_const_byte_buf_t msg, const uint32_t *exp_tag) {
+  // Construct blinded key.
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = kKeyModeHmacSha512,
+      .key_length = key_len,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kSecurityLevelLow,
+  };
+
+  uint32_t keyblob[keyblob_num_words(config)];
+  TRY(keyblob_from_key_and_mask(key, kTestMask, config, keyblob));
+  crypto_blinded_key_t blinded_key = {
+      .config = config,
+      .keyblob = keyblob,
+      .keyblob_length = sizeof(keyblob),
+      .checksum = 0,
+  };
+  blinded_key.checksum = integrity_blinded_checksum(&blinded_key);
+
+  uint32_t act_tag[kTagLenWords];
+  crypto_word32_buf_t tag_buf = {
+      .data = act_tag,
+      .len = ARRAYSIZE(act_tag),
+  };
+
+  TRY(otcrypto_hmac(&blinded_key, msg, kHashModeSha512, &tag_buf));
+  TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
+  return OK_STATUS();
+}
+
+/**
+ * Simple test with a short message.
+ *
+ * HMAC-SHA512(kBasicTestKey, 'Test message.')
+ *   =
+ * 0xa574367b4c84120c0bef3a2e0c5675b86fe0f21f980cc82cfe21b63442d3d12a2d33377a6471d9167eb9b3155543273bac2146e26208c95dc3490727417802ba
+ */
+static status_t simple_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_byte_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0x7b3674a5, 0x0c12844c, 0x2e3aef0b, 0xb875560c, 0x1ff2e06f, 0x2cc80c98,
+      0x34b621fe, 0x2ad1d342, 0x7a37332d, 0x16d97164, 0x15b3b97e, 0x3b274355,
+      0xe24621ac, 0x5dc90862, 0x270749c3, 0xba027841,
+
+  };
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test with an empty message.
+ *
+ * HMAC-SHA512(kBasicTestKey, '')
+ *   =
+ * 0xef725f225b5c7e880aabfb5c3dd6d8d5f3027aaf1a532e502f65e48a1c9196cff712e44f3b2700d9c02321a363b7b9c51a598b9226a737704a6d19dff79c582d
+ */
+static status_t empty_test(void) {
+  const uint32_t exp_tag[] = {
+      0x225f72ef, 0x887e5c5b, 0x5cfbab0a, 0xd5d8d63d, 0xaf7a02f3, 0x502e531a,
+      0x8ae4652f, 0xcf96911c, 0x4fe412f7, 0xd900273b, 0xa32123c0, 0xc5b9b763,
+      0x928b591a, 0x7037a726, 0xdf196d4a, 0x2d589cf7,
+
+  };
+  crypto_const_byte_buf_t msg_buf = {
+      .data = NULL,
+      .len = 0,
+  };
+  return run_test(kBasicTestKey, sizeof(kBasicTestKey), msg_buf, exp_tag);
+}
+
+/**
+ * Test using a long key.
+ *
+ * HMAC-SHA512(kLongTestKey, 'Test message.')
+ *   =
+ * 0x6f18c6e54d2498dfd73bd6e04b38a85d2c94fcfc2ac7e54ea2eb5884a8e4ebb0a5e0954f7ec5fdc26b3c15aed8706620d72d97a3f0b986b631b2d550249c724d
+ */
+static status_t long_key_test(void) {
+  const char plaintext[] = "Test message.";
+  crypto_const_byte_buf_t msg_buf = {
+      .data = (unsigned char *)plaintext,
+      .len = sizeof(plaintext) - 1,
+  };
+  const uint32_t exp_tag[] = {
+      0xe5c6186f, 0xdf98244d, 0xe0d63bd7, 0x5da8384b, 0xfcfc942c, 0x4ee5c72a,
+      0x8458eba2, 0xb0ebe4a8, 0x4f95e0a5, 0xc2fdc57e, 0xae153c6b, 0x206670d8,
+      0xa3972dd7, 0xb686b9f0, 0x50d5b231, 0x4d729c24,
+
+  };
+  return run_test(kLongTestKey, sizeof(kLongTestKey), msg_buf, exp_tag);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Holds the test result.
+static volatile status_t test_result;
+
+bool test_main(void) {
+  test_result = OK_STATUS();
+  EXECUTE_TEST(test_result, empty_test);
+  EXECUTE_TEST(test_result, simple_test);
+  EXECUTE_TEST(test_result, long_key_test);
+  return status_ok(test_result);
+}


### PR DESCRIPTION
We already had  streaming implementations of SHA384 and SHA-512. Since HMAC is a thin layer on top of hashing, it made sense to add support for larger SHA2s to the streaming HMAC interface, in addition to SHA256 (which was already present).