### PR TITLE
[rom_ext] Add a unified boot-time OTBN program.

### DIFF
--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -6,6 +6,19 @@ load("//rules:otbn.bzl", "otbn_binary", "otbn_library")
 
 package(default_visibility = ["//visibility:public"])
 
+otbn_binary(
+    name = "boot",
+    srcs = [
+        "boot.s",
+    ],
+    deps = [
+        ":p256_base",
+        ":p256_sign",
+        ":rsa_verify_3072",
+        ":rsa_verify_3072_rr",
+    ],
+)
+
 otbn_library(
     name = "ed25519",
     srcs = [

--- a/sw/otbn/crypto/boot.s
+++ b/sw/otbn/crypto/boot.s
@@ -1,0 +1,374 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Unified boot-services OTBN program.
+ *
+ * During the boot process, this program should remain loaded. This binary has
+ * the following modes:
+ *   1. MODE_SEC_BOOT_SIGVERIFY: RSA-3072 modexp (to verify a code signature).
+ *   2. MODE_ATTESTATION_KEYGEN: Derive a new attestation keypair (ECDSA-P256).
+ *   3. MODE_ATTESTATION_ENDORSE: Sign with a saved attestation signing key.
+ *   4. MODE_ATTESTATION_KEY_SAVE: Save an attestation signing key.
+ *
+ * Ibex will run `MODE_SEC_BOOT_SIGVERIFY` as part of checking the code
+ * signature of the next boot stage. This mode doesn't interact or interfere
+ * with any other modes, and can be called at any point.
+ *
+ * The attestation modes are more entangled with each other. Part of the
+ * purpose of this program is to store the attestation key of a particular key
+ * manager stage long enough to sign the public key of the next stage, without
+ * rebooting. At each key manager stage, Ibex should:
+ *   - Call `MODE_ATTESTATION_KEYGEN` to get the current public key
+ *   - Construct the attestation certificate for the current stage, including
+ *     the public key
+ *   - Call `MODE_ATTESTATION_ENDORSE` to sign the certificate with the stored
+ *     signing key from the *previous stage* and clear the key
+ *   - Call `MODE_ATTESTATION_KEY_SAVE` to save the current stage's signing
+ *     key, which will later endorse the next stage's certificate
+ *
+ * Of course, in the first stage there is no previous stage signing key and no
+ * certificate, so Ibex should skip the `MODE_ATTESTATION_ENDORSE` step. Ibex
+ * may clear IMEM/DMEM if it needs to run a different OTBN routine (e.g.
+ * signature verification for ownership transfer), but doing so will wipe any
+ * saved keys. This binary is designed so that it should not need to be
+ * cleared and re-loaded on a normal boot.
+ *
+ * The attestation keys are derived from a key manager seed value, which is
+ * XORed with output from a specially seeded DRBG in order to satisfy the FIPS
+ * 186-5 requirement that the seed comes from a DRBG (other FIPS documents say
+ * it is permissible to XOR DRBG output with implementation-specific values, so
+ * the key manager seed is effectively ignored for FIPS compliance).  The saved
+ * signing key is stored in OTBN's scratchpad memory, which is not accessible
+ * to Ibex over the bus.
+ */
+
+/**
+ * Mode magic values, generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 4 -n 11 --avoid-zero -s 3357382482
+ *
+ * Call the same utility with the same arguments and a higher -m to generate
+ * additional value(s) without changing the others or sacrificing mutual HD.
+ *
+ * TODO(#17727): in some places the OTBN assembler support for .equ directives
+ * is lacking, so they cannot be used in bignum instructions or pseudo-ops such
+ * as `li`. If support is added, we could use 32-bit values here instead of
+ * 11-bit.
+ */
+.equ MODE_SEC_BOOT_SIGVERIFY, 0x7d3
+.equ MODE_ATTESTATION_KEYGEN, 0x2bf
+.equ MODE_ATTESTATION_ENDORSE, 0x5e8
+.equ MODE_ATTESTATION_KEY_SAVE, 0x64d
+
+.section .text.start
+start:
+  /* Read the mode and tail-call the requested operation. */
+  la    x2, mode
+  lw    x2, 0(x2)
+
+  addi  x3, x0, MODE_SEC_BOOT_SIGVERIFY
+  beq   x2, x3, sec_boot_sigverify
+
+  addi  x3, x0, MODE_ATTESTATION_KEYGEN
+  beq   x2, x3, attestation_keygen
+
+  addi  x3, x0, MODE_ATTESTATION_ENDORSE
+  beq   x2, x3, attestation_endorse
+
+  addi  x3, x0, MODE_ATTESTATION_KEY_SAVE
+  beq   x2, x3, attestation_key_save
+
+  /* Invalid mode; fail. */
+  unimp
+  unimp
+  unimp
+
+/**
+ * RSA-3072 modular exponentation.
+ *
+ * Computes msg = (sig^65537) mod M, where
+ *          sig is the signature
+ *          M is the public key modulus
+ *
+ * Uses the specialized RSA-3072 OTBN modexp implementation to recover an
+ * encoded message from an input signature. Ibex needs to check that the
+ * encoded message matches the encoding of the expected message to complete
+ * signature verification.
+ *
+ * Assumes that the Montgomery constant m0_inv is provided, but computes the RR
+ * constant on the fly. The only exponent supported is e=65537.
+ *
+ * @param[in] dmem[rsa_mod]: Modulus of the RSA public key
+ * @param[in] dmem[rsa_inout]: Signature to check against
+ * @param[in] dmem[m0inv]: Montgomery constant (-(M^-1)) mod 2^256
+ * @param[out] dmem[rsa_inout]: Recovered message digest
+ */
+sec_boot_sigverify:
+  /* Compute R^2 (same for both exponents): dmem[rr] <= R^2 */
+  jal      x1, compute_rr
+
+  /* Set pointers to buffers for modexp. */
+  la        x24, rsa_inout
+  la        x16, rsa_mod
+  la        x23, rsa_inout
+  la        x26, rr
+  la        x17, m0inv
+
+  /* run modular exponentiation */
+  jal      x1, modexp_var_3072_f4
+
+  ecall
+
+/**
+ * Generate an attestation keypair from a sideloaded seed.
+ *
+ * Takes two input seeds, one from the key manager in the key-sideload slots
+ * and one from DMEM that is expected to be the output of a DRBG and fully
+ * independent from the first. For both seeds, only the first 320 bits are used
+ * and the rest are ignored.
+ *
+ * @param[in]  dmem[attestation_additional_seed]: DRBG output.
+ * @param[out]  dmem[x]: Public key x-coordinate.
+ * @param[out]  dmem[y]: Public key y-coordinate.
+ */
+attestation_keygen:
+  /* Initialize all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Generate secret key in shares.
+       w20, w21 <= d0 (first share of secret key)
+       w10, w11 <= d1 (second share of secret key) */
+  jal      x1, attestation_secret_key_from_seed
+
+  /* Call scalar multiplication with base point.
+     R = (x_p, y_p, z_p) = (w8, w9, w10) <= d*G */
+  la        x21, p256_gx
+  la        x22, p256_gy
+  jal       x1, scalar_mult_int
+
+  /* Convert masked result back to affine coordinates.
+     R = (x_a, y_a) = (w11, w12) */
+  jal       x1, proj_to_affine
+
+  /* Store public key in DMEM.
+     dmem[x] <= x_a = w11
+     dmem[y] <= y_a = w12 */
+  li        x2, 11
+  la        x21, x
+  bn.sid    x2++, 0(x21)
+  la        x22, y
+  bn.sid    x2, 0(x22)
+
+  ecall
+
+/**
+ * Sign a message using the saved signing key from the scratchpad.
+ *
+ * Clears the saved key after use, so only one signature is possible with a
+ * saved key.
+ *
+ * @param[in]  dmem[msg]: Message digest (256 bits)
+ * @param[in]   dmem[d0]: First share of private key d (320 bits)
+ * @param[in]   dmem[d1]: Second share of private key d (320 bits)
+ * @param[out]   dmem[r]: Buffer for r component of signature (256 bits)
+ * @param[out]   dmem[s]: Buffer for s component of signature (256 bits)
+ */
+attestation_endorse:
+  /* Generate a fresh random scalar for signing.
+       dmem[k0] <= first share of k
+       dmem[k1] <= second share of k */
+  jal      x1, p256_generate_k
+
+  /* Generate the signature.
+       dmem[r], dmem[s] <= signature */
+  jal      x1, p256_sign
+
+  /* Clear the saved key by overwriting with random data.
+       dmem[d0], dmem[d1] <= RND */
+  li        x20, 20
+  la        x2, d0
+  bn.wsrr   w20, 0x1 /* RND */
+  bn.sid    x20, 0(x2++)
+  bn.wsrr   w20, 0x1 /* RND */
+  bn.sid    x20, 0(x2)
+  la        x2, d1
+  bn.wsrr   w20, 0x1 /* RND */
+  bn.sid    x20, 0(x2++)
+  bn.wsrr   w20, 0x1 /* RND */
+  bn.sid    x20, 0(x2)
+
+  ecall
+
+/**
+ * Save an attestation signing key to the scratchpad.
+ *
+ * @param[in]  dmem[attestation_additional_seed]: DRBG output.
+ * @param[out]  dmem[d0]: First share of private key (320 bits).
+ * @param[out]  dmem[d1]: Second share of private key (320 bits).
+ */
+attestation_key_save:
+  /* Initialize all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Generate secret key in shares.
+       w20, w21 <= d0 (first share of secret key)
+       w10, w11 <= d1 (second share of secret key) */
+  jal      x1, attestation_secret_key_from_seed
+
+  /* Store secret key in DMEM.
+     dmem[d0] <= w20, w21 = d0
+     dmem[d1] <= w10, w11 = d1 */
+  li        x2, 20
+  la        x3, d0
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2, 32(x3)
+  li        x2, 10
+  la        x3, d1
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2, 32(x3)
+
+  ecall
+
+/**
+ * Generate an attestation secret key from a sideloaded seed.
+ *
+ * Takes two input seeds, one from the key manager in the key-sideload slots
+ * and one from DMEM that is expected to be the output of a DRBG and fully
+ * independent from the first. For both seeds, only the first 320 bits are used
+ * and the rest are ignored.
+ *
+ * Returns the key in two 320-bit shares d0 and d1, such that the secret key d
+ * = (d0 + d1) mod n.
+ *
+ * @param[in]   w31: all-zero
+ * @param[in]  dmem[attestation_additional_seed]: DRBG output seed
+ * @param[out]  w20: Lower 256 bits of first share of secret key (d0)
+ * @param[out]  w21: Upper 64 bits of first share of secret key (d0)
+ * @param[out]  w10: Lower 256 bits of first share of secret key (d1)
+ * @param[out]  w11: Upper 64 bits of second share of secret key (d1)
+ *
+ * clobbered registers: x2, x3, x20, w1 to w4, w10, w11, w20 to w29
+ * clobbered flag groups: FG0
+ */
+attestation_secret_key_from_seed:
+  /* Load keymgr seeds from WSRs.
+       w20,w21 <= seed0
+       w10,w11 <= seed1 */
+  bn.wsrr  w20, 4 /*KEY_S0_L*/
+  bn.wsrr  w10, 6 /*KEY_S1_L*/
+  bn.wsrr  w21, 5 /*KEY_S0_H*/
+  bn.wsrr  w11, 7 /*KEY_S1_H*/
+
+  /* Load the additional DRBG seed from DMEM and XOR with one share of the
+     sideloaded seed.
+       w20, w21 <= seed0 ^ dmem[attestation_additional_seed] */
+  la       x2, attestation_additional_seed
+  li       x3, 22
+  bn.xor   w20, w20, w22
+  bn.lid   x3++, 0(x2)
+  bn.xor   w21, w21, w23
+  bn.lid   x3, 32(x2)
+
+  /* Tail-call `p256_key_from_seed` to generate secret key shares.
+       w20, w21 <= d0
+       w10, w11 <= d1 */
+  jal      x0, p256_key_from_seed
+
+.bss
+
+/* Operation mode. */
+.globl mode
+.balign 4
+mode:
+.zero 4
+
+/* Input buffer for RSA-3072 modulus. */
+.globl rsa_mod
+.balign 32
+rsa_mod:
+.zero 384
+
+/* Input buffer for precomputed RSA-3072 Montgomery constant:
+      m0' = (- M) mod 2^256. */
+.globl rsa_m0inv
+.balign 32
+rsa_m0inv:
+.zero 32
+
+/* Input/output buffer for RSA-3072 modexp:
+     input: signature
+     output: recovered message = (signature ^ 65537) mod M */
+.globl rsa_inout
+.balign 32
+rsa_inout:
+.zero 384
+
+/* Input buffer for an ECDSA-P256 message digest. */
+.globl msg
+.balign 32
+msg:
+.zero 32
+
+/* Output buffer for the first part of an ECDSA-P256 signature. */
+.globl r
+.balign 32
+r:
+.zero 32
+
+/* Output buffer for the second part of an ECDSA-P256 signature. */
+.globl s
+.balign 32
+s:
+.zero 32
+
+/* ECDSA-P256 public key x-coordinate. */
+.globl x
+.balign 32
+x:
+.zero 32
+
+/* ECDSA-P256 public key y-coordinate. */
+.globl y
+.balign 32
+y:
+.zero 32
+
+/* DRBG output to XOR with key manager seed. */
+.globl attestation_additional_seed
+.balign 32
+attestation_additional_seed:
+.zero 64
+
+.section .scratchpad
+
+/* First share of the saved attestation ECDSA-P256 private key (d). */
+.globl d0
+.balign 32
+d0:
+.zero 64
+
+/* Second share of the saved attestation ECDSA-P256 private key (d). */
+.globl d1
+.balign 32
+d1:
+.zero 64
+
+/* First share of the per-signature ECDSA-P256 secret scalar (k). */
+.globl k0
+.balign 32
+k0:
+.zero 64
+
+/* Second share of the per-signature ECDSA-P256 secret scalar (k). */
+.globl k1
+.balign 32
+k1:
+.zero 64
+
+/* Buffer for the squared Mongomery Radix RR = (2^3072)^2 mod M.
+   Populated by the RSA-3072 implementation. */
+.balign 32
+.globl rr
+rr:
+.zero 384

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -10,10 +10,8 @@
  * https://chromium.googlesource.com/chromiumos/platform/ec/+/refs/heads/cr50_stab/chip/g/dcrypto/dcrypto_p256.c
  */
 
-.globl p256_isoncurve
 .globl p256_scalar_mult
 .globl p256_base_mult
-.globl p256_verify
 .globl p256_generate_k
 .globl p256_generate_random_key
 .globl p256_key_from_seed
@@ -21,7 +19,6 @@
 .globl mod_mul_256x256
 .globl mod_mul_320x128
 .globl scalar_mult_int
-.globl mod_inv_var
 .globl proj_add
 .globl proj_to_affine
 
@@ -318,103 +315,6 @@ mod_mul_320x128:
 
   ret
 
-/**
- * Checks if a point is a valid curve point on curve P-256 (secp256r1)
- *
- * Returns r = x^3 + ax + b  mod p
- *     and s = y^2  mod p
- *         with x,y being the affine coordinates of the curve point
- *              a, b and p being the domain parameters of P-256
- *
- * This routine checks if a point with given x- and y-coordinate is a valid
- * curve point on P-256.
- * The routine checks whether the coordinates are a solution of the
- * Weierstrass equation y^2 = x^3 + ax + b  mod p.
- * The routine makes use of the property that the domain parameter 'a' can be
- * written as a=-3 for the P-256 curve, hence the routine is limited to P-256.
- * The routine does not return a boolean result but computes the left side
- * and the right sight of the Weierstrass equation and leaves the final
- * comparison to the caller.
- * The routine runs in constant time.
- *
- * Flags: Flags have no meaning beyond the scope of this subroutine.
- *
- * @param[in]  dmem[x]: affine x-coordinate of input point
- * @param[in]  dmem[y]: affine y-coordinate of input point
- * @param[out] dmem[r]: right side result r
- * @param[out] dmem[s]: left side result s
- *
- * clobbered registers: x2, x3, x19, x20, w0, w19 to w25
- * clobbered flag groups: FG0
- */
-p256_isoncurve:
-
-  /* setup all-zero reg */
-  bn.xor    w31, w31, w31
-
-  /* setup modulus p and Barrett constant u
-     MOD <= w29 <= dmem[p256_p] = p; w28 <= dmem[p256_u_p] = u_p */
-  li        x2, 29
-  la        x3, p256_p
-  bn.lid    x2, 0(x3)
-  bn.wsrw   0, w29
-  li        x2, 28
-  la        x3, p256_u_p
-  bn.lid    x2, 0(x3)
-
-  /* load domain parameter b from dmem
-     w27 <= b = dmem[p256_b] */
-  li        x2, 27
-  la        x3, p256_b
-  bn.lid    x2, 0(x3)
-
-  /* load affine y-coordinate of curve point from dmem
-     w26 <= dmem[y] */
-  la        x3, y
-  li        x2, 24
-  bn.lid    x2, 0(x3)
-
-  /* w19 <= y^2 = w24*w24 */
-  bn.mov    w25, w24
-  jal       x1, mod_mul_256x256
-
-  /* store left side result: dmem[s] <= w19 = y^2  mod p */
-  la        x20, s
-  li        x2, 19
-  bn.sid    x2, 0(x20)
-
-  /* load affine x-coordinate of curve point from dmem
-     w26 <= dmem[x] */
-  la        x3, x
-  li        x2, 26
-  bn.lid    x2, 0(x3)
-
-  /* w19 <= x^2 = w26*w26 */
-  bn.mov    w25, w26
-  bn.mov    w24, w26
-  jal       x1, mod_mul_256x256
-
-  /* w19 = x^3 <= x^2 * x = w25*w24 = w26*w19 */
-  bn.mov    w25, w19
-  bn.mov    w24, w26
-  jal       x1, mod_mul_256x256
-
-  /* for curve P-256, 'a' can be written as a = -3, therefore we subtract
-     x three times from x^3.
-     w19 = x^3 + ax <= x^3 - 3x  mod p */
-  bn.subm   w19, w19, w26
-  bn.subm   w19, w19, w26
-  bn.subm   w19, w19, w26
-
-  /* w24 <= x^3 + ax + b mod p = w19 + w27 mod p */
-  bn.addm   w19, w19, w27
-
-  /* store right side result: dmem[r] <= w19 = x^3 + ax + b mod p */
-  la        x19, r
-  li        x2, 19
-  bn.sid    x2, 0(x19)
-
-  ret
 
 
 /**
@@ -1307,141 +1207,6 @@ p256_base_mult:
 
   ret
 
-
-/**
- * Variable time modular multiplicative inverse computation
- *
- * Returns c <= a^(-1) mod m
- *         with a being a bigint of length 256 bit with a < m
- *              m being the modulus with a length of 256 bit
- *              c being a 256-bit result
- *
- * This routine implements the computation of the modular multiplicative
- * inverse based on the binary GCD or Stein's algorithm.
- * The implemented variant is based on the
- * "right-shift binary extended GCD" as it is described in section 3.1 of [1]
- * (Algorithm 1).
- * [1] https://doi.org/10.1155/ES/2006/32192
- *
- * Note that this is a variable time implementation. I.e. this routine will
- * show a data dependent timing and execution profile. Only use in situations
- * where a full white-box environment is acceptable.
- *
- * Flags: Flags have no meaning beyond the scope of this subroutine.
- *
- * @param[in]  w0: a, operand
- * @param[in]  MOD: m, modulus
- * @param[in]  w31: all-zero
- * @param[out]  w1: result c
- *
- * clobbered registers: x2, w2, w3, w4, w7
- * clobbered flag groups: FG0
- */
-mod_inv_var:
-
-  /* w2 = r = 0 */
-  bn.mov    w2, w31
-
-  /* w3 = s = 1 */
-  bn.addi   w3, w31, 1
-
-  /* w4 = u = MOD */
-  bn.wsrr   w4, 0
-  bn.wsrr   w7, 0
-
-  /* w5 = v = w0 */
-  bn.mov    w5, w0
-
-  ebgcd_loop:
-  /* test if u is odd */
-  bn.or     w4, w4, w4
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 4
-  bne       x2, x0, ebgcd_u_odd
-
-  /* u is even: */
-  /* w4 = u <= u/2 = w4 >> 1 */
-  bn.rshi   w4, w31, w4 >> 1
-
-  /* test if r is odd */
-  bn.or     w2, w2, w2
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 4
-  bne       x2, x0, ebgcd_r_odd
-
-  /* r is even: */
-  /* w2 = r <= r/2 = w2 >> 1 */
-  bn.rshi   w2, w31, w2 >> 1
-  jal       x0, ebgcd_loop
-
-  ebgcd_r_odd:
-  /* w2 = r <= (r + m)/2 = (w2 + w7) >> 1 */
-  bn.add    w2, w7, w2
-  bn.addc   w6, w31, w31
-  bn.rshi   w2, w6, w2 >> 1
-  jal       x0, ebgcd_loop
-
-  ebgcd_u_odd:
-  /* test if v is odd */
-  bn.or     w5, w5, w5
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 4
-  bne       x2, x0, ebgcd_uv_odd
-
-  /* v is even: */
-  /* w5 = v <= v/2 = w5 >> 1 */
-  bn.rshi   w5, w31, w5 >> 1
-
-  /* test if s is odd */
-  bn.or     w3, w3, w3
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 4
-  bne       x2, x0, ebgcd_s_odd
-
-  /* s is even: */
-  /* w3 = s <= s/2 = w3 >> 1 */
-  bn.rshi   w3, w31, w3 >> 1
-  jal       x0, ebgcd_loop
-
-  ebgcd_s_odd:
-  /* w3 = s <= (s + m)/2 = (w3 + w7) >> 1 */
-  bn.add    w3, w7, w3
-  bn.addc   w6, w31, w31
-  bn.rshi   w3, w6, w3 >> 1
-  jal       x0, ebgcd_loop
-
-  ebgcd_uv_odd:
-  /* test if v >= u */
-  bn.cmp    w5, w4
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 1
-  beq       x2, x0, ebgcd_v_gte_u
-
-  /* u > v: */
-  /* w2 = r <= r - s = w2 - w3; if (r < 0): r <= r + m */
-  bn.subm   w2, w2, w3
-
-  /* w4 = u <= u - v = w4 - w5 */
-  bn.sub    w4, w4, w5
-  jal       x0, ebgcd_loop
-
-  ebgcd_v_gte_u:
-  /* w3 = s <= s - r = w3 - w2; if (s < 0) s <= s + m */
-  bn.subm   w3, w3, w2
-
-  /* w5 = v <= v - u = w5 - w4 */
-  bn.sub    w5, w5, w4
-
-  /* if v > 0 go back to start of loop */
-  csrrs     x2, 0x7c0, x0
-  andi      x2, x2, 8
-  beq       x2, x0, ebgcd_loop
-
-  /* v <= 0: */
-  /* if (r > m): w1 = a = r - m = w2 - MOD else: w1 = a = r = w2 */
-  bn.addm   w1, w2, w31
-
-  ret
 
 /**
  * Externally callable wrapper for P-256 scalar point multiplication

--- a/sw/otbn/crypto/p256_verify.s
+++ b/sw/otbn/crypto/p256_verify.s
@@ -10,9 +10,10 @@
  * https://chromium.googlesource.com/chromiumos/platform/ec/+/refs/heads/cr50_stab/chip/g/dcrypto/dcrypto_p256.c
  */
 
- .globl p256_verify
+.globl p256_isoncurve
+.globl p256_verify
 
- .text
+.text
 
  /**
  * P-256 ECDSA signature verification
@@ -247,6 +248,239 @@ p256_verify:
   la        x17, x_r
   li        x2, 24
   bn.sid    x2, 0(x17)
+
+  ret
+
+/**
+ * Checks if a point is a valid curve point on curve P-256 (secp256r1)
+ *
+ * Returns r = x^3 + ax + b  mod p
+ *     and s = y^2  mod p
+ *         with x,y being the affine coordinates of the curve point
+ *              a, b and p being the domain parameters of P-256
+ *
+ * This routine checks if a point with given x- and y-coordinate is a valid
+ * curve point on P-256.
+ * The routine checks whether the coordinates are a solution of the
+ * Weierstrass equation y^2 = x^3 + ax + b  mod p.
+ * The routine makes use of the property that the domain parameter 'a' can be
+ * written as a=-3 for the P-256 curve, hence the routine is limited to P-256.
+ * The routine does not return a boolean result but computes the left side
+ * and the right sight of the Weierstrass equation and leaves the final
+ * comparison to the caller.
+ * The routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  dmem[x]: affine x-coordinate of input point
+ * @param[in]  dmem[y]: affine y-coordinate of input point
+ * @param[out] dmem[r]: right side result r
+ * @param[out] dmem[s]: left side result s
+ *
+ * clobbered registers: x2, x3, x19, x20, w0, w19 to w25
+ * clobbered flag groups: FG0
+ */
+p256_isoncurve:
+
+  /* setup all-zero reg */
+  bn.xor    w31, w31, w31
+
+  /* setup modulus p and Barrett constant u
+     MOD <= w29 <= dmem[p256_p] = p; w28 <= dmem[p256_u_p] = u_p */
+  li        x2, 29
+  la        x3, p256_p
+  bn.lid    x2, 0(x3)
+  bn.wsrw   0, w29
+  li        x2, 28
+  la        x3, p256_u_p
+  bn.lid    x2, 0(x3)
+
+  /* load domain parameter b from dmem
+     w27 <= b = dmem[p256_b] */
+  li        x2, 27
+  la        x3, p256_b
+  bn.lid    x2, 0(x3)
+
+  /* load affine y-coordinate of curve point from dmem
+     w26 <= dmem[y] */
+  la        x3, y
+  li        x2, 24
+  bn.lid    x2, 0(x3)
+
+  /* w19 <= y^2 = w24*w24 */
+  bn.mov    w25, w24
+  jal       x1, mod_mul_256x256
+
+  /* store left side result: dmem[s] <= w19 = y^2  mod p */
+  la        x20, s
+  li        x2, 19
+  bn.sid    x2, 0(x20)
+
+  /* load affine x-coordinate of curve point from dmem
+     w26 <= dmem[x] */
+  la        x3, x
+  li        x2, 26
+  bn.lid    x2, 0(x3)
+
+  /* w19 <= x^2 = w26*w26 */
+  bn.mov    w25, w26
+  bn.mov    w24, w26
+  jal       x1, mod_mul_256x256
+
+  /* w19 = x^3 <= x^2 * x = w25*w24 = w26*w19 */
+  bn.mov    w25, w19
+  bn.mov    w24, w26
+  jal       x1, mod_mul_256x256
+
+  /* for curve P-256, 'a' can be written as a = -3, therefore we subtract
+     x three times from x^3.
+     w19 = x^3 + ax <= x^3 - 3x  mod p */
+  bn.subm   w19, w19, w26
+  bn.subm   w19, w19, w26
+  bn.subm   w19, w19, w26
+
+  /* w24 <= x^3 + ax + b mod p = w19 + w27 mod p */
+  bn.addm   w19, w19, w27
+
+  /* store right side result: dmem[r] <= w19 = x^3 + ax + b mod p */
+  la        x19, r
+  li        x2, 19
+  bn.sid    x2, 0(x19)
+
+  ret
+
+/**
+ * Variable time modular multiplicative inverse computation
+ *
+ * Returns c <= a^(-1) mod m
+ *         with a being a bigint of length 256 bit with a < m
+ *              m being the modulus with a length of 256 bit
+ *              c being a 256-bit result
+ *
+ * This routine implements the computation of the modular multiplicative
+ * inverse based on the binary GCD or Stein's algorithm.
+ * The implemented variant is based on the
+ * "right-shift binary extended GCD" as it is described in section 3.1 of [1]
+ * (Algorithm 1).
+ * [1] https://doi.org/10.1155/ES/2006/32192
+ *
+ * Note that this is a variable time implementation. I.e. this routine will
+ * show a data dependent timing and execution profile. Only use in situations
+ * where a full white-box environment is acceptable.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  w0: a, operand
+ * @param[in]  MOD: m, modulus
+ * @param[in]  w31: all-zero
+ * @param[out]  w1: result c
+ *
+ * clobbered registers: x2, w2, w3, w4, w7
+ * clobbered flag groups: FG0
+ */
+mod_inv_var:
+
+  /* w2 = r = 0 */
+  bn.mov    w2, w31
+
+  /* w3 = s = 1 */
+  bn.addi   w3, w31, 1
+
+  /* w4 = u = MOD */
+  bn.wsrr   w4, 0
+  bn.wsrr   w7, 0
+
+  /* w5 = v = w0 */
+  bn.mov    w5, w0
+
+  ebgcd_loop:
+  /* test if u is odd */
+  bn.or     w4, w4, w4
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 4
+  bne       x2, x0, ebgcd_u_odd
+
+  /* u is even: */
+  /* w4 = u <= u/2 = w4 >> 1 */
+  bn.rshi   w4, w31, w4 >> 1
+
+  /* test if r is odd */
+  bn.or     w2, w2, w2
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 4
+  bne       x2, x0, ebgcd_r_odd
+
+  /* r is even: */
+  /* w2 = r <= r/2 = w2 >> 1 */
+  bn.rshi   w2, w31, w2 >> 1
+  jal       x0, ebgcd_loop
+
+  ebgcd_r_odd:
+  /* w2 = r <= (r + m)/2 = (w2 + w7) >> 1 */
+  bn.add    w2, w7, w2
+  bn.addc   w6, w31, w31
+  bn.rshi   w2, w6, w2 >> 1
+  jal       x0, ebgcd_loop
+
+  ebgcd_u_odd:
+  /* test if v is odd */
+  bn.or     w5, w5, w5
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 4
+  bne       x2, x0, ebgcd_uv_odd
+
+  /* v is even: */
+  /* w5 = v <= v/2 = w5 >> 1 */
+  bn.rshi   w5, w31, w5 >> 1
+
+  /* test if s is odd */
+  bn.or     w3, w3, w3
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 4
+  bne       x2, x0, ebgcd_s_odd
+
+  /* s is even: */
+  /* w3 = s <= s/2 = w3 >> 1 */
+  bn.rshi   w3, w31, w3 >> 1
+  jal       x0, ebgcd_loop
+
+  ebgcd_s_odd:
+  /* w3 = s <= (s + m)/2 = (w3 + w7) >> 1 */
+  bn.add    w3, w7, w3
+  bn.addc   w6, w31, w31
+  bn.rshi   w3, w6, w3 >> 1
+  jal       x0, ebgcd_loop
+
+  ebgcd_uv_odd:
+  /* test if v >= u */
+  bn.cmp    w5, w4
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 1
+  beq       x2, x0, ebgcd_v_gte_u
+
+  /* u > v: */
+  /* w2 = r <= r - s = w2 - w3; if (r < 0): r <= r + m */
+  bn.subm   w2, w2, w3
+
+  /* w4 = u <= u - v = w4 - w5 */
+  bn.sub    w4, w4, w5
+  jal       x0, ebgcd_loop
+
+  ebgcd_v_gte_u:
+  /* w3 = s <= s - r = w3 - w2; if (s < 0) s <= s + m */
+  bn.subm   w3, w3, w2
+
+  /* w5 = v <= v - u = w5 - w4 */
+  bn.sub    w5, w5, w4
+
+  /* if v > 0 go back to start of loop */
+  csrrs     x2, 0x7c0, x0
+  andi      x2, x2, 8
+  beq       x2, x0, ebgcd_loop
+
+  /* v <= 0: */
+  /* if (r > m): w1 = a = r - m = w2 - MOD else: w1 = a = r = w2 */
+  bn.addm   w1, w2, w31
 
   ret
 

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -301,6 +301,7 @@ otbn_sim_test(
     exp = "p256_isoncurve_test.exp",
     deps = [
         "//sw/otbn/crypto:p256_base",
+        "//sw/otbn/crypto:p256_verify",
     ],
 )
 


### PR DESCRIPTION
This is the product of some discussions between @timothytrippel; this is one single OTBN binary that provides all the crypto services ROM_EXT needs for attestation/secure boot. The purpose is to
- provide a safe way to store the attestation signing key just long enough to sign the next stage's public key without rebooting
- save boot time from wiping/re-loading OTBN programs

The first commit moves some code that signing doesn't use from `p256_base.s` (shared between sign and verify) to `p256_verify.s` so that P-256 signing and RSA-3072 modexp fit together in OTBN's IMEM. No code is changed in that commit, only moved to a different file.