### PR TITLE
[rom_ext_e2e] Test the boot_svc empty message 

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -48,7 +48,6 @@ cc_library(
         ":boot_svc_header",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/base:chip",
-        "//sw/device/silicon_creator/lib/drivers:rnd",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
@@ -4,8 +4,6 @@
 
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
 
-#include "sw/device/silicon_creator/lib/drivers/rnd.h"
-
 void boot_svc_empty_init(boot_svc_empty_t *msg) {
   // We use `uint32_t` instead of `size_t` so that end-of-loop check passes both
   // on- and off-target tests.
@@ -13,7 +11,7 @@ void boot_svc_empty_init(boot_svc_empty_t *msg) {
   for (; launder32(i) < kBootSvcEmptyPayloadWordCount &&
          launder32(j) < kBootSvcEmptyPayloadWordCount;
        ++i, --j) {
-    msg->rand_data[i] = rnd_uint32();
+    msg->payload[i] = 0;
   }
   HARDENED_CHECK_EQ(i, kBootSvcEmptyPayloadWordCount);
   HARDENED_CHECK_EQ(j, UINT32_MAX);

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
@@ -23,25 +23,26 @@ enum {
 /**
  * An empty boot services message.
  *
- * This message type consists of a random payload that is as large as the
- * largest boot services message. ROM_EXT should use an object of this type to
- * initialize the boot services area in the retention SRAM or to clear a boot
- * services request before writing the response. Silicon owner code should use
- * an object of this type to clear a boot services response.
+ * This message type consists of a payload that is as large as the largest boot
+ * services message. ROM_EXT should use an object of this type to initialize the
+ * boot services area in the retention SRAM or to clear a boot services request
+ * before writing the response. Silicon owner code should use an object of this
+ * type to clear a boot services response.
  */
+
 typedef struct boot_svc_empty {
   /**
    * Boot services message header.
    */
   boot_svc_header_t header;
   /**
-   * Random data.
+   * An arbitrary payload.
    */
-  uint32_t rand_data[kBootSvcEmptyPayloadWordCount];
+  uint32_t payload[kBootSvcEmptyPayloadWordCount];
 } boot_svc_empty_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, header, 0);
-OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, rand_data,
+OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, payload,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE);
 OT_ASSERT_SIZE(boot_svc_empty_t, CHIP_BOOT_SVC_MSG_SIZE_MAX);
 

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
@@ -10,7 +10,6 @@
 
 #include "gtest/gtest.h"
 #include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
-#include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 bool operator==(boot_svc_empty_t lhs, boot_svc_empty_t rhs) {
@@ -24,23 +23,19 @@ using ::testing::Return;
 
 class BootSvcEmptyTest : public rom_test::RomTest {
  protected:
-  rom_test::MockRnd rnd_;
   rom_test::MockBootSvcHeader boot_svc_header_;
 };
 
 TEST_F(BootSvcEmptyTest, Init) {
-  std::array<uint32_t, kBootSvcEmptyPayloadWordCount> rand_data;
-  std::iota(rand_data.begin(), rand_data.end(), 0xcafe0000);
-  for (auto v : rand_data) {
-    EXPECT_CALL(rnd_, Uint32).WillOnce(Return(v));
-  }
+  std::array<uint32_t, kBootSvcEmptyPayloadWordCount> payload{0};
+
   boot_svc_empty_t msg{};
   EXPECT_CALL(boot_svc_header_,
               Finalize(kBootSvcEmptyType, sizeof(msg), &msg.header));
 
   boot_svc_empty_init(&msg);
 
-  EXPECT_THAT(msg.rand_data, ElementsAreArray(rand_data));
+  EXPECT_THAT(msg.payload, ElementsAreArray(payload));
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -1,0 +1,52 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+load(
+    "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
+    "DEFAULT_TEST_SUCCESS_MSG",
+    "EARLGREY_TEST_ENVS",
+    "cw310_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boot_svc_test_lib",
+    srcs = ["boot_svc_test_lib.c"],
+    hdrs = ["boot_svc_test_lib.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)
+
+opentitan_test(
+    name = "boot_svc_empty_test",
+    srcs = ["boot_svc_empty_test.c"],
+    cw310 = cw310_params(
+        assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
+        bitstream = "//sw/device/silicon_creator/rom_ext/e2e:bitstream_secret2_locked",
+        exit_failure = "BFV|PASS|FAIL",
+        exit_success = "FinalBootLog: 2:AA\r\n",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    manifest = "//sw/device/silicon_owner:manifest_virtual",
+    deps = [
+        ":boot_svc_test_lib",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_empty",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
+  boot_svc_msg_t msg = {0};
+  boot_svc_empty_init(&msg.empty);
+  retram->creator.boot_svc_msg = msg;
+  state->state = kBootSvcTestStateCheckEmpty;
+  rstmgr_reset();
+  return INTERNAL();
+}
+
+static status_t check_empty(retention_sram_t *retram,
+                            boot_svc_retram_t *state) {
+  boot_svc_msg_t msg = retram->creator.boot_svc_msg;
+  TRY(boot_svc_header_check(&msg.header));
+  TRY_CHECK(msg.header.type == kBootSvcEmptyType);
+  state->state = kBootSvcTestStateFinal;
+  return OK_STATUS();
+}
+
+static status_t empty_message_test(void) {
+  retention_sram_t *retram = retention_sram_get();
+  TRY(boot_svc_test_init(retram, kBootSvcTestEmpty));
+  boot_svc_retram_t *state = (boot_svc_retram_t *)&retram->owner;
+
+  for (;;) {
+    LOG_INFO("Test state = %d", state->state);
+    switch (state->state) {
+      case kBootSvcTestStateInit:
+        TRY(initialize(retram, state));
+        break;
+      case kBootSvcTestStateCheckEmpty:
+        TRY(check_empty(retram, state));
+        break;
+      case kBootSvcTestStateFinal:
+        LOG_INFO("FinalBootLog: %d:%s", state->boots, state->partition);
+        return OK_STATUS();
+      default:
+        return UNKNOWN();
+    }
+  }
+}
+
+bool test_main(void) {
+  status_t sts = empty_message_test();
+  if (status_err(sts)) {
+    LOG_ERROR("empty_message_test: %r", sts);
+  }
+  return status_ok(sts);
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+
+status_t boot_svc_test_init(retention_sram_t *retram, boot_svc_test_t test) {
+  boot_log_t *boot_log = &retram->creator.boot_log;
+  TRY(boot_log_check(boot_log));
+
+  boot_svc_retram_t *state = (boot_svc_retram_t *)&retram->owner;
+
+  if (bitfield_bit32_read(retram->creator.reset_reasons,
+                          kRstmgrReasonPowerOn)) {
+    memset(&retram->owner, 0, sizeof(retram->owner));
+  }
+
+  if (state->test != 0 && state->test != test) {
+    return INTERNAL();
+  }
+
+  if (state->test == 0) {
+    state->test = test;
+    state->state = kBootSvcTestStateInit;
+  }
+  state->partition[state->boots] = (boot_log->bl0_slot == kBl0BootSlotA) ? 'A'
+                                   : (boot_log->bl0_slot == kBl0BootSlotB)
+                                       ? 'B'
+                                       : 'x';
+  state->boots += 1;
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_E2E_BOOT_SVC_BOOT_SVC_TEST_LIB_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_E2E_BOOT_SVC_BOOT_SVC_TEST_LIB_H_
+#include "sw/device/lib/base/status.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+typedef enum boot_svc_test {
+  kBootSvcTestEmpty = 1,
+} boot_svc_test_t;
+
+typedef enum boot_svc_test_state {
+  kBootSvcTestStateInit = 0,
+  kBootSvcTestStateCheckEmpty,
+  kBootSvcTestStateFinal,
+} boot_svc_test_state_t;
+
+typedef struct boot_svc_retram {
+  // Which boot service test is running.
+  boot_svc_test_t test;
+  // The state of the test.
+  boot_svc_test_state_t state;
+  // The number of boots the test has performed.
+  int boots;
+  // The owner partition that was booted on each boot.
+  char partition[10];
+} boot_svc_retram_t;
+
+status_t boot_svc_test_init(retention_sram_t *retram, boot_svc_test_t test);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_E2E_BOOT_SVC_BOOT_SVC_TEST_LIB_H_


### PR DESCRIPTION
1. Send an empty message from an owner-stage test program.  Verify no
   change in the boot ordering.