### PR TITLE
[bazel] Enable build/test for ROM_EXT environments

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -91,6 +91,24 @@ fpga_cw310(
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
 )
 
+fpga_cw310(
+    name = "fpga_cw310_rom_ext",
+    testonly = True,
+    base = ":fpga_cw310_test_rom",
+    bitstream = "//hw/bitstream:rom_with_fake_keys",
+    exec_env = "fpga_cw310_rom_ext",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+    manifest = "//sw/device/silicon_owner:manifest_standard",
+    param = {
+        "interface": "cw310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@0 {firmware}@0x10000",
+    },
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_fpga_cw310_bin_signed_fake_rsa_test_key_0",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
+)
+
 ###########################################################################
 # FPGA CW305 Environments
 #

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -349,6 +349,10 @@ opentitan_test = rv_rule(
             allow_files = True,
             doc = "ROM image override for this test",
         ),
+        "rom_ext": attr.label(
+            allow_files = True,
+            doc = "ROM_EXT image override for this test",
+        ),
         "otp": attr.label(
             allow_single_file = True,
             doc = "OTP image override for this test",

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -173,6 +173,7 @@ def opentitan_test(
             test_harness = tparam.test_harness,
             binaries = tparam.binaries,
             rom = tparam.rom,
+            rom_ext = tparam.rom_ext,
             otp = tparam.otp,
             bitstream = tparam.bitstream,
             test_cmd = tparam.test_cmd,

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -12,6 +12,7 @@ _FIELDS = {
     "spx_key": ("attr.spx_key", False),
     "manifest": ("file.manifest", False),
     "rom": ("attr.rom", False),
+    "rom_ext": ("attr.rom_ext", False),
     "otp": ("file.otp", False),
     "bitstream": ("file.bitstream", False),
     "args": ("attr.args", False),
@@ -127,6 +128,11 @@ def exec_env_common_attrs(**kwargs):
             default = kwargs.get("rom"),
             allow_files = True,
             doc = "ROM image to use in this environment",
+        ),
+        "rom_ext": attr.label(
+            default = kwargs.get("rom_ext"),
+            allow_files = True,
+            doc = "ROM_EXT image to use in this environment",
         ),
         "otp": attr.label(
             default = kwargs.get("otp"),

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -9,7 +9,12 @@ load(
     "Cw340BinaryInfo",
     "get_one_binary_file",
 )
-load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
+load(
+    "@lowrisc_opentitan//rules/opentitan:util.bzl",
+    "assemble_for_test",
+    "get_fallback",
+    "get_files",
+)
 load(
     "//rules/opentitan:exec_env.bzl",
     "ExecEnvInfo",
@@ -113,6 +118,7 @@ def _test_dispatch(ctx, exec_env, provider):
     bitstream = get_fallback(ctx, "file.bitstream", exec_env)
     otp = get_fallback(ctx, "file.otp", exec_env)
     rom = get_fallback(ctx, "attr.rom", exec_env)
+    rom_ext = get_fallback(ctx, "attr.rom_ext", exec_env)
     data_labels = ctx.attr.data + exec_env.data
     data_files = get_files(data_labels)
     if bitstream:
@@ -120,6 +126,9 @@ def _test_dispatch(ctx, exec_env, provider):
     if rom:
         rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
         data_files.append(rom)
+    if rom_ext:
+        rom_ext = get_one_binary_file(rom_ext, field = "signed_bin", providers = [exec_env.provider])
+        data_files.append(rom_ext)
     if otp:
         data_files.append(otp)
     data_files.append(test_harness)
@@ -128,6 +137,7 @@ def _test_dispatch(ctx, exec_env, provider):
     # param and and some extra file references.
     param = dict(exec_env.param)
     param.update(ctx.attr.param)
+    action_param = dict(param)
 
     for attr, name in ctx.attr.binaries.items():
         file = get_one_binary_file(attr, field = "default", providers = [exec_env.provider])
@@ -135,19 +145,44 @@ def _test_dispatch(ctx, exec_env, provider):
         if name in param:
             fail("The binaries substitution name", name, "already exists")
         param[name] = file.short_path
+        action_param[name] = file.path
 
     if bitstream and "bitstream" not in param:
         param["bitstream"] = bitstream.short_path
+        action_param["bitstream"] = bitstream.path
     if rom and "rom" not in param:
         param["rom"] = rom.short_path
+        action_param["rom"] = rom.path
+    if rom_ext and "rom_ext" not in param:
+        param["rom_ext"] = rom_ext.short_path
+        action_param["rom_ext"] = rom_ext.path
     if otp and "otp" not in param:
         param["otp"] = otp.short_path
+        action_param["otp"] = otp.path
     if provider:
         data_files.append(provider.default)
         if "firmware" not in param:
             param["firmware"] = provider.default.short_path
+            action_param["firmware"] = provider.default.path
         else:
             fail("This test builds firmware, but the firmware param has already been provided")
+
+    # If the test requested an assembled image, then use opentitantool to
+    # assemble the image.  Replace the firmware param with the newly assembled
+    # image.
+    if "assemble" in param:
+        assemble = param["assemble"].format(**action_param)
+        assemble = ctx.expand_location(assemble, data_labels)
+        image = assemble_for_test(
+            ctx,
+            name = ctx.attr.name,
+            spec = assemble.split(" "),
+            data_files = data_files,
+            opentitantool = exec_env._opentitantool,
+        )
+        param["firmware"] = image.short_path
+        action_param["firmware"] = image.path
+        data_files.append(image)
 
     # FIXME: maybe splice a bitstream here
 
@@ -223,6 +258,7 @@ def cw310_params(
         test_harness = None,
         binaries = {},
         rom = None,
+        rom_ext = None,
         otp = None,
         bitstream = None,
         test_cmd = "",
@@ -237,6 +273,7 @@ def cw310_params(
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binary labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
       otp: Use an alternate OTP configuration for this test.
       bitstream: Use an alternate bitstream for this test.
       test_cmd: Use an alternate test_cmd for this test.
@@ -252,6 +289,7 @@ def cw310_params(
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,
+        rom_ext = rom_ext,
         otp = otp,
         bitstream = bitstream,
         test_cmd = test_cmd,
@@ -266,6 +304,7 @@ def cw310_jtag_params(
         test_harness = None,
         binaries = {},
         rom = None,
+        rom_ext = None,
         otp = None,
         bitstream = None,
         test_cmd = OPENTITANTOOL_OPENOCD_TEST_CMD,
@@ -283,6 +322,7 @@ def cw310_jtag_params(
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binary labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
       otp: Use an alternate OTP configuration for this test.
       bitstream: Use an alternate bitstream for this test.
       test_cmd: Use an alternate test_cmd for this test.
@@ -298,6 +338,7 @@ def cw310_jtag_params(
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,
+        rom_ext = rom_ext,
         otp = otp,
         bitstream = bitstream,
         test_cmd = test_cmd,

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -197,6 +197,7 @@ def dv_params(
         test_harness = None,
         binaries = None,
         rom = None,
+        rom_ext = None,
         otp = None,
         test_cmd = "",
         data = [],
@@ -210,6 +211,7 @@ def dv_params(
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binaries labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
       otp: Use an alternate OTP configuration for this test.
       test_cmd: Use an alternate test_cmd for this test.
       data: Additional files needed by this test.
@@ -224,6 +226,7 @@ def dv_params(
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,
+        rom_ext = rom_ext,
         otp = otp,
         bitstream = None,
         test_cmd = test_cmd,

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -193,6 +193,7 @@ def verilator_params(
         test_harness = None,
         binaries = {},
         rom = None,
+        rom_ext = None,
         otp = None,
         test_cmd = "",
         data = [],
@@ -206,6 +207,7 @@ def verilator_params(
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binaries labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
       otp: Use an alternate OTP configuration for this test.
       test_cmd: Use an alternate test_cmd for this test.
       data: Additional files needed by this test.
@@ -220,6 +222,7 @@ def verilator_params(
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,
+        rom_ext = rom_ext,
         otp = otp,
         bitstream = None,
         test_cmd = test_cmd,

--- a/rules/opentitan/util.bzl
+++ b/rules/opentitan/util.bzl
@@ -53,3 +53,31 @@ def get_files(attrs):
         else:
             print("No DefaultInfo in ", attr)
     return files
+
+def assemble_for_test(ctx, name, spec, data_files, opentitantool):
+    """Assemble a set of images into a flash binary for testing.
+
+    Args:
+      ctx: A context object.
+      name: The base name of the output image.
+      spec: A list of strings specifying the assembly parameters.
+            e.g.: ["rom_ext_path@0x0", "test_path@0x10000"].
+      data_files: A list of files needed by the spec.
+      opentitantool: The opentitantool executable.
+    Returns:
+      File: the assembled image.
+    """
+    image = ctx.actions.declare_file(name + ".img")
+    ctx.actions.run(
+        outputs = [image],
+        inputs = data_files,
+        arguments = [
+            "--rcfile=",
+            "image",
+            "assemble",
+            "--mirror=false",
+            "--output={}".format(image.path),
+        ] + spec,
+        executable = opentitantool,
+    )
+    return image

--- a/sw/device/silicon_creator/rom_ext/e2e/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/BUILD
@@ -1,0 +1,49 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+load("//rules:splice.bzl", "bitstream_splice")
+
+package(default_visibility = ["//visibility:public"])
+
+otp_json(
+    name = "otp_json_secret2_locked",
+    partitions = [
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                # We aren't testing keymgr for ROM_EXT tests and we want
+                # reproducible bitstreams for all tests.
+                "RMA_TOKEN": "0000000000000005",
+                "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
+                "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
+            },
+            lock = True,
+        ),
+    ],
+    visibility = ["//visibility:private"],
+)
+
+otp_image(
+    name = "otp_img_secret2_locked_rma",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [
+        ":otp_json_secret2_locked",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+bitstream_splice(
+    name = "bitstream_secret2_locked",
+    src = "//hw/bitstream:rom_with_fake_keys",
+    data = ":otp_img_secret2_locked_rma",
+    meminfo = "//hw/bitstream:otp_mmi",
+    update_usr_access = True,
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
+    "cw310_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+opentitan_test(
+    name = "boot_test",
+    srcs = ["boot_test.c"],
+    cw310 = cw310_params(
+        bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+status_t boot_log_print(boot_log_t *boot_log) {
+  TRY(boot_log_check(boot_log));
+  LOG_INFO("boot_log identifier = %08x", boot_log->identifier);
+  LOG_INFO("boot_log chip_version = %08x%08x",
+           boot_log->chip_version.scm_revision_high,
+           boot_log->chip_version.scm_revision_low);
+  LOG_INFO("boot_log rom_ext_slot = %s",
+           (boot_log->rom_ext_slot == kRomExtBootSlotA)   ? "A"
+           : (boot_log->rom_ext_slot == kRomExtBootSlotB) ? "B"
+                                                          : "error");
+  LOG_INFO("boot_log bl0_slot = %s", (boot_log->bl0_slot == kBl0BootSlotA) ? "A"
+                                     : (boot_log->bl0_slot == kBl0BootSlotB)
+                                         ? "B"
+                                         : "error");
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t sts = boot_log_print(&retention_sram_get()->creator.boot_log);
+  if (status_err(sts)) {
+    LOG_ERROR("boot_log_print: %r", sts);
+  }
+  return status_ok(sts);
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
@@ -10,45 +10,47 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 void rom_ext_epmp_unlock_owner_stage_rx(epmp_region_t region) {
-  const int kEntry = 8;
+  const int kEntry = 1;
   epmp_state_configure_tor(kEntry, region, kEpmpPermLockedReadExecute);
 
   // Update the hardware configuration (CSRs).
   //
-  // Entry is hardcoded as 8. Make sure to modify hardcoded values if changing
+  // Entry is hardcoded as 1. Make sure to modify hardcoded values if changing
   // kEntry.
   //
   // The `pmp1cfg` configuration is the second field in `pmpcfg0`.
   //
   //            32          24          16           8           0
   //             +-----------+-----------+-----------+-----------+
-  // `pmpcfg2` = | `pmp11cfg | `pmp10cfg`| `pmp9cfg` | `pmp8cfg` |
+  // `pmpcfg0` = |  `pmp3cfg |  `pmp2cfg`| `pmp1cfg` | `pmp0cfg` |
   //             +-----------+-----------+-----------+-----------+
-  CSR_WRITE(CSR_REG_PMPADDR7, ((uint32_t)region.start) >> 2);
-  CSR_WRITE(CSR_REG_PMPADDR8, ((uint32_t)region.end) >> 2);
-  CSR_CLEAR_BITS(CSR_REG_PMPCFG2, 0xff);
-  CSR_SET_BITS(CSR_REG_PMPCFG2, (kEpmpModeTor | kEpmpPermLockedReadExecute));
+
+  CSR_WRITE(CSR_REG_PMPADDR0, ((uint32_t)region.start) >> 2);
+  CSR_WRITE(CSR_REG_PMPADDR1, ((uint32_t)region.end) >> 2);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, 0xff << 8);
+  CSR_SET_BITS(CSR_REG_PMPCFG0, (kEpmpModeTor | kEpmpPermLockedReadExecute)
+                                    << 8);
 }
 
 void rom_ext_epmp_unlock_owner_stage_r(epmp_region_t region) {
-  const int kEntry = 9;
+  const int kEntry = 2;
   epmp_state_configure_napot(kEntry, region, kEpmpPermLockedReadOnly);
 
   // Update the hardware configuration (CSRs).
   //
-  // Entry is hardcoded as 9. Make sure to modify hardcoded values if changing
+  // Entry is hardcoded as 2. Make sure to modify hardcoded values if changing
   // kEntry.
   //
-  // The `pmp6cfg` configuration is the second field in `pmpcfg1`.
+  // The `pmp2cfg` configuration is the third field in `pmpcfg0`.
   //
   //            32          24          16           8           0
   //             +-----------+-----------+-----------+-----------+
-  // `pmpcfg2` = | `pmp11cfg`| `pmp10cfg`| `pmp9cfg` | `pmp8cfg` |
+  // `pmpcfg0` = |  `pmp3cfg |  `pmp2cfg`| `pmp1cfg` | `pmp0cfg` |
   //             +-----------+-----------+-----------+-----------+
-  CSR_WRITE(CSR_REG_PMPADDR9,
+  CSR_WRITE(CSR_REG_PMPADDR2,
             (uint32_t)region.start >> 2 |
                 ((uint32_t)region.end - (uint32_t)region.start - 1) >> 3);
-  CSR_CLEAR_BITS(CSR_REG_PMPCFG2, 0xff << 8);
-  CSR_SET_BITS(CSR_REG_PMPCFG2,
-               ((kEpmpModeNapot | kEpmpPermLockedReadOnly) << 8));
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, 0xff << 16);
+  CSR_SET_BITS(CSR_REG_PMPCFG0,
+               ((kEpmpModeNapot | kEpmpPermLockedReadOnly) << 16));
 }

--- a/sw/device/silicon_owner/BUILD
+++ b/sw/device/silicon_owner/BUILD
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
+
+package(default_visibility = ["//visibility:public"])
+
+manifest({
+    "name": "manifest_standard",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+})


### PR DESCRIPTION
1. Add a `rom_ext` field to the execution environment.
2. When executing a test, if the test requests image assembly, assemble
   a flash image for test dispatch.
3. Define an `fpga_cw310_rom_ext` execution environment.
4. Add a simple boot test for the ROM_EXT.

Drawbacks: this only works in a CW310 environment.
- Considering the time it takes to perform signature verifications in simulation, we may not even want to run these types of tests in simulation.
- `opentitantool image assemble` currently doesn't understand VMEM files, so assembling a multi-stage binary for SIM environments will be tedious.

Fixes: #19905 
Addresses: #19589 
