### PR TITLE
[hw,prim,rtl] Fix Mubi RW1S/RW1C behaviour and usages

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -638,7 +638,7 @@
     core: [
       { name: "DIS",
         desc: "Disable flash functionality",
-        swaccess: "rw0c",
+        swaccess: "rw1s",
         hwaccess: "hro",
         fields: [
           { bits: "3:0",
@@ -649,9 +649,8 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               Since this register is rw0c instead of rw, to disable, write any value in the form of
-               0xxx or xxx0, where x could be either 0 or 1.
-
+               Since this register is rw1s instead of rw, to disable, write the value kMuBi4True
+               to the register to disable the flash.
               '''
             resval: false,
           },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -639,7 +639,7 @@
     core: [
       { name: "DIS",
         desc: "Disable flash functionality",
-        swaccess: "rw0c",
+        swaccess: "rw1s",
         hwaccess: "hro",
         fields: [
           { bits: "3:0",
@@ -650,9 +650,8 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               Since this register is rw0c instead of rw, to disable, write any value in the form of
-               0xxx or xxx0, where x could be either 0 or 1.
-
+               Since this register is rw1s instead of rw, to disable, write the value kMuBi4True
+               to the register to disable the flash.
               '''
             resval: false,
           },

--- a/hw/ip/flash_ctrl/doc/registers.md
+++ b/hw/ip/flash_ctrl/doc/registers.md
@@ -215,22 +215,21 @@ Disable flash functionality
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "VAL", "bits": 4, "attr": ["rw0c"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "VAL", "bits": 4, "attr": ["rw1s"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name             |
 |:------:|:------:|:-------:|:-----------------|
 |  31:4  |        |         | Reserved         |
-|  3:0   |  rw0c  |   0x9   | [VAL](#dis--val) |
+|  3:0   |  rw1s  |   0x9   | [VAL](#dis--val) |
 
 ### DIS . VAL
 Disables flash functionality completely.
 This is a shortcut mechanism used by the software to completely
 kill flash in case of emergency.
 
-Since this register is rw0c instead of rw, to disable, write any value in the form of
-0xxx or xxx0, where x could be either 0 or 1.
-
+Since this register is rw1s instead of rw, to disable, write the value kMuBi4True
+to the register to disable the flash.
 
 ## EXEC
 Controls whether flash can be used for code execution fetches

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1539,7 +1539,7 @@ module flash_ctrl_core_reg_top (
   // R[dis]: V(False)
   prim_subreg #(
     .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1)
   ) u_dis (

--- a/hw/ip/prim/rtl/prim_subreg_arb.sv
+++ b/hw/ip/prim/rtl/prim_subreg_arb.sv
@@ -60,21 +60,21 @@ module prim_subreg_arb
     assign wr_en   = we | de;
     if (Mubi) begin : gen_mubi
       if (DW == 4) begin : gen_mubi4
-        assign wr_data = prim_mubi_pkg::mubi4_and_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
-                                                     (we ? prim_mubi_pkg::mubi4_t'(wd) :
-                                                           prim_mubi_pkg::MuBi4False));
+        assign wr_data = prim_mubi_pkg::mubi4_or_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                    (we ? prim_mubi_pkg::mubi4_t'(wd) :
+                                                          prim_mubi_pkg::MuBi4False));
       end else if (DW == 8) begin : gen_mubi8
-        assign wr_data = prim_mubi_pkg::mubi8_and_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
-                                                     (we ? prim_mubi_pkg::mubi8_t'(wd) :
-                                                           prim_mubi_pkg::MuBi8False));
+        assign wr_data = prim_mubi_pkg::mubi8_or_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                    (we ? prim_mubi_pkg::mubi8_t'(wd) :
+                                                          prim_mubi_pkg::MuBi8False));
       end else if (DW == 12) begin : gen_mubi12
-        assign wr_data = prim_mubi_pkg::mubi12_and_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
-                                                      (we ? prim_mubi_pkg::mubi12_t'(wd) :
-                                                            prim_mubi_pkg::MuBi12False));
+        assign wr_data = prim_mubi_pkg::mubi12_or_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi12_t'(wd) :
+                                                           prim_mubi_pkg::MuBi12False));
       end else if (DW == 16) begin : gen_mubi16
-        assign wr_data = prim_mubi_pkg::mubi16_and_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
-                                                      (we ? prim_mubi_pkg::mubi16_t'(wd) :
-                                                            prim_mubi_pkg::MuBi16False));
+        assign wr_data = prim_mubi_pkg::mubi16_or_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi16_t'(wd) :
+                                                           prim_mubi_pkg::MuBi16False));
       end else begin : gen_invalid_mubi
         $error("%m: Invalid width for MuBi");
       end
@@ -88,21 +88,21 @@ module prim_subreg_arb
     assign wr_en   = we | de;
     if (Mubi) begin : gen_mubi
       if (DW == 4) begin : gen_mubi4
-        assign wr_data = prim_mubi_pkg::mubi4_or_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
-                                                    (we ? prim_mubi_pkg::mubi4_t'(~wd) :
-                                                          prim_mubi_pkg::MuBi4True));
+        assign wr_data = prim_mubi_pkg::mubi4_and_hi(prim_mubi_pkg::mubi4_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi4_t'(~wd) :
+                                                           prim_mubi_pkg::MuBi4True));
       end else if (DW == 8) begin : gen_mubi8
