### PR TITLE
[sca, aes] Add commands for alternative batch capture mode

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -30,6 +30,8 @@
  *   - FvsR batch fixed key set ('f')*,
  *   - FvsR batch generate ('g')*,
  *   - FvsR batch encrypt and generate ('e')*,
+ *   - Batch encrypt alternative routine ('a')*,
+ *   - Batch encrypt alternative routine, initial plaintext input ('i')*.
  * Commands marked with * are implemented in this file. Those marked with + are
  * implemented in the simple serial library. Encryption is done in AES-ECB-128
  * mode. See https://wiki.newae.com/SimpleSerial for details on the protocol.
@@ -88,6 +90,11 @@ bool sample_fixed = true;
  * Fixed key for fvsr key TVLA batch capture.
  */
 uint8_t key_fixed[kAesKeyLength];
+
+/**
+ * batch_plaintext for batch capture to initially set it using command.
+ */
+uint8_t batch_plaintext[kAesTextLength];
 
 /**
  * Block counter variable for manually handling reseeding operations of the
@@ -293,6 +300,89 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
 }
 
 /**
+ * Simple serial 'a' (alternative batch encrypt) command handler.
+ *
+ * This command is designed to maximize the capture rate for side-channel
+ * attacks. It uses the first supplied plaintext and repeats AES encryptions
+ * by using every ciphertext as next plaintext with a constant key. This
+ * minimizes the overhead of UART communication and significantly improves the
+ * capture rate.
+
+ * Packet payload must be a `uint32_t` representation of the number of
+ * encryptions to perform. Since generated plaintexts are not cached, there is
+ * no limit on the number of encryptions.
+ *
+ * The key should also be set using 'k' (key set) command.
+ *
+ * The host can verify the operation by checking the last 'r' (ciphertext)
+ * packet that is sent at the end.
+ *
+ * @param data Packet payload.
+ * @param data_len Packet payload length.
+ */
+static void aes_serial_batch_alternative_encrypt(const uint8_t *data,
+                                                 size_t data_len) {
+  // Get num_encryptions from input
+  uint32_t num_encryptions = 0;
+  SS_CHECK(data_len == sizeof(num_encryptions));
+  num_encryptions = read_32(data);
+
+  // Add to current block_ctr to check if > kBlockCtrMax
+  block_ctr += num_encryptions;
+  // Rewrite the key to reset the internal block counter. Otherwise, the AES
+  // peripheral might trigger the reseeding of the internal masking PRNG which
+  // disturbs SCA measurements.
+  if (block_ctr > kBlockCtrMax) {
+    aes_key_mask_and_config(key_fixed, kAesKeyLength);
+    block_ctr = num_encryptions;
+  }
+
+  // First plaintext has been set through command into batch_plaintext
+
+  // Set trigger high outside of loop
+  // On FPGA, the trigger is AND-ed with AES !IDLE and creates a LO-HI-LO per
+  // AES operation
+  sca_set_trigger_high();
+  dif_aes_data_t ciphertext;
+  for (uint32_t i = 0; i < num_encryptions; ++i) {
+    // Encrypt
+    aes_encrypt(batch_plaintext, kAesTextLength);
+
+    // Get ciphertext
+    bool ready = false;
+    do {
+      SS_CHECK_DIF_OK(
+          dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready));
+    } while (!ready);
+    SS_CHECK_DIF_OK(dif_aes_read_output(&aes, &ciphertext));
+
+    // Use ciphertext as next plaintext (incl. next call to this function)
+    memcpy(batch_plaintext, ciphertext.data, kAesTextLength);
+  }
+  sca_set_trigger_low();
+
+  // send last ciphertext
+  simple_serial_send_packet('r', (uint8_t *)ciphertext.data, kAesTextLength);
+}
+
+/**
+ * Simple serial 'i' (batch plaintext) command handler.
+ *
+ * This command is designed to set the initial plaintext for
+ * aes_serial_batch_alternative_encrypt.
+ *
+ * The plaintext must be `kAesTextLength` bytes long.
+ *
+ * @param plaintext.
+ * @param len.
+ */
+static void aes_serial_batch_plaintext_set(const uint8_t *plaintext,
+                                           size_t len) {
+  SS_CHECK(len == kAesTextLength);
+  memcpy(batch_plaintext, plaintext, len);
+}
+
+/**
  * Simple serial 'f' (fvsr key set) command handler.
  *
  * This command is designed to set the fixed key which is used for fvsr key TVLA
@@ -414,12 +504,21 @@ static void aes_serial_fvsr_key_batch_encrypt(const uint8_t *data,
  * Simple serial 'l' (seed lfsr) command handler.
  *
  * This function only supports 4-byte seeds.
+ * Enables/disables masking depending on seed value, i.e. 0 for disable.
  *
  * @param seed A buffer holding the seed.
  */
 static void aes_serial_seed_lfsr(const uint8_t *seed, size_t seed_len) {
   SS_CHECK(seed_len == sizeof(uint32_t));
-  sca_seed_lfsr(read_32(seed));
+  uint32_t seed_local = read_32(seed);
+  if (seed_local == 0) {
+    // disable masking
+    transaction.force_masks = true;
+  } else {
+    // enable masking
+    transaction.force_masks = false;
+  }
+  sca_seed_lfsr(seed_local);
 }
 
 /**
@@ -451,6 +550,8 @@ bool test_main(void) {
   simple_serial_register_handler('g', aes_serial_fvsr_key_batch_generate);
   simple_serial_register_handler('e', aes_serial_fvsr_key_batch_encrypt);
   simple_serial_register_handler('l', aes_serial_seed_lfsr);
+  simple_serial_register_handler('a', aes_serial_batch_alternative_encrypt);
+  simple_serial_register_handler('i', aes_serial_batch_plaintext_set);
 
   LOG_INFO("Initializing AES unit.");
   init_aes();


### PR DESCRIPTION
Added two commands to support WaveRunner batch capture (see ot-sca PR [194](https://github.com/lowRISC/ot-sca/pull/194)).
Also added mask-off switch to seed_lfsr command (masks off if '0'). Note this is only available on FPGA.

The binary has been generated from:
https://github.com/vogelpi/opentitan/tree/ot-sca_2023-07-15_dd8b709_cw310