### PR TITLE
[bazel] Update the coremark test to use the new rules

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1528,7 +1528,7 @@
     {
       name: chip_sw_coremark
       uvm_test_seq: chip_sw_uart_tx_vseq
-      sw_images: ["//third_party/coremark/top_earlgrey:coremark_test:1"]
+      sw_images: ["//third_party/coremark/top_earlgrey:coremark_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",
                  "+sw_test_timeout_ns=100_000_000"]

--- a/third_party/coremark/top_earlgrey/BUILD
+++ b/third_party/coremark/top_earlgrey/BUILD
@@ -2,7 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
+    "opentitan_test",
+    "verilator_params",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,7 +17,7 @@ cc_library(
     includes = ["."],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "coremark_test",
     srcs = [
         "core_portme.c",
@@ -30,6 +35,7 @@ opentitan_functest(
         "-DTOTAL_DATA_SIZE=2000",
         "-DMAIN_HAS_NOARGC=1",
     ],
+    exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),


### PR DESCRIPTION
1. Converts //third_party/coremark/top_earlgrey/BUILD to the new build rules.

Fixes #19929