### PR TITLE
[sram_ctrl] Initial part of sival testplan

### DIFF
--- a/hw/ip/sram_ctrl/README.md
+++ b/hw/ip/sram_ctrl/README.md
@@ -22,7 +22,7 @@ The SRAM controller contains the SRAM data and address scrambling device and pro
 
 ## Features
 
-- [Lightweight scrambling mechanism](../prim/doc/prim_ram_1p_scr.md#custom-substitution-permutation-network) based on the PRINCE prince cipher.
+- [Lightweight scrambling mechanism](../prim/doc/prim_ram_1p_scr.md#custom-substitution-permutation-network) based on the PRINCE cipher.
 - Key request logic for the lightweight memory and address scrambling device.
 - Alert sender and checking logic for detecting bus integrity failures.
 - LFSR-based memory initialization feature.

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -88,6 +88,49 @@
     },
   ]
 
+  features: [
+    { name: "SRAM_CTRL.INTEGRITY",
+      desc: '''
+        Words are stored with integrity bits (7 integrity bits for each 32 data bits).
+      '''
+    },
+    { name: "SRAM_CTRL.SCRAMBLED",
+      desc: '''
+        Backing memory is scrambled.
+        The scrambling depends on keys configurable by a CSR.
+      '''
+    },
+    { name: "SRAM_CTRL.LOCK_ON_ERROR",
+      desc: '''
+        The block disallows transactions and sends out an alert if it detects an error.
+        This can come from a bus integrity failure or from a message from the lifecycle controller.
+      '''
+    },
+    { name: "SRAM_CTRL.MEMSET",
+      desc: '''
+        The block can initialise the contents of memory with a pseudo-random stream.
+        This avoids leaking the cipher key (which would be possible with a CTR-based cipher).
+      '''
+    },
+    { name: "SRAM_CTRL.FETCH_ALLOW",
+      desc: '''
+        Access for instruction fetches can be allowed or disallowed.
+        Instruction fetches can be completely disallowed for an instance by a parameter.
+        If possible in this instance, the choice depends on either life-cycle state or a CSR.
+      '''
+    },
+    { name: "SRAM_CTRL.SUBWORD_ACCESS",
+      desc: '''
+        Sub-word reads and writes are supported.
+      '''
+    },
+    { name: "SRAM_CTRL.REGWEN",
+      desc: '''
+        Configuration can be locked, using a REGWEN CSR.
+      '''
+    },
+  ]
+
   /////////////////////////////
   // Intermodule Connections //
   /////////////////////////////

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -32,6 +32,7 @@
     "hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
   ]
 
