### PR TITLE
[rv_plic,sival] Add sival testplan entries for rv_plic

### DIFF
--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -97,6 +97,17 @@
     }
   ]
 
+  features: [
+    { name: "RV_PLIC.PRIORITY",
+      desc: '''Each interrupt source can be given a configurable priority.'''
+    }
+    { name: "RV_PLIC.ENABLE",
+      desc: '''Each target has an associated set of interrupt enable bits. Configuring these
+               controls whether a target will be notified when the interrupt is triggered.
+            '''
+    }
+  ]
+
   regwidth: "32",
   registers: [
 % for i in range(src):

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -37,6 +37,7 @@
     "hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson",
@@ -319,43 +320,6 @@
             '''
       stage: V2
       tests: ["chip_sw_data_integrity_escalation"]
-    }
-
-    // PLIC integration tests:
-    {
-      name: chip_sw_plic_all_irqs
-      desc: '''Verify all interrupts from all peripherals aggregated at the PLIC.
-
-            The automated SW test enables all interrupts at the PLIC to interrupt the core. It uses
-            the `intr_test` CSR in each peripheral to mock assert an interrupt, looping through all
-            available interrupts in that peripheral. The ISR verifies that the right interrupt
-            occurred. This is used as a catch-all interrupt test for all peripheral integration
-            testing within which functionally asserting an interrupt is hard to achieve or not of
-            high value.
-            '''
-      stage: V2
-      tests: ["chip_plic_all_irqs"]
-    }
-    {
-      name: chip_sw_plic_sw_irq
-      desc: '''Verify the SW interrupt to the CPU.
-
-            Enable all peripheral interrupts at PLIC. Enable all types of interrupt at the CPU core.
-            Write to the MSIP CSR to generate a SW interrupt to the CPU. Verify that the only
-            interrupt that is seen is the SW interrupt.
-            '''
-      stage: V2
-      tests: ["chip_sw_plic_sw_irq"]
-    }
-    {
-      name: chip_sw_plic_alerts
-      desc: '''Verify alerts from PLIC due to both, TL intg and reg WE onehot check faults.
-
-            - Since PLIC is not pre-verified in a DV environment, we need to ensure these are tested
-              separately.
-            '''
-      stage: V3
-      tests: ["chip_sw_all_escalation_resets"]
     }
 
     // SYSRST_CTRL (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: rv_plic
+  testpoints: [
+    // PLIC integration tests:
+    {
+      name: chip_sw_plic_all_irqs
+      desc: '''Verify all interrupts from all peripherals aggregated at the PLIC.
+
+            The automated SW test enables all interrupts at the PLIC to interrupt the core. It uses
+            the `intr_test` CSR in each peripheral to mock assert an interrupt, looping through all
+            available interrupts in that peripheral. The ISR verifies that the right interrupt
+            occurred. This is used as a catch-all interrupt test for all peripheral integration
+            testing within which functionally asserting an interrupt is hard to achieve or not of
+            high value.
+            '''
+      stage: V2
+      tests: ["chip_plic_all_irqs"]
+    }
+    {
+      name: chip_sw_plic_sw_irq
+      desc: '''Verify the SW interrupt to the CPU.
+
+            Enable all peripheral interrupts at PLIC. Enable all types of interrupt at the CPU core.
+            Write to the MSIP CSR to generate a SW interrupt to the CPU. Verify that the only
+            interrupt that is seen is the SW interrupt.
+            '''
+      stage: V2
+      tests: ["chip_sw_plic_sw_irq"]
+    }
+    {
+      name: chip_sw_plic_alerts
+      desc: '''Verify alerts from PLIC due to both, TL intg and reg WE onehot check faults.
+
+            - Since PLIC is not pre-verified in a DV environment, we need to ensure these are tested
+              separately.
+            '''
+      stage: V3
+      tests: ["chip_sw_all_escalation_resets"]
+    }
+  ]
+}

--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -17,6 +17,8 @@
             high value.
             '''
       stage: V2
+      si_stage: SV2
+      features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: ["chip_plic_all_irqs"]
     }
     {
@@ -28,6 +30,8 @@
             interrupt that is seen is the SW interrupt.
             '''
       stage: V2
+      si_stage: SV3
+      features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: ["chip_sw_plic_sw_irq"]
     }
     {
@@ -38,6 +42,7 @@
               separately.
             '''
       stage: V3
+      si_stage: None
       tests: ["chip_sw_all_escalation_resets"]
     }
   ]

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -96,6 +96,17 @@
     }
   ]
 
+  features: [
+    { name: "RV_PLIC.PRIORITY",
+      desc: '''Each interrupt source can be given a configurable priority.'''
+    }
+    { name: "RV_PLIC.ENABLE",
+      desc: '''Each target has an associated set of interrupt enable bits. Configuring these
+               controls whether a target will be notified when the interrupt is triggered.
+            '''
+    }
+  ]
+
   regwidth: "32",
   registers: [
     { name: "PRIO0",


### PR DESCRIPTION
There's nothing very exciting here: the main change is moving the entries out of chip_testplan.hjson.

This is equivalent to #19790, but I've split the changes into separate commits, which should make things a bit easier to review.