### PR TITLE
[uart,sival] Add initial sival testplan for uart block

### DIFF
--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -75,6 +75,42 @@
       '''
     }
   ],
+  features: [
+    { name: "UART.PARITY",
+      desc: '''
+        The UART can be configured to so that it sends (or expects) a parity bit after each 8 data bits.
+        In receive mode, the UART sends the rx_parity_err interrupt if it receives a parity bit of the wrong polarity.
+        The parity mode is configurable (ensuring words are even or odd).
+      '''
+    },
+    { name: "UART.LINE_LOOPBACK",
+      desc: '''
+        The UART can be configured so that incoming bits are sent on the TX side.
+      '''
+    },
+    { name: "UART.SYSTEM_LOOPBACK",
+      desc: '''
+        The UART can be configured so that outgoing bits are registered as having been received on the RX side.
+      '''
+    },
+    { name: "UART.BAUD_RATE_CONTROL",
+      desc: '''
+        The UART baud rate can be configured.
+      '''
+    },
+    { name: "UART.LINE_BREAK",
+      desc: '''
+        The UART can detect line breaks (defined as the RX pin being continuously low for several bit-times).
+        The threshold for number of low bits to signal a line break is configurable.
+      '''
+    },
+    { name: "UART.FIFO_INTERRUPTS",
+      desc: '''
+        The UART can be configured to send an "watermark" interrupt when RX or TX FIFO is nearly full/empty, respectively.
+        It sends an rx_overflow interrupt if it sees an extra character when the RX FIFO is full.
+      '''
+    },
+  ]
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -34,74 +34,20 @@
     "hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_uart_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
-    "hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson",
   ]
 
   testpoints: [
     ///////////////////////////////////////////////////////////////////////////
     // IO Peripherals                                                        //
-    // UART, I2C, SPIDEV, USB, PINMUX & PADCTRL, PATTGEN, PWM                //
+    // I2C, SPIDEV, USB, PINMUX & PADCTRL, PATTGEN, PWM                      //
     ///////////////////////////////////////////////////////////////////////////
 
-    // UART (pre-verified IP) integration tests:
-    {
-      name: chip_sw_uart_tx_rx
-      desc: '''Verify transmission of data over the TX and RX port.
-
-            SW test sends a known payload over the TX port. The testbench, at the same time
-            sends a known payload over RX. On reception, both payloads are checked for integrity.
-            SW validates the reception of TX watermark, RX watermark, and the TX empty interrupts.
-            Choosing the max supported baud rate for the UART is sufficient.
-
-            Verify each UART instance at the chip level independently. Verify there is no aliasing
-            on all UART ports across the instances.
-            '''
-      stage: V1
-      tests: ["chip_sw_uart_tx_rx"]
-      tags: ["gls"]
-    }
-    {
-      name: chip_sw_uart_rx_overflow
-      desc: '''Verify the RX overflow interrupt.
-
-            The testbench sends a random payload of size greater than the RX fifo size (32). The SW
-            ignores the received the data to allow the RX overflow interrupt to assert.
-
-            Verify each UART instance at the chip level independently. Verify there is no aliasing
-            on all UART ports across the instances.
-            '''
-      stage: V1
-      tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
-              "chip_sw_uart_tx_rx_idx3"]
-    }
-    {
-      name: chip_sw_uart_rand_baudrate
-      desc: '''Verify UART transmission of data at various speeds.
-
-            Randomly pick one of the UART instances and configure it to run with any of these baud
-            rates - 9600bps, 115200bps, 230400bps, 128Kbps, 256Kbps, 1Mkbps, 1.5Mkbps.
-
-            '''
-      stage: V1
-      tests: ["chip_sw_uart_rand_baudrate"]
-    }
-    {
-      name: chip_sw_uart_tx_rx_alt_clk_freq
-      desc: '''Verify the transmission of UART via using external clock as uart core clock.
-
-            Extend from chip_sw_uart_rand_baudrate with following added settings.
-            - Configure LC to RMA state, so that it allows clkmgr to use external clock.
-            - Configure clkmgr to select external clock.
-            - Randomize `HI_SPEED_SEL`, so that uart core clock frequency can be either
-              ext_clk_freq / 4 or ext_clk_freq / 2.
-            '''
-      stage: V1
-      tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
-    }
 
     // USB (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -17,6 +17,8 @@
             on all UART ports across the instances.
             '''
       stage: V1
+      si_stage: SV2
+      features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx"]
       tags: ["gls"]
     }
@@ -31,6 +33,8 @@
             on all UART ports across the instances.
             '''
       stage: V1
+      si_stage: SV3
+      features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
               "chip_sw_uart_tx_rx_idx3"]
     }
@@ -43,6 +47,8 @@
 
             '''
       stage: V1
