### PR TITLE
[top_level,dpi] Add dpi to chip level sim_dv

### DIFF
--- a/hw/dv/dpi/chip_dpi_sim_cfg.hjson
+++ b/hw/dv/dpi/chip_dpi_sim_cfg.hjson
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options for enabling the compilation of chip DPI
+  // with DV simulators such as VCS and Xcelium.
+  chip_dpi_common_core: "lowrisc:dv_dpi:tcp_server:0.1"
+  chip_dpi_common_dir: "{eval_cmd} echo \"{chip_dpi_common_core}\" | tr ':' '_'"
+
+  build_modes: [
+    {
+      name: vcs_chip_dpi_build_opts
+      build_opts: ["-CFLAGS -I{build_dir}/src/{chip_dpi_common_dir}", "-lutil"]
+    }
+
+    {
+      name: xcelium_chip_dpi_build_opts
+      build_opts: ["-I{build_dir}/src/{chip_dpi_common_dir}", "-lutil"]
+    }
+  ]
+}

--- a/hw/dv/dpi/dmidpi/dmidpi.core
+++ b/hw/dv/dpi/dmidpi/dmidpi.core
@@ -6,15 +6,14 @@ name: "lowrisc:dv_dpi:dmidpi:0.1"
 description: "DMI DPI for OpenOCD remote_bitbang driver"
 
 filesets:
-  files_rtl:
+  files_c:
     depend:
       - lowrisc:dv_dpi:tcp_server
     files:
-      - dmidpi.sv: { file_type: systemVerilogSource }
       - dmidpi.c: { file_type: cSource }
       - dmidpi.h: { file_type: cSource, is_include_file: true }
 
 targets:
   default:
     filesets:
-      - files_rtl
+      - files_c

--- a/hw/dv/dpi/dmidpi/dmidpi_verilator.core
+++ b/hw/dv/dpi/dmidpi/dmidpi_verilator.core
@@ -2,17 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_verilator:dmidpi:0.1"
+description: "DMI DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
-
+      - dmidpi.sv: { file_type: systemVerilogSource }
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/dv/dpi/gpiodpi/gpiodpi.core
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.core
@@ -6,9 +6,8 @@ name: "lowrisc:dv_dpi:gpiodpi:0.1"
 description: "GPIO-DPI"
 
 filesets:
-  files_rtl:
+  files_c:
     files:
-      - gpiodpi.sv: { file_type: systemVerilogSource }
       - gpiodpi.c: { file_type: cppSource }
       - gpiodpi.h: { file_type: cppSource, is_include_file: true }
 
@@ -16,4 +15,4 @@ filesets:
 targets:
   default:
     filesets:
-      - files_rtl
+      - files_c

--- a/hw/dv/dpi/gpiodpi/gpiodpi_verilator.core
+++ b/hw/dv/dpi/gpiodpi/gpiodpi_verilator.core
@@ -2,17 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_verilator:gpiodpi:0.1"
+description: "GPIO DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
-
+      - gpiodpi.sv: { file_type: systemVerilogSource }
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/dv/dpi/jtagdpi/jtagdpi.core
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.core
@@ -6,15 +6,14 @@ name: "lowrisc:dv_dpi:jtagdpi:0.1"
 description: "JTAG DPI for OpenOCD remote_bitbang driver (JTAG over TCP)"
 
 filesets:
-  files_rtl:
+  files_c:
     depend:
       - lowrisc:dv_dpi:tcp_server
     files:
-      - jtagdpi.sv: { file_type: systemVerilogSource }
       - jtagdpi.c: { file_type: cSource }
       - jtagdpi.h: { file_type: cSource, is_include_file: true }
 
 targets:
   default:
     filesets:
-      - files_rtl
+      - files_c

--- a/hw/dv/dpi/jtagdpi/jtagdpi_verilator.core
+++ b/hw/dv/dpi/jtagdpi/jtagdpi_verilator.core
@@ -2,17 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_verilator:jtagdpi:0.1"
+description: "JTAG DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
-
+      - jtagdpi.sv: { file_type: systemVerilogSource }
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/dv/dpi/spidpi/spidpi.core
+++ b/hw/dv/dpi/spidpi/spidpi.core
@@ -6,9 +6,8 @@ name: "lowrisc:dv_dpi:spidpi:0.1"
 description: "SPI-DPI"
 
 filesets:
-  files_rtl:
+  files_c:
     files:
-      - spidpi.sv: { file_type: systemVerilogSource }
       - spidpi.c: { file_type: cppSource }
       - monitor_spi.c: { file_type: cppSource }
       - spidpi.h: { file_type: cppSource, is_include_file: true }
@@ -17,4 +16,4 @@ filesets:
 targets:
   default:
     filesets:
-      - files_rtl
+      - files_c

--- a/hw/dv/dpi/spidpi/spidpi_verilator.core
+++ b/hw/dv/dpi/spidpi/spidpi_verilator.core
@@ -2,17 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_verilator:spidpi:0.1"
+description: "SPI-DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
+      - spidpi.sv: { file_type: systemVerilogSource }
 
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/dv/dpi/uartdpi/uartdpi_verilator.core
+++ b/hw/dv/dpi/uartdpi/uartdpi_verilator.core
@@ -2,17 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_verilator:uartdpi:0.1"
+description: "UART-DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
+      - uartdpi.sv: { file_type: systemVerilogSource }
 
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/dv/dpi/usbdpi/usbdpi.core
+++ b/hw/dv/dpi/usbdpi/usbdpi.core
@@ -6,9 +6,8 @@ name: "lowrisc:dv_dpi:usbdpi:0.1"
 description: "USB-DPI"
 
 filesets:
-  files_rtl:
+  files_c:
     files:
