### PR TITLE
[otp_ctrl] add test util to read OTP array

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -75,6 +75,21 @@ status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
   return OK_STATUS();
 }
 
+status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
+                                             dif_otp_ctrl_partition_t partition,
+                                             uint32_t start_address,
+                                             uint32_t *buffer, size_t len) {
+  uint32_t stop_address = start_address + (len * sizeof(uint32_t));
+  for (uint32_t addr = start_address, i = 0; addr < stop_address;
+       addr += sizeof(uint32_t), ++i) {
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(dif_otp_ctrl_dai_read_start(otp, partition, addr));
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(dif_otp_ctrl_dai_read32_end(otp, &buffer[i]));
+  }
+  return OK_STATUS();
+}
+
 status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
                                        dif_otp_ctrl_partition_t partition,
                                        uint32_t address, uint64_t *result) {
@@ -82,6 +97,21 @@ status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
   TRY(dif_otp_ctrl_dai_read_start(otp, partition, address));
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
   TRY(dif_otp_ctrl_dai_read64_end(otp, result));
+  return OK_STATUS();
+}
+
+status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
+                                             dif_otp_ctrl_partition_t partition,
+                                             uint32_t start_address,
+                                             uint64_t *buffer, size_t len) {
+  uint32_t stop_address = start_address + (len * sizeof(uint64_t));
+  for (uint32_t addr = start_address, i = 0; addr < stop_address;
+       addr += sizeof(uint64_t), ++i) {
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(dif_otp_ctrl_dai_read_start(otp, partition, addr));
+    TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(dif_otp_ctrl_dai_read64_end(otp, &buffer[i]));
+  }
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -56,6 +56,23 @@ status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
                                        uint32_t address, uint32_t *result);
 
 /**
+ * Reads a 32bit array from OTP using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param start_address Address of array relative to the start of the
+ *                      `partition`. Must be a 32bit aligned address.
+ * @param[out] buffer The 32bit array buffer.
+ * @param len The number of 32bit words to read into the buffer.
+ * @return OK_STATUS on successful read.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
+                                             dif_otp_ctrl_partition_t partition,
+                                             uint32_t start_address,
+                                             uint32_t *buffer, size_t len);
+
+/**
  * Reads a 64bit value from OTP using the DAI interface.
  *
  * @param otp otp_ctrl instance.
@@ -69,6 +86,23 @@ OT_WARN_UNUSED_RESULT
 status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
                                        dif_otp_ctrl_partition_t partition,
                                        uint32_t address, uint64_t *result);
+
+/**
+ * Reads a 64bit array from OTP using the DAI interface.
+ *
+ * @param otp otp_ctrl instance.
+ * @param partition OTP partition.
+ * @param start_address Address of array relative to the start of the
+ *                      `partition`. Must be a 64bit aligned address.
+ * @param[out] buffer The 64bit array buffer.
+ * @param len The number of 64bit words to read into the buffer.
+ * @return OK_STATUS on successful read.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
+                                             dif_otp_ctrl_partition_t partition,
+                                             uint32_t start_address,
+                                             uint64_t *buffer, size_t len);
 
 /**
  * Writes `len` number of 32bit words from buffer into otp `partition` starting


### PR DESCRIPTION
Adds testutils for reading OTP arrays, which is useful for provisioning code developement.