### PR TITLE
[aes,SiVal] Add SiVal test plans

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -232,6 +232,92 @@
     }
   ],
 
+  //////////////
+  // Features //
+  //////////////
+
+  features: [
+    {
+      name: "AES.KEY_LEN.128",
+      desc: "AES can perform both operations (encryption and decryption) for key length 128."
+    }
+    {
+      name: "AES.KEY_LEN.192",
+      desc: '''
+            AES can perform both operations (encryption and decryption) for key length 192.
+            This feature can be disabled using a compile-time Verilog parameter.
+            '''
+    }
+    {
+      name: "AES.KEY_LEN.256",
+      desc: "AES can perform both operations (encryption and decryption) for key length 256."
+    }
+    {
+      name: "AES.MODE.ECB",
+      desc: "AES can perform both operations (encryption and decryption) in Electronic Codebook (ECB) Mode for all three key lengths (128/192/256)."
+    }
+    {
+      name: "AES.MODE.CBC",
+      desc: "AES can perform both operations (encryption and decryption) in Cipher Block Chaining (CBC) Mode for all three key lengths (128/192/256)."
+    }
+    {
+      name: "AES.MODE.CFB-128",
+      desc: '''
+            AES can perform both operations (encryption and decryption) in Cipher Feedback (CFB) Mode for all three key lengths (128/192/256).
+            Note that the only supported data-segment size is 128.
+            '''
+    }
+    {
+      name: "AES.MODE.OFB",
+      desc: "AES can perform both operations (encryption and decryption) in Output Feedback (OFB) Mode for all three key lengths (128/192/256)."
+    }
+    {
+      name: "AES.MODE.CTR",
+      desc: "AES can perform both operations (encryption and decryption) in Counter (CTR) Mode for all three key lengths (128/192/256)."
+    }
+    {
+      name: "AES.KEY.SIDELOAD",
+      desc: "The key can be loaded directly from the keymgr."
+    }
+    {
+      name: "AES.CLEAR.DATA_OUT",
+      desc: "Output data registers can be cleared using pseudo-random data."
+    }
+    {
+      name: "AES.CLEAR.KEY_IV_DATA_IN",
+      desc: "Keys, IV registers and input data registers can be cleared using pseudo-random data."
+    }
+    {
+      name: "AES.PRNG.RESEED_RATE",
+      desc: '''
+            Reseed rate of the internal PRNG used for masking.
+            It can be set to three different values:
+            -Once per block
+            -Once per approximately 64 blocks
+            -Once per approximately 8K blocks
+            '''
+    }
+    {
+      name: "AES.PRNG.KEY_TOUCH_FORCES_RESEED",
+      desc: "AES can force re-seeding of internal PRNGs used for masking and clearing every time a new key is provided."
+    }
+    {
+      name: "AES.PRNG.FORCE_MASKS",
+      desc: '''
+            AES can block advancing of the internal PRNG used for masking, thereby forcing masks to a constant value.
+            This feature can be disabled using tha compile-time Verilog parameter.
+            '''
+    }
+    {
+      name: "AES.MANUAL_OPERATION",
+      desc: '''
+            Operations (encryption and decryption) could be processed in two ways:
+            -AES tracks whether data has been written/read, and starts the operation automatically (default).
+            -AES only starts the operation after receiving a start trigger.
+            '''
+    }
+  ],
+
   /////////////////////
   // Countermeasures //
   /////////////////////

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -19,6 +19,7 @@
     "sw/device/silicon_creator/manuf/data/manuf_testplan.hjson"
 
     // IP block specific top level test plans.
+    "hw/top_earlgrey/data/ip/chip_aes_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson",
@@ -656,104 +657,6 @@
         "chip_sw_adc_ctrl_sleep_debug_cable_wakeup",
         "chip_sw_sysrst_ctrl_ulp_z3_wakeup"
       ]
