### PR TITLE
[rom_ext_e2e] Test the fault/shutdown handler

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -1,0 +1,90 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:linker.bzl", "ld_library")
+load("//rules:manifest.bzl", "manifest")
+load("//rules/opentitan:defs.bzl", "cw310_params", "opentitan_test")
+
+package(default_visibility = ["//visibility:public"])
+
+ld_library(
+    name = "ld_common",
+    includes = ["fault_common.ld"],
+    deps = [
+        "//sw/device:info_sections",
+        "//sw/device/silicon_creator/lib/base:static_critical_sections",
+    ],
+)
+
+ld_library(
+    name = "ld_slot_a",
+    script = "fault_slot_a.ld",
+    deps = [
+        ":ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
+_FAULT_TEST_CASES = {
+    "none": {
+        "defines": ["NO_FAULT=1"],
+        "exit_success": "PASS!",
+    },
+    "load_access": {
+        "defines": ["LOAD_ACCESS_FAULT=1"],
+        "exit_success": "BFV:05524902",
+    },
+    "store_access": {
+        "defines": ["STORE_ACCESS_FAULT=1"],
+        "exit_success": "BFV:07524902",
+    },
+    "illegal_instruction": {
+        "defines": ["ILLEGAL_INSTRUCTION_FAULT=1"],
+        "exit_success": "BFV:02524902",
+    },
+    "hardware_interrupt": {
+        "defines": ["HARDWARE_INTERRUPT=1"],
+        "exit_success": "BFV:8b524902",
+    },
+}
+
+[
+    opentitan_test(
+        name = "fault_{}".format(name),
+        srcs = [
+            "fault_start.S",
+            "fault_test.c",
+        ],
+        cw310 = cw310_params(
+            bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
+            exit_success = test_data["exit_success"],
+        ),
+        defines = test_data["defines"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        },
+        linker_script = ":ld_slot_a",
+        manifest = "//sw/device/silicon_owner:manifest_standard",
+        deps = [
+            "//hw/ip/uart/data:uart_regs",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:bitfield",
+            "//sw/device/lib/base:hardened",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/crt",
+            "//sw/device/lib/dif:rv_plic",
+            "//sw/device/lib/runtime:irq",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib:rom_print",
+            "//sw/device/silicon_creator/lib/base:static_critical",
+        ],
+    )
+    for name, test_data in _FAULT_TEST_CASES.items()
+]
+
+test_suite(
+    name = "faults",
+    tests = ["fault_{}".format(name) for name in _FAULT_TEST_CASES],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_common.ld
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_common.ld
@@ -1,0 +1,167 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * NOTE:
+ * This is an incomplete common portion of the first Silicon Owner stage linker
+ * file, and should not be used directly. Instead it should be included by a
+ * top level slot linker file.
+ */
+
+OUTPUT_ARCH(riscv)
+
+/**
+ * Indicate that there are no dynamic libraries, whatsoever.
+ */
+__DYNAMIC = 0;
+
+/**
+ * Marking the entry point correctly for the ELF file. The signer tool will
+ * transfer this value to the `entry_point` field of the manifest, which will
+ * then be used by the ROM_EXT to handover execution to ROM_EXT.
+ */
+ENTRY(_start_boot)
+
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x20000;
+
+/*
+ * The start of the .text section relative to the beginning of the associated
+ * slot for use in the manifest.
+ */
+_manifest_code_start = _text_start - _slot_start_address;
+/*
+ * The end of the .text section relative to the beginning of the associated slot
+ * for use in the manifest.
+ */
+_manifest_code_end = _text_end - _slot_start_address;
+/*
+ * The location of the entry point relative to the beginning of the associated
+ * slot for use in the manifest.
+ */
+_manifest_entry_point = _start_boot - _slot_start_address;
+
+/**
+ * NOTE: We have to align each section to word boundaries as our current
+ * s19->slm conversion scripts are not able to handle non-word aligned sections.
+ */
+SECTIONS {
+  .manifest _slot_start_address : {
+    KEEP(*(.manifest))
+    . = ALIGN(256);
+  } > owner_flash
+
+  /**
+   * Ibex interrupt vector.
+   *
+   * This has to be set up at a 256-byte offset, so that we can use it with
+   * Ibex.
+   */
+  .vectors : ALIGN(256) {
+    _text_start = .;
+    KEEP(*(.vectors))
+  } > owner_flash
+
+  /**
+   * C runtime (CRT) section, containing program initialization code.
+   */
+  .crt : ALIGN(4) {
+    KEEP(*(.crt))
+  } > owner_flash
+
+  /**
+   * Standard text section, containing program code.
+   */
+  .text : ALIGN(4) {
+    *(.text)
+    *(.text.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _text_end = .;
+  } > owner_flash
+
+  /**
+   * Read-only data section, containing all large compile-time constants, like
+   * strings.
+   */
+  .rodata : ALIGN(4) {
+    /* Small read-only data comes before regular read-only data for the same
+     * reasons as in the data section */
+    *(.srodata)
+    *(.srodata.*)
+    *(.rodata)
+    *(.rodata.*)
+  } > owner_flash
+
+  /**
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
+   */
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
+
+  /**
+   * Mutable data section, at the bottom of ram_main. This will be initialized
+   * from flash at runtime by the CRT.
+   *
+   * Load this by copying the bytes from [_data_init_start, _data_init_end] into
+   * the range [_data_start, _data_end].
+   */
+  .data : ALIGN(4) {
+    _data_start = .;
+    _data_init_start = LOADADDR(.data);
+
+    /* This will get loaded into `gp`, and the linker will use that register for
+     * accessing data within [-2048,2047] of `__global_pointer$`.
+     *
+     * This is much cheaper (for small data) than materializing the
+     * address and loading from that (which will take one extra instruction).
+     */
+    __global_pointer$ = . + 2048;
+
+    /* Small data should come before larger data. This helps to ensure small
+     * globals are within 2048 bytes of the value of `gp`, making their accesses
+     * hopefully only take one instruction. */
+    *(.sdata)
+    *(.sdata.*)
+
+    /* Other data will likely need multiple instructions to load, so we're less
+     * concerned about address materialisation taking more than one instruction.
+     */
+    *(.data)
+    *(.data.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _data_end = .;
+    _data_init_end = LOADADDR(.data) + SIZEOF(.data);
+
+    /* This puts it in ram_main at runtime (for the VMA), but puts the section
+     * into flash for load time (for the LMA). This is why `_data_init_*` uses
+     * `LOADADDR`.
+     *
+     * Using `AT>` means we don't have to keep track of the next free part of
+     * flash, as we do in our other linker scripts. */
+  } > ram_main AT> owner_flash
+
+  /**
+   * Standard BSS section. This will be zeroed at runtime by the CRT.
+   */
+  .bss : ALIGN(4) {
+    _bss_start = .;
+
+    /* Small BSS comes before regular BSS for the same reasons as in the data
+     * section */
+    *(.sbss)
+    *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _bss_end = .;
+  } > ram_main
+
+  INCLUDE sw/device/info_sections.ld
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_slot_a.ld
@@ -1,0 +1,24 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan first Silicon Owner stage.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The first Silicon Owner stage kept in flash, and can be loaded into either
+ * Slot A (lower half o the flash), or Slot B (upper half of flash), this
+ * linker script only targets Slot A.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Slot A starts at the start of the eFlash plus the fixed size of the first
+ * Silicon Owner stage */
+ /* TODO(#9045): Move ROM_EXT size to a common location. */
+_slot_start_address = ORIGIN(eflash) + 0x10000;
+
+REGION_ALIAS("owner_flash", eflash);
+
+INCLUDE sw/device/silicon_creator/rom_ext/e2e/handoff/fault_common.ld

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+
+/**
+ * Runtime initialization code.
+ */
+
+  /**
+   * NOTE: The "ax" flag below is necessary to ensure that this section
+   * is allocated executable space by the linker.
+   */
+  .section .crt, "ax"
+
+  /**
+   * Entry point.
+   */
+  .balign 4
+  .global _start_boot
+  .type _start_boot, @function
+_start_boot:
+  /**
+   * Set up the global pointer `gp`.
+   *
+   * Linker relaxations are disabled until the global pointer is setup below,
+   * because otherwise some sequences may be turned into `gp`-relative
+   * sequences, which is incorrect when `gp` is not initialized.
+   */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
+  /**
+   * Disable Interrupts.
+   *
+   * We cannot disable exceptions, or Ibex's non-maskable interrupts (interrupt
+   * 31), so we still need to be careful.
+   */
+
+  // Clear `MIE` field of `mstatus` (disable interrupts globally).
+  csrci mstatus, 0x8
+
+  /**
+   * Clear all the machine-defined interrupts, `MEIE`, `MTIE`, and `MSIE` fields
+   * of `mie`.
+   */
+  li   t0, 0xFFFF0888
+  csrc mie, t0
+
+  /**
+   * Set up the stack pointer.
+   *
+   * In RISC-V, the stack grows downwards, so we load the address of the highest
+   * word in the stack into sp. We don't load in `_stack_end`, as that points
+   * beyond the end of RAM, and we always want it to be valid to dereference
+   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   *
+   * If an exception fires, the handler is conventionaly only allowed to clobber
+   * memory at addresses below `sp`.
+   */
+  la   sp, (_stack_end - 16)
+
+  /**
+   * Do NOT set interrupt/exception handlers.  We want to leave the ROM_EXT
+   * handlers in place so we can verify them.
+   *
+   * la   t0, (_interrupt_vector + 1)
+   * csrw mtvec, t0
+   */
+
+  /**
+   * Setup C Runtime
+   */
+
+  /**
+   * Initialize the `.data` section in RAM from RO memory.
+   */
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  call crt_section_copy
+
+  /**
+   * Initialize the `.bss` section.
+   *
+   * We do this despite zeroing all of SRAM above, so that we still zero `.bss`
+   * once we've enabled SRAM scrambling.
+   */
+  la   a0, _bss_start
+  la   a1, _bss_end
+  call crt_section_clear
+
+  // Re-clobber all of the temporary registers.
+  li t0, 0x0
+  li t1, 0x0
+  li t2, 0x0
+  li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Re-clobber all of the argument registers.
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
+
+  /**
+   * Jump to C Code
+   */
+  tail fault_test_main
+  .size _start_boot, .-_start_boot

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_test.c
@@ -1,0 +1,86 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdalign.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+#include "sw/device/silicon_creator/lib/rom_print.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "uart_regs.h"  // Generated.
+
+dif_rv_plic_t plic;
+
+void fault_test_main(void) {
+#if defined(LOAD_ACCESS_FAULT)
+  // This address is not a valid address.  It is located near the end of the
+  // peripheral MMIO regiion 0x4000_0000 to 0x5000_0000, but there is no
+  // peripheral located there.
+  //
+  // We expeect the ROM_EXT to report BFV:05524902.
+  volatile uint32_t *p = (volatile uint32_t *)0x4FFF0000;
+  uint32_t value = *p;
+  OT_DISCARD(rom_printf("Got value: %x\r\n", value));
+  OT_DISCARD(rom_printf("LOAD_ACCESS_FAULT: FAIL!\r\n"));
+#elif defined(STORE_ACCESS_FAULT)
+  // This address is not a valid address.  It is located near the end of the
+  // peripheral MMIO regiion 0x4000_0000 to 0x5000_0000, but there is no
+  // peripheral located there.
+  //
+  // We expeect the ROM_EXT to report BFV:07524902.
+  volatile uint32_t *p = (volatile uint32_t *)0x4FFF0000;
+  *p = 100;
+  OT_DISCARD(rom_printf("STORE_ACCESS_FAULT: FAIL!\r\n"));
+#elif defined(ILLEGAL_INSTRUCTION_FAULT)
+  // The "HARDENED_TRAP" emits some "unimp" instructions into the instruction
+  // stream.
+  //
+  // We expeect the ROM_EXT to report BFV:02524902.
+  HARDENED_TRAP();
+  OT_DISCARD(rom_printf("ILLEGAL_INSTRUCTION_FAULT: FAIL!\r\n"));
+#elif defined(HARDWARE_INTERRUPT)
+  // To check that hardware interrupts cause a fault, we need to enable
+  // IRQs at the CPU, the PLIC and the peripheral itself.  We'll use the
+  // UART INTR_TEST register to cause a TX_WATERMARK interrupt.
+  //
+  // We expeect the ROM_EXT to report BFV:8b524902.
+  dif_result_t result = dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic);
+  OT_DISCARD(rom_printf("plic_init = 0x%x\r\n", result));
+  // Set IRQ priorities to MAX
+  result = (dif_rv_plic_irq_set_priority(
+      &plic, kTopEarlgreyPlicIrqIdUart0TxWatermark, kDifRvPlicMaxPriority));
+  OT_DISCARD(rom_printf("plic_set_priority = 0x%x\r\n", result));
+  // Set Ibex IRQ priority threshold level
+  result = (dif_rv_plic_target_set_threshold(&plic, kTopEarlgreyPlicTargetIbex0,
+                                             kDifRvPlicMinPriority));
+  OT_DISCARD(rom_printf("plic_target_set_threshold = 0x%x\r\n", result));
+  // Enable IRQs in PLIC
+  result = dif_rv_plic_irq_set_enabled(
+      &plic, kTopEarlgreyPlicIrqIdUart0TxWatermark, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled);
+  OT_DISCARD(rom_printf("plic_set_enabled = 0x%x\r\n", result));
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+  uint32_t val =
+      bitfield_bit32_write(0, UART_INTR_COMMON_TX_WATERMARK_BIT, true);
+  abs_mmio_write32(TOP_EARLGREY_UART0_BASE_ADDR + UART_INTR_ENABLE_REG_OFFSET,
+                   val);
+  abs_mmio_write32(TOP_EARLGREY_UART0_BASE_ADDR + UART_INTR_TEST_REG_OFFSET,
+                   val);
+  OT_DISCARD(rom_printf("HARDWARE_INTERRUPT: FAIL!\r\n"));
+#elif defined(NO_FAULT)
+  OT_DISCARD(rom_printf("NO_FAULT: PASS!\r\n"));
+#else
+  OT_DISCARD(rom_printf("Fault not defined. FAIL!\r\n"));
+#endif
+  while (true) {
+  }
+}


### PR DESCRIPTION
This is a bare metal test program that does not install its own MTVEC, thus leaving the ROM_EXT vectors in place.  The test program can create several different fault types; the test configurations look for an appropriate `BFV` in the console output.