### PR TITLE
[quality] Exclude build-site from clang-format.

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -88,6 +88,7 @@ format_exclude = [
     # Directories used exclusively to store build artifacts are still copied into.
     "./build-out/**",
     "./build-bin/**",
+    "./build-site/**",
     # fusesoc build dir
     "./build/**",
 ]


### PR DESCRIPTION
I noticed that recently `bazel run //quality:clang_format_fix` had been taking a really long time, so I dug into why a little bit. Looks like it was going through all the build junk from `build-site` for those who have built the website since cleaning; on my machine this change takes `clang_format_fix` from 4m38s to 7s.