### PR TITLE
[opentitantool] remove dependency on proc_macro_error

### DIFF
--- a/sw/host/opentitanlib/opentitantool_derive/BUILD
+++ b/sw/host/opentitanlib/opentitantool_derive/BUILD
@@ -10,7 +10,6 @@ rust_proc_macro(
     name = "opentitantool_derive",
     srcs = ["src/lib.rs"],
     deps = [
-        "@crate_index//:proc-macro-error",
         "@crate_index//:proc-macro2",
         "@crate_index//:quote",
         "@crate_index//:syn",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -45,7 +45,6 @@ p256 = "0.13.2"
 pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
 pqcrypto-sphincsplus = { version = "0.6.4", default-features = false, features = ["std"] }
 pqcrypto-traits = "0.3.4"
-proc-macro-error = "1.0"
 proc-macro2 = "1.0.45"
 quote = "1.0"
 rand = "0.8.4"
@@ -89,6 +88,7 @@ libftdi1-sys = "1.0.0"
 ansi_term = "0.12"
 pest = "2.2"
 pest_derive = "2.2"
+proc-macro-error = "1.0"
 
 # documentation generation tools
 mdbook = "0.4.31"


### PR DESCRIPTION
syn already provides a nice diagnostics utility and there's no need to use extra crates.

Removing proc-macro-error can shrink the dependency closure by a few crates. However, this PR doesn't yet remove proc-macro-error because it's a dependency of the current serde-annotate release. We can get rid of it when bumping serde-annotate.