### PR TITLE
[bazel,new rules] Convert rom/e2e/sigverify_always

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -123,7 +123,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -139,7 +139,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -155,7 +155,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -171,7 +171,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -187,7 +187,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -202,7 +202,7 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
@@ -218,7 +218,7 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_dev:4",
       ]
@@ -234,7 +234,7 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod:4",
       ]
@@ -250,7 +250,7 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod_end:4",
       ]
@@ -266,7 +266,7 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_rma:4",
       ]
@@ -282,8 +282,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -298,8 +298,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_dev
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -314,8 +314,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -330,8 +330,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -346,8 +346,8 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_rma
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -363,7 +363,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -379,7 +379,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -395,7 +395,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -411,7 +411,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -427,7 +427,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -443,7 +443,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -459,7 +459,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -475,7 +475,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -491,7 +491,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
@@ -507,7 +507,7 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -192,8 +192,8 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     manifest = get_fallback(ctx, "file.manifest", exec_env)
     rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
     spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
-    if manifest and kind != "ram":
-        if not rsa_key:
+    if (manifest or rsa_key) and kind != "ram":
+        if not (manifest and rsa_key):
             fail("Signing requires a manifest and an rsa_key, and optionally an spx_key")
         signed = sign_binary(
             ctx,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -39,6 +39,7 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:keyutils.bzl",
+    _rsa_key_by_name = "rsa_key_by_name",
     _rsa_key_for_lc_state = "rsa_key_for_lc_state",
 )
 
@@ -68,6 +69,7 @@ sim_dv = _sim_dv
 dv_params = _dv_params
 
 rsa_key_for_lc_state = _rsa_key_for_lc_state
