### PR TITLE
[bazel] Reorganize and simplify the bitstream targets

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -57,31 +57,17 @@ config_setting(
 )
 
 filegroup(
-    name = "test_rom",
+    name = "bitstream",
     testonly = True,
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],
-        "bitstream_gcp_splice": [":gcp_spliced_test_rom"],
-        "//conditions:default": [":gcp_spliced_test_rom"],
+        "bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_bitstream"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_bitstream"],
     }),
     tags = ["manual"],
+    visibility = ["//visibility:private"],
 )
-
-[
-    filegroup(
-        name = "rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        srcs = select({
-            "bitstream_skip": ["skip.bit"],
-            "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_with_{}_keys".format(authenticity)],
-            "bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
-            "//conditions:default": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
-        }),
-        tags = ["manual"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
 
 filegroup(
     name = "rom_mmi",
@@ -89,6 +75,7 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
+        "bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_rom_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_rom_mmi"],
     }),
     tags = ["manual"],
@@ -100,50 +87,33 @@ filegroup(
     srcs = select({
         "bitstream_skip": ["skip.bit"],
         "bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],
+        "bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_otp_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_otp_mmi"],
     }),
     tags = ["manual"],
 )
 
-[
-    filegroup(
-        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
-        testonly = True,
-        srcs = select({
-            "bitstream_skip": ["skip.bit"],
-            "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-            "bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-            "//conditions:default": [":gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-        }),
-        tags = ["manual"],
-    )
-    for (otp_name, _) in get_otp_images()
-    for authenticity in KEY_AUTHENTICITY
-]
-
-# Build the Test ROM and splice it into a cached bitstream.
+# Build the Test ROM and splice it into the bitstream.
 bitstream_splice(
-    name = "gcp_spliced_test_rom",
+    name = "test_rom",
     testonly = True,
-    src = "@bitstreams//:chip_earlgrey_cw310_bitstream",
+    src = ":bitstream",
     data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],
     update_usr_access = True,
-    visibility = ["//visibility:private"],
 )
 
 # Build the ROM and splice it into a cached bitstream.
 [
     bitstream_splice(
-        name = "gcp_spliced_rom_with_{}_keys".format(authenticity),
+        name = "rom_with_{}_keys".format(authenticity),
         testonly = True,
-        src = "@bitstreams//:chip_earlgrey_cw310_bitstream",
+        src = ":bitstream",
         data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw310_scr_vmem".format(authenticity),
         meminfo = ":rom_mmi",
         tags = ["manual"],
         update_usr_access = True,
-        visibility = ["//visibility:private"],
     )
     for authenticity in KEY_AUTHENTICITY
 ]
@@ -151,14 +121,13 @@ bitstream_splice(
 # Splice OTP images into the locally-spliced ROM bitstream.
 [
     bitstream_splice(
-        name = "gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
+        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
         testonly = True,
-        src = ":gcp_spliced_rom_with_{}_keys".format(authenticity),
+        src = ":rom_with_{}_keys".format(authenticity),
         data = img_target,
         meminfo = ":otp_mmi",
         tags = ["manual"],
         update_usr_access = True,
-        visibility = ["//visibility:private"],
     )
     for (otp_name, img_target) in get_otp_images()
     for authenticity in KEY_AUTHENTICITY

--- a/hw/bitstream/cw340/BUILD
+++ b/hw/bitstream/cw340/BUILD
@@ -12,77 +12,26 @@ KEY_AUTHENTICITY = [
 
 package(default_visibility = ["//visibility:public"])
 
-[
-    bitstream_splice(
-        name = "fpga_cw340_rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        src = "//hw/bitstream/vivado:fpga_cw340_test_rom",
-        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw340_scr_vmem".format(authenticity),
-        meminfo = "//hw/bitstream/vivado:fpga_cw340_rom_mmi",
-        tags = ["manual"],
-        visibility = ["//visibility:private"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
-
-bitstream_splice(
-    name = "gcp_spliced_test_rom",
-    testonly = True,
-    src = "@bitstreams//:chip_earlgrey_cw340_bitstream",
-    data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw340_scr_vmem",
-    meminfo = "@bitstreams//:chip_earlgrey_cw340_rom_mmi",
-    tags = ["manual"],
-    update_usr_access = True,
-    visibility = ["//visibility:private"],
-)
-
-[
-    bitstream_splice(
-        name = "gcp_spliced_rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        src = "@bitstreams//:chip_earlgrey_cw340_bitstream",
-        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw340_scr_vmem".format(authenticity),
-        meminfo = "@bitstreams//:chip_earlgrey_cw340_rom_mmi",
-        tags = ["manual"],
-        update_usr_access = True,
-        visibility = ["//visibility:private"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
-
 filegroup(
-    name = "test_rom",
+    name = "bitstream",
     testonly = True,
     srcs = select({
         "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
         "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_test_rom"],
-        "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_test_rom"],
-        "//conditions:default": [":gcp_spliced_test_rom"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw340_bitstream"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_bitstream"],
     }),
     tags = ["manual"],
+    visibility = ["//visibility:private"],
 )
-
-[
-    filegroup(
-        name = "rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        srcs = select({
-            "//hw/bitstream:bitstream_skip": ["skip.bit"],
-            "//hw/bitstream:bitstream_vivado": [":fpga_cw340_rom_with_{}_keys".format(authenticity)],
-            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
-            "//conditions:default": [":gcp_spliced_rom_with_fake_keys"],
-        }),
-        tags = ["manual"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
 
 filegroup(
     name = "rom_mmi",
     testonly = True,
     srcs = select({
-        "//hw/bitstream:bitstream_skip": ["skip.bit"],
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
         "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_rom_mmi"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw340_rom_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_rom_mmi"],
     }),
     tags = ["manual"],
@@ -92,9 +41,50 @@ filegroup(
     name = "otp_mmi",
     testonly = True,
     srcs = select({
-        "//hw/bitstream:bitstream_skip": ["skip.bit"],
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
         "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_otp_mmi"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw340_otp_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_otp_mmi"],
     }),
     tags = ["manual"],
 )
+
+# Build the Test ROM and splice it into the bitstream.
+bitstream_splice(
+    name = "test_rom",
+    testonly = True,
+    src = ":bitstream",
+    data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw340_scr_vmem",
+    meminfo = ":rom_mmi",
+    tags = ["manual"],
+    update_usr_access = True,
+)
+
+# Build the ROM and splice it into a cached bitstream.
+[
+    bitstream_splice(
+        name = "rom_with_{}_keys".format(authenticity),
+        testonly = True,
+        src = ":bitstream",
+        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw340_scr_vmem".format(authenticity),
+        meminfo = ":rom_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+    )
+    for authenticity in KEY_AUTHENTICITY
+]
+
+# Splice OTP images into the locally-spliced ROM bitstream.
+[
+    bitstream_splice(
+        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
+        testonly = True,
+        src = ":rom_with_{}_keys".format(authenticity),
+        data = img_target,
+        meminfo = ":otp_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+    )
+    for (otp_name, img_target) in get_otp_images()
+    for authenticity in KEY_AUTHENTICITY
+]

--- a/hw/bitstream/hyperdebug/BUILD
+++ b/hw/bitstream/hyperdebug/BUILD
@@ -9,38 +9,25 @@ load("//rules:const.bzl", "KEY_AUTHENTICITY")
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "test_rom",
+    name = "bitstream",
     testonly = True,
     srcs = select({
         "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
-        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],
-        "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_test_rom"],
-        "//conditions:default": [":gcp_spliced_test_rom"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom_hyp"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream"],
+        "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream"],
     }),
     tags = ["manual"],
+    visibility = ["//visibility:private"],
 )
-
-[
-    filegroup(
-        name = "rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        srcs = select({
-            "//hw/bitstream:bitstream_skip": ["skip.bit"],
-            "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_with_{}_keys".format(authenticity)],
-            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
-            "//conditions:default": [":gcp_spliced_rom_with_{}_keys".format(authenticity)],
-        }),
-        tags = ["manual"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
 
 filegroup(
     name = "rom_mmi",
     testonly = True,
     srcs = select({
-        "//hw/bitstream:bitstream_skip": ["skip.bit"],
-        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi"],
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:rom_mmi_hyp"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_rom_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_rom_mmi"],
     }),
     tags = ["manual"],
@@ -50,51 +37,35 @@ filegroup(
     name = "otp_mmi",
     testonly = True,
     srcs = select({
-        "//hw/bitstream:bitstream_skip": ["skip.bit"],
-        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi"],
+        "//hw/bitstream:bitstream_skip": ["//hw/bitstream:skip.bit"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:otp_mmi_hyp"],
+        "//hw/bitstream:bitstream_gcp_splice": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_otp_mmi"],
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw310_hyperdebug_otp_mmi"],
     }),
     tags = ["manual"],
 )
 
-[
-    filegroup(
-        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
-        testonly = True,
-        srcs = select({
-            "//hw/bitstream:bitstream_skip": ["skip.bit"],
-            "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-            "//hw/bitstream:bitstream_gcp_splice": [":gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-            "//conditions:default": [":gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name)],
-        }),
-        tags = ["manual"],
-    )
-    for (otp_name, _) in get_otp_images()
-    for authenticity in KEY_AUTHENTICITY
-]
-
-# Build the Test ROM and splice it into a cached bitstream.
+# Build the Test ROM and splice it into the bitstream.
 bitstream_splice(
-    name = "gcp_spliced_test_rom",
+    name = "test_rom",
     testonly = True,
-    src = "@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream",
+    src = ":bitstream",
     data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
     meminfo = ":rom_mmi",
     tags = ["manual"],
     update_usr_access = True,
-    visibility = ["//visibility:private"],
 )
 
+# Build the ROM and splice it into a cached bitstream.
 [
     bitstream_splice(
-        name = "gcp_spliced_rom_with_{}_keys".format(authenticity),
+        name = "rom_with_{}_keys".format(authenticity),
         testonly = True,
-        src = "@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream",
+        src = ":bitstream",
         data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw310_scr_vmem".format(authenticity),
         meminfo = ":rom_mmi",
         tags = ["manual"],
         update_usr_access = True,
-        visibility = ["//visibility:private"],
     )
     for authenticity in KEY_AUTHENTICITY
 ]
@@ -102,14 +73,13 @@ bitstream_splice(
 # Splice OTP images into the locally-spliced ROM bitstream.
 [
     bitstream_splice(
-        name = "gcp_spliced_rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
+        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
         testonly = True,
-        src = ":gcp_spliced_rom_with_{}_keys".format(authenticity),
+        src = ":rom_with_{}_keys".format(authenticity),
         data = img_target,
         meminfo = ":otp_mmi",
         tags = ["manual"],
         update_usr_access = True,
-        visibility = ["//visibility:private"],
     )
     for (otp_name, img_target) in get_otp_images()
     for authenticity in KEY_AUTHENTICITY

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -85,32 +85,6 @@ filegroup(
     tags = ["manual"],
 )
 
-[
-    bitstream_splice(
-        name = "fpga_cw310_rom_with_{}_keys".format(authenticity),
-        testonly = True,
-        src = "@bitstreams//:chip_earlgrey_cw310_bitstream",
-        data = "//sw/device/silicon_creator/rom:rom_with_{}_keys_fpga_cw310_scr_vmem".format(authenticity),
-        meminfo = ":rom_mmi",
-        tags = ["manual"],
-    )
-    for authenticity in KEY_AUTHENTICITY
-]
-
-# Splice OTP images into the ROM bitstream.
-[
-    bitstream_splice(
-        name = "fpga_cw310_rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
-        testonly = True,
-        src = ":fpga_cw310_rom_with_{}_keys".format(authenticity),
-        data = img_target,
-        meminfo = ":otp_mmi",
-        tags = ["manual"],
-    )
-    for (otp_name, img_target) in get_otp_images()
-    for authenticity in KEY_AUTHENTICITY
-]
-
 # Standalone CW310 image for use with hyperdebug.
 fusesoc_build(
     name = "fpga_cw310_hyperdebug",


### PR DESCRIPTION
This is an attempt at simplifying the bitstream targets. It also fixes some obviously wrong splices that look like the result of a bad copy/paste. @a-will 