### PR TITLE
[ci] Enable more usage of the bitstream cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -424,53 +424,10 @@ jobs:
   pool: ci-public-eda
   timeoutInMinutes: 240
   steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      ci/scripts/get-bitstream-strategy.sh "chip_earlgrey_cw310" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
-    displayName: Configure bitstream strategy
-  - bash: |
-      set -ex
-      . util/build_consts.sh
-      cached_archive=//hw/bitstream:earlgrey_cw310_cached_archive
-      ci/bazelisk.sh build "${cached_archive}"
-      bitstream_archive=$($REPO_TOP/bazelisk.sh outquery "${cached_archive}")
-      cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
-    condition: eq(variables.bitstreamStrategy, 'cached')
-    displayName: Extract cached bitstream
-  - bash: |
-      set -ex
-      trap 'get_logs' EXIT
-      get_logs() {
-        mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310/
-        cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310/ \
-          $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310)
-        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery \
-          //hw/bitstream/vivado:earlgrey_cw310_archive)
-        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
-      }
-
-      . util/build_consts.sh
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh build //hw/bitstream/vivado:earlgrey_cw310_archive
-    condition: ne(variables.bitstreamStrategy, 'cached')
-    displayName: Build bitstream with Vivado
-  - bash: |
-      . util/build_consts.sh
-      echo "Synthesis log"
-      cat $OBJ_DIR/hw/top_earlgrey/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/synth_1/runme.log || true
-
-      echo "Implementation log"
-      cat $OBJ_DIR/hw/top_earlgrey/build.fpga_cw310/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.runs/impl_1/runme.log || true
-    condition: ne(variables.bitstreamStrategy, 'cached')
-    displayName: Display synthesis & implementation logs
-  - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
-    artifact: partial-build-bin-$(System.PhaseName)
-    displayName: Upload step outputs
-  - publish: "$(Build.ArtifactStagingDirectory)"
-    artifact: chip_earlgrey_cw310-build-out
-    displayName: Upload artifacts for CW310
-    condition: failed()
+  - template: ci/fpga-template.yml
+    parameters:
+      top_name: earlgrey
+      design_suffix: cw310
 
 - job: chip_earlgrey_cw310_hyperdebug
   displayName: CW310's Earl Grey Bitstream for Hyperdebug
@@ -481,40 +438,10 @@ jobs:
   pool: ci-public-eda
   timeoutInMinutes: 240
   steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      set -ex
-      trap 'get_logs' EXIT
-      get_logs() {
-        mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/
-        cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/ \
-          $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw310_hyperdebug)
-        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery \
-          //hw/bitstream/vivado:earlgrey_cw310_hyperdebug_archive)
-        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
-      }
-
-      . util/build_consts.sh
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh build //hw/bitstream/vivado:earlgrey_cw310_hyperdebug_archive
-    displayName: Build bitstream with Vivado
-  - bash: |
-      . util/build_consts.sh
-      echo "Synthesis log"
-      cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/build.fpga_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/synth_1/runme.log || true
-
-      echo "Implementation log"
-      cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/build.fpga_cw310_hyperdebug/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_hyperdebug_0.1.runs/impl_1/runme.log || true
-    displayName: Display synthesis & implementation logs
-    condition: succeededOrFailed()
-  - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
-    artifact: partial-build-bin-$(System.PhaseName)
-    displayName: Upload step outputs
-  - publish: "$(Build.ArtifactStagingDirectory)"
-    artifact: chip_earlgrey_cw310_hyperdebug-build-out
-    displayName: Upload artifacts for CW310
-    condition: failed()
+  - template: ci/fpga-template.yml
+    parameters:
+      top_name: earlgrey
+      design_suffix: cw310_hyperdebug
 
 - job: chip_earlgrey_cw340
   displayName: CW340's Earl Grey Bitstream
@@ -525,40 +452,10 @@ jobs:
   pool: ci-public-eda
   timeoutInMinutes: 150
   steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      set -ex
