### PR TITLE
[spi_host,sival] Silicon validation test for SPI host

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -107,6 +107,58 @@
       '''
     }
   ],
+  features: [
+    { name: "SPIHOST.USECASE.SERIALNORFLASH",
+      desc: '''
+        The SPI host block can talk to serial NOR flash devices.
+      '''
+    },
+    { name: "SPIHOST.USECASE.PASSTHROUGH",
+      desc: '''
+        The SPI host block can work together with a device to create a pass through.
+      '''
+    },
+    { name: "SPIHOST.RATE.STANDARD",
+      desc: '''
+        Host can operate in standard SPI data rate.
+      '''
+    },
+    { name: "SPIHOST.RATE.DUAL",
+      desc: '''
+        Host can operate in dual SPI data rate.
+      '''
+    },
+    { name: "SPIHOST.RATE.QUAD",
+      desc: '''
+        Host can operate in quad SPI data rate.
+      '''
+    },
+    { name: "SPIHOST.CONFIG.CPOL",
+      desc: '''
+        The polarity of the SPI can be configured.
+      '''
+    },
+    { name: "SPIHOST.CONFIG.CLOCKDIV",
+      desc: '''
+        The clock divider in the SPI host can be configured.
+      '''
+    },
+    { name: "SPIHOST.EVENT.WATERMARK",
+      desc: '''
+        The block can be configured to raise an event on watermarks for transmit and receive queues.
+      '''
+    },
+    { name: "SPIHOST.EVENT.FULL",
+      desc: '''
+        The block can be configured to raise an event when the receive queue is full.
+      '''
+    },
+    { name: "SPIHOST.EVENT.EMPTY",
+      desc: '''
+        The block can be configured to raise an event when the transmit queue is empty.
+      '''
+    }
+  ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -35,6 +35,7 @@
     "hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson",
@@ -43,7 +44,7 @@
   testpoints: [
     ///////////////////////////////////////////////////////////////////////////
     // IO Peripherals                                                        //
-    // UART, I2C, SPIDEV, SPIHOST, USB, PINMUX & PADCTRL, PATTGEN, PWM       //
+    // UART, I2C, SPIDEV, USB, PINMUX & PADCTRL, PATTGEN, PWM                //
     ///////////////////////////////////////////////////////////////////////////
 
     // UART (pre-verified IP) integration tests:
@@ -100,23 +101,6 @@
             '''
       stage: V1
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
-    }
-
-    // SPI_HOST (pre-verified IP) integration tests:
-    {
-      name: chip_sw_spi_host_tx_rx
-      desc: '''Verify the transmission of data on the chip's SPI host port.
-
-            - Program the SPI host to send a known payload out of the chip on the SPI host ports.
-            - The testbench receives the payload and plays it back to the SPI host interface.
-            - The SW verifies the sent payload matches the read response and services SPI event
-              interrupts.
-            - Run with min and max SPI clk frequencies and with single, dual and quad SPI modes.
-
-            Verify all SPI host instances in the chip.
-            '''
-      stage: V2
-      tests: ["chip_sw_spi_host_tx_rx"]
     }
 
     // USB (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -16,9 +16,80 @@
             - Run with min and max SPI clk frequencies and with single, dual and quad SPI modes.
 
             Verify all SPI host instances in the chip.
+
+            Notes for silicon targets:
+            - The testbench that mimics a physical SPI device should measure the clock to verify that the frequencies for each speed mode is correct.
+              This can be done by checking timing of the beginning and the end of the packet.
             '''
+      features: [
+        "SPIHOST.RATE.STANDARD",
+        "SPIHOST.RATE.DUAL",
+        "SPIHOST.RATE.QUAD",
+      ]
       stage: V2
+      si_stage: SV2
       tests: ["chip_sw_spi_host_tx_rx"]
+    }
+    {
+      name: chip_sw_spi_host_pass_through
+      desc: '''Verify that the SPI host can be configured in pass through mode.
+            Essentially the configuration is as follows: (real) host -> OT -> flash device
+
+            - Connect one of the OpenTitan SPI hosts to a SPI device on a serial NOR flash.
+            - Configure an OpenTitan SPI device and the above mentioned OpenTitan SPI host in pass through mode.
+            - Use the testbench's (external) SPI host to write a word to the flash through the passthrough SPI host and device in OpenTitan.
+            - Let the testbench read that word back, again through the pass through of the SPI host and device on OpenTitan.
+            - The testbench should check that the word read back is the same as the one written.
+            '''
+      features: [
+        "SPIHOST.USECASE.SERIALNORFLASH",
+        "SPIHOST.USECASE.PASSTHROUGH",
+      ]
+      stage: V3
+      si_stage: SV3
+      tests: []
+    }
+    {
+      name: chip_sw_spi_host_configuration
+      desc: ''' Verifiy that the polarity and clock divider configurations work appropriately.
+
+            1. Send a packet with no clock division and no polarity switch.
+            2. Send a packet with no clock division and a polarity switch.
+            3. Send a packet with clock divided by two and a polarity switch.
+
+            The testbench should compare the three packets that are received; the second packet should be inverted from the first and the third should be send half as fast as the second.
+            '''
+      features: [
+        "SPIHOST.CONFIG.CPOL",
+        "SPIHOST.CONFIG.CLOCKDIV",
+      ]
+      stage: V3
+      si_stage: SV3
+      tests: []
+    }
+    {
+      name: chip_sw_spi_host_events
+      desc: ''' Verify that various events are correctly triggered by the SPI host.
+
+            - For the transmit empty and watermark events:
+              - Fill the transmit queue on the Ibex side.
+              - Clear and enable the respective interrupt.
+              - Testbench should check that it receives the same data as Ibex has sent.
+              - Ibex should check whether it has received the transmit empty or watermark interrupt within a reasonable amount of time.
+            - For the receive full and watermark events:
+              - Empty the receive queue.
+              - Clear and enable the respective interrupt.
+              - Testbench sends as much data as the receive queue can hold for the full interrupt or the amount necessary to hit the watermark.
+              - Ibex checks that the receive full or watermark interrupt is raised.
+            '''
+      features: [
+        "SPIHOST.EVENT.WATERMARK",
+        "SPIHOST.EVENT.FULL",
+        "SPIHOST.EVENT.EMPTY",
+      ]
+      stage: V3
+      si_stage: SV3
+      tests: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_spi_host
+  testpoints: [
+    // SPI_HOST (pre-verified IP) integration tests:
+    {
+      name: chip_sw_spi_host_tx_rx
+      desc: '''Verify the transmission of data on the chip's SPI host port.
+
+            - Program the SPI host to send a known payload out of the chip on the SPI host ports.
+            - The testbench receives the payload and plays it back to the SPI host interface.
+            - The SW verifies the sent payload matches the read response and services SPI event
+              interrupts.
+            - Run with min and max SPI clk frequencies and with single, dual and quad SPI modes.
+
+            Verify all SPI host instances in the chip.
+            '''
+      stage: V2
+      tests: ["chip_sw_spi_host_tx_rx"]
+    }
+  ]
+}


### PR DESCRIPTION
This is an initial go at creating silicon validation tests for the SPI host block. For now I've listed features and created a separate file, but still need to add additional tests.

Adding @hcallahan-lowrisc for visibility.