### PR TITLE
[flash_ctrl,dv] update expected double bit error set

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -642,6 +642,6 @@
 // Do not leave this macro in other source files in the remote repo.
 `ifndef OTDBG
   `define OTDBG(x) \
-  $write($sformatf("%t:OTDBG:",$time));\
+  $write($sformatf("%t:OTDBG:%s:%d:",$time,`__FILE__, `__LINE__));\
   $display($sformatf x);
 `endif


### PR DESCRIPTION
When multiple writes are issued to the same address of flash device, data corruption is exected and detected by checking ecc. However, flash device can only be updated from 1 to 0 (not the other way), 
and multiple writes can make data bits converge to all 0s, which can cause to fail detecting double bit error.
So expected double bit error in the error tests, is updated 
such that it can only be set after tb caculates ecc and confirms it to generate double bit error.