### PR TITLE
OTTF debugger and status report rework

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -225,6 +225,20 @@ cc_library(
 )
 
 cc_library(
+    name = "ottf_debugger",
+    srcs = ["ottf_debugger.c"],
+    hdrs = ["ottf_debugger.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
+    ],
+)
+
+cc_library(
     name = "ottf_main",
     srcs = ["ottf_main.c"],
     hdrs = ["ottf_main.h"],
@@ -246,6 +260,7 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_debugger",
         "//third_party/freertos",
         "@manufacturer_test_hooks//:test_hooks",
     ],

--- a/sw/device/lib/testing/test_framework/ottf_debugger.c
+++ b/sw/device/lib/testing/test_framework/ottf_debugger.c
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_debugger.h"
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf_commands.h"
+
+static status_t _ottf_debugger_loop(ujson_t *uj) {
+  LOG_INFO("Debugger started");
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    status_t status = ujson_ottf_dispatch(uj, command);
+    if (status_err(status) == kUnimplemented) {
+      RESP_ERR(uj, status);
+    } else if (status_err(status) != kOk) {
+      return status;
+    }
+  }
+}
+
+status_t ottf_debugger_loop(ujson_t *ujson) {
+  if (ujson == NULL) {
+    ujson_t uj = ujson_ottf_console();
+    return _ottf_debugger_loop(&uj);
+  } else {
+    return _ottf_debugger_loop(ujson);
+  }
+}

--- a/sw/device/lib/testing/test_framework/ottf_debugger.h
+++ b/sw/device/lib/testing/test_framework/ottf_debugger.h
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_DEBUGGER_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_DEBUGGER_H_
+
+#include <stdbool.h>
+#include <stdnoreturn.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+/**
+ * Put the OTTF into debugger mode where it can receive commands from the host.
+ *
+ * @param uj A ujson IO context. Pass NULL to create a temporary one.
+ * @return The status result of the operation, where kOk means that the host
+ *         asked to exit the debugger loop, and any other status represents an
+ *         error that occurred during the handling of a command.
+ */
+status_t ottf_debugger_loop(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_DEBUGGER_H_

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -100,7 +100,7 @@ void status_report(status_t status) {
   status_report_list_cnt++;
 }
 
-static void report_test_status(bool result) {
+noreturn void ottf_abort(bool result) {
   // Reinitialize UART before print any debug output if the test clobbered it.
   if (kDeviceType != kDeviceSimDV) {
     if (kOttfTestConfig.console.test_may_clobber) {
@@ -131,6 +131,9 @@ static void report_test_status(bool result) {
   }
 
   coverage_send_buffer();
+}
+
+static void report_test_status(bool result) {
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 }
 
@@ -162,6 +165,7 @@ void _ottf_main(void) {
       &rv_core_ibex));
   rand_testutils_rng_ctx = rand_testutils_init(&rv_core_ibex);
 
+  test_status_set_abort_handler(ottf_abort);
   // Run the test.
   if (kOttfTestConfig.enable_concurrency) {
     // Run `test_main()` in a FreeRTOS task, allowing other FreeRTOS tasks to

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -23,8 +23,10 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/coverage.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
+#include "sw/device/lib/testing/test_framework/ottf_debugger.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
 // TODO: make this toplevel agnostic.
@@ -131,6 +133,9 @@ noreturn void ottf_abort(bool result) {
   }
 
   coverage_send_buffer();
+  while (true) {
+    ottf_debugger_loop(NULL);
+  }
 }
 
 static void report_test_status(bool result) {

--- a/sw/device/lib/testing/test_framework/status.c
+++ b/sw/device/lib/testing/test_framework/status.c
@@ -9,6 +9,17 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 
+static test_status_abort_fn_t abort_handler = NULL;
+
+static noreturn void test_status_abort(bool result) { abort(); }
+
+void test_status_set_abort_handler(test_status_abort_fn_t fn) {
+  if (fn == NULL)
+    abort_handler = test_status_abort;
+  else
+    abort_handler = fn;
+}
+
 /**
  * Writes the test status to the test status device address.
  *
@@ -27,13 +38,13 @@ void test_status_set(test_status_t test_status) {
     case kTestStatusPassed: {
       LOG_INFO("PASS!");
       test_status_device_write(test_status);
-      abort();
+      abort_handler(true);
       break;
     }
     case kTestStatusFailed: {
       LOG_INFO("FAIL!");
       test_status_device_write(test_status);
-      abort();
+      abort_handler(false);
       break;
     }
     default: {

--- a/sw/device/lib/testing/test_framework/status.h
+++ b/sw/device/lib/testing/test_framework/status.h
@@ -5,6 +5,9 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_STATUS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_STATUS_H_
 
+#include <stdbool.h>
+#include <stdnoreturn.h>
+
 /**
  * Indicates the status of the software running on the CPU, from a testing
  * perspective.
@@ -84,5 +87,12 @@ typedef enum test_status {
  * @param test_status current status of the test.
  */
 void test_status_set(test_status_t test_status);
+
+/**
+ * Set the function to call when test_status_set is called to abort a test.
+ * If set to NULL, it will call abort on failure.
+ */
+typedef void (*test_status_abort_fn_t)(bool result);
+void test_status_set_abort_handler(test_status_abort_fn_t fn);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_STATUS_H_


### PR DESCRIPTION
This PR does several things:
- modify the test framework `status` so that it can call a custom abort function
- modify ottf to override the status abort function so it can report status in all case and run the debugger
- implement a ujson debugger that is called when a test passes or failed, this debugger accepts the memory commands
- the debugger also has an `exit` command to exit the loop

NOTE:
The whole `check`, `status`, `ottf_main` situation is a mess, this PR maybe makes it worse. I don't think it's right that the `status` library should abort on `test_status_set(kFailed)` since this is a DV-only status reporting functionality. Ideally, we would want a unified framework to wait for the host to do something, remove `test_status` entirely, make sure that only `check` can abort and when that happens, it call into ottf.