+      si_stage: SV3
+      features: ["UART.BAUD_RATE_CONTROL"]
       tests: ["chip_sw_uart_rand_baudrate"]
     }
     {
@@ -54,8 +60,18 @@
             - Configure clkmgr to select external clock.
             - Randomize `HI_SPEED_SEL`, so that uart core clock frequency can be either
               ext_clk_freq / 4 or ext_clk_freq / 2.
+
+            Notes for silicon targets:
+
+            - This testpoint currently has an empty list of associated features, because the choice
+              of clock is really a clkmgr/chip-level feature, rather than a feature of the UART
+              block.
+
             '''
       stage: V1
+      si_stage: SV3
+      features: []
+      lc_states: ["RMA"]
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: chip_uart
+  testpoints: [
+    {
+      name: chip_sw_uart_tx_rx
+      desc: '''Verify transmission of data over the TX and RX port.
+
+            SW test sends a known payload over the TX port. The testbench, at the same time
+            sends a known payload over RX. On reception, both payloads are checked for integrity.
+            SW validates the reception of TX watermark, RX watermark, and the TX empty interrupts.
+            Choosing the max supported baud rate for the UART is sufficient.
+
+            Verify each UART instance at the chip level independently. Verify there is no aliasing
+            on all UART ports across the instances.
+            '''
+      stage: V1
+      tests: ["chip_sw_uart_tx_rx"]
+      tags: ["gls"]
+    }
+    {
+      name: chip_sw_uart_rx_overflow
+      desc: '''Verify the RX overflow interrupt.
+
+            The testbench sends a random payload of size greater than the RX fifo size (32). The SW
+            ignores the received the data to allow the RX overflow interrupt to assert.
+
+            Verify each UART instance at the chip level independently. Verify there is no aliasing
+            on all UART ports across the instances.
+            '''
+      stage: V1
+      tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
+              "chip_sw_uart_tx_rx_idx3"]
+    }
+    {
+      name: chip_sw_uart_rand_baudrate
+      desc: '''Verify UART transmission of data at various speeds.
+
+            Randomly pick one of the UART instances and configure it to run with any of these baud
+            rates - 9600bps, 115200bps, 230400bps, 128Kbps, 256Kbps, 1Mkbps, 1.5Mkbps.
+
+            '''
+      stage: V1
+      tests: ["chip_sw_uart_rand_baudrate"]
+    }
+    {
+      name: chip_sw_uart_tx_rx_alt_clk_freq
+      desc: '''Verify the transmission of UART via using external clock as uart core clock.
+
+            Extend from chip_sw_uart_rand_baudrate with following added settings.
+            - Configure LC to RMA state, so that it allows clkmgr to use external clock.
+            - Configure clkmgr to select external clock.
+            - Randomize `HI_SPEED_SEL`, so that uart core clock frequency can be either
+              ext_clk_freq / 4 or ext_clk_freq / 2.
+            '''
+      stage: V1
+      tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -74,5 +74,81 @@
       lc_states: ["RMA"]
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
     }
+    {
+      name: chip_sw_uart_parity
+      desc: '''Verify transmission of data in both directions with parity enabled.
+
+            This is very similar to chip_sw_uart_tx_rx except that parity (generation and checking)
+            should be enabled. Control expected word parity by configuring CTRL.PARITY_ODD register.
+
+            Test the rx_parity_err interrupt by sending a word with incorrect parity.
+
+            '''
+      stage: V3
+      si_stage: SV3
+      features: ["UART.PARITY"]
+      tests: []
+    }
+    {
+      name: chip_sw_uart_line_loopback
+      desc: '''Verify UART line loopback feature.
+
+            Configure the UART to enable RX, TX and line loopback. Send it some data and check that
+            the bits appear on its TX side.
+
+            '''
+      stage: V3
+      si_stage: SV3
+      features: ["UART.LINE_LOOPBACK"]
+      tests: []
+    },
+    {
+      name: chip_sw_uart_system_loopback
+      desc: '''Verify UART system loopback feature.
+
+            Configure the UART to enable RX, TX and system loopback. Transmit some data and check
+            that the data that was transmitted also appears on the RX side.
+
+            '''
+      stage: V3
+      si_stage: SV3
+      features: ["UART.SYSTEM_LOOPBACK"]
+      tests: []
+    },
+    {
+      name: chip_sw_uart_line_break
+      desc: '''Check that the UART can detect line breaks.
+
+            Enable RX and configure the line break threshold. On the host side, send data but hold
+            the signal low for enough characters that this should be detected as a line break. Check
+            that the rx_break_err interrupt was asserted.
+
+            Repeat with parity enabled and with different line break thresholds (controlled by
+            CTRL.RXBLVL).
+
+            '''
+      stage: V3
+      si_stage: SV3
+      features: ["UART.LINE_BREAK"]
+      tests: []
+    },
+    {
+      name: chip_sw_uart_watermarks
+      desc: '''Observe UART watermark interrupts.
+
+            Transmit data from the host and receive it on the OT side by servicing the rx_watermark
+            interrupt. Check that the data matches the sequence that the host was expected to send.
+
+            Send the data back from OT to the host, refilling the TX FIFO on reception of the
+            tx_watermark interrupt. On the host side, check that the data that came back matches the
+            sequence that was sent in the first place.
+
+            '''
+      stage: V3
+      si_stage: SV3
+      features: ["UART.FIFO_INTERRUPTS"]
+      tests: []
+    },
+
   ]
 }


### PR DESCRIPTION
This comes in several commits. It's a bit difficult to know how many features/tests to define for the UART: it has lots! So I've tried to extract the features that look like they will be important for sival.

I'm very happy to add more! But maybe that would be a sensible thing to do as a followup, so that we can at least land *something* soon.