### PR TITLE
[crypto] Allow NULL for ECC domain parameters.

### DIFF
--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -102,8 +102,9 @@ typedef enum ecc_curve_type {
 typedef struct ecc_curve {
   // Type of the Weierstrass curve, custom curve or named curve.
   ecc_curve_type_t curve_type;
-  // Domain parameters for a custom Weierstrass curve.
-  ecc_domain_t domain_parameter;
+  // Domain parameters for a custom Weierstrass curve. May be NULL for a named
+  // curve.
+  const ecc_domain_t *const domain_parameter;
 } ecc_curve_t;
 
 /**

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -37,17 +37,7 @@ static_assert(OTP_CTRL_PARAM_RMA_TOKEN_SIZE == 16,
 // ECC curve to use with ECDH keygen.
 static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
-    .domain_parameter =
-        (ecc_domain_t){
-            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .gx = NULL,
-            .gy = NULL,
-            .cofactor = 0u,
-            .checksum = 0u,
-        },
+    .domain_parameter = NULL,
 };
 
 // ECDH private key configuration.

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -14,17 +14,7 @@
 
 static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
-    .domain_parameter =
-        (ecc_domain_t){
-            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .gx = NULL,
-            .gy = NULL,
-            .cofactor = 0u,
-            .checksum = 0u,
-        },
+    .domain_parameter = NULL,
 };
 
 // Configuration for the private key.

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -30,17 +30,7 @@ enum {
 
 static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
-    .domain_parameter =
-        (ecc_domain_t){
-            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .gx = NULL,
-            .gy = NULL,
-            .cofactor = 0u,
-            .checksum = 0u,
-        },
+    .domain_parameter = NULL,
 };
 
 // Versions for private keys A and B.

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -17,17 +17,7 @@ static const char kMessage[] = "test message";
 
 static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
-    .domain_parameter =
-        (ecc_domain_t){
-            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .gx = NULL,
-            .gy = NULL,
-            .cofactor = 0u,
-            .checksum = 0u,
-        },
+    .domain_parameter = NULL,
 };
 
 static const crypto_key_config_t kPrivateKeyConfig = {

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -26,17 +26,7 @@ static const char kMessage[] = "test message";
 
 static const ecc_curve_t kCurveP256 = {
     .curve_type = kEccCurveTypeNistP256,
-    .domain_parameter =
-        (ecc_domain_t){
-            .p = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .a = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .b = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .q = (crypto_const_byte_buf_t){.data = NULL, .len = 0},
-            .gx = NULL,
-            .gy = NULL,
-            .cofactor = 0u,
-            .checksum = 0u,
-        },
+    .domain_parameter = NULL,
 };
 
 static const crypto_key_config_t kPrivateKeyConfig = {


### PR DESCRIPTION
This is a small cleanup, but it makes instantiating named curves a lot easier. Previously, as you can see in the tests, the caller had to construct a whole dummy domain parameters struct for named curves.

Part of #19549