### PR TITLE
[prim_prince] Split an array in the RTL

### DIFF
--- a/hw/ip/prim/lint/prim_cipher.vlt
+++ b/hw/ip/prim/lint/prim_cipher.vlt
@@ -12,4 +12,5 @@
 split_var -module "prim_present" -var "data_state"
 split_var -module "prim_present" -var "round_idx"
 split_var -module "prim_present" -var "round_key"
-split_var -module "prim_prince" -var "data_state"
+split_var -module "prim_prince" -var "data_state_lo"
+split_var -module "prim_prince" -var "data_state_hi"

--- a/hw/ip/prim/lint/prim_cipher.vlt
+++ b/hw/ip/prim/lint/prim_cipher.vlt
@@ -6,9 +6,10 @@
 
 // Tell the Verilator scheduler to split up these variables into
 // separate pieces when it's figuring out process scheduling. This
-// avoids spurious UNOPTFLAT warnings caused by the fact that the
-// arrays feed into themselves (with different bits for different
-// positions in the tree).
+// avoids spurious UNOPTFLAT warnings caused by the fact that (if you
+// don't track the indices carefully) it looks like the arrays feed
+// into themselves.
 split_var -module "prim_present" -var "data_state"
 split_var -module "prim_present" -var "round_idx"
 split_var -module "prim_present" -var "round_key"
+split_var -module "prim_prince" -var "data_state"

--- a/hw/ip/prim/rtl/prim_prince.sv
+++ b/hw/ip/prim/rtl/prim_prince.sv
@@ -106,14 +106,7 @@ module prim_prince #(
   //////////////
 
   // State variable for holding the rounds
-  //
-  // The "split_var" hint that we pass to verilator here tells it to schedule the different parts of
-  // data_state separately. This avoids an UNOPTFLAT error where it would otherwise see a dependency
-  // chain
-  //
-  //    data_state -> data_state_round -> data_state_xor -> data_state
-  //
-  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state /* verilator split_var */;
+  logic [NumRoundsHalf*2+1:0][DataWidth-1:0] data_state;
 
   // pre-round XOR
   always_comb begin : p_pre_round_xor


### PR DESCRIPTION
No functional change (hopefully!), but this works around a warning that is triggered with recent versions of Verilator.