### PR TITLE
[RV_DM]jtag_dtm_idle_hint

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -166,7 +166,7 @@
               successfully, without dmistat reflecting an error.
             '''
       stage: V2
-      tests: [] // TODO(#17033)
+      tests: [rv_dm_jtag_dtm_idle_hint]
     }
     {
       name: jtag_dmi_failed_op

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/rv_dm_cmderr_halt_resume_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_dataaddr_rw_access_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_halt_resume_whereto_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//rv_dm_jtag_dtm_idle_hint
+class rv_dm_jtag_dtm_idle_hint_vseq  extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_jtag_dtm_idle_hint_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+	  lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
+  task body();
+     uvm_reg_data_t wdata;
+     uvm_reg_data_t rdata;
+     wdata= $urandom_range(0,31);
+     csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
+     `DV_CHECK_EQ(1,get_field_val(jtag_dtm_ral.dtmcs.idle,rdata))
+     cfg.m_jtag_agent_cfg.min_rti = 1;
+     //back to back DMI accesses
+     csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(wdata));
+     csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(wdata));
+     csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
+     `DV_CHECK_EQ(0,get_field_val(jtag_dtm_ral.dtmcs.dmistat,rdata))
+  endtask
+
+endclass : rv_dm_jtag_dtm_idle_hint_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -18,3 +18,4 @@
 `include "rv_dm_cmderr_halt_resume_vseq.sv"
 `include "rv_dm_dataaddr_rw_access_vseq.sv"
 `include "rv_dm_halt_resume_whereto_vseq.sv"
+`include "rv_dm_jtag_dtm_idle_hint_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -225,6 +225,11 @@
       uvm_test_seq: rv_dm_halt_resume_whereto_vseq
       reseed: 2
     }
+    {
+      name: rv_dm_jtag_dtm_idle_hint
+      uvm_test_seq: rv_dm_jtag_dtm_idle_hint_vseq
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This test verify that debugger does not need to stay any longer than advertized idle time indicated in dtmcs register.
@jdonjdon please review it. Thanks.