### PR TITLE
[ci] Avoiding timeout in "CW310 ROM Tests"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -556,7 +556,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh cw310 cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf,-hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 


### PR DESCRIPTION
It seems that recently, every CI run of "CW310 ROM Tests" times out waiting for hw/bitstream/vivado/build.fpga_cw310_hyperdebug, which it should not be needing.

Alex suggested this as a remedy.

Example problematic run:
https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=130827&view=logs&j=f9206ac2-13eb-5806-2180-615f4d046dc1&t=c1c08aa9-be7b-5018-2cf1-c73aaa1c8058
