### PR TITLE
Flash info acc cw310

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -452,6 +452,27 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sival_flash_info_access_testunlock
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:flash_ctrl_info_access_lc:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStTestUnlocked0"]
+    }
+    {
+      name: chip_sival_flash_info_access_dev
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:flash_ctrl_info_access_lc:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStDev"]
+    }
+    {
+      name: chip_sival_flash_info_access_prod
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:flash_ctrl_info_access_lc:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=OtpTypeLcStProd"]
+    }
+    {
       name: chip_sw_all_escalation_resets
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
       sw_images: ["//sw/device/tests/sim_dv:all_escalation_resets_test:1:new_rules"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1022,6 +1022,26 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "flash_ctrl_info_access_lc",
+    srcs = ["flash_ctrl_info_access_lc.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "flash_ctrl_clock_freqs_test",
     srcs = ["flash_ctrl_clock_freqs_test.c"],
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1021,25 +1021,53 @@ opentitan_test(
     ],
 )
 
-opentitan_test(
-    name = "flash_ctrl_info_access_lc",
-    srcs = ["flash_ctrl_info_access_lc.c"],
-    exec_env = EARLGREY_TEST_ENVS,
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/dif:lc_ctrl",
-        "//sw/device/lib/dif:rv_plic",
-        "//sw/device/lib/runtime:irq",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
-        "//sw/device/lib/testing:isr_testutils",
-        "//sw/device/lib/testing:lc_ctrl_testutils",
-        "//sw/device/lib/testing:rv_plic_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
+_FLASH_CTRL_INFO_ACCESS_LC_STATES = {
+    'test_unlocked0': 0x02108421,
+    'dev': 0x21084210,
+    'dev_individualized': 0x21084210,
+    'prod': 0x2318c631,
+    'prod_end': 0x25294a52
+}
+load(
+    "//rules:opentitan.bzl",
+    "RSA_ONLY_KEY_STRUCTS",
 )
+load(
+    "//rules/opentitan:defs.bzl",
+    "rsa_key_for_lc_state",
+)
+
+[
+    opentitan_test(
+        name = "flash_ctrl_info_access_lc_{}".format(lc_state),
+        srcs = ["flash_ctrl_info_access_lc.c"],
+        cw310 = new_cw310_params(
+            bitstream = "//hw/bitstream:rom_with_fake_keys_otp_{}".format(lc_state),
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        rsa_key = rsa_key_for_lc_state(
+            RSA_ONLY_KEY_STRUCTS,
+            _FLASH_CTRL_INFO_ACCESS_LC_STATES[lc_state],
+        ),
+        deps = [
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:mmio",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:rv_plic",
+            "//sw/device/lib/runtime:irq",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:flash_ctrl_testutils",
+            "//sw/device/lib/testing:isr_testutils",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
+            "//sw/device/lib/testing:rv_plic_testutils",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for lc_state, lc_state_val in _FLASH_CTRL_INFO_ACCESS_LC_STATES.items()
+]
 
 opentitan_test(
     name = "flash_ctrl_clock_freqs_test",

--- a/sw/device/tests/flash_ctrl_info_access_lc.c
+++ b/sw/device/tests/flash_ctrl_info_access_lc.c
@@ -1,0 +1,241 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "lc_ctrl_regs.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+#define FLASH_CTRL_NUM_IRQS 5
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_lc_ctrl_t lc_ctrl;
+static dif_rv_plic_t plic0;
+static dif_flash_ctrl_state_t flash_state;
+static dif_flash_ctrl_t flash_ctrl;
+
+static plic_isr_ctx_t plic_ctx = {
+    .rv_plic = &plic0,
+    .hart_id = kTopEarlgreyPlicTargetIbex0,
+};
+
+static flash_ctrl_isr_ctx_t flash_ctx = {
+    .flash_ctrl = &flash_ctrl,
+    .plic_flash_ctrl_start_irq_id = kTopEarlgreyPlicIrqIdFlashCtrlProgEmpty,
+    .is_only_irq = false,
+};
+
+enum {
+  kFlashInfoBank = 0,
+  kPartitionId = 0,
+  kFlashInfoPageIdCreatorSecret = 1,
+  kFlashInfoPageIdOwnerSecret = 2,
+  kFlashInfoPageIdIsoPart = 3,
+  kInfoSize = 16,
+};
+
+const uint32_t kRandomData1[kInfoSize] = {
+    0xb295d21b, 0xecdfbdcd, 0x67e7ab2d, 0x6f660b08, 0x273bf65c, 0xe80f1695,
+    0x586b80db, 0xc3dba27e, 0xdc124c5d, 0xb01ccd52, 0x815713e1, 0x31a141b2,
+    0x2124be3b, 0x299a6f2a, 0x1f2a4741, 0x1a073cc0,
+};
+
+const uint32_t kRandomData2[kInfoSize] = {
+    0x69e705a0, 0x65c2ec6b, 0x04b0b634, 0x59313526, 0x1858aee1, 0xd49f3ba9,
+    0x230bcd38, 0xc1eb6b3e, 0x68c15e3b, 0x024d02a9, 0x0b062ae4, 0x334dd155,
+    0x53fdbf8a, 0x3792f1e2, 0xee317161, 0x33b19bf3,
+};
+
+const uint32_t kRandomData3[kInfoSize] = {
+    0x2b78dbf5, 0x3e6e5a00, 0xbf82c6d5, 0x68d8e33f, 0x9c524bbc, 0xac5beeef,
+    0x1287ca5a, 0x12b61419, 0x872e709f, 0xf91b7c0c, 0x18312a1f, 0x325cef9a,
+    0x19fefa95, 0x4ceb421b, 0xa57d74c4, 0xaf1d723d,
+};
+
+static volatile bool expected_irqs[FLASH_CTRL_NUM_IRQS];
+static volatile bool fired_irqs[FLASH_CTRL_NUM_IRQS];
+
+/**
+ * Provides external IRQ handling for this test.
+ *
+ * This function overrides the default OTTF external ISR.
+ */
+void ottf_external_isr(void) {
+  top_earlgrey_plic_peripheral_t peripheral_serviced;
+  dif_flash_ctrl_irq_t irq_serviced;
+  isr_testutils_flash_ctrl_isr(plic_ctx, flash_ctx, &peripheral_serviced,
+                               &irq_serviced);
+  CHECK(peripheral_serviced == kTopEarlgreyPlicPeripheralFlashCtrl,
+        "Interurpt from unexpected peripheral: %d", peripheral_serviced);
+  fired_irqs[irq_serviced] = true;
+}
+
+/**
+ * Clear the volatile IRQ variables.
+ */
+static void clear_irq_variables(void) {
+  for (int i = 0; i < FLASH_CTRL_NUM_IRQS; ++i) {
+    expected_irqs[i] = false;
+    fired_irqs[i] = false;
+  }
+}
+
+/**
+ * Initializes FLASH_CTRL and enables the relevant interrupts.
+ */
+static void flash_ctrl_init_with_irqs(mmio_region_t base_addr,
+                                      dif_flash_ctrl_state_t *flash_state,
+                                      dif_flash_ctrl_t *flash_ctrl) {
+  CHECK_DIF_OK(dif_flash_ctrl_init(base_addr, flash_ctrl));
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(flash_state, base_addr));
+
+  for (dif_flash_ctrl_irq_t i = 0; i < FLASH_CTRL_NUM_IRQS; ++i) {
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        flash_ctrl, kDifFlashCtrlIrqProgEmpty + i, kDifToggleEnabled));
+  }
+  clear_irq_variables();
+}
+
+/**
+ * Compares the expected and fired IRQs and clears both.
+ */
+static void compare_and_clear_irq_variables(void) {
+  for (int i = 0; i < FLASH_CTRL_NUM_IRQS; ++i) {
+    CHECK(expected_irqs[i] == fired_irqs[i], "expected IRQ mismatch = %d", i);
+  }
+  clear_irq_variables();
+}
+
+/**
+ * Access infomation partition.
+ * If write or read is not allowed, device will generate recoverable alert
+ * (mp_err) and task status of write or read will fail.
+ */
+static void test_info_part(uint32_t partition_number, const uint32_t *test_data,
+                           bool write_allowed, bool read_allowed) {
+  uint32_t address = 0;
+  CHECK_STATUS_OK(flash_ctrl_testutils_info_region_setup(
+      &flash_state, partition_number, kFlashInfoBank, kPartitionId, &address));
+
+  CHECK_DIF_OK(dif_flash_ctrl_set_prog_fifo_watermark(&flash_state, 0));
+  CHECK_DIF_OK(dif_flash_ctrl_set_read_fifo_watermark(&flash_state, 8));
+  clear_irq_variables();
+
+  // Write task:
+  // Erase before program the page with test_data.
+  if (write_allowed) {
+    expected_irqs[kDifFlashCtrlIrqOpDone] = true;
+    CHECK_STATUS_OK(flash_ctrl_testutils_erase_page(
+        &flash_state, address, kPartitionId, kDifFlashCtrlPartitionTypeInfo));
+    compare_and_clear_irq_variables();
+
+    LOG_INFO("partition:%1d erase done", partition_number);
+    expected_irqs[kDifFlashCtrlIrqOpDone] = true;
+    expected_irqs[kDifFlashCtrlIrqProgEmpty] = true;
+    expected_irqs[kDifFlashCtrlIrqProgLvl] = true;
+    CHECK_STATUS_OK(flash_ctrl_testutils_write(
+        &flash_state, address, kPartitionId, test_data,
+        kDifFlashCtrlPartitionTypeInfo, kInfoSize));
+    compare_and_clear_irq_variables();
+  } else {
+    CHECK_STATUS_NOT_OK(flash_ctrl_testutils_write(
+        &flash_state, address, kPartitionId, test_data,
+        kDifFlashCtrlPartitionTypeInfo, kInfoSize));
+  }
+  LOG_INFO("partition:%1d write done", partition_number);
+
+  // Read task:
+  // Read page and compared with test_data.
+  uint32_t readback_data[kInfoSize];
+  if (read_allowed) {
+    expected_irqs[kDifFlashCtrlIrqOpDone] = true;
+    expected_irqs[kDifFlashCtrlIrqRdLvl] = true;
+    expected_irqs[kDifFlashCtrlIrqRdFull] = true;
+    CHECK_STATUS_OK(flash_ctrl_testutils_read(
+        &flash_state, address, kPartitionId, readback_data,
+        kDifFlashCtrlPartitionTypeInfo, kInfoSize, 1));
+    compare_and_clear_irq_variables();
+    CHECK_ARRAYS_EQ(readback_data, test_data, kInfoSize);
+
+  } else {
+    CHECK_STATUS_NOT_OK(flash_ctrl_testutils_read(
+        &flash_state, address, kPartitionId, readback_data,
+        kDifFlashCtrlPartitionTypeInfo, kInfoSize, 1));
+  }
+  LOG_INFO("partition:%1d read done", partition_number);
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic0));
+
+  flash_ctrl_init_with_irqs(
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR),
+      &flash_state, &flash_ctrl);
+  rv_plic_testutils_irq_range_enable(&plic0, plic_ctx.hart_id,
+                                     kTopEarlgreyPlicIrqIdFlashCtrlProgEmpty,
+                                     kTopEarlgreyPlicIrqIdFlashCtrlOpDone);
+
+  // Enable the external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  dif_lc_ctrl_id_state_t lc_id_state;
+  dif_lc_ctrl_state_t lc_state;
+  bool personalized = false;
+  // Check if device is personalized.
+  CHECK_DIF_OK(dif_lc_ctrl_get_id_state(&lc_ctrl, &lc_id_state));
+  personalized = (lc_id_state == LC_CTRL_LC_ID_STATE_STATE_VALUE_PERSONALIZED);
+  LOG_INFO("test: personalized : %d", personalized);
+
+  // Read lc state and execute info part access test.
+  // Life cycle controlled info partition access is summarized in
+  // (https://opentitan.org/book/hw/ip/lc_ctrl/doc/theory_of_operation.html#
+  // life-cycle-access-control-signals)
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &lc_state));
+  CHECK_STATUS_OK(lc_ctrl_testutils_lc_state_log(&lc_state));
+
+  switch (lc_state) {
+    case kDifLcCtrlStateTestUnlocked0:
+      test_info_part(kFlashInfoPageIdCreatorSecret, kRandomData1, 0, 0);
+      test_info_part(kFlashInfoPageIdOwnerSecret, kRandomData2, 0, 0);
+      test_info_part(kFlashInfoPageIdIsoPart, kRandomData3, 1, 0);
+      break;
+    case kDifLcCtrlStateDev:
+      test_info_part(kFlashInfoPageIdCreatorSecret, kRandomData1, !personalized,
+                     !personalized);
+      test_info_part(kFlashInfoPageIdOwnerSecret, kRandomData2, 1, 1);
+      test_info_part(kFlashInfoPageIdIsoPart, kRandomData3, 1, 0);
+      break;
+    case kDifLcCtrlStateProd:
+    case kDifLcCtrlStateProdEnd:
+      test_info_part(kFlashInfoPageIdCreatorSecret, kRandomData1, !personalized,
+                     !personalized);
+      test_info_part(kFlashInfoPageIdOwnerSecret, kRandomData2, 1, 1);
+      test_info_part(kFlashInfoPageIdIsoPart, kRandomData3, 1, 1);
+      break;
+    case kDifLcCtrlStateRma:
+      test_info_part(kFlashInfoPageIdCreatorSecret, kRandomData1, 1, 1);
+      test_info_part(kFlashInfoPageIdOwnerSecret, kRandomData2, 1, 1);
+      test_info_part(kFlashInfoPageIdIsoPart, kRandomData3, 1, 1);
+      break;
+    default:
+      LOG_ERROR("Unexpected lc state 0x%x", lc_state);
+  }
+  return true;
+}


### PR DESCRIPTION
test will pass with
./bazelisk.sh test --test_output=streamed //sw/device/tests:flash_ctrl_info_access_lc_test_unlocked0_fpga_cw310_rom_with_fake_keys

but fail with
./bazelisk.sh test --test_output=streamed //sw/device/tests:flash_ctrl_info_access_lc_dev_fpga_cw310_rom_with_fake_keys
./bazelisk.sh test --test_output=streamed //sw/device/tests:flash_ctrl_info_access_lc_prod_fpga_cw310_rom_with_fake_keys