### PR TITLE
[bazel] Migrate e2e sigverify_mod_exp to new build/test rules.

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/BUILD
@@ -3,20 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
     "cw310_params",
-    "opentitan_functest",
+    "opentitan_test",
+    "rsa_key_for_lc_state",
+)
+load(
+    "//rules:opentitan.bzl",
+    "RSA_ONLY_KEY_STRUCTS",
 )
 load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
-    "hex",
-)
-load(
-    "//rules:opentitan.bzl",
-    "get_key_structs_for_lc_state",
-    "opentitan_flash_binary",
 )
 load(
     "//rules:otp.bzl",
@@ -33,10 +32,6 @@ load(
 load(
     "//rules:splice.bzl",
     "bitstream_splice",
-)
-load(
-    "@bazel_skylib//lib:shell.bzl",
-    "shell",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -58,28 +53,6 @@ SIGVERIFY_MOD_EXP_CASES = [
         "exit_success": {lc_state: "use_sw_rsa_verify=0x00000000" for lc_state, lc_state_val in get_lc_items()},
     },
 ]
-
-opentitan_flash_binary(
-    name = "empty_test_sigverify_mod_exp",
-    testonly = True,
-    srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-    devices = [
-        "fpga_cw310",
-        "sim_dv",
-    ],
-    local_defines = [
-        shell.quote("EMPTY_TEST_MSG=\"use_sw_rsa_verify=0x%08x\", otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN_OFFSET)"),
-    ],
-    signed = True,
-    deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-        "//sw/device/silicon_creator/lib/sigverify:spx_verify",
-    ],
-)
 
 [
     otp_json(
@@ -127,11 +100,12 @@ opentitan_flash_binary(
 ]
 
 [
-    opentitan_functest(
+    opentitan_test(
         name = "sigverify_mod_exp_{}_{}".format(
             lc_state,
             t["name"],
         ),
+        srcs = ["sigverify_mod_exp.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_mod_exp_{}_{}".format(
                 lc_state,
@@ -140,13 +114,22 @@ opentitan_flash_binary(
             exit_success = t["exit_success"][lc_state],
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        key_struct = get_key_structs_for_lc_state(
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+        rsa_key = rsa_key_for_lc_state(
+            RSA_ONLY_KEY_STRUCTS,
             lc_state_val,
-            spx = None,
-        )[0],
-        ot_flash_binary = ":empty_test_sigverify_mod_exp",
-        signed = True,
-        targets = ["cw310_rom_with_fake_keys"],
+        ),
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
     )
     for lc_state, lc_state_val in get_lc_items()
     for t in SIGVERIFY_MOD_EXP_CASES

--- a/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/sigverify_mod_exp.c
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/sigverify_mod_exp.c
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+#include "sw/device/silicon_creator/lib/sigverify/spx_verify.h"
+
+#include "otp_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  LOG_INFO(
+      "use_sw_rsa_verify=0x%08x",
+      otp_read32(
+          OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN_OFFSET));
+  return true;
+}


### PR DESCRIPTION
Fixes #20104.