### PR TITLE
[opentitantool] Do not specify OpenOCD ports

### DIFF
--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -21,10 +21,6 @@ pub struct JtagParams {
     #[arg(long, default_value = "openocd")]
     pub openocd: PathBuf,
 
-    /// Port used to start and connect to OpenOCD over.
-    #[arg(long, default_value = "6666")]
-    pub openocd_port: u16,
-
     /// Timeout when waiting for OpenOCD to start.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "3s")]
     pub openocd_timeout: Duration,


### PR DESCRIPTION
When backend transports choose to start openocd as a sub-process, for use as part of the implementation of the `Jtag` trait, the caller needs not care or know which TCP port is being used for communication between the struct implementing `Jtag` and the sub-process.

This CL instructs openocd to choose any available port, and has the helper functions in `openocd.rs` recognize the chosen port among the stderr output of the openocd sub-process, in order to establish connection.

This will ensure that tests or manual invocations of opentitanlib are not adversely affected by an unrelated OpenOCD process already having bound to one of the default ports.