### PR TITLE
[top, fpga] Rework SCA/FI trigger signal selection and generation

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -1093,54 +1093,69 @@ module chip_earlgrey_cw340 #(
 
   // Capture trigger.
   // We use the clkmgr_aon_idle signal of the IP of interest to form a precise capture trigger.
-  // GPIO[11:9] is used for selecting the IP of interest. The encoding is as follows (see
+  // GPIO[11:10] is used for selecting the IP of interest. The encoding is as follows (see
   // hint_names_e enum in clkmgr_pkg.sv for details).
   //
-  // IP              - GPIO[11:9] - Index for clkmgr_aon_idle
-  // ------------------------------------------------------------
-  //  AES            -   000      -  0
-  //  HMAC           -   001      -  1 - not implemented on CW305
-  //  KMAC           -   010      -  2 - not implemented on CW305
-  //  OTBN (IO_DIV4) -   011      -  3 - not implemented on CW305
-  //  OTBN           -   100      -  4 - not implemented on CW305
+  // IP              - GPIO[11:10] - Index for clkmgr_aon_idle
+  // -------------------------------------------------------------
+  //  AES            -   00       -  0
+  //  HMAC           -   01       -  1 - not implemented on CW305
+  //  KMAC           -   10       -  2 - not implemented on CW305
+  //  OTBN           -   11       -  3 - not implemented on CW305
   //
-  // In addition, GPIO8 is used for gating the capture trigger in software.
-  // Note that GPIO[11:8] are connected to LED[3:0] on the CW310.
-  // On the CW305, GPIO[9,8] are connected to LED[5,7].
+  // GPIO9 is used for gating the selected capture trigger in software. Alternatively, GPIO8
+  // can be used to implement a less precise but fully software-controlled capture trigger
+  // similar to what can be done on ASIC.
+  //
+  // Note that on the CW305, GPIO[9,8] are connected to LED[5(Green),7(Red)].
 
   prim_mubi_pkg::mubi4_t clk_trans_idle, manual_in_io_clk_idle;
 
   clkmgr_pkg::hint_names_e trigger_sel;
   always_comb begin : trigger_sel_mux
-    unique case ({mio_out[MioOutGpioGpio11], mio_out[MioOutGpioGpio10], mio_out[MioOutGpioGpio9]})
-      3'b000:  trigger_sel = clkmgr_pkg::HintMainAes;
-      3'b001:  trigger_sel = clkmgr_pkg::HintMainHmac;
-      3'b010:  trigger_sel = clkmgr_pkg::HintMainKmac;
-      3'b100:  trigger_sel = clkmgr_pkg::HintMainOtbn;
+    unique case ({mio_out[MioOutGpioGpio11], mio_out[MioOutGpioGpio10]})
+      2'b00:   trigger_sel = clkmgr_pkg::HintMainAes;
+      2'b01:   trigger_sel = clkmgr_pkg::HintMainHmac;
+      2'b10:   trigger_sel = clkmgr_pkg::HintMainKmac;
+      2'b11:   trigger_sel = clkmgr_pkg::HintMainOtbn;
       default: trigger_sel = clkmgr_pkg::HintMainAes;
     endcase;
   end
   assign clk_trans_idle = top_earlgrey.clkmgr_aon_idle[trigger_sel];
 
-  logic clk_io_div4_trigger_en, manual_in_io_clk_trigger_en;
-  logic clk_io_div4_trigger_oe, manual_in_io_clk_trigger_oe;
-  assign clk_io_div4_trigger_en = mio_out[MioOutGpioGpio8];
-  assign clk_io_div4_trigger_oe = mio_oe[MioOutGpioGpio8];
+  logic clk_io_div4_trigger_hw_en, manual_in_io_clk_trigger_hw_en;
+  logic clk_io_div4_trigger_hw_oe, manual_in_io_clk_trigger_hw_oe;
+  logic clk_io_div4_trigger_sw_en, manual_in_io_clk_trigger_sw_en;
+  logic clk_io_div4_trigger_sw_oe, manual_in_io_clk_trigger_sw_oe;
+  assign clk_io_div4_trigger_hw_en = mio_out[MioOutGpioGpio9];
+  assign clk_io_div4_trigger_hw_oe = mio_oe[MioOutGpioGpio9];
+  assign clk_io_div4_trigger_sw_en = mio_out[MioOutGpioGpio8];
+  assign clk_io_div4_trigger_sw_oe = mio_oe[MioOutGpioGpio8];
 
   // Synchronize signals to manual_in_io_clk.
   prim_flop_2sync #(
