### PR TITLE
[crypto] Add support for sideloaded keys in ECDSA P-256.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
@@ -36,6 +36,16 @@ typedef struct ecdsa_p256_signature_t {
 status_t ecdsa_p256_keygen_start(void);
 
 /**
+ * Start an async ECDSA/P-256 sideloaded keypair generation operation on OTBN.
+ *
+ * Expects a sideloaded key from keymgr to be already loaded on OTBN. Returns
+ * an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_sideload_keygen_start(void);
+
+/**
  * Finish an async ECDSA/P-256 keypair generation operation on OTBN.
  *
  * Blocks until OTBN is idle.
@@ -48,6 +58,17 @@ status_t ecdsa_p256_keygen_finalize(p256_masked_scalar_t *private_key,
                                     p256_point_t *public_key);
 
 /**
+ * Start an async ECDSA/P-256 sideloaded keypair generation operation on OTBN.
+ *
+ * This routine will only read back the public key, instead of both public and
+ * private as with `ecdsa_p256_keygen_finalize`. Blocks until OTBN is idle.
+ *
+ * @param[out] public_key Public key.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_sideload_keygen_finalize(p256_point_t *public_key);
+
+/**
  * Start an async ECDSA/P-256 signature generation operation on OTBN.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
@@ -58,6 +79,18 @@ status_t ecdsa_p256_keygen_finalize(p256_masked_scalar_t *private_key,
  */
 status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
                                const p256_masked_scalar_t *private_key);
