### PR TITLE
Update Tock to latest `master`.

### DIFF
--- a/sw/device/silicon_owner/tock/kernel/src/io.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/io.rs
@@ -5,10 +5,12 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
+use earlgrey::chip_config::EarlGreyConfig;
 use kernel::debug;
 use kernel::debug::IoWrite;
 
 use crate::CHIP;
+use crate::ChipConfig;
 use crate::PROCESSES;
 use crate::PROCESS_PRINTER;
 
@@ -29,7 +31,7 @@ impl IoWrite for Writer {
         // during panic.
         earlgrey::uart::Uart::new(
             earlgrey::uart::UART0_BASE,
-            earlgrey::chip_config::CONFIG.peripheral_freq,
+            ChipConfig::PERIPHERAL_FREQ,
         )
         .transmit_sync(buf);
         buf.len()

--- a/sw/device/silicon_owner/tock/tests/basic/BUILD
+++ b/sw/device/silicon_owner/tock/tests/basic/BUILD
@@ -37,11 +37,8 @@ tock_image(
 
 opentitan_test(
     name = "basic_test",
-    # TODO(tock#3639, opentitan#19479): Tock needs to update the earlgrey chip
-    # config to use the new fpga_cw310 clock frequencies.
     cw310 = cw310_params(
         binaries = {":image": "firmware"},
-        tags = ["broken"],
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,

--- a/sw/device/silicon_owner/tock/upstream_kernel/BUILD
+++ b/sw/device/silicon_owner/tock/upstream_kernel/BUILD
@@ -35,6 +35,7 @@ rust_binary(
     srcs = [
         "@tock//boards/opentitan/earlgrey-cw310:kernel_srcs",
     ],
+    crate_features = ["fpga_cw310"],
     rustc_flags = [
         "-g",
         # TODO(opentitan#19491): determine the appropriate set of linker flags.

--- a/third_party/tock/repos.bzl
+++ b/third_party/tock/repos.bzl
@@ -40,9 +40,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "tock",
         local = tock,
-        strip_prefix = "tock-1a111a3e748815117b0ef939ab730b31d77a409d",
-        url = "https://github.com/tock/tock/archive/1a111a3e748815117b0ef939ab730b31d77a409d.tar.gz",
-        sha256 = "9b146f28dea14e51e77736e781745dfd140f71afb963e35b52795edf7e72b0d3",
+        strip_prefix = "tock-3a0527d586702b8ae8cb242391fa72eb3a412f49",
+        url = "https://github.com/tock/tock/archive/3a0527d586702b8ae8cb242391fa72eb3a412f49.tar.gz",
+        sha256 = "8108d5b2bf8bc5c6b8c1ca09940c96b0b8c2541a8215293234f32803464cd748",
         additional_files_content = {
             "BUILD": """exports_files(glob(["**"]))""",
             "arch/riscv/BUILD": crate_build(


### PR DESCRIPTION
This PR makes use of the new configuration mechanism introduced in https://github.com/tock/tock/pull/3640 to handle the new cw310 frequencies (changed in #19479). This change fixes the basic Tock test.

I also updated our board definition to work with the changes in https://github.com/tock/tock/pull/3551.