@@ -1505,95 +1506,6 @@
             '''
       stage: V3
       tests: []
-    }
-
-    // SRAM (pre-verified IP) integration tests:
-    {
-      name: chip_sw_sram_scrambled_access
-      desc: '''Verify scrambled memory accesses to both main and retention SRAMs.
-
-            - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
-              done by the test_rom startup code).
-            - Trigger both SRAMs to fetch a new key and nonce from the OTP_CTRL
-            - Drive the CPU to perform random accesses to both RAMs and verify these operations
-              complete successfully by using the backdoor interface
-            - Fetch a new key from the OTP_CTRL and ensure that the previous contents cannot be
-              read anymore.
-            - Verify the validity of EDN's output to OTP_CTRL via assertions
-              (unique, non-zero data).
-            '''
-      stage: V2
-      tests: ["chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
-    }
-    {
-      name: chip_sw_sleep_sram_ret_contents
-      desc: '''Verify that the data within the retention SRAM survives low power entry-exit and reset.
-
-            Ensure that the data within the retention SRAM survives as described in this table.
-              |             Mode             | Scrambled | Data Preserved |
-              |:----------------------------:|:---------:|:--------------:|
-              |          Normal sleep        |    No     |       Yes      |
-              |           Deep sleep         |    No     |       Yes      |
-              | Reset due to a reset request |    No     |       Yes      |
-              |          Normal sleep        |    Yes    |       Yes      |
-              |           Deep sleep         |    Yes    |       Yes      |
-              | Reset due to a reset request |    Yes    |       No       |
-            '''
-      stage: V2
-      tests: ["chip_sw_sleep_sram_ret_contents"]
-    }
-    {
-      name: chip_sw_sram_execution
-      desc: '''Verify that CPU can fetch instructions from SRAM if enabled.
-
-            - Create the following combinations of 8 scenarios:
-              - The fetch enable bit in the HW_CFG partition of OTP controller set and not set.
-              - A life cycle state that enables (TEST_UNLOCKED, DEV or RMA) and disables (PROD)
-                hardware debug.
-              - The execution CSR programmed to be enabled and disabled.
-
-            - For both, main and the retention SRAM in each of these 8 scenarios:
-              - Load instruction data into the SRAMs.
-              - If the instruction execution is enabled, verify that the CPU can fetch and execute
-                the instruction from the SRAM correctly.
-              - If the instruction execution is not enabled, verify that the SRAM throws an error
-                response via an exception handler.
-
-            The following table indicates in which of these scenarios should the instruction
-            execution be enabled, for both, main and the retention SRAM instances.
-
-              | OTP HW_CFG[IFETCH] | HW_DEBUG_EN via LC state | EXEC CSR | MAIN SRAM | RET SRAM |
-              |:------------------:|:------------------------:|:--------:|:---------:|:--------:|
-              |          0         |             0            |     0    |  disabled | disabled |
-              |          0         |             0            |     1    |  disabled | disabled |
-              |          0         |             1            |     0    |  enabled  | disabled |
-              |          0         |             1            |     1    |  enabled  | disabled |
-              |          1         |             0            |     0    |  disabled | disabled |
-              |          1         |             0            |     1    |  enabled  | disabled |
-              |          1         |             1            |     0    |  disabled | disabled |
-              |          1         |             1            |     1    |  enabled  | disabled |
-
-            For the retention SRAM, instruction fetch is completely disabled via design parameter.
-            '''
-      stage: V2
-      tests: ["chip_sw_sram_ctrl_execution_main"]
-    }
-    {
-      name: chip_sw_sram_lc_escalation
-      desc: '''Verify the LC escalation path to the SRAMs.
-
-            - Configure the LC_CTRL to trigger an escalation request to the SRAMs.
-            - Verify that the SRAMs stop accepting and responding to new memory requests.
-            - Reset the system to exit the terminal escalation state.
-            - Re-initialize the SRAMs and verify that they can now respond correctly to
-              any further memory requests.
-
-            X-ref with chip_sw_all_escalation_resets and chip_sw_data_integrity.
-            '''
-      stage: V2
-      tests: ["chip_sw_all_escalation_resets",
-              "chip_sw_data_integrity_escalation"]
     }
 
     // OTP (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_sram_ctrl
+  testpoints: [
+    // SRAM (pre-verified IP) integration tests:
+    {
+      name: chip_sw_sram_scrambled_access
+      desc: '''Verify scrambled memory accesses to both main and retention SRAMs.
+
+            - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
+              done by the test_rom startup code).
+            - Trigger both SRAMs to fetch a new key and nonce from the OTP_CTRL
+            - Drive the CPU to perform random accesses to both RAMs and verify these operations
+              complete successfully by using the backdoor interface
+            - Fetch a new key from the OTP_CTRL and ensure that the previous contents cannot be
+              read anymore.
+            - Verify the validity of EDN's output to OTP_CTRL via assertions
+              (unique, non-zero data).
+            '''
+      stage: V2
+      tests: ["chip_sw_sram_ctrl_scrambled_access",
+              "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
+    }
+    {
+      name: chip_sw_sleep_sram_ret_contents
+      desc: '''Verify that the data within the retention SRAM survives low power entry-exit and reset.
+
+            Ensure that the data within the retention SRAM survives as described in this table.
+              |             Mode             | Scrambled | Data Preserved |
+              |:----------------------------:|:---------:|:--------------:|
+              |          Normal sleep        |    No     |       Yes      |
+              |           Deep sleep         |    No     |       Yes      |
+              | Reset due to a reset request |    No     |       Yes      |
+              |          Normal sleep        |    Yes    |       Yes      |
+              |           Deep sleep         |    Yes    |       Yes      |
+              | Reset due to a reset request |    Yes    |       No       |
+            '''
+      stage: V2
+      tests: ["chip_sw_sleep_sram_ret_contents"]
+    }
+    {
+      name: chip_sw_sram_execution
+      desc: '''Verify that CPU can fetch instructions from SRAM if enabled.
+
+            - Create the following combinations of 8 scenarios:
+              - The fetch enable bit in the HW_CFG partition of OTP controller set and not set.
+              - A life cycle state that enables (TEST_UNLOCKED, DEV or RMA) and disables (PROD)
+                hardware debug.
+              - The execution CSR programmed to be enabled and disabled.
+
+            - For both, main and the retention SRAM in each of these 8 scenarios:
+              - Load instruction data into the SRAMs.
+              - If the instruction execution is enabled, verify that the CPU can fetch and execute
+                the instruction from the SRAM correctly.
+              - If the instruction execution is not enabled, verify that the SRAM throws an error
+                response via an exception handler.
+
+            The following table indicates in which of these scenarios should the instruction
+            execution be enabled, for both, main and the retention SRAM instances.
+
+              | OTP HW_CFG[IFETCH] | HW_DEBUG_EN via LC state | EXEC CSR | MAIN SRAM | RET SRAM |
+              |:------------------:|:------------------------:|:--------:|:---------:|:--------:|
+              |          0         |             0            |     0    |  disabled | disabled |
+              |          0         |             0            |     1    |  disabled | disabled |
+              |          0         |             1            |     0    |  enabled  | disabled |
+              |          0         |             1            |     1    |  enabled  | disabled |
+              |          1         |             0            |     0    |  disabled | disabled |
+              |          1         |             0            |     1    |  enabled  | disabled |
+              |          1         |             1            |     0    |  disabled | disabled |
+              |          1         |             1            |     1    |  enabled  | disabled |
+
+            For the retention SRAM, instruction fetch is completely disabled via design parameter.
+            '''
+      stage: V2
+      tests: ["chip_sw_sram_ctrl_execution_main"]
+    }
+    {
+      name: chip_sw_sram_lc_escalation
+      desc: '''Verify the LC escalation path to the SRAMs.
+
+            - Configure the LC_CTRL to trigger an escalation request to the SRAMs.
+            - Verify that the SRAMs stop accepting and responding to new memory requests.
+            - Reset the system to exit the terminal escalation state.
+            - Re-initialize the SRAMs and verify that they can now respond correctly to
+              any further memory requests.
+
+            X-ref with chip_sw_all_escalation_resets and chip_sw_data_integrity.
+            '''
+      stage: V2
+      tests: ["chip_sw_all_escalation_resets",
+              "chip_sw_data_integrity_escalation"]
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -18,8 +18,14 @@
               read anymore.
             - Verify the validity of EDN's output to OTP_CTRL via assertions
               (unique, non-zero data).
+
+            Note: In simulation, this uses a backdoor interface. However, most of the test should be
+                  possible on a silicon target (with no EDN assertions, and no backdoor accesses to
+                  check operations).
             '''
