### PR TITLE
[dvsim] fix seed in json report

### DIFF
--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -597,6 +597,9 @@ class SimCfg(FlowCfg):
         results['report_type'] = 'simulation'
         results['tool'] = self.tool.lower()
 
+        if self.build_seed and not self.run_only:
+            results['build_seed'] = str(self.build_seed)
+
         # Create dictionary to store results.
         results['results'] = {
             'testpoints': [],
@@ -683,7 +686,7 @@ class SimCfg(FlowCfg):
                     frs = []
                     for test, line, context in test_runs:
                         frs.append({
-                            'seed': test.seed,
+                            'seed': str(test.seed),
                             'failure_message': {
                                 'log_file_path': test.get_log_path(),
                                 'log_file_line_num': line,


### PR DESCRIPTION
Since #20036 the seed is changed to 256-bit, which exceeds what's representable in JSON and causes the Grafana dashboard scraper to fail. This large integer should be represented with a string.

Also, take the opportunity to add build_seed into the JSON report file so we don't have to scrap it from the HTML.
