### PR TITLE
[sival,mgr_tests] Update clk/pwr/rstmgr tests

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -132,6 +132,9 @@
     { name: "CLKMGR.JITTER.ENABLE",
       desc: "Enable clock jitter."
     }
+    { name: "CLKMGR.ALERT_HANDLER.CLOCK_STATUS",
+      desc: "Inform alert handler about clock enable status for each clock."
+    }
 ]
 
   inter_signal_list: [

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -182,7 +182,7 @@
       desc: "Enable capture of cpu crash dump information."
     }
     { name: "RSTMGR.ALERT_HANDLER.RESET_STATUS",
-      desc: "Inform alert handler about reset status for each reset."
+      desc: "Inform alert handler about reset enable status for each reset."
     }
   ]
   // Define rstmgr struct package

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -380,5 +380,28 @@
       tests: ["chip_sw_all_escalation_resets"]
       bazel: []
     }
+    {
+      name: chip_sw_clkmgr_alert_handler_clock_enables
+      desc: '''Verify the clock manager sends the correct information to the alert handler
+            regarding individual clocks being active so it can ignore missing ping responses
+            from them and avoid triggering spurious escalation. This scenario is caused by
+            peripheral and transactional clocks being disabled among others. The check is
+            that spurious escalation is not triggered.
+            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
+            This tests already run in CW310.
+            '''
+      stage: V2
+      si_stage: SV3
+      lc_states: [
+        "TEST_UNLOCKED0",
+        "DEV",
+        "PROD",
+        "PROD_END",
+        "RMA",
+      ]
+      features: ["CLKMGR.ALERT_HANDLER.CLOCK_STATUS"]
+      tests: ["chip_sw_alert_handler_lpg_clkoff"]
+      bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test_cw310_test_rom"]
+    }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -36,10 +36,10 @@
               "chip_sw_kmac_idle",
               "chip_sw_otbn_randomness"]
       bazel: [
-        "//sw/device/tests:aes_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:hmac_enc_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:kmac_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:otbn_randomness_test_fpga_cw310_test_rom",
+        "//sw/device/tests:aes_idle_test_cw310_test_rom",
+        "//sw/device/tests:hmac_enc_idle_test_cw310_test_rom",
+        "//sw/device/tests:kmac_idle_test_cw310_test_rom",
+        "//sw/device/tests:otbn_randomness_test_cw310_test_rom",
       ]
     }
     {
@@ -77,10 +77,10 @@
               "chip_sw_clkmgr_off_kmac_trans",
               "chip_sw_clkmgr_off_otbn_trans"]
       bazel: [
-        "//sw/device/tests:clkmgr_off_aes_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_hmac_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_kmac_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_otbn_trans_test_fpga_cw310_test_rom"
+        "//sw/device/tests:clkmgr_off_aes_trans_test_cw310_test_rom",
+        "//sw/device/tests:clkmgr_off_hmac_trans_test_cw310_test_rom",
+        "//sw/device/tests:clkmgr_off_kmac_trans_test_cw310_test_rom",
+        "//sw/device/tests:clkmgr_off_otbn_trans_test_cw310_test_rom"
       ]
     }
     {
@@ -110,7 +110,7 @@
         "CLKMGR.ENABLE.USB",
       ]
       tests: ["chip_sw_clkmgr_off_peri"]
