### PR TITLE
[edn/dv] Add new coverpoints to cs_cmds cover group

### DIFF
--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -36,8 +36,17 @@ package edn_env_pkg;
 
   typedef enum int {
     AutoReqMode = 1,
-    BootReqMode = 2
+    BootReqMode = 2,
+    SwMode      = 3
   } hw_req_mode_e;
+
+  typedef enum int {
+    BootIns = 1,
+    BootGen = 2,
+    AutoGen = 3,
+    AutoRes = 4,
+    Sw      = 5
+  } cmd_type_e;
 
   typedef enum int {
     invalid_edn_enable    = 0,

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -29,10 +29,12 @@ class edn_alert_vseq extends edn_base_vseq;
     cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
 
     // Send INS cmd
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4True), .glen(0));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4True),
+           .glen(0), .mode(edn_env_pkg::AutoReqMode));
 
     // Send GEN cmd w/ GLEN 1 (request single genbits)
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4True), .glen(1));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4True),
+           .glen(1), .mode(edn_env_pkg::AutoReqMode));
     // Load constant genbits data
     cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
     // Request data
@@ -54,7 +56,8 @@ class edn_alert_vseq extends edn_base_vseq;
     m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
 
     // Send GEN cmd w/ GLEN 1 (request single genbits)
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4True), .glen(1));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4True),
+           .glen(1), .mode(edn_env_pkg::AutoReqMode));
 
     // Load constant genbits data
     cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -93,7 +93,6 @@ class edn_base_vseq extends cip_base_vseq #(
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(glen, glen dist { 0 :/ 20, [1:$] :/ 80 };)
-      cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
       wr_cmd(.cmd_type("reseed"), .acmd(csrng_pkg::RES), .clen(clen), .flags(flags), .glen(glen));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -102,7 +101,6 @@ class edn_base_vseq extends cip_base_vseq #(
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       glen = 1;
-      cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
       wr_cmd(.cmd_type("generate"), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags), .glen(glen));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -142,7 +140,6 @@ class edn_base_vseq extends cip_base_vseq #(
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
     `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(glen, glen dist { 0 :/ 20, [1:$] :/ 80 };)
-    cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
     wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(clen), .flags(flags), .glen(glen));
     for (int i = 0; i < clen; i++) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -153,6 +150,8 @@ class edn_base_vseq extends cip_base_vseq #(
   virtual task wr_cmd(string cmd_type = "", csrng_pkg::acmd_e acmd = csrng_pkg::INV,
                       bit[3:0] clen = '0, bit[3:0] flags = MuBi4False, bit[17:0] glen = '0,
                       bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0] cmd_data = '0);
+
+    cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
 
     case (cmd_type)
       "boot_ins": csr_wr(.ptr(ral.boot_ins_cmd), .value({glen, flags, clen, 1'b0, acmd}));

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -151,7 +151,7 @@ class edn_base_vseq extends cip_base_vseq #(
                       bit[3:0] clen = '0, bit[3:0] flags = MuBi4False, bit[17:0] glen = '0,
                       bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0] cmd_data = '0);
 
-    cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
+    cov_vif.cg_cs_cmds_sample(.acmd(acmd), .clen(clen), .flags(flags), .glen(glen));
 
     case (cmd_type)
       "boot_ins": csr_wr(.ptr(ral.boot_ins_cmd), .value({glen, flags, clen, 1'b0, acmd}));

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -159,7 +159,8 @@ class edn_base_vseq extends cip_base_vseq #(
                       edn_env_pkg::hw_req_mode_e mode);
 
     if (!additional_data) begin
-      cov_vif.cg_cs_cmds_sample(.acmd(acmd), .clen(clen), .flags(flags), .glen(glen));
+      cov_vif.cg_cs_cmds_sample(.acmd(acmd), .clen(clen), .flags(flags),
+                          .glen(glen), .mode(mode), .cmd_src(cmd_type));
     end
 
     case (cmd_type)

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -118,7 +118,7 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
         // requests between reseeds to 1 (to maximize coverage over time).
         super.edn_init();
         cfg.clk_rst_vif.wait_clks(1);
-        instantiate_csrng();
+        instantiate_csrng(.mode("auto_mode"));
         csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(1));
       ,
         // Exit thread: Wait for a signal from the thread that randomly disables EDN.

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -81,7 +81,6 @@ class edn_genbits_vseq extends edn_base_vseq;
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(glen, glen dist { 0 :/ 20, [1:$] :/ 80 };)
-      cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
       wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(clen), .flags(flags), .glen(glen));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -94,7 +93,6 @@ class edn_genbits_vseq extends edn_base_vseq;
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       glen = num_cs_reqs;
-      cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
       wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags), .glen(glen));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -128,6 +126,7 @@ class edn_genbits_vseq extends edn_base_vseq;
                                          acmd inside {csrng_pkg::INS, csrng_pkg::GEN,
                                                       csrng_pkg::RES, csrng_pkg::UPD,
                                                       csrng_pkg::UNI};)
+      cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
       csr_wr(.ptr(ral.sw_cmd_req), .value({glen, flags, clen, 1'b0, acmd}));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
@@ -146,7 +145,6 @@ class edn_genbits_vseq extends edn_base_vseq;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
         `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
         glen = num_cs_reqs - cfg.m_csrng_agent_cfg.generate_cnt;
-        cov_vif.cg_cs_cmds_sample(.clen(clen), .flags(flags), .glen(glen));
         wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags),
                .glen(glen));
         for (int i = 0; i < clen; i++) begin

--- a/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
@@ -17,10 +17,12 @@ class edn_intr_vseq extends edn_base_vseq;
 
   task test_edn_cmd_req_done();
     // Send INS cmd
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False), .glen(0));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False),
+           .glen(0), .mode(edn_env_pkg::SwMode));
 
     // Send GEN cmd w/ GLEN 1 (request single genbits)
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False), .glen(1));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False),
+           .glen(1), .mode(edn_env_pkg::SwMode));
 
     // Load expected genbits data
     m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::

--- a/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
@@ -17,7 +17,8 @@ class edn_smoke_vseq extends edn_base_vseq;
         create("m_endpoint_pull_seq[0]");
 
     // Send instantiate cmd
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False), .glen(0));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(0), .flags(MuBi4False),
+           .glen(0), .mode(edn_env_pkg::SwMode));
 
     // Request data
     m_endpoint_pull_seq[0] = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
@@ -28,11 +29,13 @@ class edn_smoke_vseq extends edn_base_vseq;
     join_none
 
     // Send generate cmd
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False), .glen(1));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False),
+           .glen(1), .mode(edn_env_pkg::SwMode));
 
     // Send uninstantiate cmd
     `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::UNI), .clen(0), .flags(flags), .glen(0));
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::UNI), .clen(0), .flags(flags),
+           .glen(0), .mode(edn_env_pkg::SwMode));
   endtask
 
 endclass


### PR DESCRIPTION
This PR adds new cover points to the cs_cmds cover group.
Namely acmd, the operational mode and the cmd src registers.
For more information on the added features please see the commit
messages.
This PR closes issue #19855.