### PR TITLE
[crypto] Fix the nightly OTBN test run.

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -105,27 +105,18 @@ jobs:
   - template: ../ci/publish-bazel-test-results.yml
 
 - job: slow_otbn_crypto_tests
-  displayName: Run slow OTBN crypto tests
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool:
-    vmImage: ubuntu-20.04
-  timeoutInMinutes: 120
+  displayName: "Slow OTBN Crypto Tests"
+  timeoutInMinutes: 180
+  dependsOn: checkout
+  pool: FPGA
   steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - task: DownloadSecureFile@1
-    condition: eq(variables['Build.SourceBranchName'], 'master')
-    name: bazelCacheGcpKey
-    inputs:
-      secureFile: "bazel_cache_gcp_key.json"
-  - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
-    condition: eq(variables['Build.SourceBranchName'], 'master')
-    displayName: GCP key path
-    # Set the remote cache GCP key path
+  - template: ../ci/checkout-template.yml
+  - template: ../ci/install-package-dependencies.yml
   - bash: |
+      set -x
       ci/bazelisk.sh test --test_tag_filters=nightly //sw/otbn/crypto/...
-    displayName: Execute tests
+    displayName: "Run the tests"
+  - template: ../ci/publish-bazel-test-results.yml
 
 - job: bob_spi_i2c
   displayName: "BoB: SPI and I2C Tests"


### PR DESCRIPTION
The previous implementation was based on the CI OTBN tests and didn't run correctly, see https://github.com/lowRISC/opentitan/pull/20195. I think this will fix it (I used the ROM e2e nightly tests as a template instead). This time I'll manually trigger a nightly run to test it -- I didn't realize that was possible before, sorry for the previous break!