-      bazel: ["//sw/device/tests:clkmgr_off_peri_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:clkmgr_off_peri_test_cw310_test_rom"]
     }
     {
       name: chip_sw_clkmgr_div
@@ -148,9 +148,9 @@
               "manuf_cp_unlock_raw",
               "manuf_cp_yield_test"]
       bazel: [
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_fpga_cw310_test_rom",
+        "//sw/device/tests:ast_clk_outs_test_cw310_test_rom",
+        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_cw310_test_rom",
+        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_cw310_test_rom",
       ]
     }
     {
@@ -315,7 +315,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_ast_clk_outputs"]
-      bazel: ["//sw/device/tests:ast_clk_outs_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:ast_clk_outs_test_cw310_test_rom"]
     }
     {
       name: chip_sw_clkmgr_sleep_frequency
@@ -324,7 +324,8 @@
             Enable clock cycle counts. Put the chip in shallow sleep with pwrmgr's CONTROL CSR
             keeping some clocks disabled. Upon wakeup the clock measurements should be on, and the
             recoverable fault status should show no errors for the disabled clocks.
-            SiVal: Can be run anytime or life cycle after clocks are calibrated.
+            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
+            This tests already run in CW310.
             '''
       stage: V2
       si_stage: SV3
@@ -338,7 +339,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_clkmgr_sleep_frequency"]
-      bazel: ["//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:clkmgr_sleep_frequency_test_cw310_test_rom"]
     }
     {
       name: chip_sw_clkmgr_reset_frequency
@@ -347,7 +348,8 @@
             Enable clock cycle counts, configured to cause errors. Trigger a chip reset via SW.
             After reset the clock measurements should be off and the recoverable fault status
             should be cleared.
-            SiVal: Can be run anytime or life cycle after clocks are calibrated.
+            SiVal: CPU must be enabled and clocks must be calibrated, but no other OTP or
+            lifecycle dependencies. This tests already run in CW310.
             '''
       stage: V2
       si_stage: SV3
@@ -361,7 +363,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_clkmgr_reset_frequency"]
-      bazel: ["//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:clkmgr_reset_frequency_test_cw310_test_rom"]
     }
     {
       name: chip_sw_clkmgr_escalation_reset

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -178,7 +178,7 @@
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_wdog_reset"]
-      bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test_cw310_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_aon_power_glitch_reset
@@ -349,7 +349,7 @@
       ]
       features: ["PWRMGR.LOW_POWER.ENTRY"]
       tests: ["chip_sw_pwrmgr_sleep_disabled"]
-      bazel: ["//sw/device/tests:pwrmgr_sleep_disabled_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_sleep_disabled_test_cw310_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_usb_clk_disabled_when_active
@@ -369,7 +369,7 @@
       ]
       features: ["PWRMGR.CLOCK_CONTROL.USB_WHEN_ACTIVE"]
       tests: ["chip_sw_pwrmgr_usb_clk_disabled_when_active"]
-      bazel: ["//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_cw310_test_rom"]
     }
     {
       name: chip_sw_all_resets

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -44,7 +44,7 @@
         "chip_sw_pwrmgr_random_sleep_all_reset_reqs",
         "chip_sw_pwrmgr_wdog_reset",
       ]
-      bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test_cw310_test_rom"]
     }
     {
       name: chip_sw_rstmgr_sys_reset_info
@@ -90,6 +90,7 @@
 
             SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
             This can be an important diagnostic tool, so setting it to SV2.
+            This test already runs in CW310.
             '''
       stage: V2
       si_stage: SV2
@@ -105,7 +106,7 @@
         "RSTMGR.CPU_INFO.ENABLE",
       ]
       tests: ["chip_sw_rstmgr_cpu_info"]
-      bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_cpu_info_test_cw310_test_rom"]
     }
     {
       name: chip_sw_rstmgr_sw_req_reset
@@ -118,6 +119,7 @@
 
             SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
             For early SiV we could rely on the external reset, so this seems SV3.
+            This test already runs in CW310.
             '''
       stage: V2
       si_stage: SV3
@@ -130,7 +132,7 @@
       ]
       features: ["RSTMGR.SW_RST.CHIP_RESET"]
       tests: ["chip_sw_rstmgr_sw_req"]
-      bazel: ["//sw/device/tests:rstmgr_sw_req_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_sw_req_test_cw310_test_rom"]
     }
     {
       name: chip_sw_rstmgr_alert_info
@@ -145,6 +147,7 @@
 
             SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
             This can be an important diagnostic tool, so setting it to SV2.
+            This test already runs in CW310.
             '''
       stage: V2
       si_stage: SV2
@@ -160,7 +163,7 @@
         "RSTMGR.ALERT_INFO.ENABLE",
       ]
       tests: ["chip_sw_rstmgr_alert_info"]
-      bazel: ["//sw/device/tests:rstmgr_alert_info_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_alert_info_test_cw310_test_rom"]
     }
     {
       name: chip_sw_rstmgr_sw_rst
@@ -174,7 +177,9 @@
               `spi_device`, `spi_host0`, `spi_host1`, `usb`, `i2c0`, `i2c1`, `i2c2`.
 
             Notice the two `spi_host` IPs receive two different resets, `spi_host*`.
+
             SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
+            This test already runs in CW310.
             '''
       stage: V2
       si_stage: SV3
@@ -202,7 +207,7 @@
         "RSTMGR.SW_RST.SPI_DEVICE_REQUEST",
       ]
       tests: ["chip_sw_rstmgr_sw_rst"]
