### PR TITLE
[Bazel] convert manuf/lib to the new rules

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -149,12 +149,15 @@ def opentitan_test(
         "verilator": verilator,
     }
     test_parameters.update(kwargs)
+    kwargs_unused = kwargs.keys()
 
     all_tests = []
     for (env, pname) in exec_env.items():
         pname = _parameter_name(env, pname)
         extra_tags = _hacky_tags(env)
         tparam = test_parameters[pname]
+        if pname in kwargs_unused:
+            kwargs_unused.remove(pname)
         (_, suffix) = env.split(":")
         test_name = "{}_{}".format(name, suffix)
         all_tests.append(":" + test_name)
@@ -189,6 +192,11 @@ def opentitan_test(
             spx_key = spx_key,
             manifest = manifest,
         )
+
+    # Make sure that we used all elements in kwargs
+    if len(kwargs_unused) > 0:
+        fail("the following arguments passed to opentitan_test were not used: {}".format(", ".join(kwargs_unused)))
+
     native.test_suite(
         name = name,
         tests = all_tests,

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -308,7 +308,7 @@ def cw310_jtag_params(
         rom_ext = None,
         otp = None,
         bitstream = None,
-        test_cmd = OPENTITANTOOL_OPENOCD_TEST_CMD,
+        test_cmd = "",
         data = [],
         **kwargs):
     """A macro to create CW310 parameters for OpenTitan JTAG tests.
@@ -342,7 +342,7 @@ def cw310_jtag_params(
         rom_ext = rom_ext,
         otp = otp,
         bitstream = bitstream,
-        test_cmd = test_cmd,
+        test_cmd = OPENTITANTOOL_OPENOCD_TEST_CMD + test_cmd,
         data = OPENTITANTOOL_OPENOCD_DATA_DEPS + data,
         param = kwargs,
     )

--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -16,5 +16,4 @@ OPENTITANTOOL_OPENOCD_TEST_CMD = """
     --openocd-lc-target-config="$(rootpath //util/openocd/target:lowrisc-earlgrey-lc.cfg)"
     --clear-bitstream
     --bitstream={bitstream}
-    --elf={firmware}
 """

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -3,16 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
-    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
-    "OPENTITANTOOL_OPENOCD_TEST_CMDS",
-    "cw310_params",
-    "opentitan_functest",
-)
-load(
-    "//rules:opentitan.bzl",
+    "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
-    "RSA_ONLY_KEY_STRUCTS",
+    "cw310_jtag_params",
+    "cw310_params",
+    "opentitan_binary",
+    "opentitan_test",
 )
 load("//rules:linker.bzl", "ld_library")
 
@@ -103,17 +99,17 @@ cc_library(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "individualize_functest",
     srcs = ["individualize_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_dev_initial",
         tags = ["manuf"],
     ),
-    key_struct = RSA_ONLY_KEY_STRUCTS[1],
-    targets = [
-        "cw310_rom_with_fake_keys",
-    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
     deps = [
         ":individualize",
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
@@ -156,16 +152,16 @@ cc_library(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "individualize_sw_cfg_functest",
     srcs = ["individualize_sw_cfg_functest.c"],
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked0",
         tags = ["manuf"],
     ),
-    targets = [
-        "cw310_rom_with_fake_keys",
-    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
     deps = [
         ":individualize_sw_cfg_earlgrey_a0_sku_generic",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -204,27 +200,25 @@ cc_library(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "personalize_functest",
     srcs = ["personalize_functest.c"],
-    cw310 = cw310_params(
+    cw310 = cw310_jtag_params(
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_dev_individualized",
+        data = [
+            "//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der",
+        ],
         tags = ["manuf"],
-        test_cmds = [
-            "--clear-bitstream",
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-            "--hsm-ecdh-sk=\"$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)\"",
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        test_cmd = """
+            --bootstrap={firmware}
+            --hsm-ecdh-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
+        """,
+        test_harness = "//sw/host/tests/manuf/personalize",
     ),
-    data = [
-        "//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der",
-    ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    key_struct = RSA_ONLY_KEY_STRUCTS[1],
-    targets = [
-        "cw310_rom_with_fake_keys",
-    ],
-    test_harness = "//sw/host/tests/manuf/personalize",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
     deps = [
         ":personalize",
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -240,6 +240,7 @@ cc_library(
         srcs = ["sram_empty_functest.c"],
         cw310 = cw310_jtag_params(
             bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
         ),
         exec_env = {

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -266,11 +266,6 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
-    targets = [
-        "cw310_test_rom",
-        "verilator",
-        "dv",
-    ],
     verilator = verilator_params(
         timeout = "eternal",
     ),


### PR DESCRIPTION
This PR contains two other changes:
- fix support for overriding the RSA/SPX key and manifest in `opentitan_test`
- fix cw310_jtag_params
- add a test to make sure that all arguments of `opentitan_test` are used
See individual commits for details.

