### PR TITLE
[opentitantool] Move SPI pin declaration from Rust into json

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -40,6 +40,10 @@
   "spi": [
     {
       "name": "BOOTSTRAP",
+      "serial_clock": "USB_SPI_SCK",
+      "host_out_device_in": "USB_SPI_COPI",
+      "host_in_device_out": "USB_SPI_CIPO",
+      "chip_select": "USB_SPI_CS",
       "alias_of": "0"
     }
   ],

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw340.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw340.json
@@ -40,6 +40,10 @@
   "spi": [
     {
       "name": "BOOTSTRAP",
+      "serial_clock": "PA27",
+      "host_out_device_in": "PA26",
+      "host_in_device_out": "PA25",
+      "chip_select": "PA28",
       "alias_of": "0"
     }
   ],

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -480,6 +480,15 @@ impl TransportWrapperBuilder {
                 }
             };
             // Apply configuration from this level
+            if let Some(serial_clock) = entry.serial_clock.as_ref() {
+                conf.serial_clock = Some(map_name(pin_alias_map, serial_clock));
+            }
+            if let Some(host_out_device_in) = entry.host_out_device_in.as_ref() {
+                conf.host_out_device_in = Some(map_name(pin_alias_map, host_out_device_in));
+            }
+            if let Some(host_in_device_out) = entry.host_in_device_out.as_ref() {
+                conf.host_in_device_out = Some(map_name(pin_alias_map, host_in_device_out));
+            }
             if let Some(chip_select) = entry.chip_select.as_ref() {
                 conf.chip_select = Some(map_name(pin_alias_map, chip_select));
             }

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
@@ -6,19 +6,8 @@ pub trait Board {
     const VENDOR_ID: u16 = 0x2b3e;
     const PRODUCT_ID: u16;
 
-    // Pins needed for SPI on the Chip Whisperer board.
-    const PIN_CLK: &'static str;
-    const PIN_SDI: &'static str;
-    const PIN_SDO: &'static str;
-    const PIN_CS: &'static str;
     // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_TRST: &'static str;
     const PIN_POR_N: &'static str;
-    const PIN_SW_STRAP0: &'static str;
-    const PIN_SW_STRAP1: &'static str;
-    const PIN_SW_STRAP2: &'static str;
-    const PIN_TAP_STRAP0: &'static str;
-    const PIN_TAP_STRAP1: &'static str;
 }
 
 pub struct Cw310 {}
@@ -26,19 +15,8 @@ pub struct Cw310 {}
 impl Board for Cw310 {
     const PRODUCT_ID: u16 = 0xc310;
 
-    // Pins needed for SPI on the Chip Whisperer board.
-    const PIN_CLK: &'static str = "USB_SPI_SCK";
-    const PIN_SDI: &'static str = "USB_SPI_COPI";
-    const PIN_SDO: &'static str = "USB_SPI_CIPO";
-    const PIN_CS: &'static str = "USB_SPI_CS";
     // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_TRST: &'static str = "USB_A13";
     const PIN_POR_N: &'static str = "USB_A14";
-    const PIN_SW_STRAP0: &'static str = "USB_A15";
-    const PIN_SW_STRAP1: &'static str = "USB_A16";
-    const PIN_SW_STRAP2: &'static str = "USB_A17";
-    const PIN_TAP_STRAP0: &'static str = "USB_A18";
-    const PIN_TAP_STRAP1: &'static str = "USB_A19";
 }
 
 pub struct Cw340 {}
@@ -46,17 +24,6 @@ pub struct Cw340 {}
 impl Board for Cw340 {
     const PRODUCT_ID: u16 = 0xc340;
 
-    // Pins needed for SPI on the Chip Whisperer board.
-    const PIN_SDI: &'static str = "PA26";
-    const PIN_SDO: &'static str = "PA25";
-    const PIN_CLK: &'static str = "PA27";
-    const PIN_CS: &'static str = "PA28";
     // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_TRST: &'static str = "USB_A13";
     const PIN_POR_N: &'static str = "PC30";
-    const PIN_SW_STRAP0: &'static str = "PC23";
-    const PIN_SW_STRAP1: &'static str = "PC22";
-    const PIN_SW_STRAP2: &'static str = "PC21";
-    const PIN_TAP_STRAP0: &'static str = "PB13";
-    const PIN_TAP_STRAP1: &'static str = "PB12";
 }

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/gpio.rs
@@ -53,4 +53,8 @@ impl<B: Board> GpioPin for Pin<B> {
             _ => Err(GpioError::UnsupportedPullMode(mode).into()),
         }
     }
+
+    fn get_internal_pin_name(&self) -> Option<&str> {
+        Some(&self.pinname)
+    }
 }


### PR DESCRIPTION
This is one more step on the way to moving all pin declarations out of `chip_whisperer/board.rs` and into json configuration files to be parsed by `TransportWrapper`.