-      trap 'get_logs' EXIT
-      get_logs() {
-        mkdir -p $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw340/
-        cp -rLvt $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw340/ \
-          $($REPO_TOP/bazelisk.sh outquery-all //hw/bitstream/vivado:fpga_cw340)
-        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery \
-          //hw/bitstream/vivado:earlgrey_cw340_archive)
-        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
-      }
-
-      . util/build_consts.sh
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh build //hw/bitstream/vivado:earlgrey_cw340_archive
-    displayName: Build bitstream with Vivado
-  - bash: |
-      . util/build_consts.sh
-      echo "Synthesis log"
-      cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw340/build.fpga_cw340/synth-vivado/lowrisc_systems_chip_earlgrey_cw340_0.1.runs/synth_1/runme.log || true
-
-      echo "Implementation log"
-      cat $OBJ_DIR/hw/top_earlgrey/chip_earlgrey_cw340/build.fpga_cw340/synth-vivado/lowrisc_systems_chip_earlgrey_cw340_0.1.runs/impl_1/runme.log || true
-    displayName: Display synthesis & implementation logs
-    condition: succeededOrFailed()
-  - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
-    artifact: partial-build-bin-$(System.PhaseName)
-    displayName: Upload step outputs
-  - publish: "$(Build.ArtifactStagingDirectory)"
-    artifact: chip_earlgrey_cw340-build-out
-    displayName: Upload artifacts for CW340
-    condition: failed()
+  - template: ci/fpga-template.yml
+    parameters:
+      top_name: earlgrey
+      design_suffix: cw340
 
 - job: chip_englishbreakfast_cw305
   displayName: CW305's Bitstream

--- a/ci/fpga-template.yml
+++ b/ci/fpga-template.yml
@@ -14,7 +14,18 @@ steps:
 - template: ./checkout-template.yml
 - template: ./install-package-dependencies.yml
 - bash: |
-    ci/scripts/get-bitstream-strategy.sh "chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
+    ci/scripts/get-bitstream-strategy.sh "chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}" \
+      ':!/sw/' \
+      ':!/*.hjson' \
+      ':!/*.tpl' \
+      ':!/site/' \
+      ':!/doc/' \
+      ':!/COMMITTERS' \
+      ':!/CLA' \
+      ':!/*.md' \
+      ':!/.github/' \
+      ':!/hw/**/dv/*' \
+      ':!/hw/dv/'
   displayName: Configure bitstream strategy
 - bash: |
     set -ex

--- a/ci/fpga-template.yml
+++ b/ci/fpga-template.yml
@@ -1,0 +1,66 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Azure template for building an FPGA bitstream
+
+parameters:
+- name: top_name
+  type: string
+- name: design_suffix
+  type: string
+
+steps:
+- template: ./checkout-template.yml
+- template: ./install-package-dependencies.yml
+- bash: |
+    ci/scripts/get-bitstream-strategy.sh "chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}" ':!/sw/' ':!/*testplan.hjson' ':!/site/' ':!/doc/' ':!/COMMITTERS' ':!/CLA' ':!/*.md' ':!/hw/**/dv/*'
+  displayName: Configure bitstream strategy
+- bash: |
+    set -ex
+    . util/build_consts.sh
+    bazel_package="//hw/bitstream"
+    design_name=chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}
+    cached_archive="${bazel_package}:${design_name}_cached_archive"
+    ci/bazelisk.sh build "${cached_archive}"
+    bitstream_archive=$($REPO_TOP/bazelisk.sh outquery "${cached_archive}")
+    cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
+  condition: eq(variables.bitstreamStrategy, 'cached')
+  displayName: Extract cached bitstream
+- bash: |
+    set -ex
+    bazel_package=//hw/bitstream/vivado
+    bitstream_target=${bazel_package}:fpga_${{ parameters.design_suffix }}
+    archive_target=${bazel_package}:${{ parameters.top_name }}_${{ parameters.design_suffix }}_archive
+    trap 'get_logs' EXIT
+    get_logs() {
+      design_name=chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}
+      SUB_PATH="hw/top_${{ parameters.top_name }}/${design_name}"
+      mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
+      cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
+        $($REPO_TOP/bazelisk.sh outquery-all ${bitstream_target})
+      bitstream_archive=$($REPO_TOP/bazelisk.sh outquery ${archive_target})
+      cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
+    }
+
+    . util/build_consts.sh
+    module load "xilinx/vivado/$(VIVADO_VERSION)"
+    ci/bazelisk.sh build ${archive_target}
+  condition: ne(variables.bitstreamStrategy, 'cached')
+  displayName: Build and splice bitstream with Vivado
+- bash: |
+    . util/build_consts.sh
+    echo "Synthesis log"
+    cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/synth_1/runme.log || true
+
+    echo "Implementation log"
+    cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/impl_1/runme.log || true
+  condition: ne(variables.bitstreamStrategy, 'cached')
+  displayName: Display synthesis & implementation logs
+- publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
+  artifact: partial-build-bin-$(System.PhaseName)
+  displayName: Upload step outputs
+- publish: "$(Build.ArtifactStagingDirectory)"
+  artifact: chip_${{ parameters.top_name }}_cw310-build-out
+  displayName: Upload artifacts for CW310
+  condition: failed()

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -179,6 +179,28 @@ pkg_tar(
     tags = ["manual"],
 )
 
+bitstream_fragment_from_manifest(
+    name = "chip_earlgrey_cw340_cached_fragment",
+    srcs = [
+        "@bitstreams//:chip_earlgrey_cw340_bitstream",
+        "@bitstreams//:chip_earlgrey_cw340_otp_mmi",
+        "@bitstreams//:chip_earlgrey_cw340_rom_mmi",
+    ],
+    design = "chip_earlgrey_cw340",
+    manifest = "@bitstreams//:manifest",
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "earlgrey_cw340_cached_archive",
+    testonly = True,
+    srcs = [":chip_earlgrey_cw340_cached_fragment"],
+    mode = "0444",
+    package_dir = "build-bin/hw/top_earlgrey/chip_earlgrey_cw340",
+    strip_prefix = "/hw/bitstream/chip_earlgrey_cw340_cached_fragment",
+    tags = ["manual"],
+)
+
 # Packaging rule for spliced bitstreams
 pkg_files(
     name = "package",


### PR DESCRIPTION
Add a manifest fragment target for the cached CW340 bitstream.

Consolidate the various FPGA build scripts into a template. This is largely copied from the other repo, and moving to the template for chip_earlgrey_cw310_hyperdebug and chip_earlgrey_cw340 enables them to use the same logic for using cached bitstreams and skipping Vivado builds.

Exempt more files from triggering bitstream builds when they change, such as hjson files and templates. Because we check in generated RTL, checking for changes to the generated code is sufficient. Checking *only* that code also prunes unrelated changes.