### PR TITLE
[pattgen,SiVal] Silicon validation testplan for pattern generator

### DIFF
--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -64,6 +64,29 @@
       local:   "true"
     }
   ],
+  features: [
+    { name: "PATTGEN.CHANNEL.ONE",
+      desc: "Pattern generator can generate patterns on two separate channels, this is the first one."
+    },
+    { name: "PATTGEN.CHANNEL.TWO",
+      desc: "Pattern generator can generate patterns on two separate channels, this is the second one."
+    },
+    { name: "PATTGEN.CONFIG.PATTERN",
+      desc: "Each channel can be programmed with a pattern with a length of between 1 and 64 bits, inclusive."
+    },
+    { name: "PATTGEN.CONFIG.DIVIDER",
+      desc: "Each channel has an independent clock divider."
+    },
+    { name: "PATTGEN.CONFIG.REPEAT",
+      desc: "Each channel can be configured to repeat the pattern up to 1024 times."
+    },
+    { name: "PATTGEN.CONFIG.POLARITY",
+      desc: "Each channel's clock can be inverted."
+    },
+    { name: "PATTGEN.COMPLETE",
+      desc: "Once a pattern is finished, an interrupt is raised."
+    }
+  ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -538,8 +538,26 @@
             - Verify that the correct pattern is seen on the IOs by hooking up the pattgen monitor.
             - Validate the reception of the done interrupt.
             - Verify both pattgen channels independently.
+
+            Notes for silicon targets:
+            - Repeat the above test for different patterns and lengths.
+            - Repeat the above test for different clock divider.
+            - Repeat the above test for different repeat values.
+            - Repeat the above test with the clock inverted.
+            - Repeat the above test while using both channels at the same time.
+            - Monitor the clock and data pins on the silicon test setup.
             '''
+      features: [
+        "PATTGEN.CHANNEL.ONE",
+        "PATTGEN.CHANNEL.TWO",
+        "PATTGEN.CONFIG.PATTERN",
+        "PATTGEN.CONFIG.DIVIDER",
+        "PATTGEN.CONFIG.REPEAT",
+        "PATTGEN.CONFIG.POLARITY",
+        "PATTGEN.COMPLETE"
+      ]
       stage: V2
+      si_stage: SV2
       tests: ["chip_sw_pattgen_ios"]
     }
 


### PR DESCRIPTION
This PR is based on previous silicon validation test plans. It really only contains one test, but it is simple enough that I don't think it is necessary to split it into separate tests. Happy to make adjustments based on feedback though.