-    }
-
-    ///////////////////////////////////////////////////////
-    // Security Peripherals                              //
-    // AES                                               //
-    ///////////////////////////////////////////////////////
-
-    // AES (pre-verified IP) integration tests:
-    {
-      name: chip_sw_aes_enc
-      desc: '''Verify the AES operation.
-
-            Write a 32-byte key and a 16-byte plain text to the AES registers and trigger the AES
-            computation to start. Wait for the AES operation to complete by polling the status
-            register. Check the digest registers for correctness against the expected digest value.
-            '''
-      stage: V2
-      tests: ["chip_sw_aes_enc",
-              "chip_sw_aes_enc_jitter_en"]
-    }
-    {
-      name: chip_sw_aes_entropy
-      desc: '''Verify the AES entropy input used by the internal PRNGs.
-
-            - Write the initial key share, IV and data in CSRs (known combinations).
-            - Configure the entropy_src to generate entropy in LFSR mode.
-            - Write the PRNG_RESEED bit to reseed the internal state of the PRNG.
-            - Poll the status idle bit to ensure reseed operation is complete.
-            - Trigger the AES operation to run and wait for it to complete.
-            - Check the digest against the expected value.
-            - Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and wait for it to
-              complete by polling the status idle bit.
-            - Read back the data out CSRs - they should all read garbage values.
-            - Assertion check verifies that the IV are also garbage, i.e. different from the
-              originally written values.
-            '''
-      stage: V2
-      tests: ["chip_sw_aes_entropy"]
-    }
-    {
-      name: chip_sw_aes_idle
-      desc: '''Verify AES idle signaling to clkmgr.
-
-            - Write the AES clk hint to 0 within clkmgr to indicate AES clk can be gated and
-              verify that the AES clk hint status within clkmgr reads 0 (AES is disabled).
-            - Write the AES clk hint to 1 within clkmgr to indicate AES clk can be enabled.
-            - Initiate an AES operation with a known key, plain text and digest, write AES clk
-              hint to 0 and verify that the AES clk hint status within clkmgr now reads 1 (AES
-              is enabled), before the AES operation is complete.
-            - After the AES operation is complete verify that the AES clk hint status within
-              clkmgr now reads 0 again (AES is disabled).
-            - Write the AES clk hint to 1, read and check the AES output for correctness.
-            '''
-      stage: V2
-      tests: ["chip_sw_aes_idle"]
-    }
-    {
-      name: chip_sw_aes_sideload
-      desc: '''Verify the AES sideload mechanism.
-
-            - Configure the keymgr to generate an aes key.
-            - Configure the AES to use the sideloaded key.
-            - Load the plaintext into the AES.
-            - Trigger the AES encryption and wait for it to complete.
-            - Verify that the ciphertext is different from the plaintext.
-            - Load the ciphertext into the AES.
-            - Trigger the AES decryption and wait for it to complete.
-            - Verify that the output is equal to the plain text.
-            - Clear the key in the keymgr and decrypt the ciphertext again.
-            - Verify that output is not equal to the plain text.
-            '''
-      stage: V2
-      tests: ["chip_sw_keymgr_sideload_aes"]
-    }
-    {
-      name: chip_sw_aes_masking_off
-      desc: '''Verify the AES masking off feature for ES.
-
-            - Perform known-answer test using CSRNG SW application interface.
-            - Verify CSRNG produces the deterministic seed leading to an all-zero output of the AES
-              masking PRNG.
-            - Configure EDN to perform a CSRNG instantiate followed by repeated generate and reseed
-              commands using the maximum amount of additional data and no entropy input in automatic
-              mode.
-            - Let CSRNG produce and forward to EDN the deterministic seed leading to an all-zero
-              output of the AES masking PRNG.
-            - Initialize AES and set the force_masks configuration bit.
-            - Configure an AES key of which the second share is zero.
-            - Trigger a reseed operation of the masking PRNG inside AES to load the deterministic
-              seed produced by CSRNG and distributed by EDN.
-            - Verify that the masking PRNG outputs an all-zero vector.
-            - Encrypt a message of multiple blocks using AES.
-            - Verify that the second share of the initial, intermediate and output state is zero.
-            - Verify that the second share of the SubBytes input and output is zero.
-            - Verify that the produced cipher text is correct.
-            '''
-      stage: V2S
-      tests: ["chip_sw_aes_masking_off"]
     }
 
     /////////////////////////////////////////////////////

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_aes
+  testpoints: [
+    {
+      name: chip_sw_aes_enc
+      desc: '''Verify the AES operation.
+
+            Write a 32-byte key and a 16-byte plain text to the AES registers and trigger the AES
+            computation to start. Wait for the AES operation to complete by polling the status
+            register. Check the digest registers for correctness against the expected digest value.
+            '''
+      stage: V2
+      tests: ["chip_sw_aes_enc",
+              "chip_sw_aes_enc_jitter_en"]
+    }
+    {
+      name: chip_sw_aes_entropy
+      desc: '''Verify the AES entropy input used by the internal PRNGs.
+
+            - Write the initial key share, IV and data in CSRs (known combinations).
+            - Configure the entropy_src to generate entropy in LFSR mode.
+            - Write the PRNG_RESEED bit to reseed the internal state of the PRNG.
+            - Poll the status idle bit to ensure reseed operation is complete.
+            - Trigger the AES operation to run and wait for it to complete.
+            - Check the digest against the expected value.
+            - Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and wait for it to
+              complete by polling the status idle bit.
+            - Read back the data out CSRs - they should all read garbage values.
+            - Assertion check verifies that the IV are also garbage, i.e. different from the
+              originally written values.
+            '''
+      stage: V2
+      tests: ["chip_sw_aes_entropy"]
+    }
+    {
+      name: chip_sw_aes_idle
+      desc: '''Verify AES idle signaling to clkmgr.
+
+            - Write the AES clk hint to 0 within clkmgr to indicate AES clk can be gated and
+              verify that the AES clk hint status within clkmgr reads 0 (AES is disabled).
+            - Write the AES clk hint to 1 within clkmgr to indicate AES clk can be enabled.
+            - Initiate an AES operation with a known key, plain text and digest, write AES clk
+              hint to 0 and verify that the AES clk hint status within clkmgr now reads 1 (AES
+              is enabled), before the AES operation is complete.
+            - After the AES operation is complete verify that the AES clk hint status within
+              clkmgr now reads 0 again (AES is disabled).
+            - Write the AES clk hint to 1, read and check the AES output for correctness.
+            '''
+      stage: V2
+      tests: ["chip_sw_aes_idle"]
+    }
+    {
+      name: chip_sw_aes_sideload
+      desc: '''Verify the AES sideload mechanism.
+
+            - Configure the keymgr to generate an aes key.
+            - Configure the AES to use the sideloaded key.
+            - Load the plaintext into the AES.
+            - Trigger the AES encryption and wait for it to complete.
+            - Verify that the ciphertext is different from the plaintext.
+            - Load the ciphertext into the AES.
+            - Trigger the AES decryption and wait for it to complete.
+            - Verify that the output is equal to the plain text.
+            - Clear the key in the keymgr and decrypt the ciphertext again.
+            - Verify that output is not equal to the plain text.
+            '''
+      stage: V2
+      tests: ["chip_sw_keymgr_sideload_aes"]
+    }
+    {
+      name: chip_sw_aes_masking_off
+      desc: '''Verify the AES masking off feature for ES.
+
+            - Perform known-answer test using CSRNG SW application interface.
+            - Verify CSRNG produces the deterministic seed leading to an all-zero output of the AES
+              masking PRNG.
+            - Configure EDN to perform a CSRNG instantiate followed by repeated generate and reseed
+              commands using the maximum amount of additional data and no entropy input in automatic
+              mode.
+            - Let CSRNG produce and forward to EDN the deterministic seed leading to an all-zero
+              output of the AES masking PRNG.
+            - Initialize AES and set the force_masks configuration bit.
+            - Configure an AES key of which the second share is zero.
+            - Trigger a reseed operation of the masking PRNG inside AES to load the deterministic
+              seed produced by CSRNG and distributed by EDN.
+            - Verify that the masking PRNG outputs an all-zero vector. (Note: This may not be
+              possible to verify in silicon.)
+            - Encrypt a message of multiple blocks using AES.
+            - Verify that the second share of the initial, intermediate and output state is zero.
+            - Verify that the second share of the SubBytes input and output is zero. (Note: This
+              may not possible to verify in silicon.)
+            - Verify that the produced cipher text is correct.
+            - Repeat the entire procedure with PRNG_RESEED_RATE set to PER_1. Verify that the
+              second share of intermediate and output state is not zero.
+            '''
+      stage: V2S
+      tests: ["chip_sw_aes_masking_off"]
+     }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -8,13 +8,102 @@
       name: chip_sw_aes_enc
       desc: '''Verify the AES operation.
 
-            Write a 32-byte key and a 16-byte plain text to the AES registers and trigger the AES
-            computation to start. Wait for the AES operation to complete by polling the status
-            register. Check the digest registers for correctness against the expected digest value.
+            Procedure:
+            -Set up the desired operation, ECB mode, 256b key length, and set the engine to
+            manual operation. Set mask_reseeding to 1 per block.
+            -Trigger the encryption by loading the plaintext.
+            -Wait for the AES operation to complete by polling the status register and read the
+            result.
+
+            -The above procedure should be performed twice. First for encryption. Second for
+            decryption of the result using the same key.
+            -Check that the decryption result matches the original plaintext.
             '''
+      features: [
+        "AES.MODE.ECB",
+        "AES.KEY_LEN.256",
+        "AES.MANUAL_OPERATION",
+      ]
       stage: V2
+      si_stage: SV1
+      lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_aes_enc",
               "chip_sw_aes_enc_jitter_en"]
