### PR TITLE
[sival] Add SiVal OTP SKU.

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -134,6 +134,26 @@ bitstream_splice(
     for authenticity in KEY_AUTHENTICITY
 ]
 
+# TODO(#20231): Remove once support for new splicing infrastructure is
+# available.
+[
+    bitstream_splice(
+        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
+        testonly = True,
+        src = ":rom_with_{}_keys".format(authenticity),
+        data = img_target,
+        meminfo = ":otp_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+    )
+    for (otp_name, img_target) in [
+        ("sival_prod_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized"),
+        ("sival_prod_end_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_personalized"),
+        ("sival_dev_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized"),
+    ]
+    for authenticity in KEY_AUTHENTICITY
+]
+
 # Create manifest fragments for all the cached bitstreams
 bitstream_fragment_from_manifest(
     name = "chip_earlgrey_cw310_cached_fragment",

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -341,6 +341,23 @@ otp_json(
     ],
 )
 
+otp_json(
+    name = "otp_json_fixed_secret2",
+    partitions = [
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                # We aren't testing keymgr for ROM_EXT tests and we want
+                # reproducible bitstreams for all tests.
+                "RMA_TOKEN": "0000000000000005",
+                "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
+                "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
+            },
+            lock = True,
+        ),
+    ],
+)
+
 # OTP LC STATE-SPECIFIC CONFIGS
 otp_json(
     name = "otp_json_raw",

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
@@ -19,7 +19,7 @@ load("//rules:const.bzl", "CONST", "EARLGREY_ALERTS", "EARLGREY_LOC_ALERTS")
 
 package(default_visibility = ["//visibility:public"])
 
-# Dummy partition used in `otp_image_header` targets.
+# Dummy partition used in `otp_image_consts` targets.
 otp_json(
     name = "otp_json_baseline",
     seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
@@ -27,24 +27,24 @@ otp_json(
 
 # Create an overlay for the alert_handler digest.
 otp_alert_digest(
-    name = "generic_alert_digest_cfg",
+    name = "alert_digest_cfg",
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
 # OTP SW Configuration for Test SKU.
 otp_image_consts(
-    name = "generic_otp_sw_cfg_c_file",
+    name = "otp_sw_cfg_c_file",
     src = ":otp_json_baseline",
     overlays = [
-        ":generic_alert_digest_cfg",
+        ":alert_digest_cfg",
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
     ],
 )
 
 cc_library(
-    name = "generic_otp_sw_cfg",
-    srcs = [":generic_otp_sw_cfg_c_file"],
+    name = "otp_sw_cfg",
+    srcs = [":otp_sw_cfg_c_file"],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/silicon_creator/manuf/lib:otp_img_types",

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
@@ -1,0 +1,66 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules:otp.bzl",
+    "otp_image",
+    "otp_image_consts",
+    "otp_json",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+# Dummy partition used in `otp_image_consts` targets.
+otp_json(
+    name = "otp_json_baseline",
+    seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
+)
+
+# OTP SW Configuration for Test SKU.
+otp_image_consts(
+    name = "otp_sw_cfg_c_file",
+    src = ":otp_json_baseline",
+    overlays = [
+        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
+        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
+        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
+    ],
+)
+
+cc_library(
+    name = "otp_sw_cfg",
+    srcs = [":otp_sw_cfg_c_file"],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/silicon_creator/manuf/lib:otp_img_types",
+    ],
+)
+
+MISSION_MODE_OVERLAYS = [
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
+    "//hw/ip/otp_ctrl/data:otp_json_secret1",
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
+]
+
+otp_image(
+    name = "otp_img_prod_personalized",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
+    overlays = MISSION_MODE_OVERLAYS,
+)
+
+otp_image(
+    name = "otp_img_prod_end_personalized",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod_end",
+    overlays = MISSION_MODE_OVERLAYS,
+)
+
+otp_image(
+    name = "otp_img_dev_personalized",
+    src = "//hw/ip/otp_ctrl/data:otp_json_dev",
+    overlays = MISSION_MODE_OVERLAYS,
+)

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -117,6 +117,7 @@ fpga_cw310(
     name = "fpga_cw310_sival",
     testonly = True,
     base = ":fpga_cw310_rom_with_fake_keys",
+    bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_prod_personalized",
     exec_env = "fpga_cw310_sival",
 
     # PROD keys are allowed to run across all life cycle stages. This prod key
@@ -131,7 +132,9 @@ fpga_cw310(
     name = "fpga_cw310_sival_rom_ext",
     testonly = True,
     base = ":fpga_cw310_rom_ext",
+    bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_prod_personalized",
     exec_env = "fpga_cw310_sival_rom_ext",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_sival_prod_signed_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
 )
 

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -163,7 +163,7 @@ cc_library(
     name = "individualize_sw_cfg_earlgrey_a0_sku_generic",
     deps = [
         ":individualize_sw_cfg",
-        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus:generic_otp_sw_cfg",
+        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_sw_cfg",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -261,6 +261,23 @@ opentitan_binary(
 )
 
 opentitan_binary(
+    name = "rom_ext_sival_prod_signed_slot_a",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_a",
+    manifest = ":manifest_standard",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    deps = [
+        ":rom_ext",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+    ],
+)
+
+opentitan_binary(
     name = "rom_ext_slot_b",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
@@ -270,6 +287,23 @@ opentitan_binary(
     linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    deps = [
+        ":rom_ext",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+    ],
+)
+
+opentitan_binary(
+    name = "rom_ext_sival_prod_signed_slot_b",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = ":ld_slot_b",
+    manifest = ":manifest_standard",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load(
+    "//rules:opentitan.bzl",
+    "OPENTITAN_CPU",
+    "RSA_ONLY_KEY_STRUCTS",
+)
 load(
     "//rules:opentitan_test.bzl",
     "OPENTITANTOOL_OPENOCD_DATA_DEPS",
@@ -19,20 +23,13 @@ load(
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
     "opentitan_test",
+    "rsa_key_for_lc_state",
     new_cw310_params = "cw310_params",
     new_dv_params = "dv_params",
     new_verilator_params = "verilator_params",
 )
 load("//rules:splice.bzl", "bitstream_splice")
 load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_image", "otp_json", "otp_partition")
-load(
-    "//rules:opentitan.bzl",
-    "RSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules/opentitan:defs.bzl",
-    "rsa_key_for_lc_state",
-)
 load(
     "//rules:const.bzl",
     "CONST",
@@ -74,7 +71,14 @@ opentitan_test(
 opentitan_test(
     name = "aes_entropy_test",
     srcs = ["aes_entropy_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This commit adds a set of SiVal SKU configurations for prod, prod_end
and dev life cycle stages.
    
The CW310 SiVal emulation targets were updated to use the prod
personalized configuration to reflect the configuration of device we are
planning to use for silicon validation.