### PR TITLE
[crypto] Adjust ECDSA to use message digests.

### DIFF
--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -281,8 +281,8 @@ crypto_status_t otcrypto_rsa_sign_async_start(
   // Check the caller-provided private key buffer.
   HARDENED_TRY(private_key_structural_check(rsa_private_key));
 
-  // Check for NULL input buffer.
-  if (message_digest->len != 0 && message_digest->data == NULL) {
+  // Check for NULL digest buffer.
+  if (message_digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -477,7 +477,7 @@ crypto_status_t otcrypto_rsa_verify_async_finalize(
   *verification_result = kHardenedBoolFalse;
 
   // Check for NULL pointers.
-  if (message_digest->len != 0 && message_digest->data == NULL) {
+  if (message_digest->data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (verification_result == NULL) {

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -141,15 +141,21 @@ crypto_status_t otcrypto_ecdsa_keygen(const ecc_curve_t *elliptic_curve,
  * only for a custom curve. For named curves this field is ignored
  * and can be set to `NULL`.
  *
+ * The message digest must be exactly the right length for the curve in use
+ * (e.g. 256 bits for P-256), but may use any hash mode. The caller is
+ * responsible for ensuring that the security strength of the hash function is
+ * at least equal to the security strength of the curve. See FIPS 186-5 for
+ * details.
+ *
  * @param private_key Pointer to the blinded private key (d) struct.
- * @param input_message Input message to be signed.
+ * @param message_digest Message digest to be signed (pre-hashed).
  * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] signature Pointer to the signature struct with (r,s) values.
  * @return Result of the ECDSA signature generation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
-                                    crypto_const_byte_buf_t input_message,
+                                    const hash_digest_t *message_digest,
                                     const ecc_curve_t *elliptic_curve,
                                     const ecc_signature_t *signature);
 
@@ -160,8 +166,14 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  * only for a custom curve. For named curves this field is ignored
  * and can be set to `NULL`.
  *
+ * The message digest must be exactly the right length for the curve in use
+ * (e.g. 256 bits for P-256), but may use any hash mode. The caller is
+ * responsible for ensuring that the security strength of the hash function is
+ * at least equal to the security strength of the curve. See FIPS 186-5 for
+ * details.
+ *
  * @param public_key Pointer to the unblinded public key (Q) struct.
- * @param input_message Input message to be signed for verification.
+ * @param message_digest Message digest to be verified (pre-hashed).
  * @param signature Pointer to the signature to be verified.
  * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] verification_result Result of signature verification
@@ -170,7 +182,7 @@ crypto_status_t otcrypto_ecdsa_sign(const crypto_blinded_key_t *private_key,
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_verify(const ecc_public_key_t *public_key,
-                                      crypto_const_byte_buf_t input_message,
+                                      const hash_digest_t *message_digest,
                                       const ecc_signature_t *signature,
                                       const ecc_curve_t *elliptic_curve,
                                       hardened_bool_t *verification_result);
@@ -374,14 +386,14 @@ crypto_status_t otcrypto_ecdsa_keygen_async_finalize(
  * curves this field is ignored and can be set to `NULL`.
  *
  * @param private_key Pointer to the blinded private key (d) struct.
- * @param input_message Input message to be signed.
+ * @param message_digest Message digest to be signed (pre-hashed).
  * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @return Result of async ECDSA start operation.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_sign_async_start(
     const crypto_blinded_key_t *private_key,
-    crypto_const_byte_buf_t input_message, const ecc_curve_t *elliptic_curve);
+    const hash_digest_t *message_digest, const ecc_curve_t *elliptic_curve);
 
 /**
  * Finalizes the asynchronous ECDSA digital signature generation.
@@ -411,14 +423,14 @@ crypto_status_t otcrypto_ecdsa_sign_async_finalize(
  * curves this field is ignored and can be set to `NULL`.
  *
  * @param public_key Pointer to the unblinded public key (Q) struct.
- * @param input_message Input message to be signed for verification.
+ * @param message_digest Message digest to be verified (pre-hashed).
  * @param signature Pointer to the signature to be verified.
  * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @return Result of async ECDSA verify start function.
  */
 OT_WARN_UNUSED_RESULT
 crypto_status_t otcrypto_ecdsa_verify_async_start(
-    const ecc_public_key_t *public_key, crypto_const_byte_buf_t input_message,
+    const ecc_public_key_t *public_key, const hash_digest_t *message_digest,
     const ecc_signature_t *signature, const ecc_curve_t *elliptic_curve);
 
 /**

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -176,6 +176,7 @@ opentitan_test(
     ),
     deps = [
         "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",
@@ -187,6 +188,7 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p256_sideload_functest",
     srcs = ["ecdsa_p256_sideload_functest.c"],
+    exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -195,6 +197,7 @@ opentitan_test(
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:keymgr_testutils",

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -7,10 +7,16 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /* Number of 32-bit words in a SHA256 digest. */
+  kSha256DigestWords = 256 / 32,
+};
 
 // Message
 static const char kMessage[] = "test message";
@@ -72,11 +78,18 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   CHECK_STATUS_OK(
       otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
 
-  // Package message in a cryptolib-style struct.
-  crypto_const_byte_buf_t message = {
+  // Hash the message.
+  crypto_const_byte_buf_t msg = {
       .len = sizeof(kMessage) - 1,
       .data = (unsigned char *)&kMessage,
   };
+  uint32_t msg_digest_data[kSha256DigestWords];
+  hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+      .mode = kHashModeSha256,
+  };
+  TRY(otcrypto_hash(msg, &msg_digest));
 
   // Allocate space for the signature.
   uint32_t sigR[kP256ScalarWords] = {0};
@@ -91,11 +104,11 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   // Generate a signature for the message.
   LOG_INFO("Signing...");
   CHECK_STATUS_OK(
-      otcrypto_ecdsa_sign(&private_key, message, &kCurveP256, &signature));
+      otcrypto_ecdsa_sign(&private_key, &msg_digest, &kCurveP256, &signature));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_verify(&public_key, message, &signature,
+  CHECK_STATUS_OK(otcrypto_ecdsa_verify(&public_key, &msg_digest, &signature,
                                         &kCurveP256, verification_result));
 
   return OTCRYPTO_OK;

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/keymgr_testutils.h"
@@ -15,6 +16,8 @@
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
 enum {
+  /* Number of 32-bit words in a SHA256 digest. */
+  kSha256DigestWords = 256 / 32,
   /* Number of 32-bit words in a P-256 coordinate (256 bits). */
   kP256CoordWords = 256 / 32,
   /* Number of 32-bit words in a P-256 scalar (256 bits). */
@@ -88,11 +91,18 @@ status_t sign_then_verify_test(void) {
   LOG_INFO("Generating keypair...");
   TRY(otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
 
-  // Package message in a cryptolib-style struct.
+  // Hash the message.
   crypto_const_byte_buf_t message = {
       .len = sizeof(kMessage) - 1,
       .data = (unsigned char *)&kMessage,
   };
+  uint32_t message_digest_data[kSha256DigestWords];
+  hash_digest_t message_digest = {
+      .data = message_digest_data,
+      .len = ARRAYSIZE(message_digest_data),
+      .mode = kHashModeSha256,
+  };
+  TRY(otcrypto_hash(message, &message_digest));
 
   // Allocate space for the signature.
   uint32_t sigR[kP256ScalarWords] = {0};
@@ -106,13 +116,14 @@ status_t sign_then_verify_test(void) {
 
   // Generate a signature for the message.
   LOG_INFO("Signing...");
-  TRY(otcrypto_ecdsa_sign(&private_key, message, &kCurveP256, &signature));
+  TRY(otcrypto_ecdsa_sign(&private_key, &message_digest, &kCurveP256,
+                          &signature));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   hardened_bool_t verification_result;
-  TRY(otcrypto_ecdsa_verify(&public_key, message, &signature, &kCurveP256,
-                            &verification_result));
+  TRY(otcrypto_ecdsa_verify(&public_key, &message_digest, &signature,
+                            &kCurveP256, &verification_result));
 
   // The signature should pass verification.
   TRY_CHECK(verification_result == kHardenedBoolTrue);


### PR DESCRIPTION
Much like #20138, this PR adjusts the cryptolib signature API to use message digests instead of raw messages, which is more flexible for the caller.

Follow-up to #20045
Part of #19549