+    }
+    {
+      name: chip_sw_aes_multi_block
+      desc: '''Verify the AES operations on multi-block messages.
+            This test should be performed for all supported modes (ECB, CBC, CFB-128, OFB and CTR)
+            and all supported key lengths (128/192/256).
+
+            Note: The number of message blocks has to be at least 4.
+
+            Note: AES should start this test using the automatic (default) operation. This means
+                  that the MANUAL_OPERATION bit in CTRL_SHADOWED register is set to 0.
+
+            Procedure:
+            -Configure the desired operation, mode, key length, and set the engine to automatic
+             operation. Configure the IV for modes that require it.
+            -Using dif_aes_start()  and dif_aes_process_data(), encrypt the message.
+            -Check the output for correctness against the expected value.
+
+            -The above procedure should be performed twice. First for encryption. Second for
+            decryption of the result using the same key (and same IV if needed).
+            -Check that the decryption result matches the original plaintext.
+            '''
+      features: [
+        "AES.MODE.ECB",
+        "AES.MODE.CBC",
+        "AES.MODE.CFB-128",
+        "AES.MODE.OFB",
+        "AES.MODE.CTR",
+        "AES.KEY_LEN.128",
+        "AES.KEY_LEN.192",
+        "AES.KEY_LEN.256",
+      ]
+      stage: V2
+      si_stage: SV1
+      lc_states: ["PROD"]
+      tests: []
+    }
+    {
+      name: chip_sw_aes_interrupt_encryption
+      desc: '''Verify that a multi-block encryption can be interrupted and continued.
+
+            This test should:
+              - start the encryption of a four-block message.
+              - interrupt it after two blocks by reading back the IV register.
+              - perform an encryption of a different message using a different key.
+              - re-store and complete the original encryption
+
+            Note: AES should start this test using the automatic (default) operation. This means
+                  that the MANUAL_OPERATION bit in CTRL_SHADOWED register is set to 0.
+
+            Procedure:
+            -Configure encryption using the desired mode, key length, IV, and set the engine to
+            automatic operation.
+            -Using dif_aes_process_data, encrypt the first two blocks.
+            -Using dif_aes_read_iv read the IV. Note that AES has automatically updated the content
+             of this register. This IV will be needed later to continue this encryption.
+            -De-initialize automatic operation. This step is necessary to clear all registers.
+            -Perform an encryption using a different data and key. Message size, key size and mode
+             can be chosen arbitrarily.
+            -Continue the original encryption:
+                -Configure the operation using the previously read IV
+                -Process the remaining plaintext blocks using dif_aes_process_data
+            -Decrypt the result (using the original key and IV)
+            -Check that the decryption result matches the original plaintext.
+            '''
+      features: [
+        "AES.MODE.CBC",
+        "AES.MODE.CFB-128",
+        "AES.MODE.OFB",
+        "AES.MODE.CTR",
+      ]
+      stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
     }
     {
       name: chip_sw_aes_entropy
@@ -32,8 +121,88 @@
             - Assertion check verifies that the IV are also garbage, i.e. different from the
               originally written values.
             '''
+      features: [
+        "AES.MODE.CBC",
+        "AES.CLEAR.DATA_OUT",
+        "AES.CLEAR.KEY_IV_DATA_IN",
+      ]
       stage: V2
+      si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_aes_entropy"]
+    }
+    {
+      name: chip_sw_aes_prng_reseed
+      desc: '''Verify that PRNG reseeding is triggered
+
+            This test should start encryption, disable the EDN, and verify that the
+            encryption stalls when reseed is required. Afterwards it should verify that AES
+            finishes encryption after EDN is re-enabled.
+
+            Procedure:
+            -Configure encryption using the ECB mode, desired key length, and set the engine to
+            automatic operation.
+                -Set the mask_reseeding to once per 64 blocks (kDifAesReseedPer64Block)
+            -Using dif_aes_process_data() encrypt some number of blocks (fewer than 64).
+            -Disable the EDN using dif_edn_stop().
+            -Encrypt more blocks and verify that encryption stalls after 64 blocks.
+                -Once the first 64 blocks are encrypted, a reseed request will be sent to EDN.
+                Since the EDN should be disabled at this point, this should cause encryption
+                to stall.
+            -Re-enable EDN. In order to do this it is required to first disable and re-enable the
+             CSRNG. In order to re-enable CSRNG, it is required to first disable and re-enable
+             the entropy source. The following sequence of steps should be used:
+                -Disable CSRNG
+                -Disable Entropy Source
+                -Enable Entropy Source
+                -Enable CSRNG
+                -Enable EDN
+            -Verify that the AES completes encryption of the remaining blocks.
+
+            -Repeat the test for a reseed rate kDifAesReseedPer8kBlock and a message longer than 8K
+            blocks.
+            '''
+      features: [
+        "AES.MODE.ECB",
+        "AES.PRNG.RESEED_RATE",
+      ]
+      stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: ["chip_sw_aes_prng_reseed"]
+    }
+    {
+      name: chip_sw_aes_force_prng_reseed
+      desc: '''Verify that when KEY_TOUCH_FORCES_RESEED is set, the PRNG reseed is
+               triggered every time a key changes
+
+            Procedure:
+            -Configures the auxiliary options for AES to enable KEY_TOUCH_FORCES_RESEED
+            -Disable the EDN using dif_edn_stop()
+            -Configure the encryption operation, mode, key length, and set the engine to manual
+             operation.
+            -Set up encryption using aes_testutils_setup_encryption()
+              -At this point dif_aes_start() will write the key register which will trigger reseed
+               request. This request will stall the encryption until EDN is re-enabled.
+            -Verify that the encryption stalls.
+            -Re-enable EDN. In order to do this it is required to first disable and re-enable the
+             CSRNG. In order to re-enable CSRNG, it is required to first disable and re-enable
+             the entropy source. The following sequence of steps should be used:
+                -Disable CSRNG
+                -Disable Entropy Source
+                -Enable Entropy Source
+                -Enable CSRNG
+                -Enable EDN
+            -Verify that the AES completes encryption.
+            '''
+      features: [
+        "AES.MODE.ECB",
+        "AES.PRNG.KEY_TOUCH_FORCES_RESEED",
+      ]
+      stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: ["chip_sw_aes_force_prng_reseed"]
     }
     {
       name: chip_sw_aes_idle
@@ -49,7 +218,12 @@
               clkmgr now reads 0 again (AES is disabled).
             - Write the AES clk hint to 1, read and check the AES output for correctness.
             '''
+      features: [
+        "AES.MODE.ECB",
+      ]
       stage: V2
+      si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_aes_idle"]
     }
     {
@@ -67,7 +241,13 @@
             - Clear the key in the keymgr and decrypt the ciphertext again.
             - Verify that output is not equal to the plain text.
             '''
+      features: [
+        "AES.MODE.ECB",
+        "AES.KEY.SIDELOAD",
+      ]
       stage: V2
+      si_stage: SV2
+      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_keymgr_sideload_aes"]
     }
     {
@@ -97,6 +277,7 @@
               second share of intermediate and output state is not zero.
             '''
       stage: V2S
+      si_stage: None
       tests: ["chip_sw_aes_masking_off"]
      }
   ]

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -109,12 +109,13 @@
       name: chip_sw_aes_entropy
       desc: '''Verify the AES entropy input used by the internal PRNGs.
 
+            - Configure encryption using the CBC mode, key length 256, and set the engine to
+              manual operation.
             - Write the initial key share, IV and data in CSRs (known combinations).
-            - Configure the entropy_src to generate entropy in LFSR mode.
             - Write the PRNG_RESEED bit to reseed the internal state of the PRNG.
             - Poll the status idle bit to ensure reseed operation is complete.
             - Trigger the AES operation to run and wait for it to complete.
-            - Check the digest against the expected value.
+            - Check the ciphertext against the expected value.
             - Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and wait for it to
               complete by polling the status idle bit.
             - Read back the data out CSRs - they should all read garbage values.


### PR DESCRIPTION
This PR adds a list of features to `aes.hjson`, moves AES testplan into a separate file and extends existing tests to cover more features.