### PR TITLE
[doc] Updates to crypto user guide doc

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -102,6 +102,11 @@ This way, a later version of the cryptolib can still recognize and interpret a d
 
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_lib_version }}
 
+The required security level for the blinded key is chosen using the enum below.
+At high security levels, the crypto library will prioritize protecting the key from sophisticated attacks, even at large performance costs. If the security level is low, the crypto library will still try to protect the key, but may forgo the most costly protections against it.
+
+{{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_key_security_level }}
+
 Data structures for key types and modes help the cryptolib recognize and prevent misuse of a key for the wrong algorithm or mode.
 
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h key_type }}
@@ -212,11 +217,11 @@ Additionally, the GHASH operation can be used to construct GCM with block cipher
 
 ### AES-KWP
 
-AES Key Wrapping with Padding (KWP) is an authenticated encryption scheme designed for encrypting cryptographic keys.
+Key Wrap with Padding (KWP) mode is used for the protection of cryptographic keys.
 AES-KWP is specified in [NIST SP800-38F][kwp-spec].
 
-{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_kwp_encrypt }}
-{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_kwp_decrypt }}
+{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_kwp_wrap }}
+{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_kwp_unwrap }}
 
 ## Hash functions
 

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -702,14 +702,14 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_aes_kwp_encrypt(
+crypto_status_t otcrypto_aes_kwp_wrap(
     const crypto_blinded_key_t *key_to_wrap,
     const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key) {
   // TODO: AES-KWP is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word32_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_unwrap(crypto_const_word32_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key) {
   // TODO: AES-KWP is not yet implemented.

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -702,16 +702,16 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
   return OTCRYPTO_OK;
 }
 
-crypto_status_t otcrypto_aes_kwp_wrap(
-    const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key) {
+crypto_status_t otcrypto_aes_kwp_wrap(const crypto_blinded_key_t *key_to_wrap,
+                                      const crypto_blinded_key_t *key_kek,
+                                      crypto_word32_buf_t *wrapped_key) {
   // TODO: AES-KWP is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
 crypto_status_t otcrypto_aes_kwp_unwrap(crypto_const_word32_buf_t wrapped_key,
-                                         const crypto_blinded_key_t *key_kek,
-                                         crypto_blinded_key_t *unwrapped_key) {
+                                        const crypto_blinded_key_t *key_kek,
+                                        crypto_blinded_key_t *unwrapped_key) {
   // TODO: AES-KWP is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -311,9 +311,9 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
                                       crypto_byte_buf_t output);
 
 /**
- * Performs the AES-KWP authenticated encryption operation.
+ * Performs the cryptographic key wrapping operation.
  *
- * This encrypt function takes an input key `key_to_wrap` and using
+ * This key wrap function takes an input key `key_to_wrap` and using
  * the encryption key `key_kek` outputs a wrapped key `wrapped_key`.
  *
  * The caller should allocate space for the `wrapped_key` buffer,
@@ -324,24 +324,24 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
  * @param key_to_wrap Pointer to the blinded key to be wrapped.
  * @param key_kek Input Pointer to the blinded encryption key.
  * @param[out] wrapped_key Pointer to the output wrapped key.
- * @return Result of the aes-kwp encrypt operation.
+ * @return Result of the aes-kwp wrap operation.
  */
-crypto_status_t otcrypto_aes_kwp_encrypt(
+crypto_status_t otcrypto_aes_kwp_wrap(
     const crypto_blinded_key_t *key_to_wrap,
     const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key);
 
 /**
- * Performs the AES-KWP authenticated decryption operation.
+ * Performs the cryptographic key unwrapping operation.
  *
- * This decrypt function takes a wrapped key `wrapped_key` and using
+ * This key unwrap function takes a wrapped key `wrapped_key` and using
  * encryption key `key_kek` outputs an unwrapped key `unwrapped_key`.
  *
  * @param wrapped_key Pointer to the input wrapped key.
  * @param key_kek Input Pointer to the blinded encryption key.
  * @param[out] unwrapped_key Pointer to the output unwrapped key struct.
- * @return Result of the aes-kwp decrypt operation.
+ * @return Result of the aes-kwp unwrap operation.
  */
-crypto_status_t otcrypto_aes_kwp_decrypt(crypto_const_word32_buf_t wrapped_key,
+crypto_status_t otcrypto_aes_kwp_unwrap(crypto_const_word32_buf_t wrapped_key,
                                          const crypto_blinded_key_t *key_kek,
                                          crypto_blinded_key_t *unwrapped_key);
 

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -326,9 +326,9 @@ crypto_status_t otcrypto_aes_gcm_gctr(const crypto_blinded_key_t *key,
  * @param[out] wrapped_key Pointer to the output wrapped key.
  * @return Result of the aes-kwp wrap operation.
  */
-crypto_status_t otcrypto_aes_kwp_wrap(
-    const crypto_blinded_key_t *key_to_wrap,
-    const crypto_blinded_key_t *key_kek, crypto_word32_buf_t *wrapped_key);
+crypto_status_t otcrypto_aes_kwp_wrap(const crypto_blinded_key_t *key_to_wrap,
+                                      const crypto_blinded_key_t *key_kek,
+                                      crypto_word32_buf_t *wrapped_key);
 
 /**
  * Performs the cryptographic key unwrapping operation.
@@ -342,8 +342,8 @@ crypto_status_t otcrypto_aes_kwp_wrap(
  * @return Result of the aes-kwp unwrap operation.
  */
 crypto_status_t otcrypto_aes_kwp_unwrap(crypto_const_word32_buf_t wrapped_key,
-                                         const crypto_blinded_key_t *key_kek,
-                                         crypto_blinded_key_t *unwrapped_key);
+                                        const crypto_blinded_key_t *key_kek,
+                                        crypto_blinded_key_t *unwrapped_key);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
1. Added the missing crypto_key_security_level enum.
2. Updated the AES-KWP function names as wrap/unwrap instead of encrypt/decrypt, to match NIST spec.