### PR TITLE
[chip-level/powervirus] Change generate length of csrng command header

### DIFF
--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -771,7 +771,7 @@ static void configure_entropy_complex(void) {
               .cmd = csrng_cmd_header_build(kCsrngAppCmdGenerate,
                                             kDifCsrngEntropySrcToggleEnable,
                                             /*cmd_len=*/0,
-                                            /*generate_len=*/4096),
+                                            /*generate_len=*/4095),
               .seed_material = edn_empty_seed,
           },
       .reseed_interval = 0,


### PR DESCRIPTION
This commit adds a small bugfix regarding a csrng command header. For a generate command the maximum generate length is 4095. In the previous powervirus test there was a CSRNG command header with a generate length of 4096.