### PR TITLE
[sival] Add OTP and bitstream docs.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -400,6 +400,8 @@
 
 - [Device Software](./sw/device/README.md)
   - [Build & Test Rules](./rules/opentitan/README.md)
+    - [FPGA Bitstreams](./hw/bitstream/README.md)
+    - [OTP Build and Test Infrastructure](./hw/ip/otp_ctrl/data/README.md)
   - [Device Libraries](./sw/device/lib/README.md)
     - [DIF Library](./sw/device/lib/dif/README.md)
       - [ADC Checklist](sw/device/lib/dif/dif_adc_ctrl.md)

--- a/hw/bitstream/README.md
+++ b/hw/bitstream/README.md
@@ -1,0 +1,129 @@
+# FPGA Bitstreams
+
+## Overview
+
+The build infrastructure supports the ability to override the ROM and OTP
+default values in precompiled FPGA bitstreams. The following configurations
+are available for use in FPGA based test programs:
+
+1. `rom_with_<key_type>_keys_<life_cycle_state>`
+2. `test_rom`
+
+`key_type` valid values are `real` or `fake`, with `fake` representing keys
+that are part of the code base and can be used to sign objects. `fake` keys
+are **not for production use cases**.
+
+`life_cycle_state` maps to any of the life cycle states supported by the
+OpenTitan design.
+
+The following command shows a list of targets provided by `//hw/bitstream`:
+
+```
+bazel query //hw/bitstream:*
+```
+
+## Overriding Defaults in FPGA test cases
+
+`opentitan_test` rules support the ability to override the `bitstream` used
+in the test. To do this, simply set the `bitstream` argument to the bitstream
+target.
+
+The following example is taken from `sw/device/silicon_creator/manuf/lib/BUILD`:
+
+```python
+opentitan_test(
+    name = "individualize_sw_cfg_functest",
+    srcs = ["individualize_sw_cfg_functest.c"],
+    cw310 = cw310_params(
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked0",
+        tags = ["manuf"],
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    deps = [
+        ":individualize_sw_cfg_earlgrey_a0_sku_generic",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+```
+
+## Creating custom images for test cases
+
+### Splicing the OTP memory
+
+The `bitstream_slice` rule can be used to generate custom images. The following
+example shows how to integrate a custom OTP image into a bitstream using the
+`test_rom` image configuration.
+
+```python
+# Create a custom OTP JSON with flash scrambling and ECC enabled in the
+# CREATOR_SW_CFG OTP partition.
+otp_json(
+    name = "power_virus_systemtest_otp_overlay",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                # Enable flash scrambling and ECC.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+            },
+        ),
+    ],
+)
+
+# Integrate the custom OTP JSON into an OTP image based on the `RMA` baseline
+# configuration. The result will be an OTP configuration reflecting RMA
+# life cycle state with flash scrambling and ECC enabled.
+otp_image(
+    name = "power_virus_systemtest_otp_img_rma",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":power_virus_systemtest_otp_overlay"],
+    visibility = ["//visibility:private"],
+)
+
+# Generate an FPGA bitstream using `//hw/bitstream:test_rom` as the baseline
+# bitstream, and splicing the OTP image provided by the target above.
+bitstream_splice(
+    name = "power_virus_systemtest_bitstream",
+    src = "//hw/bitstream:test_rom",
+    data = ":power_virus_systemtest_otp_img_rma",
+    meminfo = "//hw/bitstream:otp_mmi",
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+```
+
+### Splicing the ROM memory
+
+The splicing mechanism can also be used to override the ROM in a bitstream by:
+
+1. Setting `meminfo = //hw/bitstream:rom_mmi`; and,
+2. Pointing the `data` attribute to a binary compiled against the ROM memory
+   layout. For example:
+   `data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem"`.
+
+The following example shows how to splice a bitstream with the `test_rom`
+binary.
+
+```python
+bitstream_splice(
+    name = "test_rom",
+    testonly = True,
+    src = ":bitstream",
+    data = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem",
+    meminfo = ":rom_mmi",
+    tags = ["manual"],
+    update_usr_access = True,
+)
+```
+
+## Read More
+
+* [OTP Build and Test Infrastructure](../ip/otp_ctrl/data/README.md)

--- a/hw/ip/otp_ctrl/data/README.md
+++ b/hw/ip/otp_ctrl/data/README.md
@@ -1,0 +1,72 @@
+# OTP Build and Test Infrastructure
+
+OTP image configurations are defined using hjson objects. Currently there are
+two ways to build images:
+
+1. Pre-built OTP image overlays defined in hjson. These is the approach
+   currently used in most DV test cases.
+2. Dynamically built OTP image overlays defined in [Bazel](#bazel). This is the
+   approach currently used in FPGA and Silicon Validation (SiVal) targets.
+
+## Bazel
+
+See `//hw/ip/otp_ctrl/data/BUILD` for detailed references on the rules
+described below.
+
+### OTP HJSON Map
+
+OTP image overlays are first defined using the `otp_json` Bazel rule. The
+following example shows the definition of a `SECRET2` partition configuration:
+
+```python
+otp_json(
+    name = "otp_json_secret2_unlocked",
+    partitions = [
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                "RMA_TOKEN": "<random>",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+            lock = False,
+        ),
+    ],
+)
+```
+
+See `//rules/otp.bzl` for additional documentation on additional parameters
+available in the `otp_json` rule.
+
+### OTP Image
+
+An OTP image is a collection of OTP JSON files used to create an OTP image.
+An OTP can have multiple `otp_json` dependencies. Each dependency has the
+ability of override the values of the previous dependency, so the order in
+which these are listed is important.
+
+```python
+# Represents a device in DEV state with the SECRET0 and SECRET1 partitions in
+# locked state. SECRET2 partition is unlocked.
+otp_image(
+    name = "img_dev_individualized",
+    src = ":otp_json_dev",
+    overlays = [
+        ":otp_json_secret0",
+        ":otp_json_secret1",
+    ] + STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS,
+)
+```
+
+In this example, the `src` attribute points to the baseline OTP JSON
+configuration, and the list of overlay dependencies are applied in order
+of precedence in the `overlays` attribute.
+
+The `STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS` definition imported from
+`//rules:otp.bzl` declares a list of `otp_json` targets that are used
+as overlays. There are other list of predefined overlays that are used
+throughout the code base.
+
+### FPGA Integration
+
+See [FPGA bitstreams](../../../bitstream/README.md) documentation for more details.

--- a/sw/device/tests/README.md
+++ b/sw/device/tests/README.md
@@ -1,11 +1,11 @@
 # Chip-Level Tests
 
-# Overview
+## Overview
 
 This subtree contains three types of chip-level tests that are capable of running across all OpenTitan verification targets, using the [on-device test framework](../lib/testing/test_framework/README.md).
 These targets include: DV simulation, Verilator simulation, FPGA, and eventually silicon.
 
-# Test Types
+## Test Types
 - **Chip-level Tests** - A collection of software level tests that run on OpenTitan hardware, whose main purpose is pre-silicon verification and post-silicon bringup.
 These tests consist of: smoke, IP integration, and system-level tests.
 While most of these tests are top-level agnostic, some are not.
@@ -14,9 +14,9 @@ While most of these tests are top-level agnostic, some are not.
   - **System-level Scenario Test** - A software level test, written in C, that mimics complex system level use case scenarios.
   Such a test is designed to encompass multiple pieces of functionality tested by the IP integration tests.
 
-# Organization and Style Guide
+## Organization and Style Guide
 
-## File Naming Conventions
+### File Naming Conventions
 *   Smoke tests: **{IP name}\_smoketest.c**
 *   IP Integration tests: **{IP name}[\_{feature}]\_test.c**
 *   System-level tests: **{use case}\_systemtest.c**
@@ -31,7 +31,7 @@ While most of these tests are top-level agnostic, some are not.
 *   IP Integration Test data (some tests, e.g. OTBN, load data files): **sw/device/tests/{IP}\_data/**
 *   Target-specific tests will be subfoldered by target (see below).
 
-### Subfoldering Target-Specific Tests
+#### Subfoldering Target-Specific Tests
 Ideally all smoke, IP integration, and system-level tests should be target agnostic.
 However, some tests require emulation of host capabilities, such as an external SPI or I2C host, an external host to encrypt/decrypt data, or an external host that toggles GPIO pins.
 Eventually, host-side test initiation tools and the [on-device test framework](../lib/testing/test_framework/README.md) will make host emulation opaque to each chip-level test.
@@ -39,18 +39,12 @@ However, until then, host emulation depends on the target (e.g., DV vs. Verilato
 Therefore, chip-level tests that require external stimulation from the host, will be subfoldered by target, under the appropriate toplevel folder above.
 One example of such a test is the [`sw/device/tests/sim_dv/gpio_test.c`](https://github.com/lowRISC/opentitan/blob/master/sw/device/tests/sim_dv/gpio_test.c), which is subfoldered under `../sim_dv/` to indicate it is a target-specific test.
 
-# Writing a Chip-Level Test
+## Writing a Chip-Level Test
 For instructions on how to write a chip-level test, refer to the [on-device test framework](../lib/testing/test_framework/README.md) page.
 
-# List of Tests
+## Read More
 
-## Smoke
-
-TBD
-
-## IP Integration
-{{< incGenFromIpDesc "/hw/top_earlgrey/data/chip_testplan.hjson" "testplan" >}}
-
-## System-Level (Use Case)
-
-TBD
+* [Build & Test Rules](../../../rules/opentitan/README.md)
+* [On-Device Test Framework (OTTF)](../lib//testing/test_framework/README.md)
+* [OTP Build and Test Infrastructure](../../../hw/ip/otp_ctrl/data/README.md)
+* [FPGA Bitstreams](../../../hw/bitstream/README.md)


### PR DESCRIPTION
This change adds initial documentation for build infrastructure support for OTP and bitstream configurations.

The new documents are cross-referenced in device test documentation.