### PR TITLE
[opentitanlib] OpenOcd related refactor and cleanup

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -283,6 +283,7 @@ rust_library(
         "@crate_index//:rsa",
         "@crate_index//:rusb",
         "@crate_index//:rustix",
+        "@crate_index//:scopeguard",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:serialport",

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -21,10 +21,6 @@ pub struct JtagParams {
     #[arg(long, default_value = "openocd")]
     pub openocd: PathBuf,
 
-    /// Timeout when waiting for OpenOCD to start.
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "3s")]
-    pub openocd_timeout: Duration,
-
     #[arg(long, default_value = "200")]
     pub adapter_speed_khz: u64,
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -31,7 +31,7 @@ use crate::transport::common::uart::{flock_serial, SerialPortExclusiveLock, Seri
 use crate::transport::{
     Capabilities, Capability, Transport, TransportError, TransportInterfaceType, UpdateFirmware,
 };
-use crate::util::openocd::OpenOcdServer;
+use crate::util::openocd::OpenOcdJtagChain;
 use crate::util::usb::UsbBackend;
 
 pub mod c2d2;
@@ -637,15 +637,14 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
         // Tell OpenOCD to use its CMSIS-DAP driver, and to connect to the same exact USB
         // HyperDebug device that we are.
         let usb_device = self.inner.usb_device.borrow();
-        let new_jtag: Rc<dyn Jtag> = Rc::new(OpenOcdServer::new(
-            None,
-            Some(format!(
+        let new_jtag: Rc<dyn Jtag> = Rc::new(OpenOcdJtagChain::new(
+            format!(
                 "{}; cmsis_dap_vid_pid 0x{:04x} 0x{:04x}; adapter serial \"{}\";",
                 include_str!(env!("openocd_cmsis_dap_adapter_cfg")),
                 usb_device.get_vendor_id(),
                 usb_device.get_product_id(),
                 usb_device.get_serial_number(),
-            )),
+            ),
             opts,
         )?);
         *jtag = Some(Rc::clone(&new_jtag));

--- a/sw/host/tests/rom/e2e_openocd_debug_test/src/main.rs
+++ b/sw/host/tests/rom/e2e_openocd_debug_test/src/main.rs
@@ -471,8 +471,7 @@ fn main() -> Result<()> {
     log::info!("Loading symbols from ELF {}", opts.elf.display());
     dbg.load_elf(&opts.elf)?;
 
-    dbg.reset(false)?;
-    let result = dbg.remove_all_breakpoints();
+    let result = dbg.reset(false);
     assert_eq!(result.is_err(), opts.expect_fail);
     if opts.expect_fail {
         return Ok(());

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "rsa-der",
  "rusb",
  "rustix",
+ "scopeguard",
  "secrecy",
  "serde",
  "serde_bytes",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -52,6 +52,7 @@ regex = "1.7"
 rsa = "0.9.2"
 rusb = "0.9.3"
 rustix = { version = "0.38", features = ["event", "fs", "net", "process", "stdio"] }
+scopeguard = "1.2"
 serde = { version = "1.0.188", features = ["derive"] }
 
 serde_bytes = "0.11"

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -326,6 +326,12 @@ alias(
 )
 
 alias(
+    name = "scopeguard",
+    actual = "@crate_index__scopeguard-1.2.0//:scopeguard",
+    tags = ["manual"],
+)
+
+alias(
     name = "secrecy",
     actual = "@crate_index__secrecy-0.8.0//:secrecy",
     tags = ["manual"],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -344,6 +344,7 @@ _NORMAL_DEPENDENCIES = {
             "rsa-der": "@crate_index__rsa-der-0.3.0//:rsa_der",
             "rusb": "@crate_index__rusb-0.9.3//:rusb",
             "rustix": "@crate_index__rustix-0.38.10//:rustix",
+            "scopeguard": "@crate_index__scopeguard-1.2.0//:scopeguard",
             "secrecy": "@crate_index__secrecy-0.8.0//:secrecy",
             "serde": "@crate_index__serde-1.0.189//:serde",
             "serde_bytes": "@crate_index__serde_bytes-0.11.12//:serde_bytes",


### PR DESCRIPTION
This is the first PR of a series of OpenOCD-related code cleanup for opentitanlib.

The motivation is to split the monolithic `OpenOcdServer` code into multiple pieces for reuse. The current code is a single struct that handles:
* spawning and communication with openocd process and TCL server
* handling adapter setup
* handling JTAG TAP and target setup

In this PR separates the first out and enables the OpenOCD server handling part to be reused without going through the `Jtag` trait.