### PR TITLE
[opentitantool] Leave IOC5 and IOC8 unconfigured

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -27,16 +27,10 @@
     },
     {
       "name": "TAP_STRAP0",
-      "mode": "PushPull",
-      "level": false,
-      "pull_mode": "None",
       "alias_of": "IOC8"
     },
     {
       "name": "TAP_STRAP1",
-      "mode": "PushPull",
-      "level": false,
-      "pull_mode": "None",
       "alias_of": "IOC5"
     }
   ],
@@ -80,10 +74,12 @@
       "pins": [
         {
           "name": "TAP_STRAP0",
+          "mode": "PushPull",
           "level": true
         },
         {
           "name": "TAP_STRAP1",
+          "mode": "PushPull",
           "level": false
         }
       ]
@@ -93,10 +89,12 @@
       "pins": [
         {
           "name": "TAP_STRAP0",
+          "mode": "PushPull",
           "level": false
         },
         {
           "name": "TAP_STRAP1",
+          "mode": "PushPull",
           "level": true
         }
       ]


### PR DESCRIPTION
When third parties test their software on OpenTitan ASIC development boards, they are probably going to have their .json configuration file, declaring which pins are used for input or output in their code, in order to allow HyperDebug to properly stimulate and verify behavior.

Such a file would probably include `/__builtin__/hyperdebug_cw310.json`, in order to be able to refer to e.g. IOA0 when declaring aliases and pin configurations.

Since IOC5 and IOC8 can be used as GPIO when they are not used as TAP_STRAPn, and since opentitantool does not have a concept of one .json file "overriding" configuration from another .json file, it becomes a problem to declare the two pins as `PushPull` and `level: false` in the built-in `opentitan.json` (which is in turn included from `hyperdebug_cw310.json`), as that would conflict with any third party declaration of the two being input, or defaulting to high level.

Instead, this PR lets the two pins remain unconfigured, except when either of the named strappings `PINMUX_TAP_LC` or `PINMUX_TAP_RISCV` are explicitly applied by test scripts.