-      - usbdpi.sv: { file_type: systemVerilogSource }
       - usbdpi.c: { file_type: cppSource }
       - usbdpi_stream.c: { file_type: cppSource }
       - usbdpi_test.c: { file_type: cppSource }
@@ -26,4 +25,4 @@ filesets:
 targets:
   default:
     filesets:
-      - files_rtl
+      - files_c

--- a/hw/dv/dpi/usbdpi/usbdpi_sv.core
+++ b/hw/dv/dpi/usbdpi/usbdpi_sv.core
@@ -2,17 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv_dpi:uartdpi:0.1"
-description: "UART-DPI"
+name: "lowrisc:dv_sv:usbdpi:0.1"
+description: "USB-DPI verilator SV"
 
 filesets:
-  files_c:
+  files_rtl:
     files:
-      - uartdpi.c: { file_type: cppSource }
-      - uartdpi.h: { file_type: cppSource, is_include_file: true }
-
+      - usbdpi.sv: { file_type: systemVerilogSource }
 
 targets:
   default:
     filesets:
-      - files_c
+      - files_rtl

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -30,6 +30,11 @@ filesets:
       - lowrisc:dv:sw_test_status
       - lowrisc:dv:sw_logger_if
       - lowrisc:dv:mem_bkdr_util
+      - lowrisc:dv_dpi:uartdpi
+      - lowrisc:dv_dpi:gpiodpi
+      - lowrisc:dv_dpi:jtagdpi
+      - lowrisc:dv_dpi:dmidpi
+      - lowrisc:dv_dpi:spidpi
       - lowrisc:dv_dpi:usbdpi
       - lowrisc:dv:usb20_usbdpi
     files:

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -31,11 +31,17 @@ filesets:
       - lowrisc:dv:sw_logger_if
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv_dpi:uartdpi
+      - lowrisc:dv_verilator:uartdpi
       - lowrisc:dv_dpi:gpiodpi
+      - lowrisc:dv_verilator:gpiodpi
       - lowrisc:dv_dpi:jtagdpi
+      - lowrisc:dv_verilator:jtagdpi
       - lowrisc:dv_dpi:dmidpi
+      - lowrisc:dv_verilator:dmidpi
       - lowrisc:dv_dpi:spidpi
+      - lowrisc:dv_verilator:spidpi
       - lowrisc:dv_dpi:usbdpi
+      - lowrisc:dv_sv:usbdpi
       - lowrisc:dv:usb20_usbdpi
     files:
       - tb/chip_hier_macros.svh: {is_include_file: true}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -54,6 +54,8 @@
                 "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
                 "{top_dv_path}/chip_smoketests.hjson",
                 "{top_dv_path}/chip_rom_tests.hjson",
+                // Enable C compilation of chip level dpi
+                "{proj_root}/hw/dv/dpi/chip_dpi_sim_cfg.hjson",
                 ]
 
   // Override existing project defaults to supply chip-specific values.
@@ -222,7 +224,8 @@
   en_build_modes: ["{tool}_otbn_memutil_build_opts",
                    "{tool}_otbn_tracer_build_opts",
                    "{tool}_memutil_dpi_scrambled_build_opts",
-                   "{tool}_aes_model_build_opts"]
+                   "{tool}_aes_model_build_opts",
+                   "{tool}_chip_dpi_build_opts"]
 
   // Setup for generating OTP images.
   gen_otp_images_cfg_dir: "{proj_root}/hw/ip/otp_ctrl/data"

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -44,7 +44,6 @@ filesets:
       - chip_env.sv: {is_include_file: true}
       - chip_virtual_sequencer.sv: {is_include_file: true}
       - chip_scoreboard.sv: {is_include_file: true}
-      - chip_env.sv: {is_include_file: true}
       - seq_lib/chip_vseq_list.sv: {is_include_file: true}
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_stub_cpu_base_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -8,11 +8,17 @@ filesets:
   files_sim_verilator:
     depend:
       - lowrisc:dv_dpi:uartdpi
+      - lowrisc:dv_verilator:uartdpi
       - lowrisc:dv_dpi:gpiodpi
+      - lowrisc:dv_verilator:gpiodpi
       - lowrisc:dv_dpi:jtagdpi
+      - lowrisc:dv_verilator:jtagdpi
       - lowrisc:dv_dpi:dmidpi
+      - lowrisc:dv_verilator:dmidpi
       - lowrisc:dv_dpi:spidpi
+      - lowrisc:dv_verilator:spidpi
       - lowrisc:dv_dpi:usbdpi
+      - lowrisc:dv_sv:usbdpi
       - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
       - lowrisc:dv:sim_sram

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -10,11 +10,17 @@ filesets:
       - lowrisc:systems:top_englishbreakfast:0.1
       - lowrisc:systems:topgen
       - lowrisc:dv_dpi:uartdpi
+      - lowrisc:dv_verilator:uartdpi
       - lowrisc:dv_dpi:gpiodpi
+      - lowrisc:dv_verilator:gpiodpi
       - lowrisc:dv_dpi:jtagdpi
+      - lowrisc:dv_verilator:jtagdpi
       - lowrisc:dv_dpi:dmidpi
+      - lowrisc:dv_verilator:dmidpi
       - lowrisc:dv_dpi:spidpi
+      - lowrisc:dv_verilator:spidpi
       - lowrisc:dv_dpi:usbdpi
+      - lowrisc:dv_sv:usbdpi
       - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
       - lowrisc:ibex:ibex_tracer


### PR DESCRIPTION
This has 4 simple commits, two of which are lint and fixes to compile dpi .c files as C and not C++ files. Another one splits the dpi core files into the C and the SV components. The most important change is instantiating the uart and gpio dpi in the sim_dv testbench, in preparation for hooking up sim_dv to opentitanlib.