### PR TITLE
[codeowners] Remove @milesdai from CI codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,5 +56,5 @@ COPYING*            @mundaym
 /util/licence-checker.hjson  @mundaym
 
 # CI and testing
-/ci/                @milesdai @rswarbrick
-azure-pipelines.yml @milesdai @rswarbrick
+/ci/                @rswarbrick
+azure-pipelines.yml @rswarbrick


### PR DESCRIPTION
I'm spending less time on the CI now, and this helps reduce my email volume.