### PR TITLE
[top_level,tests] Fix chip_sw_alert_handler_lpg_sleep_mode_alerts config

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1245,7 +1245,7 @@
      {
       name: chip_sw_alert_handler_lpg_sleep_mode_alerts
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:1:new_rules"]
+      sw_images: ["//sw/device/tests/sim_dv:alert_handler_lpg_sleep_mode_alerts_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_scb=0",
                  "+sw_test_timeout_ns=3000_000_000",


### PR DESCRIPTION
The sw_image used in this test is under the sim_dv subdirectory.