### PR TITLE
[rom_ext_e2e] Add more tests to the test plan

### DIFF
--- a/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
@@ -15,7 +15,7 @@
             - The test program should be tested in the A slot, the B slot and the virtual slot.
             '''
       tags: ["rom_ext", "fpga", "silicon"]
-      stage: V2
+      stage: V3
       tests: []
     }
 
@@ -28,9 +28,101 @@
             - The test program should be signed with the fake `test` key, the fake `dev` key and an invalid key.
             '''
       tags: ["rom_ext", "fpga", "silicon"]
-      stage: V2
+      stage: V3
       tests: []
     }
 
+    {
+      name: rom_ext_e2e_handoff_expectations
+      desc: '''Verify that ROM_EXT checks and verifies expectations.
+
+            - Use JTAG to halt the CPU upon ROM_EXT entry.
+            - Use JTAG to corrupt registers known to the sec_mmio expectations.
+            - Resume execution and verify the ROM_EXT faults.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: rom_ext_e2e_handoff_fault
+      desc: '''Verify that ROM_EXT goes to shutdown if there is a CPU fault.
+
+            - Write a bare-metal program that does not install its own interrupt vector.
+            - Cause CPU faults (e.g. alignment fault, invalid address, hardware interrupt).
+            - Verify that the ROM_EXT shutdown handler reports the fault.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: rom_ext_e2e_bootsvc_empty
+      desc: '''Verify that ROM_EXT processes the BootSvcEmpty message.
+
+            - The test program should be launched via the OTTF.
+            - Create a boot services empty message.
+            - Reboot.
+            - Verify the ROM_EXT response to the empty message.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: rom_ext_e2e_bootsvc_next_bl0
+      desc: '''Verify that ROM_EXT processes the BootSvcNextBl0SlotReq message.
+
+            - The test program should be launched via the OTTF.
+            - The test program should log the side it booted over several boots.
+            - Boot on side A
+            - Create a boot services next BL0 slot request message requesting side B.
+            - Reboot.
+            - Verify the ROM_EXT booted the owner stage on side B.
+            - Reboot.
+            - Verify the ROM_EXT booted the owner stage on side A.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: rom_ext_e2e_bootsvc_primary_bl0
+      desc: '''Verify that ROM_EXT processes the BootSvcPrimaryBl0SlotReq message.
+
+            - The test program should be launched via the OTTF.
+            - The test program should log the side it booted over several boots.
+            - Boot on side A
+            - Create a boot services primary BL0 slot request message requesting side B.
+            - Reboot.
+            - Verify the ROM_EXT booted the owner stage on side B.
+            - Reboot.
+            - Verify the ROM_EXT booted the owner stage on side B again.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
+
+    {
+      name: rom_ext_e2e_bootsvc_bl0_sec_ver
+      desc: '''Verify that ROM_EXT processes the BootSvcMinBl0SecVerReq message.
+
+            - The test program should be launched via the OTTF.
+            - The test program should be signed twice: once with securtiy version N and once with version N+1.
+            - Assemble the image such that version N and N+1 are in slots A and B.
+            - Verify the ROM_EXT can boot both sides.
+            - Create a boot services minimum BL0 version message setting the version to N+1.
+            - Reboot.
+            - Verify the ROM_EXT will only boot side B.
+            '''
+      tags: ["rom_ext", "fpga", "silicon"]
+      stage: V3
+      tests: []
+    }
   ]
 }


### PR DESCRIPTION
Add tests to cover ROM-to-ROM_EXT handoff behavior and currently implemented boot services requests.