### PR TITLE
[bazel] Migrate e2e shutdown_output to new build/test rules.

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_binary",
+)
+load(
     "//rules:opentitan_test.bzl",
     "cw310_params",
     "dv_params",
@@ -12,7 +16,6 @@ load(
 load(
     "//rules:const.bzl",
     "CONST",
-    "hex",
     "hex_digits",
 )
 load(
@@ -103,25 +106,52 @@ opentitan_functest(
     ],
 )
 
-[opentitan_flash_binary(
-    name = "empty_test_slot_{}".format(slot),
-    testonly = True,
-    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-    devices = [
-        "fpga_cw310",
-        "sim_dv",
-        "sim_verilator",
-    ],
-    signed = True,
-    deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
-        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
-    ],
-) for slot in SLOTS]
+[
+    opentitan_flash_binary(
+        name = "empty_test_slot_{}".format(slot),
+        testonly = True,
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        devices = [
+            "fpga_cw310",
+            "sim_dv",
+            "sim_verilator",
+        ],
+        signed = True,
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
+    )
+    for slot in SLOTS
+]
+
+[
+    # TODO(#19923): This target has been temporarily added until the original
+    # target and its dependencies are migrated to the new build and test rules.
+    opentitan_binary(
+        name = "new_empty_test_slot_{}".format(slot),
+        testonly = True,
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:sim_dv",
+            "//hw/top_earlgrey:sim_verilator",
+        ],
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
+    )
+    for slot in SLOTS
+]
 
 [
     genrule(

--- a/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
@@ -3,10 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
     "cw310_params",
     "dv_params",
-    "opentitan_functest",
+    "opentitan_test",
+    "rsa_key_for_lc_state",
+)
+load(
+    "//rules:opentitan.bzl",
+    "RSA_ONLY_KEY_STRUCTS",
 )
 load(
     "//rules:const.bzl",
@@ -23,7 +28,6 @@ load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
-    "otp_json",
 )
 load(
     "//rules:rom_e2e.bzl",
@@ -36,19 +40,20 @@ load(
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_PASS",
-    "MSG_TEMPLATE_BFV",
     "MSG_TEMPLATE_BFV_LCV",
 )
 
 package(default_visibility = ["//visibility:public"])
 
-[otp_image(
-    name = "otp_img_shutdown_output_{}".format(lc_state),
-    src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-    overlays = STD_OTP_OVERLAYS,
-) for lc_state, _ in get_lc_items()]
+[
+    otp_image(
+        name = "otp_img_shutdown_output_{}".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+        overlays = STD_OTP_OVERLAYS,
+    )
+    for lc_state, _ in get_lc_items()
+]
 
-# Splice OTP images into bitstreams
 [
     bitstream_splice(
         name = "bitstream_shutdown_output_{}".format(lc_state),
@@ -60,36 +65,45 @@ package(default_visibility = ["//visibility:public"])
     for lc_state, _ in get_lc_items()
 ]
 
-manifest({
-    "name": "manifest_bad_identifier",
-    "address_translation": hex(CONST.HARDENED_FALSE),
-    "identifier": "0",
-})
+manifest(
+    d = {
+        "name": "manifest_bad_identifier",
+        "address_translation": hex(CONST.HARDENED_FALSE),
+        "identifier": "0",
+    },
+)
 
-[opentitan_functest(
-    name = "shutdown_output_{}".format(lc_state),
-    cw310 = cw310_params(
-        bitstream = ":bitstream_shutdown_output_{}".format(lc_state),
-        exit_failure = MSG_PASS,
-        exit_success = MSG_TEMPLATE_BFV_LCV.format(
-            hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
-            hex_digits(lc_state_val),
+[
+    opentitan_test(
+        name = "shutdown_output_{}".format(lc_state),
+        cw310 = cw310_params(
+            binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
+            bitstream = ":bitstream_shutdown_output_{}".format(lc_state),
+            exit_failure = MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV_LCV.format(
+                hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
+                hex_digits(lc_state_val),
+            ),
+            otp = ":otp_img_shutdown_output_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
         ),
-        otp = ":otp_img_shutdown_output_{}".format(lc_state),
-        tags = maybe_skip_in_ci(lc_state_val),
-    ),
-    dv = dv_params(
-        otp = ":otp_img_shutdown_output_{}".format(lc_state),
-        rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
-    ),
-    manifest = ":manifest_bad_identifier",
-    ot_flash_binary = "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a",
-    signed = False,
-    targets = [
-        "cw310_rom_with_fake_keys",
-        "dv",
-    ],
-) for lc_state, lc_state_val in get_lc_items()]
+        dv = dv_params(
+            binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
+            otp = ":otp_img_shutdown_output_{}".format(lc_state),
+            rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:sim_dv": None,
+        },
+        manifest = ":manifest_bad_identifier",
+        rsa_key = rsa_key_for_lc_state(
+            RSA_ONLY_KEY_STRUCTS,
+            lc_state_val,
+        ),
+    )
+    for lc_state, lc_state_val in get_lc_items()
+]
 
 test_suite(
     name = "shutdown_output",


### PR DESCRIPTION
Fixes #20088.