### PR TITLE
[rom/e2e] Fix shutdown watchdog

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
@@ -46,7 +46,7 @@ SHUTDOWN_WATCHDOG_CASES = [
         "lc_state": lc_state[0],
         "lc_state_val": lc_state[1],
         # Make sure that the watchdog was not enabled so the count stayed 0.
-        "exit_success": "Returning after 2 seconds\r\n[^\r\n]*Watchdog count: 0",
+        "exit_success": "Wait done: after [0-9]+ ms, watchdog count=0",
         "bite_threshold": bite_threshold,
     }
     for lc_state in get_lc_items(
@@ -58,7 +58,7 @@ SHUTDOWN_WATCHDOG_CASES = [
     {
         "lc_state": lc_state[0],
         "lc_state_val": lc_state[1],
-        "exit_success": "Returning after 2 seconds\r\n[^\r\n]*Watchdog count: 0" if bite_threshold == 0 else "I00000[^\r\n]*\r\nROM:[0-9a-f]{8}\r\n",
+        "exit_success": "Wait done: after [0-9]+ ms, watchdog count=0" if bite_threshold == 0 else "I0000[^\r\n]*\r\nROM:[0-9a-f]{8}\r\n",
         "bite_threshold": bite_threshold,
     }
     for lc_state in get_lc_items(


### PR DESCRIPTION
The problem turned out to be really stupid: LOG_INFO prefixes every message with `I<number>` where `<number>` has 6 digits. For some reason, the BUILD specified one zero too many so the harness failed to match the message.
During debugging, I added a function to regularly print a status which is quite useful to help narrow down problems and might be useful in CI as well so I decided to leave it.