### PR TITLE
[chip_earlgrey,spi_device,sival] Add new metadata to chip testplan for SiVal

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -190,6 +190,208 @@
       act:     "req"
     }
   ],
+  features: [
+    {
+      name: "SPI_DEVICE.MODE.GENERIC",
+      desc: '''Single-lane SPI device interface implementing a raw data transfer protocol for bulk-data loading.
+            AKA. Firmware Operation Mode
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.FLASH_EMULATION",
+      desc: '''Emulates the behaviour of a Serial Flash device when connected to an upstream SPI Host.
+            In this mode, the block recognizes SPI Flash commands and can respond entirely in HW.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH",
+      desc: '''The block acts as a proxy to a downstream external SPI Flash, with optional inline filtering and monitoring.
+
+            In this mode, an upstream SPI Host communicates with a downstream external SPI Flash.
+            Traffic received by this block is forwarded to a SPI_HOST instance, which then
+            relays the traffic onto the downstream external SPI flash.
+            Runtime-configurable filtering, payload interception, payload substitution and monitoring operations
+            on the passthrough traffic are provided by the block.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.TPM",
+      desc: '''Acts as a device-side endpoint in compliance with TPM PC Client Platform over SPI.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.CPOL",
+      desc: '''The SPI clock polarity is configurable at runtime via the "CSR.CFG.CPOL" register.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.CPHA",
+      desc: '''The SPI clock phase is configurable at runtime via the "CSR.CFG.CPHA" register.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.LANES",
+      desc: '''1,2 or 4 lane operation is supported by the block.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.SERDES_ORDERING",
+      desc: '''The block allows serialization ordering control for SDI/SDO that can be controlled at runtime.
+            CSR.CFG.rx_order : "RX bit order on SDI. 0 for MSB first, 1 for LSB first."
+            CSR.CFG.tx_order : "TX bit order on SDO. 0 for MSB first, 1 for LSB first.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.CSB_STATUS",
+      desc: '''CSR.STATUS fields show the current status of the two CSB signals (.csb/.tpm_csb).
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.GENERIC.ASYNC_FIFOS",
+      desc: '''A pair of asynchronous FIFOs (RXFIFO/TXFIFO) interface with the bus in Generic mode.
+
+            - The bus-facing side of the FIFOs is driven by the bus-CLK.
+            - The internal-facing side of the FIFOs is driven by the core-CLK.
+            - Generic-mode logic interfaces the internal-facing sides of the FIFOs with the DPSRAM.
+            - Generic-mode uses the entire DPSRAM space exclusively (See feature SPI_DEVICE.MODE.GENERIC.DPSRAM_TXF_RXF).
+            - Writing to "CSR.CONTROL.rst_txfifo" soft-resets the contents of the TXFIFO.
+            - Received data is normally written from the RXFIFO output to the DPSRAM receive buffer on 32b word boundaries.
+            - "CSR.CFG.timer_v" provides configurable control of the delay between the end of unaligned receive data and
+              the construction of an (abnormal) sub-word write to the DPSRAM receive buffer.
+            - "CSR.ASYNC_FIFO_LEVEL.txlvl" and "CSR.ASYNC_FIFO_LEVEL.rxlvl" contain the current levels of each FIFO.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.GENERIC.DPSRAM_TXF_RXF",
+      desc: '''A dual-port SRAM, notionally split into transmit (TXF) and receive (RXF) circular buffers, holds data in Generic Mode.
+
+            - TXF and RXF sections are defined by CSR.RXF_ADDR and CSR.TXF_ADDR, each of which contains a base and limit value.
+            - The boundary between TXF and RXF sections is configurable at runtime by writing to CSR.RXF_ADDR and CSR.TXF_ADDR.
+            - The current contents of TXF and RXF is defined by CSR.TXF_PTR and CSR.RXF_PTR, each of which contain a rptr and wptr.
+            - HW interfaces the buffers with the bus through two async-fifos (See feature SPI_DEVICE.MODE.GENERIC.ASYNC_FIFOS).
+            - CSR.TXF_PTR.rptr and CSR.RXF_PTR.wptr are controlled by HW in response to bus operations that consume or provide data.
+            - SW updates the rptr/wptr values to indicate it has written-to or read-from each buffer.
+            - CSR.STATUS contains empty and full flags for each buffer (.txf_empty/.txf_full/.rxf_empty/.rxf_full)
+            -
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.FLASH_EMULATION.COMMANDS",
+      desc: '''Device should respond to all specified standard SPI Flash Commands.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
+      desc: '''Hardware contains a number of submodules for handling certain commands.
+            cmdparse, READ, EN4B/EX4B, SFDP, JEDEC, status/busy
+
+            - CSR.FLASH_STATUS contains SW-writable bits that define the response to a Read Status Register command.
+            - Some fields in CSR.FLASH_STATUS may also be modified by HW.
+              - WRDI/WREN commands modify the CSR.FLASH_STATUS.status.WEL bit.
+              - CSR.FLASH_STATUS.status.BUSY may be modified by HW depending on command upload configuration of the
+                CSR.CMDINFO[x].busy field.
+
+            - CSR.JEDEC_CC and CSR.JEDEC_ID provide data for the JEDEC Read command.
+            - The SFDP section of DPSRAM provides data for the Read SFDP command.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.FLASH_EMULATION.READ_COMMAND_PROCESSOR",
+      desc: '''SPI Flash Read commands are provided with data from a DPSRAM section with a ping-pong buffering scheme, or a fixed mailbox region.
+
+            - The readptr crossing the buffer boundary creates a readbuf_flip interrupt.
+            - The readptr crossing the offset CSR.READ_THRESHOLD within a buffer creates a readbuf_watermark interrupt.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.FLASH_EMULATION.DUMMY_CYCLE",
+      desc: '''Insertion of dummy cycles between SPI Flash opcode and data.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.FLASH_EMULATION.WRITE_ENABLE_DISABLE",
+      desc: '''The block supports SPI Flash WREN/WRDI commands from the external host.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.LAST_READ_ADDR",
+      desc: '''The register CSR.LAST_READ_ADDR shows the last address a SPI Flash Read command accessed before CSb de-assertion.
+            MODES : FLASH_EMULATION,PASSTHROUGH
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.CMDINFOS",
+      desc: '''Registers that can contain custom opcode + data for responding to SPI Flash Commands.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.COMMAND_UPLOAD",
+      desc: '''HW can store the received command into the command/address FIFOs and payload buffer.
+            MODES:FLASH_EMULATION,PASSTHROUGH
+
+            - A received SPI Flash command can conditionally be written to the command,address and payload FIFOs.
+            - SW can access data about the uploaded commands via CSR.UPLOAD_STATUS and CSR.UPLOAD_STATUS2.
+            - SW can read CSR.UPLOAD_CMDFIFO to access the command FIFO.
+            - SW can read CSR.UPLOAD_ADDRFIFO to access the address FIFO.
+            - The payload FIFO can be read by accessing the DPSRAM window.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.HW.3B4B_ADDRESSING",
+      desc: '''Support CSR control of 3B/4B operation, plus host control with EN4B/EX4B
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
+      desc: '''Passthrough logic filters the command based on the 256-bit value of the "CMD_FILTER_0" CSR.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.ADDRESS_MANIPULATION",
+      desc: '''By configuring ADDR_SWAP_MASK and ADDR_SWAP_DATA CSRs, certain address bits of Flash Commands can be overwritten on passthrough.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.STATUS_MANIPULATION",
+      desc: '''By configuring PAYLOAD_SWAP_MASK and PAYLOAD_SWAP_DATA CSRs, certain bits of the first 4 payload bytes may be overwritten on passthrough.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.OUTPUT_ENABLE_CONTROL",
+      desc: '''Passthrough module can control the output enable signals on both host and downstream side.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.INTERCEPT_EN",
+      desc: '''Allow the block to reply to SPI Flash commands, taking precedence over the data returned by the passthrough device.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.PASSTHROUGH.MAILBOX",
+      desc: '''Return data from the 1kB Mailbox read/write buffer if the command address falls in the range (MAILBOX_ADDR:MAILBOX_ADDR+1kB).
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.TPM.RETURN-BY-HW_REGS",
+      desc: '''Block can auto-respond to a TPM host when the address falls within a configured range using the RETURN-BY-HW registers.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.TPM.AUTO_WAIT",
+      desc: '''If the address of a command does not fall into a pre-configured range, the block automatically returns a WAIT on the bus.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.TPM.READ_FIFO_MODE",
+      desc: '''If not activating the RETURN-BY-HW mode, the block responds to a Host TPM commands when the TPM_READ_FIFO has data >= requested transfer size.
+            '''
+    }
+    {
+      name: "SPI_DEVICE.MODE.TPM.CAPABILITY",
+      desc: '''TPM-mode can advertise the capabilities it supports to the upstream Host by setting CSR.TPM_CAP.
+            '''
+    }
+  ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -33,6 +33,7 @@
     "hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
   ]