+
+/**
+ * Start an async ECDSA/P-256 signature generation operation on OTBN.
+ *
+ * Expects a sideloaded key from keymgr to be already loaded on OTBN. Returns
+ * an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param digest Digest of the message to sign.
+ * @return Result of the operation (OK or error).
+ */
+status_t ecdsa_p256_sideload_sign_start(
+    const uint32_t digest[kP256ScalarWords]);
 
 /**
  * Finish an async ECDSA/P-256 signature generation operation on OTBN.

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -320,8 +320,11 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
 /**
  * Starts the asynchronous key generation for ECDSA operation.
  *
- * Initializes OTBN and starts the OTBN routine to compute the private
- * key (d) and public key (Q) for ECDSA operation.
+ * Initializes OTBN and begins generating an ECDSA key pair. The caller should
+ * set the `config` field of `private_key` with their desired key configuration
+ * options. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle such as the kind returned by
+ * `otcrypto_hw_backed_key`.
  *
  * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
@@ -332,12 +335,12 @@ crypto_status_t otcrypto_x25519(const crypto_blinded_key_t *private_key,
  * started.
  *
  * @param elliptic_curve Pointer to the elliptic curve to be used.
- * @param config Private key configuration.
+ * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous ECDSA keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config);
+    const ecc_curve_t *elliptic_curve, const crypto_blinded_key_t *private_key);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -444,8 +447,11 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
 /**
  * Starts the asynchronous key generation for ECDH operation.
  *
- * Initializes OTBN and starts the OTBN routine to compute the private
- * key (d) and public key (Q) for ECDH operation.
+ * Initializes OTBN and begins generating an ECDH key pair. The caller should
+ * set the `config` field of `private_key` with their desired key configuration
+ * options. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle such as the kind returned by
+ * `otcrypto_hw_backed_key`.
  *
  * The `domain_parameter` field of the `elliptic_curve` is required
  * only for a custom curve. For named curves this field is ignored
@@ -456,12 +462,12 @@ crypto_status_t otcrypto_ecdsa_verify_async_finalize(
  * started.
  *
  * @param elliptic_curve Pointer to the elliptic curve to be used.
- * @param config Private key configuration.
+ * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous ECDH keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdh_keygen_async_start(
-    const ecc_curve_t *elliptic_curve, const crypto_key_config_t *config);
+    const ecc_curve_t *elliptic_curve, const crypto_blinded_key_t *private_key);
 
 /**
  * Finalizes the asynchronous key generation for ECDSA operation.
@@ -527,17 +533,20 @@ crypto_status_t otcrypto_ecdh_async_finalize(
 /**
  * Starts the asynchronous key generation for Ed25519.
  *
- * Initializes OTBN and starts the OTBN routine to compute the private
- * exponent (d) and public key (Q) based on Curve25519.
+ * Initializes OTBN and begins generating an Ed25519 key pair. The caller
+ * should set the `config` field of `private_key` with their desired key
+ * configuration options. If the key is hardware-backed, the caller should pass
+ * a fully populated private key handle such as the kind returned by
+ * `otcrypto_hw_backed_key`.
  *
  * No `domain_parameter` is needed and is automatically set for X25519.
  *
- * @param config Private key configuration.
+ * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous ed25519 keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ed25519_keygen_async_start(
-    const crypto_key_config_t *config);
+    const crypto_blinded_key_t *private_key);
 
 /**
  * Finalizes the asynchronous key generation for Ed25519.
@@ -628,17 +637,20 @@ crypto_status_t otcrypto_ed25519_verify_async_finalize(
 /**
  * Starts the asynchronous key generation for X25519.
  *
- * Initializes OTBN and starts the OTBN routine to compute the private
- * exponent (d) and public key (Q) based on Curve25519.
+ * Initializes OTBN and begins generating an X25519 key pair. The caller
+ * should set the `config` field of `private_key` with their desired key
+ * configuration options. If the key is hardware-backed, the caller should pass
+ * a fully populated private key handle such as the kind returned by
+ * `otcrypto_hw_backed_key`.
  *
  * No `domain_parameter` is needed and is automatically set for X25519.
  *
- * @param config Private key configuration.
+ * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous X25519 keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_x25519_keygen_async_start(
-    const crypto_key_config_t *config);
+    const crypto_blinded_key_t *private_key);
 
 /**
  * Finalizes the asynchronous key generation for X25519.

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -165,6 +165,24 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "ecdsa_p256_sideload_functest",
+    srcs = ["ecdsa_p256_sideload_functest.c"],
+    verilator = verilator_params(
+        timeout = "eternal",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/drivers:keymgr",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/crypto/impl:key_transport",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 autogen_cryptotest_header(
     name = "ecdsa_p256_verify_testvectors_hardcoded_header",
     hjson = "//sw/device/tests/crypto/testvectors:ecdsa_p256_verify_testvectors_hardcoded",

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+enum {
+  /* Number of 32-bit words in a P-256 coordinate (256 bits). */
+  kP256CoordWords = 256 / 32,
+  /* Number of 32-bit words in a P-256 scalar (256 bits). */
+  kP256ScalarWords = 256 / 32,
+};
+
+// Message
+static const char kMessage[] = "test message";
+
+static const ecc_curve_t kCurveP256 = {
+    .curve_type = kEccCurveTypeNistP256,
+    .domain_parameter =
+        (ecc_domain_t){
+            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
+            .gx = NULL,
+            .gy = NULL,
+            .cofactor = 0u,
+            .checksum = 0u,
+        },
+};
+
+static const crypto_key_config_t kPrivateKeyConfig = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeEcdsa,
+    .key_length = 258 / 8,
+    .hw_backed = kHardenedBoolTrue,
+    .security_level = kSecurityLevelLow,
+};
+
+static const uint32_t kPrivateKeySalt[7] = {0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
+                                            0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
+                                            0xdeadbeef};
+
+static const uint32_t kPrivateKeyVersion = 0x9;
+
+status_t sign_then_verify_test(void) {
+  // Allocate space for a hardware-backed key.
+  uint32_t keyblob[8] = {0};
+  crypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Construct the private key handle.
+  TRY(otcrypto_hw_backed_key(kPrivateKeyVersion, kPrivateKeySalt,
+                             &private_key));
+
+  // Allocate space for a public key.
+  uint32_t pk_x[kP256CoordWords] = {0};
+  uint32_t pk_y[kP256CoordWords] = {0};
+  ecc_public_key_t public_key = {
+      .x =
+          {
+              .key_mode = kKeyModeEcdsa,
+              .key_length = sizeof(pk_x),
+              .key = pk_x,
+          },
+      .y =
+          {
+              .key_mode = kKeyModeEcdsa,
+              .key_length = sizeof(pk_y),
+              .key = pk_y,
+          },
+  };
+
+  // Generate a keypair.
+  LOG_INFO("Generating keypair...");
+  TRY(otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
+
+  // Package message in a cryptolib-style struct.
+  crypto_const_byte_buf_t message = {
+      .len = sizeof(kMessage) - 1,
+      .data = (unsigned char *)&kMessage,
+  };
+
+  // Allocate space for the signature.
+  uint32_t sigR[kP256ScalarWords] = {0};
+  uint32_t sigS[kP256ScalarWords] = {0};
+  ecc_signature_t signature = {
+      .len_r = sizeof(sigR),
+      .r = sigR,
+      .len_s = sizeof(sigS),
+      .s = sigS,
+  };
+
+  // Generate a signature for the message.
+  LOG_INFO("Signing...");
+  TRY(otcrypto_ecdsa_sign(&private_key, message, &kCurveP256, &signature));
+
+  // Verify the signature.
+  LOG_INFO("Verifying...");
+  hardened_bool_t verification_result;
+  TRY(otcrypto_ecdsa_verify(&public_key, message, &signature, &kCurveP256,
+                            &verification_result));
+
+  // The signature should pass verification.
+  TRY_CHECK(verification_result == kHardenedBoolTrue);
+  return OK_STATUS();
+}
+
+static status_t test_setup(void) {
+  // Initialize the key manager and advance to OwnerRootKey state.
+  dif_keymgr_t keymgr;
+  dif_kmac_t kmac;
+  TRY(keymgr_testutils_startup(&keymgr, &kmac));
+  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
+
+  // Initialize entropy complex, which the key manager uses to clear sideloaded
+  // keys. The `keymgr_testutils_startup` function restarts the device, so this
+  // should happen afterwards.
+  return entropy_complex_init();
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  CHECK_STATUS_OK(test_setup());
+  EXECUTE_TEST(result, sign_then_verify_test);
+
+  return status_ok(result);
+}

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -179,6 +179,7 @@ secret_key_from_seed:
        w10, w11 <= d1 */
   jal      x1, p256_key_from_seed
 
+  /* TODO(##19875): do not store keymgr-derived values in DMEM! */
   /* Store secret key shares.
        dmem[d0] <= d0
        dmem[d1] <= d1 */


### PR DESCRIPTION
This adds the infrastructure to support sideloaded ECDSA-P256 keys. The OTBN code already existed (although I did spot a security issue with it and added an issue + TODO).

Contains some small API changes; because of the recent change to move diversification data into the keyblob from the key configuration, I had to make asynchronous ECC keygen routines take full keys instead of just configurations.