### PR TITLE
[manuf] move SECRET1 provisioning function to `personalize` lib

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -474,15 +474,16 @@ otp_image(
     for i in range(0, 7)
 ]
 
-# Represents a DEV state OTP image emulating the state of the device after the
-# exit test token has been applied and before running individualization.
-# The following partitions are missing to ensure the image is initialize with
-# default values: SECRET1, SECRET2, HW_CFG.
-# The following partitions are expected to be configured in previous lifecycle
-# stages: SECRET0, CREATOR_SW, OWNER_SW.
+# Represents a TEST_UNLOCKED1 state OTP image emulating the state of the device
+# after the test tokens have been applied and before running individualization.
+# The following partitions are missing to ensure the image is initialized with
+# values that would be present prior to the final individualization
+# manufacturing stage: SECRET1, SECRET2, HW_CFG.
+# The following partitions are expected to be configured in previous
+# manufacturing stages: SECRET0, CREATOR_SW, OWNER_SW.
 otp_image(
-    name = "img_dev_initial",
-    src = ":otp_json_dev",
+    name = "img_test_unlocked1_initial",
+    src = ":otp_json_test_unlocked1",
     overlays = [
         ":otp_json_secret0",
         ":otp_json_creator_sw_cfg",
@@ -565,7 +566,6 @@ filegroup(
     srcs = [
         ":img_dev",
         ":img_dev_individualized",
-        ":img_dev_initial",
         ":img_prod",
         ":img_raw",
         ":img_rma",
@@ -578,6 +578,7 @@ filegroup(
         ":img_test_locked6",
         ":img_test_unlocked0",
         ":img_test_unlocked1",
+        ":img_test_unlocked1_initial",
         ":img_test_unlocked2",
         ":img_test_unlocked3",
         ":img_test_unlocked4",

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -492,14 +492,13 @@ otp_image(
     ],
 )
 
-# Represents a device in DEV state with the SECRET0 and SECRET1 partitions in
-# locked state. SECRET2 partition is unlocked.
+# Represents a device in DEV state with the SECRET0 partition in the locked
+# state. SECRET1 and SECRET2 partitions are in the unlocked state.
 otp_image(
     name = "img_dev_individualized",
     src = ":otp_json_dev",
     overlays = [
         ":otp_json_secret0",
-        ":otp_json_secret1",
     ] + STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS,
 )
 

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -51,7 +51,6 @@ def get_otp_images():
 
     img_targets = [
         "//hw/ip/otp_ctrl/data:img_dev",
-        "//hw/ip/otp_ctrl/data:img_dev_initial",
         "//hw/ip/otp_ctrl/data:img_dev_individualized",
         "//hw/ip/otp_ctrl/data:img_rma",
         "//hw/ip/otp_ctrl/data:img_test_locked0",
@@ -63,6 +62,7 @@ def get_otp_images():
         "//hw/ip/otp_ctrl/data:img_test_locked6",
         "//hw/ip/otp_ctrl/data:img_test_unlocked0",
         "//hw/ip/otp_ctrl/data:img_test_unlocked1",
+        "//hw/ip/otp_ctrl/data:img_test_unlocked1_initial",
         "//hw/ip/otp_ctrl/data:img_test_unlocked2",
         "//hw/ip/otp_ctrl/data:img_test_unlocked3",
         "//hw/ip/otp_ctrl/data:img_test_unlocked4",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -56,8 +56,12 @@ cc_library(
 
 cc_library(
     name = "otp_fields",
+    srcs = ["otp_fields.c"],
     hdrs = ["otp_fields.h"],
-    deps = ["//hw/ip/otp_ctrl/data:otp_ctrl_regs"],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base:bitfield",
+    ],
 )
 
 cc_library(
@@ -88,6 +92,8 @@ cc_library(
         ":flash_info_fields",
         ":otp_fields",
         ":util",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:multibits",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:hash",
@@ -184,6 +190,7 @@ cc_library(
         ":flash_info_fields",
         ":otp_fields",
         ":util",
+        "//sw/device/lib/base:multibits",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:aes",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -106,13 +106,13 @@ opentitan_test(
     name = "individualize_functest",
     srcs = ["individualize_functest.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_dev_initial",
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked1_initial",
         tags = ["manuf"],
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
         ":individualize",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -121,6 +121,7 @@ opentitan_test(
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -157,7 +158,7 @@ opentitan_test(
     name = "individualize_sw_cfg_functest",
     srcs = ["individualize_sw_cfg_functest.c"],
     cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked0",
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked1",
         tags = ["manuf"],
     ),
     exec_env = {

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -67,13 +67,6 @@ const hw_cfg_settings_t kHwCfgSettings = {
  */
 OT_WARN_UNUSED_RESULT
 static status_t hw_cfg_enable_knobs_set(const dif_otp_ctrl_t *otp_ctrl) {
-#define HW_CFG_EN_OFFSET(m, i) ((bitfield_field32_t){.mask = m, .index = i})
-  static const bitfield_field32_t kSramFetch = HW_CFG_EN_OFFSET(0xff, 0);
-  static const bitfield_field32_t kCsrngAppRead = HW_CFG_EN_OFFSET(0xff, 8);
-  static const bitfield_field32_t kEntropySrcFwRd = HW_CFG_EN_OFFSET(0xff, 16);
-  static const bitfield_field32_t kEntropySrcFwOvr = HW_CFG_EN_OFFSET(0xff, 24);
-#undef HW_CFG_EN_OFFSET
-
   uint32_t val =
       bitfield_field32_write(0, kSramFetch, kHwCfgSettings.en_sram_ifetch);
   val = bitfield_field32_write(val, kCsrngAppRead,

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -265,9 +265,6 @@ status_t manuf_individualize_device_secret0_check(
 
 status_t manuf_individualize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
                                             const dif_otp_ctrl_t *otp_ctrl) {
-  // Check life cycle in either PROD or DEV.
-  TRY(lc_ctrl_testutils_operational_state_check(lc_ctrl));
-
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
                                       &is_locked));

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -186,40 +186,6 @@ status_t manuf_individualize_device_hw_cfg_check(
   return is_locked ? OK_STATUS() : INTERNAL();
 }
 
-OT_WARN_UNUSED_RESULT
-static status_t otp_secret_write(const dif_otp_ctrl_t *otp_ctrl,
-                                 uint32_t offset, size_t len) {
-  enum {
-    kBufferSize = 4,
-  };
-  if (len > kBufferSize) {
-    return INTERNAL();
-  }
-
-  TRY(entropy_csrng_reseed(/*disable_trng_inpu=*/kHardenedBoolFalse,
-                           /*seed_material=*/NULL));
-
-  size_t len_in_32bit_words = len * 2;
-  uint64_t data[kBufferSize];
-  TRY(entropy_csrng_generate(/*seed_material=*/NULL, (uint32_t *)data,
-                             len_in_32bit_words,
-                             /*fips_check=*/kHardenedBoolTrue));
-
-  bool found_error = false;
-  uint64_t prev_val = 0;
-  for (size_t i = 0; i < len; ++i) {
-    found_error |= data[i] == 0 || data[i] == UINT64_MAX || data[i] == prev_val;
-    prev_val = data[i];
-  }
-  if (found_error) {
-    return INTERNAL();
-  }
-
-  TRY(otp_ctrl_testutils_dai_write64(otp_ctrl, kDifOtpCtrlPartitionSecret1,
-                                     offset, data, len));
-  return OK_STATUS();
-}
-
 status_t manuf_individualize_device_secret0(
     const dif_lc_ctrl_t *lc_ctrl, const dif_otp_ctrl_t *otp_ctrl,
     const manuf_cp_provisioning_data_t *provisioning_data) {
@@ -259,41 +225,6 @@ status_t manuf_individualize_device_secret0_check(
     const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret0,
-                                      &is_locked));
-  return is_locked ? OK_STATUS() : INTERNAL();
-}
-
-status_t manuf_individualize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
-                                            const dif_otp_ctrl_t *otp_ctrl) {
-  bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
-                                      &is_locked));
-  if (is_locked) {
-    return OK_STATUS();
-  }
-
-  TRY(entropy_complex_init());
-  TRY(entropy_csrng_instantiate(/*disable_trng_input=*/kHardenedBoolFalse,
-                                /*seed_material=*/NULL));
-
-  TRY(otp_secret_write(otp_ctrl, kSecret1FlashAddrKeySeedOffset,
-                       kSecret1FlashAddrKeySeed64BitWords));
-  TRY(otp_secret_write(otp_ctrl, kSecret1FlashDataKeySeedOffset,
-                       kSecret1FlashDataKeySeed64BitWords));
-  TRY(otp_secret_write(otp_ctrl, kSecret1SramDataKeySeedOffset,
-                       kSecret1SramDataKeySeed64Bitwords));
-
-  TRY(entropy_csrng_uninstantiate());
-  TRY(otp_ctrl_testutils_lock_partition(otp_ctrl, kDifOtpCtrlPartitionSecret1,
-                                        /*digest=*/0));
-
-  return OK_STATUS();
-}
-
-status_t manuf_individualize_device_secret1_check(
-    const dif_otp_ctrl_t *otp_ctrl) {
-  bool is_locked;
-  TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret1,
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -73,7 +73,7 @@ status_t manuf_individualize_device_secret0(
  * Checks the SECRET0 OTP partition end state.
  *
  * @param otp_ctrl OTP controller interface.
- * @return OK_STATUS if the SECRET1 partition is locked.
+ * @return OK_STATUS if the SECRET0 partition is locked.
  */
 status_t manuf_individualize_device_secret0_check(
     const dif_otp_ctrl_t *otp_ctrl);
@@ -84,9 +84,6 @@ status_t manuf_individualize_device_secret0_check(
  * The SECRET1 partition contains the Flash and SRAM scrambling seeds for the
  * device.
  *
- * Preconditions:
- * - Device is in DEV, PROD, or PROD_END lifecycle stage.
- *
  * Note: The test will skip all programming steps and succeed if the SECRET1
  * parition is already locked. This is to facilitate test re-runs.
  *
@@ -96,7 +93,7 @@ status_t manuf_individualize_device_secret0_check(
  *
  * @param lc_ctrl Lifecycle controller instance.
  * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the HW_CFG partition is locked.
+ * @return OK_STATUS on success.
  */
 status_t manuf_individualize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
                                             const dif_otp_ctrl_t *otp_ctrl);

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -78,33 +78,4 @@ status_t manuf_individualize_device_secret0(
 status_t manuf_individualize_device_secret0_check(
     const dif_otp_ctrl_t *otp_ctrl);
 
-/**
- * Configures the SECRET1 OTP partition.
- *
- * The SECRET1 partition contains the Flash and SRAM scrambling seeds for the
- * device.
- *
- * Note: The test will skip all programming steps and succeed if the SECRET1
- * parition is already locked. This is to facilitate test re-runs.
- *
- * The caller should reset the device after calling this function and call
- * `manuf_individualize_device_secret1_check()` afterwards to confirm that the
- * OTP partition was successfully locked.
- *
- * @param lc_ctrl Lifecycle controller instance.
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS on success.
- */
-status_t manuf_individualize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
-                                            const dif_otp_ctrl_t *otp_ctrl);
-
-/**
- * Checks the SECRET1 OTP partition end state.
- *
- * @param otp_ctrl OTP controller interface.
- * @return OK_STATUS if the SECRET1 partition is locked.
- */
-status_t manuf_individualize_device_secret1_check(
-    const dif_otp_ctrl_t *otp_ctrl);
-
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_H_

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -62,10 +62,5 @@ bool test_main(void) {
     sw_reset();
   }
 
-  if (!status_ok(manuf_individualize_device_secret1_check(&otp_ctrl))) {
-    CHECK_STATUS_OK(manuf_individualize_device_secret1(&lc_ctrl, &otp_ctrl));
-    sw_reset();
-  }
-
   return true;
 }

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -53,6 +54,8 @@ void sw_reset(void) {
 
 bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
+  CHECK_STATUS_OK(
+      lc_ctrl_testutils_check_lc_state(&lc_ctrl, kDifLcCtrlStateTestUnlocked1));
 
   if (!status_ok(manuf_individualize_device_hw_cfg_check(&otp_ctrl))) {
     CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(&flash_state, &otp_ctrl));

--- a/sw/device/silicon_creator/manuf/lib/otp_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/otp_fields.c
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
+
+#include "sw/device/lib/base/bitfield.h"
+
+#define HW_CFG_EN_OFFSET(m, i) ((bitfield_field32_t){.mask = m, .index = i})
+const bitfield_field32_t kSramFetch = HW_CFG_EN_OFFSET(0xff, 0);
+const bitfield_field32_t kCsrngAppRead = HW_CFG_EN_OFFSET(0xff, 8);
+const bitfield_field32_t kEntropySrcFwRd = HW_CFG_EN_OFFSET(0xff, 16);
+const bitfield_field32_t kEntropySrcFwOvr = HW_CFG_EN_OFFSET(0xff, 24);
+#undef HW_CFG_EN_OFFSET

--- a/sw/device/silicon_creator/manuf/lib/otp_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/otp_fields.h
@@ -5,7 +5,14 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_OTP_FIELDS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_OTP_FIELDS_H_
 
+#include "sw/device/lib/base/bitfield.h"
+
 #include "otp_ctrl_regs.h"  // Generated.
+
+extern const bitfield_field32_t kSramFetch;
+extern const bitfield_field32_t kCsrngAppRead;
+extern const bitfield_field32_t kEntropySrcFwRd;
+extern const bitfield_field32_t kEntropySrcFwOvr;
 
 enum {
   /**

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -271,10 +271,10 @@ static status_t otp_partition_secret2_configure(
   return OK_STATUS();
 }
 
-status_t manuf_personalize_device(dif_flash_ctrl_state_t *flash_state,
-                                  const dif_lc_ctrl_t *lc_ctrl,
-                                  const dif_otp_ctrl_t *otp_ctrl,
-                                  manuf_perso_data_out_t *export_data) {
+status_t manuf_personalize_device_secrets(dif_flash_ctrl_state_t *flash_state,
+                                          const dif_lc_ctrl_t *lc_ctrl,
+                                          const dif_otp_ctrl_t *otp_ctrl,
+                                          manuf_perso_data_out_t *export_data) {
   // Check life cycle in either PROD, PROD_END, or DEV.
   TRY(lc_ctrl_testutils_operational_state_check(lc_ctrl));
 
@@ -369,7 +369,8 @@ static status_t otp_secret_write(const dif_otp_ctrl_t *otp_ctrl,
   return OK_STATUS();
 }
 
-status_t manuf_personalize_device_check(const dif_otp_ctrl_t *otp_ctrl) {
+status_t manuf_personalize_device_secrets_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
   bool is_locked;
   TRY(dif_otp_ctrl_is_digest_computed(otp_ctrl, kDifOtpCtrlPartitionSecret2,
                                       &is_locked));

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -72,10 +72,10 @@ status_t manuf_personalize_device_secret1_check(const dif_otp_ctrl_t *otp_ctrl);
  * @param[out] export_data UJSON struct of data to export from the device.
  * @return OK_STATUS on success.
  */
-status_t manuf_personalize_device(dif_flash_ctrl_state_t *flash_state,
-                                  const dif_lc_ctrl_t *lc_ctrl,
-                                  const dif_otp_ctrl_t *otp_ctrl,
-                                  manuf_perso_data_out_t *export_data);
+status_t manuf_personalize_device_secrets(dif_flash_ctrl_state_t *flash_state,
+                                          const dif_lc_ctrl_t *lc_ctrl,
+                                          const dif_otp_ctrl_t *otp_ctrl,
+                                          manuf_perso_data_out_t *export_data);
 
 /**
  * Checks the device personalization end state.
@@ -85,6 +85,6 @@ status_t manuf_personalize_device(dif_flash_ctrl_state_t *flash_state,
  * @param otp_ctrl OTP controller instance.
  * @return OK_STATUS if the SECRET2 OTP partition is locked.
  */
-status_t manuf_personalize_device_check(const dif_otp_ctrl_t *otp_ctrl);
+status_t manuf_personalize_device_secrets_check(const dif_otp_ctrl_t *otp_ctrl);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_PERSONALIZE_H_

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -16,6 +16,34 @@
 #include "otp_ctrl_regs.h"  // Generated.
 
 /**
+ * Configures the SECRET1 OTP partition.
+ *
+ * The SECRET1 partition contains the Flash and SRAM scrambling seeds for the
+ * device.
+ *
+ * Note: The test will skip all programming steps and succeed if the SECRET1
+ * parition is already locked. This is to facilitate test re-runs.
+ *
+ * The caller should reset the device after calling this function and call
+ * `manuf_personalize_device_secret1_check()` afterwards to confirm that the
+ * OTP partition was successfully locked.
+ *
+ * @param lc_ctrl Lifecycle controller instance.
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS on success.
+ */
+status_t manuf_personalize_device_secret1(const dif_lc_ctrl_t *lc_ctrl,
+                                          const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Checks the SECRET1 OTP partition end state.
+ *
+ * @param otp_ctrl OTP controller interface.
+ * @return OK_STATUS if the SECRET1 partition is locked.
+ */
+status_t manuf_personalize_device_secret1_check(const dif_otp_ctrl_t *otp_ctrl);
+
+/**
  * Personalize device with unique secrets.
  *
  * The device is provisioned with a unique set of secrets, which are hidden from

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -21,6 +21,9 @@
  * The SECRET1 partition contains the Flash and SRAM scrambling seeds for the
  * device.
  *
+ * Preconditions:
+ * - Device has SW CSRNG data access (configured in HW_CFG parition).
+ *
  * Note: The test will skip all programming steps and succeed if the SECRET1
  * parition is already locked. This is to facilitate test re-runs.
  *
@@ -56,8 +59,7 @@ status_t manuf_personalize_device_secret1_check(const dif_otp_ctrl_t *otp_ctrl);
  * 2. the RMA unlock token (OTP - SECRET2 Partition)
  *
  * Preconditions:
- * - Device is in DEV, PROD, or PROD_END lifecycle state.
- * - Device has SW CSRNG data access.
+ * - Device has SW CSRNG data access (configured in HW_CFG parition).
  *
  * Note: The test will skip all programming steps and succeed if the SECRET2
  * partition is already locked. This is to facilitate test re-runs.

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -16,10 +16,7 @@
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/manuf/lib/personalize.h"
 
-#include "flash_ctrl_regs.h"  // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "lc_ctrl_regs.h"   // Generated
-#include "otp_ctrl_regs.h"  // Generated
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
@@ -103,10 +100,10 @@ bool test_main(void) {
     sw_reset();
   } else if (info == kDifRstmgrResetInfoSw) {
     // Provision the OTP SECRET2 partition.
-    if (!status_ok(manuf_personalize_device_check(&otp_ctrl))) {
+    if (!status_ok(manuf_personalize_device_secrets_check(&otp_ctrl))) {
       LOG_INFO("Provisioning OTP SECRET2 ...");
-      CHECK_STATUS_OK(manuf_personalize_device(&flash_state, &lc_ctrl,
-                                               &otp_ctrl, export_data));
+      CHECK_STATUS_OK(manuf_personalize_device_secrets(&flash_state, &lc_ctrl,
+                                                       &otp_ctrl, export_data));
       sw_reset();
     }
 

--- a/sw/host/tests/manuf/personalize/src/main.rs
+++ b/sw/host/tests/manuf/personalize/src/main.rs
@@ -49,11 +49,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
     // Get UART, set flow control, and wait for for test to start running.
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(
-        &*uart,
-        r"Personalization complete. Checking status ...",
-        opts.timeout,
-    )?;
+    let _ = UartConsole::wait_for(&*uart, r"Exporting RMA unlock token ...", opts.timeout)?;
 
     // Wait for exported data to be transimitted over the console.
     let export_data = ManufPersoDataOut::recv(&*uart, opts.timeout, false)?;


### PR DESCRIPTION
The SECRET1 provisioning requires access to the CSRNG SW interface. Such access is only granted after the HW_CFG is provisioned during the "individualization" phase. Since the chip is already reset between individualization and personalization, which is required to activate the HW_CFG partition, we move this provisioning operation to the "personalize" phase. 