-        assign wr_data = prim_mubi_pkg::mubi8_or_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
-                                                    (we ? prim_mubi_pkg::mubi8_t'(~wd) :
-                                                          prim_mubi_pkg::MuBi8True));
+        assign wr_data = prim_mubi_pkg::mubi8_and_hi(prim_mubi_pkg::mubi8_t'(de ? d : q),
+                                                     (we ? prim_mubi_pkg::mubi8_t'(~wd) :
+                                                           prim_mubi_pkg::MuBi8True));
       end else if (DW == 12) begin : gen_mubi12
-        assign wr_data = prim_mubi_pkg::mubi12_or_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
-                                                     (we ? prim_mubi_pkg::mubi12_t'(~wd) :
-                                                           prim_mubi_pkg::MuBi12True));
+        assign wr_data = prim_mubi_pkg::mubi12_and_hi(prim_mubi_pkg::mubi12_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi12_t'(~wd) :
+                                                            prim_mubi_pkg::MuBi12True));
       end else if (DW == 16) begin : gen_mubi16
-        assign wr_data = prim_mubi_pkg::mubi16_or_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
-                                                     (we ? prim_mubi_pkg::mubi16_t'(~wd) :
-                                                           prim_mubi_pkg::MuBi16True));
+        assign wr_data = prim_mubi_pkg::mubi16_and_hi(prim_mubi_pkg::mubi16_t'(de ? d : q),
+                                                      (we ? prim_mubi_pkg::mubi16_t'(~wd) :
+                                                            prim_mubi_pkg::MuBi16True));
       end else begin : gen_invalid_mubi
         $error("%m: Invalid width for MuBi");
       end

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -556,7 +556,7 @@
         desc: '''
           Software fatal error
         ''',
-        swaccess: "rw0c",
+        swaccess: "rw1s",
         hwaccess: "hro",
         fields: [
           { bits: "3:0",

--- a/hw/ip/rv_core_ibex/doc/registers.md
+++ b/hw/ip/rv_core_ibex/doc/registers.md
@@ -80,13 +80,13 @@ Software fatal error
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "VAL", "bits": 4, "attr": ["rw0c"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "VAL", "bits": 4, "attr": ["rw1s"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                              |
 |:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  31:4  |        |         |        | Reserved                                                                                                                                                                                 |
-|  3:0   |  rw0c  |   0x9   | VAL    | Software fatal alert. When set to any value other than kMultiBitBool4False, a fatal alert is sent. Note, this field once cleared cannot be set and will continuously cause alert events. |
+|  3:0   |  rw1s  |   0x9   | VAL    | Software fatal alert. When set to any value other than kMultiBitBool4False, a fatal alert is sent. Note, this field once cleared cannot be set and will continuously cause alert events. |
 
 ## IBUS_REGWEN
 Ibus address control regwen.

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -360,7 +360,7 @@ module rv_core_ibex_cfg_reg_top (
   // R[sw_fatal_err]: V(False)
   prim_subreg #(
     .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1)
   ) u_sw_fatal_err (

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_all_escalation_resets_vseq.sv
@@ -49,8 +49,7 @@ class chip_sw_all_escalation_resets_vseq extends chip_sw_base_vseq;
     '{"*rstmgr*prim_reg_we_check*", TopEarlgreyAlertIdRstmgrAonFatalFault},
     // TopEarlgreyAlertIdRstmgrAonFatalCnstyFault cannot use this test.
     //
-    // TODO: The case below fails due to bug lowrisc/opentitan#19774
-    //'{"*rv_core_ibex*sw_fatal_err*", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
+    '{"*rv_core_ibex*sw_fatal_err*", TopEarlgreyAlertIdRvCoreIbexFatalSwErr},
     '{"*rv_core_ibex*prim_reg_we_check*", TopEarlgreyAlertIdRvCoreIbexFatalHwErr},
     '{"*rv_dm*prim_reg_we_check*", TopEarlgreyAlertIdRvDmFatalFault},
     '{"*rv_plic*prim_reg_we_check*", TopEarlgreyAlertIdRvPlicFatalFault},

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -644,7 +644,7 @@
     core: [
       { name: "DIS",
         desc: "Disable flash functionality",
-        swaccess: "rw0c",
+        swaccess: "rw1s",
         hwaccess: "hro",
         fields: [
           { bits: "3:0",
@@ -655,9 +655,8 @@
                This is a shortcut mechanism used by the software to completely
                kill flash in case of emergency.
 
-               Since this register is rw0c instead of rw, to disable, write any value in the form of
-               0xxx or xxx0, where x could be either 0 or 1.
-
+               Since this register is rw1s instead of rw, to disable, write the value kMuBi4True
+               to the register to disable the flash.
               '''
             resval: false,
           },

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -1539,7 +1539,7 @@ module flash_ctrl_core_reg_top (
   // R[dis]: V(False)
   prim_subreg #(
     .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1)
   ) u_dis (


### PR DESCRIPTION
This PR is a port of https://github.com/lowRISC/opentitan-integrated/pull/550 for the discrete OT.

This PR corrects the register behaviour of Mubi RW1S/RW1C registers and uses them instead of RW0C to preserve the API of their instances.


Closes https://github.com/lowRISC/opentitan/issues/19774