### PR TITLE
[edn/dv] Fill csrng cmd coverage holes

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cov.sv
@@ -26,6 +26,7 @@ covergroup device_cmd_cg with function sample(csrng_item item, bit sts);
     bins res = {RES};
     bins gen = {GEN};
     bins uni = {UNI};
+    bins upd = {UPD};
     illegal_bins il = default;
   }
   csrng_clen_cp: coverpoint item.clen {

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -71,6 +71,7 @@
       name: edn_genbits
       uvm_test: edn_genbits_test
       uvm_test_seq: edn_genbits_vseq
+      reseed: 300
     }
 
     {

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -28,6 +28,8 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   bit abort_sw_cmd = 0;
   bit backdoor_disable = 1'b0;
 
+  int min_auto_reseeds = 2;
+
   // Knobs & Weights
   uint   enable_pct, boot_req_mode_pct, auto_req_mode_pct, cmd_fifo_rst_pct,
          force_disable_pct,
@@ -37,6 +39,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   bit    use_invalid_mubi;
 
+  rand int       glen_auto_mode;
   rand mubi4_t   enable, boot_req_mode, auto_req_mode, cmd_fifo_rst;
   rand uint      num_endpoints, num_boot_reqs;
   rand bit       force_disable;
@@ -49,6 +52,10 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   rand invalid_mubi_e   which_invalid_mubi;
 
   // Constraints
+  constraint glen_auto_mode_c {glen_auto_mode dist {
+    1 :/ 50,
+    [2:100] :/ 49,
+    4095 :/ 1 };}
   constraint force_disable_c {force_disable dist {
     1 :/ force_disable_pct,
     0 :/ (100 - force_disable_pct) };}

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -103,9 +103,8 @@ class edn_base_vseq extends cip_base_vseq #(
       end
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-      glen = 1;
       wr_cmd(.cmd_type(edn_env_pkg::AutoGen), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags),
-             .glen(glen), .mode(edn_env_pkg::AutoReqMode));
+             .glen(cfg.glen_auto_mode), .mode(edn_env_pkg::AutoReqMode));
       for (int i = 0; i < clen; i++) begin
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
         wr_cmd(.cmd_type(edn_env_pkg::AutoGen), .cmd_data(cmd_data),

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -159,7 +159,7 @@ class edn_base_vseq extends cip_base_vseq #(
 
     if (!additional_data) begin
       cov_vif.cg_cs_cmds_sample(.acmd(acmd), .clen(clen), .flags(flags),
-                          .glen(glen), .mode(mode), .cmd_src(cmd_type));
+                                .glen(glen), .mode(mode), .cmd_src(cmd_type));
     end
 
     case (cmd_type)

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -118,7 +118,7 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
         // requests between reseeds to 1 (to maximize coverage over time).
         super.edn_init();
         cfg.clk_rst_vif.wait_clks(1);
-        instantiate_csrng(.mode("auto_mode"));
+        instantiate_csrng(.mode(edn_env_pkg::AutoReqMode));
         csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(1));
       ,
         // Exit thread: Wait for a signal from the thread that randomly disables EDN.

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -10,7 +10,8 @@ class edn_genbits_vseq extends edn_base_vseq;
       m_endpoint_pull_seq[MAX_NUM_ENDPOINTS];
 
   uint   num_requesters, extra_requester, num_boot_reqs, num_auto_reqs,
-         num_ep_reqs, num_cs_reqs, num_reqs_between_reseeds, endpoint_q[$];
+         num_ep_reqs, num_reqs_between_reseeds, endpoint_q[$];
+  uint total_glen = 0;
   state_e exp_state;
   csrng_pkg::acmd_e acmd;
   edn_env_pkg::hw_req_mode_e mode = edn_env_pkg::SwMode;