@@ -97,138 +98,6 @@
             '''
       stage: V1
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
-    }
-
-    // SPI_DEVICE (pre-verified IP) integration tests:
-    {
-      name: chip_sw_spi_device_tx_rx
-      desc: '''Verify the transmission of data on the chip's SPI device port in firmware mode with
-               single mode.
-
-            - The testbench sends a known payload over the chip's SPI device input port.
-            - The SW test, at the same time sends a known payload out over the chip's SPI device
-              output port.
-            - On reception, both payloads are checked for integrity.
-            - SW validates the reception of RX fifo full, RX fifo over level, TX fifo under level,
-              RX overflow and TX underflow interrupts.
-            - Run with min (6MHz), typical (30-48Mhz) and max(48MHz) SPI clk frequencies.
-              should use
-            - Also, ensure that the spi_device does not receive transactions when the csb is high.
-            - TODO, consider to test this mode with a real use case. The actual use case of this
-              mdoe is not clear right now.
-            '''
-      stage: V2
-      tests: ["chip_sw_spi_device_tx_rx"]
-    }
-    {
-      name: chip_sw_spi_device_flash_mode
-      desc: '''Verify the SPI device in flash mode.
-
-            - SW puts the SPI device in flash mode
-            - Load a firmware image (bootstrap) through flash commands to the spi_device memory.
-            - SW verifies the integrity of the image upon reception by reading the spi_device
-              memory.
-            - Ensure the image is executed correctly
-            '''
-      stage: V2
-      tests: ["chip_sw_uart_tx_rx_bootstrap"]
-    }
-    {
-      name: chip_sw_spi_device_pass_through
-      desc: '''Verify the pass through mode from an end-to-end perspective.
-
-            - Configure the SPI device and host in pass through mode.
-            - Program the cmd_filter_* CSRs to filter out random commands.
-            - Configure and enable both spi_host0 and spi_host1
-            - Send a random flash commands over the SPI device interface (chip IOs) from the
-              testbench.
-            - Verify the flash commands which pass through spi_host0, are received on chip IOs.
-            - Verify that only the payloads that are not filtered show up on the SPI host interface
-              at chip IOs.
-            - Verify spi_host1 doesn't send out any data from spi_device
-            - Run with min (6MHz), typical (24Mhz) and max (30MHz) SPI clk frequencies.
-            - Run with single, dual and quad SPI modes.
-            - Testbench should test the following commands:
-            - Read Normal, Fast Read, Fast Dual, Fast Quad, Chip Erase, Program
-            '''
-      stage: V2
-      tests: ["chip_sw_spi_device_pass_through"]
-    }
-
-    {
-      name: chip_sw_spi_device_pass_through_flash_model
-      desc: '''Verify the command filtering mechanism in passthrough mode.
-
-            - Extend the chip_spi_device_pass_through test.
-            - Connect with a real flash model on spi_host
-            - Verify that the flash commands are received and interpreted correctly in the flash
-              model
-            '''
-      stage: V3
-      tests: []
-    }
-
-    {
-      name: chip_sw_spi_device_pass_through_collision
-      desc: '''Verify the collisions on driving spi_host is handled properly.
-
-            - Enable upload related interrupts and configure the spi_device in passthrough mode.
-            - Configure a command slot to enable upload for a flash program/erase command.
-            - Excecute two parallel threads:
-              1. SPI host agent.
-                - Send this command via an upstream SPI host agent, then the agent keeps sending
-                read_status to poll the busy bit.
-                - When the busy bit is low, issue a read command to read data from the downstream
-                  SPI port, and check data correctness.
-              2. A SW process.
-                - SW receives an upload interrupt and reads the command in the upload fifo to check.
-                - SW configures the SPI host that shows the same downstream port, to send the
-                  uploaded command to the downstream SPI port.
-                - SW clears busy bit to allow the upstream SPI host to proceed to the next command.
-            '''
-      stage: V2
-      tests: ["chip_sw_spi_device_pass_through_collision"]
-    }
-    {
-      name: chip_sw_spi_device_tpm
-      desc: '''Verify the basic operation of the spi tpm mode.
-
-            - The testbench sends a known payload over the chip's SPI device tpm input port.
-            - The testbench sends a read command.
-            - The software test should playback the data received in the write command as the read
-              response.
-            - The testbench should check if the written and read data match.
-            '''
-      stage: V2
-      tests: ["chip_sw_spi_device_tpm"]
-    }
-
-    {
-      name: chip_sw_spi_device_output_when_disabled_or_sleeping
-      desc: '''Verify spi_device output values when spi_device is disabled or the chip is sleeping.
-
-               SW needs to be able to set the SPI output value when spi_device is disabled or the
-               chip is sleeping, to either all-zeros or all-ones, depending on integration
-               requirements.  The following scenarios have to be verified:
-
-               After power-on reset:
-               - SW to configure pinmux retention logic so that the chip pins connected to
-                 spi_device outputs are (a) always zero or (b) always one (SW needs to be able to
-                 choose between a and b).
-               - DV environment to check that SPI outputs match configuration by SW.
-
-               Going to sleep:
-               - SW to disable spi_device, wait until CSb is high, configure pinmux retention logic
-                 as it would after POR, and put chip to sleep.
-               - DV environment to check that SPI outputs match configuration by SW.
-
-               Wake up from sleep:
-               - DV environment to wake chip from sleep.
-               - SW to enable spi_device and disable retention logic.
-               - DV environment to check that SPI transactions work as usual.
-             '''
-      stage: V3
-      tests: []
     }
 
     // SPI_HOST (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -1,0 +1,139 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_spi_device
+  testpoints: [
+    // SPI_DEVICE (pre-verified IP) integration tests:
+    {
+      name: chip_sw_spi_device_tx_rx
+      desc: '''Verify the transmission of data on the chip's SPI device port in firmware mode with
+               single mode.
+
+            - The testbench sends a known payload over the chip's SPI device input port.
+            - The SW test, at the same time sends a known payload out over the chip's SPI device
+              output port.
+            - On reception, both payloads are checked for integrity.
+            - SW validates the reception of RX fifo full, RX fifo over level, TX fifo under level,
+              RX overflow and TX underflow interrupts.
+            - Run with min (6MHz), typical (30-48Mhz) and max(48MHz) SPI clk frequencies.
+              should use
+            - Also, ensure that the spi_device does not receive transactions when the csb is high.
+            - TODO, consider to test this mode with a real use case. The actual use case of this
+              mdoe is not clear right now.
+            '''
+      stage: V2
+      tests: ["chip_sw_spi_device_tx_rx"]
+    }
+    {
+      name: chip_sw_spi_device_flash_mode
+      desc: '''Verify the SPI device in flash mode.
+
+            - SW puts the SPI device in flash mode
+            - Load a firmware image (bootstrap) through flash commands to the spi_device memory.
+            - SW verifies the integrity of the image upon reception by reading the spi_device
+              memory.
+            - Ensure the image is executed correctly
+            '''
+      stage: V2
+      tests: ["chip_sw_uart_tx_rx_bootstrap"]
+    }
+    {
+      name: chip_sw_spi_device_pass_through
+      desc: '''Verify the pass through mode from an end-to-end perspective.
+
+            - Configure the SPI device and host in pass through mode.
+            - Program the cmd_filter_* CSRs to filter out random commands.
+            - Configure and enable both spi_host0 and spi_host1
+            - Send a random flash commands over the SPI device interface (chip IOs) from the
+              testbench.
+            - Verify the flash commands which pass through spi_host0, are received on chip IOs.
+            - Verify that only the payloads that are not filtered show up on the SPI host interface
+              at chip IOs.
+            - Verify spi_host1 doesn't send out any data from spi_device
+            - Run with min (6MHz), typical (24Mhz) and max (30MHz) SPI clk frequencies.
+            - Run with single, dual and quad SPI modes.
+            - Testbench should test the following commands:
+            - Read Normal, Fast Read, Fast Dual, Fast Quad, Chip Erase, Program
+            '''
+      stage: V2
+      tests: ["chip_sw_spi_device_pass_through"]
+    }
+
+    {
+      name: chip_sw_spi_device_pass_through_flash_model
+      desc: '''Verify the command filtering mechanism in passthrough mode.
+
+            - Extend the chip_spi_device_pass_through test.
+            - Connect with a real flash model on spi_host
+            - Verify that the flash commands are received and interpreted correctly in the flash
+              model
+            '''
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: chip_sw_spi_device_pass_through_collision
+      desc: '''Verify the collisions on driving spi_host is handled properly.
+
+            - Enable upload related interrupts and configure the spi_device in passthrough mode.
+            - Configure a command slot to enable upload for a flash program/erase command.
+            - Excecute two parallel threads:
+              1. SPI host agent.
+                - Send this command via an upstream SPI host agent, then the agent keeps sending
+                read_status to poll the busy bit.
+                - When the busy bit is low, issue a read command to read data from the downstream
+                  SPI port, and check data correctness.
+              2. A SW process.
+                - SW receives an upload interrupt and reads the command in the upload fifo to check.
+                - SW configures the SPI host that shows the same downstream port, to send the
+                  uploaded command to the downstream SPI port.
+                - SW clears busy bit to allow the upstream SPI host to proceed to the next command.
+            '''
+      stage: V2
+      tests: ["chip_sw_spi_device_pass_through_collision"]
+    }
+    {
+      name: chip_sw_spi_device_tpm
+      desc: '''Verify the basic operation of the spi tpm mode.
+
+            - The testbench sends a known payload over the chip's SPI device tpm input port.
+            - The testbench sends a read command.
+            - The software test should playback the data received in the write command as the read
+              response.
+            - The testbench should check if the written and read data match.
+            '''
+      stage: V2
+      tests: ["chip_sw_spi_device_tpm"]
+    }
+
+    {
+      name: chip_sw_spi_device_output_when_disabled_or_sleeping
+      desc: '''Verify spi_device output values when spi_device is disabled or the chip is sleeping.
+
+               SW needs to be able to set the SPI output value when spi_device is disabled or the
+               chip is sleeping, to either all-zeros or all-ones, depending on integration
+               requirements.  The following scenarios have to be verified:
+
+               After power-on reset:
+               - SW to configure pinmux retention logic so that the chip pins connected to
+                 spi_device outputs are (a) always zero or (b) always one (SW needs to be able to
+                 choose between a and b).
+               - DV environment to check that SPI outputs match configuration by SW.
+
+               Going to sleep:
+               - SW to disable spi_device, wait until CSb is high, configure pinmux retention logic
+                 as it would after POR, and put chip to sleep.
+               - DV environment to check that SPI outputs match configuration by SW.
+
+               Wake up from sleep:
+               - DV environment to wake chip from sleep.
+               - SW to enable spi_device and disable retention logic.
+               - DV environment to check that SPI transactions work as usual.
+             '''
+      stage: V3
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -1,63 +1,101 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
 {
   name: chip_spi_device
   testpoints: [
     // SPI_DEVICE (pre-verified IP) integration tests:
     {
       name: chip_sw_spi_device_tx_rx
-      desc: '''Verify the transmission of data on the chip's SPI device port in firmware mode with
-               single mode.
+      desc: '''Verify the transmission of data on the chip's SPI device port in generic mode.
 
             - The testbench sends a known payload over the chip's SPI device input port.
-            - The SW test, at the same time sends a known payload out over the chip's SPI device
+            - At the same time, the SW test sends a known payload out over the chip's SPI device
               output port.
             - On reception, both payloads are checked for integrity.
-            - SW validates the reception of RX fifo full, RX fifo over level, TX fifo under level,
-              RX overflow and TX underflow interrupts.
-            - Run with min (6MHz), typical (30-48Mhz) and max(48MHz) SPI clk frequencies.
-              should use
-            - Also, ensure that the spi_device does not receive transactions when the csb is high.
-            - TODO, consider to test this mode with a real use case. The actual use case of this
-              mdoe is not clear right now.
+            - SW validates the reception of the following interrupts:
+              - RX fifo full
+              - RX fifo over level
+              - TX fifo under level
+              - RX overflow
+              - TX underflow
+            - Run with min (6MHz), typical (24Mhz) and max(30MHz) SPI clk frequencies.
+            - Ensure that the spi_device does not receive transactions when the csb is high.
             '''
       stage: V2
