### PR TITLE
[chip,sival,flash_ctrl] fix fpga test

### DIFF
--- a/sw/device/lib/dif/dif_flash_ctrl.c
+++ b/sw/device/lib/dif/dif_flash_ctrl.c
@@ -264,6 +264,8 @@ dif_result_t dif_flash_ctrl_get_status(const dif_flash_ctrl_state_t *handle,
           bitfield_bit32_read(reg, FLASH_CTRL_STATUS_PROG_EMPTY_BIT),
       .controller_init_wip =
           bitfield_bit32_read(reg, FLASH_CTRL_STATUS_INIT_WIP_BIT),
+      .controller_initialized =
+          bitfield_bit32_read(reg, FLASH_CTRL_STATUS_INITIALIZED_BIT),
   };
   *status_out = status;
   return kDifOk;

--- a/sw/device/lib/dif/dif_flash_ctrl.h
+++ b/sw/device/lib/dif/dif_flash_ctrl.h
@@ -169,6 +169,10 @@ typedef struct dif_flash_ctrl_status {
    * Flash controller undergoing init.
    */
   bool controller_init_wip : 1;
+  /**
+   * Flash controller initialized.
+   */
+  bool controller_initialized : 1;
 } dif_flash_ctrl_status_t;
 
 /**

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1002,10 +1002,11 @@ opentitan_test(
     name = "flash_ctrl_ops_test",
     srcs = ["flash_ctrl_ops_test.c"],
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-    cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    verilator = new_verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:rv_plic",


### PR DESCRIPTION
Current bootstrap set default region property from programmed otp value
[as in here](https://github.com/lowRISC/opentitan/blob/2f58b40b9ce2f44b8e1f65cf87043eff97b0ad6c/sw/device/silicon_creator/lib/drivers/flash_ctrl.c#L270-L275)
Adjust region parameter accordingly to match current flash contents wrriten by bootstrap.