@@ -35,17 +36,24 @@ class edn_genbits_vseq extends edn_base_vseq;
 
     for (int i = 0; i < num_requesters; i++) begin
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_ep_reqs,
-                                         num_ep_reqs inside
-                                             { [cfg.min_num_ep_reqs:cfg.max_num_ep_reqs] };)
-      num_cs_reqs += num_ep_reqs/(csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
-      if (num_ep_reqs % (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH)) begin
-        num_cs_reqs += 1;
-      end
-
+                                         num_ep_reqs dist
+                                             { cfg.min_num_ep_reqs :/ 50,
+                                               [cfg.min_num_ep_reqs:cfg.max_num_ep_reqs] :/ 50 };)
+      // Add additional requests for the generated bits from auto mode or the boot sequence
       if (i == extra_requester) begin
         if (cfg.boot_req_mode == MuBi4True) begin
           num_ep_reqs += cfg.num_boot_reqs * (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
         end
+
+        if (cfg.auto_req_mode == MuBi4True) begin
+          num_ep_reqs += (cfg.min_auto_reseeds + 1) * cfg.glen_auto_mode
+                         * (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
+        end
+      end
+      // set total_glen to track the total number of generated words from the CSRNG
+      total_glen += num_ep_reqs/(csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
+      if (num_ep_reqs % (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH)) begin
+        total_glen += 1;
       end
 
       // Create/Configure endpoint_pull_seq
@@ -65,24 +73,30 @@ class edn_genbits_vseq extends edn_base_vseq;
       join_none;
     end
 
+    // set generate length and num_reqs_between_reseeds depending on the operational mode
+    if (cfg.boot_req_mode == MuBi4True) begin
+      mode = edn_env_pkg::BootReqMode;
+      glen = total_glen - cfg.num_boot_reqs;
+    end
+
     if (cfg.auto_req_mode == MuBi4True) begin
       mode = edn_env_pkg::AutoReqMode;
-      if (num_cs_reqs <= 2) begin
-        num_reqs_between_reseeds = 1;
-      end
-      else begin
-        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reqs_between_reseeds,
-                                           num_reqs_between_reseeds inside
-                                           { [1:num_cs_reqs/2] };)
-      end
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(glen, glen dist { 0 :/ 20, [1:$] :/ 80 };)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reqs_between_reseeds,
+                                          num_reqs_between_reseeds inside
+                                          { [1:(total_glen/cfg.glen_auto_mode)
+                                               /(cfg.min_auto_reseeds + 1)] };)
       csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(num_reqs_between_reseeds));
+    end
+
+    if ((cfg.boot_req_mode == MuBi4False) && (cfg.auto_req_mode == MuBi4False)) begin
+      glen = total_glen;
     end
 
     if (cfg.boot_req_mode != MuBi4True) begin
       // Send instantiate cmd
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(glen, glen dist { 0 :/ 20, [1:$] :/ 80 };)
       wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(clen), .flags(flags),
              .glen(glen), .mode(mode));
       for (int i = 0; i < clen; i++) begin
@@ -95,7 +109,6 @@ class edn_genbits_vseq extends edn_base_vseq;
       // Send generate cmd
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-      glen = num_cs_reqs;
       wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags),
              .glen(glen), .mode(mode));
       for (int i = 0; i < clen; i++) begin
@@ -168,32 +181,25 @@ class edn_genbits_vseq extends edn_base_vseq;
         `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
         csr_wr(.ptr(ral.sw_cmd_req), .value(cmd_data));
       end
-      // Disable auto_req_mode after at least 2 reseeds
-      wait (cfg.m_csrng_agent_cfg.reseed_cnt >= 2)
+      // Disable auto_req_mode after the minimum number of expected reseeds
+      wait (cfg.m_csrng_agent_cfg.reseed_cnt >= cfg.min_auto_reseeds)
       ral.ctrl.auto_req_mode.set(MuBi4False);
       csr_update(.csr(ral.ctrl));
       mode = edn_env_pkg::SwMode;
       // Give the hardware time to quiesce
       csr_spinwait(.ptr(ral.main_sm_state), .exp_data(edn_pkg::Idle), .backdoor(1'b1));
       `DV_CHECK_EQ(cfg.m_csrng_agent_cfg.generate_between_reseeds_cnt, num_reqs_between_reseeds)
-      // End test gracefully
-      if (num_cs_reqs > cfg.m_csrng_agent_cfg.generate_cnt) begin
-        // Send generate cmd
+      // If the endpoint agents still expect more data, send another generate command
+      if (total_glen > cfg.m_csrng_agent_cfg.generate_cnt*cfg.glen_auto_mode) begin
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
         `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-        glen = num_cs_reqs - cfg.m_csrng_agent_cfg.generate_cnt;
+        glen = total_glen - cfg.m_csrng_agent_cfg.generate_cnt*cfg.glen_auto_mode;
         wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::GEN), .clen(clen), .flags(flags),
                .glen(glen), .mode(mode));
         for (int i = 0; i < clen; i++) begin
           `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
           wr_cmd(.cmd_type(edn_env_pkg::Sw), .cmd_data(cmd_data), .mode(mode));
         end
-      end
-      else if (num_cs_reqs < cfg.m_csrng_agent_cfg.generate_cnt) begin
-        m_endpoint_pull_seq[endpoint_q[extra_requester]].num_trans = 4 *
-            (cfg.m_csrng_agent_cfg.generate_cnt - num_cs_reqs);
-        m_endpoint_pull_seq[endpoint_q[extra_requester]].start
-            (p_sequencer.endpoint_sequencer_h[endpoint_q[extra_requester]]);
       end
     end
 


### PR DESCRIPTION
This PR contains multiple commits relating to filling csrng cmd coverage holes.
Please see the individual commit messages for more detailed information.

This PR closes issue #19833.