### PR TITLE
[dv/clkmgr] Fix clkmgr_env.core dependencies

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -9,6 +9,8 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:systems:clkmgr_pkg
     files:
       - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv


### PR DESCRIPTION
The clkmgr_pkg and pwrmgr_pkg are obviously missing.