### PR TITLE
[edn/dv] Add output FIFO errors to edn_err test

### DIFF
--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -57,20 +57,22 @@ package edn_env_pkg;
   typedef enum int {
     sfifo_rescmd_err      = 0,
     sfifo_gencmd_err      = 1,
-    edn_ack_sm_err        = 2,
-    edn_main_sm_err       = 3,
-    edn_cntr_err          = 4,
-    fifo_write_err        = 5,
-    fifo_read_err         = 6,
-    fifo_state_err        = 7,
-    sfifo_rescmd_err_test = 8,
-    sfifo_gencmd_err_test = 9,
-    edn_ack_sm_err_test   = 10,
-    edn_main_sm_err_test  = 11,
-    edn_cntr_err_test     = 12,
-    fifo_write_err_test   = 13,
-    fifo_read_err_test    = 14,
-    fifo_state_err_test   = 15
+    sfifo_output_err      = 2,
+    edn_ack_sm_err        = 3,
+    edn_main_sm_err       = 4,
+    edn_cntr_err          = 5,
+    fifo_write_err        = 6,
+    fifo_read_err         = 7,
+    fifo_state_err        = 8,
+    sfifo_rescmd_err_test = 9,
+    sfifo_gencmd_err_test = 10,
+    sfifo_output_err_test = 11,
+    edn_ack_sm_err_test   = 12,
+    edn_main_sm_err_test  = 13,
+    edn_cntr_err_test     = 14,
+    fifo_write_err_test   = 15,
+    fifo_read_err_test    = 16,
+    fifo_state_err_test   = 17
   } err_code_e;
 
   typedef enum int {

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -223,9 +223,13 @@ class edn_base_vseq extends cip_base_vseq #(
     csr_spinwait(.ptr(reg_field), .exp_data(exp_data));
     // Clear interrupt_enable
     csr_wr(.ptr(ral.intr_enable), .value(32'd0));
+    // This assertion has to be disabled, since FIFO clear on edn_disable leads
+    // to unstable h_data (when FIFO write error introduced unaccounted values in FIFO)
+    $assertoff(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
     ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4False);
     ral.ctrl.cmd_fifo_rst.set(prim_mubi_pkg::MuBi4True);
     csr_update(.csr(ral.ctrl));
+    $asserton(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
     // Expect/Clear interrupt bit
     check_interrupts(.interrupts((1 << FifoErr)), .check_set(1'b1));
     `DV_CHECK(uvm_hdl_release(path1));

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -187,7 +187,7 @@ class edn_err_vseq extends edn_base_vseq;
     // Insert the selected error.
     `uvm_info(`gfn, $sformatf("which_err_code = %s", cfg.which_err_code.name()), UVM_HIGH)
     case (cfg.which_err_code) inside
-      sfifo_rescmd_err, sfifo_gencmd_err: begin
+      sfifo_rescmd_err, sfifo_gencmd_err, sfifo_output_err: begin
         fld = csr.get_field_by_name(fld_name);
         fifo_base_path = fld_name.substr(0, last_index-1);
 
@@ -250,8 +250,9 @@ class edn_err_vseq extends edn_base_vseq;
           cov_vif.cg_error_sample(.err_code(backdoor_err_code_val));
         end
       end
-      sfifo_rescmd_err_test, sfifo_gencmd_err_test, edn_ack_sm_err_test, edn_main_sm_err_test,
-      edn_cntr_err_test, fifo_write_err_test, fifo_read_err_test, fifo_state_err_test: begin
+      sfifo_rescmd_err_test, sfifo_gencmd_err_test, sfifo_output_err_test, edn_ack_sm_err_test,
+      edn_main_sm_err_test, edn_cntr_err_test, fifo_write_err_test, fifo_read_err_test,
+      fifo_state_err_test: begin
         fld = csr.get_field_by_name(fld_name.substr(0, last_index-1));
         err_code_test_bit = fld.get_lsb_pos();
         csr_wr(.ptr(ral.err_code_test.err_code_test), .value(err_code_test_bit));


### PR DESCRIPTION
Added output FIFO error codes to the err_code_e enum type and to the err_vseq. This means that now errors for the output FIFO are tested in the same way as the errors for the other EDN FIFOs. The H_DataStableWhenValidAndNotReady_A assertion caused the test to fail for the newly added error codes. The assertion was triggered because the FIFO clear in the test sequence causes the host data to be unstable.
Since this is the expected behaviour in this case, the assertion is disabled shortly before the FIFO clear and reenabled right after. This commit closes issue #18223.