### PR TITLE
[crypto] Add a ceil-division operation to `math.h`.

### DIFF
--- a/sw/device/lib/base/math.c
+++ b/sw/device/lib/base/math.c
@@ -6,6 +6,11 @@
 
 #include <stddef.h>
 
+/**
+ * Extern declaration of inline function.
+ */
+extern size_t ceil_div(size_t a, size_t b);
+
 uint64_t udiv64_slow(uint64_t a, uint64_t b, uint64_t *rem_out) {
   uint64_t quot = 0, rem = 0;
 

--- a/sw/device/lib/base/math.h
+++ b/sw/device/lib/base/math.h
@@ -47,6 +47,24 @@ extern "C" {
 OT_WARN_UNUSED_RESULT
 uint64_t udiv64_slow(uint64_t a, uint64_t b, uint64_t *rem_out);
 
+/**
+ * Computes ceil(a / b) in an overflow-safe way.
+ *
+ * If `b == 0`, this function produces undefined behavior.
+ *
+ * @param a The dividend.
+ * @param b The divisor.
+ * @return Result, ceil(a / b).
+ */
+OT_WARN_UNUSED_RESULT
+inline size_t ceil_div(size_t a, size_t b) {
+  size_t out = a / b;
+  if (a % b != 0) {
+    out++;
+  }
+  return out;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -111,6 +111,7 @@ cc_library(
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:math",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/impl:status",
     ],

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -836,7 +837,7 @@ status_t entropy_csrng_generate_start(
     const entropy_seed_material_t *seed_material, size_t len) {
   // Round up the number of 128bit blocks. Aligning with respect to uint32_t.
   // TODO(#6112): Consider using a canonical reference for alignment operations.
-  const uint32_t num_128bit_blocks = (len + 3) / 4;
+  const uint32_t num_128bit_blocks = ceil_div(len, 4);
   return csrng_send_app_cmd(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET,
                             (entropy_csrng_cmd_t){
                                 .id = kEntropyDrbgOpGenerate,
@@ -850,7 +851,7 @@ status_t entropy_csrng_generate_data_get(uint32_t *buf, size_t len,
                                          hardened_bool_t fips_check) {
   static_assert(kEntropyCsrngBitsBufferNumWords == 4,
                 "kEntropyCsrngBitsBufferNumWords must be 4.");
-  size_t nblocks = (len + 3) / 4;
+  size_t nblocks = ceil_div(len, 4);
   status_t res = OTCRYPTO_OK;
   for (size_t block_idx = 0; block_idx < nblocks; ++block_idx) {
     // Block until there is more data available in the genbits buffer. CSRNG

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -36,6 +36,7 @@ cc_library(
     deps = [
         ":status",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:math",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/include:datatypes",
     ],
@@ -102,6 +103,7 @@ cc_library(
         ":integrity",
         ":status",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:math",
         "//sw/device/lib/crypto/drivers:keymgr",
         "//sw/device/lib/crypto/include:datatypes",
     ],

--- a/sw/device/lib/crypto/impl/aes_kwp/BUILD
+++ b/sw/device/lib/crypto/impl/aes_kwp/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:math",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:aes",
     ],

--- a/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
+++ b/sw/device/lib/crypto/impl/aes_kwp/aes_kwp.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
@@ -32,10 +33,7 @@ status_t aes_kwp_wrap(const aes_key_t kek, const uint32_t *plaintext,
 
   // Calculate the number of semiblocks needed for the plaintext (round up to
   // the next semiblock).
-  size_t plaintext_semiblocks = plaintext_len / kSemiblockBytes;
-  if (plaintext_len % kSemiblockBytes != 0) {
-    plaintext_semiblocks++;
-  }
+  size_t plaintext_semiblocks = ceil_div(plaintext_len, kSemiblockBytes);
   size_t pad_len = kSemiblockBytes * plaintext_semiblocks - plaintext_len;
 
   if (plaintext_semiblocks < 2) {
@@ -57,10 +55,7 @@ status_t aes_kwp_wrap(const aes_key_t kek, const uint32_t *plaintext,
   };
 
   // Initialize the output buffer with (A || plaintext || padding).
-  size_t plaintext_words = plaintext_len / sizeof(uint32_t);
-  if (plaintext_len % sizeof(uint32_t) != 0) {
-    plaintext_words++;
-  }
+  size_t plaintext_words = ceil_div(plaintext_len, sizeof(uint32_t));
   hardened_memcpy(ciphertext, block.data, kSemiblockWords);
   hardened_memcpy(ciphertext + kSemiblockWords, plaintext, plaintext_words);
   unsigned char *pad_start =
@@ -178,10 +173,7 @@ status_t aes_kwp_unwrap(const aes_key_t kek, const uint32_t *ciphertext,
   }
 
   // Copy the plaintext into the destination buffer.
-  size_t plaintext_words = plaintext_len / sizeof(uint32_t);
-  if (plaintext_len % sizeof(uint32_t) != 0) {
-    plaintext_words++;
-  }
+  size_t plaintext_words = ceil_div(plaintext_len, sizeof(uint32_t));
   hardened_memcpy(plaintext, r, plaintext_words);
 
   // Return success.

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/include/drbg.h"
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -30,7 +31,7 @@ static crypto_status_t seed_material_construct(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  size_t nwords = (value.len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  size_t nwords = ceil_div(value.len, sizeof(uint32_t));
   seed_material->len = nwords;
 
   // Initialize the set words to zero.
@@ -70,7 +71,7 @@ static crypto_status_t seed_material_xor(
 
   // Copy into a word-aligned buffer. Using a word-wise XOR is slightly safer
   // from a side channel perspective than byte-wise.
-  size_t nwords = (value.len + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+  size_t nwords = ceil_div(value.len, sizeof(uint32_t));
   uint32_t value_words[nwords];
   value_words[nwords - 1] = 0;
   memcpy(value_words, value.data, value.len);

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
@@ -51,10 +52,7 @@ static size_t keyblob_share_num_bytes(const crypto_key_config_t config) {
 
 size_t keyblob_share_num_words(const crypto_key_config_t config) {
   size_t len_bytes = keyblob_share_num_bytes(config);
-  if (len_bytes % sizeof(uint32_t) == 0) {
-    return len_bytes / sizeof(uint32_t);
-  }
-  return (len_bytes / sizeof(uint32_t)) + 1;
+  return ceil_div(len_bytes, sizeof(uint32_t));
 }
 
 size_t keyblob_num_words(const crypto_key_config_t config) {


### PR DESCRIPTION
Use it in the crypto library in various places where the divisor is a known nonzero number.

This operation is pretty useful for determining e.g. how many words are needed to store a certain number of bytes. I added it as part of adding the RSA-PSS padding mode, but it's useful in a bunch of other places as well so I gave it its own PR to keep the changes logically separate. As you can see in the diff, it replaces a lot of ad-hoc versions of itself that are either verbose or not overflow-safe (it's kind of one or the other).