### PR TITLE
[opentitantool] Add gpio MultiSet to proxy protocol

### DIFF
--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -89,6 +89,15 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_pull_mode(*pull)?;
                         Ok(Response::Gpio(GpioResponse::SetPullMode))
                     }
+                    GpioRequest::MultiSet {
+                        mode,
+                        value,
+                        pull,
+                        analog_value,
+                    } => {
+                        instance.set(*mode, *value, *pull, *analog_value)?;
+                        Ok(Response::Gpio(GpioResponse::MultiSet))
+                    }
                 }
             }
             Request::GpioMonitoring { command } => {

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -59,10 +59,22 @@ pub enum Response {
 
 #[derive(Serialize, Deserialize)]
 pub enum GpioRequest {
-    Write { logic: bool },
+    Write {
+        logic: bool,
+    },
     Read,
-    SetMode { mode: PinMode },
-    SetPullMode { pull: PullMode },
+    SetMode {
+        mode: PinMode,
+    },
+    SetPullMode {
+        pull: PullMode,
+    },
+    MultiSet {
+        mode: Option<PinMode>,
+        value: Option<bool>,
+        pull: Option<PullMode>,
+        analog_value: Option<f32>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -71,6 +83,7 @@ pub enum GpioResponse {
     Read { value: bool },
     SetMode,
     SetPullMode,
+    MultiSet,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -72,6 +72,24 @@ impl GpioPin for ProxyGpioPin {
         }
     }
 
+    fn set(
+        &self,
+        mode: Option<PinMode>,
+        value: Option<bool>,
+        pull: Option<PullMode>,
+        analog_value: Option<f32>,
+    ) -> Result<()> {
+        match self.execute_command(GpioRequest::MultiSet {
+            mode,
+            value,
+            pull,
+            analog_value,
+        })? {
+            GpioResponse::MultiSet => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn get_internal_pin_name(&self) -> Option<&str> {
         Some(&self.pinname)
     }


### PR DESCRIPTION
The gpio trait has a `set()` method that allows simultaneously setting mode, logic level and weak pull mode.  This both improves performance on HyperDebug (by saving roundtrips of the textual protocol), and eliminates glitches.

For transports that do not natively support this, the trait does provide a default implementation which resolves to one, two or three separate method calls.

It appears that when this was added, I failed to extend the proxy protocol to be able to pass the `set()` method natively, and instead, the operation currently goes through the above fallback to be broken into multiple sub-operations on the client side, which is inefficient.  This CL adds straight-forward code to pass the multi-set operation via the proxy protocol.