### PR TITLE
[chip-level/sival] Implement sival EDN boot mode test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -64,7 +64,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       bazel: []
-      tests: []
+      tests: ["chip_sw_edn_boot_mode"]
     },
     {
       name: chip_sw_edn_auto_mode

--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -30,15 +30,30 @@
             - Enable ENTROPY_SRC in boot-time mode, e.g., by setting CONF.FIPS_ENABLE to kMultiBitBool4False.
             - Enable CSRNG.
             - Enable EDN1 (the one connected to OTBN RND) in boot-time request mode.
+            - Disable ENTROPY_SRC.
+            - Since EDN1 provides entropy only to the OTBN, CSRNG will be idle.
+            - Enable ENTROPY_SRC in FIPS mode.
             - Enable EDN0 (the one connected to OTBN URND and other endpoints) in auto request mode.
             - Launch an OTBN program consuming entropy via both the RND and the URND interface.
-            - Verify that the OTBN program completes (entropy available) and that OTBN signals a recoverable alert and sets ERR_BITS.RND_FIPS_CHK_FAIL to indicate the reception of non-FIPS/CC-compliant entropy over the RND interface.
+            - Verify that the OTBN program completes (entropy available) and that OTBN sets ERR_BITS.RND_FIPS_CHK_FAIL to indicate the reception of non-FIPS/CC-compliant entropy over the RND interface.
+            - Consume entropy through rv_core_ibex.RND_DATA and verify, using rv_core_ibex.RND_STATUS, that the received bits are FIPS compliant.
+            - Disable the entropy complex.
+            - Enable ENTROPY_SRC in FIPS mode.
+            - Enable CSRNG.
+            - Enable EDN1 (the one connected to OTBN RND) in auto request mode.
+            - Disable ENTROPY_SRC.
+            - Enable ENTROPY_SRC in boot-time mode.
+            - Enable EDN0 (the one connected to OTBN URND and other endpoints) in boot-time request mode.
+            - Launch an OTBN program consuming entropy via both the RND and the URND interface.
+            - Verify that the OTBN program completes (entropy available) and that OTBN does not set ERR_BITS.RND_FIPS_CHK_FAIL.
+            - Consume entropy through rv_core_ibex.RND_DATA and verify, using rv_core_ibex.RND_STATUS, that the received bits are FIPS NON-compliant.
             - Disable the entropy complex.
             - Enable ENTROPY_SRC in FIPS mode.
             - Enable CSRNG.
             - Enable EDN1 and EDN0 in auto request mode and with non-deterministic seeds (flag0 = kMultiBitBool4False for Instantiate and Reseed commands).
             - Re-launch the OTBN program.
-            - Verify that the OTBN program completes (entropy available) and that OTBN does not signal a recoverable alert and does not set ERR_BITS.RND_FIPS_CHK_FAIL.
+            - Verify that the OTBN program completes (entropy available) and that OTBN does not set ERR_BITS.RND_FIPS_CHK_FAIL.
+            - Consume entropy through rv_core_ibex.RND_DATA and verify, using rv_core_ibex.RND_STATUS, that the received bits are FIPS compliant.
             '''
       features: [
         EDN.MODE.BOOT,

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1350,6 +1350,15 @@
       run_timeout_mins: 300
     }
     {
+      name: chip_sw_edn_boot_mode
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:edn_boot_mode:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom", "fast_sim"]
+      // Set rng_srate_value=5 to shorten the time it takes for entropy to be delivered.
+      run_opts: ["+sw_test_timeout_ns=300_000_000_000", "+rng_srate_value=5"]
+      run_timeout_mins: 300
+    }
+    {
       name: chip_sw_edn_sw_mode
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:edn_sw_mode:1:new_rules"]

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -135,6 +135,88 @@ typedef enum dif_edn_status {
 } dif_edn_status_t;
 
 /**
+ * EDN SM states as defined in the EDN state machine RTL.
+ */
+typedef enum dif_edn_sm_state {
+  /**
+   * Device is idle.
+   */
+  kDifEdnSmStateIdle = 389,
+  /**
+   * Boot mode: load the instantiate command.
+   */
+  kDifEdnSmStateBootLoadIns = 439,
+  /**
+   * Boot mode: load the generate command.
+   */
+  kDifEdnSmStateBootLoadGen = 3,
+  /**
+   * Boot mode: wait for instantiate command ack.
+   */
+  kDifEdnSmStateBootInsAckWait = 210,
+  /**
+   * Boot mode: capture the gen fifo count.
+   */
+  kDifEdnSmStateBootCaptGenCnt = 186,
+  /**
+   * Boot mode: send the generate command.
+   */
+  kDifEdnSmStateBootSendGenCmd = 228,
+  /**
+   * Boot mode: wait for generate command ack.
+   */
+  kDifEdnSmStateBootGenAckWait = 364,
+  /**
+   * Boot mode: signal a done pulse.
+   */
+  kDifEdnSmStateBootPulse = 266,
+  /**
+   * Boot mode: stay in done state until reset.
+   */
+  kDifEdnSmStateBootDone = 223,
+  /**
+   * Auto mode: load the instantiate command.
+   */
+  kDifEdnSmStateAutoLoadIns = 112,
+  /**
+   * Auto mode: wait for first instantiate command ack.
+   */
+  kDifEdnSmStateAutoFirstAckWait = 77,
+  /**
+   * Auto mode: wait for instantiate command ack.
+   */
+  kDifEdnSmStateAutoAckWait = 355,
+  /**
+   * Auto mode: determine next command to be sent.
+   */
+  kDifEdnSmStateAutoDispatch = 430,
+  /**
+   * Auto mode: capture the gen fifo count.
+   */
+  kDifEdnSmStateAutoCaptGenCnt = 53,
+  /**
+   * Auto mode: send the generate command.
+   */
+  kDifEdnSmStateAutoSendGenCmd = 504,
+  /**
+   * Auto mode: capture the reseed fifo count.
+   */
+  kDifEdnSmStateAutoCaptReseedCnt = 38,
+  /**
+   * Auto mode: send the reseed command.
+   */
+  kDifEdnSmStateAutoSendReseedCmd = 342,
+  /**
+   * Sw port: no hw request mode.
+   */
+  kDifEdnSmStateSWPortMode = 313,
+  /**
+   * Illegal state reached and hang.
+   */
+  kDifEdnSmStateError = 145,
+} dif_edn_sm_state_t;
+
+/**
  * Enumeration of EDN FIFOs, which indicates which part of the hardware
  * produced an error.
  */

--- a/sw/device/lib/testing/edn_testutils.c
+++ b/sw/device/lib/testing/edn_testutils.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/dif/dif_csrng_shared.h"
 #include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 
 /**
  * Returns randomized seed material.

--- a/sw/device/lib/testing/edn_testutils.h
+++ b/sw/device/lib/testing/edn_testutils.h
@@ -6,6 +6,31 @@
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_EDN_TESTUTILS_H_
 
 #include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+/**
+ * Returns the value of the EDN status flag.
+ *
+ * @param edn An edn DIF handle.
+ * @param status Status value to query.
+ */
+inline bool edn_testutils_get_status(dif_edn_t *edn, uint32_t state_val) {
+  uint32_t state;
+  dif_result_t res = dif_edn_get_main_state_machine(edn, &state);
+  return (res == kDifOk) && (state == state_val);
+}
+
+/**
+ * Waits for the given EDN status flag to be set the given value.
+ *
+ * @param edn An edn DIF handle.
+ * @param flag Status flag value.
+ * @param status The status value.
+ * @param timeout_usec Timeout in microseconds.
+ */
+#define EDN_TESTUTILS_WAIT_FOR_STATUS(edn_, state_, flag_, timeout_usec_)  \
+  IBEX_TRY_SPIN_FOR(edn_testutils_get_status((edn_), (state_)) == (flag_), \
+                    (timeout_usec_))
 
 /**
  * Returns randomized seed material.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -810,6 +810,34 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "edn_boot_mode",
+    srcs = ["edn_boot_mode.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = new_verilator_params(
+        timeout = "eternal",
+    ),
+    deps = [
+        "//hw/ip/edn/data:edn_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:edn_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests:otbn_randomness_impl",
+    ],
+)
+
+opentitan_test(
     name = "edn_sw_mode",
     srcs = ["edn_sw_mode.c"],
     exec_env = EARLGREY_TEST_ENVS,

--- a/sw/device/tests/edn_boot_mode.c
+++ b/sw/device/tests/edn_boot_mode.c
@@ -1,0 +1,170 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/edn_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/otbn_testutils.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/tests/otbn_randomness_impl.h"
+
+#include "edn_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kEdnBootModeTimeout = (10 * 1000 * 1000),
+  kEdnBootModeOtbnRandomnessIterations = 1,
+};
+
+static dif_entropy_src_t entropy_src;
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+static dif_edn_t edn1;
+static dif_otbn_t otbn;
+static dif_rv_core_ibex_t rv_core_ibex;
+
+dif_entropy_src_config_t entropy_src_config = {
+    .fips_enable = false,
+    .route_to_firmware = false,
+    .bypass_conditioner = false,
+    .single_bit_mode = kDifEntropySrcSingleBitModeDisabled,
+    .health_test_window_size = 0x0200,
+    .alert_threshold = 2,
+};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Initializes the peripherals used in this test.
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+  CHECK_DIF_OK(
+      dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
+  CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+}
+
+static void configure_otbn(void) {
+  otbn_randomness_test_prepare(&otbn, kEdnBootModeOtbnRandomnessIterations);
+}
+
+// configure the entropy complex
+static status_t entropy_config(unsigned int round) {
+  // EDN params with high values for glen so we don't have to reseed.
+  dif_edn_auto_params_t edn_params0 = edn_testutils_auto_params_build(
+      true, /*res_itval=*/32, /*glen_val=*/4095);
+  dif_edn_auto_params_t edn_params1 = edn_testutils_auto_params_build(
+      true, /*res_itval=*/32, /*glen_val=*/4095);
+  // Disable the entropy complex.
+  TRY(entropy_testutils_stop_all());
+  // Enable ENTROPY_SRC in Non-FIPS/FIPS mode based on the value of round.
+  entropy_src_config.fips_enable = (round != 1);
+  CHECK_DIF_OK(dif_entropy_src_configure(&entropy_src, entropy_src_config,
+                                         kDifToggleEnabled));
+  // Enable CSRNG.
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
+
+  if (round == 1) {
+    // Enable EDN1 (the one connected to OTBN RND) in boot-time request mode.
+    CHECK_DIF_OK(dif_edn_set_boot_mode(&edn1));
+    CHECK_DIF_OK(dif_edn_configure(&edn1));
+    EDN_TESTUTILS_WAIT_FOR_STATUS(&edn1, kDifEdnSmStateBootGenAckWait, true,
+                                  kEdnBootModeTimeout);
+    // Re-enable ENTROPY_SRC in FIPS mode.
+    CHECK_DIF_OK(dif_entropy_src_stop(&entropy_src));
+    entropy_src_config.fips_enable = true;
+    CHECK_DIF_OK(dif_entropy_src_configure(&entropy_src, entropy_src_config,
+                                           kDifToggleEnabled));
+    // Enable EDN0 in auto request mode.
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn_params0));
+  }
+
+  if (round == 2) {
+    // Enable EDN1 (the one connected to OTBN RND) in auto request mode.
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn_params1));
+    EDN_TESTUTILS_WAIT_FOR_STATUS(&edn1, kDifEdnSmStateAutoAckWait, true,
+                                  kEdnBootModeTimeout);
+    // Re-enable ENTROPY_SRC in Non-FIPS mode.
+    CHECK_DIF_OK(dif_entropy_src_stop(&entropy_src));
+    entropy_src_config.fips_enable = false;
+    CHECK_DIF_OK(dif_entropy_src_configure(&entropy_src, entropy_src_config,
+                                           kDifToggleEnabled));
+    // Enable EDN0 in boot-time request mode.
+    CHECK_DIF_OK(dif_edn_set_boot_mode(&edn0));
+    CHECK_DIF_OK(dif_edn_configure(&edn0));
+    EDN_TESTUTILS_WAIT_FOR_STATUS(&edn0, kDifEdnSmStateBootGenAckWait, true,
+                                  kEdnBootModeTimeout);
+  }
+
+  if (round == 3) {
+    // Enable both EDNs in auto request mode.
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn0, edn_params0));
+    CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn_params1));
+  }
+
+  return OK_STATUS();
+}
+
+static void consume_entropy(unsigned int round,
+                            dif_otbn_err_bits_t otbn_err_val,
+                            dif_rv_core_ibex_rnd_status_t ibex_rnd_fips) {
+  uint32_t ibex_rnd_data;
+  dif_rv_core_ibex_rnd_status_t ibex_rnd_status;
+  dif_otbn_irq_state_snapshot_t intr_state;
+  CHECK_STATUS_OK(entropy_config(round));
+  // Launch an OTBN program consuming entropy via both
+  // the RND and the URND interface.
+  CHECK_STATUS_OK(otbn_testutils_execute(&otbn));
+  // Verify that the OTBN finishes with the expected error values
+  // and interrupt flags.
+  CHECK_STATUS_OK(otbn_testutils_wait_for_done(&otbn, otbn_err_val));
+  CHECK_DIF_OK(dif_otbn_irq_get_state(&otbn, &intr_state));
+  CHECK(intr_state & 0x1);
+  CHECK_DIF_OK(dif_otbn_irq_acknowledge_all(&otbn));
+  // Read rnd data through the IBEX and verify if the FIPS compliance
+  // status is as expected.
+  // The first read gets rid of leftover entropy from previous configurations
+  // of the entropy complex.
+  CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &ibex_rnd_data));
+  IBEX_SPIN_FOR(rv_core_ibex_testutils_is_rnd_data_valid(&rv_core_ibex),
+                kEdnBootModeTimeout);
+  CHECK_DIF_OK(
+      dif_rv_core_ibex_get_rnd_status(&rv_core_ibex, &ibex_rnd_status));
+  // The second read now contains the entropy from the current configuration.
+  CHECK_DIF_OK(dif_rv_core_ibex_read_rnd_data(&rv_core_ibex, &ibex_rnd_data));
+  CHECK((ibex_rnd_status & kDifRvCoreIbexRndStatusFipsCompliant) ==
+        ibex_rnd_fips);
+}
+
+bool test_main(void) {
+  init_peripherals();
+  // Prepare the OTBN for execution.
+  configure_otbn();
+  // Run the Procedure and check if EDN1 produces FIPS non-compliant entropy.
+  consume_entropy(/*round=*/1, kDifOtbnErrBitsRndFipsChkFail,
+                  kDifRvCoreIbexRndStatusFipsCompliant);
+  // Run the Procedure and check if EDN0 produces FIPS non-compliant entropy.
+  consume_entropy(/*round=*/2, kDifOtbnErrBitsNoError, 0);
+  // Run the Procedure and check if both EDNs produce FIPS compliant entropy.
+  consume_entropy(/*round=*/3, kDifOtbnErrBitsNoError,
+                  kDifRvCoreIbexRndStatusFipsCompliant);
+
+  return true;
+}


### PR DESCRIPTION
This commit mainly implements the EDN sival boot mode test.
For more detailed information please see the individual commit
messages. Part of this PR is already covered by [this](https://github.com/lowRISC/opentitan/pull/20149) PR.

This PR resolves [#20055](https://github.com/lowRISC/opentitan/issues/20055).