+rsa_key_by_name = _rsa_key_by_name
 
 # The default set of test environments for Earlgrey.
 EARLGREY_TEST_ENVS = {

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -13,3 +13,14 @@ def rsa_key_for_lc_state(key_structs, hw_lc_state):
     return {
         keys[0].rsa.label: keys[0].rsa.name,
     }
+
+def rsa_key_by_name(key_structs, nickname):
+    """Return a dictionary containing a single key that matches the name given.
+    The format of the dictionary is compatible with opentitan_test.
+    """
+    keys = [k for k in key_structs if (k.rsa != None and k.rsa.name == nickname)]
+    if len(keys) == 0:
+        fail("There are no RSA keys compatible with name {} in key structs".format(nickname))
+    return {
+        keys[0].rsa.label: keys[0].rsa.name,
+    }

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -7,7 +7,7 @@ def rsa_key_for_lc_state(key_structs, hw_lc_state):
     """Return a dictionary containing a single key that can be used in the given
     LC state. The format of the dictionary is compatible with opentitan_test.
     """
-    keys = [k for k in key_structs if (not k.rsa or key_allowed_in_lc_state(k.rsa, hw_lc_state))]
+    keys = [k for k in key_structs if (k.rsa != None and key_allowed_in_lc_state(k.rsa, hw_lc_state))]
     if len(keys) == 0:
         fail("There are no RSA keys compatible with HW LC state {} in key structs".format(hw_lc_state))
     return {

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -46,6 +46,13 @@ load(
     "SIGVERIFY_LC_KEYS",
     "SLOTS",
 )
+load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_binary",
+    "opentitan_test",
+    "rsa_key_by_name",
+    new_cw310_params = "cw310_params",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -154,28 +161,77 @@ opentitan_functest(
 ]
 
 [
-    genrule(
-        name = "empty_test_slot_{}_corrupted_{}_bin_signed_{}".format(slot, device, key),
+    opentitan_binary(
+        name = "empty_test_slot_{}_{}".format(slot, key),
         testonly = True,
-        srcs = [":empty_test_slot_{}_{}_bin_signed_{}".format(slot, device, key)],
-        outs = ["empty_test_slot_{}_corrupted_{}.{}.signed.bin".format(slot, device, key)],
-        cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=1971 count=1 conv=notrunc status=none".format(slot),
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        # We need to specify the manifest because the simulation environments do not
+        # specify one by default.
+        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+        rsa_key = rsa_key_by_name(RSA_ONLY_KEY_STRUCTS, key),
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
     )
     for slot in SLOTS
-    for device in [
-        "sim_dv",
-        "fpga_cw310",
-    ]
     for key in SIGVERIFY_LC_KEYS
 ]
 
+# Extract the various signed binaries for corruption
+[
+    filegroup(
+        name = "empty_test_slot_{}_{}_{}_signed_bin".format(slot, key, group),
+        testonly = True,
+        srcs = [":empty_test_slot_{}_{}".format(slot, key)],
+        output_group = "{}_signed_bin".format(group),
+    )
+    for slot in SLOTS
+    for key in SIGVERIFY_LC_KEYS
+    for group in [
+        "fpga_cw310_rom_with_fake_keys",
+        "sim_dv",
+    ]
+]
+
+# Corrupt binaries
+# Note: the naming of the files is important for dvsim. The code expects fiel to be named:
+# - binary: <something>.<key_name>.signed.bin
+# - vmem: <something>.<key_name>.signed.64.vmem
+# - flash vmem: <something>.<key_name>.signed.64.scr.vmem
+[
+    genrule(
+        name = "empty_test_slot_{}_{}_corrupted_{}_signed_bin".format(slot, key, group),
+        testonly = True,
+        srcs = [":empty_test_slot_{}_{}_{}_signed_bin".format(slot, key, group)],
+        outs = ["empty_test_slot_{}_corrupted_{}.{}.signed.bin".format(slot, group, key)],
+        cmd_bash = "cat $(SRCS) > $(OUTS) && dd if=/dev/zero of=$(OUTS) bs=4 seek=1971 count=1 conv=notrunc status=none",
+    )
+    for slot in SLOTS
+    for key in SIGVERIFY_LC_KEYS
+    for group in [
+        "fpga_cw310_rom_with_fake_keys",
+        "sim_dv",
+    ]
+]
+
 # The below three rule sets (bin_to_vmem, scramble_flash_vmem, and filegroup)
-# are needed to run `sigverify_always` test in DV.
+# are needed to run `sigverify_always` tests in DV.
 [
     bin_to_vmem(
-        name = "empty_test_slot_{}_corrupted_sim_dv_vmem64_signed_{}".format(slot, key),
+        name = "empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
         testonly = True,
-        bin = "empty_test_slot_{}_corrupted_sim_dv_bin_signed_{}".format(slot, key),
+        bin = "empty_test_slot_{}_{}_corrupted_sim_dv_signed_bin".format(slot, key),
         word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
     )
     for slot in SLOTS
@@ -184,24 +240,27 @@ opentitan_functest(
 
 [
     scramble_flash_vmem(
-        name = "empty_test_slot_{}_corrupted_sim_dv_scr_vmem64_signed_{}".format(slot, key),
+        name = "empty_test_slot_{}_{}_corrupted_sim_dv_scr_vmem64_signed".format(slot, key),
         testonly = True,
-        vmem = "empty_test_slot_{}_corrupted_sim_dv_vmem64_signed_{}".format(slot, key),
+        vmem = "empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
     )
     for slot in SLOTS
     for key in SIGVERIFY_LC_KEYS
 ]
 
+# This file group is here to simplify the naming of the files in the hjson testplan:
+# the file group contains the files for all possible keys that follow the expected
+# name format specified by the tags.
 [
     filegroup(
         name = "empty_test_slot_{}_corrupted_sim_dv".format(slot),
         testonly = True,
         srcs = [
-            "empty_test_slot_{}_corrupted_sim_dv_{}_signed_{}".format(slot, file_type, key)
+            "empty_test_slot_{}_{}_corrupted_sim_dv_{}".format(slot, key, file_type)
             for file_type in [
-                "bin",
-                "vmem64",
-                "scr_vmem64",
+                "signed_bin",
+                "vmem64_signed",
+                "scr_vmem64_signed",
             ]
             for key in SIGVERIFY_LC_KEYS
         ],

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
     "cw310_params",
-    "opentitan_functest",
+    "opentitan_binary",
+    "opentitan_test",
+    "rsa_key_for_lc_state",
 )
 load(
     "//rules:const.bzl",
@@ -53,31 +55,8 @@ BOOT_POLICY_VALID_CASES = [
     },
     {
         "desc": "bad",
-        "suffix": "_corrupted",
+        "suffix": "_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin",
     },
-]
-
-[
-    opentitan_multislot_flash_binary(
-        name = "boot_policy_valid_img_a_{}_b_{}".format(
-            a["desc"],
-            b["desc"],
-        ),
-        testonly = True,
-        srcs = {
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a{}".format(a["suffix"]): {
-                "key": RSA_ONLY_KEY_STRUCTS[2],
-                "offset": SLOTS["a"],
-            },
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b{}".format(b["suffix"]): {
-                "key": RSA_ONLY_KEY_STRUCTS[2],
-                "offset": SLOTS["b"],
-            },
-        },
-        devices = ["fpga_cw310"],
-    )
-    for a in BOOT_POLICY_VALID_CASES
-    for b in BOOT_POLICY_VALID_CASES
 ]
 
 [
@@ -102,24 +81,30 @@ BOOT_POLICY_VALID_CASES = [
 ]
 
 [
-    opentitan_functest(
+    opentitan_test(
         name = "boot_policy_valid_{}_a_{}_b_{}".format(
             lc_state,
             a["desc"],
             b["desc"],
         ),
         cw310 = cw310_params(
+            assemble = "{{slot_a}}@{} {{slot_b}}@{}".format(
+                SLOTS["a"],
+                SLOTS["b"],
+            ),
+            binaries = {
+                # PROD keys can sign binaries able to run across all life cycle states.
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_rsa_prod_key_0{}".format(a["suffix"]): "slot_a",
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_rsa_prod_key_0{}".format(b["suffix"]): "slot_b",
+            },
             bitstream = "bitstream_boot_policy_valid_{}".format(lc_state),
             exit_failure = MSG_PASS if a["desc"] == b["desc"] and a["desc"] == "bad" else DEFAULT_TEST_FAILURE_MSG,
             exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.SIGVERIFY.BAD_RSA_SIGNATURE)) if a["desc"] == b["desc"] and a["desc"] == "bad" else MSG_PASS,
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        key_struct = "multislot",
-        ot_flash_binary = ":boot_policy_valid_img_a_{}_b_{}".format(
-            a["desc"],
-            b["desc"],
-        ),
-        targets = ["cw310_rom_with_fake_keys"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
     )
     for lc_state, lc_state_val in get_lc_items()
     for a in BOOT_POLICY_VALID_CASES

--- a/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
     "cw310_params",
-    "dv_params",
-    "opentitan_functest",
+    "opentitan_binary",
+    "opentitan_test",
 )
 load(
     "//rules:const.bzl",
@@ -19,7 +20,6 @@ load(
     "//rules:opentitan.bzl",
     "RSA_ONLY_KEY_STRUCTS",
     "filter_key_structs_for_lc_state",
-    "opentitan_multislot_flash_binary",
 )
 load(
     "//rules:otp.bzl",
@@ -45,91 +45,6 @@ load(
 )
 
 package(default_visibility = ["//visibility:public"])
-
-[
-    opentitan_multislot_flash_binary(
-        name = "sigverify_always_img_a_{}_b_{}_{}".format(
-            "nothing" if slot == "b" else "bad",
-            "nothing" if slot == "a" else "bad",
-            key,
-        ),
-        testonly = True,
-        srcs = {
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_{}_corrupted".format(slot): {
-                "key": key,
-                "offset": offset,
-            },
-        },
-        devices = [
-            "sim_dv",
-            "fpga_cw310",
-        ],
-    )
-    for slot, offset in SLOTS.items()
-    for key in SIGVERIFY_LC_KEYS
-]
-
-[
-    opentitan_multislot_flash_binary(
-        name = "sigverify_always_img_a_bad_b_bad_{}".format(key),
-        testonly = True,
-        srcs = {
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted": {
-                "key": key,
-                "offset": SLOTS["a"],
-            },
-            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted": {
-                "key": key,
-                "offset": SLOTS["b"],
-            },
-        },
-        devices = [
-            "sim_dv",
-            "fpga_cw310",
-        ],
-    )
-    for key in SIGVERIFY_LC_KEYS
-]
-
-# Since we cannot feed the `assemble_flash_image` rule that is instantiated by
-# the `opentitan_multislot_flash_binary` macro an empty dictionary, we create
-# two images with "nothing" in them by created files of all ones, and stitching
-# them together.
-[
-    genrule(
-        name = "sigverify_always_img_{}_nothing_{}_bin_signed_{}".format(slot, device, key),
-        outs = ["sigverify_always_img_{}_all_ones_{}_bin_signed_{}".format(slot, device, key)],
-        cmd_bash = "touch $(OUTS)",
-    )
-    for slot in SLOTS
-    for device in [
-        "sim_dv",
-        "fpga_cw310",
-    ]
-    for key in SIGVERIFY_LC_KEYS
-]
-
-[
-    opentitan_multislot_flash_binary(
-        name = "sigverify_always_img_a_nothing_b_nothing_{}".format(key),
-        testonly = True,
-        srcs = {
-            ":sigverify_always_img_a_nothing": {
-                "key": key,
-                "offset": SLOTS["a"],
-            },
-            ":sigverify_always_img_b_nothing": {
-                "key": key,
-                "offset": SLOTS["b"],
-            },
-        },
-        devices = [
-            "sim_dv",
-            "fpga_cw310",
-        ],
-    )
-    for key in SIGVERIFY_LC_KEYS
-]
 
 [otp_image(
     name = "otp_img_sigverify_always_{}".format(lc_state),
@@ -174,13 +89,27 @@ SIGVERIFY_BAD_CASES = [
 ]
 
 [
-    opentitan_functest(
+    opentitan_test(
         name = "sigverify_always_{}_a_{}_b_{}".format(
             lc_state,
             case["a"],
             case["b"],
         ),
         cw310 = cw310_params(
+            assemble = " ".join([
+                "{{slot_{}}}@{}".format(slot, addr)
+                for (slot, addr) in SLOTS.items()
+                if case[slot] == "bad"
+            ]),
+            binaries = {
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_{}_{}_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin"
+                    .format(
+                    slot,
+                    filter_key_structs_for_lc_state(RSA_ONLY_KEY_STRUCTS, lc_state_val)[0].rsa.name,
+                ): "slot_{}".format(slot)
+                for (slot, addr) in SLOTS.items()
+                if case[slot] == "bad"
+            },
             bitstream = ":bitstream_sigverify_always_{}".format(lc_state),
             exit_failure = MSG_PASS,
             exit_success = MSG_TEMPLATE_BFV_LCV.format(
@@ -190,20 +119,9 @@ SIGVERIFY_BAD_CASES = [
             otp = ":otp_img_sigverify_always_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        dv = dv_params(
-            otp = ":otp_img_sigverify_always_{}".format(lc_state),
-            rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
-        ),
-        key_struct = "multislot",
-        ot_flash_binary = ":sigverify_always_img_a_{}_b_{}_{}".format(
-            case["a"],
-            case["b"],
-            filter_key_structs_for_lc_state(RSA_ONLY_KEY_STRUCTS, lc_state_val)[0].rsa.name,
-        ),
-        targets = [
-            "dv",
-            "cw310_rom_with_fake_keys",
-        ],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
     )
     for case in SIGVERIFY_BAD_CASES
     for lc_state, lc_state_val in get_lc_items()

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -149,6 +149,9 @@ opentitan_test(
         "@//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "@//hw/top_earlgrey:sim_dv": None,
     },
+    # We need to specify the manifest because the simulation environments do not
+    # specify one by default.
+    manifest = "@//sw/device/silicon_creator/rom_ext:manifest_standard",
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,
         CONST.LCV.TEST_UNLOCKED0,
@@ -187,6 +190,9 @@ opentitan_test(
         "@//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "@//hw/top_earlgrey:sim_dv": None,
     },
+    # We need to specify the manifest because the simulation environments do not
+    # specify one by default.
+    manifest = "@//sw/device/silicon_creator/rom_ext:manifest_standard",
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,
         CONST.LCV.TEST_UNLOCKED0,


### PR DESCRIPTION
There is a difficult yin this BUILD file that a file needs to be a corrupted. Previously this was easy but with the new rules, this becomes a bit harder. To simplify some test cases, I modified opentitantool to allow the creation of empty files which were previously disallowed (not sure why).

Another aspect that was overlooked is dvsim: the simulator currently expects file names to follow a specific pattern when using the `signed` and key tags. This does not quite match the names produced by the new rules because the old rules could produce several names of the `<something>.<key name>` for several key names. But the new ones can only produce one such name (one for each `opentitan_binary`). For the corrupted empty_test, I got away with using a filegroup for that purpose.

For context, [this is the simulator code that creates the filename](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/dv/env/chip_env_cfg.sv#L419)