### PR TITLE
[bitstreams] Redirect missing targets in the cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,6 +198,9 @@ jobs:
       set -x -e
       # Check the entire build graph for conflicts in loading or analysis
       # phases. For context, see issue #18726.
+      # First, test with an empty bitstream cache entry.
+      ci/scripts/test-empty-bitstream-cache.sh
+      # Now redo with the real bitstream cache included.
       ci/bazelisk.sh build --nobuild //...
       # This command builds all software and runs all unit tests that run on the
       # host, with a few exceptions:

--- a/ci/scripts/test-empty-bitstream-cache.sh
+++ b/ci/scripts/test-empty-bitstream-cache.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test that the analysis phase completes when the bitstream cache is missing
+# entries.
+
+set -e
+
+empty_cache_dir=$(mktemp -d)
+mkdir -p "${empty_cache_dir}/cache/0123456789"
+
+echo '{"schema_version":2,"designs":{}}' \
+    > "${empty_cache_dir}/cache/0123456789/manifest.json"
+
+BAZEL_BITSTREAMS_CACHE="${empty_cache_dir}" BITSTREAM="--offline 0123456789" \
+    ci/bazelisk.sh build --nobuild //...

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -119,6 +119,36 @@ filegroup(
     name = "manifest",
     srcs = ["cache/abcd/substitute_manifest.json"],
 )
+
+alias(
+    name = "chip_earlgrey_cw310_hyperdebug_bitstream",
+    actual = "@//hw/bitstream/vivado:fpga_cw310_test_rom_hyp",
+)
+
+alias(
+    name = "chip_earlgrey_cw310_hyperdebug_rom_mmi",
+    actual = "@//hw/bitstream/vivado:rom_mmi_hyp",
+)
+
+alias(
+    name = "chip_earlgrey_cw310_hyperdebug_otp_mmi",
+    actual = "@//hw/bitstream/vivado:otp_mmi_hyp",
+)
+
+alias(
+    name = "chip_earlgrey_cw340_bitstream",
+    actual = "@//hw/bitstream/vivado:fpga_cw340_test_rom",
+)
+
+alias(
+    name = "chip_earlgrey_cw340_rom_mmi",
+    actual = "@//hw/bitstream/vivado:fpga_cw340_rom_mmi",
+)
+
+alias(
+    name = "chip_earlgrey_cw340_otp_mmi",
+    actual = "@//hw/bitstream/vivado:fpga_cw340_otp_mmi",
+)
 ''')
 
         # This is more of an implementation detail, but it verifies that we hit


### PR DESCRIPTION
Add a list of known / required designs to the bitstreams workspace generator, and for cache entries that do not contain all the designs, redirect the targets back to the Vivado-built ones.

This eliminates errors that may happen during the analysis phase due to missing referenced targets. Previously, if the bitstreams cache was missing an entry, the targets would not be created in the @bitstreams repo. Now, those targets will always exist, and builds may continue even when the cache entry is incomplete.