### PR TITLE
[ci] Add CW310 demand to FPGA pool requirements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -509,7 +509,9 @@ jobs:
 
 - job: execute_test_rom_fpga_tests_cw310
   displayName: CW310 Test ROM Tests
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310
@@ -533,7 +535,9 @@ jobs:
 
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310
@@ -557,7 +561,9 @@ jobs:
 
 - job: execute_hyperdebug_tests_cw310
   displayName: Hyperdebug CW310 Tests (Experimental)
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310_hyperdebug
@@ -621,7 +627,9 @@ jobs:
 
 - job: execute_fpga_manuf_tests_cw310
   displayName: CW310 Manufacturing Tests
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
     - chip_earlgrey_cw310

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -52,7 +52,9 @@ jobs:
   displayName: "Hyperdebug tests"
   timeoutInMinutes: 30
   dependsOn: checkout
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   steps:
   - template: ../ci/checkout-template.yml
   - template: ../ci/install-package-dependencies.yml
@@ -87,7 +89,9 @@ jobs:
   displayName: "ROM E2E Tests"
   timeoutInMinutes: 180
   dependsOn: checkout
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   steps:
   - template: ../ci/checkout-template.yml
   - template: ../ci/install-package-dependencies.yml
@@ -108,7 +112,9 @@ jobs:
   displayName: "Slow OTBN Crypto Tests"
   timeoutInMinutes: 180
   dependsOn: checkout
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   steps:
   - template: ../ci/checkout-template.yml
   - template: ../ci/install-package-dependencies.yml
@@ -122,7 +128,9 @@ jobs:
   displayName: "BoB: SPI and I2C Tests"
   timeoutInMinutes: 30
   dependsOn: checkout
-  pool: FPGA
+  pool:
+    name: FPGA
+    demands: BOARD -equals cw310
   steps:
   - template: ../ci/checkout-template.yml
   - template: ../ci/install-package-dependencies.yml


### PR DESCRIPTION
## Summary

This PR adds the `BOARD -equals cw310` demand to the Azure pipeline for jobs running in the FPGA pool.

This PR itself is harmless, but makes way for future work that simplifies our CI setup.

## Details

Currently, all Azure CI agents in our `FPGA` pool have a CW310 connected and meet this demand.

We have a second pool called `FPGA CW340` with CW340 boards connected (which have the `BOARD -equals cw340` property set).

We would like to merge these two pools into one `FPGA` pool and select the correct board using `demands:`.

This will allow us to make the `FPGA` string an Azure variable which can be changed to `FPGA Staging` when testing hardware without having to open a PR and manually manipulate azure-pipelines.yaml. (The `FPGA Staging` pool is where we put boards that have had a hardware problem like a loose cable, and we want to check them).

## Timeline

My plan is:

1. Add the cw310 demand (this PR).
2. Wait ~2 weeks after merging, then add a CW340 to the `FPGA` pool with the cw340 demand.
   * Waiting 2 weeks allows time for people to rebase their PRs.
   * If we didn't wait, people may update a PR and their CW310 job might run on a CW340 and fail.
   * I will put out an announcement asking people to rebase if their PRs are too old.
   * The CW340 in the `FPGA CW340` pool will stay where it is.
3. Wait ~2 weeks, then remove the `FPGA CW340` pool.
   * Waiting 2 weeks again allows time for PRs to be rebase that are still using the `FPGA CW340` pool.
   * If we didn't wait, people may update a PR and their CW340 test would try to run in the `FPGA CW340 pool which is now deleted.
   * Again, I will put out an announcement asking people to rebase if their PRs are too old.

The "2 weeks" here is very open to being extended to a longer period. I will have a look at open PRs after each week and see how many are active before making any changes.