### PR TITLE
[gpio,SiVal] Testplan update for gpio

### DIFF
--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -75,7 +75,25 @@
       desc: "End-to-end bus integrity scheme."
     }
   ]
-
+  features: [
+    {
+      name: "GPIO.IN.INTR_CTRL"
+      desc: '''Input interrupts can be triggered identified by detecting either level or edge.
+      There are four detection modes available: rising edge, falling edge, high-level, and low-level.
+      '''
+    }
+    {
+      name: "GPIO.IN.FILTER"
+      desc: '''GPIO module provides noise filter control.
+      It can be enabled with programing GPIO.CTRL_EN_INPUT_FILTER.
+      Once it enables, input value must be stable for 16cycles before transitioning
+      '''
+    }
+    {
+      name: "GPIO.OUT.MASK"
+      desc: 'Masked output access enables to modify either upper or lower 16bits of output register  without a Read-Modify-Write.'
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "DATA_IN",

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -25,6 +25,7 @@
     "hw/top_earlgrey/data/ip/chip_edn_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson"
     "hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson",
@@ -38,7 +39,7 @@
   testpoints: [
     ///////////////////////////////////////////////////////////////////////////
     // IO Peripherals                                                        //
-    // UART, GPIO, I2C, SPIDEV, SPIHOST, USB, PINMUX & PADCTRL, PATTGEN, PWM //
+    // UART, I2C, SPIDEV, SPIHOST, USB, PINMUX & PADCTRL, PATTGEN, PWM       //
     ///////////////////////////////////////////////////////////////////////////
 
     // UART (pre-verified IP) integration tests:
@@ -95,40 +96,6 @@
             '''
       stage: V1
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
-    }
-
-    // GPIO (pre-verified IP) integration tests:
-    {
-      name: chip_sw_gpio_out
-      desc: '''Verify GPIO outputs.
-
-            SW test configures the GPIOs to be in the output mode. The test walks a 1 through the
-            pins. The testbench checks the value for correctness and verifies that there is no
-            aliasing between the pins.
-            '''
-      stage: V1
-      tests: ["chip_sw_gpio"]
-    }
-    {
-      name: chip_sw_gpio_in
-      desc: '''Verify GPIO inputs.
-
-            The SW test configures the GPIOs to be in input mode. The testbench walks a 1 through
-            the pins. SW test ensures that the GPIO values read from the CSR is correct.
-            '''
-      stage: V1
-      tests: ["chip_sw_gpio"]
-    }
-    {
-      name: chip_sw_gpio_irq
-      desc: '''Verify GPIO interrupts.
-
-            The SW test configures the GPIOs to be in input mode and enables all of them to generate
-            an interrupt. The testbench walks a 1 through the pins. SW test ensures that the
-            interrupt corresponding to the right pin is seen.
-            '''
-      stage: V1
-      tests: ["chip_sw_gpio"]
     }
 
     // SPI_DEVICE (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_gpio
+  testpoints: [
+    {
+      name: chip_sw_gpio_out
+      desc: '''Verify GPIO outputs.
+
+            SW test configures the GPIOs to be in the output mode. The test walks a 1 through the
+            pins. The testbench checks the value for correctness and verifies that there is no
+            aliasing between the pins.
+            '''
+      features: ["GPIO.OUT.MASK"]
+      stage: V1
+      si_stage: SV1
+      tests: ["chip_sw_gpio"]
+    }
+    {
+      name: chip_sw_gpio_in
+      desc: '''Verify GPIO inputs.
+
+            The SW test configures the GPIOs to be in input mode. The testbench walks a 1 through
+            the pins. SW test ensures that the GPIO values read from the CSR is correct.
+            '''
+      features: ["GPIO.IN.INTR_CTRL", "GPIO.IN.FILTER"]
+      stage: V1
+      si_stage: SV1
+      tests: ["chip_sw_gpio"]
+    }
+    {
+      name: chip_sw_gpio_irq
+      desc: '''Verify GPIO interrupts.
+
+            The SW test configures the GPIOs to be in input mode and enables all of them to generate
+            an interrupt. The testbench walks a 1 through the pins. SW test ensures that the
+            interrupt corresponding to the right pin is seen.
+            '''
+      features: ["GPIO.IN.INTR_CTRL", "GPIO.IN.FILTER"]
+      stage: V1
+      si_stage: SV1
+      tests: ["chip_sw_gpio"]
+    }
+  ]
+}


### PR DESCRIPTION
1. Added list of features to the gpio specification.
2. Moved adc_ctrl chip tests to chip_gpio_testplan.hjson
3. Added si_stage: SV* test cases to cover functionality enumerated in the list of features.
4. Updated the pre-silicon test cases with relevant SV* labels.