-    .Width ($bits(clk_trans_idle) + 2)
+    .Width ($bits(clk_trans_idle) + 4)
   ) u_sync_trigger (
     .clk_i (manual_in_io_clk),
     .rst_ni(manual_in_por_n),
-    .d_i   ({clk_trans_idle,        clk_io_div4_trigger_en,      clk_io_div4_trigger_oe}),
-    .q_o   ({manual_in_io_clk_idle, manual_in_io_clk_trigger_en, manual_in_io_clk_trigger_oe})
+    .d_i   ({clk_trans_idle,
+             clk_io_div4_trigger_hw_en,
+             clk_io_div4_trigger_hw_oe,
+             clk_io_div4_trigger_sw_en,
+             clk_io_div4_trigger_sw_oe}),
+    .q_o   ({manual_in_io_clk_idle,
+             manual_in_io_clk_trigger_hw_en,
+             manual_in_io_clk_trigger_hw_oe,
+             manual_in_io_clk_trigger_sw_en,
+             manual_in_io_clk_trigger_sw_oe})
   );
 
-  // Generate the actual trigger signal.
+  // Generate the actual trigger signal as trigger_sw OR trigger_hw.
   assign manual_attr_io_trigger = '0;
-  assign manual_oe_io_trigger  = manual_in_io_clk_trigger_oe;
-  assign manual_out_io_trigger = manual_in_io_clk_trigger_en &
-      prim_mubi_pkg::mubi4_test_false_strict(manual_in_io_clk_idle);
+  assign manual_oe_io_trigger  =
+      manual_in_io_clk_trigger_sw_oe | manual_in_io_clk_trigger_hw_oe;
+  assign manual_out_io_trigger =
+      manual_in_io_clk_trigger_sw_en | (manual_in_io_clk_trigger_hw_en &
+          prim_mubi_pkg::mubi4_test_false_strict(manual_in_io_clk_idle));
 
 endmodule : chip_earlgrey_cw340

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -27,9 +27,9 @@
  *   - Version ('v')+,
  *   - Seed PRNG ('s')+,
  *   - Batch encrypt ('b')*,
- *   - FvsR batch fixed key set ('t')*,
+ *   - FvsR batch fixed key set ('f')*,
  *   - FvsR batch generate ('g')*,
- *   - FvsR batch encrypt and generate ('f')*,
+ *   - FvsR batch encrypt and generate ('e')*,
  * Commands marked with * are implemented in this file. Those marked with + are
  * implemented in the simple serial library. Encryption is done in AES-ECB-128
  * mode. See https://wiki.newae.com/SimpleSerial for details on the protocol.
@@ -142,7 +142,7 @@ static void aes_manual_trigger(void) {
 }
 
 /**
- * Simple serial 't' (key set) command handler.
+ * Simple serial 'k' (key set) command handler.
  *
  * This command is designed to set the fixed_key variable and in addition also
  * configures the key into the AES peripheral.
@@ -290,7 +290,7 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
 }
 
 /**
- * Simple serial 't' (fvsr key set) command handler.
+ * Simple serial 'f' (fvsr key set) command handler.
  *
  * This command is designed to set the fixed key which is used for fvsr key TVLA
  * captures.
@@ -353,7 +353,7 @@ static void aes_serial_fvsr_key_batch_generate(const uint8_t *data,
 }
 
 /**
- * Simple serial 'f' (fixed vs random key batch encrypt and generate) command
+ * Simple serial 'e' (fixed vs random key batch encrypt and generate) command
  * handler.
  *
  * This command is designed to maximize the capture rate for side-channel
@@ -444,9 +444,9 @@ bool test_main(void) {
   simple_serial_register_handler('k', aes_serial_key_set);
   simple_serial_register_handler('p', aes_serial_single_encrypt);
   simple_serial_register_handler('b', aes_serial_batch_encrypt);
-  simple_serial_register_handler('t', aes_serial_fvsr_key_set);
+  simple_serial_register_handler('f', aes_serial_fvsr_key_set);
   simple_serial_register_handler('g', aes_serial_fvsr_key_batch_generate);
-  simple_serial_register_handler('f', aes_serial_fvsr_key_batch_encrypt);
+  simple_serial_register_handler('e', aes_serial_fvsr_key_batch_encrypt);
   simple_serial_register_handler('l', aes_serial_seed_lfsr);
 
   LOG_INFO("Initializing AES unit.");

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -46,17 +46,20 @@ enum {
    * noise during AES operations. Caution: This number should be chosen to
    * provide enough time. Otherwise, Ibex might wake up while AES is still busy
    * and disturb the capture. Currently, we use a start trigger delay of 320
-   * clock cycles and the scope captures 60 clock cycles at kClockFreqCpuHz
-   * (1200 samples).
+   * clock cycles and the scope captures 60 clock cycles at kClockFreqCpuHz.
    */
   kIbexAesSleepCycles = 680,
   /**
-   * Max number of encryption that can be captured with the scope
-   * 81 is selected for AES with CW Husky
-   * Note: Maybe it would be better if we use dynamic memory allocation but I
-   * am not sure whether we are supporting it or not.
+   * The maximum number of encryptions to do per batch. The ChipWhisperer Husky
+   * scope determines how many encryptions (capture segments) it wants to record
+   * per batch based on the number of samples per segment. As the plaintexts
+   * and keys are generated in advance for fixed-vs-random batch captures, we
+   * need to make sure the corresponding buffers are sufficiently large. Note
+   * that on both CW305 and CW310, the main SRAM has a size of 128 kBytes. So it
+   * should be fine to allocate space for 256 segments (2 * 16 Bytes * 256 = 8
+   * kBytes).
    */
