### PR TITLE
[top_earlgrey,sim_cfg] Fix sw image for alert_handler lpg_sleep_mode_alerts

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1275,7 +1275,7 @@
      {
       name: chip_sw_alert_handler_lpg_sleep_mode_alerts
       uvm_test_seq: chip_sw_all_escalation_resets_vseq
-      sw_images: ["//sw/device/tests:alert_handler_lpg_sleep_mode_alerts_test:1:new_rules"]
+      sw_images: ["//sw/device/tests/sim_dv:alert_handler_lpg_sleep_mode_alerts_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_scb=0",
                  "+sw_test_timeout_ns=3000_000_000",


### PR DESCRIPTION
The image resides in sim_dv.