### PR TITLE
[usbdev] Single port packet buffer

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -145,8 +145,8 @@
       struct:  "logic",
       width:   "1"
     },
-    { struct:  "ram_2p_cfg",
-      package: "prim_ram_2p_pkg",
+    { struct:  "ram_1p_cfg",
+      package: "prim_ram_1p_pkg",
       type:    "uni",
       name:    "ram_cfg",
       act:     "rcv"

--- a/hw/ip/usbdev/doc/interfaces.md
+++ b/hw/ip/usbdev/doc/interfaces.md
@@ -33,7 +33,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | usb_aon_bus_reset          | logic                       | uni     | rcv   |       1 |                                                                                                    |
 | usb_aon_sense_lost         | logic                       | uni     | rcv   |       1 |                                                                                                    |
 | usb_aon_wake_detect_active | logic                       | uni     | rcv   |       1 |                                                                                                    |
-| ram_cfg                    | prim_ram_2p_pkg::ram_2p_cfg | uni     | rcv   |       1 |                                                                                                    |
+| ram_cfg                    | prim_ram_1p_pkg::ram_1p_cfg | uni     | rcv   |       1 |                                                                                                    |
 | tl                         | tlul_pkg::tl                | req_rsp | rsp   |       1 |                                                                                                    |
 
 ## Interrupts

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:tlul:socket_1n
       - lowrisc:prim:edge_detector
-      - lowrisc:prim:ram_2p_adv
+      - lowrisc:prim:ram_1p_adv
       - lowrisc:ip:usb_fs_nb_pe
       - lowrisc:ip:usbdev_pkg
     files:

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2596,14 +2596,14 @@
         }
         {
           name: ram_cfg
-          struct: ram_2p_cfg
-          package: prim_ram_2p_pkg
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
           type: uni
           act: rcv
           width: 1
           inst_name: usbdev
           default: ""
-          top_signame: ast_usb_ram_2p_cfg
+          top_signame: ast_usb_ram_1p_cfg
           index: -1
         }
         {
@@ -7983,17 +7983,17 @@
           conn_type: true
         }
         {
-          struct: ram_2p_cfg
-          package: prim_ram_2p_pkg
+          struct: ram_1p_cfg
+          package: prim_ram_1p_pkg
           type: uni
-          name: usb_ram_2p_cfg
+          name: usb_ram_1p_cfg
           act: rcv
           inst_name: ast
           width: 1
           default: ""
           end_idx: -1
           top_type: broadcast
-          top_signame: ast_usb_ram_2p_cfg
+          top_signame: ast_usb_ram_1p_cfg
           index: -1
           external: true
           conn_type: true
@@ -8053,7 +8053,7 @@
       [
         spi_device.ram_cfg
       ]
-      ast.usb_ram_2p_cfg:
+      ast.usb_ram_1p_cfg:
       [
         usbdev.ram_cfg
       ]
@@ -8640,7 +8640,7 @@
       ast.obs_ctrl: obs_ctrl
       ast.ram_1p_cfg: ram_1p_cfg
       ast.spi_ram_2p_cfg: spi_ram_2p_cfg
-      ast.usb_ram_2p_cfg: usb_ram_2p_cfg
+      ast.usb_ram_1p_cfg: usb_ram_1p_cfg
       ast.rom_cfg: rom_cfg
       clkmgr_aon.jitter_en: clk_main_jitter_en
       clkmgr_aon.io_clk_byp_req: io_clk_byp_req
@@ -16670,14 +16670,14 @@
       }
       {
         name: ram_cfg
-        struct: ram_2p_cfg
-        package: prim_ram_2p_pkg
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
         type: uni
         act: rcv
         width: 1
         inst_name: usbdev
         default: ""
-        top_signame: ast_usb_ram_2p_cfg
+        top_signame: ast_usb_ram_1p_cfg
         index: -1
       }
       {
@@ -20369,17 +20369,17 @@
         conn_type: true
       }
       {
-        struct: ram_2p_cfg
-        package: prim_ram_2p_pkg
+        struct: ram_1p_cfg
+        package: prim_ram_1p_pkg
         type: uni
-        name: usb_ram_2p_cfg
+        name: usb_ram_1p_cfg
         act: rcv
         inst_name: ast
         width: 1
         default: ""
         end_idx: -1
         top_type: broadcast
-        top_signame: ast_usb_ram_2p_cfg
+        top_signame: ast_usb_ram_1p_cfg
         index: -1
         external: true
         conn_type: true
@@ -20516,16 +20516,16 @@
         netname: ast_spi_ram_2p_cfg
       }
       {
-        package: prim_ram_2p_pkg
-        struct: ram_2p_cfg
-        signame: usb_ram_2p_cfg_i
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: usb_ram_1p_cfg_i
         width: 1
         type: uni
         default: ""
         direction: in
         conn_type: true
         index: -1
-        netname: ast_usb_ram_2p_cfg
+        netname: ast_usb_ram_1p_cfg
       }
       {
         package: prim_rom_pkg
@@ -21104,15 +21104,15 @@
         default: prim_ram_2p_pkg::RAM_2P_CFG_DEFAULT
       }
       {
-        package: prim_ram_2p_pkg
-        struct: ram_2p_cfg
-        signame: ast_usb_ram_2p_cfg
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: ast_usb_ram_1p_cfg
         width: 1
         type: uni
         end_idx: -1
         act: rcv
         suffix: ""
-        default: prim_ram_2p_pkg::RAM_2P_CFG_DEFAULT
+        default: prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT
       }
       {
         package: prim_rom_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -854,10 +854,10 @@
           act:     "rcv"
         },
 
-        { struct:  "ram_2p_cfg",
-          package: "prim_ram_2p_pkg",
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
           type:    "uni",
-          name:    "usb_ram_2p_cfg",
+          name:    "usb_ram_1p_cfg",
           // The activity direction for a port inter-signal is "opposite" of
           // what the external module actually needs.
           act:     "rcv"
@@ -899,7 +899,7 @@
                                    'sram_ctrl_ret_aon.cfg',
                                    'rv_core_ibex.ram_cfg'],
       'ast.spi_ram_2p_cfg'      : ['spi_device.ram_cfg'],
-      'ast.usb_ram_2p_cfg'      : ['usbdev.ram_cfg'],
+      'ast.usb_ram_1p_cfg'      : ['usbdev.ram_cfg'],
       'ast.rom_cfg'             : ['rom_ctrl.rom_cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'alert_handler.esc_rx'    : ['rv_core_ibex.esc_rx',
@@ -1103,7 +1103,7 @@
         'ast.obs_ctrl'                    : 'obs_ctrl',
         'ast.ram_1p_cfg'                  : 'ram_1p_cfg',
         'ast.spi_ram_2p_cfg'              : 'spi_ram_2p_cfg',
-        'ast.usb_ram_2p_cfg'              : 'usb_ram_2p_cfg',
+        'ast.usb_ram_1p_cfg'              : 'usb_ram_1p_cfg',
         'ast.rom_cfg'                     : 'rom_cfg',
         'clkmgr_aon.jitter_en'            : 'clk_main_jitter_en',
         'clkmgr_aon.io_clk_byp_req'       : 'io_clk_byp_req',

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -60,4 +60,4 @@
 `define OTP_MEM_HIER          `OTP_GENERIC_HIER.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
 `define OTBN_IMEM_HIER        `OTBN_HIER.u_imem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
 `define OTBN_DMEM_HIER        `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.u_mem.`MEM_ARRAY_SUB
-`define USBDEV_BUF_HIER       `USBDEV_HIER.gen_no_stubbed_memory.u_memory_2p.i_prim_ram_2p_async_adv.u_mem.`MEM_ARRAY_SUB
+`define USBDEV_BUF_HIER       `USBDEV_HIER.gen_no_stubbed_memory.u_memory_1p.u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -790,7 +790,7 @@ module chip_earlgrey_asic #(
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
   prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
+  prim_ram_1p_pkg::ram_1p_cfg_t usb_ram_1p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -805,18 +805,15 @@ module chip_earlgrey_asic #(
               }
   };
 
