### PR TITLE
[lc_ctrl/sw] Correct ID state enum

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -1228,11 +1228,11 @@
               name:  "BLANK",
               desc:  "The device has not yet been personalized."
             }
-            { value: "0x11111111",
+            { value: "0x55555555",
               name:  "PERSONALIZED",
               desc:  "The device has been personalized."
             }
-            { value: "0x22222222",
+            { value: "0xAAAAAAAA",
               name:  "INVALID",
               desc:  "The state is not valid."
             }

--- a/hw/ip/lc_ctrl/doc/registers.md
+++ b/hw/ip/lc_ctrl/doc/registers.md
@@ -496,8 +496,8 @@ The encoding is straightforward replication: [val, val, ... val]."
 | Value      | Name         | Description                               |
 |:-----------|:-------------|:------------------------------------------|
 | 0x00000000 | BLANK        | The device has not yet been personalized. |
-| 0x11111111 | PERSONALIZED | The device has been personalized.         |
-| 0x22222222 | INVALID      | The state is not valid.                   |
+| 0x55555555 | PERSONALIZED | The device has been personalized.         |
+| 0xaaaaaaaa | INVALID      | The state is not valid.                   |
 
 Other values are reserved.
 


### PR DESCRIPTION
Cherry-picked change.

This is only a SW fix since it does not impact the RTL.

Fixes #20206.
