### PR TITLE
[cryptotest] Add AES block cipher commands and aes_nist_kat test

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -1,0 +1,122 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load(
+    "//rules/opentitan:defs.bzl",
+    "cw310_params",
+    "opentitan_binary",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+# TODO(#20277): Running all test vectors causes the UART on the device to fail after about 140 seconds.
+# For now, split the tests by the block mode to avoid the 140 second limit.
+# testvector_targets = [
+#     "//sw/host/cryptotest/testvectors/data/aes_nist_kat:{}_{}_{}_json".format(alg, kat_type, key_len)
+#     for alg in ("cbc", "cfb128", "ecb", "ofb")
+#     for kat_type in ("varkey", "gfsbox", "vartxt", "keysbox")
+#     for key_len in ("128", "192", "256")
+# ]
+
+# testvector_args = " ".join([
+#     "--aes-json=\"$(rootpath {})\"".format(target)
+#     for target in testvector_targets
+# ])
+
+# opentitan_test(
+#     name = "aes_kat_test",
+#     cw310 = cw310_params(
+#         timeout = "long",
+#         binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+#         data = testvector_targets,
+#         test_cmd = """
+#             --bootstrap={firmware}
+#             --bitstream={bitstream}
+#         """ + testvector_args,
+#         test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+#     ),
+#     exec_env = {
+#         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+#     },
+# )
+
+KAT_TYPE = [
+    "varkey",
+    "gfsbox",
+    "vartxt",
+    "keysbox",
+]
+
+KEY_LEN = [
+    "128",
+    "192",
+    "256",
+]
+
+TESTVECTOR_TARGETS = {
+    "cbc": [
+        "//sw/host/cryptotest/testvectors/data/aes_nist_kat:cbc_{}_{}_json".format(kat_type, key_len)
+        for kat_type in KAT_TYPE
+        for key_len in KEY_LEN
+    ],
+    "cfb128": [
+        "//sw/host/cryptotest/testvectors/data/aes_nist_kat:cfb128_{}_{}_json".format(kat_type, key_len)
+        for kat_type in KAT_TYPE
+        for key_len in KEY_LEN
+    ],
+    "ecb": [
+        "//sw/host/cryptotest/testvectors/data/aes_nist_kat:ecb_{}_{}_json".format(kat_type, key_len)
+        for kat_type in KAT_TYPE
+        for key_len in KEY_LEN
+    ],
+    "ofb": [
+        "//sw/host/cryptotest/testvectors/data/aes_nist_kat:ofb_{}_{}_json".format(kat_type, key_len)
+        for kat_type in KAT_TYPE
+        for key_len in KEY_LEN
+    ],
+}
+
+TESTVECTOR_ARGS = {
+    "cbc": " ".join([
+        "--aes-json=\"$(rootpath {})\"".format(target)
+        for target in TESTVECTOR_TARGETS["cbc"]
+    ]),
+    "cfb128": " ".join([
+        "--aes-json=\"$(rootpath {})\"".format(target)
+        for target in TESTVECTOR_TARGETS["cfb128"]
+    ]),
+    "ecb": " ".join([
+        "--aes-json=\"$(rootpath {})\"".format(target)
+        for target in TESTVECTOR_TARGETS["ecb"]
+    ]),
+    "ofb": " ".join([
+        "--aes-json=\"$(rootpath {})\"".format(target)
+        for target in TESTVECTOR_TARGETS["ofb"]
+    ]),
+}
+
+[
+    opentitan_test(
+        name = "aes_{}_kat".format(mode),
+        cw310 = cw310_params(
+            timeout = "long",
+            binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+            data = TESTVECTOR_TARGETS[mode],
+            test_cmd = """
+                --bootstrap={firmware}
+                --bitstream={bitstream}
+            """ + TESTVECTOR_ARGS[mode],
+            test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    )
+    for mode in [
+        "cbc",
+        "cfb128",
+        "ecb",
+        "ofb",
+    ]
+]

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load(
+    "//rules/opentitan:defs.bzl",
+    "cw310_params",
+    "opentitan_binary",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "aes",
+    srcs = ["aes.c"],
+    hdrs = ["aes.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:aes_commands",
+    ],
+)
+
+opentitan_binary(
+    name = "firmware",
+    testonly = True,
+    srcs = [":firmware.c"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_test_rom",
+    ],
+    deps = [
+        ":aes",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:aes_commands",
+        "//sw/device/tests/crypto/cryptotest/json:commands",
+    ],
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/aes.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes.c
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/aes.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
+
+enum {
+  kAesBlockBytes = 128 / 8,
+  kAesBlockWords = kAesBlockBytes / sizeof(uint32_t),
+  kAesMaxKeyBytes = 256 / 8,
+  kAesMaxKeyWords = kAesMaxKeyBytes / 4,
+};
+
+// Arbitrary mask for testing (borrowed from aes_functest.c).
+static const uint32_t kKeyMask[8] = {
+    0x1b81540c, 0x220733c9, 0x8bf85383, 0x05ab50b4,
+    0x8acdcb7e, 0x15e76440, 0x8459b2ce, 0xdc2110cc,
+};
+
+status_t handle_aes_block(ujson_t *uj) {
+  cryptotest_aes_mode_t uj_mode;
+  cryptotest_aes_operation_t uj_op;
+  cryptotest_aes_padding_t uj_padding;
+  cryptotest_aes_data_t uj_data;
+  TRY(ujson_deserialize_cryptotest_aes_mode_t(uj, &uj_mode));
+  TRY(ujson_deserialize_cryptotest_aes_operation_t(uj, &uj_op));
+  TRY(ujson_deserialize_cryptotest_aes_padding_t(uj, &uj_padding));
+  TRY(ujson_deserialize_cryptotest_aes_data_t(uj, &uj_data));
+
+  block_cipher_mode_t mode;
+  key_mode_t key_mode;
+  switch (uj_mode) {
+    case kCryptotestAesModeEcb:
+      mode = kBlockCipherModeEcb;
+      key_mode = kKeyModeAesEcb;
+      break;
+    case kCryptotestAesModeCbc:
+      mode = kBlockCipherModeCbc;
+      key_mode = kKeyModeAesCbc;
+      break;
+    case kCryptotestAesModeCfb:
+      mode = kBlockCipherModeCfb;
+      key_mode = kKeyModeAesCfb;
+      break;
+    case kCryptotestAesModeOfb:
+      mode = kBlockCipherModeOfb;
+      key_mode = kKeyModeAesOfb;
+      break;
+    case kCryptotestAesModeCtr:
+      mode = kBlockCipherModeCtr;
+      key_mode = kKeyModeAesCtr;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES block cipher mode: %d", uj_mode);
+      return INVALID_ARGUMENT();
+  }
+
+  aes_operation_t op;
+  switch (uj_op) {
+    case kCryptotestAesOperationEncrypt:
+      op = kAesOperationEncrypt;
+      break;
+    case kCryptotestAesOperationDecrypt:
+      op = kAesOperationDecrypt;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES operation: %d", uj_op);
+      return INVALID_ARGUMENT();
+  }
+
+  aes_padding_t padding;
+  switch (uj_padding) {
+    case kCryptotestAesPaddingPkcs7:
+      padding = kAesPaddingPkcs7;
+      break;
+    case kCryptotestAesPaddingIso9797M2:
+      padding = kAesPaddingIso9797M2;
+      break;
+    case kCryptotestAesPaddingNull:
+      padding = kAesPaddingNull;
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES padding scheme: %d", uj_op);
+      return INVALID_ARGUMENT();
+  }
+
+  // Convert the data struct into cryptolib types
+  const size_t AES_IV_SIZE = 4;
+  uint32_t iv_buf[AES_IV_SIZE];
+  memcpy(iv_buf, uj_data.iv, AES_IV_SIZE * 4);
+  crypto_word32_buf_t iv = {
+      .data = iv_buf,
+      .len = kAesBlockWords,
+  };
+
+  crypto_const_byte_buf_t input = {
+      .data = uj_data.input,
+      .len = (size_t)uj_data.input_len,
+  };
+
+  // Build the key configuration
+  crypto_key_config_t config = {
+      .version = kCryptoLibVersion1,
+      .key_mode = key_mode,
+      .key_length = uj_data.key_length,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kSecurityLevelLow,
+  };
+  // Create buffer to store key
+  uint32_t key_buf[kAesMaxKeyWords];
+  memcpy(key_buf, uj_data.key, kAesMaxKeyBytes);
+  // Create keyblob
+  uint32_t keyblob[keyblob_num_words(config)];
+  // Create blinded key
+  TRY(keyblob_from_key_and_mask(key_buf, kKeyMask, config, keyblob));
+  crypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  key.checksum = integrity_blinded_checksum(&key);
+
+  size_t padded_len_bytes;
+  otcrypto_aes_padded_plaintext_length((size_t)uj_data.input_len, padding,
+                                       &padded_len_bytes);
+  if (padded_len_bytes > AES_CMD_MAX_MSG_BYTES) {
+    return OUT_OF_RANGE();
+  }
+  uint32_t output_buf[padded_len_bytes / sizeof(uint32_t)];
+  crypto_byte_buf_t output = {
+      .data = (unsigned char *)output_buf,
+      .len = sizeof(output_buf),
+  };
+
+  otcrypto_aes(&key, iv, mode, op, input, padding, output);
+
+  cryptotest_aes_output_t uj_output;
+  uj_output.output_len = padded_len_bytes;
+  memset(uj_output.output, 0, AES_CMD_MAX_MSG_BYTES);
+  memcpy(uj_output.output, output_buf, uj_output.output_len);
+  RESP_OK(ujson_serialize_cryptotest_aes_output_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+status_t handle_aes(ujson_t *uj) {
+  aes_subcommand_t cmd;
+  TRY(ujson_deserialize_aes_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kAesSubcommandAesBlock:
+      return handle_aes_block(uj);
+      break;
+    default:
+      LOG_ERROR("Unrecognized AES subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/aes.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes.h
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_aes_block(ujson_t *uj);
+status_t handle_aes(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_AES_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <stdbool.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+// Include commands
+#include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/commands.h"
+
+// Include handlers
+#include "aes.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+status_t process_cmd(ujson_t *uj) {
+  while (true) {
+    cryptotest_cmd_t cmd;
+    TRY(ujson_deserialize_cryptotest_cmd_t(uj, &cmd));
+    switch (cmd) {
+      case kCryptotestCommandAes:
+        RESP_ERR(uj, handle_aes(uj));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", cmd);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+
+  return OK_STATUS(0);
+}
+
+bool test_main(void) {
+  ujson_t uj = ujson_ottf_console();
+  return status_ok(process_cmd(&uj));
+}

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "commands",
+    srcs = ["commands.c"],
+    hdrs = ["commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "aes_commands",
+    srcs = ["aes_commands.c"],
+    hdrs = ["aes_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)

--- a/sw/device/tests/crypto/cryptotest/json/aes_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/aes_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "aes_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/aes_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/aes_commands.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define AES_CMD_MAX_MSG_BYTES 64
+#define AES_CMD_MAX_KEY_BYTES 32  // 256 / 8
+
+// clang-format off
+
+#define AES_SUBCOMMAND(_, value) \
+    value(_, AesBlock) \
+    value(_, AesGcm)
+UJSON_SERDE_ENUM(AesSubcommand, aes_subcommand_t, AES_SUBCOMMAND);
+
+// AES arguments
+#define AES_MODE(_, value) \
+    value(_, Ecb) \
+    value(_, Cbc) \
+    value(_, Cfb) \
+    value(_, Ofb) \
+    value(_, Ctr)
+UJSON_SERDE_ENUM(CryptotestAesMode, cryptotest_aes_mode_t, AES_MODE);
+
+#define AES_OPERATION(_, value) \
+    value(_, Encrypt) \
+    value(_, Decrypt)
+UJSON_SERDE_ENUM(CryptotestAesOperation, cryptotest_aes_operation_t, AES_OPERATION);
+
+#define AES_PADDING(_, value) \
+    value(_, Pkcs7) \
+    value(_, Iso9797M2) \
+    value(_, Null)
+UJSON_SERDE_ENUM(CryptotestAesPadding, cryptotest_aes_padding_t, AES_PADDING);
+
+#define AES_DATA(field, string) \
+    field(key, uint8_t, AES_CMD_MAX_KEY_BYTES) \
+    field(key_length, size_t) \
+    field(iv, uint8_t, 16) \
+    field(input, uint8_t, AES_CMD_MAX_MSG_BYTES) \
+    field(input_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestAesData, cryptotest_aes_data_t, AES_DATA);
+
+#define AES_OUTPUT(field, string) \
+    field(output, uint8_t, AES_CMD_MAX_MSG_BYTES) \
+    field(output_len, uint32_t)
+UJSON_SERDE_STRUCT(CryptotestAesOutput, cryptotest_aes_output_t, AES_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_AES_COMMANDS_H_

--- a/sw/device/tests/crypto/cryptotest/json/commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define COMMAND(_, value) \
+    value(_, Aes)
+UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_COMMANDS_H_

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -1,0 +1,40 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ujson_rust(
+    name = "commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:commands"],
+)
+
+ujson_rust(
+    name = "aes_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:aes_commands"],
+)
+
+rust_library(
+    name = "cryptotest_commands",
+    srcs = [
+        "src/aes_commands.rs",
+        "src/commands.rs",
+        "src/lib.rs",
+    ],
+    compile_data = [
+        ":commands_rust",
+        ":aes_commands_rust",
+    ],
+    rustc_env = {
+        "commands_loc": "$(execpath :commands_rust)",
+        "aes_commands_loc": "$(execpath :aes_commands_rust)",
+    },
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:arrayvec",
+        "@crate_index//:serde",
+    ],
+)

--- a/sw/host/cryptotest/ujson_lib/src/aes_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/aes_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("aes_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+pub mod commands;
+pub mod aes_commands;

--- a/sw/host/tests/crypto/BUILD
+++ b/sw/host/tests/crypto/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/sw/host/tests/crypto/aes_nist_kat/BUILD
+++ b/sw/host/tests/crypto/aes_nist_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -1,0 +1,155 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use std::time::Duration;
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use std::fs;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::aes_commands::{
+    AesSubcommand,
+    CryptotestAesMode,
+    CryptotestAesData,
+    CryptotestAesPadding,
+    CryptotestAesOperation,
+    CryptotestAesOutput,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    aes_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AesTestCase {
+    algorithm: String,
+    operation: String,
+    key_len: usize,
+    mode: String,
+    padding: String,
+    key: Vec<u8>,
+    iv: Option<Vec<u8>>,
+    ciphertext: Vec<u8>,
+    plaintext: Vec<u8>,
+}
+
+const AES_CMD_MAX_MSG_BYTES: usize = 64;
+const AES_CMD_MAX_KEY_BYTES: usize = 256 / 8;
+const AES_BLOCK_BYTES: usize = 128 / 8;
+
+fn run_aes_testcase(test_case: &AesTestCase, opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+
+    assert_eq!(test_case.algorithm.as_str(), "aes");
+    CryptotestCommand::Aes.send(&*uart)?;
+    AesSubcommand::AesBlock.send(&*uart)?;
+
+    match test_case.mode.as_str() {
+        "cbc" => CryptotestAesMode::Cbc.send(&*uart)?,
+        "cfb128" => CryptotestAesMode::Cfb.send(&*uart)?,
+        "ecb" => CryptotestAesMode::Ecb.send(&*uart)?,
+        "ofb" => CryptotestAesMode::Ofb.send(&*uart)?,
+        _ => panic!("Invalid AES mode"),
+    }
+    match test_case.operation.as_str() {
+        "encrypt" => CryptotestAesOperation::Encrypt.send(&*uart)?,
+        "decrypt" => CryptotestAesOperation::Decrypt.send(&*uart)?,
+        _ => panic!("Invalid AES operation"),
+    }
+    match test_case.padding.as_str() {
+        "null" => CryptotestAesPadding::Null.send(&*uart)?,
+        "pkcs7" => CryptotestAesPadding::Pkcs7.send(&*uart)?,
+        "iso9797m2" => CryptotestAesPadding::Iso9797M2.send(&*uart)?,
+        _ => panic!("Invalid AES padding scheme"),
+    }
+
+    let mut iv: ArrayVec<u8, AES_BLOCK_BYTES>;
+    match &test_case.iv {
+        Some(iv_val) => {
+            iv = ArrayVec::new();
+            iv.try_extend_from_slice(iv_val)?
+        },
+        None => iv = ArrayVec::from([0; AES_BLOCK_BYTES]),
+    }
+
+    let mut key: ArrayVec<u8, AES_CMD_MAX_KEY_BYTES> = ArrayVec::new();
+    key.try_extend_from_slice(&test_case.key)?;
+
+    // Configure input and output based on operation
+    let input_len;
+    let mut input: ArrayVec<u8, AES_CMD_MAX_MSG_BYTES> = ArrayVec::new();
+    let expected_output;
+    match test_case.operation.as_str() {
+        "encrypt" => {
+            input.try_extend_from_slice(&test_case.plaintext)?;
+            input_len = test_case.plaintext.len();
+            expected_output = &test_case.ciphertext;
+        },
+        "decrypt" => {
+            input.try_extend_from_slice(&test_case.ciphertext)?;
+            input_len = test_case.ciphertext.len();
+            expected_output = &test_case.plaintext;
+        },
+        _ => panic!("Invalid AES operation"),
+    }
+
+    CryptotestAesData {
+        key,
+        key_length: test_case.key_len / 8,
+        iv,
+        input,
+        input_len,
+    }.send(&*uart)?;
+
+    let aes_output = CryptotestAesOutput::recv(&*uart, opts.timeout, false)?;
+    assert_eq!(aes_output.output[0..input_len], expected_output[0..input_len]);
+    Ok(())
+}
+
+fn test_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let test_vector_files = &opts.aes_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let aes_tests: Vec<AesTestCase> = serde_json::from_str(&raw_json)?;
+
+        for aes_test in &aes_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_aes_testcase(aes_test, opts, transport)?;
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_aes, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This commit adds the cryptotest commands for AES block cipher modes. It also provides an example of how to use these commands to run a test with the NIST KAT testvectors.

There are three components to this code:

1. AES Block Cipher uJSON Commands: the commands are defined under sw/device/tests/crypto/cryptotest/json. There are corresponding rust import stubs located at sw/host/cryptotest/ujson_lib.
2. Cryptotest Device Binary: the cryptotest binary (i.e. the on-device command handler) is located at sw/device/tests/crypto/cryptotest/firmware.
3. AES NIST KAT test program: the host-side test harness is located at sw/host/tests/crypto/aes_nist_kat.

This PR implements the framework described in #19480