-  kNumBatchOpsMax = 81,
+  kNumBatchOpsMax = 256,
   /**
    * Max number of encryptions that can be captured before we rewrite the key to
    * reset the internal block counter. Otherwise, the AES peripheral might

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -590,7 +590,7 @@ bool test_main(void) {
   simple_serial_register_handler('k', sha3_serial_set_key);
   simple_serial_register_handler('p', sha3_serial_single_absorb);
   simple_serial_register_handler('b', sha3_serial_batch);
-  simple_serial_register_handler('t', sha3_serial_fixed_key_set);
+  simple_serial_register_handler('f', sha3_serial_fixed_key_set);
   simple_serial_register_handler('l', sha3_serial_seed_lfsr);
 
   LOG_INFO("Initializing the KMAC peripheral.");

--- a/sw/device/sca/lib/BUILD
+++ b/sw/device/sca/lib/BUILD
@@ -25,6 +25,7 @@ cc_library(
     hdrs = ["simple_serial.h"],
     deps = [
         ":prng",
+        ":sca",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -34,27 +34,37 @@
 /**
  * Bitfield for the trigger source.
  *
- * Bits 9 to 11 are used to select the trigger source. See chiplevel.sv.tpl for
- * details.
+ * Bits 10 and 11 are used to select the trigger source. See chiplevel.sv.tpl
+ * for details.
  */
 static const bitfield_field32_t kTriggerSourceBitfield = {
-    .index = 9,
-    .mask = 0x7,
+    .index = 10,
+    .mask = 0x3,
 };
 
 enum {
   /**
-   * Bit index of the trigger gate signal for gating the trigger from software.
+   * Bit index of the hardware trigger gate signal for gating the hardware
+   * trigger from software.
    *
    * See chiplevel.sv.tpl for details.
    */
-  kTriggerGateBitIndex = 8,
+  kTriggerHwGateBitIndex = 9,
+  /**
+   * Bit index of the software trigger signal.
+   *
+   * See chiplevel.sv.tpl for details.
+   */
+  kTriggerSwBitIndex = 8,
   /**
    * RV timer settings.
    */
   kRvTimerComparator = 0,
   kRvTimerHart = kTopEarlgreyPlicTargetIbex0,
 };
+
+// By default, we use the precise, hardware-gated capture trigger.
+static unsigned int trigger_bit_index = kTriggerHwGateBitIndex;
 
 static dif_uart_t uart0;
 static dif_gpio_t gpio;
