### PR TITLE
[crypto] Add a specialized buffer type for hash digests.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -139,8 +139,7 @@ Data structures for key types and modes help the cryptolib recognize and prevent
 #### Hash data structures
 
 {{#header-snippet sw/device/lib/crypto/include/hash.h hash_mode }}
-{{#header-snippet sw/device/lib/crypto/include/hash.h xof_cshake_mode }}
-{{#header-snippet sw/device/lib/crypto/include/hash.h xof_shake_mode }}
+{{#header-snippet sw/device/lib/crypto/include/hash.h hash_digest }}
 
 #### Key derivation data structures
 

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -26,44 +26,28 @@ extern "C" {
  */
 typedef enum hash_mode {
   // SHA2-256 mode.
-  kHashModeSha256 = 0x783,
+  kHashModeSha256 = 0x69b,
   // SHA2-384 mode.
-  kHashModeSha384 = 0xd16,
+  kHashModeSha384 = 0x7ae,
   // SHA2-512 mode.
-  kHashModeSha512 = 0x2e9,
+  kHashModeSha512 = 0x171,
   // SHA3-224 mode.
-  kHashModeSha3_224 = 0x13d,
+  kHashModeSha3_224 = 0x516,
   // SHA3-256 mode.
-  kHashModeSha3_256 = 0xc99,
+  kHashModeSha3_256 = 0x2d4,
   // SHA3-384 mode.
-  kHashModeSha3_384 = 0xb58,
+  kHashModeSha3_384 = 0x267,
   // SHA3-512 mode.
-  kHashModeSha3_512 = 0x963,
-} hash_mode_t;
-
-/**
- * Enum to define the supported SHAKE (extendable-output) functions.
- *
- * Values are hardened.
- */
-typedef enum xof_shake_mode {
+  kHashModeSha3_512 = 0x44d,
   // Shake128 mode.
-  kXofShakeModeShake128 = 0x9bd,
+  kHashXofModeShake128 = 0x5d8,
   // Shake256 mode.
-  kXofShakeModeShake256 = 0x758,
-} xof_shake_mode_t;
-
-/**
- * Enum to define the supported CSHAKE (extendable-output) functions.
- *
- * Values are hardened.
- */
-typedef enum xof_cshake_mode {
+  kHashXofModeShake256 = 0x34a,
   // cShake128 mode.
-  kXofCshakeModeCshake128 = 0xbd3,
+  kHashXofModeCshake128 = 0x0bd,
   // cShake256 mode.
-  kXofCshakeModeCshake256 = 0x0fa,
-} xof_cshake_mode_t;
+  kHashXofModeCshake256 = 0x4e2,
+} hash_mode_t;
 
 /**
  * Generic hash context.
@@ -79,87 +63,83 @@ typedef struct hash_context {
 } hash_context_t;
 
 /**
+ * Container for a hash digest.
+ */
+typedef struct hash_digest {
+  // Digest type.
+  hash_mode_t mode;
+  // Digest length 32-bit words.
+  size_t len;
+  // Digest data.
+  uint32_t *data;
+} hash_digest_t;
+
+/**
  * Performs the required hash function on the input data.
  *
- * The caller should allocate space for the `digest` buffer, (expected
- * length depends on `hash_mode`, refer table above), and set the
- * length of expected output in the `len` field of `digest`. If the
- * user-set length and the output length does not match, an error
- * message will be returned.
+ * The caller should allocate space for the `digest` buffer and set the `mode`
+ * and `len` fields. If the length does not match the mode, an error message
+ * will be returned.
  *
- * This function hashes the `input_message` using the `hash_mode_t`
- * hash function and returns a `digest`.
+ * This function should only be used for fixed-length hash functions (SHA-2 and
+ * SHA-3 families). Use `otcrypto_xof_shake` and `otcrypto_xof_cshake` for
+ * extendable-output functions.
  *
  * @param input_message Input message to be hashed.
- * @param hash_mode Required hash mode for the digest.
  * @param[out] digest Output digest after hashing the input message.
  * @return Result of the hash operation.
  */
 crypto_status_t otcrypto_hash(crypto_const_byte_buf_t input_message,
-                              hash_mode_t hash_mode,
-                              crypto_word32_buf_t *digest);
+                              hash_digest_t *digest);
 
 /**
  * Performs the SHAKE extendable output function (XOF) on input data.
  *
- * The caller should allocate space for the `digest` buffer, with a word-length
- * long enough to hold `required_output_len`, and set the `len` field of
- * `digest` to the word-length of the allocated buffer. If the `len` field of
- * digest does not match `required_output_len`, the function will return an
- * error.
+ * The caller should allocate space for the `digest` buffer and set the `mode`
+ * and `len` fields.  The `mode` parameter must be `kHashXofModeShake128` or
+ * `kHashXofModeShake256`; other values will result in errors.
  *
  * @param input_message Input message for extendable output function.
- * @param shake_mode Required extendable output function.
- * @param required_output_len Required output length, in bytes.
  * @param[out] digest Output from the extendable output function.
  * @return Result of the xof operation.
  */
 crypto_status_t otcrypto_xof_shake(crypto_const_byte_buf_t input_message,
-                                   xof_shake_mode_t shake_mode,
-                                   size_t required_output_len,
-                                   crypto_word32_buf_t *digest);
+                                   hash_digest_t *digest);
 
 /**
  * Performs the CSHAKE extendable output function (XOF) on input data.
  *
- * The `function_name_string` is used by NIST to define functions
- * based on cSHAKE. When no function other than cSHAKE is desired; it
- * can be empty. The `customization_string` is used to define a
- * variant of the cSHAKE function. If no customization is desired it
- * can be empty.
+ * The `function_name_string` is used by NIST to define functions based on
+ * cSHAKE. When no function other than cSHAKE is desired; it can be empty. The
+ * `customization_string` is used to define a variant of the cSHAKE function.
+ * If no customization is desired it can be empty.
  *
- * The caller should allocate space for the `digest` buffer,
- * (expected length same as `required_output_len`), and set the length
- * of expected output in the `len` field of `digest`. If the user-set
- * length and the output length does not match, an error message will
- * be returned.
+ * The caller should allocate space for the `digest` buffer and set the `mode`
+ * and `len` fields. The `mode` parameter must be `kHashXofModeCshake128` or
+ * `kHashXofModeCshake256`; other values will result in errors.
  *
  * @param input_message Input message for extendable output function.
- * @param cshake_mode Required extendable output function.
  * @param function_name_string NIST Function name string.
  * @param customization_string Customization string for cSHAKE.
- * @param required_output_len Required output length, in bytes.
  * @param[out] digest Output from the extendable output function.
  * @return Result of the xof operation.
  */
 crypto_status_t otcrypto_xof_cshake(
-    crypto_const_byte_buf_t input_message, xof_cshake_mode_t cshake_mode,
+    crypto_const_byte_buf_t input_message,
     crypto_const_byte_buf_t function_name_string,
-    crypto_const_byte_buf_t customization_string, size_t required_output_len,
-    crypto_word32_buf_t *digest);
+    crypto_const_byte_buf_t customization_string, hash_digest_t *digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.
  *
- * Initializes the generic hash context. The required hash mode is
- * selected through the `hash_mode` parameter. Only `kHashModeSha256`,
- * `kHashModeSha384` and `kHashModeSha512` are supported. Other modes
- * are not supported and an error would be returned.
+ * Initializes the generic hash context. The required hash mode is selected
+ * through the `hash_mode` parameter. Only `kHashModeSha256`, `kHashModeSha384`
+ * and `kHashModeSha512` are supported. Other modes are not supported and an
+ * error would be returned.
  *
- * Populates the hash context with the selected hash mode and its
- * digest and block sizes. The structure of hash context and how it
- * populates the required fields are internal to the specific hash
- * implementation.
+ * Populates the hash context with the selected hash mode and its digest and
+ * block sizes. The structure of hash context and how it populates the required
+ * fields are internal to the specific hash implementation.
  *
  * @param ctx Pointer to the generic hash context struct.
  * @param hash_mode Required hash mode.
@@ -171,10 +151,10 @@ crypto_status_t otcrypto_hash_init(hash_context_t *const ctx,
 /**
  * Performs the UPDATE operation for a cryptographic hash function.
  *
- * The update operation processes the `input_message` using the selected
- * hash compression function. The intermediate digest is stored in the
- * context `ctx`. Any partial data is stored back in the context and
- * combined with the subsequent bytes.
+ * The update operation processes the `input_message` using the selected hash
+ * compression function. The intermediate digest is stored in the context
+ * `ctx`. Any partial data is stored back in the context and combined with the
+ * subsequent bytes.
  *
  * #otcrypto_hash_init should be called before this function.
  *
@@ -188,23 +168,21 @@ crypto_status_t otcrypto_hash_update(hash_context_t *const ctx,
 /**
  * Performs the FINAL operation for a cryptographic hash function.
  *
- * The final operation processes the remaining partial blocks,
- * computes the final hash and copies it to the `digest` parameter.
+ * The final operation processes the remaining partial blocks, computes the
+ * final hash and copies it to the `digest` parameter.
  *
  * #otcrypto_hash_update should be called before this function.
  *
- * The caller should allocate space for the `digest` buffer, (expected
- * length depends on `hash_mode`, refer table-1), and set the length
- * of expected output in the `len` field of `digest`. If the user-set
- * length and the output length does not match, an error message will
- * be returned.
+ * The caller should allocate space for the `digest` buffer and set the `mode`
+ * and `len` fields. If the `mode` doesn't match the mode of the hash context,
+ * the function will return an error.
  *
  * @param ctx Pointer to the generic hash context struct.
  * @param[out] digest Output digest after hashing the input blocks.
  * @return Result of the hash final operation.
  */
 crypto_status_t otcrypto_hash_final(hash_context_t *const ctx,
-                                    crypto_word32_buf_t *digest);
+                                    hash_digest_t *digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -56,11 +56,12 @@ static const uint8_t kExactBlockExpDigest[] = {
 static status_t run_test(crypto_const_byte_buf_t msg,
                          const uint32_t *exp_digest) {
   uint32_t act_digest[kHmacDigestNumWords];
-  crypto_word32_buf_t digest_buf = {
+  hash_digest_t digest_buf = {
       .data = act_digest,
       .len = kHmacDigestNumWords,
+      .mode = kHashModeSha256,
   };
-  TRY(otcrypto_hash(msg, kHashModeSha256, &digest_buf));
+  TRY(otcrypto_hash(msg, &digest_buf));
   TRY_CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
   return OK_STATUS();
 }
@@ -118,9 +119,10 @@ static status_t one_update_streaming_test(void) {
   size_t digest_num_words =
       (sizeof(kExactBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t act_digest[digest_num_words];
-  crypto_word32_buf_t digest_buf = {
+  hash_digest_t digest_buf = {
       .data = act_digest,
       .len = digest_num_words,
+      .mode = kHashModeSha256,
   };
   TRY(otcrypto_hash_final(&ctx, &digest_buf));
   TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kExactBlockExpDigest,
@@ -153,9 +155,10 @@ static status_t multiple_update_streaming_test(void) {
   size_t digest_num_words =
       (sizeof(kTwoBlockExpDigest) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
   uint32_t act_digest[digest_num_words];
-  crypto_word32_buf_t digest_buf = {
+  hash_digest_t digest_buf = {
       .data = act_digest,
       .len = digest_num_words,
+      .mode = kHashModeSha256,
   };
   TRY(otcrypto_hash_final(&ctx, &digest_buf));
   TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kTwoBlockExpDigest,

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -59,11 +59,12 @@ status_t sha384_test(const unsigned char *msg, const size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[384 / 32];
-  crypto_word32_buf_t actual_digest = {
+  hash_digest_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
+      .mode = kHashModeSha384,
   };
-  TRY(otcrypto_hash(input_message, kHashModeSha384, &actual_digest));
+  TRY(otcrypto_hash(input_message, &actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
@@ -95,9 +96,10 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[384 / 32];
-  crypto_word32_buf_t actual_digest = {
+  hash_digest_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
+      .mode = kHashModeSha384,
   };
   TRY(otcrypto_hash_final(&ctx, &actual_digest));
 

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -52,11 +52,12 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[512 / 32];
-  crypto_word32_buf_t actual_digest = {
-      .data = actual_digest_data,
+  hash_digest_t actual_digest = {
       .len = ARRAYSIZE(actual_digest_data),
+      .data = actual_digest_data,
+      .mode = kHashModeSha512,
   };
-  TRY(otcrypto_hash(input_message, kHashModeSha512, &actual_digest));
+  TRY(otcrypto_hash(input_message, &actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
@@ -88,9 +89,10 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
 
   // Allocate space for the computed digest.
   uint32_t actual_digest_data[512 / 32];
-  crypto_word32_buf_t actual_digest = {
+  hash_digest_t actual_digest = {
       .data = actual_digest_data,
       .len = ARRAYSIZE(actual_digest_data),
+      .mode = kHashModeSha512,
   };
   TRY(otcrypto_hash_final(&ctx, &actual_digest));
 


### PR DESCRIPTION
Part of https://github.com/lowRISC/opentitan/issues/19549

This is a precursor to switching some signature schemes from taking raw messages to taking hash digests as input, and also generally makes some things a little clearer because hash digests now "remember" which hash function they came from.