### PR TITLE
[opentitantool] Eliminate POR pin from board.rs

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -60,6 +60,10 @@ impl LoadBitstream {
             rom_timeout: self.rom_timeout,
             progress: Box::new(progress),
         };
+
+        if operation.should_skip(transport)? {
+            return Ok(None);
+        }
         transport.dispatch(&operation)
     }
 }

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/board.rs
@@ -5,25 +5,16 @@
 pub trait Board {
     const VENDOR_ID: u16 = 0x2b3e;
     const PRODUCT_ID: u16;
-
-    // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_POR_N: &'static str;
 }
 
 pub struct Cw310 {}
 
 impl Board for Cw310 {
     const PRODUCT_ID: u16 = 0xc310;
-
-    // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_POR_N: &'static str = "USB_A14";
 }
 
 pub struct Cw340 {}
 
 impl Board for Cw340 {
     const PRODUCT_ID: u16 = 0xc340;
-
-    // Pins needed for reset & bootstrap on the Chip Whisperer board.
-    const PIN_POR_N: &'static str = "PC30";
 }

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
@@ -152,18 +152,6 @@ impl<B: Board + 'static> Transport for ChipWhisperer<B> {
 
     fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
         if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
-            // Open the console UART.  We do this first so we get the receiver
-            // started and the uart buffering data for us.
-            let uart = self.uart("0")?;
-            let reset_pin = self.gpio_pin(B::PIN_POR_N)?;
-            if fpga_program.skip() {
-                log::info!("Skip loading the __skip__ bitstream.");
-                return Ok(None);
-            }
-            if fpga_program.check_correct_version(&*uart, &*reset_pin)? {
-                return Ok(None);
-            }
-
             // Program the FPGA bitstream.
             log::info!("Programming the FPGA bitstream.");
             let usb = self.device.borrow();

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -77,7 +77,7 @@ pub trait Flavor {
     }
     fn get_default_usb_vid() -> u16;
     fn get_default_usb_pid() -> u16;
-    fn load_bitstream(_transport: &impl Transport, _fpga_program: &FpgaProgram) -> Result<()> {
+    fn load_bitstream(_fpga_program: &FpgaProgram) -> Result<()> {
         Err(TransportError::UnsupportedOperation.into())
     }
     fn clear_bitstream(_clear: &ClearBitstream) -> Result<()> {
@@ -617,7 +617,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
                 update_firmware_action.force,
             )
         } else if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
-            T::load_bitstream(self, fpga_program).map(|_| None)
+            T::load_bitstream(fpga_program).map(|_| None)
         } else if let Some(clear) = action.downcast_ref::<ClearBitstream>() {
             T::clear_bitstream(clear).map(|_| None)
         } else {
@@ -745,25 +745,10 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
     fn get_default_usb_pid() -> u16 {
         StandardFlavor::get_default_usb_pid()
     }
-    fn load_bitstream(transport: &impl Transport, fpga_program: &FpgaProgram) -> Result<()> {
-        if fpga_program.skip() {
-            log::info!("Skip loading the __skip__ bitstream.");
-            return Ok(());
-        }
-
+    fn load_bitstream(fpga_program: &FpgaProgram) -> Result<()> {
         // First, try to establish a connection to the native Chip Whisperer interface
         // which we will use for bitstream loading.
         let board = ChipWhisperer::<B>::new(None, None, None, &[], None)?;
-
-        // The transport does not provide name resolution for the IO interface
-        // names, so: console=UART2 and RESET=CN10_29 on the Hyp+CW310.
-        // Open the console UART.  We do this first so we get the receiver
-        // started and the uart buffering data for us.
-        let uart = transport.uart("UART2")?;
-        let reset_pin = transport.gpio_pin("CN10_29")?;
-        if fpga_program.check_correct_version(&*uart, &*reset_pin)? {
-            return Ok(());
-        }
 
         // Program the FPGA bitstream.
         log::info!("Programming the FPGA bitstream.");

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -43,6 +43,10 @@ impl CommandDispatch for LoadBitstream {
             rom_timeout: self.rom_timeout,
             progress: Box::new(progress),
         };
+
+        if operation.should_skip(transport)? {
+            return Ok(None);
+        }
         transport.dispatch(&operation)
     }
 }


### PR DESCRIPTION
Checking the version of the currently running bitstream relies only on console UART and reset GPIO pin, and need not be coded at the low level of the transport backend implementation.

This PR moves the logic up above the TransportWrapper, allowing the use of aliases from JSON configuration files, rather than Rust traits.