+      features: ["SRAM_CTRL.SCRAMBLED"]
       stage: V2
+      si_stage: SV2
       tests: ["chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
     }
@@ -36,8 +42,14 @@
               |          Normal sleep        |    Yes    |       Yes      |
               |           Deep sleep         |    Yes    |       Yes      |
               | Reset due to a reset request |    Yes    |       No       |
+
+            Notes for silicon targets:
+            - This test has an empty list of associated "features" because those list block-level
+              features and this is really testing a chip-level property.
             '''
+      features: []
       stage: V2
+      si_stage: SV3
       tests: ["chip_sw_sleep_sram_ret_contents"]
     }
     {
@@ -72,8 +84,17 @@
               |          1         |             1            |     1    |  enabled  | disabled |
 
             For the retention SRAM, instruction fetch is completely disabled via design parameter.
+
+            Notes for silicon targets:
+
+            - This test will be reasonably trivial for silicon validation, because the behaviour
+              depends on lifecycle state and we're expecting to do these tests on PROD silicon,
+              where execution from SRAM is disallowed.
+
             '''
+      features: ["SRAM_CTRL.FETCH_ALLOW"]
       stage: V2
+      si_stage: SV3
       tests: ["chip_sw_sram_ctrl_execution_main"]
     }
     {
@@ -88,7 +109,9 @@
 
             X-ref with chip_sw_all_escalation_resets and chip_sw_data_integrity.
             '''
+      features: ["SRAM_CTRL.LOCK_ON_ERROR"]
       stage: V2
+      si_stage: SV3
       tests: ["chip_sw_all_escalation_resets",
               "chip_sw_data_integrity_escalation"]
     }


### PR DESCRIPTION
This PR isn't all that clever: it's just re-arranging things to match the "sival-enabled" format that we're expecting to use. This adds feature/sv_stage tags to existing tests, but doesn't define any new ones. Those can come next, but I thought it was worth splitting out reviewing the refactor and reviewing new proposed tests.