### PR TITLE
[ci] Move slowest OTBN-simulator tests to nightly.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -410,7 +410,7 @@ jobs:
     displayName: GCP key path
     # Set the remote cache GCP key path
   - bash: |
-      ci/bazelisk.sh test //sw/otbn/crypto/...
+      ci/bazelisk.sh test --test_tag_filters=-nightly //sw/otbn/crypto/...
     displayName: Execute tests
 
 - job: chip_earlgrey_cw310

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -104,6 +104,29 @@ jobs:
     displayName: "Run all ROM E2E tests"
   - template: ../ci/publish-bazel-test-results.yml
 
+- job: slow_otbn_crypto_tests
+  displayName: Run slow OTBN crypto tests
+  dependsOn: lint
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
+  pool:
+    vmImage: ubuntu-20.04
+  timeoutInMinutes: 120
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - task: DownloadSecureFile@1
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    name: bazelCacheGcpKey
+    inputs:
+      secureFile: "bazel_cache_gcp_key.json"
+  - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    displayName: GCP key path
+    # Set the remote cache GCP key path
+  - bash: |
+      ci/bazelisk.sh test --test_tag_filters=nightly //sw/otbn/crypto/...
+    displayName: Execute tests
+
 - job: bob_spi_i2c
   displayName: "BoB: SPI and I2C Tests"
   timeoutInMinutes: 30

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -729,6 +729,7 @@ otbn_sim_test(
         "rsa_keygen_checkp_good_test.s",
     ],
     exp = "rsa_keygen_checkp_good_test.exp",
+    tags = ["nightly"],  # slow, do not run in CI
     deps = [
         ":rsa_keygen_checkpq_test_data",
         "//sw/otbn/crypto:div",
@@ -803,6 +804,7 @@ otbn_sim_test(
         "rsa_keygen_checkq_good_test.s",
     ],
     exp = "rsa_keygen_checkq_good_test.exp",
+    tags = ["nightly"],  # slow, do not run in CI
     deps = [
         ":rsa_keygen_checkpq_test_data",
         "//sw/otbn/crypto:div",


### PR DESCRIPTION
Adds a "nightly" tag and filters these test out of CI, running them as a nightly pipeline instead.

We previously discussed this option in https://github.com/lowRISC/opentitan/pull/19604; now that I want to add more slow tests in https://github.com/lowRISC/opentitan/pull/20136, I think it's a better option than increasing the timeout. I also added the tag to the two current slowest tests. (FPGA tests should catch most errors anyway, but it's useful to have the OTBN-simulator tests available e.g. to get accurate cycle counts.)