### PR TITLE
[crypto] Add a core implementation of AES-KWP and basic tests.

### DIFF
--- a/sw/device/lib/crypto/impl/aes_kwp/BUILD
+++ b/sw/device/lib/crypto/impl/aes_kwp/BUILD
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "aes_kwp",
+    srcs = ["aes_kwp.c"],
+    hdrs = ["aes_kwp.h"],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/drivers:aes",
+    ],
+)

--- a/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
+++ b/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
@@ -1,0 +1,190 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/aes.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('k', 'w', 'p')
+
+enum {
+  /** Number of bytes in a semiblock (half an AES block). */
+  kSemiblockBytes = kAesBlockNumBytes / 2,
+  /** Number of 32-bit words in a semiblock (half an AES block). */
+  kSemiblockWords = kSemiblockBytes / sizeof(uint32_t),
+};
+
+status_t aes_kwp_wrap(const aes_key_t kek, const uint32_t *plaintext,
+                      const size_t plaintext_len, uint32_t *ciphertext) {
+  // The plaintext length is expected to be at most 2^32 bytes.
+  if (plaintext_len > UINT32_MAX || plaintext_len == 0) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Calculate the number of semiblocks needed for the plaintext (round up to
+  // the next semiblock).
+  size_t plaintext_semiblocks = plaintext_len / kSemiblockBytes;
+  if (plaintext_len % kSemiblockBytes != 0) {
+    plaintext_semiblocks++;
+  }
+  size_t pad_len = kSemiblockBytes * plaintext_semiblocks - plaintext_len;
+
+  if (plaintext_semiblocks < 2) {
+    // Plaintext is too short.
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Load the AES block with the encryption key.
+  HARDENED_TRY(aes_encrypt_begin(kek, /*iv=*/NULL));
+
+  // This implementation follows the "indexing" method for the wrapping
+  // function, as described in RFC 3394, section 2.2.1:
+  //   https://datatracker.ietf.org/doc/html/rfc3394#section-2.2.1
+
+  // Construct the first semiblock (A): a fixed 32-bit prefix followed by the
+  // byte-length encoded as a big-endian 32-bit integer.
+  aes_block_t block = {
+      .data = {0xa65959a6, __builtin_bswap32(plaintext_len), 0, 0},
+  };
+
+  // Initialize the output buffer with (A || plaintext || padding).
+  size_t plaintext_words = plaintext_len / sizeof(uint32_t);
+  if (plaintext_len % sizeof(uint32_t) != 0) {
+    plaintext_words++;
+  }
+  hardened_memcpy(ciphertext, block.data, kSemiblockWords);
+  hardened_memcpy(ciphertext + kSemiblockWords, plaintext, plaintext_words);
+  unsigned char *pad_start =
+      ((unsigned char *)ciphertext) + kSemiblockBytes + plaintext_len;
+  memset(pad_start, 0, pad_len);
+
+  uint64_t t = 1;
+  for (size_t j = 0; j < 6; j++) {
+    for (size_t i = 1; i <= plaintext_semiblocks; i++) {
+      // Copy R[i] into the block (A should already be present).
+      hardened_memcpy(block.data + kSemiblockWords,
+                      ciphertext + i * kSemiblockWords, kSemiblockWords);
+      HARDENED_TRY(aes_update(/*dest=*/NULL, &block));
+      HARDENED_TRY(aes_update(&block, /*src=*/NULL));
+
+      // Encode the index and XOR it with the first semiblock, creating A for
+      // the next iteration.
+      block.data[0] ^= __builtin_bswap32((uint32_t)(t >> 32));
+      block.data[1] ^= __builtin_bswap32((uint32_t)(t & UINT32_MAX));
+      t++;
+
+      // Copy the last two words back into R[i].
+      hardened_memcpy(ciphertext + i * kSemiblockWords,
+                      block.data + kSemiblockWords, kSemiblockWords);
+    }
+  }
+
+  // Copy A into the first semiblock of the ciphertext.
+  hardened_memcpy(ciphertext, block.data, kSemiblockWords);
+  return OTCRYPTO_OK;
+}
+
+status_t aes_kwp_unwrap(const aes_key_t kek, const uint32_t *ciphertext,
+                        const size_t ciphertext_len, hardened_bool_t *success,
+                        uint32_t *plaintext) {
+  // The ciphertext length is expected to be nonempty, at most 2^32 bytes, and
+  // a multiple of the semiblock size.
+  if (ciphertext_len > UINT32_MAX || ciphertext_len == 0 ||
+      ciphertext_len % kSemiblockBytes != 0) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Calculate the number of semiblocks.
+  size_t ciphertext_semiblocks = ciphertext_len / kSemiblockBytes;
+
+  if (ciphertext_semiblocks < 3) {
+    // Ciphertext is too short.
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Load the AES block with the decryption key.
+  HARDENED_TRY(aes_decrypt_begin(kek, /*iv=*/NULL));
+
+  // This implementation follows the "indexing" method for the wrapping
+  // function, as described in RFC 3394, section 2.2.2:
+  //   https://datatracker.ietf.org/doc/html/rfc3394#section-2.2.2
+
+  // Set the first semiblock, A.
+  aes_block_t block = {
+      .data = {ciphertext[0], ciphertext[1], 0, 0},
+  };
+
+  // Initialize the working buffer, R.
+  uint32_t r[(ciphertext_semiblocks - 1) * kSemiblockWords];
+  hardened_memcpy(r, ciphertext + kSemiblockWords, ARRAYSIZE(r));
+
+  uint64_t t = 6 * ((uint64_t)ciphertext_semiblocks - 1);
+  for (size_t j = 0; j < 6; j++) {
+    for (size_t i = ciphertext_semiblocks - 1; 1 <= i; i--) {
+      // Encode the index and XOR it with the first semiblock (A ^ t).
+      block.data[0] ^= __builtin_bswap32((uint32_t)(t >> 32));
+      block.data[1] ^= __builtin_bswap32((uint32_t)(t & UINT32_MAX));
+      t--;
+
+      // Copy R[i] into the block (A ^ t should already be present).
+      hardened_memcpy(block.data + kSemiblockWords,
+                      r + (i - 1) * kSemiblockWords, kSemiblockWords);
+      HARDENED_TRY(aes_update(/*dest=*/NULL, &block));
+      HARDENED_TRY(aes_update(&block, /*src=*/NULL));
+
+      // Copy the last two words back into R[i].
+      hardened_memcpy(r + (i - 1) * kSemiblockWords,
+                      block.data + kSemiblockWords, kSemiblockWords);
+    }
+  }
+
+  // Check that the first 32 bits of A match the AES-KWP fixed prefix.
+  if (block.data[0] != 0xa65959a6) {
+    *success = kHardenedBoolFalse;
+    return OTCRYPTO_OK;
+  }
+
+  // Decode the next 32 bits of A as the plaintext length.
+  size_t plaintext_len = __builtin_bswap32(block.data[1]);
+  size_t pad_len =
+      kSemiblockBytes * (ciphertext_semiblocks - 1) - plaintext_len;
+
+  // Check that the padding length is valid.
+  if (pad_len >= kSemiblockBytes) {
+    *success = kHardenedBoolFalse;
+    return OTCRYPTO_OK;
+  }
+
+  // Check that the padding bytes are zero. Note: this should happen only after
+  // the prefix check. Otherwise it could expose a padding oracle, because
+  // memcmp is not constant-time.
+  if (pad_len != 0) {
+    uint8_t exp_pad[pad_len];
+    memset(exp_pad, 0, pad_len);
+    unsigned char *pad_start = ((unsigned char *)r) + plaintext_len;
+    if (memcmp(pad_start, exp_pad, pad_len) != 0) {
+      *success = kHardenedBoolFalse;
+      return OTCRYPTO_OK;
+    }
+  }
+
+  // Copy the plaintext into the destination buffer.
+  size_t plaintext_words = plaintext_len / sizeof(uint32_t);
+  if (plaintext_len % sizeof(uint32_t) != 0) {
+    plaintext_words++;
+  }
+  hardened_memcpy(plaintext, r, plaintext_words);
+
+  // Return success.
+  *success = kHardenedBoolTrue;
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h
+++ b/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_KWP_AES_KWP_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_KWP_AES_KWP_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/aes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * AES Key Wrapping with Padding (KWP) authenticated encryption.
+ *
+ * As defined by NIST SP800-38F (section 6.3, algorithm 5).
+ *
+ * The cipher block mode for the AES key should be ECB, since AES-KWP does not
+ * use an IV.
+ *
+ * The key material must be aligned to 32-bit word boundaries for hardening
+ * purposes. The length is still given in bytes, and bytes higher than the
+ * length are ignored (although they may be copied, so they should not be
+ * uninitialized). The plaintext must be at least 16 bytes long, and must be
+ * shorter than 2^32 bytes.
+ *
+ * The ciphertext buffer must be long enough to hold the *padded* version of
+ * the plaintext; this means the length should be rounded up to the next
+ * multiple of 64 bits. If the key length is a multiple of 64 bits, then the
+ * ciphertext and plaintext should be the same length.
+ *
+ * @param kek Key encryption key, AES key to encrypt with.
+ * @param plaintext Key material to wrap.
+ * @param plaintext_len Plaintext length in bytes.
+ * @param[out] ciphertext Output buffer.
+ * @return Error status; OK if no errors
+ */
+OT_WARN_UNUSED_RESULT
+status_t aes_kwp_wrap(const aes_key_t kek, const uint32_t *plaintext,
+                      const size_t plaintext_len, uint32_t *ciphertext);
+
+/**
+ * AES Key Wrapping with Padding (KWP) authenticated decryption.
+ *
+ * As defined by NIST SP800-38F (section 6.3, algorithm 6).
+ *
+ * The cipher block mode for the AES key should be ECB, since AES-KWP does not
+ * use an IV.
+ *
+ * The key material must be aligned to 32-bit word boundaries for hardening
+ * purposes. The length is still given in bytes and bytes higher than the given
+ * length are ignored (although they may be copied, so they should not be
+ * uninitialized). The ciphertext must be at least 24 bytes long, and must be
+ * shorter than 2^32 bytes.
+ *
+ * The output buffer should be the same length as the ciphertext, even if the
+ * plaintext is not expected to be as long; this is because the implementation
+ * will internally use it as a working buffer.
+ *
+ * An OK status from this routine does NOT mean that the unwrapping succeeded,
+ * only that there were no errors during execution. The caller must check both
+ * the returned status and the `success` parameter before reading the
+ * plaintext.
+ *
+ * @param kek Key encryption key, AES key to decrypt with.
+ * @param ciphertext Key material to unwrap.
+ * @param ciphertext_len Ciphertext length in bytes.
+ * @param[out] success Whether the ciphertext was valid.
+ * @param[out] plaintext Output buffer, same length as ciphertext
+ * @return Error status; OK if no errors
+ */
+OT_WARN_UNUSED_RESULT
+status_t aes_kwp_unwrap(const aes_key_t kek, const uint32_t *ciphertext,
+                        const size_t ciphertext_len, hardened_bool_t *success,
+                        uint32_t *plaintext);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_AES_KWP_AES_KWP_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -29,6 +29,20 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "aes_kwp_kat_functest",
+    srcs = ["aes_kwp_kat_functest.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/impl/aes_kwp",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "aes_sideload_functest",
     srcs = ["aes_sideload_functest.c"],
     exec_env = EARLGREY_TEST_ENVS,

--- a/sw/device/tests/crypto/aes_kwp_kat_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_kat_functest.c
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+// Buffer with 256 bits of zeroes to use for the second shares of AES keys.
+static const uint32_t kZero[256 / 32] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+/**
+ * Construct an AES key struct for AES-KWP from a raw word buffer.
+ *
+ * @param key Wrapping key data.
+ * @param key_words Wrapping key length in 32-bit words.
+ * @return Constructed AES key.
+ */
+static aes_key_t make_aes_key(const uint32_t *key, size_t key_words) {
+  return (aes_key_t){
+      .mode = kAesCipherModeEcb,
+      .sideload = kHardenedBoolFalse,
+      .key_len = key_words,
+      .key_shares = {key, kZero},
+  };
+}
+
+/**
+ * Run an AES-KWP encryption known-answer test.
+ *
+ * This test uses the internal AES-KWP implementation rather than the cryptolib
+ * API, since the cryptolib API pre-formats the key input and stores
+ * configuration information along with the key, which makes it insuitable for
+ * known-answer tests.
+ *
+ * @param kek Key to wrap with (key encryption key).
+ * @param kek_words Length of the key encryption key in 32-bit words.
+ * @param ptext Key material to wrap.
+ * @param ptext_bytes Length of plaintext in bytes.
+ * @param ctext Expected ciphertext.
+ * @param ctext_words Length of expected ciphertext in 32-bit words.
+ */
+static status_t aes_kwp_wrap_kat(const uint32_t *kek, size_t kek_words,
+                                 const uint32_t *ptext, size_t ptext_bytes,
+                                 const uint32_t *ctext, size_t ctext_words) {
+  // Construct an AES key.
+  aes_key_t aes_kek = make_aes_key(kek, kek_words);
+
+  // Run key wrapping and check the result.
+  uint32_t act_ctext[ctext_words + 1];
+  act_ctext[ctext_words] = 0xffffffff;
+  TRY(aes_kwp_wrap(aes_kek, ptext, ptext_bytes, act_ctext));
+  TRY_CHECK_ARRAYS_EQ(act_ctext, ctext, ctext_words);
+
+  // Check that the last word of the "actual ciphertext" buffer is still the
+  // same (i.e. the kwp routine did not write past the expected point).
+  TRY_CHECK(act_ctext[ctext_words] == 0xffffffff);
+  return OK_STATUS();
+}
+
+/**
+ * Run an AES-KWP decryption known-answer test.
+ *
+ * This test uses the internal AES-KWP implementation rather than the cryptolib
+ * API, since the cryptolib API pre-formats the key input and stores
+ * configuration information along with the key, which makes it insuitable for
+ * known-answer tests.
+ *
+ * @param kek Key to wrap with (key encryption key).
+ * @param kek_words Length of the key encryption key in 32-bit words.
+ * @param ctext Ciphertext.
+ * @param ctext_words Length of expected ciphertext in 32-bit words.
+ * @param valid Whether the ciphertext is valid or not.
+ * @param ptext Expected plaintext (ignored if valid=false).
+ * @param ptext_bytes Length of plaintext in bytes.
+ */
+static status_t aes_kwp_unwrap_kat(const uint32_t *kek, size_t kek_words,
+                                   const uint32_t *ctext, size_t ctext_words,
+                                   bool valid, const uint32_t *ptext,
+                                   size_t ptext_bytes) {
+  // Construct an AES key.
+  aes_key_t aes_kek = make_aes_key(kek, kek_words);
+
+  // Run key unwrapping.
+  size_t ptext_words = (ptext_bytes + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  uint32_t act_ptext[ptext_words];
+  hardened_bool_t success;
+  TRY(aes_kwp_unwrap(aes_kek, ctext, ctext_words * sizeof(uint32_t), &success,
+                     act_ptext));
+
+  // Check results.
+  if (valid) {
+    TRY_CHECK(success == kHardenedBoolTrue);
+    TRY_CHECK_ARRAYS_EQ((unsigned char *)act_ptext, (unsigned char *)ptext,
+                        ptext_bytes);
+  } else {
+    TRY_CHECK(success == kHardenedBoolFalse);
+  }
+
+  return OK_STATUS();
+}
+
+/**
+ * Basic test with valid data and no padding.
+ *
+ * This test data was taken from the Wycheproof test set (kwp_test.json, test
+ * ID 1).
+ */
+static status_t no_padding_test(void) {
+  uint32_t kek[] = {0x6d48676f, 0x1944911e, 0x85c243cb, 0xeac1c709};
+  uint32_t ptext[] = {0x2d63c08d, 0xe40bee92, 0x840240f7, 0x7082b010};
+  uint32_t ctext[] = {0xa63fd68c, 0xeda58a78, 0xc83f75fa,
+                      0x675a647d, 0x7c10142b, 0xe719453b};
+
+  TRY(aes_kwp_wrap_kat(kek, ARRAYSIZE(kek), ptext, sizeof(ptext), ctext,
+                       ARRAYSIZE(ctext)));
+  return aes_kwp_unwrap_kat(kek, ARRAYSIZE(kek), ctext, ARRAYSIZE(ctext),
+                            /*valid=*/true, ptext, sizeof(ptext));
+}
+
+/**
+ * Basic test with valid data and padding.
+ *
+ * This test data was taken from the NIST CAVP test set (first test in the set
+ * with plaintext_len=72 from KWP_AE_128.txt).
+ */
+static status_t needs_padding_test(void) {
+  uint32_t kek[] = {0x0fe26578, 0x9a65213c, 0x620b69b4, 0xc43cdf9c};
+  // Last word padded with 1 bits; these should be replaced with 0s during
+  // padding.
+  uint32_t ptext[] = {0xd44368bd, 0xc88d3720, 0xffffff96};
+  size_t ptext_len = 9;
+  uint32_t ctext[] = {0x56a9ec41, 0x7e04aad4, 0xfe4ecfb5,
+                      0xe7619665, 0xc5f8b64d, 0x0035e264};
+
+  TRY(aes_kwp_wrap_kat(kek, ARRAYSIZE(kek), ptext, ptext_len, ctext,
+                       ARRAYSIZE(ctext)));
+  return aes_kwp_unwrap_kat(kek, ARRAYSIZE(kek), ctext, ARRAYSIZE(ctext),
+                            /*valid=*/true, ptext, ptext_len);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  EXECUTE_TEST(result, no_padding_test);
+  EXECUTE_TEST(result, needs_padding_test);
+
+  return status_ok(result);
+}


### PR DESCRIPTION
This adds an implementation and test for AES-KWP.

Unlike most of the cryptolib API, our top-level interface for AES-KWP is slightly different than the spec; it encrypts entire blinded keys, not bytestreams:
https://github.com/lowRISC/opentitan/blob/1845d62ae788da1bf57a0153c6e53eae5dc1987e/sw/device/lib/crypto/include/aes.h#L310-L312

This means we won't be able to run KAT tests through the API, so it's important to have an internal interface that matches the spec and is suitable for encrypting raw bytestreams.