### PR TITLE
[usbdev] Support for CW340 in top level tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2330,6 +2330,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     verilator = verilator_params(
@@ -2354,6 +2355,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     deps = [
@@ -2373,6 +2375,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     deps = [
@@ -2392,6 +2395,7 @@ opentitan_functest(
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     deps = [
@@ -2411,9 +2415,13 @@ opentitan_functest(
     cw310 = cw310_params(
         tags = ["manual"],
     ),
+    cw340 = cw340_params(
+        tags = ["manual"],
+    ),
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     verilator = verilator_params(
@@ -2439,9 +2447,14 @@ opentitan_functest(
         timeout = "eternal",
         tags = ["manual"],
     ),
+    cw340 = cw340_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     verilator = verilator_params(
@@ -2466,9 +2479,14 @@ opentitan_functest(
         timeout = "eternal",
         tags = ["manual"],
     ),
+    cw340 = cw340_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     verilator = verilator_params(
@@ -2493,9 +2511,14 @@ opentitan_functest(
         timeout = "eternal",
         tags = ["manual"],
     ),
+    cw340 = cw340_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     targets = [
         "verilator",
         "cw310_test_rom",
+        "cw340_test_rom",
         "dv",
     ],
     verilator = verilator_params(

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -34,9 +34,9 @@
 //
 // Note: because Isochronous streams are guaranteed the requested amount of
 // bus bandwidth, the number of concurrent streams that may be supported is
-// limited to six.
-#if !defined(NUM_STREAMS) || NUM_STREAMS > 6U
-#define NUM_STREAMS 6U
+// limited to four if connected through a hub (6 without hub(s)).
+#if !defined(NUM_STREAMS) || NUM_STREAMS > 4U
+#define NUM_STREAMS 4U
 #endif
 
 // This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -71,13 +71,13 @@ static const char *xfr_name[] = {
 //
 // Note: because Isochronous and Interrupt streams are guaranteed the requested
 // amount of bus bandwidth, the number of concurrent streams of these types is
-// limited to six.
+// limited to four if connected through a hub (six without hub(s)).
 static const usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX] = {
-    kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
+    kUsbTransferTypeIsochronous, kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
-    kUsbTransferTypeBulk,        kUsbTransferTypeIsochronous,
+    kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeInterrupt,   kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,

--- a/sw/device/tests/usbdev_setuprx_test.c
+++ b/sw/device/tests/usbdev_setuprx_test.c
@@ -125,12 +125,6 @@ static status_t delay(bool prompt, uint32_t timeout_micros) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK(kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator ||
-            kDeviceType == kDeviceFpgaCw310,
-        "This test is not expected to run on platforms other than the "
-        "Verilator/DV simulation or CW310 FPGA. It needs either the DPI model "
-        "or a physical host, OS and drivers.");
-
   // In simulation the DPI model connects VBUS shortly after reset and
   // prolonged delays when asserting or deasserting pull ups are wasteful.
   uint32_t timeout_micros = 1000u;

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -193,6 +193,8 @@ bool test_main(void) {
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
+    case kDeviceFpgaCw340:
+      break;
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;


### PR DESCRIPTION
This PR updates all of the current `usbdev` top level tests to get them passing on the CW340.

Add cw340 targets to usbdev top-level tests.
Remove lingering device type checks.
Reduce the demand for guaranteed bandwidth, to accommodate the presence of a hub.