### PR TITLE
[crypto] Add symmetric key generation interface to cryptolib.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -173,13 +173,6 @@ Padding schemes are defined in the **aes\_padding\_t** structure from [this sect
 
 Because the crypto library uses the hardware AES block, it does not expose an init/update/final interface for AES, since this would risk locking up the block if an operation is not finalized.
 
-### Key generation
-
-Given a key configuration, generate an AES key.
-The key may be either randomly generated or derived using the key manager, depending on the configuration.
-
-{{#header-snippet sw/device/lib/crypto/include/aes.h otcrypto_aes_keygen }}
-
 ### Block Cipher
 
 A one-shot API initializes the required block cipher mode of operation (ECB, CBC, CFB, OFB or CTR) and performs the required encryption/decryption.
@@ -261,13 +254,6 @@ OpenTitan supports two kinds of message authentication codes (MACs):
 
 OpenTitan's [HMAC block][hmac] supports HMAC-SHA256 with a key length of 256 bits.
 The [KMAC block][kmac] supports KMAC128 and KMAC256, with a key length of 128, 192, 256, 384, or 512 bits.
-
-### Key Generation
-
-Given a key configuration, generate an HMAC or KMAC key.
-The key may be either randomly generated or derived using the key manager, depending on the configuration.
-
-{{#header-snippet sw/device/lib/crypto/include/mac.h otcrypto_mac_keygen }}
 
 ### One-shot mode
 
@@ -506,6 +492,14 @@ The crypto library provides four functions for this purpose:
 
 To import a private key generated elsewhere, for example, the user can call `otcrypto_build_blinded_key`.
 To export a blinded key, the user can convert it to an unblinded key, at which point the plain data is accessible.
+
+### Generate random keys
+
+{{#header-snippet sw/device/lib/crypto/include/key_transport.h otcrypto_symmetric_keygen }}
+
+### Package hardware-backed keys
+
+{{#header-snippet sw/device/lib/crypto/include/key_transport.h otcrypto_hw_backed_key }}
 
 ### Build Keys
 

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -121,6 +121,9 @@ cc_library(
     hdrs = ["//sw/device/lib/crypto/include:key_transport.h"],
     deps = [
         ":status",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -128,6 +128,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "key_transport_unittest",
+    srcs = ["key_transport_unittest.cc"],
+    deps = [
+        ":key_transport",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rsa",
     srcs = ["rsa.c"],

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/key_transport.h"
+
+#include <array>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+
+namespace key_transport_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+
+// Key configuration for testing (128-bit AES-CTR hardware-backed key).
+constexpr crypto_key_config_t kConfigCtr128 = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeAesCtr,
+    .key_length = 128 / 8,
+    .hw_backed = kHardenedBoolTrue,
+    .security_level = kSecurityLevelLow,
+};
+
+// Invalid RSA key configuration for testing (sideloaded RSA-2048 key).
+constexpr crypto_key_config_t kConfigRsaInvalid = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeRsaSignPkcs,
+    .key_length = 2048 / 8,
+    .hw_backed = kHardenedBoolTrue,
+    .security_level = kSecurityLevelLow,
+};
+
+TEST(Keyblob, HwBackedKeyToDiversificationData) {
+  uint32_t test_version = 0xf0f1f2f3;
+  std::array<uint32_t, 7> test_salt = {0x01234567, 0x89abcdef, 0x00010203,
+                                       0x04050607, 0x08090a0b, 0x0c0d0e0f,
+                                       0x10111213};
+
+  // Create a key handle from the test data.
+  uint32_t keyblob[32] = {0};
+  crypto_blinded_key_t key = {
+      .config = kConfigCtr128,
+      .keyblob_length = 32,
+      .keyblob = keyblob,
+  };
+  EXPECT_EQ(
+      status_ok(otcrypto_hw_backed_key(test_version, test_salt.data(), &key)),
+      true);
+
+  // Expect that converting to keymgr diversification data generates the same
+  // version and salt.
+  keymgr_diversification_t diversification;
+  EXPECT_EQ(
+      status_ok(keyblob_to_keymgr_diversification(&key, &diversification)),
+      true);
+  EXPECT_EQ(diversification.version, test_version);
+  for (size_t i = 0; i < kKeymgrSaltNumWords - 1; i++) {
+    EXPECT_EQ(diversification.salt[i], test_salt[i]);
+  }
+  EXPECT_EQ(diversification.salt[kKeymgrSaltNumWords - 1],
+            kConfigCtr128.key_mode);
+}
+
+TEST(Keyblob, HwBackedRsaKeyFails) {
+  uint32_t test_version = 0xf0f1f2f3;
+  std::array<uint32_t, 7> test_salt = {0x01234567, 0x89abcdef, 0x00010203,
+                                       0x04050607, 0x08090a0b, 0x0c0d0e0f,
+                                       0x10111213};
+
+  // Create a key handle from the test data.
+  uint32_t keyblob[32] = {0};
+  crypto_blinded_key_t key = {
+      .config = kConfigRsaInvalid,
+      .keyblob_length = 32,
+      .keyblob = keyblob,
+  };
+
+  // Expect the hardware-backed RSA key to be rejected.
+  EXPECT_EQ(
+      status_ok(otcrypto_hw_backed_key(test_version, test_salt.data(), &key)),
+      false);
+}
+
+}  // namespace
+}  // namespace key_transport_unittest

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -110,17 +110,7 @@ status_t keyblob_to_keymgr_diversification(
   return OTCRYPTO_OK;
 }
 
-/**
- * Checks that the configuration represents a key masked with XOR.
- *
- * Returns false if the key is for an algorithm that uses a different masking
- * method (e.g. arithmetic masking for asymmetric crypto) or if the key is
- * hardware-backed.
- *
- * @param config Key configuration.
- * @return OK if `config` represents an XOR-masked key, BAD_ARGS otherwise.
- */
-static status_t ensure_xor_masked(const crypto_key_config_t config) {
+status_t keyblob_ensure_xor_masked(const crypto_key_config_t config) {
   // Reject hardware-backed keys, since the keyblob is not the actual key
   // material in this case but the version/salt.
   if (config.hw_backed != kHardenedBoolFalse) {
@@ -170,7 +160,7 @@ status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
                                    const crypto_key_config_t config,
                                    uint32_t *keyblob) {
   // Check that the key is masked with XOR.
-  HARDENED_TRY(ensure_xor_masked(config));
+  HARDENED_TRY(keyblob_ensure_xor_masked(config));
 
   size_t key_words = keyblob_share_num_words(config);
   // share0 = key ^ mask, share1 = mask
@@ -184,7 +174,7 @@ status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
 
 status_t keyblob_remask(crypto_blinded_key_t *key, const uint32_t *mask) {
   // Check that the key is masked with XOR.
-  HARDENED_TRY(ensure_xor_masked(key->config));
+  HARDENED_TRY(keyblob_ensure_xor_masked(key->config));
 
   size_t key_share_words = keyblob_share_num_words(key->config);
   size_t keyblob_words = keyblob_num_words(key->config);

--- a/sw/device/lib/crypto/impl/keyblob.h
+++ b/sw/device/lib/crypto/impl/keyblob.h
@@ -83,6 +83,19 @@ status_t keyblob_to_keymgr_diversification(
     const crypto_blinded_key_t *key, keymgr_diversification_t *diversification);
 
 /**
+ * Checks that the configuration represents a key masked with XOR.
+ *
+ * Returns false if the key is for an algorithm that uses a different masking
+ * method (e.g. arithmetic masking for asymmetric crypto) or if the key is
+ * hardware-backed.
+ *
+ * @param config Key configuration.
+ * @return OK if `config` represents an XOR-masked key, BAD_ARGS otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keyblob_ensure_xor_masked(const crypto_key_config_t config);
+
+/**
  * Construct a blinded keyblob from the given key and mask.
  *
  * The size of the key and mask should be `key_len` rounded up to the next

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -94,25 +94,6 @@ typedef struct gcm_ghash_context {
 } gcm_ghash_context_t;
 
 /**
- * Generates a new AES key.
- *
- * The caller should allocate and partially populate the blinded
- * key struct, including populating the key configuration and
- * allocating space for the keyblob. The caller should indicate
- * the length of the allocated keyblob; this function will
- * return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0
- * and the keyblob pointer may be `NULL`. For non-hardware-backed keys,
- * the keyblob should be twice the length of the key. The value in
- * the `checksum` field of the blinded key struct will be populated
- * by the key generation function.
- *
- * @param[out] key Destination blinded key struct.
- * @return The result of the cipher operation.
- */
-crypto_status_t otcrypto_aes_keygen(crypto_blinded_key_t *key);
-
-/**
  * Get the number of blocks needed for the plaintext length and padding mode.
  *
  * This returns the size of the padded plaintext, which is the same as the

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -49,10 +49,35 @@ extern "C" {
  *
  * @param perso_string Optional personalization string to be passed to DRBG.
  * @param[out] key Destination blinded key struct.
- * @return The result of the cipher operation.
+ * @return The result of the operation.
  */
 crypto_status_t otcrypto_symmetric_keygen(crypto_const_byte_buf_t perso_string,
                                           crypto_blinded_key_t *key);
+
+/**
+ * Creates a handle for a hardware-backed key.
+ *
+ * This routine may be used for both symmetric and asymmetric algorithms, since
+ * conceptually it only creates some data that the key manager can use to
+ * generate key material at the time of use. However, not all algorithms are
+ * suitable for hardware-backed keys (for example, RSA is not suitable), so
+ * some choices of algorithm may result in errors.
+ *
+ * The caller should partially populate the blinded key struct; they should set
+ * the full key configuration and the keyblob length (always 32 bytes), and
+ * then allocate 32 bytes of space for the keyblob and set the keyblob pointer.
+ *
+ * This function will populate the `checksum` field and copy the salt/version
+ * data into the keyblob buffer in the specific order that the rest of
+ * cryptolib expects.
+ *
+ * @param version Key version.
+ * @param salt Key salt (diversification data for KDF).
+ * @param[out] key Destination blinded key struct.
+ * @return The result of the operation.
+ */
+crypto_status_t otcrypto_hw_backed_key(uint32_t version, const uint32_t salt[7],
+                                       crypto_blinded_key_t *key);
 
 /**
  * Builds an unblinded key struct from a user (plain) key.

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -20,6 +20,41 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Generates a new, random symmetric key.
+ *
+ * Use this only for symmetric algorithms (e.g. AES, HMAC, KMAC). Asymmetric
+ * algorithms (e.g. ECDSA, RSA) have their own specialized key-generation
+ * routines.
+ *
+ * The caller should allocate space for the keyblob and populate the blinded
+ * key struct with the length of the keyblob, the pointer to the keyblob
+ * buffer, and the key configuration. The value in the `checksum` field of
+ * the blinded key struct will be populated by the key generation function.
+ * The keyblob should be twice the length of the unblinded key.  This function
+ * will return an error if the keyblob length does not match expectations based
+ * on the key mode and configuration.
+ *
+ * For hardware-backed keys, the keyblob length should always be 256 bits and
+ * the caller should populate the key blob with their desired key version and
+ * salt value. The first 32 bits of the key blob are interpreted in
+ * little-endian form as the version, and the remaining 224 bits are
+ * concatenated with the one-word key mode to become the salt.
+ *
+ * For non-hardware-backed keys, the keyblob should be twice the length of the
+ * key, and the caller only needs to allocate the keyblob, not populate it.
+ *
+ * The personalization string may empty, and may be up to 48 bytes long; any
+ * longer will result in an error. It is passed as an extra seed input to the
+ * DRBG, in addition to the hardware TRNG.
+ *
+ * @param perso_string Optional personalization string to be passed to DRBG.
+ * @param[out] key Destination blinded key struct.
+ * @return The result of the cipher operation.
+ */
+crypto_status_t otcrypto_symmetric_keygen(crypto_const_byte_buf_t perso_string,
+                                          crypto_blinded_key_t *key);
+
+/**
  * Builds an unblinded key struct from a user (plain) key.
  *
  * @param plain_key Pointer to the user defined plain key.

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -43,23 +43,6 @@ typedef struct hmac_context {
 } hmac_context_t;
 
 /**
- * Generates a new HMAC or KMAC key.
- *
- * The caller should allocate and partially populate the blinded key struct,
- * including populating the key configuration and allocating space for the
- * keyblob. The caller should indicate the length of the allocated keyblob;
- * this function will return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0 and the
- * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
- * should be twice the length of the key. The value in the `checksum` field of
- * the blinded key struct will be populated by the key generation function.
- *
- * @param[out] key Destination blinded key struct.
- * @return The result of the key generation operation.
- */
-crypto_status_t otcrypto_mac_keygen(crypto_blinded_key_t *key);
-
-/**
  * Performs the HMAC function on the input data.
  *
  * This function computes the HMAC function on the `input_message` using the

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -312,6 +312,21 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "symmetric_keygen_functest",
+    srcs = ["symmetric_keygen_functest.c"],
+    deps = [
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/crypto/impl:key_transport",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:randomness_quality",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 py_binary(
     name = "ecdsa_p256_verify_set_testvectors",
     srcs = ["ecdsa_p256_verify_set_testvectors.py"],

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -32,6 +32,7 @@ opentitan_functest(
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/drbg.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/randomness_quality.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Statistical significance for randomness-quality checks. This setting results
+// in a 1% failure rate on truly random data.
+static const randomness_quality_significance_t kSignificance =
+    kRandomnessQualitySignificanceOnePercent;
+
+// Personalization data for testing.
+static const uint8_t kPersonalizationData[5] = {0xf0, 0xf1, 0xf2, 0xf3, 0xf4};
+static const crypto_const_byte_buf_t kPersonalization = {
+    .data = kPersonalizationData,
+    .len = sizeof(kPersonalizationData),
+};
+
+// Represents a 192-bit AES-CBC key.
+static const crypto_key_config_t kAesKeyConfig = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeAesCbc,
+    .key_length = 192 / 8,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kSecurityLevelLow,
+};
+
+// Represents a 256-bit HMAC-SHA256 key.
+static const crypto_key_config_t kHmacKeyConfig = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeHmacSha256,
+    .key_length = 256 / 8,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kSecurityLevelLow,
+};
+
+// Represents a 128-bit KMAC key.
+static const crypto_key_config_t kKmacKeyConfig = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeKmac128,
+    .key_length = 128 / 8,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kSecurityLevelLow,
+};
+
+static status_t entropy_complex_init_test(void) {
+  // This initialization should happen in ROM_EXT, so there is no public API
+  // for it in cryptolib.
+  TRY(entropy_complex_init());
+
+  // Check the configuration.
+  return entropy_complex_check();
+}
+
+/**
+ * Basic test for generating a symmetric key.
+ *
+ * Generates the key, runs basic statistical tests, and logs the output. This
+ * test may fail sometimes because statistical tests are inherently
+ * proababilistic.
+ *
+ * @param config Key configuration.
+ */
+static status_t basic_keygen_test(crypto_key_config_t config) {
+  // Allocate and zeroize keyblob.
+  size_t key_share_words = config.key_length / sizeof(uint32_t);
+  uint32_t keyblob[key_share_words * 2];
+  memset(keyblob, 0, sizeof(keyblob));
+
+  // Create the blinded key structure and call keygen.
+  crypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  TRY(otcrypto_symmetric_keygen(kPersonalization, &key));
+
+  // Ensure the checksum passes.
+  TRY_CHECK(integrity_blinded_key_check(&key) == kHardenedBoolTrue);
+
+  // Do a basic statistical test.
+  TRY(randomness_quality_monobit_test((unsigned char *)keyblob, sizeof(keyblob),
+                                      kSignificance));
+
+  // Log the generated key.
+  uint32_t *share0;
+  uint32_t *share1;
+  HARDENED_TRY(keyblob_to_shares(&key, &share0, &share1));
+  for (size_t i = 0; i < key_share_words; i++) {
+    LOG_INFO("key[%d] = 0x%08x", i, share0[i] ^ share1[i]);
+  }
+
+  return OK_STATUS();
+}
+
+static status_t aes_keygen_test(void) {
+  return basic_keygen_test(kAesKeyConfig);
+}
+
+static status_t hmac_keygen_test(void) {
+  return basic_keygen_test(kHmacKeyConfig);
+}
+
+static status_t kmac_keygen_test(void) {
+  return basic_keygen_test(kKmacKeyConfig);
+}
+
+static status_t generate_multiple_keys_test(void) {
+  // Create a double-length blob for two keys.
+  size_t key_share_words = kAesKeyConfig.key_length / sizeof(uint32_t);
+  uint32_t keyblob_buffer[key_share_words * 4];
+  uint32_t *keyblob1 = keyblob_buffer;
+  uint32_t *keyblob2 = &keyblob_buffer[key_share_words * 2];
+  memset(keyblob_buffer, 0, sizeof(keyblob_buffer));
+
+  // Generate two AES keys.
+  crypto_blinded_key_t key1 = {
+      .config = kAesKeyConfig,
+      .keyblob_length = sizeof(keyblob_buffer) / 2,
+      .keyblob = keyblob1,
+  };
+  crypto_blinded_key_t key2 = {
+      .config = kAesKeyConfig,
+      .keyblob_length = sizeof(keyblob_buffer) / 2,
+      .keyblob = keyblob2,
+  };
+  TRY(otcrypto_symmetric_keygen(kPersonalization, &key1));
+  TRY(otcrypto_symmetric_keygen(kPersonalization, &key2));
+
+  // Do a statistical test on the entire keyblob (this will check if the keys
+  // are statistically related to each other).
+  TRY(randomness_quality_monobit_test((unsigned char *)keyblob_buffer,
+                                      sizeof(keyblob_buffer), kSignificance));
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  EXECUTE_TEST(result, entropy_complex_init_test);
+  EXECUTE_TEST(result, aes_keygen_test);
+  EXECUTE_TEST(result, hmac_keygen_test);
+  EXECUTE_TEST(result, kmac_keygen_test);
+  EXECUTE_TEST(result, generate_multiple_keys_test);
+  return status_ok(result);
+}


### PR DESCRIPTION
- Adds functions to the key-transport interface that generate symmetric keys or new handles for hardware-backed keys
- Adds unit tests for the hardware-backed key interface, and also uses it in the AES test
- Adds a basic test for symmetric key generation

As part of https://github.com/lowRISC/opentitan/issues/19549, this unifies the interface for generating symmetric keys (as opposed to having an AES keygen, a KMAC keygen, and an HMAC keygen that all do the same thing and fail if the user-set mode is wrong).