-  // this maps as follows:
-  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
-  assign usb_ram_2p_cfg = '{
-    a_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_a,
-                   cfg:    ast_ram_2p_fcfg.marg_a
-                 },
-    b_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
-    default: '0
+  assign usb_ram_1p_cfg = '{
+    ram_cfg: '{
+                cfg_en: ast_ram_1p_cfg.marg_en,
+                cfg:    ast_ram_1p_cfg.marg
+              },
+    rf_cfg:  '{
+                cfg_en: ast_rf_cfg.marg_en,
+                cfg:    ast_rf_cfg.marg
+              }
   };
 
   // this maps as follows:
@@ -838,6 +835,9 @@ module chip_earlgrey_asic #(
     cfg: ast_rom_cfg.marg
   };
 
+  // unused cfg bits
+  logic unused_ram_cfg;
+  assign unused_ram_cfg = ^ast_ram_2p_fcfg;
 
   //////////////////////////////////
   // AST - Custom for targets     //
@@ -1171,7 +1171,7 @@ module chip_earlgrey_asic #(
     // Memory attributes
     .ram_1p_cfg_i                 ( ram_1p_cfg                 ),
     .spi_ram_2p_cfg_i             ( spi_ram_2p_cfg             ),
-    .usb_ram_2p_cfg_i             ( usb_ram_2p_cfg             ),
+    .usb_ram_1p_cfg_i             ( usb_ram_1p_cfg             ),
 
     .rom_cfg_i                    ( rom_cfg                    ),
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -734,7 +734,7 @@ module chip_earlgrey_cw310 #(
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
   prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
