### PR TITLE
[ottf] Announce all test_status_set calls

### DIFF
--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -94,6 +94,7 @@ interface sw_logger_if #(
   // Indicate when the log was printed and what was the final string.
   event  printed_log_event;
   arg_t  printed_log;
+  arg_t  printed_format;
   arg_t  printed_arg [];
 
   // Sets the sw_name with the provided path.
@@ -390,6 +391,7 @@ interface sw_logger_if #(
   // print the log captured from the SW.
   function automatic void print_sw_log(sw_log_t sw_log);
     string log_header = sw_log.name;
+    string original_format = sw_log.format;
     if (sw_log.file != "") begin
       // Append the SW file and line to the header.
       log_header = {log_header, "(", sw_log.file, ":",
@@ -532,6 +534,7 @@ interface sw_logger_if #(
       $fwrite(sw_logs_output_fd, "[%15t]: [%0s] %0s\n", $time, log_header, sw_log.format);
     end
 
+    printed_format = original_format;
     printed_log = sw_log.format;
     printed_arg = sw_log.arg;
     ->printed_log_event;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -229,9 +229,10 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
 
     sw_symbol_backdoor_overwrite("kBackdoorExpectedBytes", backdoor_data);
 
-    sync_with_sw(kTestPhaseMainSram);
+    `DV_WAIT(cfg.sw_logger_vif.printed_format == "RET_SRAM addr: %0h MAIN_SRAM addr: %0h");
     ret_sram_offset = int'(cfg.sw_logger_vif.printed_arg[0]);
     main_sram_offset = int'(cfg.sw_logger_vif.printed_arg[1]);
+    sync_with_sw(kTestPhaseMainSram);
 
     `uvm_info(`gfn, $sformatf("Testing main sram addr: %x", main_sram_offset), UVM_LOW);
     fork
@@ -239,9 +240,10 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
       main_backdoor_write(main_sram_offset);
     join_none
 
-    sync_with_sw(kTestPhaseRetSram);
+    `DV_WAIT(cfg.sw_logger_vif.printed_format == "RET_SRAM addr: %0h MAIN_SRAM addr: %0h");
     ret_sram_offset = int'(cfg.sw_logger_vif.printed_arg[0]);
     main_sram_offset = int'(cfg.sw_logger_vif.printed_arg[1]);
+    sync_with_sw(kTestPhaseRetSram);
 
     `uvm_info(`gfn, $sformatf("Testing ret sram addr: %x", ret_sram_offset), UVM_LOW);
     fork

--- a/sw/device/lib/testing/test_framework/status.c
+++ b/sw/device/lib/testing/test_framework/status.c
@@ -37,6 +37,7 @@ void test_status_set(test_status_t test_status) {
       break;
     }
     default: {
+      LOG_INFO("test_status_set to 0x%x", test_status);
       test_status_device_write(test_status);
       break;
     }

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -391,12 +391,12 @@ bool test_main(void) {
 
   scrambling_frame = (scramble_test_frame *)main_sram_addr;
   reference_frame = (scramble_test_frame *)ret_sram_addr;
-  LOG_INFO("RET_SRAM addr: %x MAIN_SRAM addr: %x", ret_sram_addr,
-           main_sram_addr);
 
   dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
   uint8_t current_phase = kTestPhase[0];
   if (info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("RET_SRAM addr: %x MAIN_SRAM addr: %x", ret_sram_addr,
+             main_sram_addr);
     sync_testbench(current_phase);
     CHECK(kTestPhase[0] == kTestPhaseMainSram);
     LOG_INFO("First boot, testing main sram");


### PR DESCRIPTION
test_status_set() is often used in DV for synchronization. Announce all such calls via the console, so the majority of these synchronization points become available to SiVal's tester host.

Note that these announcements only occur if OTTF has a console active.