### PR TITLE
[opentitantool] Avoid relying on udev for Sam3X serial ports

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -60,10 +60,7 @@ fpga_cw310(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
-    ] + select({
-        "@//ci:lowrisc_fpga_cw310": ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
-        "//conditions:default": [],
-    }),
+    ],
     base = ":fpga_cw310",
     bitstream = "//hw/bitstream:test_rom",
     exec_env = "fpga_cw310_test_rom",

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -635,9 +635,7 @@ def opentitan_functest(
                 "//conditions:default": [],
             }
             fpga_name = _fpga_from_fpga_target(target)
-            if fpga_name == "cw310":
-                select_options["@//ci:lowrisc_fpga_cw310"] = ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"]
-            elif fpga_name == "cw340":
+            if fpga_name == "cw340":
                 # The CW340 supports different options for the UARTs: they can be wired to the SAM3x or the FTDI.
                 # The CI currently uses the FTDI.
                 select_options["@//ci:lowrisc_fpga_cw340"] = ["--uarts=/dev/ttyCW340_FTDI_2,/dev/ttyCW340_FTDI_3"]

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/usb.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/usb.rs
@@ -118,6 +118,11 @@ impl<B: Board> Backend<B> {
         })
     }
 
+    /// Access to the lower level USB driver.
+    pub fn usb(&self) -> &UsbBackend {
+        &self.usb
+    }
+
     /// Send a control write transaction to the Chip Whisperer board.
     pub fn send_ctrl(&self, cmd: u8, value: u16, data: &[u8]) -> Result<usize> {
         log::debug!("WRITE_CTRL: bmRequestType: {:02x}, bRequest: {:02x}, wValue: {:04x}, wIndex: {:04x}, data: {:?}",


### PR DESCRIPTION
Chrome OS has a "chroot" development environment and OpenTitan CI uses VMs.  The HyperDebug backend has no trouble with accessing UARTs inside chroot or VMs, but the CW310 backend does not automatically recognize its UARTs.  This is because udev enumeration does not work properly in these two kinds of sandboxes.

There is one major reason why the HyperDebug backend does not use `serialport::available_ports()` (other than the fact that I did not know about the method).  The HyperDebug family of debuggers (consisting of HyperDebug, a range of Google debuggers: "Servo Micro", "C2D2", as well as Titan chips running GSC firmware) present a varying number of UARTs as USB interfaces, and they label each such interface with a text string in the USB descriptor.  We want that text string to become the "name" of the UART for `Transport::uart()`, rather than merely numbering the UARTs, as their ordering may vary between the various debuggers listed above.  It seems that `serialport::available_ports()` only advertises the USB serial number of the debugger that each UART belongs to, not any identification of the particular USB interface, and so it is insufficient for the HyperDebug backend transport.

Since it is now apparent that the HyperDebug way of discovering the like between USB devices, their USB interfaces, and logical `/dev/ttyXXX` devices actually work in chroot and VM environments, unlike the udev-based `serialport::available_ports()`, I thought that it would make sense to make both CW310 and HyperDebug backend use the same approach, and I thought that I could solve my own problems with using CW310 inside chroot by changing CW310.  At the same time, if this change can eliminate the need for passing UART parameters in CI, that would be an added bonus.