+  prim_ram_1p_pkg::ram_1p_cfg_t usb_ram_1p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -749,18 +749,15 @@ module chip_earlgrey_cw310 #(
               }
   };
 
-  // this maps as follows:
-  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
-  assign usb_ram_2p_cfg = '{
-    a_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_a,
-                   cfg:    ast_ram_2p_fcfg.marg_a
-                 },
-    b_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
-    default: '0
+  assign usb_ram_1p_cfg = '{
+    ram_cfg: '{
+                cfg_en: ast_ram_1p_cfg.marg_en,
+                cfg:    ast_ram_1p_cfg.marg
+              },
+    rf_cfg:  '{
+                cfg_en: ast_rf_cfg.marg_en,
+                cfg:    ast_rf_cfg.marg
+              }
   };
 
   // this maps as follows:
@@ -782,6 +779,9 @@ module chip_earlgrey_cw310 #(
     cfg: ast_rom_cfg.marg
   };
 
+  // unused cfg bits
+  logic unused_ram_cfg;
+  assign unused_ram_cfg = ^ast_ram_2p_fcfg;
 
   //////////////////////////////////
   // AST - Custom for targets     //
@@ -1081,7 +1081,7 @@ module chip_earlgrey_cw310 #(
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),
     .spi_ram_2p_cfg_i( '0 ),
-    .usb_ram_2p_cfg_i( '0 ),
+    .usb_ram_1p_cfg_i( '0 ),
     .rom_cfg_i       ( '0 ),
 
     // DFT signals

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -725,7 +725,7 @@ module chip_earlgrey_cw340 #(
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
   prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
+  prim_ram_1p_pkg::ram_1p_cfg_t usb_ram_1p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -740,18 +740,15 @@ module chip_earlgrey_cw340 #(
               }
   };
 
-  // this maps as follows:
-  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
-  assign usb_ram_2p_cfg = '{
-    a_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_a,
-                   cfg:    ast_ram_2p_fcfg.marg_a
-                 },
-    b_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
-    default: '0
+  assign usb_ram_1p_cfg = '{
+    ram_cfg: '{
+                cfg_en: ast_ram_1p_cfg.marg_en,
+                cfg:    ast_ram_1p_cfg.marg
+              },
+    rf_cfg:  '{
+                cfg_en: ast_rf_cfg.marg_en,
+                cfg:    ast_rf_cfg.marg
+              }
   };
 
   // this maps as follows:
@@ -773,6 +770,9 @@ module chip_earlgrey_cw340 #(
     cfg: ast_rom_cfg.marg
   };
 
+  // unused cfg bits
+  logic unused_ram_cfg;
+  assign unused_ram_cfg = ^ast_ram_2p_fcfg;
 
   //////////////////////////////////
   // AST - Custom for targets     //