@@ -109,7 +119,8 @@ static void sca_init_gpio(sca_trigger_source_t trigger) {
 
   uint32_t select_mask =
       bitfield_field32_write(0, kTriggerSourceBitfield, UINT32_MAX);
-  uint32_t enable_mask = bitfield_bit32_write(0, kTriggerGateBitIndex, true);
+  uint32_t enable_mask = bitfield_bit32_write(0, kTriggerHwGateBitIndex, true);
+  enable_mask = bitfield_bit32_write(enable_mask, kTriggerSwBitIndex, true);
 
   // Configure the pinmux to enable the GPIOs.
   for (size_t i = 0; i < 32; ++i) {
@@ -282,12 +293,20 @@ const dif_uart_t *sca_get_uart(void) {
 #endif
 }
 
+void sca_select_trigger_type(sca_trigger_type_t trigger_type) {
+  if (trigger_type == kScaTriggerTypeHwGated) {
+    trigger_bit_index = kTriggerHwGateBitIndex;
+  } else if (trigger_type == kScaTriggerTypeSw) {
+    trigger_bit_index = kTriggerSwBitIndex;
+  }
+}
+
 void sca_set_trigger_high(void) {
-  OT_DISCARD(dif_gpio_write(&gpio, kTriggerGateBitIndex, true));
+  OT_DISCARD(dif_gpio_write(&gpio, trigger_bit_index, true));
 }
 
 void sca_set_trigger_low(void) {
-  OT_DISCARD(dif_gpio_write(&gpio, kTriggerGateBitIndex, false));
+  OT_DISCARD(dif_gpio_write(&gpio, trigger_bit_index, false));
 }
 
 void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -24,27 +24,42 @@ typedef enum sca_trigger_source {
   /**
    * Use AES for capture trigger.
    *
-   * The trigger signal will go high 40 cycles after `dif_aes_trigger()` is
+   * The trigger signal will go high 320 cycles after `dif_aes_trigger()` is
    * called and remain high until the operation is complete.
    */
-  kScaTriggerSourceAes,
+  kScaTriggerSourceAes = 0,
   /**
    * Use HMAC for capture trigger.
    */
-  kScaTriggerSourceHmac,
+  kScaTriggerSourceHmac = 1,
   /**
    * Use KMAC for capture trigger.
    */
-  kScaTriggerSourceKmac,
-  /**
-   * Use OTBN (IO_DIV4 clock) for capture trigger.
-   */
-  kScaTriggerSourceOtbnIoDiv4,
+  kScaTriggerSourceKmac = 2,
   /**
    * Use OTBN for capture trigger.
    */
-  kScaTriggerSourceOtbn,
+  kScaTriggerSourceOtbn = 3,
 } sca_trigger_source_t;
+
+/**
+ * Trigger type.
+ */
+typedef enum sca_trigger_type {
+  /**
+   * Use the precise hardware capture trigger gateable by software. If selected,
+   * the actual capture trigger is generated based on the clkmgr_aon_idle signal
+   * of the peripheral corresponding to selected trigger source.
+   *
+   * Note that this is available on FPGA only.
+   */
+  kScaTriggerTypeHwGated = 0,
+  /**
+   * Use the fully software controlled capture trigger. If selected, the
+   * configured trigger source is not relevant.
+   */
+  kScaTriggerTypeSw = 1,
+} sca_trigger_type_t;
 
 /**
  * Peripherals.
@@ -127,6 +142,13 @@ void sca_init(sca_trigger_source_t trigger, sca_peripherals_t enable);
  * @return Handle to the initialized UART device.
  */
 const dif_uart_t *sca_get_uart(void);
+
+/**
+ * Select the capture trigger type.
+ *
+ * @param trigger_type The trigger type to select.
+ */
+void sca_select_trigger_type(sca_trigger_type_t trigger_type);
 
 /**
  * Sets capture trigger high.

--- a/sw/device/sca/lib/simple_serial.c
+++ b/sw/device/sca/lib/simple_serial.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/sca/lib/prng.h"
+#include "sw/device/sca/lib/sca.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -34,11 +35,11 @@ enum {
  * Command handlers.
  *
  * Clients can register handlers for commands 'a'-'z' using
- * `simple_serial_register_handler()` except for 'v' (version) and 's' (seed
- * PRNG), which are handled by this library. This array has an extra element
- * (27) that is initialized in `simple_serial_init()` to point to
- * `simple_serial_unknown_command()` in order to simplify handling of invalid
- * commands in `simple_serial_process_packet()`.
+ * `simple_serial_register_handler()` except for 'v' (version), 's' (seed
+ * PRNG), and 't' (select trigger type) which are handled by this library. This
+ * array has an extra element (27) that is initialized in `simple_serial_init()`
+ * to point to `simple_serial_unknown_command()` in order to simplify handling
+ * of invalid commands in `simple_serial_process_packet()`.
  */
 static simple_serial_command_handler handlers[27];
 static const dif_uart_t *uart;
@@ -162,6 +163,20 @@ static void simple_serial_seed_prng(const uint8_t *seed, size_t seed_len) {
 }
 
 /**
+ * Simple serial 't' (select trigger type) command handler.
+ *
+ * This function only supports 1-byte trigger values.
+ *
+ * @param trigger A buffer holding the trigger type.
+ * @param trigger_len Buffer length.
+ */
+static void simple_serial_select_trigger_type(const uint8_t *trigger,
+                                              size_t trigger_len) {
+  SS_CHECK(trigger_len == 1);
+  sca_select_trigger_type((sca_trigger_type_t)trigger[0]);
+}
+
+/**
  * Handler for uninmplemented simple serial commands.
  *
  * Sends an error packet over UART.
@@ -181,6 +196,8 @@ void simple_serial_init(const dif_uart_t *uart_) {
     handlers[i] = simple_serial_unknown_command;
   }
   handlers[simple_serial_get_handler_index('s')] = simple_serial_seed_prng;
+  handlers[simple_serial_get_handler_index('t')] =
+      simple_serial_select_trigger_type;
   handlers[simple_serial_get_handler_index('v')] = simple_serial_version;
 }
 
@@ -188,7 +205,7 @@ simple_serial_result_t simple_serial_register_handler(
     uint8_t cmd, simple_serial_command_handler handler) {
   if (!simple_serial_is_valid_command(cmd)) {
     return kSimpleSerialError;
-  } else if (cmd == 's' || cmd == 'v') {
+  } else if (cmd == 's' || cmd == 't' || cmd == 'v') {
     // Cannot register handlers for built-in commands.
     return kSimpleSerialError;
   } else {

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -518,7 +518,7 @@ bool test_main(void) {
   simple_serial_init(sca_get_uart());
   simple_serial_register_handler('p', sha3_serial_single_absorb);
   simple_serial_register_handler('b', sha3_serial_batch);
-  simple_serial_register_handler('t', sha3_serial_fixed_message_set);
+  simple_serial_register_handler('f', sha3_serial_fixed_message_set);
   simple_serial_register_handler('l', sha3_serial_seed_lfsr);
   simple_serial_register_handler('m', kmac_disable_masking);
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1253,20 +1253,21 @@ module chip_${top["name"]}_${target["name"]} #(
 
   // Capture trigger.
   // We use the clkmgr_aon_idle signal of the IP of interest to form a precise capture trigger.
-  // GPIO[11:9] is used for selecting the IP of interest. The encoding is as follows (see
+  // GPIO[11:10] is used for selecting the IP of interest. The encoding is as follows (see
   // hint_names_e enum in clkmgr_pkg.sv for details).
   //
-  // IP              - GPIO[11:9] - Index for clkmgr_aon_idle
-  // ------------------------------------------------------------
-  //  AES            -   000      -  0
-  //  HMAC           -   001      -  1 - not implemented on CW305
-  //  KMAC           -   010      -  2 - not implemented on CW305
-  //  OTBN (IO_DIV4) -   011      -  3 - not implemented on CW305
-  //  OTBN           -   100      -  4 - not implemented on CW305
+  // IP              - GPIO[11:10] - Index for clkmgr_aon_idle
+  // -------------------------------------------------------------
+  //  AES            -   00       -  0
+  //  HMAC           -   01       -  1 - not implemented on CW305
+  //  KMAC           -   10       -  2 - not implemented on CW305
+  //  OTBN           -   11       -  3 - not implemented on CW305
   //
-  // In addition, GPIO8 is used for gating the capture trigger in software.
-  // Note that GPIO[11:8] are connected to LED[3:0] on the CW310.
-  // On the CW305, GPIO[9,8] are connected to LED[5,7].
+  // GPIO9 is used for gating the selected capture trigger in software. Alternatively, GPIO8
+  // can be used to implement a less precise but fully software-controlled capture trigger
+  // similar to what can be done on ASIC.
+  //
+  // Note that on the CW305, GPIO[9,8] are connected to LED[5(Green),7(Red)].
 
   prim_mubi_pkg::mubi4_t clk_trans_idle, manual_in_io_clk_idle;
 
@@ -1275,37 +1276,51 @@ module chip_${top["name"]}_${target["name"]} #(
   % else:
   clkmgr_pkg::hint_names_e trigger_sel;
   always_comb begin : trigger_sel_mux
-    unique case ({mio_out[MioOutGpioGpio11], mio_out[MioOutGpioGpio10], mio_out[MioOutGpioGpio9]})
-      3'b000:  trigger_sel = clkmgr_pkg::HintMainAes;
-      3'b001:  trigger_sel = clkmgr_pkg::HintMainHmac;
-      3'b010:  trigger_sel = clkmgr_pkg::HintMainKmac;
-      3'b100:  trigger_sel = clkmgr_pkg::HintMainOtbn;
+    unique case ({mio_out[MioOutGpioGpio11], mio_out[MioOutGpioGpio10]})
+      2'b00:   trigger_sel = clkmgr_pkg::HintMainAes;
+      2'b01:   trigger_sel = clkmgr_pkg::HintMainHmac;
+      2'b10:   trigger_sel = clkmgr_pkg::HintMainKmac;
+      2'b11:   trigger_sel = clkmgr_pkg::HintMainOtbn;
       default: trigger_sel = clkmgr_pkg::HintMainAes;
     endcase;
   end
   assign clk_trans_idle = top_${top["name"]}.clkmgr_aon_idle[trigger_sel];
   % endif
 
-  logic clk_io_div4_trigger_en, manual_in_io_clk_trigger_en;
-  logic clk_io_div4_trigger_oe, manual_in_io_clk_trigger_oe;
-  assign clk_io_div4_trigger_en = mio_out[MioOutGpioGpio8];
-  assign clk_io_div4_trigger_oe = mio_oe[MioOutGpioGpio8];
+  logic clk_io_div4_trigger_hw_en, manual_in_io_clk_trigger_hw_en;
+  logic clk_io_div4_trigger_hw_oe, manual_in_io_clk_trigger_hw_oe;
+  logic clk_io_div4_trigger_sw_en, manual_in_io_clk_trigger_sw_en;
+  logic clk_io_div4_trigger_sw_oe, manual_in_io_clk_trigger_sw_oe;
+  assign clk_io_div4_trigger_hw_en = mio_out[MioOutGpioGpio9];
+  assign clk_io_div4_trigger_hw_oe = mio_oe[MioOutGpioGpio9];
+  assign clk_io_div4_trigger_sw_en = mio_out[MioOutGpioGpio8];
+  assign clk_io_div4_trigger_sw_oe = mio_oe[MioOutGpioGpio8];
 
   // Synchronize signals to manual_in_io_clk.
   prim_flop_2sync #(
-    .Width ($bits(clk_trans_idle) + 2)
+    .Width ($bits(clk_trans_idle) + 4)
   ) u_sync_trigger (
     .clk_i (manual_in_io_clk),
     .rst_ni(manual_in_por_n),
-    .d_i   ({clk_trans_idle,        clk_io_div4_trigger_en,      clk_io_div4_trigger_oe}),
-    .q_o   ({manual_in_io_clk_idle, manual_in_io_clk_trigger_en, manual_in_io_clk_trigger_oe})
+    .d_i   ({clk_trans_idle,
+             clk_io_div4_trigger_hw_en,
+             clk_io_div4_trigger_hw_oe,
+             clk_io_div4_trigger_sw_en,
+             clk_io_div4_trigger_sw_oe}),
+    .q_o   ({manual_in_io_clk_idle,
+             manual_in_io_clk_trigger_hw_en,
+             manual_in_io_clk_trigger_hw_oe,
+             manual_in_io_clk_trigger_sw_en,
+             manual_in_io_clk_trigger_sw_oe})
   );
 
-  // Generate the actual trigger signal.
+  // Generate the actual trigger signal as trigger_sw OR trigger_hw.
   assign manual_attr_io_trigger = '0;
-  assign manual_oe_io_trigger  = manual_in_io_clk_trigger_oe;
-  assign manual_out_io_trigger = manual_in_io_clk_trigger_en &
-      prim_mubi_pkg::mubi4_test_false_strict(manual_in_io_clk_idle);
+  assign manual_oe_io_trigger  =
+      manual_in_io_clk_trigger_sw_oe | manual_in_io_clk_trigger_hw_oe;
+  assign manual_out_io_trigger =
+      manual_in_io_clk_trigger_sw_en | (manual_in_io_clk_trigger_hw_en &
+          prim_mubi_pkg::mubi4_test_false_strict(manual_in_io_clk_idle));
 % endif
 ## This separate UART debugging output is needed for the CW305 only.
 % if target["name"] == "cw305":


### PR DESCRIPTION
This PR modifies the SCA/FI trigger signal generation on FPGA to also add the option for a fully software-controlled trigger. This is required to prepare the SCA capture setup for the penetration testing of the ES silicon.

This is related to lowRISC/ot-sca#198.

I've successfully tested the CW310 bitstream and the AES binary generated from this PR. What's left to change / align is the CW305 as well as KMAC and OTBN binaries.