### PR TITLE
[manuf] add flash data config function to `individualize_sw_cfg` lib

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/BUILD
@@ -78,6 +78,8 @@ otp_json(
                 # `kSigverifySpxDisabledOtp` and `kSigverifySpxEnabledOtp` in
                 # sw/device/silicon_creator/lib/sigverify/spx_verify.h.
                 "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x8d6c8c17),
+                # Enable flash data page scrambling and ECC.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
                 # Enable use of entropy for countermeasures. See the definition
                 # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
                 "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_TRUE),

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
@@ -63,7 +63,9 @@ ${fileheader}
     else:
       raise f"Invalid alignment: {alignment}"
 
-    base_declaration = f"static const {type_str} {ToConstLabelValue(item['name'])}"
+    base_declaration = f"const {type_str} {ToConstLabelValue(item['name'])}"
+    if item["name"] != "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG":
+      base_declaration = "static " + base_declaration
 
     if item["num_items"] == 1:
       return f"{base_declaration} = {item['values'][0]};"

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -143,6 +143,7 @@ cc_library(
     deps = [
         ":otp_img_types",
         ":util",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:otp_ctrl",
@@ -166,6 +167,12 @@ opentitan_test(
     cw310 = cw310_params(
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked1",
         tags = ["manuf"],
+        test_cmd = """
+        --clear-bitstream
+        --bitstream={bitstream}
+        --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/manuf/individualize_sw_cfg",
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
@@ -176,7 +183,8 @@ opentitan_test(
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
-        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -14,6 +14,7 @@
  */
 extern const size_t kOtpKvCreatorSwCfgSize;
 extern const otp_kv_t kOtpKvCreatorSwCfg[];
+extern const uint32_t kCreatorSwCfgFlashDataDefaultCfgValue;
 
 /**
  * OTP Owner Software Configuration Partition.
@@ -30,17 +31,60 @@ extern const otp_kv_t kOtpKvOwnerSwCfg[];
  * - AST and entropy complex configuration
  * - Various ROM feature knobs
  *
- * Note: The operation will fail if there are any pre-programmed words not equal
- * to the expected test values.
- *
- * This partition must be configured, and the chip reset, before the ROM can be
- * booted, thus enabling bootstrap.
+ * Note:
+ * - The operation will fail if there are any pre-programmed words not equal
+ *   to the expected test values.
+ * - This operation will explicitly NOT provision the FLASH_DATA_DEFAULT_CFG
+ *   field in the CREATOR_SW_CFG partition. This field must be explicitly
+ *   configured after all other provisioning operations are done, but before the
+ *   partition is locked, and the final transport image is loaded.
+ * - This function will NOT lock the partition either. This must be done after
+ *   provisioning the final FLASH_DATA_DEFAULT_CFG filed mentioned above.
+ * - The partition must be configured and the chip reset, before the ROM can be
+ *   booted, thus enabling bootstrap.
  *
  * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the HW_CFG partition is locked.
+ * @return OK_STATUS if the CREATOR_SW_CFG partition was provisioned.
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_individualize_device_creator_sw_cfg(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Configures the FLASH_DATA_DEFAULT_CFG field in the CREATOR_SW_CFG OTP
+ * partition.
+ *
+ * This must be called before `manuf_individualize_device_creator_sw_cfg_lock()`
+ * is called. The operation will fail if there are any pre-programmed words not
+ * equal to the expected test values.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the FLASH_DATA_DEFAULT_CFG field was provisioned.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_flash_data_default_cfg(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Locks the CREATOR_SW_CFG OTP partition.
+ *
+ * This must be called after both `manuf_individualize_device_creator_sw_cfg()`
+ * and `manuf_individualize_device_flash_data_default_cfg()` have been called.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the CREATOR_SW_CFG partition was locked.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_creator_sw_cfg_lock(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Checks the CREATOR_SW_CFG OTP partition end state.
+ *
+ * @param otp_ctrl OTP controller interface.
+ * @return OK_STATUS if the CREATOR_SW_CFG partition is locked.
+ */
+status_t manuf_individualize_device_creator_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**
@@ -52,23 +96,16 @@ status_t manuf_individualize_device_creator_sw_cfg(
  * - ROM bootstrap disablement
  * - ROM_EXT bootstrap enablement
  *
- * Note: The operation will fail if there are any pre-programmed words not equal
- * to the expected test values.
+ * Note:
+ *  - The operation will fail if there are any pre-programmed words not equal to
+ *    the expected test values.
+ *  - The operation will lock the OWNER_SW_CFG OTP partition.
  *
  * @param otp_ctrl OTP controller instance.
  * @return OK_STATUS if the HW_CFG partition is locked.
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_individualize_device_owner_sw_cfg(
-    const dif_otp_ctrl_t *otp_ctrl);
-
-/**
- * Checks the CREATOR_SW_CFG OTP partition end state.
- *
- * @param otp_ctrl OTP controller interface.
- * @return OK_STATUS if the CREATOR_SW_CFG partition is locked.
- */
-status_t manuf_individualize_device_creator_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize.c
@@ -67,8 +67,12 @@ bool test_main(void) {
   // Check we are in a mission mode LC state (i.e., DEV, PROD, or PROD_END).
   CHECK_STATUS_OK(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
 
-  // Check {CREATOR,OWNER}_SW_CFG and HW_CFG OTP partitions have been locked.
-  CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg_check(&otp_ctrl));
+  // Check the CREATOR_SW_CFG is NOT yet be locked, as the flash data page
+  // configuration field should not yet be provisioned.
+  CHECK_STATUS_NOT_OK(
+      manuf_individualize_device_creator_sw_cfg_check(&otp_ctrl));
+
+  // Check OWNER_SW_CFG and HW_CFG OTP partitions have been locked.
   CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg_check(&otp_ctrl));
   CHECK_STATUS_OK(manuf_individualize_device_hw_cfg_check(&otp_ctrl));
 

--- a/sw/host/tests/manuf/individualize_sw_cfg/BUILD
+++ b/sw/host/tests/manuf/individualize_sw_cfg/BUILD
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "individualize_sw_cfg",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)

--- a/sw/host/tests/manuf/individualize_sw_cfg/src/main.rs
+++ b/sw/host/tests/manuf/individualize_sw_cfg/src/main.rs
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use regex::Regex;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Get UART, set flow control, and wait for for test to start running.
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Provisioned and locked CREATOR_SW_CFG OTP partition.",
+        opts.timeout,
+    )?;
+
+    // Bootstrap test program into flash again, since we have since enabled flash scrambling.
+    uart.clear_rx_buffer()?;
+    opts.init.bootstrap.init(transport)?;
+
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Provisioned and locked OWNER_SW_CFG OTP partition.",
+        opts.timeout,
+    )?;
+
+    // Reset chip, run flash stage, and wait for test status pass over the UART.
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let result = console.interact(&*uart, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(rma_unlock_token_export, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
The `individualize_sw_cfg` lib contains functions to provision and lock the CREATOR_SW_CFG and OWNER_SW_CFG OTP partitions. The CREATOR_SW_CFG provisioning needed to be updated to take into consideration ordering dependencies between the provisioning of various OTP partitions. Namely, the FLASH_DATA_DEFAULT_CFG field should only be provisioned after the SECRET1 partition, which can only be provisioned after the HW_CFG partition (since this enables use of the CSRNG SW interface).

To address this, API functions have been added to enable provisioning the FLASH_DATA_DEFAULT_CFG OTP field in isolation from provisioning the rest of the CREATOR_SW_CFG OTP fields.

This partially addresses #19455.