### PR TITLE
[ottf] Allow printing cycle counts that don't fit in uint32_t.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,7 +175,7 @@ jobs:
 - job: sw_build
   displayName: Earl Grey SW Build & Test
   # Build and test Software for Earl Grey toplevel design
-  timeoutInMinutes: 180
+  timeoutInMinutes: 210
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
   pool: ci-public


### PR DESCRIPTION
Ask me how I ran into this one (it was RSA key generation). Doing the arithmetic to get microseconds here would require importing `math.h` and using `udiv64_slow` and also be annoying to print, so for the large cycle counts I just didn't print the microseconds.