### PR TITLE
[sival] Update flash_ctrl info access tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1198,57 +1198,18 @@ test_suite(
     tests = ["flash_ctrl_info_access_lc_{}".format(lc_state.lower()) for lc_state, _ in _FLASH_CTRL_INFO_ACCESS_LC_STATES],
 )
 
-_FLASH_CTRL_INFO_ACCESS_PER = [
-    "dev",
-    "prod",
-    "prod_end",
-]
-
-otp_json(
-    name = "flash_info_access_otp_json_secret2_locked_overlay",
-    partitions = [
-        otp_partition(
-            name = "SECRET2",
-            lock = True,
-        ),
-    ],
-    visibility = ["//visibility:private"],
-)
-
-[
-    otp_image(
-        name = "flash_info_access_otp_img_{}_secret2_locked".format(lc_state),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-        overlays = STD_OTP_OVERLAYS + [":flash_info_access_otp_json_secret2_locked_overlay"],
-        visibility = ["//visibility:private"],
-    )
-    for lc_state in _FLASH_CTRL_INFO_ACCESS_PER
-]
-
-[
-    bitstream_splice(
-        name = "flash_ctrl_info_access_{}_secret2_locked_bitstream".format(lc_state),
-        src = "//hw/bitstream:test_rom",
-        data = ":flash_info_access_otp_img_{}_secret2_locked".format(lc_state),
-        meminfo = "//hw/bitstream:otp_mmi",
-        update_usr_access = True,
-        visibility = ["//visibility:private"],
-    )
-    for lc_state in _FLASH_CTRL_INFO_ACCESS_PER
-]
-
 [
     opentitan_test(
         name = "flash_ctrl_info_access_lc_{}_personalized".format(lc_state),
         srcs = ["flash_ctrl_info_access_lc.c"],
         cw310 = new_cw310_params(
-            bitstream = ":flash_ctrl_info_access_{}_secret2_locked_bitstream".format(lc_state),
+            bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_{}_personalized".format(lc_state),
         ),
         dv = new_dv_params(
-            otp = ":flash_info_access_otp_img_{}_secret2_locked".format(lc_state),
+            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_{}_personalized".format(lc_state),
         ),
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -1266,12 +1227,23 @@ otp_json(
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for lc_state in _FLASH_CTRL_INFO_ACCESS_PER
+    for lc_state in [
+        "prod",
+        "prod_end",
+        "dev",
+    ]
 ]
 
 test_suite(
     name = "flash_ctrl_info_access_lc_states_personalized",
-    tests = ["flash_ctrl_info_access_lc_{}_personalized".format(lc_state) for lc_state in _FLASH_CTRL_INFO_ACCESS_PER],
+    tests = [
+        "flash_ctrl_info_access_lc_{}_personalized".format(lc_state)
+        for lc_state in [
+            "prod",
+            "prod_end",
+            "dev",
+        ]
+    ],
 )
 
 opentitan_test(


### PR DESCRIPTION
Update the flash_ctrl_info_access_lc_states_personalized test suite to use
the SiVal CW310 targets.
    
The SiVal targets use the canonical SKU configurations for earlgrey A0. 

Only the last commit is relevant in this PR. The other commits are part of #20257.