### PR TITLE
[ottf/ujson] Add common command handler to OTTF

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -268,6 +268,19 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "ujson_ottf_commands",
+    srcs = ["ujson_ottf_commands.c"],
+    hdrs = ["ujson_ottf_commands.h"],
+    deps = [
+        ":ujson_ottf",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:mem",
+        "//sw/device/lib/ujson",
+    ],
+)
+
 dual_cc_library(
     name = "ottf_console",
     srcs = dual_inputs(

--- a/sw/device/lib/testing/test_framework/ujson_ottf_commands.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf_commands.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ujson_ottf_commands.h"
+
+#include "sw/device/lib/testing/json/mem.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+status_t ujson_ottf_dispatch(ujson_t *uj, test_command_t command) {
+  if (uj == NULL) {
+    return INVALID_ARGUMENT();
+  }
+  switch (command) {
+    case kTestCommandMemRead32:
+      RESP_ERR(uj, ujcmd_mem_read32(uj));
+      break;
+    case kTestCommandMemRead:
+      RESP_ERR(uj, ujcmd_mem_read(uj));
+      break;
+    case kTestCommandMemWrite32:
+      RESP_ERR(uj, ujcmd_mem_write32(uj));
+      break;
+    case kTestCommandMemWrite:
+      RESP_ERR(uj, ujcmd_mem_write(uj));
+      break;
+    default:
+      return UNIMPLEMENTED();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/test_framework/ujson_ottf_commands.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf_commands.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_COMMANDS_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Handles basic memory commands known to the OTTF ujson framework.
+ *
+ * For unrecognized command codes, no response is sent back to the requester.
+ * This function returns a status with code `kUnimplemented`, and the caller
+ * chooses whether to send an error response or to forward the command code to
+ * some other handling routine.
+ *
+ * @param uj A ujson IO context.
+ * @param command The identifier for the command that was received.
+ * @return The status result of the operation, where kOk means the command's
+ *         operation completed, kUnimplemented means the command ID is unknown
+ *         to the function and may belong to a different space, and any other
+ *         status represents an error.
+ */
+status_t ujson_ottf_dispatch(ujson_t *uj, test_command_t command);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_UJSON_OTTF_COMMANDS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -990,9 +990,9 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/testing/json:command",
-        "//sw/device/lib/testing/json:mem",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
     ],
 )
 


### PR DESCRIPTION
Add common ujson command handler to OTTF, which may be used to dispatch the implementing logic for memory access commands.