### PR TITLE
[Sival, i2c] Nak detection

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -137,6 +137,7 @@
       stage: V3
       si_stage: SV2
       tests: []
+      bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test_cw310_test_rom"]
     }
     {
       name: chip_sw_i2c_repeatedstart

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -192,6 +192,7 @@ cc_library(
         "//sw/device/lib/dif:i2c",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -203,6 +203,7 @@ status_t i2c_testutils_fifo_empty(const dif_i2c_t *i2c) {
 
 status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
                             uint8_t byte_count, uint8_t *data, size_t timeout) {
+  uint32_t nak_count = 0;
   ibex_timeout_t timer = ibex_timeout_init(timeout);
 
   // Make sure to start from a clean state.
@@ -210,6 +211,7 @@ status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
   TRY(dif_i2c_reset_rx_fifo(i2c));
   // Loop until we get an ACK from the device or a timeout.
   while (TRY(i2c_testutils_issue_read(i2c, addr, byte_count)) == true) {
+    nak_count++;
     if (ibex_timeout_check(&timer)) {
       return DEADLINE_EXCEEDED();
     }
@@ -220,7 +222,7 @@ status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
     TRY(dif_i2c_read_byte(i2c, data++));
   }
 
-  return OK_STATUS();
+  return OK_STATUS((int32_t)nak_count);
 }
 
 status_t i2c_testutils_target_check_start(const dif_i2c_t *i2c, uint8_t *addr) {

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -331,6 +331,18 @@ status_t i2c_testutils_select_pinmux(const dif_pinmux_t *pinmux, uint8_t i2c_id,
   return OK_STATUS();
 }
 
+status_t i2c_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
+                                     uint8_t i2c_id) {
+  // Configure sda pin.
+  TRY(dif_pinmux_input_select(pinmux, kI2cPinmuxPins[i2c_id].sda.peripheral_in,
+                              kTopEarlgreyPinmuxInselConstantZero));
+
+  // Configure scl pin.
+  TRY(dif_pinmux_input_select(pinmux, kI2cPinmuxPins[i2c_id].scl.peripheral_in,
+                              kTopEarlgreyPinmuxInselConstantZero));
+  return OK_STATUS();
+}
+
 status_t i2c_testutils_set_speed(const dif_i2c_t *i2c, dif_i2c_speed_t speed) {
   uint32_t speed_khz = 0;
   switch (speed) {

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -172,7 +172,9 @@ status_t i2c_testutils_fifo_empty(const dif_i2c_t *i2c);
  * @param byte_count The number of bytes to be read.
  * @param[out] data Buffer to receive the fifo data.
  * @param timeout Timeout in microseconds.
- * @return The result of the operation.
+ * @return Return an error code if fails to read, otherwise `kOk(nak_count)`,
+ * where `nak_count` is the number of NAKs received or attempts needed before
+ * the success`.
  */
 OT_WARN_UNUSED_RESULT
 status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -145,6 +145,16 @@ status_t i2c_testutils_select_pinmux(const dif_pinmux_t *pinmux,
                                      i2c_pinmux_platform_id_t platform);
 
 /**
+ * Disconnect the i2c input pins from mio pads and wire it to zero.
+ *
+ * @param pimmux A pinmux handler.
+ * @param i2c_id The i2c instance identifier.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t i2c_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
+                                     uint8_t i2c_id);
+/**
  * Return whether the fifo is empty.
  *
  * @param i2c An I2C DIF handle.

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -108,7 +108,7 @@ status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint8_t byte_count);
  * @param i2c A I2C DIF handle.
  * @param byte_count The number of bytes to be written.
  * @param[out] addr Address that received the I2C write.
- * @param[out] bytes Array of bytes to store the result of the write.
+ * @param[out] bytes Array of bytes to stores the result of the write.
  * @param[out] cont_byte Received continuation byte. Can be null if test expects
  *                       STOP signal.
  * @return kOk(dir) Where dir indicates that repeated START has signaled that

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -121,15 +121,28 @@ status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
                                           uint8_t *bytes, uint8_t *cont_byte);
 
 /**
- * Initialize the pinmux.
+ * Define the available platforms which i2c is mapped
+ */
+typedef enum i2c_pinmux_platform_id {
+  I2cPinmuxPlatformIdHyper310 = 0,
+  I2cPinmuxPlatformIdDvsim,
+  I2cPinmuxPlatformIdCw310Pmod,
+  I2cPinmuxPlatformIdCount,
+} i2c_pinmux_platform_id_t;
+
+/**
+ * Connect the i2c pins to mio pins via pinmux based on the platform the test is
+ * running.
  *
  * @param pimmux A pinmux handler.
- * @param kI2cIdx The i2c identifier.
+ * @param kI2cIdx The i2c instance identifier.
+ * @param platform The platform which the test is running.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 status_t i2c_testutils_select_pinmux(const dif_pinmux_t *pinmux,
-                                     uint8_t kI2cIdx);
+                                     uint8_t kI2cIdx,
+                                     i2c_pinmux_platform_id_t platform);
 
 /**
  * Return whether the fifo is empty.

--- a/sw/device/lib/testing/pinmux_testutils.h
+++ b/sw/device/lib/testing/pinmux_testutils.h
@@ -14,6 +14,22 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 /**
+ * Define a pinmux configuration for a peripheral input and output .
+ */
+typedef struct pinmux_testutils_peripheral_pin {
+  const top_earlgrey_pinmux_peripheral_in_t peripheral_in;
+  const top_earlgrey_pinmux_outsel_t outsel;
+} pinmux_testutils_peripheral_pin_t;
+
+/**
+ * Define a pinmux configuration for a mio input and output.
+ */
+typedef struct pinmux_testutils_mio_pin {
+  const top_earlgrey_pinmux_mio_out_t mio_out;
+  const top_earlgrey_pinmux_insel_t insel;
+} pinmux_testutils_mio_pin_t;
+
+/**
  * Default pinmux initialization.
  *
  * Initializes GPIOs to map to the lowest-numbered MIOs, except where it

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -272,7 +272,7 @@ static status_t test_init(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 0));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 0, I2cPinmuxPlatformIdHyper310));
 
   TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard));
   TRY(dif_i2c_device_set_enabled(&i2c, kDifToggleEnabled));

--- a/sw/device/tests/pmod/i2c_host_accelerometer_test.c
+++ b/sw/device/tests/pmod/i2c_host_accelerometer_test.c
@@ -129,7 +129,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_ambient_light_detector_test.c
+++ b/sw/device/tests/pmod/i2c_host_ambient_light_detector_test.c
@@ -138,7 +138,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
@@ -223,7 +223,7 @@ static status_t test_init(void) {
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);

--- a/sw/device/tests/pmod/i2c_host_compass_test.c
+++ b/sw/device/tests/pmod/i2c_host_compass_test.c
@@ -107,7 +107,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_eeprom_test.c
+++ b/sw/device/tests/pmod/i2c_host_eeprom_test.c
@@ -123,7 +123,7 @@ static status_t i2c_configure(dif_i2c_t *i2c, dif_pinmux_t *pinmux,
   base_addr = mmio_region_from_addr(i2c_base_addr);
   TRY(dif_i2c_init(base_addr, i2c));
 
-  TRY(i2c_testutils_select_pinmux(pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_eeprom_test.c
+++ b/sw/device/tests/pmod/i2c_host_eeprom_test.c
@@ -33,18 +33,16 @@ enum {
   kAckPollTimeoutMicros = 80000,
 };
 
-static dif_rv_core_ibex_t rv_core_ibex;
-static dif_pinmux_t pinmux;
-static dif_i2c_t i2c;
-
-static status_t write_byte(const uint8_t addr[2], uint8_t byte) {
+static status_t write_byte(dif_i2c_t *i2c, const uint8_t addr[2],
+                           uint8_t byte) {
   uint8_t data[3] = {addr[0], addr[1], byte};
-  return i2c_testutils_write(&i2c, kDeviceAddr, sizeof(data), data, false);
+  return i2c_testutils_write(i2c, kDeviceAddr, sizeof(data), data, false);
 }
 
-static status_t read_byte(const uint8_t addr[2], uint8_t *byte) {
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, 2, addr, true));
-  return i2c_testutils_read(&i2c, kDeviceAddr, 1, byte, kDefaultTimeoutMicros);
+static status_t read_byte(dif_i2c_t *i2c, const uint8_t addr[2],
+                          uint8_t *byte) {
+  TRY(i2c_testutils_write(i2c, kDeviceAddr, 2, addr, true));
+  return i2c_testutils_read(i2c, kDeviceAddr, 1, byte, kDefaultTimeoutMicros);
 }
 
 /**
@@ -54,30 +52,30 @@ static status_t read_byte(const uint8_t addr[2], uint8_t *byte) {
  * microsecond timeout. The EEPROM device will not acknowledge the device
  * address until it is finished writing.
  */
-static status_t poll_while_busy(void) {
-  return i2c_testutils_read(&i2c, kDeviceAddr, 0, NULL, kAckPollTimeoutMicros);
+static status_t poll_while_busy(dif_i2c_t *i2c) {
+  return i2c_testutils_read(i2c, kDeviceAddr, 0, NULL, kAckPollTimeoutMicros);
 }
 
-static status_t write_read_random(void) {
+static status_t write_read_random(dif_i2c_t *i2c) {
   // Write a byte to some random address.
   const uint8_t kAddr[2] = {0x03, 0x21};
-  TRY(write_byte(kAddr, 0xAB));
+  TRY(write_byte(i2c, kAddr, 0xAB));
 
   // Wait for the write to finish.
-  TRY(poll_while_busy());
+  TRY(poll_while_busy(i2c));
 
   // Read back the data at that address.
   uint8_t read_data = 0x00;
-  TRY(read_byte(kAddr, &read_data));
+  TRY(read_byte(i2c, kAddr, &read_data));
 
   // Check the written byte matches what we wrote.
   TRY_CHECK(read_data == 0xAB, "Unexpected value: 0x%02x", read_data);
 
   // Erase the value we just wrote to prevent the success state persisting to
   // subsequent runs of the test.
-  TRY(write_byte(kAddr, 0xFF));
-  TRY(poll_while_busy());
-  TRY(read_byte(kAddr, &read_data));
+  TRY(write_byte(i2c, kAddr, 0xFF));
+  TRY(poll_while_busy(i2c));
+  TRY(read_byte(i2c, kAddr, &read_data));
 
   // Check the over-written byte matches the new value.
   TRY_CHECK(read_data == 0xFF, "Unexpected value: 0x%02x", read_data);
@@ -85,19 +83,19 @@ static status_t write_read_random(void) {
   return OK_STATUS();
 }
 
-static status_t write_read_page(void) {
+static status_t write_read_page(dif_i2c_t *i2c) {
   // Write multiple bytes to the 9th page (of 64 bytes each).
   const uint8_t kAddr[2] = {0x02, 0x01};
   uint8_t data[5] = {kAddr[0], kAddr[1], 0xAB, 0xCD, 0xEF};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(data), data, false));
+  TRY(i2c_testutils_write(i2c, kDeviceAddr, sizeof(data), data, false));
 
   // Wait for the write to finish.
-  TRY(poll_while_busy());
+  TRY(poll_while_busy(i2c));
 
   // Read back the data at that address.
   uint8_t read_data[3] = {0x00, 0x00, 0x00};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(kAddr), kAddr, true));
-  TRY(i2c_testutils_read(&i2c, kDeviceAddr, sizeof(read_data), read_data,
+  TRY(i2c_testutils_write(i2c, kDeviceAddr, sizeof(kAddr), kAddr, true));
+  TRY(i2c_testutils_read(i2c, kDeviceAddr, sizeof(read_data), read_data,
                          kDefaultTimeoutMicros));
 
   // Check the written bytes match what we wrote.
@@ -106,10 +104,10 @@ static status_t write_read_page(void) {
   // Erase the values we just wrote to prevent the success state persisting to
   // subsequent runs of the test.
   data[2] = data[3] = data[4] = 0xFF;
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(data), data, false));
-  TRY(poll_while_busy());
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, sizeof(kAddr), kAddr, true));
-  TRY(i2c_testutils_read(&i2c, kDeviceAddr, sizeof(read_data), read_data,
+  TRY(i2c_testutils_write(i2c, kDeviceAddr, sizeof(data), data, false));
+  TRY(poll_while_busy(i2c));
+  TRY(i2c_testutils_write(i2c, kDeviceAddr, sizeof(kAddr), kAddr, true));
+  TRY(i2c_testutils_read(i2c, kDeviceAddr, sizeof(read_data), read_data,
                          kDefaultTimeoutMicros));
 
   // Check the over-written bytes match the new erased value.
@@ -118,37 +116,37 @@ static status_t write_read_page(void) {
   return OK_STATUS();
 }
 
-static status_t test_init(void) {
-  mmio_region_t base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
+static status_t i2c_configure(dif_i2c_t *i2c, dif_pinmux_t *pinmux,
+                          uintptr_t i2c_base_addr) {
+  mmio_region_t base_addr;
 
-  TRY(dif_rv_core_ibex_init(base_addr, &rv_core_ibex));
+  base_addr = mmio_region_from_addr(i2c_base_addr);
+  TRY(dif_i2c_init(base_addr, i2c));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_I2C2_BASE_ADDR);
-  TRY(dif_i2c_init(base_addr, &i2c));
+  TRY(i2c_testutils_select_pinmux(pinmux, 2));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
-  TRY(dif_pinmux_init(base_addr, &pinmux));
-
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
-
-  TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
+  TRY(dif_i2c_host_set_enabled(i2c, kDifToggleEnabled));
 
   return OK_STATUS();
 }
 
 bool test_main(void) {
-  status_t test_result;
-  CHECK_STATUS_OK(test_init());
+  dif_pinmux_t pinmux;
+  dif_i2c_t i2c;
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+
+  CHECK_STATUS_OK(i2c_configure(&i2c, &pinmux, TOP_EARLGREY_I2C2_BASE_ADDR));
 
   dif_i2c_speed_t speeds[] = {kDifI2cSpeedStandard, kDifI2cSpeedFast,
                               kDifI2cSpeedFastPlus};
 
-  test_result = OK_STATUS();
+  status_t test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(speeds); ++i) {
     CHECK_STATUS_OK(i2c_testutils_set_speed(&i2c, speeds[i]));
-    EXECUTE_TEST(test_result, write_read_random);
-    EXECUTE_TEST(test_result, write_read_page);
+    EXECUTE_TEST(test_result, write_read_random, &i2c);
+    EXECUTE_TEST(test_result, write_read_page, &i2c);
   }
 
   return status_ok(test_result);

--- a/sw/device/tests/pmod/i2c_host_fram_test.c
+++ b/sw/device/tests/pmod/i2c_host_fram_test.c
@@ -143,7 +143,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_gas_sensor_test.c
+++ b/sw/device/tests/pmod/i2c_host_gas_sensor_test.c
@@ -129,7 +129,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_hdc1080_humidity_temp_test.c
+++ b/sw/device/tests/pmod/i2c_host_hdc1080_humidity_temp_test.c
@@ -111,7 +111,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_irq_test.c
+++ b/sw/device/tests/pmod/i2c_host_irq_test.c
@@ -283,7 +283,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
 

--- a/sw/device/tests/pmod/i2c_host_power_monitor_test.c
+++ b/sw/device/tests/pmod/i2c_host_power_monitor_test.c
@@ -152,7 +152,7 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   TRY(dif_pinmux_init(base_addr, &pinmux));
 
-  TRY(i2c_testutils_select_pinmux(&pinmux, 2));
+  TRY(i2c_testutils_select_pinmux(&pinmux, 2, I2cPinmuxPlatformIdCw310Pmod));
 
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   // Enable the external IRQ at Ibex.

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -168,7 +168,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
 
-  CHECK_STATUS_OK(i2c_testutils_select_pinmux(&pinmux, kI2cIdx));
+  CHECK_STATUS_OK(i2c_testutils_select_pinmux(&pinmux, kI2cIdx, kI2cIdx));
 
   // Enable functional interrupts as well as error interrupts to make sure
   // everything is behaving as expected.


### PR DESCRIPTION
The existing test `i2c_host_eeprom_test` already cover the NAK detection test. Therefore, this PR refactor the `i2c_host_eeprom_test` to run with multiple instances of i2c for full compliance with the test description.

Fix https://github.com/lowRISC/opentitan/issues/19839