### PR TITLE
[bazel] Refactor `_test_dispatch` functions

### DIFF
--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -31,6 +31,18 @@ ALL_BINARY_PROVIDERS = [
     SimVerilatorBinaryInfo,
 ]
 
+PROVIDER_FIELDS = [
+    "elf",
+    "binary",
+    "default",
+    "rom",
+    "signed_bin",
+    "disassembly",
+    "logs",
+    "mapfile",
+    "vmem",
+]
+
 def get_binary_files(attrs, field = "binary", providers = ALL_BINARY_PROVIDERS):
     """Get the list of binary files associated with a list of labels.
 

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "SimVerilatorBinaryInfo", "get_one_binary_file")
-load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "SimVerilatorBinaryInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback")
 load(
     "//rules/opentitan:exec_env.bzl",
     "ExecEnvInfo",
+    "common_test_setup",
     "exec_env_as_dict",
     "exec_env_common_attrs",
 )
@@ -96,61 +97,20 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "rom32": rom32,
     }
 
-def _test_dispatch(ctx, exec_env, provider):
+def _test_dispatch(ctx, exec_env, firmware):
     """Dispatch a test for the sim_verilator environment.
 
     Args:
       ctx: The rule context.
       exec_env: The ExecEnvInfo for this environment.
-      provider: A label with a SimVerilatorBinaryInfo provider attached.
+      firmware: A label with a SimVerilatorBinaryInfo provider attached.
     Returns:
       (File, List[File]) The test script and needed runfiles.
     """
     if ctx.attr.kind == "ram":
         fail("verilator is not capable of executing RAM tests")
 
-    # If there is no explicitly specified test_harness, then the harness is opentitantool.
-    test_harness = ctx.executable.test_harness
-    if test_harness == None:
-        test_harness = exec_env._opentitantool
-
-    # Get the files we'll need to run the test.
-    otp = get_fallback(ctx, "file.otp", exec_env)
-    rom = get_fallback(ctx, "attr.rom", exec_env)
-    data_labels = ctx.attr.data + exec_env.data
-    data_files = get_files(data_labels)
-    if rom:
-        rom = get_one_binary_file(rom, field = "rom", providers = [exec_env.provider])
-        data_files.append(rom)
-    if otp:
-        data_files.append(otp)
-    data_files.append(test_harness)
-    if ctx.attr.kind == "rom" and provider:
-        # For a ROM test, the default test binary is the item to load into ROM.
-        rom = provider.default
-
-    # Construct a param dictionary by combining the exec_env.param, the rule's
-    # param and and some extra file references.
-    param = dict(exec_env.param)
-    param.update(ctx.attr.param)
-
-    for attr, name in ctx.attr.binaries.items():
-        file = get_one_binary_file(attr, field = "default", providers = [exec_env.provider])
-        data_files.append(file)
-        if name in param:
-            fail("The binaries substitution name", name, "already exists")
-        param[name] = file.short_path
-
-    if rom and "rom" not in param:
-        param["rom"] = rom.short_path
-    if otp and "otp" not in param:
-        param["otp"] = otp.short_path
-    if provider:
-        data_files.append(provider.default)
-        if "firmware" not in param:
-            param["firmware"] = provider.default.short_path
-        else:
-            fail("This test builds firmware, but the firmware param has already been provided")
+    test_harness, data_labels, data_files, param, action_param = common_test_setup(ctx, exec_env, firmware)
 
     # Perform all relevant substitutions on the test_cmd.
     test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)


### PR DESCRIPTION
1. Refactor the `_test_dispatch` functions into common code.
2. Create `param` dictionary entries for all files carried by the binary info providers.  This allows a test to pass specific resources built by a binary rule to the test command.  The "default" field is added to the param dictionary without adornments whereas all of the other fields are added to the dictionary with as `name:fieldname` (e.g. `firmware:elf`).

Partially addresses #19908