@@ -1067,7 +1067,7 @@ module chip_earlgrey_cw340 #(
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),
     .spi_ram_2p_cfg_i( '0 ),
-    .usb_ram_2p_cfg_i( '0 ),
+    .usb_ram_1p_cfg_i( '0 ),
     .rom_cfg_i       ( '0 ),
 
     // DFT signals

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -141,7 +141,7 @@ module top_earlgrey #(
   input  ast_pkg::ast_obs_ctrl_t       obs_ctrl_i,
   input  prim_ram_1p_pkg::ram_1p_cfg_t       ram_1p_cfg_i,
   input  prim_ram_2p_pkg::ram_2p_cfg_t       spi_ram_2p_cfg_i,
-  input  prim_ram_2p_pkg::ram_2p_cfg_t       usb_ram_2p_cfg_i,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       usb_ram_1p_cfg_i,
   input  prim_rom_pkg::rom_cfg_t       rom_cfg_i,
   output prim_mubi_pkg::mubi4_t       clk_main_jitter_en_o,
   output prim_mubi_pkg::mubi4_t       io_clk_byp_req_o,
@@ -530,7 +530,7 @@ module top_earlgrey #(
   ast_pkg::ast_obs_ctrl_t       ast_obs_ctrl;
   prim_ram_1p_pkg::ram_1p_cfg_t       ast_ram_1p_cfg;
   prim_ram_2p_pkg::ram_2p_cfg_t       ast_spi_ram_2p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t       ast_usb_ram_2p_cfg;
+  prim_ram_1p_pkg::ram_1p_cfg_t       ast_usb_ram_1p_cfg;
   prim_rom_pkg::rom_cfg_t       ast_rom_cfg;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   prim_esc_pkg::esc_rx_t [3:0] alert_handler_esc_rx;
@@ -754,7 +754,7 @@ module top_earlgrey #(
   assign ast_obs_ctrl = obs_ctrl_i;
   assign ast_ram_1p_cfg = ram_1p_cfg_i;
   assign ast_spi_ram_2p_cfg = spi_ram_2p_cfg_i;
-  assign ast_usb_ram_2p_cfg = usb_ram_2p_cfg_i;
+  assign ast_usb_ram_1p_cfg = usb_ram_1p_cfg_i;
   assign ast_rom_cfg = rom_cfg_i;
 
   // define partial inter-module tie-off
@@ -1666,7 +1666,7 @@ module top_earlgrey #(
       .usb_aon_bus_reset_i(usbdev_usb_aon_bus_reset),
       .usb_aon_sense_lost_i(usbdev_usb_aon_sense_lost),
       .usb_aon_wake_detect_active_i(pinmux_aon_usbdev_wake_detect_active),
-      .ram_cfg_i(ast_usb_ram_2p_cfg),
+      .ram_cfg_i(ast_usb_ram_1p_cfg),
       .tl_i(usbdev_tl_req),
       .tl_o(usbdev_tl_rsp),
 

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -581,7 +581,7 @@ module chip_earlgrey_verilator (
     // This is different between verilator and the rest of the platforms right now
     .ram_1p_cfg_i                 ('0),
     .spi_ram_2p_cfg_i             ('0),
-    .usb_ram_2p_cfg_i             ('0),
+    .usb_ram_1p_cfg_i             ('0),
     .rom_cfg_i                    ('0),
 
     // DFT signals

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -510,10 +510,10 @@
           act:     "rcv"
         },
 
-        { struct:  "ram_2p_cfg",
-          package: "prim_ram_2p_pkg",
+        { struct:  "ram_1p_cfg",
+          package: "prim_ram_1p_pkg",
           type:    "uni",
-          name:    "usb_ram_2p_cfg",
+          name:    "usb_ram_1p_cfg",
           // The activity direction for a port inter-signal is "opposite" of
           // what the external module actually needs.
           act:     "rcv"
@@ -623,7 +623,7 @@
         'ast.lc_dft_en'                : '',
         'ast.ram_1p_cfg'               : 'ram_1p_cfg',
         'ast.spi_ram_2p_cfg'           : 'spi_ram_2p_cfg',
-        'ast.usb_ram_2p_cfg'           : 'usb_ram_2p_cfg',
+        'ast.usb_ram_1p_cfg'           : 'usb_ram_1p_cfg',
         'ast.rom_cfg'                  : 'rom_cfg',
         'clkmgr_aon.jitter_en'         : 'clk_main_jitter_en',
         'clkmgr_aon.hi_speed_sel'      : 'hi_speed_sel',

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -214,7 +214,7 @@ module chip_englishbreakfast_verilator (
     // Memory attributes
     .ram_1p_cfg_i                 ('0),
     .spi_ram_2p_cfg_i             ('0),
-    .usb_ram_2p_cfg_i             ('0),
+    .usb_ram_1p_cfg_i             ('0),
     .rom_cfg_i                    ('0),
 
     // DFT signals

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -570,7 +570,7 @@ module chip_${top["name"]}_${target["name"]} #(
 
   prim_ram_1p_pkg::ram_1p_cfg_t ram_1p_cfg;
   prim_ram_2p_pkg::ram_2p_cfg_t spi_ram_2p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t usb_ram_2p_cfg;
+  prim_ram_1p_pkg::ram_1p_cfg_t usb_ram_1p_cfg;
   prim_rom_pkg::rom_cfg_t rom_cfg;
 
   // conversion from ast structure to memory centric structures
@@ -585,18 +585,15 @@ module chip_${top["name"]}_${target["name"]} #(
               }
   };
 
-  // this maps as follows:
-  // assign usb_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_fcfg, ram_2p_cfg_i.b_ram_fcfg};
-  assign usb_ram_2p_cfg = '{
-    a_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_a,
-                   cfg:    ast_ram_2p_fcfg.marg_a
-                 },
-    b_ram_lcfg: '{
-                   cfg_en: ast_ram_2p_fcfg.marg_en_b,
-                   cfg:    ast_ram_2p_fcfg.marg_b
-                 },
-    default: '0
+  assign usb_ram_1p_cfg = '{
+    ram_cfg: '{
+                cfg_en: ast_ram_1p_cfg.marg_en,
+                cfg:    ast_ram_1p_cfg.marg
+              },
+    rf_cfg:  '{
+                cfg_en: ast_rf_cfg.marg_en,
+                cfg:    ast_rf_cfg.marg
+              }
   };
 
   // this maps as follows:
@@ -618,6 +615,9 @@ module chip_${top["name"]}_${target["name"]} #(
     cfg: ast_rom_cfg.marg
   };
 
+  // unused cfg bits
+  logic unused_ram_cfg;
+  assign unused_ram_cfg = ^ast_ram_2p_fcfg;
 
   //////////////////////////////////
   // AST - Custom for targets     //
@@ -1042,7 +1042,7 @@ module chip_${top["name"]}_${target["name"]} #(
     // Memory attributes
     .ram_1p_cfg_i                 ( ram_1p_cfg                 ),
     .spi_ram_2p_cfg_i             ( spi_ram_2p_cfg             ),
-    .usb_ram_2p_cfg_i             ( usb_ram_2p_cfg             ),
+    .usb_ram_1p_cfg_i             ( usb_ram_1p_cfg             ),
 
     .rom_cfg_i                    ( rom_cfg                    ),
 
@@ -1218,7 +1218,7 @@ module chip_${top["name"]}_${target["name"]} #(
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),
     .spi_ram_2p_cfg_i( '0 ),
-    .usb_ram_2p_cfg_i( '0 ),
+    .usb_ram_1p_cfg_i( '0 ),
     .rom_cfg_i       ( '0 ),
 
     // DFT signals


### PR DESCRIPTION
This PR switch the usbdev packet buffer to a Single Port RAM implementation, in place of the current Dual Port RAM.

_Background_

Dual port memories are generally more problematic/expensive and should be avoided where possible. The packet buffer memory in `usbdev` has very little justification for being implemented as a Dual Port RAM. Although it works well on FPGA implementations, it may be unavailable on some process technologies/memory compilers.

_Proposal_

Collisions are very infrequent and we can just delay the TL-UL access when a collision occurs. `usbdev` hardware, even during active transfers, will access the packet buffer memory only every 128 clock cycles (4x oversampling, transfers 32 bits at a time) except at the end of packet reception where two writes may occur closer together.

In practice, the Ibex is used to perform Programmed I/O transfers to/from the packet buffer memory and even with a minimal sequence of 'lw' and 'sw' instructions and reduced loop overhead, the peak transfer rate has been observed to be one 32-bit word every 6 cycles on the 100MHz clock, translating to one word every 2-4 cycles on the 48MHz clock. The transfers are short (at most 16 words, because of the 64-byte packet length), and there is no potential for writethrough issues because the API between `usbdev` and software ensures that they are never both accessing the same address (or even the same 64-byte buffer within the RAM).

The only complication is that the read data on the usbdev side must remain static after it has requested a read, because the packet engine uses bytes rather than full 32-bit words, and thus uses the bits within the word much later. This implementation registers the read data locally within the spram implementation option.

_Testing_

Done: usbdev_stream_test passes in Verilator chip simulation and on an updated FPGA build.

Future: It may be worth building a SiVal/chip-level test to exercise collision handling and increase confidence in any particular implementation of either RAM model. If there were a block level test bench, collisions would be easier to induce and observe in simulation.

~~_To be resolved_~~

~~Chip simulation uses cross-module reference to access the packet buffer memory, and the module hierarchy is now implementation-dependent. (chip_hier_macros.svh)
It is not clear how best to provide RAM configuration to the implementation-dependent RAM model; shall we provide both and select within `usbdev`, or can the ports be parameterized somehow?~~

@a-will @msfschaffner @GregAC 