### PR TITLE
[WIP][sival,sysrst_ctrl] Implement chip_sw_sysrst_ctrl_input

### DIFF
--- a/sw/device/lib/testing/json/BUILD
+++ b/sw/device/lib/testing/json/BUILD
@@ -62,6 +62,21 @@ cc_library(
 )
 
 cc_library(
+    name = "sysrst_ctrl",
+    srcs = ["sysrst_ctrl.c"],
+    hdrs = ["sysrst_ctrl.h"],
+    deps = [
+        ":pinmux",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+    ],
+)
+
+cc_library(
     name = "spi_passthru",
     srcs = ["spi_passthru.c"],
     hdrs = ["spi_passthru.h"],

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -35,7 +35,8 @@ extern "C" {
     value(_, SpiMailboxUnmap) \
     value(_, SpiMailboxWrite) \
     value(_, SpiPassthruSetAddressMap) \
-    value(_, SwStrapRead)
+    value(_, SwStrapRead) \
+    value(_, SysrstCtrlCommand)
 UJSON_SERDE_ENUM(TestCommand, test_command_t, ENUM_TEST_COMMAND);
 
 // clang-format on

--- a/sw/device/lib/testing/json/sysrst_ctrl.c
+++ b/sw/device/lib/testing/json/sysrst_ctrl.c
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/runtime/log.h"
 
 // Convert a sysrst_ctrl_pin_t to dif_sysrst_ctrl_pin_t.
 // The values were chose to be equal so that this operation is trivial.
@@ -35,6 +36,7 @@ static status_t config_pin_override(ujson_t *uj,
       .allow_one = cfg.allow_one,
       .override_value = cfg.override_value,
   };
+  LOG_INFO("dif_sysrst_ctrl_output_pin_override_configure: pin=%d, en=%d", pin_to_dif_pin(cfg.pin), dif_cfg.enabled);
   TRY(dif_sysrst_ctrl_output_pin_override_configure(
       sysrst_ctrl, pin_to_dif_pin(cfg.pin), dif_cfg));
 

--- a/sw/device/lib/testing/json/sysrst_ctrl.c
+++ b/sw/device/lib/testing/json/sysrst_ctrl.c
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sw/device/lib/testing/json/sysrst_ctrl.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+// Convert a sysrst_ctrl_pin_t to dif_sysrst_ctrl_pin_t.
+// The values were chose to be equal so that this operation is trivial.
+static dif_sysrst_ctrl_pin_t pin_to_dif_pin(sysrst_ctrl_pin_t pin) {
+  return (dif_sysrst_ctrl_pin_t)pin;
+}
+
+static status_t read_pin(ujson_t *uj, dif_sysrst_ctrl_t *sysrst_ctrl) {
+  sysrst_ctrl_pin_t pin;
+  TRY(ujson_deserialize_sysrst_ctrl_pin_t(uj, &pin));
+
+  bool value;
+  TRY(dif_sysrst_ctrl_input_pin_read(sysrst_ctrl, pin_to_dif_pin(pin), &value));
+
+  return RESP_OK(ujson_serialize_bool, uj, &value);
+}
+
+static status_t config_pin_override(ujson_t *uj,
+                                    dif_sysrst_ctrl_t *sysrst_ctrl) {
+  sysrst_ctrl_pin_config_t cfg;
+  TRY(ujson_deserialize_sysrst_ctrl_pin_config_t(uj, &cfg));
+
+  dif_sysrst_ctrl_pin_config_t dif_cfg = {
+      .enabled = cfg.enabled,
+      .allow_zero = cfg.allow_zero,
+      .allow_one = cfg.allow_one,
+      .override_value = cfg.override_value,
+  };
+  TRY(dif_sysrst_ctrl_output_pin_override_configure(
+      sysrst_ctrl, pin_to_dif_pin(cfg.pin), dif_cfg));
+
+  return RESP_OK_STATUS(uj);
+}
+
+status_t sysrst_ctrl_command(ujson_t *uj, dif_sysrst_ctrl_t *sysrst_ctrl) {
+  sysrst_ctrl_command_t command;
+  TRY(ujson_deserialize_sysrst_ctrl_command_t(uj, &command));
+
+  switch (command) {
+    case kSysrstCtrlCommandReadPin:
+      return read_pin(uj, sysrst_ctrl);
+    case kSysrstCtrlCommandConfigurePinOverride:
+      return config_pin_override(uj, sysrst_ctrl);
+    default:
+      RESP_ERR(uj, INVALID_ARGUMENT());
+      return INVALID_ARGUMENT();
+  }
+}

--- a/sw/device/lib/testing/json/sysrst_ctrl.h
+++ b/sw/device/lib/testing/json/sysrst_ctrl.h
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SYSRST_CTRL_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SYSRST_CTRL_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+// Note: these values match the ones of `dif_sysrst_ctrl_pin_t` in
+// `sw/device/lib/dif/sysrst_ctrl.h`.
+#define ENUM_SYSRST_CTRL_PIN(_, value) \
+    value(_, Key0In, 1 << 0) \
+    value(_, Key0Out, 1 << 1) \
+    value(_, Key1In, 1 << 2) \
+    value(_, Key1Out, 1 << 3) \
+    value(_, Key2In, 1 << 4) \
+    value(_, Key2Out, 1 << 5) \
+    value(_, PowerButtonIn, 1 << 6) \
+    value(_, PowerButtonOut, 1 << 7) \
+    value(_, AcPowerPresentIn, 1 << 8) \
+    value(_, BatteryDisableOut, 1 << 9) \
+    value(_, LidOpenIn, 1 << 10) \
+    value(_, Z3WakeupOut, 1 << 11) \
+    value(_, EcResetInOut, 1 << 12) \
+    value(_, FlashWriteProtectInOut, 1 << 13)
+UJSON_SERDE_ENUM(SysrstCtrlPin, sysrst_ctrl_pin_t, ENUM_SYSRST_CTRL_PIN);
+
+// See `dif_sysrst_ctrl_pin_config_t` in `sw/device/lib/dif/sysrst_ctrl.h`
+// for documentation.
+#define STRUCT_SYSRST_CTRL_PIN_CONFIG(field, string) \
+    field(pin, sysrst_ctrl_pin_t) \
+    field(enabled, bool) \
+    field(allow_zero, bool) \
+    field(allow_one, bool) \
+    field(override_value, bool)
+UJSON_SERDE_STRUCT(SysrstCtrlPinConfig, sysrst_ctrl_pin_config_t,
+                   STRUCT_SYSRST_CTRL_PIN_CONFIG);
+
+#define ENUM_SYSRST_CTRL_COMMAND(_, value) \
+    /* followed by SysrstCtrlPin, returns a bool */ \
+    value(_, ReadPin) \
+    /* followed by SysrstCtrlPinConfig, returns a status_t */ \
+    value(_, ConfigurePinOverride)
+UJSON_SERDE_ENUM(SysrstCtrlCommand, sysrst_ctrl_command_t,
+                 ENUM_SYSRST_CTRL_COMMAND);
+
+// clang-format on
+
+#ifndef RUST_PREPROCESSOR_EMIT
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+/**
+ * Process a sysrst ctrl command.
+ */
+status_t sysrst_ctrl_command(ujson_t *uj, dif_sysrst_ctrl_t *pinmux);
+#endif  // RUST_PREPROCESSOR_EMIT
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_SYSRST_CTRL_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2945,3 +2945,30 @@ opentitan_functest(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_functest(
+    name = "sysrst_ctrl_test",
+    srcs = ["sysrst_ctrl_test.c"],
+    cw310 = cw310_params(
+        interface = "hyper310",
+        test_cmds = [
+            "--bitstream=\"$(location {bitstream})\"",
+            "--bootstrap=\"$(location {flash})\"",
+        ],
+    ),
+    targets = [
+        "cw310_rom_with_fake_keys",
+    ],
+    test_harness = "//sw/host/tests/chip/sysrst_ctrl",
+    verilator = verilator_params(
+        timeout = "eternal",
+        test_cmds = [],
+    ),
+    deps = [
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:pinmux_config",
+        "//sw/device/lib/testing/json:sysrst_ctrl",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)

--- a/sw/device/tests/sysrst_ctrl_test.c
+++ b/sw/device/tests/sysrst_ctrl_test.c
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/json/sysrst_ctrl.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/pinmux_config.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_pinmux_t pinmux;
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandPinmuxConfig:
+        RESP_ERR(uj, pinmux_config(uj, &pinmux));
+        break;
+      case kTestCommandSysrstCtrlCommand:
+        RESP_ERR(uj, sysrst_ctrl_command(uj, &sysrst_ctrl));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  // We should never reach here.
+  return INTERNAL();
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+
+  ujson_t uj = ujson_ottf_console();
+
+  status_t s = command_processor(&uj);
+  LOG_INFO("status = %r", s);
+  return status_ok(s);
+}

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -37,6 +37,12 @@ ujson_rust(
     defines = ["opentitanlib=crate"],
 )
 
+ujson_rust(
+    name = "sysrst_ctrl",
+    srcs = ["//sw/device/lib/testing/json:sysrst_ctrl"],
+    defines = ["opentitanlib=crate"],
+)
+
 filegroup(
     name = "config",
     srcs = glob(["src/app/config/*.json"]),
@@ -129,6 +135,7 @@ rust_library(
         "src/test_utils/rpc.rs",
         "src/test_utils/spi_passthru.rs",
         "src/test_utils/status.rs",
+        "src/test_utils/sysrst_ctrl.rs",
         "src/tpm/access.rs",
         "src/tpm/driver.rs",
         "src/tpm/mod.rs",
@@ -212,6 +219,7 @@ rust_library(
         ":e2e_command",
         ":pinmux_config",
         ":spi_passthru",
+        ":sysrst_ctrl",
         "@hyperdebug_firmware//:hyperdebug/ec.bin",
     ],
     crate_features = [
@@ -230,6 +238,7 @@ rust_library(
         "i2c_target": "$(location :i2c_target)",
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
+        "sysrst_ctrl": "$(location :sysrst_ctrl)",
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",
     },
     deps = [

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -22,6 +22,7 @@ pub mod poll;
 pub mod rpc;
 pub mod spi_passthru;
 pub mod status;
+pub mod sysrst_ctrl;
 
 /// The `execute_test` macro should be used in end-to-end tests to
 /// invoke each test from the `main` function.

--- a/sw/host/opentitanlib/src/test_utils/sysrst_ctrl.rs
+++ b/sw/host/opentitanlib/src/test_utils/sysrst_ctrl.rs
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+include!(env!("sysrst_ctrl"));
+
+impl SysrstCtrlPin {
+    pub fn read(&self, uart: &dyn Uart) -> Result<bool> {
+        TestCommand::SysrstCtrlCommand.send(uart)?;
+        SysrstCtrlCommand::ReadPin.send(uart)?;
+        self.send(uart)?;
+        bool::recv(uart, Duration::from_secs(300), false)
+    }
+
+    pub fn configure_override(
+        &self,
+        uart: &dyn Uart,
+        enabled: bool,
+        allow_zero: bool,
+        allow_one: bool,
+        override_value: bool,
+    ) -> Result<()> {
+        TestCommand::SysrstCtrlCommand.send(uart)?;
+        SysrstCtrlCommand::ConfigurePinOverride.send(uart)?;
+        let config = SysrstCtrlPinConfig {
+            pin: self.clone(),
+            enabled,
+            allow_zero,
+            allow_one,
+            override_value,
+        };
+        config.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}

--- a/sw/host/tests/chip/sysrst_ctrl/BUILD
+++ b/sw/host/tests/chip/sysrst_ctrl/BUILD
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "sysrst_ctrl",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/sysrst_ctrl/src/main.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/src/main.rs
@@ -1,0 +1,211 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::gpio::PinMode;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::pinmux_config::PinmuxConfig;
+use opentitanlib::test_utils::sysrst_ctrl::SysrstCtrlPin;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::{collection, execute_test};
+
+use opentitanlib::chip::autogen::earlgrey::{PinmuxInsel, PinmuxPeripheralIn};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+}
+
+struct IoPin {
+    sysrst_pin: SysrstCtrlPin,
+    // IO name of the transport
+    transport_pin: &'static str,
+}
+
+struct Config {
+    // List of pinmuxes to configure.
+    pinmux: HashMap<PinmuxPeripheralIn, PinmuxInsel>,
+    // Map to the IO names of the transport.
+    pins: Vec<IoPin>,
+}
+
+static CONFIG: Lazy<HashMap<&'static str, Config>> = Lazy::new(|| {
+    collection! {
+        "hyper310" => Config {
+            // See https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_cw310.md
+            pinmux: collection! {
+                PinmuxPeripheralIn::SysrstCtrlAonPwrbIn  => PinmuxInsel::Ior2,
+                PinmuxPeripheralIn::SysrstCtrlAonKey0In  => PinmuxInsel::Ior3,
+                PinmuxPeripheralIn::SysrstCtrlAonKey1In  => PinmuxInsel::Ior4,
+                PinmuxPeripheralIn::SysrstCtrlAonKey2In  => PinmuxInsel::Ior5,
+                PinmuxPeripheralIn::SysrstCtrlAonLidOpen  => PinmuxInsel::Ior6,
+                PinmuxPeripheralIn::SysrstCtrlAonAcPresent => PinmuxInsel::Ior7,
+                // SysrstCtrlEcRst is wired to IOR8
+                // SysrstCtrlFlashWp is wired to IOR9*/
+            },
+            pins: vec! {
+                IoPin{ sysrst_pin: SysrstCtrlPin::PowerButtonIn, transport_pin: "IOR2" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::Key0In, transport_pin: "IOR3" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::Key1In, transport_pin: "IOR4" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::Key2In, transport_pin: "IOR5" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::LidOpenIn, transport_pin: "IOR6" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::AcPowerPresentIn, transport_pin: "IOR7" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::EcResetInOut, transport_pin: "IOR8" },
+                IoPin{ sysrst_pin: SysrstCtrlPin::FlashWriteProtectInOut, transport_pin: "IOR9" },
+            }
+        },
+    }
+});
+
+// The value is encoded by an integer whose ith bit represents
+// the value of the ith entry in config.pins
+// FIXME this might be overkill but allows to have proper Debug format output
+// and do some checks
+struct PinValues<'a> {
+    config: &'a Config,
+    values: u32,
+}
+
+impl<'a> PinValues<'a> {
+    fn new(config: &'a Config) -> Self {
+        PinValues {config, values: 0}
+    }
+
+    fn is_pin_set(&self, bit_idx: usize) -> bool {
+        // FIXME check index here
+        ((self.values >> bit_idx) & 1) == 1
+    }
+
+    fn set_pin(&mut self, bit_idx: usize) {
+        // FIXME check index here
+        self.values |= 1u32 << bit_idx;
+    }
+}
+
+impl std::fmt::Debug for PinValues<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:b} [", self.values)?;
+        for (i, pin) in self.config.pins.iter().enumerate() {
+            if self.is_pin_set(i) {
+                write!(f, "{:?} ", pin.sysrst_pin)?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+impl PartialEq for PinValues<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.values == other.values
+    }
+}
+
+/// Configure earlgrey and debugger pins.
+fn setup_pins(uart: &dyn Uart, transport: &TransportWrapper, config: &Config) -> Result<()> {
+    log::info!("Configuring earlgrey pinmux");
+    PinmuxConfig::configure(uart, Some(&config.pinmux), None)?;
+
+    /* On reset, the flash_wp and ec_reset pins, which are inout, have an output override
+     * enabled so that they stretch the reset and flash protection during boot. Disable this
+     * mecanism.
+     * FIXME this seems to have no impact?! */
+    SysrstCtrlPin::EcResetInOut.configure_override(
+        uart, /* enabled */ false, /* allow_zero */ true, /* allow_one */ true,
+        /* override_value */ false,
+    )?;
+    SysrstCtrlPin::FlashWriteProtectInOut.configure_override(
+        uart, /* enabled */ false, /* allow_zero */ true, /* allow_one */ true,
+        /* override_value */ false,
+    )?;
+
+    log::info!("Configuring debugger GPIOs");
+    for pin in config.pins.iter() {
+        transport
+            .gpio_pin(pin.transport_pin)?
+            .set_mode(PinMode::PushPull)?;
+    }
+
+    Ok(())
+}
+
+fn test_combination(
+    uart: &dyn Uart,
+    transport: &TransportWrapper,
+    config: &Config,
+    values: &PinValues,
+) -> Result<()> {
+    // Set pins on the transport.
+    for (i, pin) in config.pins.iter().enumerate() {
+        transport
+            .gpio_pin(pin.transport_pin)?
+            .write(values.is_pin_set(i))?;
+    }
+    // Read pins on the device.
+    let mut sysrst_values = PinValues::new(config);
+    for (i, pin) in config.pins.iter().enumerate() {
+        if pin.sysrst_pin.read(uart)? {
+            sysrst_values.set_pin(i);
+        }
+    }
+
+    if *values != sysrst_values {
+        log::error!("The pin values set on the debugger was:");
+        log::error!("{:?}", values);
+        log::error!("The pin values reported by sysrst_ctrl was:");
+        log::error!("{:?}", sysrst_values);
+        bail!("pin value mismatch");
+    }
+    Ok(())
+}
+
+fn chip_sw_sysrst_ctrl_input(
+    _opts: &Opts,
+    transport: &TransportWrapper,
+    config: &Config,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+    setup_pins(&*uart, transport, config)?;
+
+    test_combination(
+        &*uart,
+        transport,
+        config,
+        &PinValues { config, values: 0b10001011 }
+    )?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    log::info!(
+        "Use pin configuration for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
+
+    execute_test!(chip_sw_sysrst_ctrl_input, &opts, &transport, config);
+    Ok(())
+}

--- a/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_unlock_raw/src/main.rs
@@ -51,7 +51,7 @@ fn manuf_cp_unlock_raw(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
         Some(token_words),
         true,
         opts.init.bootstrap.options.reset_delay,
-        Some(JtagTap::LcTap)
+        Some(JtagTap::LcTap),
     )
     .context("failed to transition to TEST_UNLOCKED0")?;
 


### PR DESCRIPTION
This is a WIP. I have decided to go down the ujson route since most test require some interactive behavior. This should extend naturally to other sysrst_ctrl tests.

Status: I still have a problem with the flash protect and ec reset pins. I tried to disable the output override but the seems to still stay stuck at 1.