### PR TITLE
[opentitantool] Improved HyperDebug firmware

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20230922_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "b9171be8e8d9d2327670f1a058408535d0332579be59f367e040915acb4e1f35",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20231101_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "944297f725152df83b6c4396a1bb313a5c89efc3ddaeedb4e90ff0dd63b82f31",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Use a newer HyperDebug firmware, which has improved ability to capture rapid sequences of changes through the `GpioMonitoring` trait.

Going forward, HyperDebug can record one edge per microsecond, which enables capture of I2C or SPI communication, as long as the clock rate is reduced to around 100kHz.