### PR TITLE
[jtag,dv] add min rti duration knob

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -13,6 +13,11 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // JTAG debug transport module (DTM) RAL model based off of RISCV spec 0.13.2 (section 6.1.2).
   jtag_dtm_reg_block jtag_dtm_ral;
 
+  // Option to minize Run-Test/Idle duration
+  // Current RVDM has hardcoded dtmcs.idle = 1, which requires a single cycle of Run-Test/Idle duration.
+  // This knob can bypass default 1 cycle initial delay of 'driver.drive_jtag_req()' task.
+  // Use this knob only for the necessary tests.
+  bit     min_rti = 0;
   `uvm_object_utils_begin(jtag_agent_cfg)
     `uvm_field_object(jtag_dtm_ral, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -104,7 +104,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     if (req.reset_tap_fsm) begin
       drive_jtag_test_logic_reset();
     end
-    if (exit_to_rti_dr_past) begin
+    if (exit_to_rti_dr_past & ~cfg.min_rti) begin
       @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
     end else begin
       `uvm_info(`gfn, "Skip wait cycles because of past exit to RTI in drive_dr", UVM_MEDIUM)


### PR DESCRIPTION
[This rv_dm testpoint](https://cs.opensource.google/opentitan/opentitan/+/master:hw/ip/rv_dm/data/rv_dm_testplan.hjson;drc=5d8bab5473d16577c4fc1308c70b297aa4e7c16b;l=158) requires
the jtag driver to retain Run-Test/Idle cycle greater than equal to `dtmcs.idle` (as in  [RISC-V debug spec](https://github.com/riscv/riscv-debug-spec/raw/4e0bb0fc2d843473db2356623792c6b7603b94d4/riscv-debug-release.pdf)).
To achieve minimum value (1cycle), we need a knob to skip default 1 cycle delay of the driver task.