### PR TITLE
[bazel] Build ROM_EXT with the new rules 

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -105,7 +105,7 @@ fpga_cw310(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@0 {firmware}@0x10000",
     },
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_fpga_cw310_bin_signed_fake_rsa_test_key_0",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
 )
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -181,13 +181,18 @@ def _build_binary(ctx, exec_env, name, deps):
         src = elf,
     )
 
-    if exec_env.manifest:
+    manifest = get_fallback(ctx, "file.manifest", exec_env)
+    rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
+    spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
+    if manifest:
+        if not rsa_key:
+            fail("Signing requires a manifest and an rsa_key, and optionally an spx_key")
         signed = sign_binary(
             ctx,
             bin = binary,
-            rsa_key = exec_env.rsa_key,
-            spx_key = exec_env.spx_key,
-            manifest = exec_env.manifest,
+            rsa_key = rsa_key,
+            spx_key = spx_key,
+            manifest = manifest,
             # FIXME: will need to supply hsmtool when we add NitroKey signing.
             _tool = exec_env._opentitantool,
         )
@@ -253,6 +258,18 @@ common_binary_attrs = {
     "linker_script": attr.label(
         providers = [CcInfo],
         doc = "Linker script for linking this binary",
+    ),
+    "rsa_key": attr.label_keyed_string_dict(
+        allow_files = True,
+        doc = "RSA key to sign images",
+    ),
+    "spx_key": attr.label_keyed_string_dict(
+        allow_files = True,
+        doc = "SPX key to sign images",
+    ),
+    "manifest": attr.label(
+        allow_single_file = True,
+        doc = "Manifest used when signing images",
     ),
     "copts": attr.string_list(
         doc = "Add these options to the C++ compilation command.",

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -109,6 +109,9 @@ def opentitan_test(
         includes = [],
         linkopts = [],
         linker_script = None,
+        rsa_key = None,
+        spx_key = None,
+        manifest = None,
         exec_env = {},
         cw310 = _cw310_params(),
         dv = _dv_params(),
@@ -127,6 +130,9 @@ def opentitan_test(
       local_defines: Compiler defines for this test.
       includes: Additional compiler include dirs for this test.
       linker_script: Linker script for this test.
+      rsa_key: RSA key to sign the binary for this test.
+      spx_key: SPX key to sign the binary for this test.
+      manifest: manifest used during signing for this test.
       linkopts: Linker options for this test.
       exec_env: A dictionary of execution environments.  The keys are labels to
                 execution environments.  The values are the kwargs parameter names
@@ -135,7 +141,7 @@ def opentitan_test(
       cw310: Execution overrides for a CW310-based test.
       dv: Execution overrides for a DV-based test.
       verilator: Execution overrides for a verilator-based test.
-      kwargs: Additional exeuction overrides identified by the `exec_env` dict.
+      kwargs: Additional execution overrides identified by the `exec_env` dict.
     """
     test_parameters = {
         "cw310": cw310,
@@ -179,6 +185,9 @@ def opentitan_test(
             test_cmd = tparam.test_cmd,
             param = tparam.param,
             data = tparam.data,
+            rsa_key = rsa_key,
+            spx_key = spx_key,
+            manifest = manifest,
         )
     native.test_suite(
         name = name,

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_test",
+    new_cw310_params = "cw310_params",
+)
+load(
     "//rules:opentitan_test.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
@@ -601,122 +606,116 @@ test_suite(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_ext_a_flash_a",
-    cw310 = cw310_params(
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+        },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["a"],
     ),
-    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
-    targets = ["cw310_rom_with_fake_keys"],
-)
-
-opentitan_multislot_flash_binary(
-    name = "rom_ext_b_flash_b_image",
-    testonly = True,
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": SLOTS["b"],
-        },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_ext_b_flash_b",
-    cw310 = cw310_params(
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+        },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["b"],
     ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_b_flash_b_image",
-    targets = ["cw310_rom_with_fake_keys"],
-)
-
-opentitan_multislot_flash_binary(
-    name = "rom_ext_a_flash_b_image",
-    testonly = True,
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": SLOTS["b"],
-        },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_ext_a_flash_b",
-    cw310 = cw310_params(
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+        },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        offset = SLOTS["b"],
     ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_a_flash_b_image",
-    targets = ["cw310_rom_with_fake_keys"],
-)
-
-opentitan_multislot_flash_binary(
-    name = "rom_ext_b_flash_a_image",
-    testonly = True,
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": SLOTS["a"],
-        },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_ext_b_flash_a",
-    cw310 = cw310_params(
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+        },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        offset = SLOTS["a"],
     ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_b_flash_a_image",
-    targets = ["cw310_rom_with_fake_keys"],
-)
-
-opentitan_functest(
-    name = "rom_ext_v_flash_a",
-    cw310 = cw310_params(
-        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
-        exit_success = MSG_STARTING_ROM_EXT,
-    ),
-    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
-    targets = ["cw310_rom_with_fake_keys"],
-)
-
-opentitan_multislot_flash_binary(
-    name = "rom_ext_v_flash_b_image",
-    testonly = True,
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": SLOTS["b"],
-        },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
 )
 
-opentitan_functest(
-    name = "rom_ext_v_flash_b",
-    cw310 = cw310_params(
+opentitan_test(
+    name = "rom_ext_v_flash_a",
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+        },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["a"],
     ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_v_flash_b_image",
-    targets = ["cw310_rom_with_fake_keys"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
 )
 
-opentitan_functest(
+opentitan_test(
+    name = "rom_ext_v_flash_b",
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+        },
+        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
+        exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["b"],
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+)
+
+opentitan_test(
     name = "rom_ext_a_flash_a_bad_addr_trans",
-    cw310 = cw310_params(
+    cw310 = new_cw310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation": "firmware",
+        },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
+        offset = SLOTS["a"],
     ),
-    ot_flash_binary = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation",
-    targets = ["cw310_rom_with_fake_keys"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
 )
 
 test_suite(

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -4,10 +4,9 @@
 
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_flash_binary")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
-load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -248,36 +247,51 @@ manifest({
     "identifier": hex(CONST.ROM_EXT),
 })
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "rom_ext_slot_a",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_a",
     manifest = ":manifest_standard",
-    signed = True,
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
-        ":ld_slot_a",
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "rom_ext_slot_b",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
-    signed = True,
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
-        ":ld_slot_b",
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "rom_ext_slot_virtual",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_virtual",
     manifest = ":manifest_virtual",
-    signed = True,
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
-        ":ld_slot_virtual",
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
@@ -290,12 +304,17 @@ manifest({
     "identifier": hex(CONST.ROM_EXT),
 })
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "rom_ext_slot_a_bad_address_translation",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_a",
     manifest = ":manifest_bad_address_translation",
-    signed = True,
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
-        ":ld_slot_a",
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -5,29 +5,7 @@
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
-load(
-    "//rules:opentitan.bzl",
-    "RSA_ONLY_KEY_STRUCTS",
-    "RSA_ONLY_ROM_EXT_KEY_STRUCTS",
-    "opentitan_flash_binary",
-    "opentitan_multislot_flash_binary",
-)
-load("//rules:opentitan_test.bzl", "cw310_params", "opentitan_functest")
-load(
-    "//rules:otp.bzl",
-    "STD_OTP_OVERLAYS",
-    "otp_alert_classification",
-    "otp_alert_digest",
-    "otp_bytestring",
-    "otp_hex",
-    "otp_image",
-    "otp_json",
-    "otp_partition",
-    "otp_per_class_bytes",
-    "otp_per_class_ints",
-    "otp_per_class_lists",
-)
-load("//rules:splice.bzl", "bitstream_splice")
+load("//rules/opentitan:defs.bzl", "cw310_params", "opentitan_binary", "opentitan_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -91,40 +69,49 @@ manifest({
     "identifier": hex(CONST.OWNER),
 })
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "bare_metal_slot_a",
+    testonly = True,
     srcs = ["bare_metal_start.S"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+    ],
+    linker_script = ":ld_slot_a",
     manifest = ":manifest_standard",
-    signed = True,
     deps = [
         ":bare_metal",
-        ":ld_slot_a",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "bare_metal_slot_b",
+    testonly = True,
     srcs = ["bare_metal_start.S"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+    ],
+    linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
-    signed = True,
     deps = [
         ":bare_metal",
-        ":ld_slot_b",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 
-opentitan_flash_binary(
+opentitan_binary(
     name = "bare_metal_slot_virtual",
+    testonly = True,
     srcs = ["bare_metal_start.S"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+    ],
+    linker_script = ":ld_slot_virtual",
     manifest = ":manifest_virtual",
-    signed = True,
     deps = [
         ":bare_metal",
-        ":ld_slot_virtual",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
     ],
@@ -132,103 +119,43 @@ opentitan_flash_binary(
 
 ################################################################################
 # Bare metal ROM_EXT + BL0 test that DOES NOT use OTTF.
+# - This test uses stand-alone binaries emitted by the opentitan_binary rule.
+# - The test assembles an image containing the ROM_EXT from the exec_env and
+#   the binary specified in the cw310 parameters.
 ################################################################################
-opentitan_multislot_flash_binary(
-    name = "rom_ext_virtual_bare_metal_virtual",
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": "0x0",
-        },
-        ":bare_metal_slot_virtual": {
-            "key": RSA_ONLY_ROM_EXT_KEY_STRUCTS[0],
-            "offset": "0x10000",
-        },
-    },
-)
-
-otp_json(
-    name = "otp_json_secret2_locked",
-    partitions = [
-        otp_partition(
-            name = "SECRET2",
-            items = {
-                "CREATOR_ROOT_KEY_SHARE0": "<random>",
-                "CREATOR_ROOT_KEY_SHARE1": "<random>",
-            },
-            lock = True,
-        ),
-    ],
-    visibility = ["//visibility:private"],
-)
-
-otp_image(
-    name = "otp_img_secret2_locked_rma",
-    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
-    overlays = STD_OTP_OVERLAYS + [
-        ":otp_json_secret2_locked",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-bitstream_splice(
-    name = "bitstream_secret2_locked",
-    src = "//hw/bitstream:rom_with_fake_keys",
-    data = ":otp_img_secret2_locked_rma",
-    meminfo = "//hw/bitstream:otp_mmi",
-    update_usr_access = True,
-    visibility = ["//visibility:private"],
-)
-
 BOOT_SUCCESS_MSG = "Bare metal PASS!"
 
-opentitan_functest(
+opentitan_test(
     name = "rom_ext_virtual_bare_metal_virtual_boot_test",
     cw310 = cw310_params(
-        bitstream = ":bitstream_secret2_locked",
+        binaries = {
+            ":bare_metal_slot_virtual": "firmware",
+        },
+        bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
         exit_success = BOOT_SUCCESS_MSG,
     ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_virtual_bare_metal_virtual",
-    signed = True,
-    targets = ["cw310_rom_with_fake_keys"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
 )
 
 ################################################################################
 # Bare metal ROM_EXT + BL0 test that DOES use OTTF.
+# - This test build a test program in the test rule and then assembles an image
+#   containing the ROM_EXT from the exec_env an the compiled test program.
 ################################################################################
-opentitan_flash_binary(
-    name = "ottf_test_bl0_slot_virtual",
+opentitan_test(
+    name = "rom_ext_virtual_ottf_bl0_virtual",
     srcs = ["empty_test.c"],
-    manifest = "//sw/device/silicon_owner/bare_metal:manifest_virtual",
-    signed = True,
+    cw310 = cw310_params(
+        bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    manifest = ":manifest_virtual",
     deps = [
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
-)
-
-opentitan_multislot_flash_binary(
-    name = "rom_ext_virtual_ottf_bl0_virtual",
-    srcs = {
-        "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": {
-            "key": RSA_ONLY_KEY_STRUCTS[0],
-            "offset": "0x0",
-        },
-        ":ottf_test_bl0_slot_virtual": {
-            "key": RSA_ONLY_ROM_EXT_KEY_STRUCTS[0],
-            "offset": "0x10000",
-        },
-    },
-)
-
-opentitan_functest(
-    name = "rom_ext_virtual_ottf_bl0_virtual_test",
-    cw310 = cw310_params(
-        bitstream = ":bitstream_secret2_locked",
-    ),
-    key_struct = "multislot",
-    ot_flash_binary = ":rom_ext_virtual_ottf_bl0_virtual",
-    signed = True,
-    targets = ["cw310_rom_with_fake_keys"],
 )


### PR DESCRIPTION
1. Build the ROM_EXT with the new rules.
2. Rewrite the `bare_metal` examples to use the new rules.

This PR depends on #19949 and #19952.  You need only review the last 2 commits.

Fixes #19930 & #19931.