### PR TITLE
[openocd] add openocd patch to work with modern GCC 13.2.0

### DIFF
--- a/third_party/openocd/BUILD
+++ b/third_party/openocd/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-package(default_visibility = ["//visibility:private"])
-
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+
+package(default_visibility = ["//visibility:private"])
 
 # Extract the `openocd` binary from :build_openocd. Although the binary itself
 # is executable, Bazel does not believe it is runnable. If you want to run

--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -14,6 +14,9 @@ def openocd_repos(local = None):
         build_file = "//third_party/openocd:BUILD.openocd.bazel",
         sha256 = "bb367fd19ab96a65ee5b269b60326d9f36bca1c64d9865cc36985d3651aba563",
         # See Issue(#18087)
-        patches = [Label("//third_party/openocd:reset_on_dmi_op_error.patch")],
+        patches = [
+            Label("//third_party/openocd:reset_on_dmi_op_error.patch"),
+            Label("//third_party/openocd:string_truncate_build_error.patch"),
+        ],
         patch_args = ["-p1"],
     )

--- a/third_party/openocd/string_truncate_build_error.patch
+++ b/third_party/openocd/string_truncate_build_error.patch
@@ -1,0 +1,13 @@
+diff --git a/src/flash/nor/psoc4.c b/src/flash/nor/psoc4.c
+index c935bd5..6b727d8 100644
+--- a/src/flash/nor/psoc4.c
++++ b/src/flash/nor/psoc4.c
+@@ -784,7 +784,7 @@ static int psoc4_probe(struct flash_bank *bank)
+ 		flash_size_in_kb = psoc4_info->user_bank_size / 1024;
+ 	}
+ 
+-	char macros_txt[20] = "";
++	char macros_txt[30] = "";
+ 	if (num_macros > 1)
+ 		snprintf(macros_txt, sizeof(macros_txt), " in %" PRIu32 " macros", num_macros);
+ 


### PR DESCRIPTION
OpenOCD is vendored-in and built from source in our repo. The build started failing recently when the host toolchain was updated on some machines. This adds a patch to fix the compilation error.