### PR TITLE
OTTF sival library + example

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -225,6 +225,18 @@ cc_library(
 )
 
 cc_library(
+    name = "ottf_utils",
+    hdrs = ["ottf_utils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
+    ],
+)
+
+cc_library(
     name = "ottf_main",
     srcs = ["ottf_main.c"],
     hdrs = ["ottf_main.h"],

--- a/sw/device/lib/testing/test_framework/ottf_utils.h
+++ b/sw/device/lib/testing/test_framework/ottf_utils.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_UTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_UTILS_H_
+
+#include <stdbool.h>
+#include <stdnoreturn.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf_commands.h"
+
+/**
+ * Wait until a condition is true.
+ *
+ * @param cond: an expression that can be repeated tested for.
+ * @param timeout_usec: timeout in microseconds.
+ *
+ * In DV, this function will simply spin since the DV environment can do
+ * backdoor writes to make the condition true. On real device, this will wait
+ * for host to send ujson message. The condition is check after each command.
+ */
+#define OTTF_WAIT_FOR(cond, timeout_usec)                                  \
+  do {                                                                     \
+    if (kDeviceType != kDeviceSimDV) {                                     \
+      ujson_t uj = ujson_ottf_console();                                   \
+      const ibex_timeout_t timeout_ = ibex_timeout_init(timeout_usec);     \
+      test_command_t command;                                              \
+      LOG_INFO("SiVal: waiting for commands");                             \
+      while (!(cond)) {                                                    \
+        CHECK(!ibex_timeout_check(&timeout_),                              \
+              "Timed out after %d usec waiting for " #cond, timeout_usec); \
+        /* FIXME: what to do on error? */                                  \
+        CHECK_STATUS_OK(ujson_deserialize_test_command_t(&uj, &command));  \
+        CHECK_STATUS_OK(ujson_ottf_dispatch(&uj, command));                \
+      }                                                                    \
+    } else {                                                               \
+      IBEX_SPIN_FOR(cond, timeout_usec);                                   \
+    }                                                                      \
+  } while (0)
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_UTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2725,3 +2725,21 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_test(
+    name = "example_sival",
+    srcs = ["example_sival.c"],
+    cw310 = new_cw310_params(
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+            "\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/example_sival",
+    ),
+    exec_env = EARLGREY_TEST_ENVS,
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
+    ],
+)

--- a/sw/device/tests/example_sival.c
+++ b/sw/device/tests/example_sival.c
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_utils.h"
+
+/* We need control flow for the ujson messages exchanged
+ * with the host in OTTF_WAIT_FOR on real devices. */
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+enum {
+  kTestTimeoutMicros = 1000 * 1000, /* one second */
+};
+
+enum phase_t {
+  /* Wait for host to move to next phase. */
+  kWaitHost1 = 0,
+  /* Wait for device to move to next phase. */
+  kWaitDevice1 = 1,
+  /* Wait for host to move to next phase. */
+  kWaitHost2 = 2,
+  /* Test finished. */
+  kTestDone = 3,
+};
+
+/* Use a known size integer for the debugger. Mark this as
+ * volatile so it can be changed by the host/DV env. */
+volatile uint32_t kPhase = kWaitHost1;
+
+bool test_main(void) {
+  LOG_INFO("Waiting for host");
+  /* Wait until host changes the phase. On DV, this will simply until
+   * the environment change the value of the variable. On a real device,
+   * this will wait for ujson messages from the host that read/write
+   * memory. The condition is check after each message and the test will
+   * be aborted the condition is still false after the timeout. */
+  OTTF_WAIT_FOR(kPhase != kWaitHost1, kTestTimeoutMicros);
+  /* Make sure that host moved to the expected phase. */
+  CHECK(kPhase == kWaitDevice1, "kPhase should be kWaitDevice1 (%d) but is %d",
+        kWaitDevice1, kPhase);
+  LOG_INFO("Change phase to kWaitHost2");
+  /* Change phase, the host will verify that the phase matches. */
+  kPhase = kWaitHost2;
+  /* Wait until host changes the phase again. */
+  OTTF_WAIT_FOR(kPhase != kWaitHost2, kTestTimeoutMicros);
+  CHECK(kPhase == kTestDone, "kPhase should be kTestDone (%d) but is %d",
+        kTestDone, kPhase);
+  return true;
+}

--- a/sw/host/tests/chip/example_sival/BUILD
+++ b/sw/host/tests/chip/example_sival/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "example_sival",
+    srcs = [
+        "main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/example_sival/main.rs
+++ b/sw/host/tests/chip/example_sival/main.rs
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use object::{Object, ObjectSymbol};
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::mem::{MemRead32Req, MemWrite32Req};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+}
+
+/* This matches the phases in example_sival.c */
+#[repr(u32)]
+enum Phase {
+    /* Wait for host to move to next phase. */
+    WaitHost1 = 0,
+    /* Wait for device to move to next phase. */
+    WaitDevice1 = 1,
+    /* Wait for host to move to next phase. */
+    WaitHost2 = 2,
+    /* Test finished. */
+    TestDone = 3,
+}
+
+/* Wait for the device to be ready to receice ujson message,
+ * read the content of the `kPhase` variable on the device
+ * and check that it matches the expected phase. Then set the
+ * value of this variable to a new value. */
+fn check_and_set_phase(
+    uart: &dyn Uart,
+    phase_address: u32,
+    check_phase: Phase,
+    set_phase: Phase,
+) -> Result<()> {
+    let phase_value = MemRead32Req::execute(uart, phase_address)?;
+    assert!(phase_value == check_phase as u32);
+    MemWrite32Req::execute(uart, phase_address, set_phase as u32)?;
+    Ok(())
+}
+
+fn example_test(opts: &Opts, uart: &dyn Uart, phase_address: u32) -> Result<()> {
+    /* Wait for device to be ready and change phase. */
+    check_and_set_phase(uart, phase_address, Phase::WaitHost1, Phase::WaitDevice1)?;
+    /* Wait for device to be ready and change phase. */
+    check_and_set_phase(uart, phase_address, Phase::WaitHost2, Phase::TestDone)?;
+    /* Wait for test to end. */
+    let _ = UartConsole::wait_for(uart, r"PASS![^\r\n]*", opts.timeout)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    /* Load the ELF binary and get the address of the `kPhase` variable
+     * in example_sival.c */
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let elf_file = object::File::parse(&*elf_binary)?;
+    let mut symbols = HashMap::<String, u32>::new();
+    for sym in elf_file.symbols() {
+        symbols.insert(sym.name()?.to_owned(), sym.address() as u32);
+    }
+    let phase_address = symbols
+        .get("kPhase")
+        .expect("Provided ELF missing 'kPhase' symbol");
+
+    /* Initialize transport and wait until the test starts running */
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(example_test, &opts, &*uart, *phase_address,);
+    Ok(())
+}


### PR DESCRIPTION
This PR does several things:
- modify the test framework `status` so that it can call a custom abort function
- modify ottf to override the status abort function so it can report status in all case and run the debugger
- implement a ujson debugger that is called when a test passes or failed, this debugger accepts the memory commands
- the debugger also has an `exit` command to exit the loop
- a test can use the `OTTF_DEBUG_UNTIL` macros to call the debugger and wait until a condition is true, for example `OTTF_DEBUG_UNTIL(kPhase != kWaitHost1);`
- there is an example to put everything together, the device having four phases that require host intervention

Run with
```bash
./bazelisk.sh test --test_output=streamed --cache_test_results=no //sw/device/tests:example_sival_fpga_cw310_test_rom
```

Further thoughts:
- If convenient, we could extend `ottf_debugger` to take a function pointer to handle custom commands while in debugger mode. This could be convenient for tests that requires more complex interactions and where maybe poking at many registers and memory is not ideal.

NOTE:
The whole `check`, `status`, `ottf_main` situation is a mess, this PR maybe makes it worse. I don't think it's right that the `status` library should abort on `test_status_set(kFailed)` since this is a DV-only status reporting functionality. Ideally, we would want a unified framework to wait for the host to do something, remove `test_status` entirely, make sure that only `check` can abort and when that happens, it call into ottf.