### PR TITLE
[sw] Add support for memory ujson commands

### DIFF
--- a/sw/device/lib/testing/json/BUILD
+++ b/sw/device/lib/testing/json/BUILD
@@ -37,6 +37,16 @@ cc_library(
 )
 
 cc_library(
+    name = "mem",
+    srcs = ["mem.c"],
+    hdrs = ["mem.h"],
+    deps = [
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+    ],
+)
+
+cc_library(
     name = "pinmux",
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -20,6 +20,10 @@ extern "C" {
     value(_, I2cReadTransaction) \
     value(_, I2cWriteTransaction) \
     value(_, I2cWriteTransactionSlow) \
+    value(_, MemRead) \
+    value(_, MemRead32) \
+    value(_, MemWrite) \
+    value(_, MemWrite32) \
     value(_, PinmuxConfig) \
     value(_, SpiConfigureJedecId) \
     value(_, SpiReadStatus) \

--- a/sw/device/lib/testing/json/mem.c
+++ b/sw/device/lib/testing/json/mem.c
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sw/device/lib/testing/json/mem.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+#define MODULE_ID MAKE_MODULE_ID('j', 's', 'm')
+
+status_t ujcmd_mem_read32(ujson_t *uj) {
+  mem_read32_req_t op;
+  mem_read32_resp_t resp;
+  TRY(ujson_deserialize_mem_read32_req_t(uj, &op));
+  if ((op.address % sizeof(uint32_t)) != 0) {
+    return INVALID_ARGUMENT();
+  }
+  resp.value = read_32((void *)op.address);
+  return RESP_OK(ujson_serialize_mem_read32_resp_t, uj, &resp);
+}
+
+status_t ujcmd_mem_read(ujson_t *uj) {
+  mem_read_req_t op;
+  mem_read_resp_t resp;
+  TRY(ujson_deserialize_mem_read_req_t(uj, &op));
+  if (op.data_len > sizeof(resp.data)) {
+    return INVALID_ARGUMENT();
+  }
+  memcpy(resp.data, (void *)op.address, op.data_len);
+  resp.data_len = op.data_len;
+  return RESP_OK(ujson_serialize_mem_read_resp_t, uj, &resp);
+}
+
+status_t ujcmd_mem_write32(ujson_t *uj) {
+  mem_write32_req_t op;
+  TRY(ujson_deserialize_mem_write32_req_t(uj, &op));
+  if ((op.address % sizeof(uint32_t)) != 0) {
+    return INVALID_ARGUMENT();
+  }
+  write_32(op.value, (void *)op.address);
+  return RESP_OK_STATUS(uj);
+}
+
+status_t ujcmd_mem_write(ujson_t *uj) {
+  mem_write_req_t op;
+  TRY(ujson_deserialize_mem_write_req_t(uj, &op));
+  if (op.data_len > sizeof(op.data)) {
+    return INVALID_ARGUMENT();
+  }
+  memcpy((void *)op.address, op.data, op.data_len);
+  return RESP_OK_STATUS(uj);
+}

--- a/sw/device/lib/testing/json/mem.h
+++ b/sw/device/lib/testing/json/mem.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_MEM_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_MEM_H_
+
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+// clang-format off
+
+#define MODULE_ID MAKE_MODULE_ID('j', 'm', 'h')
+
+#define STRUCT_MEM_READ32_REQ(field, string) \
+    field(address, uint32_t)
+UJSON_SERDE_STRUCT(MemRead32Req, mem_read32_req_t, STRUCT_MEM_READ32_REQ);
+
+#define STRUCT_MEM_READ32_RESP(field, string) \
+    field(value, uint32_t)
+UJSON_SERDE_STRUCT(MemRead32Resp, mem_read32_resp_t, STRUCT_MEM_READ32_RESP);
+
+#define STRUCT_MEM_READ_REQ(field, string) \
+    field(address, uint32_t) \
+    field(data_len, uint16_t)
+UJSON_SERDE_STRUCT(MemReadReq, mem_read_req_t, STRUCT_MEM_READ_REQ);
+
+#define STRUCT_MEM_READ_RESP(field, string) \
+    field(data, uint8_t, 256) \
+    field(data_len, uint16_t)
+UJSON_SERDE_STRUCT(MemReadResp, mem_read_resp_t, STRUCT_MEM_READ_RESP);
+
+#define STRUCT_MEM_WRITE32_REQ(field, string) \
+    field(address, uint32_t) \
+    field(value, uint32_t)
+UJSON_SERDE_STRUCT(MemWrite32Req, mem_write32_req_t, STRUCT_MEM_WRITE32_REQ);
+
+#define STRUCT_MEM_WRITE_REQ(field, string) \
+    field(address, uint32_t) \
+    field(data, uint8_t, 256) \
+    field(data_len, uint16_t)
+UJSON_SERDE_STRUCT(MemWriteReq, mem_write_req_t, STRUCT_MEM_WRITE_REQ);
+
+#ifndef RUST_PREPROCESSOR_EMIT
+
+status_t ujcmd_mem_read32(ujson_t *uj);
+status_t ujcmd_mem_read(ujson_t *uj);
+status_t ujcmd_mem_write32(ujson_t *uj);
+status_t ujcmd_mem_write(ujson_t *uj);
+
+#endif
+
+#undef MODULE_ID
+
+// clang-format on
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_JSON_MEM_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -18,6 +18,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "opentitan_binary",
     "opentitan_test",
     new_cw310_params = "cw310_params",
     new_dv_params = "dv_params",
@@ -938,6 +939,34 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     deps = [
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
+    name = "example_mem_ujcmd_test",
+    srcs = ["example_mem_ujcmd.c"],
+    cw310 = new_cw310_params(
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+            "\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/mem",
+    ),
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = new_verilator_params(
+        timeout = "eternal",
+        tags = ["manual"],
+        test_cmd = " ".join([
+            "--firmware-elf=\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/mem",
+    ),
+    deps = [
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:mem",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/tests/example_mem_ujcmd.c
+++ b/sw/device/tests/example_mem_ujcmd.c
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/mem.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+volatile uint8_t kTestBytes[256];
+volatile uint32_t kTestWord;
+volatile uint32_t kEndTest;
+
+status_t command_processor(ujson_t *uj) {
+  while (!kEndTest) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandMemRead32:
+        RESP_ERR(uj, ujcmd_mem_read32(uj));
+        break;
+      case kTestCommandMemRead:
+        RESP_ERR(uj, ujcmd_mem_read(uj));
+        break;
+      case kTestCommandMemWrite32:
+        RESP_ERR(uj, ujcmd_mem_write32(uj));
+        break;
+      case kTestCommandMemWrite:
+        RESP_ERR(uj, ujcmd_mem_write(uj));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  kEndTest = 0;
+  kTestWord = 0xface1234u;
+  for (size_t i = 0; i < 256; ++i) {
+    kTestBytes[i] = (uint8_t)i;
+  }
+  ujson_t uj = ujson_ottf_console();
+
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, command_processor, &uj);
+  return status_ok(result);
+}

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -26,6 +26,12 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "mem",
+    srcs = ["//sw/device/lib/testing/json:mem"],
+    defines = ["opentitanlib=crate"],
+)
+
+ujson_rust(
     name = "pinmux_config",
     srcs = ["//sw/device/lib/testing/json:pinmux_config"],
     defines = ["opentitanlib=crate"],
@@ -123,6 +129,7 @@ rust_library(
         "src/test_utils/lc_transition.rs",
         "src/test_utils/load_bitstream.rs",
         "src/test_utils/load_sram_program.rs",
+        "src/test_utils/mem.rs",
         "src/test_utils/mod.rs",
         "src/test_utils/otp_ctrl.rs",
         "src/test_utils/poll.rs",
@@ -209,6 +216,7 @@ rust_library(
         ":config",
         ":gpio",
         ":i2c_target",
+        ":mem",
         ":e2e_command",
         ":pinmux_config",
         ":spi_passthru",
@@ -231,6 +239,7 @@ rust_library(
         "e2e_command": "$(location :e2e_command)",
         "gpio": "$(location :gpio)",
         "i2c_target": "$(location :i2c_target)",
+        "mem": "$(location :mem)",
         "pinmux_config": "$(location :pinmux_config)",
         "spi_passthru": "$(location :spi_passthru)",
         "hyperdebug_firmware": "$(location @hyperdebug_firmware//:hyperdebug/ec.bin)",

--- a/sw/host/opentitanlib/src/test_utils/mem.rs
+++ b/sw/host/opentitanlib/src/test_utils/mem.rs
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::test_utils::e2e_command::TestCommand;
+use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::status::Status;
+
+// Bring in the auto-generated sources.
+include!(env!("mem"));
+
+impl MemRead32Req {
+    pub fn execute(uart: &dyn Uart, address: u32) -> Result<u32> {
+        TestCommand::MemRead32.send(uart)?;
+        let op = MemRead32Req { address };
+        op.send(uart)?;
+        let resp = MemRead32Resp::recv(uart, Duration::from_secs(300), false)?;
+        Ok(resp.value)
+    }
+}
+
+impl MemReadReq {
+    pub fn execute(uart: &dyn Uart, start_address: u32, data: &mut [u8]) -> Result<()> {
+        let bytes_to_read = data.len();
+        let mut bytes_read = 0_usize;
+        while bytes_read < bytes_to_read {
+            let size_check = MemReadResp {
+                data_len: 0,
+                data: ArrayVec::new(),
+            };
+            let op_size = std::cmp::min(bytes_to_read - bytes_read, size_check.data.capacity());
+            TestCommand::MemRead.send(uart)?;
+            let op = MemReadReq {
+                address: start_address + (bytes_read as u32),
+                data_len: op_size.try_into().unwrap(),
+            };
+            op.send(uart)?;
+            let resp = MemReadResp::recv(uart, Duration::from_secs(300), false)?;
+            data[bytes_read..(bytes_read + op_size)].copy_from_slice(resp.data.as_slice());
+            bytes_read += op_size;
+        }
+        Ok(())
+    }
+}
+
+impl MemWrite32Req {
+    pub fn execute(uart: &dyn Uart, address: u32, value: u32) -> Result<()> {
+        TestCommand::MemWrite32.send(uart)?;
+        let op = MemWrite32Req { address, value };
+        op.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}
+
+impl MemWriteReq {
+    pub fn execute(uart: &dyn Uart, start_address: u32, data: &[u8]) -> Result<()> {
+        let bytes_to_write = data.len();
+        let mut bytes_written = 0_usize;
+        while bytes_written < bytes_to_write {
+            TestCommand::MemWrite.send(uart)?;
+            let mut op = MemWriteReq {
+                address: start_address + (bytes_written as u32),
+                data_len: 0,
+                data: ArrayVec::new(),
+            };
+            let op_size = std::cmp::min(bytes_to_write - bytes_written, op.data.capacity());
+            op.data
+                .try_extend_from_slice(&data[bytes_written..(bytes_written + op_size)])?;
+            op.data_len = op_size.try_into().unwrap();
+            op.send(uart)?;
+            let _ = Status::recv(uart, Duration::from_secs(300), false)?;
+            bytes_written += op_size;
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/mod.rs
@@ -13,6 +13,7 @@ pub mod init;
 pub mod lc_transition;
 pub mod load_bitstream;
 pub mod load_sram_program;
+pub mod mem;
 pub mod otp_ctrl;
 // The "english breakfast" variant of the chip doesn't have the same
 // set of IO and pinmux constants as the "earlgrey" chip.

--- a/sw/host/tests/chip/mem/BUILD
+++ b/sw/host/tests/chip/mem/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "mem",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/mem/src/main.rs
+++ b/sw/host/tests/chip/mem/src/main.rs
@@ -1,0 +1,117 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use object::{Object, ObjectSymbol};
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::mem::{MemRead32Req, MemReadReq, MemWrite32Req, MemWriteReq};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+}
+
+fn test_mem_word_commands(
+    _opts: &Opts,
+    test_word_address: u32,
+    transport: &TransportWrapper,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let read_value = MemRead32Req::execute(&*uart, test_word_address)?;
+    assert!(read_value == 0xface1234_u32);
+
+    let expected_value = 0x12345678_u32;
+    MemWrite32Req::execute(&*uart, test_word_address, expected_value)?;
+    let read_value = MemRead32Req::execute(&*uart, test_word_address)?;
+    assert!(read_value == expected_value);
+    Ok(())
+}
+
+fn test_mem_array_commands(
+    _opts: &Opts,
+    test_bytes_address: u32,
+    transport: &TransportWrapper,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let mut data: [u8; 256] = [0; 256];
+    MemReadReq::execute(&*uart, test_bytes_address, data.as_mut_slice())?;
+    let mut expected_value = Vec::<u8>::from_iter(0..=255);
+    assert!(data.as_slice() == expected_value.as_slice());
+
+    data.reverse();
+    expected_value.reverse();
+    MemWriteReq::execute(&*uart, test_bytes_address, expected_value.as_slice())?;
+    MemReadReq::execute(&*uart, test_bytes_address, data.as_mut_slice())?;
+    assert!(data.as_slice() == expected_value.as_slice());
+    Ok(())
+}
+
+fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
+    assert!(end_test_value == 0);
+    MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;
+    let _ = UartConsole::wait_for(&*uart, r"PASS![^\r\n]*", opts.timeout)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let elf_file = object::File::parse(&*elf_binary)?;
+    let mut symbols = HashMap::<String, u32>::new();
+    for sym in elf_file.symbols() {
+        symbols.insert(sym.name()?.to_owned(), sym.address() as u32);
+    }
+    let end_test_address = symbols
+        .get("kEndTest")
+        .expect("Provided ELF missing 'kEndTest' symbol");
+    let test_word_address = symbols
+        .get("kTestWord")
+        .expect("Provided ELF missing 'kTestWord' symbol");
+    let test_bytes_address = symbols
+        .get("kTestBytes")
+        .expect("Provided ELF missing 'kTestBytes' symbol");
+
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let _ = uart.clear_rx_buffer();
+
+    execute_test!(
+        test_mem_word_commands,
+        &opts,
+        *test_word_address,
+        &transport
+    );
+    execute_test!(
+        test_mem_array_commands,
+        &opts,
+        *test_bytes_address,
+        &transport
+    );
+    execute_test!(test_end, &opts, *end_test_address, &transport);
+    Ok(())
+}


### PR DESCRIPTION
Add memory utility commands for general use. These can be used to peek
and poke the system for debug and/or to replace back door accesses in DV
with frontdoor accesses on silicon.

Add a test that peeks and pokes selected variables on the device side
(using the new ujson commands). In the test, find the addresses of the
variables by looking them up in the ELF.

In a future PR, these could be integrated into OTTF, possibly allowing for dropping into a debugger / inspection mode after returning from `test_main()`.