### PR TITLE
[manuf] complete CP provisioning binary functest

### DIFF
--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -19,7 +19,10 @@ package(default_visibility = ["//visibility:public"])
 
 opentitan_ram_binary(
     name = "sram_cp_provision",
-    srcs = ["sram_cp_provision.c"],
+    srcs = [
+        "consts.h",
+        "sram_cp_provision.c",
+    ],
     hdrs = ["sram_cp_provision.h"],
     archive_symbol_prefix = "sram_cp_provision",
     deps = [
@@ -53,9 +56,12 @@ opentitan_ram_binary(
 
 opentitan_ram_binary(
     name = "sram_cp_provision_functest",
-    srcs = ["sram_cp_provision_functest.c"],
+    srcs = [
+        "consts.h",
+        "sram_cp_provision_functest.c",
+    ],
     hdrs = ["sram_cp_provision.h"],
-    archive_symbol_prefix = "sram_cp_provision",
+    archive_symbol_prefix = "sram_cp_provision_functest",
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_SKUS_EARLGREY_A0_GENERIC_CONSTS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_SKUS_EARLGREY_A0_GENERIC_CONSTS_H_
+
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+
+/**
+ * Access permissions for flash info page 0 (holds device_id and manuf_state).
+ */
+dif_flash_ctrl_region_properties_t kFlashInfoPage0Permissions = {
+    .ecc_en = kMultiBitBool4True,
+    .high_endurance_en = kMultiBitBool4False,
+    .erase_en = kMultiBitBool4True,
+    .prog_en = kMultiBitBool4True,
+    .rd_en = kMultiBitBool4True,
+    .scramble_en = kMultiBitBool4False};
+
+/**
+ * Access permissions for flash info page 3 (holds wafer_auth_secret).
+ */
+dif_flash_ctrl_region_properties_t kFlashInfoPage3WritePermissions = {
+    .ecc_en = kMultiBitBool4True,
+    .high_endurance_en = kMultiBitBool4False,
+    .erase_en = kMultiBitBool4True,
+    .prog_en = kMultiBitBool4True,
+    .rd_en = kMultiBitBool4False,
+    .scramble_en = kMultiBitBool4False};
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_SKUS_EARLGREY_A0_GENERIC_CONSTS_H_

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_cp_provision.c
@@ -23,6 +23,7 @@
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
 #include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
+#include "sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"  // Generated.
@@ -54,10 +55,10 @@ static status_t device_id_and_manuf_state_flash_info_page_erase(
     manuf_cp_provisioning_data_t *provisioning_data) {
   uint32_t byte_address = 0;
   // DeviceId and ManufState are located on the same flash info page.
-  TRY(flash_ctrl_testutils_info_region_setup(
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldDeviceId.page,
       kFlashInfoFieldDeviceId.bank, kFlashInfoFieldDeviceId.partition,
-      &byte_address));
+      kFlashInfoPage0Permissions, &byte_address));
   TRY(flash_ctrl_testutils_erase_page(&flash_ctrl_state, byte_address,
                                       kFlashInfoFieldDeviceId.partition,
                                       kDifFlashCtrlPartitionTypeInfo));
@@ -66,27 +67,23 @@ static status_t device_id_and_manuf_state_flash_info_page_erase(
 
 static status_t device_id_and_manuf_state_flash_info_page_write(
     manuf_cp_provisioning_data_t *provisioning_data) {
-  // Write DeviceId.
   uint32_t byte_address = 0;
-  TRY(flash_ctrl_testutils_info_region_setup(
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldDeviceId.page,
       kFlashInfoFieldDeviceId.bank, kFlashInfoFieldDeviceId.partition,
-      &byte_address));
+      kFlashInfoPage0Permissions, &byte_address));
+
+  // Write DeviceId.
   TRY(flash_ctrl_testutils_write(
       &flash_ctrl_state, byte_address, kFlashInfoFieldDeviceId.partition,
       provisioning_data->device_id, kDifFlashCtrlPartitionTypeInfo,
       kHwCfgDeviceIdSizeIn32BitWords));
 
-  // Write ManufState.
-  byte_address = 0;
-  TRY(flash_ctrl_testutils_info_region_setup(
-      &flash_ctrl_state, kFlashInfoFieldManufState.page,
-      kFlashInfoFieldManufState.bank, kFlashInfoFieldManufState.partition,
-      &byte_address));
+  // Write ManufState (on same page as DeviceId).
   TRY(flash_ctrl_testutils_write(
-      &flash_ctrl_state, byte_address, kFlashInfoFieldManufState.partition,
-      provisioning_data->manuf_state, kDifFlashCtrlPartitionTypeInfo,
-      kHwCfgManufStateSizeIn32BitWords));
+      &flash_ctrl_state, byte_address + kFlashInfoFieldManufState.byte_offset,
+      kFlashInfoFieldManufState.partition, provisioning_data->manuf_state,
+      kDifFlashCtrlPartitionTypeInfo, kHwCfgManufStateSizeIn32BitWords));
 
   return OK_STATUS();
 }
@@ -94,10 +91,11 @@ static status_t device_id_and_manuf_state_flash_info_page_write(
 static status_t wafer_auth_secret_flash_info_page_erase(
     manuf_cp_provisioning_data_t *provisioning_data) {
   uint32_t byte_address = 0;
-  TRY(flash_ctrl_testutils_info_region_setup(
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret.page,
       kFlashInfoFieldWaferAuthSecret.bank,
-      kFlashInfoFieldWaferAuthSecret.partition, &byte_address));
+      kFlashInfoFieldWaferAuthSecret.partition, kFlashInfoPage3WritePermissions,
+      &byte_address));
   TRY(flash_ctrl_testutils_erase_page(&flash_ctrl_state, byte_address,
                                       kFlashInfoFieldWaferAuthSecret.partition,
                                       kDifFlashCtrlPartitionTypeInfo));
@@ -107,10 +105,11 @@ static status_t wafer_auth_secret_flash_info_page_erase(
 static status_t wafer_auth_secret_flash_info_page_write(
     manuf_cp_provisioning_data_t *provisioning_data) {
   uint32_t byte_address = 0;
-  TRY(flash_ctrl_testutils_info_region_setup(
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret.page,
       kFlashInfoFieldWaferAuthSecret.bank,
-      kFlashInfoFieldWaferAuthSecret.partition, &byte_address));
+      kFlashInfoFieldWaferAuthSecret.partition, kFlashInfoPage3WritePermissions,
+      &byte_address));
   TRY(flash_ctrl_testutils_write(
       &flash_ctrl_state, byte_address, kFlashInfoFieldWaferAuthSecret.partition,
       provisioning_data->manuf_state, kDifFlashCtrlPartitionTypeInfo,


### PR DESCRIPTION
This tests the CP provisioning binary and fixes #19573.

In the process of writing the test, some bugs were fixed in the provisioning SRAM program.