### PR TITLE
[manuf] provision attestation key seed (output of DRBG) during personalization

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -70,16 +70,16 @@ typedef enum flash_ctrl_partition {
   /**
    * Bank 0 information partition type 0 pages.
    */ \
-  X(kFlashCtrlInfoPageFactoryId,         	0, 0) \
-  X(kFlashCtrlInfoPageCreatorSecret,     	0, 1) \
-  X(kFlashCtrlInfoPageOwnerSecret,       	0, 2) \
-  X(kFlashCtrlInfoPageWaferAuthSecret,   	0, 3) \
-  X(kFlashCtrlInfoPageBank0Type0Page4,   	0, 4) \
-  X(kFlashCtrlInfoPageBank0Type0Page5,   	0, 5) \
-  X(kFlashCtrlInfoPageOwnerReserved0,    	0, 6) \
-  X(kFlashCtrlInfoPageOwnerReserved1,    	0, 7) \
-  X(kFlashCtrlInfoPageOwnerReserved2,    	0, 8) \
-  X(kFlashCtrlInfoPageOwnerReserved3,    	0, 9) \
+  X(kFlashCtrlInfoPageFactoryId,           0, 0) \
+  X(kFlashCtrlInfoPageCreatorSecret,       0, 1) \
+  X(kFlashCtrlInfoPageOwnerSecret,         0, 2) \
+  X(kFlashCtrlInfoPageWaferAuthSecret,     0, 3) \
+  X(kFlashCtrlInfoPageAttestationKeySeeds, 0, 4) \
+  X(kFlashCtrlInfoPageBank0Type0Page5,     0, 5) \
+  X(kFlashCtrlInfoPageOwnerReserved0,      0, 6) \
+  X(kFlashCtrlInfoPageOwnerReserved1,      0, 7) \
+  X(kFlashCtrlInfoPageOwnerReserved2,      0, 8) \
+  X(kFlashCtrlInfoPageOwnerReserved3,      0, 9) \
   /**
    * Bank 1 information partition type 0 pages.
    */ \

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -55,6 +55,7 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/silicon_creator/lib:attestation",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -51,7 +51,11 @@ cc_library(
     name = "flash_info_fields",
     srcs = ["flash_info_fields.c"],
     hdrs = ["flash_info_fields.h"],
-    deps = ["//hw/ip/otp_ctrl/data:otp_ctrl_regs"],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+    ],
 )
 
 cc_library(

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -53,6 +53,7 @@ cc_library(
     hdrs = ["flash_info_fields.h"],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/silicon_creator/lib:attestation",
@@ -219,6 +220,7 @@ cc_library(
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/silicon_creator/lib:attestation",
     ],
 )
 
@@ -240,6 +242,7 @@ opentitan_test(
     },
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
     deps = [
+        ":flash_info_fields",
         ":personalize",
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
@@ -255,6 +258,7 @@ opentitan_test(
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/silicon_creator/lib:attestation",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/silicon_creator/lib/attestation.h"

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -6,6 +6,9 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+
 #include "otp_ctrl_regs.h"  // Generated.
 
 /**
@@ -47,3 +50,16 @@ const flash_info_field_t kFlashInfoFieldWaferAuthSecret = {
     .page = 3,
     .byte_offset = 0,
 };
+
+static status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
+                                            flash_info_field_t field,
+                                            uint32_t *data_out,
+                                            size_t num_words) {
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  uint32_t byte_address = field.page * device_info.bytes_per_page;
+  TRY(flash_ctrl_testutils_read(flash_state, byte_address, field.partition,
+                                data_out, kDifFlashCtrlPartitionTypeInfo,
+                                num_words,
+                                /*delay=*/0));
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -8,6 +8,7 @@
 
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/silicon_creator/lib/attestation.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
 
@@ -51,10 +52,30 @@ const flash_info_field_t kFlashInfoFieldWaferAuthSecret = {
     .byte_offset = 0,
 };
 
-static status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
-                                            flash_info_field_t field,
-                                            uint32_t *data_out,
-                                            size_t num_words) {
+const flash_info_field_t kFlashInfoFieldUdsAttestationKeySeed = {
+    .partition = 0,
+    .bank = 0,
+    .page = 4,
+    .byte_offset = 0,
+};
+
+const flash_info_field_t kFlashInfoFieldCdi0AttestationKeySeed = {
+    .partition = 0,
+    .bank = 0,
+    .page = 4,
+    .byte_offset = kAttestationSeedBytes,
+};
+
+const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed = {
+    .partition = 0,
+    .bank = 0,
+    .page = 4,
+    .byte_offset = (2 * kAttestationSeedBytes),
+};
+
+status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
+                                     flash_info_field_t field,
+                                     uint32_t *data_out, size_t num_words) {
   dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
   uint32_t byte_address = field.page * device_info.bytes_per_page;
   TRY(flash_ctrl_testutils_read(flash_state, byte_address, field.partition,

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 
 typedef struct flash_info_field {
@@ -29,6 +30,9 @@ extern const flash_info_field_t kFlashInfoFieldManufState;
 extern const flash_info_field_t kFlashInfoFieldCreatorSeed;
 extern const flash_info_field_t kFlashInfoFieldOwnerSeed;
 extern const flash_info_field_t kFlashInfoFieldWaferAuthSecret;
+extern const flash_info_field_t kFlashInfoFieldUdsAttestationKeySeed;
+extern const flash_info_field_t kFlashInfoFieldCdi0AttestationKeySeed;
+extern const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed;
 
 /**
  * Reads info flash page field.

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+
 typedef struct flash_info_field {
   uint32_t partition;
   uint32_t bank;
@@ -27,5 +29,22 @@ extern const flash_info_field_t kFlashInfoFieldManufState;
 extern const flash_info_field_t kFlashInfoFieldCreatorSeed;
 extern const flash_info_field_t kFlashInfoFieldOwnerSeed;
 extern const flash_info_field_t kFlashInfoFieldWaferAuthSecret;
+
+/**
+ * Reads info flash page field.
+ *
+ * Assumes the page containing the field has already been configured for read
+ * access.
+ *
+ * @param flash_state Flash controller instance.
+ * @param field Flash info field information.
+ * @param[out] data_out Output buffer.
+ * @param num_words Number of words to read from flash and write to `data_out`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
+                                     flash_info_field_t field, uint32_t *buf,
+                                     size_t len);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_FLASH_INFO_FIELDS_H_

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -30,11 +30,16 @@
  * `manuf_individualize_device_hw_cfg_check()` afterwards to confirm that the
  * OTP partition was successfully locked.
  *
+ * @param flash_state Flash controller handle and state.
  * @param otp_ctrl OTP controller instance.
+ * @param flash_info_page_0_permissions Access permissions to set on flash info
+ *                                      page 0 (which temporarily holds
+ *                                      device_id and manuf_state).
  * @return OK_STATUS on success.
  */
-status_t manuf_individualize_device_hw_cfg(dif_flash_ctrl_state_t *flash_state,
-                                           const dif_otp_ctrl_t *otp_ctrl);
+status_t manuf_individualize_device_hw_cfg(
+    dif_flash_ctrl_state_t *flash_state, const dif_otp_ctrl_t *otp_ctrl,
+    dif_flash_ctrl_region_properties_t flash_info_page_0_permissions);
 
 /**
  * Checks the HW_CFG OTP partition end state.

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -58,7 +58,15 @@ bool test_main(void) {
       lc_ctrl_testutils_check_lc_state(&lc_ctrl, kDifLcCtrlStateTestUnlocked1));
 
   if (!status_ok(manuf_individualize_device_hw_cfg_check(&otp_ctrl))) {
-    CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(&flash_state, &otp_ctrl));
+    dif_flash_ctrl_region_properties_t kFlashInfoPage0Permissions = {
+        .ecc_en = kMultiBitBool4True,
+        .high_endurance_en = kMultiBitBool4False,
+        .erase_en = kMultiBitBool4True,
+        .prog_en = kMultiBitBool4True,
+        .rd_en = kMultiBitBool4True,
+        .scramble_en = kMultiBitBool4False};
+    CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(
+        &flash_state, &otp_ctrl, kFlashInfoPage0Permissions));
     sw_reset();
   }
 

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -142,7 +142,10 @@ opentitan_test(
 opentitan_binary(
     name = "sram_ft_individualize",
     testonly = True,
-    srcs = ["sram_ft_individualize.c"],
+    srcs = [
+        "consts.h",
+        "sram_ft_individualize.c",
+    ],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h
@@ -29,4 +29,15 @@ dif_flash_ctrl_region_properties_t kFlashInfoPage3WritePermissions = {
     .rd_en = kMultiBitBool4False,
     .scramble_en = kMultiBitBool4False};
 
+/**
+ * Access permissions for flash info page 4 (holds attestation key seeds).
+ */
+dif_flash_ctrl_region_properties_t kFlashInfoPage4Permissions = {
+    .ecc_en = kMultiBitBool4True,
+    .high_endurance_en = kMultiBitBool4False,
+    .erase_en = kMultiBitBool4True,
+    .prog_en = kMultiBitBool4True,
+    .rd_en = kMultiBitBool4True,
+    .scramble_en = kMultiBitBool4True};
+
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_SKUS_EARLGREY_A0_GENERIC_CONSTS_H_

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_individualize.c
@@ -23,6 +23,7 @@
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 #include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
+#include "sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/consts.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -59,8 +60,8 @@ status_t command_processor(ujson_t *uj) {
         LOG_INFO("Writing both *_SW_CFG and HW_CFG OTP partitions ...");
         CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg(&otp_ctrl));
         CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
-        CHECK_STATUS_OK(
-            manuf_individualize_device_hw_cfg(&flash_ctrl_state, &otp_ctrl));
+        CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(
+            &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions));
         break;
       case kFtIndividualizeCommandOtpCreatorSwCfgWrite:
         LOG_INFO("Writing the CREATOR_SW_CFG OTP partition ...");
@@ -72,8 +73,8 @@ status_t command_processor(ujson_t *uj) {
         break;
       case kFtIndividualizeCommandOtpHwCfgWrite:
         LOG_INFO("Writing the HW_CFG OTP partition ...");
-        CHECK_STATUS_OK(
-            manuf_individualize_device_hw_cfg(&flash_ctrl_state, &otp_ctrl));
+        CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(
+            &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions));
         break;
       case kFtIndividualizeCommandDone:
         LOG_INFO("FT SRAM provisioning done.");


### PR DESCRIPTION
This provisions the attestation keygen DRBG output seed into flash info page 4, in bank 0, partition 0. These seeds will be read out of flash and used by the `otbn_boot_services` lib to generate the attestation keys that will be FIPS 186-5 compliant.