+      // Can function as a smoketest, but also may be useful as part of a bootloader for early bring-up.
+      si_stage: SV2
+      lc_states: [
+        "TEST_UNLOCKED",
+        "DEV",
+        "PROD",
+        "PROD_END",
+        "RMA",
+      ]
+      features: [
+        "SPI_DEVICE.MODE.GENERIC",
+        "SPI_DEVICE.MODE.GENERIC.ASYNC_FIFOS",
+        "SPI_DEVICE.MODE.GENERIC.DPSRAM_TXF_RXF",
+      ]
       tests: ["chip_sw_spi_device_tx_rx"]
+      bazel: []
     }
     {
       name: chip_sw_spi_device_flash_mode
       desc: '''Verify the SPI device in flash mode.
 
-            - SW puts the SPI device in flash mode
+            - SW puts the SPI device in flash mode.
             - Load a firmware image (bootstrap) through flash commands to the spi_device memory.
-            - SW verifies the integrity of the image upon reception by reading the spi_device
-              memory.
-            - Ensure the image is executed correctly
+            - SW verifies the integrity of the image upon reception by reading the spi_device memory.
+            - Ensure the image is executed correctly.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: [ "PROD" ]
+      features: [
+        "SPI_DEVICE.MODE.FLASH_EMULATION",
+        "SPI_DEVICE.MODE.FLASH_EMULATION.COMMANDS",
+        "SPI_DEVICE.MODE.FLASH_EMULATION.READ_COMMAND_PROCESSOR",
+        "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
+        "SPI_DEVICE.HW.LAST_READ_ADDR",
+      ]
       tests: ["chip_sw_uart_tx_rx_bootstrap"]
+      bazel: []
     }
     {
       name: chip_sw_spi_device_pass_through
-      desc: '''Verify the pass through mode from an end-to-end perspective.
+      desc: '''Verify the passthrough mode from an end-to-end perspective.
 
-            - Configure the SPI device and host in pass through mode.
+            - Configure the SPI device and host in passthrough mode.
             - Program the cmd_filter_* CSRs to filter out random commands.
-            - Configure and enable both spi_host0 and spi_host1
-            - Send a random flash commands over the SPI device interface (chip IOs) from the
+            - Configure and enable both spi_host0 and spi_host1.
+            - Send random flash commands over the SPI device interface (chip IOs) from the
               testbench.
-            - Verify the flash commands which pass through spi_host0, are received on chip IOs.
+            - Verify the flash commands which pass through spi_host0 are received on chip IOs.
             - Verify that only the payloads that are not filtered show up on the SPI host interface
               at chip IOs.
-            - Verify spi_host1 doesn't send out any data from spi_device
+            - Verify spi_host1 doesn't send out any data from spi_device.
             - Run with min (6MHz), typical (24Mhz) and max (30MHz) SPI clk frequencies.
             - Run with single, dual and quad SPI modes.
             - Testbench should test the following commands:
-            - Read Normal, Fast Read, Fast Dual, Fast Quad, Chip Erase, Program
+              - Read Normal
+              - Fast Read
+              - Fast Dual
+              - Fast Quad
+              - Chip Erase
+              - Program
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: [ "PROD" ]
+      features: [
+        "SPI_DEVICE.MODE.PASSTHROUGH",
+        "SPI_DEVICE.HW.LANES",
+        "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
+      ]
       tests: ["chip_sw_spi_device_pass_through"]
+      bazel: []
     }
 
     {
@@ -65,50 +103,72 @@
       desc: '''Verify the command filtering mechanism in passthrough mode.
 
             - Extend the chip_spi_device_pass_through test.
-            - Connect with a real flash model on spi_host
+            - Connect with a real flash model on spi_host.
             - Verify that the flash commands are received and interpreted correctly in the flash
-              model
+              model.
             '''
       stage: V3
+      si_stage: None
+      lc_states: [ "PROD" ]
+      features: [
+        "SPI_DEVICE.MODE.PASSTHROUGH",
+        "SPI_DEVICE.HW.LANES",
+        "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
+      ]
       tests: []
+      bazel: []
     }
-
     {
       name: chip_sw_spi_device_pass_through_collision
       desc: '''Verify the collisions on driving spi_host is handled properly.
 
-            - Enable upload related interrupts and configure the spi_device in passthrough mode.
+            - Enable upload-related interrupts and configure the spi_device in passthrough mode.
             - Configure a command slot to enable upload for a flash program/erase command.
             - Excecute two parallel threads:
-              1. SPI host agent.
-                - Send this command via an upstream SPI host agent, then the agent keeps sending
-                read_status to poll the busy bit.
+              1. Upstream SPI host agent.
+                - Send a flash program/erase, then keep sending read_status to poll the busy bit.
                 - When the busy bit is low, issue a read command to read data from the downstream
                   SPI port, and check data correctness.
               2. A SW process.
-                - SW receives an upload interrupt and reads the command in the upload fifo to check.
-                - SW configures the SPI host that shows the same downstream port, to send the
+                - Receives an upload interrupt, then reads the command in the upload fifo to check.
+                - Configures the SPI host that shows the same downstream port to send the
                   uploaded command to the downstream SPI port.
-                - SW clears busy bit to allow the upstream SPI host to proceed to the next command.
+                - Clears the busy bit to allow the upstream SPI host to proceed to the next command.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: [ "PROD" ]
+      features: [
+        "SPI_DEVICE.MODE.PASSTHROUGH",
+        "SPI_DEVICE.HW.CMDINFOS",
+        "SPI_DEVICE.HW.COMMAND_UPLOAD",
+        "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
+        "SPI_DEVICE.MODE.PASSTHROUGH.INTERCEPT_EN",
+      ]
       tests: ["chip_sw_spi_device_pass_through_collision"]
+      bazel: []
     }
     {
       name: chip_sw_spi_device_tpm
-      desc: '''Verify the basic operation of the spi tpm mode.
+      desc: '''Verify the basic operation of the spi_device in TPM mode.
 
-            - The testbench sends a known payload over the chip's SPI device tpm input port.
+            - The testbench sends a known payload to the spi_device TPM input port.
             - The testbench sends a read command.
             - The software test should playback the data received in the write command as the read
               response.
             - The testbench should check if the written and read data match.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: [ "PROD" ]
+      features: [
+        "SPI_DEVICE.MODE.TPM",
+        "SPI_DEVICE.MODE.TPM.READ_FIFO_MODE",
+      ]
       tests: ["chip_sw_spi_device_tpm"]
     }
-
     {
+      // This test is more a pinmux/padctrl test than a spi_device one. Consider reclassification.
       name: chip_sw_spi_device_output_when_disabled_or_sleeping
       desc: '''Verify spi_device output values when spi_device is disabled or the chip is sleeping.
 
@@ -131,9 +191,17 @@
                - DV environment to wake chip from sleep.
                - SW to enable spi_device and disable retention logic.
                - DV environment to check that SPI transactions work as usual.
+
+               Notes for silicon targets:
+               This test currently does not exercise any features of the spi_device block itself,
+               which is why the "features" list is empty. It may be reclassifed in the future.
              '''
       stage: V3
+      si_stage: None
+      lc_states: [ "PROD" ]
+      features: []
       tests: []
+      bazel: []
     }
   ]
 }


### PR DESCRIPTION
Not all 'features' are covered by the current tests, this may be further fixed by either adding new tests or changing the granularity of the features identified.