### PR TITLE
[ci, nightly] Revert the commit 636cb72b7d to fix the nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -410,7 +410,7 @@ jobs:
     displayName: GCP key path
     # Set the remote cache GCP key path
   - bash: |
-      ci/bazelisk.sh test --test_tag_filters=-nightly //sw/otbn/crypto/...
+      ci/bazelisk.sh test //sw/otbn/crypto/...
     displayName: Execute tests
 
 - job: chip_earlgrey_cw310

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -104,29 +104,6 @@ jobs:
     displayName: "Run all ROM E2E tests"
   - template: ../ci/publish-bazel-test-results.yml
 
-- job: slow_otbn_crypto_tests
-  displayName: Run slow OTBN crypto tests
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool:
-    vmImage: ubuntu-20.04
-  timeoutInMinutes: 120
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - task: DownloadSecureFile@1
-    condition: eq(variables['Build.SourceBranchName'], 'master')
-    name: bazelCacheGcpKey
-    inputs:
-      secureFile: "bazel_cache_gcp_key.json"
-  - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
-    condition: eq(variables['Build.SourceBranchName'], 'master')
-    displayName: GCP key path
-    # Set the remote cache GCP key path
-  - bash: |
-      ci/bazelisk.sh test --test_tag_filters=nightly //sw/otbn/crypto/...
-    displayName: Execute tests
-
 - job: bob_spi_i2c
   displayName: "BoB: SPI and I2C Tests"
   timeoutInMinutes: 30

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -729,7 +729,6 @@ otbn_sim_test(
         "rsa_keygen_checkp_good_test.s",
     ],
     exp = "rsa_keygen_checkp_good_test.exp",
-    tags = ["nightly"],  # slow, do not run in CI
     deps = [
         ":rsa_keygen_checkpq_test_data",
         "//sw/otbn/crypto:div",
@@ -804,7 +803,6 @@ otbn_sim_test(
         "rsa_keygen_checkq_good_test.s",
     ],
     exp = "rsa_keygen_checkq_good_test.exp",
-    tags = ["nightly"],  # slow, do not run in CI
     deps = [
         ":rsa_keygen_checkpq_test_data",
         "//sw/otbn/crypto:div",


### PR DESCRIPTION
The [commit](636cb72b7d83c29db5a4dd068e17bdd4f4a4ecce) has broken the ci nigthly, so this PR reverts it because I could not find a simple solution.