### PR TITLE
[crypto] Update DRBG interface and improve testing.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -34,6 +34,7 @@ cc_library(
     hdrs = ["//sw/device/lib/crypto/include:drbg.h"],
     deps = [
         ":status",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/include:datatypes",
     ],

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/drbg.h"
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -24,7 +25,7 @@
  * @return OK or error.
  */
 static crypto_status_t seed_material_construct(
-    crypto_byte_buf_t value, entropy_seed_material_t *seed_material) {
+    crypto_const_byte_buf_t value, entropy_seed_material_t *seed_material) {
   if (value.len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -59,7 +60,7 @@ static crypto_status_t seed_material_construct(
  * @return OK or error.
  */
 static crypto_status_t seed_material_xor(
-    crypto_byte_buf_t value, entropy_seed_material_t *seed_material) {
+    crypto_const_byte_buf_t value, entropy_seed_material_t *seed_material) {
   if (value.len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -82,7 +83,8 @@ static crypto_status_t seed_material_xor(
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_drbg_instantiate(crypto_byte_buf_t perso_string) {
+crypto_status_t otcrypto_drbg_instantiate(
+    crypto_const_byte_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -96,7 +98,7 @@ crypto_status_t otcrypto_drbg_instantiate(crypto_byte_buf_t perso_string) {
                                    &seed_material);
 }
 
-crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input) {
+crypto_status_t otcrypto_drbg_reseed(crypto_const_byte_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -110,7 +112,7 @@ crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input) {
 }
 
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_byte_buf_t entropy, crypto_byte_buf_t perso_string) {
+    crypto_const_byte_buf_t entropy, crypto_const_byte_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -130,7 +132,7 @@ crypto_status_t otcrypto_drbg_manual_instantiate(
 }
 
 crypto_status_t otcrypto_drbg_manual_reseed(
-    crypto_byte_buf_t entropy, crypto_byte_buf_t additional_input) {
+    crypto_const_byte_buf_t entropy, crypto_const_byte_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -149,36 +151,52 @@ crypto_status_t otcrypto_drbg_manual_reseed(
                               &seed_material);
 }
 
-crypto_status_t otcrypto_drbg_generate(crypto_byte_buf_t additional_input,
-                                       size_t output_len,
-                                       crypto_byte_buf_t *drbg_output) {
-  if (output_len == 0) {
+/**
+ * Common function for random-bit generation.
+ *
+ * Used for both `otcrypto_drbg_generate` and `otcrypto_drbg_manual_generate`,
+ * which have the same implementation except for one flag that determines
+ * whether we check that the flag for FIPS compatibility is true.
+ *
+ * @param additional_input Additional input to DRBG
+ * @param fips_check Whether to check FIPS hardware flags
+ * @param[out] drbg_output Buffer for output
+ * @return Result status; OK or error
+ */
+static crypto_status_t generate(hardened_bool_t fips_check,
+                                crypto_const_byte_buf_t additional_input,
+                                crypto_word32_buf_t *drbg_output) {
+  if (drbg_output == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (drbg_output->len == 0) {
     // Nothing to do.
     return OTCRYPTO_OK;
   }
-
-  // Check for NULL pointers or bad length.
-  if (additional_input.len != 0 && additional_input.data == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (drbg_output == NULL || drbg_output->data == NULL ||
-      drbg_output->len != output_len) {
+  if ((additional_input.len != 0 && additional_input.data == NULL) ||
+      drbg_output->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   entropy_seed_material_t seed_material;
   seed_material_construct(additional_input, &seed_material);
-
-  size_t nwords = (output_len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
-  uint32_t output_words[nwords];
-  HARDENED_TRY(entropy_csrng_generate(&seed_material, output_words, nwords,
-                                      /*fips_check=*/kHardenedBoolFalse));
-
-  // Copy result into destination buffer.
-  // TODO(#17711) Change to `hardened_memcpy`.
-  memcpy(drbg_output->data, output_words, output_len);
+  HARDENED_TRY(entropy_csrng_generate(&seed_material, drbg_output->data,
+                                      drbg_output->len, fips_check));
 
   return OTCRYPTO_OK;
+}
+
+crypto_status_t otcrypto_drbg_generate(crypto_const_byte_buf_t additional_input,
+                                       crypto_word32_buf_t *drbg_output) {
+  return generate(/*fips_check=*/kHardenedBoolTrue, additional_input,
+                  drbg_output);
+}
+
+crypto_status_t otcrypto_drbg_manual_generate(
+    crypto_const_byte_buf_t additional_input,
+    crypto_word32_buf_t *drbg_output) {
+  return generate(/*fips_check=*/kHardenedBoolFalse, additional_input,
+                  drbg_output);
 }
 
 crypto_status_t otcrypto_drbg_uninstantiate(void) {

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -19,30 +19,34 @@ extern "C" {
 /**
  * Instantiates the DRBG system.
  *
- * Initializes the DRBG and the context for DRBG. Gets the required
- * entropy input automatically from the entropy source.
+ * Initializes the DRBG and the context for DRBG. Gets the required entropy
+ * input automatically from the entropy source.
+ *
+ * The personalization string may empty, and may be up to 48 bytes long; any
+ * longer will result in an error.
  *
  * @param perso_string Pointer to personalization bitstring.
  * @return Result of the DRBG instantiate operation.
  */
-crypto_status_t otcrypto_drbg_instantiate(crypto_byte_buf_t perso_string);
+crypto_status_t otcrypto_drbg_instantiate(crypto_const_byte_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
  *
- * Reseeds the DRBG with fresh entropy that is automatically fetched
- * from the entropy source and updates the working state parameters.
+ * Reseeds the DRBG with fresh entropy that is automatically fetched from the
+ * entropy source and updates the working state parameters.
  *
  * @param additional_input Pointer to the additional input for DRBG.
  * @return Result of the DRBG reseed operation.
  */
-crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input);
+crypto_status_t otcrypto_drbg_reseed(crypto_const_byte_buf_t additional_input);
 
 /**
  * Instantiates the DRBG system.
  *
- * Initializes DRBG and the DRBG context. Gets the required entropy
- * input from the user through the `entropy` parameter.
+ * Initializes DRBG and the DRBG context. Gets the required entropy input from
+ * the user through the `entropy` parameter. Calling this function breaks FIPS
+ * compliance until the DRBG is uninstantiated.
  *
  * The entropy input must be exactly 384 bits long (48 bytes). The
  * personalization string must not be longer than the entropy input, and may be
@@ -53,45 +57,63 @@ crypto_status_t otcrypto_drbg_reseed(crypto_byte_buf_t additional_input);
  * @return Result of the DRBG manual instantiation.
  */
 crypto_status_t otcrypto_drbg_manual_instantiate(
-    crypto_byte_buf_t entropy, crypto_byte_buf_t perso_string);
+    crypto_const_byte_buf_t entropy, crypto_const_byte_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
  *
- * Reseeds the DRBG with entropy input from the user through `entropy`
- * parameter and updates the working state parameters.
+ * Reseeds the DRBG with entropy input from the user through the `entropy`
+ * parameter and updates the working state parameters. Calling this function
+ * breaks FIPS compliance until the DRBG is uninstantiated.
  *
  * @param entropy Pointer to the user defined entropy value.
  * @param additional_input Pointer to the additional input for DRBG.
  * @return Result of the manual DRBG reseed operation.
  */
-crypto_status_t otcrypto_drbg_manual_reseed(crypto_byte_buf_t entropy,
-                                            crypto_byte_buf_t additional_input);
+crypto_status_t otcrypto_drbg_manual_reseed(
+    crypto_const_byte_buf_t entropy, crypto_const_byte_buf_t additional_input);
 
 /**
  * DRBG function for generating random bits.
  *
- * Used to generate pseudo random bits after DRBG instantiation or
- * DRBG reseeding.
+ * This function checks the hardware flags for FIPS compatibility of the
+ * generated bits, so it will fail after `otcrypto_drbg_manual_instantiate` or
+ * `otcrypto_drbg_manual_reseed`.
  *
- * The caller should allocate space for the `drbg_output` buffer,
- * (of length `output_len`), and set the length of expected
- * output in the `len` field of `drbg_output`. If the user-set length
- * and the output length does not match, an error message will be
- * returned.
+ * The caller should allocate space for the `drbg_output` buffer and set the
+ * length of expected output in the `len` field.
  *
- * The output is generated in 16-byte blocks; if `output_len` is not a multiple
- * of 16, some output from the hardware will be discarded. This detail may be
- * important for known-answer tests.
+ * The output is generated in 16-byte blocks; if `drbg_output->len` is not a
+ * multiple of 4, some output from the hardware will be discarded. This detail
+ * may be important for known-answer tests.
  *
  * @param additional_input Pointer to the additional data.
- * @param output_len Required len of pseudorandom output, in bytes.
  * @param[out] drbg_output Pointer to the generated pseudo random bits.
  * @return Result of the DRBG generate operation.
  */
-crypto_status_t otcrypto_drbg_generate(crypto_byte_buf_t additional_input,
-                                       size_t output_len,
-                                       crypto_byte_buf_t *drbg_output);
+crypto_status_t otcrypto_drbg_generate(crypto_const_byte_buf_t additional_input,
+                                       crypto_word32_buf_t *drbg_output);
+
+/**
+ * DRBG function for generating random bits.
+ *
+ * This function does NOT check the hardware flags for FIPS compatibility of the
+ * generated bits, so it may be called after `otcrypto_drbg_manual_instantiate`
+ * or `otcrypto_drbg_manual_reseed`.
+ *
+ * The caller should allocate space for the `drbg_output` buffer and set the
+ * length of expected output in the `len` field.
+ *
+ * The output is generated in 16-byte blocks; if `drbg_output->len` is not a
+ * multiple of 4, some output from the hardware will be discarded. This detail
+ * may be important for known-answer tests.
+ *
+ * @param additional_input Pointer to the additional data.
+ * @param[out] drbg_output Pointer to the generated pseudo random bits.
+ * @return Result of the DRBG generate operation.
+ */
+crypto_status_t otcrypto_drbg_manual_generate(
+    crypto_const_byte_buf_t additional_input, crypto_word32_buf_t *drbg_output);
 
 /**
  * Uninstantiates DRBG and clears the context.

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -310,6 +310,15 @@ cc_library(
 )
 
 cc_library(
+    name = "randomness_quality",
+    srcs = ["randomness_quality.c"],
+    hdrs = ["randomness_quality.h"],
+    deps = [
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+cc_library(
     name = "rstmgr_testutils",
     srcs = ["rstmgr_testutils.c"],
     hdrs = ["rstmgr_testutils.h"],

--- a/sw/device/lib/testing/randomness_quality.c
+++ b/sw/device/lib/testing/randomness_quality.c
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/randomness_quality.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+enum {
+  /**
+   * Thresholds for the monobit test (alpha=0.05), 5% false negative rate.
+   *
+   * Based on the Handbook of Applied Cryptography, Table 5.2 and section
+   * 5.4.4. To avoid floating-point arithmetic we represent the threshold value
+   * as a fraction.
+   */
+  kMonobitFivePercentThresholdNumerator = 38415,
+  kMonobitFivePercentThresholdDenominator = 10000,
+  /**
+   * Thresholds for the monobit test (alpha=0.01), 1% false negative rate.
+   *
+   * Based on the Handbook of Applied Cryptography, Table 5.2 and section
+   * 5.4.4. To avoid floating-point arithmetic we represent the threshold value
+   * as a fraction.
+   */
+  kMonobitOnePercentThresholdNumerator = 66349,
+  kMonobitOnePercentThresholdDenominator = 10000,
+};
+
+/**
+ * Get the square of the difference of two numbers.
+ *
+ * @param a First operand.
+ * @param b Second operand.
+ * @return Result, (a - b)^2
+ */
+static uint64_t diff_squared(uint64_t a, uint64_t b) {
+  if (a <= b) {
+    return (b - a) * (b - a);
+  }
+  return (a - b) * (a - b);
+}
+
+status_t randomness_quality_monobit_test(
+    uint8_t *data, size_t len, randomness_quality_threshold_t threshold) {
+  // Guard against overflow in the bit-count.
+  TRY_CHECK(len <= UINT32_MAX);
+
+  // Count the number of zeroes and the number of ones in the data.
+  uint32_t num_ones = 0;
+  uint32_t num_zeroes = 0;
+  for (size_t i = 0; i < len; i++) {
+    uint8_t byte = data[i];
+    for (size_t j = 0; j < 8; j++) {
+      num_ones += byte & 1;
+      num_zeroes += (byte ^ 1) & 1;
+      byte >>= 1;
+    }
+  }
+
+  // Numerical result of the test is (#zeroes - #ones)^2 / bitlen.
+  uint64_t numerator = diff_squared(num_ones, num_zeroes);
+  uint64_t denominator = len * 8;
+
+  // Retrieve the threshold values.
+  uint64_t threshold_numerator = 0;
+  uint64_t threshold_denominator = 1;
+  switch (threshold) {
+    case kRandomnessQualityThresholdFivePercent: {
+      threshold_numerator = kMonobitFivePercentThresholdNumerator;
+      threshold_denominator = kMonobitFivePercentThresholdDenominator;
+      break;
+    }
+    case kRandomnessQualityThresholdOnePercent: {
+      threshold_numerator = kMonobitOnePercentThresholdNumerator;
+      threshold_denominator = kMonobitOnePercentThresholdDenominator;
+      break;
+    }
+    default:
+      return INVALID_ARGUMENT();
+  }
+
+  // Return true if the result value is <= to the threshold.
+  uint64_t lhs = (numerator * threshold_denominator);
+  uint64_t rhs = (threshold_numerator * denominator);
+  TRY_CHECK(lhs <= rhs);
+
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/randomness_quality.c
+++ b/sw/device/lib/testing/randomness_quality.c
@@ -43,7 +43,7 @@ static uint64_t diff_squared(uint64_t a, uint64_t b) {
 }
 
 status_t randomness_quality_monobit_test(
-    uint8_t *data, size_t len, randomness_quality_threshold_t threshold) {
+    uint8_t *data, size_t len, randomness_quality_significance_t significance) {
   // Guard against overflow in the bit-count.
   TRY_CHECK(len <= UINT32_MAX);
 
@@ -66,13 +66,13 @@ status_t randomness_quality_monobit_test(
   // Retrieve the threshold values.
   uint64_t threshold_numerator = 0;
   uint64_t threshold_denominator = 1;
-  switch (threshold) {
-    case kRandomnessQualityThresholdFivePercent: {
+  switch (significance) {
+    case kRandomnessQualitySignificanceFivePercent: {
       threshold_numerator = kMonobitFivePercentThresholdNumerator;
       threshold_denominator = kMonobitFivePercentThresholdDenominator;
       break;
     }
-    case kRandomnessQualityThresholdOnePercent: {
+    case kRandomnessQualitySignificanceOnePercent: {
       threshold_numerator = kMonobitOnePercentThresholdNumerator;
       threshold_denominator = kMonobitOnePercentThresholdDenominator;
       break;

--- a/sw/device/lib/testing/randomness_quality.h
+++ b/sw/device/lib/testing/randomness_quality.h
@@ -14,22 +14,23 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Test failure probability setting.
+ * Test statistical significance setting.
  *
  * The statistical tests in this file will always fail with some probability,
  * even on truly random data. Use these settings to toggle the threshold
- * values.
+ * values. In the Handbook of Applied Cryptography, this setting is denoted
+ * with the Greek letter alpha.
  */
-typedef enum randomness_quality_threshold {
+typedef enum randomness_quality_significance {
   /**
    * Set thresholds for a 5% failure rate on truly random data (alpha = 0.05).
    */
-  kRandomnessQualityThresholdFivePercent,
+  kRandomnessQualitySignificanceFivePercent,
   /**
    * Set thresholds for a 1% failure rate on truly random data (alpha = 0.01).
    */
-  kRandomnessQualityThresholdOnePercent,
-} randomness_quality_threshold_t;
+  kRandomnessQualitySignificanceOnePercent,
+} randomness_quality_significance_t;
 
 /**
  * Monobit test from section 5.4.4 of the Handbook of Applied Cryptography.
@@ -39,11 +40,11 @@ typedef enum randomness_quality_threshold {
  *
  * @param data Random data to check.
  * @param len Length of data.
- * @param threshold Test threshold setting.
+ * @param significance Test statistical significance setting.
  * @return OK if the test passes, a failure code otherwise.
  */
 status_t randomness_quality_monobit_test(
-    uint8_t *data, size_t len, randomness_quality_threshold_t threshold);
+    uint8_t *data, size_t len, randomness_quality_significance_t significance);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/testing/randomness_quality.h
+++ b/sw/device/lib/testing/randomness_quality.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_RANDOMNESS_QUALITY_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_RANDOMNESS_QUALITY_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Test failure probability setting.
+ *
+ * The statistical tests in this file will always fail with some probability,
+ * even on truly random data. Use these settings to toggle the threshold
+ * values.
+ */
+typedef enum randomness_quality_threshold {
+  /**
+   * Set thresholds for a 5% failure rate on truly random data (alpha = 0.05).
+   */
+  kRandomnessQualityThresholdFivePercent,
+  /**
+   * Set thresholds for a 1% failure rate on truly random data (alpha = 0.01).
+   */
+  kRandomnessQualityThresholdOnePercent,
+} randomness_quality_threshold_t;
+
+/**
+ * Monobit test from section 5.4.4 of the Handbook of Applied Cryptography.
+ *
+ * This test counts the number of zero and one bits in the data and expects the
+ * number to be roughly similar.
+ *
+ * @param data Random data to check.
+ * @param len Length of data.
+ * @param threshold Test threshold setting.
+ * @return OK if the test passes, a failure code otherwise.
+ */
+status_t randomness_quality_monobit_test(
+    uint8_t *data, size_t len, randomness_quality_threshold_t threshold);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_RANDOMNESS_QUALITY_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -115,6 +115,7 @@ opentitan_functest(
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:drbg",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:randomness_quality",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -66,7 +66,7 @@ static status_t random_test(void) {
   TRY(otcrypto_drbg_instantiate(/*perso_string=*/kEmptyBuffer));
 
   // Generate a relatively large amount of output data.
-  uint32_t output_data[4096];
+  uint32_t output_data[1024];
   crypto_word32_buf_t output = {
       .data = output_data,
       .len = ARRAYSIZE(output_data),
@@ -74,9 +74,9 @@ static status_t random_test(void) {
   TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer, &output));
 
   // Run a basic randomness-quality check on the output.
-  return randomness_quality_monobit_test((unsigned char *)output_data,
-                                         sizeof(output_data),
-                                         kRandomnessQualityThresholdOnePercent);
+  return randomness_quality_monobit_test(
+      (unsigned char *)output_data, sizeof(output_data),
+      kRandomnessQualitySignificanceOnePercent);
 }
 
 bool test_main(void) {

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -15,17 +15,17 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static uint32_t kTestSeed[12] = {
+static const uint32_t kTestSeed[12] = {
     0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5, 0xdfec9db3,
     0xcb7a879d, 0x5600419c, 0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa};
 // Note that the word order in the expected output is reversed compared to the
 // NIST reference.
-static uint32_t kExpOutput[16] = {
+static const uint32_t kExpOutput[16] = {
     0xd1c07cd9, 0x5af8a7f1, 0x1012c84c, 0xe48bb8cb, 0x87189e99, 0xd40fccb1,
     0x771c619b, 0xdf82ab22, 0x80b1dc2f, 0x2581f391, 0x64f7ac0c, 0x510494b3,
     0xa43c41b7, 0xdb17514c, 0x87b107ae, 0x793e01c5,
 };
-static const crypto_byte_buf_t kEmptyBuffer = {
+static const crypto_const_byte_buf_t kEmptyBuffer = {
     .data = NULL,
     .len = 0,
 };
@@ -40,8 +40,8 @@ static status_t entropy_complex_init_test(void) {
 }
 
 static status_t kat_test(void) {
-  crypto_byte_buf_t entropy = {
-      .data = (unsigned char *)kTestSeed,
+  crypto_const_byte_buf_t entropy = {
+      .data = (const unsigned char *)kTestSeed,
       .len = sizeof(kTestSeed),
   };
 
@@ -49,18 +49,18 @@ static status_t kat_test(void) {
   TRY(otcrypto_drbg_manual_instantiate(entropy, /*perso_string=*/kEmptyBuffer));
 
   uint32_t actual_output_words[ARRAYSIZE(kExpOutput)];
-  crypto_byte_buf_t actual_output = {
-      .data = (unsigned char *)actual_output_words,
-      .len = sizeof(actual_output_words),
+  crypto_word32_buf_t actual_output = {
+      .data = actual_output_words,
+      .len = ARRAYSIZE(actual_output_words),
   };
 
   // Generate output twice.
   LOG_INFO("Generating...");
-  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer,
-                             sizeof(kExpOutput), &actual_output));
+  TRY(otcrypto_drbg_manual_generate(/*additional_input=*/kEmptyBuffer,
+                                    &actual_output));
   LOG_INFO("Generating again...");
-  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer,
-                             sizeof(kExpOutput), &actual_output));
+  TRY(otcrypto_drbg_manual_generate(/*additional_input=*/kEmptyBuffer,
+                                    &actual_output));
 
   // Compare second result to expected output.
   TRY_CHECK_ARRAYS_EQ(kExpOutput, actual_output_words, ARRAYSIZE(kExpOutput));


### PR DESCRIPTION
A few minor updates to the DRBG interface and testing:
- Changes the DRBG interface to use word buffers for output
- Makes usage of `const` in the DRBG interface a little more consistent
- Adds a library with a basic statistical randomness-quality check
- Adds a DRBG test that uses the non-manual interface and a randomness-quality check

Ideally I'd like to add more tests beyond just the one that's there now, but for now it's better than nothing; for now I just wanted to have some kind of check running in CI on the non-manual DRBG interface.