### PR TITLE
[opentitantool] Support HyperDebug as I2C device

### DIFF
--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -6,10 +6,12 @@ use anyhow::Result;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
+use std::time::Duration;
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
 use crate::impl_serializable_error;
+use crate::transport::TransportError;
 use crate::util::parse_int::ParseInt;
 
 #[derive(Debug, Args)]
@@ -59,19 +61,82 @@ pub enum I2cError {
     Busy,
     #[error("Missing I2C address")]
     MissingAddress,
+    #[error("I2C port not in device mode")]
+    NotInDeviceMode,
     #[error("Generic error {0}")]
     Generic(String),
 }
 impl_serializable_error!(I2cError);
 
-/// Represents a I2C transfer.
+/// Represents a I2C transfer to be initiated by the debugger as I2C host.
 pub enum Transfer<'rd, 'wr> {
     Read(&'rd mut [u8]),
     Write(&'wr [u8]),
 }
 
+/// Status of I2C read operations (data from device to host).
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ReadStatus {
+    /// Host has asked to read data, debugger device is currently stretching the clock waiting to
+    /// be told what data to transmit via I2C.  Parameter is 7-bit I2C address.
+    WaitingForData(u8),
+    /// Host is not asking to read data, and debugger also does not have any prepared data.
+    Idle,
+    /// Host is not asking to read data, debugger has prepared data for the case the host should
+    /// ask in the future.
+    DataPrepared,
+}
+
+/// Record of one transfer initiated by the I2C host, to which the debugger responded as I2C
+/// device.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum DeviceTransfer {
+    /// The I2C host read a number of previously prepared bytes.
+    Read {
+        addr: u8,
+        /// True if `prepare_read_data()` was not called in time.
+        timeout: bool,
+        len: usize,
+    },
+    /// The I2C host wrote the given sequence of bytes.
+    Write { addr: u8, data: Vec<u8> },
+}
+
+/// A log of I2C operations performed by the I2C host since last time, as well as whether the I2C
+/// host is currently waiting to read data.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeviceStatus {
+    /// Log of transfers completed since the last time.
+    pub transfers: Vec<DeviceTransfer>,
+    /// Indicates whether the I2C host is currently waiting to read data (clock stretched by
+    /// debugger).  If that is the case, the `tranfers` field above is guaranteed to contain all
+    /// write (and read) transfers performed before the currently blocked read transfer (unless
+    /// they have been already retrieved by a previous call to `get_device_status()`).
+    pub read_status: ReadStatus,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Mode {
+    /// Put I2C debugger into host mode (this is the default).
+    Host,
+    /// Put I2C debugger into device mode, address in low 7 bits.
+    Device(u8),
+}
+
 /// A trait which represents a I2C Bus.
 pub trait Bus {
+    fn set_mode(&self, mode: Mode) -> Result<()> {
+        if let Mode::Host = mode {
+            Ok(())
+        } else {
+            Err(TransportError::UnsupportedOperation.into())
+        }
+    }
+
+    //
+    // Methods for use in host mode.
+    //
+
     /// Gets the maximum allowed speed of the I2C bus.
     fn get_max_speed(&self) -> Result<u32>;
     /// Sets the maximum allowed speed of the I2C bus, typical values are 100_000, 400_000 or
@@ -85,4 +150,24 @@ pub trait Bus {
     /// Runs a I2C transaction composed from the slice of [`Transfer`] objects.  If `addr` is
     /// `None`, then the last value given to `set_default_adress()` is used instead.
     fn run_transaction(&self, addr: Option<u8>, transaction: &mut [Transfer]) -> Result<()>;
+
+    //
+    // Methods for use in device mode.
+    //
+
+    /// Retrieve a log of I2C operations performed by the I2C host since last time, as well as
+    /// whether the I2C host is currently waiting to read data.
+    fn get_device_status(&self, _timeout: Duration) -> Result<DeviceStatus> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
+    /// Prepare data to be tranmitted to I2C host on future or currently waiting I2C read
+    /// transfer.  By default, the prepared data will be discarded if the I2C issues a write
+    /// transfer on the bus (giving the caller a chance to react to the additional data before
+    /// preparing another response).  If the `sticky` parameter is `true`, the prepared data will
+    /// be kept across any number of intervening write transfers, and used for a future read
+    /// transfer.
+    fn prepare_read_data(&self, _data: &[u8], _sticky: bool) -> Result<()> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
 }

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -304,6 +304,14 @@ impl<'a> TransportCommandHandler<'a> {
             Request::I2c { id, command } => {
                 let instance = self.transport.i2c(id)?;
                 match command {
+                    I2cRequest::SetModeHost => {
+                        instance.set_mode(i2c::Mode::Host)?;
+                        Ok(Response::I2c(I2cResponse::SetModeHost))
+                    }
+                    I2cRequest::SetModeDevice { addr } => {
+                        instance.set_mode(i2c::Mode::Device(*addr))?;
+                        Ok(Response::I2c(I2cResponse::SetModeDevice))
+                    }
                     I2cRequest::GetMaxSpeed => {
                         let speed = instance.get_max_speed()?;
                         Ok(Response::I2c(I2cResponse::GetMaxSpeed { speed }))
@@ -353,6 +361,15 @@ impl<'a> TransportCommandHandler<'a> {
                         Ok(Response::I2c(I2cResponse::RunTransaction {
                             transaction: resps,
                         }))
+                    }
+                    I2cRequest::GetDeviceStatus { timeout_millis } => {
+                        let status = instance
+                            .get_device_status(Duration::from_millis(*timeout_millis as u64))?;
+                        Ok(Response::I2c(I2cResponse::GetDeviceStatus { status }))
+                    }
+                    I2cRequest::PrepareReadData { data, sticky } => {
+                        instance.prepare_read_data(data, *sticky)?;
+                        Ok(Response::I2c(I2cResponse::PrepareReadData))
                     }
                 }
             }

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -10,6 +10,7 @@ use crate::io::emu::{EmuState, EmuValue};
 use crate::io::gpio::{
     ClockNature, MonitoringReadResponse, MonitoringStartResponse, PinMode, PullMode,
 };
+use crate::io::i2c::DeviceStatus;
 use crate::io::spi::{MaxSizes, TransferMode};
 use crate::proxy::errors::SerializedError;
 use crate::transport::Capabilities;
@@ -229,6 +230,10 @@ pub enum I2cTransferResponse {
 
 #[derive(Serialize, Deserialize)]
 pub enum I2cRequest {
+    SetModeHost,
+    SetModeDevice {
+        addr: u8,
+    },
     GetMaxSpeed,
     SetMaxSpeed {
         value: u32,
@@ -237,10 +242,19 @@ pub enum I2cRequest {
         address: Option<u8>,
         transaction: Vec<I2cTransferRequest>,
     },
+    GetDeviceStatus {
+        timeout_millis: u32,
+    },
+    PrepareReadData {
+        data: Vec<u8>,
+        sticky: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
 pub enum I2cResponse {
+    SetModeHost,
+    SetModeDevice,
     GetMaxSpeed {
         speed: u32,
     },
@@ -248,6 +262,10 @@ pub enum I2cResponse {
     RunTransaction {
         transaction: Vec<I2cTransferResponse>,
     },
+    GetDeviceStatus {
+        status: DeviceStatus,
+    },
+    PrepareReadData,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -6,9 +6,10 @@ use anyhow::{bail, ensure, Result};
 use std::cell::Cell;
 use std::cmp;
 use std::rc::Rc;
+use std::time::Duration;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
-use crate::io::i2c::{Bus, I2cError, Transfer};
+use crate::io::i2c::{self, Bus, DeviceStatus, DeviceTransfer, I2cError, ReadStatus, Transfer};
 use crate::transport::hyperdebug::{BulkInterface, Inner};
 use crate::transport::{TransportError, TransportInterfaceType};
 
@@ -17,9 +18,16 @@ pub struct HyperdebugI2cBus {
     interface: BulkInterface,
     cmsis_encapsulation: bool,
     bus_idx: u8,
+    mode: Cell<Mode>,
     max_write_size: usize,
     max_read_size: usize,
     default_addr: Cell<Option<u8>>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Mode {
+    Host,
+    Device,
 }
 
 const USB_MAX_SIZE: usize = 64;
@@ -27,7 +35,8 @@ const USB_MAX_SIZE: usize = 64;
 /// Wire format of USB packet to request a short I2C transaction
 /// (receiving at most 127 bytes).
 #[derive(AsBytes, FromBytes, FromZeroes, Debug)]
-#[repr(C)]
+#[allow(dead_code)] // Fields not explicitly read anywhere
+#[repr(packed)]
 struct CmdTransferShort {
     encapsulation_header: u8,
     port: u8,
@@ -40,7 +49,8 @@ struct CmdTransferShort {
 /// Wire format of USB packet to request a long I2C transaction
 /// (receiving up to 32767 bytes).
 #[derive(AsBytes, FromBytes, FromZeroes, Debug)]
-#[repr(C)]
+#[allow(dead_code)] // Fields not explicitly read anywhere
+#[repr(packed)]
 struct CmdTransferLong {
     encapsulation_header: u8,
     port: u8,
@@ -54,9 +64,10 @@ struct CmdTransferLong {
 
 /// Wire format of USB packet containing I2C transaction response.
 #[derive(AsBytes, FromBytes, FromZeroes, Debug)]
-#[repr(C)]
+#[allow(dead_code)] // Reserved field not read anywhere
+#[repr(packed)]
 struct RspTransfer {
-    encapsulation_header: [u8; 2],
+    encapsulation_header: u8,
     status_code: u16,
     reserved: u16,
     data: [u8; USB_MAX_SIZE],
@@ -64,12 +75,63 @@ struct RspTransfer {
 impl RspTransfer {
     fn new() -> Self {
         Self {
-            encapsulation_header: [0u8; 2],
+            encapsulation_header: 0,
             status_code: 0,
             reserved: 0,
             data: [0; USB_MAX_SIZE],
         }
     }
+}
+
+#[derive(AsBytes, FromBytes, FromZeroes, Debug)]
+#[allow(dead_code)] // Fields not explicitly read anywhere
+#[repr(packed)]
+struct CmdGetDeviceStatus {
+    encapsulation_header: u8,
+    port: u8,
+    device_cmd: u8,
+    timeout_ms: u16,
+}
+
+// Values for use in `CmdGetDeviceStatus.device_cmd`.
+const I2C_DEVICE_CMD_GET_DEVICE_STATUS: u8 = 0x00;
+const I2C_DEVICE_CMD_PREPARE_READ_DATA: u8 = 0x01;
+
+// Bits for use in upper half of `CmdGetDeviceStatus.port`.
+const I2C_DEVICE_FLAG_STICKY: u8 = 0x80;
+
+#[derive(AsBytes, FromBytes, FromZeroes, Debug)]
+#[repr(packed)]
+struct RspGetDeviceStatus {
+    encapsulation_header: u8,
+    struct_size: u16,
+    read_status: u8,
+    blocked_read_addr: u8,
+    transcript_size: u16,
+    data: [u8; USB_MAX_SIZE],
+}
+impl RspGetDeviceStatus {
+    fn new() -> Self {
+        Self {
+            encapsulation_header: 0,
+            struct_size: 0,
+            read_status: 0,
+            blocked_read_addr: 0,
+            transcript_size: 0,
+            data: [0u8; USB_MAX_SIZE],
+        }
+    }
+}
+
+#[derive(AsBytes, FromBytes, FromZeroes, Debug)]
+#[allow(dead_code)] // Fields not explicitly read anywhere
+#[repr(packed)]
+struct CmdPrepareReadData {
+    encapsulation_header: u8,
+    port: u8,
+    device_cmd: u8,
+    data_size: u16,
+    data: [u8; USB_MAX_SIZE - 4],
 }
 
 impl HyperdebugI2cBus {
@@ -78,11 +140,15 @@ impl HyperdebugI2cBus {
     /// to carry this same value as the first byte.
     const CMSIS_DAP_CUSTOM_COMMAND_I2C: u8 = 0x81;
 
+    /// Alternative command only available when protocol encapsulated in CMSIS.
+    const CMSIS_DAP_CUSTOM_COMMAND_I2C_DEVICE: u8 = 0x82;
+
     pub fn open(
         inner: &Rc<Inner>,
         i2c_interface: &BulkInterface,
         cmsis_encapsulation: bool,
         idx: u8,
+        mode: Mode,
     ) -> Result<Self> {
         ensure!(
             idx < 16,
@@ -98,6 +164,7 @@ impl HyperdebugI2cBus {
             interface: *i2c_interface,
             cmsis_encapsulation,
             bus_idx: idx,
+            mode: Cell::new(mode),
             max_read_size: 0x8000,
             max_write_size: 0x1000,
             default_addr: Cell::new(None),
@@ -158,7 +225,7 @@ impl HyperdebugI2cBus {
         let mut bytecount = 0;
         while bytecount < 4 + encapsulation_header_size {
             let read_count = self.usb_read_bulk(
-                &mut resp.as_bytes_mut()[2 - encapsulation_header_size + bytecount..][..64],
+                &mut resp.as_bytes_mut()[1 - encapsulation_header_size + bytecount..][..64],
             )?;
             ensure!(
                 read_count > 0,
@@ -168,7 +235,7 @@ impl HyperdebugI2cBus {
         }
         if encapsulation_header_size == 1 {
             ensure!(
-                resp.encapsulation_header[1] == Self::CMSIS_DAP_CUSTOM_COMMAND_I2C,
+                resp.encapsulation_header == Self::CMSIS_DAP_CUSTOM_COMMAND_I2C,
                 TransportError::CommunicationError(
                     "Unrecognized CMSIS-DAP response to I2C request".to_string()
                 )
@@ -215,9 +282,35 @@ impl HyperdebugI2cBus {
             .borrow()
             .read_bulk(self.interface.in_endpoint, buf)
     }
+
+    /// Receive one USB packet with non-default timeout.
+    fn usb_read_bulk_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        self.inner
+            .usb_device
+            .borrow()
+            .read_bulk_timeout(self.interface.in_endpoint, buf, timeout)
+    }
 }
 
 impl Bus for HyperdebugI2cBus {
+    fn set_mode(&self, mode: i2c::Mode) -> Result<()> {
+        match mode {
+            // Put I2C debugger into host mode (this is the default).
+            i2c::Mode::Host => {
+                self.inner
+                    .cmd_no_output(&format!("i2c set mode {} host", &self.bus_idx))?;
+                self.mode.set(Mode::Host);
+            }
+            // Put I2C debugger into device mode.
+            i2c::Mode::Device(addr) => {
+                self.inner
+                    .cmd_no_output(&format!("i2c set mode {} device {}", &self.bus_idx, addr))?;
+                self.mode.set(Mode::Device);
+            }
+        }
+        Ok(())
+    }
+
     /// Gets the maximum allowed speed of the I2C bus.
     fn get_max_speed(&self) -> Result<u32> {
         let mut buf = String::new();
@@ -282,6 +375,137 @@ impl Bus for HyperdebugI2cBus {
                 [] => (),
             }
         }
+        Ok(())
+    }
+
+    fn get_device_status(&self, timeout: Duration) -> Result<DeviceStatus> {
+        ensure!(
+            self.cmsis_encapsulation,
+            TransportError::UnsupportedOperation
+        );
+        ensure!(self.mode.get() == Mode::Device, I2cError::NotInDeviceMode);
+        let timeout_ms = timeout.as_millis();
+        let req = CmdGetDeviceStatus {
+            encapsulation_header: Self::CMSIS_DAP_CUSTOM_COMMAND_I2C_DEVICE,
+            port: self.bus_idx,
+            device_cmd: I2C_DEVICE_CMD_GET_DEVICE_STATUS,
+            timeout_ms: if timeout_ms > 65535 {
+                65535
+            } else {
+                timeout_ms as u16
+            },
+        };
+        self.usb_write_bulk(req.as_bytes())?;
+
+        let mut resp = RspGetDeviceStatus::new();
+        let mut bytecount = 0;
+        while bytecount < 7 {
+            let read_count = self.usb_read_bulk_timeout(
+                &mut resp.as_bytes_mut()[bytecount..][..64],
+                Duration::from_millis(req.timeout_ms as u64 + 500),
+            )?;
+            ensure!(
+                read_count > 0,
+                TransportError::CommunicationError("Truncated I2C response".to_string())
+            );
+            bytecount += read_count;
+        }
+        ensure!(
+            resp.encapsulation_header == Self::CMSIS_DAP_CUSTOM_COMMAND_I2C_DEVICE,
+            TransportError::CommunicationError(
+                "Unrecognized CMSIS-DAP response to I2C request".to_string()
+            )
+        );
+        let skip_bytes = resp.struct_size - 6;
+
+        let mut databytes: Vec<u8> = Vec::new();
+        databytes.extend_from_slice(&resp.data[..bytecount - 7]);
+
+        while databytes.len() < (skip_bytes + resp.transcript_size) as usize {
+            let original_length = databytes.len();
+            databytes.resize(original_length + 64, 0u8);
+            let c = self.usb_read_bulk(&mut databytes[original_length..])?;
+            databytes.resize(original_length + c, 0u8);
+        }
+
+        let mut transfers = Vec::new();
+        let mut idx = skip_bytes as usize;
+        while idx < databytes.len() {
+            let addr = databytes[idx] >> 1;
+            let is_read = (databytes[idx] & 0x01) != 0;
+            let timeout = (databytes[idx + 1] & 0x01) != 0;
+            let transfer_len = databytes[idx + 2] as usize + ((databytes[idx + 3] as usize) << 8);
+            idx += 4;
+            if is_read {
+                // Read transfer
+                transfers.push(DeviceTransfer::Read {
+                    addr,
+                    timeout,
+                    len: transfer_len,
+                });
+            } else {
+                // Write transfer
+                transfers.push(DeviceTransfer::Write {
+                    addr,
+                    data: databytes[idx..idx + transfer_len].to_vec(),
+                });
+                idx += (transfer_len + 3) & !3;
+            }
+        }
+
+        let read_status = match resp.read_status {
+            0 => ReadStatus::Idle,
+            1 => ReadStatus::DataPrepared,
+            2 => ReadStatus::WaitingForData(resp.blocked_read_addr >> 1),
+            _ => bail!(TransportError::CommunicationError(
+                "Unrecognized I2C read status".to_string()
+            )),
+        };
+
+        Ok(DeviceStatus {
+            transfers,
+            read_status,
+        })
+    }
+
+    fn prepare_read_data(&self, data: &[u8], sticky: bool) -> Result<()> {
+        ensure!(
+            self.cmsis_encapsulation,
+            TransportError::UnsupportedOperation
+        );
+        ensure!(self.mode.get() == Mode::Device, I2cError::NotInDeviceMode);
+        if data.len() > 256 {
+            bail!(TransportError::CommunicationError(
+                "Data exceeds maximum length".to_string()
+            ))
+        }
+        let flags = if sticky { I2C_DEVICE_FLAG_STICKY } else { 0 };
+        let mut req = CmdPrepareReadData {
+            encapsulation_header: Self::CMSIS_DAP_CUSTOM_COMMAND_I2C_DEVICE,
+            port: self.bus_idx | flags,
+            device_cmd: I2C_DEVICE_CMD_PREPARE_READ_DATA,
+            data_size: data.len() as u16,
+            data: [0; USB_MAX_SIZE - 4],
+        };
+        // Compute how many data bytes fit in the first USB packet after the header.
+        let mut index = std::cmp::min(64 - 5, data.len());
+        req.data[..index].clone_from_slice(&data[..index]);
+        self.usb_write_bulk(&req.as_bytes()[..5 + index])?;
+
+        while index < data.len() {
+            let packet_len = std::cmp::min(64, data.len() - index);
+            self.usb_write_bulk(&data[index..index + packet_len])?;
+            index += packet_len;
+        }
+
+        let mut resp = 0u8;
+        let c = self.usb_read_bulk(std::slice::from_mut(&mut resp))?;
+        ensure!(
+            c == 1 && resp == Self::CMSIS_DAP_CUSTOM_COMMAND_I2C_DEVICE,
+            TransportError::CommunicationError(
+                "Unrecognized CMSIS-DAP response to I2C request".to_string()
+            )
+        );
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Result};
 use std::rc::Rc;
 
 use crate::io::gpio::GpioPin;
+use crate::transport::hyperdebug::i2c::Mode;
 use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
 use crate::transport::{TransportError, TransportInterfaceType};
 
@@ -30,6 +31,18 @@ impl Flavor for Ti50Flavor {
         }
         bail!(TransportError::InvalidInstance(
             TransportInterfaceType::Spi,
+            instance.to_string()
+        ))
+    }
+
+    fn i2c_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, Mode)> {
+        if instance == "I2C1" {
+            return Ok((0, Mode::Host));
+        } else if instance == "I2C2" {
+            return Ok((1, Mode::Host));
+        }
+        bail!(TransportError::InvalidInstance(
+            TransportInterfaceType::I2c,
             instance.to_string()
         ))
     }

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -195,6 +195,20 @@ impl UsbBackend {
         Ok(len)
     }
 
+    /// Read bulk data bytes to given USB endpoint.
+    pub fn read_bulk_timeout(
+        &self,
+        endpoint: u8,
+        data: &mut [u8],
+        timeout: Duration,
+    ) -> Result<usize> {
+        let len = self
+            .handle
+            .read_bulk(endpoint, data, timeout)
+            .context("USB error")?;
+        Ok(len)
+    }
+
     /// Write bulk data bytes to given USB endpoint.
     pub fn write_bulk(&self, endpoint: u8, data: &[u8]) -> Result<usize> {
         let len = self

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use clap::{Args, Subcommand};
+use anyhow::{bail, Result};
+use clap::{Args, Subcommand, ValueEnum};
 use serde_annotate::Annotate;
 use std::any::Any;
+use std::convert::From;
+use std::time::Duration;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::io::i2c::{I2cParams, Transfer};
+use opentitanlib::io::i2c::{self, DeviceStatus, I2cParams, Transfer};
 use opentitanlib::tpm;
 use opentitanlib::transport::Capability;
 use opentitanlib::util::parse_int::ParseInt;
@@ -105,6 +107,156 @@ impl CommandDispatch for I2cRawWriteRead {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Mode {
+    Host,
+    Device,
+}
+
+#[derive(Debug, Args)]
+pub struct I2cSetMode {
+    pub mode: Mode,
+
+    /// 7 bit I2C device address.
+    #[arg(
+        short,
+        long,
+        value_parser = u8::from_str
+    )]
+    pub addr: Option<u8>,
+}
+
+impl CommandDispatch for I2cSetMode {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport.capabilities()?.request(Capability::I2C).ok()?;
+        let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let i2c_bus = context.params.create(transport, "DEFAULT")?;
+        match self.mode {
+            Mode::Host => i2c_bus.set_mode(i2c::Mode::Host)?,
+            Mode::Device => match self.addr {
+                Some(addr) => i2c_bus.set_mode(i2c::Mode::Device(addr))?,
+                None => bail!("Must specify `--addr` after `set-mode device`"),
+            },
+        }
+        Ok(None)
+    }
+}
+
+/// Retrieve transcript of transfers since last time, and whether the I2C host is currently
+/// waiting to READ data.
+#[derive(Debug, Args)]
+pub struct I2cGetDeviceStatus {
+    /// For how long to wait, in case of nothing to report.
+    #[arg(short,
+    long,
+    default_value="500ms",
+    value_parser = humantime::parse_duration)]
+    timeout: Duration,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub enum DeviceTransfer {
+    /// The I2C host read a number of previously prepared bytes.
+    Read {
+        addr: u8,
+        /// True if `I2cPrepareRead` was not called in time.
+        timeout: bool,
+        len: usize,
+    },
+    /// The I2C host wrote the given sequence of bytes.
+    Write { addr: u8, hexdata: String },
+}
+
+#[derive(Debug, serde::Serialize)]
+pub enum ReadStatus {
+    /// Host has asked to read data, debugger device is currently stretching the clock waiting to
+    /// be told what data to transmit via I2C.
+    WaitingForData,
+    /// Host is not asking to read data, and debugger also does not have any prepared data.
+    Idle,
+    /// Host is not asking to read data, debugger has prepared data for the case the host should
+    /// ask in the future.
+    DataPrepared,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct I2cGetDeviceStatusResponse {
+    pub transfers: Vec<DeviceTransfer>,
+    pub read_status: ReadStatus,
+}
+
+impl From<DeviceStatus> for I2cGetDeviceStatusResponse {
+    fn from(ds: DeviceStatus) -> Self {
+        let mut transfers = Vec::new();
+        for t in ds.transfers {
+            transfers.push(match t {
+                i2c::DeviceTransfer::Read { addr, timeout, len } => {
+                    DeviceTransfer::Read { addr, timeout, len }
+                }
+                i2c::DeviceTransfer::Write { addr, data } => DeviceTransfer::Write {
+                    addr,
+                    hexdata: hex::encode(data),
+                },
+            });
+        }
+        Self {
+            transfers,
+            read_status: match ds.read_status {
+                i2c::ReadStatus::WaitingForData(_) => ReadStatus::WaitingForData,
+                i2c::ReadStatus::Idle => ReadStatus::Idle,
+                i2c::ReadStatus::DataPrepared => ReadStatus::DataPrepared,
+            },
+        }
+    }
+}
+
+impl CommandDispatch for I2cGetDeviceStatus {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport.capabilities()?.request(Capability::I2C).ok()?;
+        let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let i2c_bus = context.params.create(transport, "DEFAULT")?;
+        let status = i2c_bus.get_device_status(self.timeout)?;
+        let response = I2cGetDeviceStatusResponse::from(status);
+        Ok(Some(Box::new(response)))
+    }
+}
+
+/// Provide data that I2C device should send as part of READ transfer.
+#[derive(Debug, Args)]
+pub struct I2cPrepareRead {
+    /// Hex data bytes as response to host reading.
+    #[arg(short = 'd', long)]
+    hexdata: String,
+
+    /// Keep prepared response across WRITE transfers, if false prepared data will be discarded on
+    /// any WRITE by I2C host, giving the caller a chance to review the additional data from the
+    /// host, and revise the prepared responce.
+    #[arg(short, long)]
+    sticky: bool,
+}
+
+impl CommandDispatch for I2cPrepareRead {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport.capabilities()?.request(Capability::I2C).ok()?;
+        let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let i2c_bus = context.params.create(transport, "DEFAULT")?;
+        i2c_bus.prepare_read_data(&hex::decode(&self.hexdata)?, self.sticky)?;
+        Ok(None)
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct I2cTpm {
     #[command(subcommand)]
@@ -130,6 +282,9 @@ pub enum InternalI2cCommand {
     RawRead(I2cRawRead),
     RawWrite(I2cRawWrite),
     RawWriteRead(I2cRawWriteRead),
+    GetDeviceStatus(I2cGetDeviceStatus),
+    PrepareRead(I2cPrepareRead),
+    SetMode(I2cSetMode),
     Tpm(I2cTpm),
 }
 


### PR DESCRIPTION
The HyperDebug debugger is able to act as I2C device as well as I2C host.

This PR adds methods to the `i2c::Bus` trait, as well as sub-commands to opentitantool to allow putting a particular I2C port into "device mode", and then control how the debugger should behave when addressed by the I2C host (which would be the OpenTitan chip).