### PR TITLE
[rom_ext_e2e] Implement the boot positions tests

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -10,19 +10,54 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-opentitan_test(
-    name = "boot_test",
-    srcs = ["boot_test.c"],
-    cw310 = cw310_params(
-        bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
-    ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+_POSITIONS = {
+    "slot_a": {
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "offset": "0x10000",
     },
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib:boot_log",
-        "//sw/device/silicon_creator/lib/drivers:retention_sram",
-    ],
+    "slot_b": {
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "offset": "0x90000",
+    },
+    "virtual_a": {
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        "manifest": "//sw/device/silicon_owner:manifest_virtual",
+        "offset": "0x10000",
+    },
+    "virtual_b": {
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        "manifest": "//sw/device/silicon_owner:manifest_virtual",
+        "offset": "0x90000",
+    },
+}
+
+[
+    opentitan_test(
+        name = "position_{}".format(name),
+        srcs = ["boot_test.c"],
+        cw310 = cw310_params(
+            assemble = "{rom_ext}@0 {firmware}@{offset}",
+            bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
+            offset = position["offset"],
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        },
+        linker_script = position["linker_script"],
+        manifest = position["manifest"],
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        ],
+    )
+    for name, position in _POSITIONS.items()
+]
+
+test_suite(
+    name = "positions",
+    tests = ["position_{}".format(name) for name in _POSITIONS],
 )

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -179,8 +179,7 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
     case kHardenedBoolTrue:
       HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
       ibex_addr_remap_1_set((uintptr_t)_owner_virtual_start_address,
-                            (uintptr_t)TOP_EARLGREY_EFLASH_BASE_ADDR,
-                            (size_t)_owner_virtual_size);
+                            (uintptr_t)manifest, (size_t)_owner_virtual_size);
       SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
 
       // Unlock read-only for the whole rom_ext virtual memory.

--- a/sw/device/silicon_owner/BUILD
+++ b/sw/device/silicon_owner/BUILD
@@ -13,3 +13,10 @@ manifest({
     "identifier": hex(CONST.OWNER),
     "visibility": ["//visibility:public"],
 })
+
+manifest({
+    "name": "manifest_virtual",
+    "address_translation": hex(CONST.HARDENED_TRUE),
+    "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+})


### PR DESCRIPTION
1. Test booting owner code in both the A & B slots.  Test booting owner code in A & B via the virtual remap window.
2. Fix an error in the remap window configuration in the rom_ext.