-      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test_cw310_test_rom"]
     }
     {
       name: chip_sw_rstmgr_escalation_reset
@@ -241,12 +246,22 @@
             from them and avoid triggering spurious escalation. This scenario is caused by
             software induced peripheral resets among others. The check is that spurious
             escalation is not triggered.
+
+            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
+            This test already runs in CW310.
             '''
       stage: V2
       si_stage: SV3
+      lc_states: [
+        "TEST_UNLOCKED0",
+        "DEV",
+        "PROD",
+        "PROD_END",
+        "RMA",
+      ]
       features: ["RSTMGR.ALERT_HANDLER.RESET_STATUS"]
       tests: ["chip_sw_rstmgr_sw_rst"]
-      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test_cw310_test_rom"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -260,8 +260,8 @@
         "RMA",
       ]
       features: ["RSTMGR.ALERT_HANDLER.RESET_STATUS"]
-      tests: ["chip_sw_rstmgr_sw_rst"]
-      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test_cw310_test_rom"]
+      tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
+      bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test_cw310_test_rom"]
     }
   ]
 }

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -155,6 +155,9 @@
     { name: "CLKMGR.JITTER.ENABLE",
       desc: "Enable clock jitter."
     }
+    { name: "CLKMGR.ALERT_HANDLER.CLOCK_STATUS",
+      desc: "Inform alert handler about clock enable status for each clock."
+    }
 ]
 
   inter_signal_list: [

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -219,7 +219,7 @@
       desc: "Enable capture of cpu crash dump information."
     }
     { name: "RSTMGR.ALERT_HANDLER.RESET_STATUS",
-      desc: "Inform alert handler about reset status for each reset."
+      desc: "Inform alert handler about reset enable status for each reset."
     }
   ]
   // Define rstmgr struct package

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -285,9 +285,8 @@ static void alert_handler_config_peripherals(uint32_t num_peripherals,
   // Enable all alerts coming from the chosen peripherals
   // Configure them as Class A.
   size_t array_idx = 0;
-  test_t *peri_ptr;
   for (int ii = 0; ii < num_peripherals; ii++) {
-    peri_ptr = (test_t *)first_peripheral + ii;
+    const test_t *peri_ptr = &first_peripheral[ii];
     for (int jj = 0; jj < peri_ptr->num_alert_peri; jj++) {
       alerts[array_idx] = peri_ptr->alert_ids[jj];
       alert_classes[array_idx] = kDifAlertHandlerClassA;
@@ -409,7 +408,7 @@ void ottf_external_isr(void) {
   isr_testutils_alert_handler_isr(plic_ctx, alert_handler_ctx,
                                   &peripheral_serviced, &irq_serviced);
   CHECK(peripheral_serviced == kTopEarlgreyPlicPeripheralAlertHandler,
-        "Interurpt from unexpected peripheral: %d", peripheral_serviced);
+        "Interrupt from unexpected peripheral: %d", peripheral_serviced);
 }
 
 enum {
@@ -494,8 +493,8 @@ bool test_main(void) {
       CHECK_DIF_OK(dif_alert_handler_local_alert_is_cause(
           &alert_handler, kDifAlertHandlerLocalAlertAlertPingFail, &is_cause));
       CHECK(!is_cause,
-            "Expected response is ping_timeout_fail= 0! But we got "
-            "ping_timrout_fail = 1 for peripheral[%d]",
+            "Expected response is ping_timeout_fail == 0! But we got "
+            "ping_timeout_fail = 1 for peripheral[%d]",
             peri_idx);
 
       // Enable the clock again


### PR DESCRIPTION
This has 3 commits:
- Change fpga_cw310 to cw310 in the bazel test targets
- Update testplans to deal with alert_handler clock and reset enables
- Fix simple issues in alert_handler_lpg_clkoff_test.c
