### PR TITLE
[manuf] remove un-needed OTP *SwCfg partition config function

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -102,12 +102,6 @@ status_t manuf_individualize_device_owner_sw_cfg(
   return OK_STATUS();
 }
 
-status_t manuf_individualize_device_sw_cfg(const dif_otp_ctrl_t *otp_ctrl) {
-  TRY(manuf_individualize_device_creator_sw_cfg(otp_ctrl));
-  TRY(manuf_individualize_device_owner_sw_cfg(otp_ctrl));
-  return OK_STATUS();
-}
-
 status_t manuf_individualize_device_creator_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -63,21 +63,6 @@ status_t manuf_individualize_device_owner_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**
- * Configures both the CREATOR_SW_CFG and OWNER_SW_CFG OTP partitions.
- *
- * This can be called in place of calling both of the above functions
- * individually.
- *
- * The caller should reset the device after calling this function to verify that
- * the ROM is able to boot with the new configuration.
- *
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the HW_CFG partition is locked.
- */
-OT_WARN_UNUSED_RESULT
-status_t manuf_individualize_device_sw_cfg(const dif_otp_ctrl_t *otp_ctrl);
-
-/**
  * Checks the CREATOR_SW_CFG OTP partition end state.
  *
  * @param otp_ctrl OTP controller interface.

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_provision.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_provision.c
@@ -50,7 +50,8 @@ status_t command_processor(ujson_t *uj) {
     switch (command) {
       case kFtSramProvisioningCommandWriteAll:
         LOG_INFO("Writing both *_SW_CFG OTP partitions ...");
-        CHECK_STATUS_OK(manuf_individualize_device_sw_cfg(&otp_ctrl));
+        CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg(&otp_ctrl));
+        CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
         break;
       case kFtSramProvisioningCommandOtpCreatorSwCfgWrite:
         LOG_INFO("Writing the CREATOR_SW_CFG OTP partition ...");

--- a/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
@@ -96,7 +96,8 @@ bool sram_main(void) {
           kDifFlashCtrlPartitionTypeInfo,
           kFlashInfoWaferAuthSecretSizeIn32BitWords));
       LOG_INFO("Enabling ROM execution to enable bootstrap after reset.");
-      CHECK_STATUS_OK(manuf_individualize_device_sw_cfg(&otp_ctrl));
+      CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg(&otp_ctrl));
+      CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
       LOG_INFO("Done. Perform an LC transition and run flash stage.");
       break;
     default:


### PR DESCRIPTION
This removes an un-needed function that configures both OTP *SwCfg partitions at once, since there are functions that provision each one individually. This should ease the burden of maintenance on this lib.