### PR TITLE
[e2e] Fix rom_e2e_shutdown_watchdog

### DIFF
--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -88,7 +88,7 @@
             - Verify that the chip does not reset in TEST and RMA.
             - For DEV, PROD, and PROD_END:
               - Verify that the chip resets when the `WATCHDOG_BITE_THRESHOLD_CYCLES` OTP item is
-               `0x00061a80` (2 s).
+               `0x00030d40` (1 s).
               - Verify that watchdog is disabled when `WATCHDOG_BITE_THRESHOLD_CYCLES` is `0`.
             '''
       tags: ["rom", "no_dv", "fpga", "silicon"]

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -1945,7 +1945,7 @@ test_suite(
 )
 
 SHUTDOWN_WATCHDOG_BITE_THRESHOLDS = [
-    400000,  # 2 seconds at 200 kHz
+    200000,  # 1 seconds at 200 kHz
     0,  # Watchdog disabled
 ]
 
@@ -1953,7 +1953,8 @@ SHUTDOWN_WATCHDOG_CASES = [
     {
         "lc_state": lc_state[0],
         "lc_state_val": lc_state[1],
-        "exit_success": "Returning after 1 seconds",
+        # Make sure that the watchdog was not enabled so the count stayed 0.
+        "exit_success": "Returning after 2 seconds\r\n[^\r\n]*Watchdog count: 0",
         "bite_threshold": bite_threshold,
     }
     for lc_state in get_lc_items(
@@ -1965,7 +1966,7 @@ SHUTDOWN_WATCHDOG_CASES = [
     {
         "lc_state": lc_state[0],
         "lc_state_val": lc_state[1],
-        "exit_success": "Returning after 1 seconds" if bite_threshold == 0 else "I00000[^\r\n]*\r\nROM:[0-9a-f]{8}\r\n",
+        "exit_success": "Returning after 2 seconds\r\n[^\r\n]*Watchdog count: 0" if bite_threshold == 0 else "I00000[^\r\n]*\r\nROM:[0-9a-f]{8}\r\n",
         "bite_threshold": bite_threshold,
     }
     for lc_state in get_lc_items(
@@ -2050,10 +2051,12 @@ SHUTDOWN_WATCHDOG_CASES = [
             spx = None,
         )[0],
         local_defines = [
-            "HANG_SECS=1",
+            "HANG_SECS=2",
         ],
         targets = ["cw310_rom_with_fake_keys"],
         deps = [
+            "//sw/device/lib/base:memory",
+            "//sw/device/lib/dif:aon_timer",
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )

--- a/sw/device/silicon_creator/rom/e2e/hang_test.c
+++ b/sw/device/silicon_creator/rom/e2e/hang_test.c
@@ -4,16 +4,28 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
+  dif_aon_timer_t aon_timer;
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  /* Pet the watchdog to have make sure that we start from a known value */
+  CHECK_DIF_OK(dif_aon_timer_watchdog_pet(&aon_timer));
   ibex_timeout_t timeout = ibex_timeout_init(HANG_SECS * 1000000);
   while (!ibex_timeout_check(&timeout)) {
   }
+  /* Get the watchdog count value */
+  uint32_t count;
+  CHECK_DIF_OK(dif_aon_timer_watchdog_get_count(&aon_timer, &count));
   LOG_INFO("Returning after %d seconds", HANG_SECS);
+  LOG_INFO("Watchdog count: %d", count);
   return true;
 }


### PR DESCRIPTION
The test does not make sense: it asks the watchdog to shutdown after 2 seconds but the waits only 1 second before returning. Therefore the shutdown nevers happens while waiting and the tests fails. This commit fixes the test by setting the watchdog bite threshold at 1 second and change the test to wait 2 seconds. This way, and with some margin, it will always reset during the wait.

I also change the flash program to display the value of the watchdog count after the loop. The idea is for the test to verify that in certain LC states, the watchdog was actually disabled. Ideally, a further test should be added to verify that in PROD, if we wait only half a second, the value will be printed before the shutdown and show the expected value.