### PR TITLE
[ci, sival] Create a linter for the testplans

### DIFF
--- a/hw/lint/sival_testplan_schema.json
+++ b/hw/lint/sival_testplan_schema.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "additionalProperties": false,
+      "testpoints": {
+        "type": "array",
+        "items": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "desc": {
+              "type": "string"
+            },
+            "stage": {
+              "enum": ["V1", "V2", "V2S", "V3"]
+            },
+            "si_stage": {
+              "enum": ["SV1", "SV2", "SV3", "NA", "None"]
+            },
+            "bazel": {
+              "type": "array"
+            },
+            "lc_states": {
+              "type": "array",
+              "items": {
+                "enum": ["PROD", "TEST_UNLOCKED", "RAW", "SCRAP", "TEST_LOCKED",
+                  "TEST_LOCKED0", "DEV", "RMA", "TEST_UNLOCKED0", "PROD_END"]
+              }
+            },
+            "features": {
+              "type": "array"
+            },
+            "tests": {
+              "type": "array"
+            },
+            "otp_mutate": {
+              "type": "boolean"
+            },
+            "host_support": {
+              "type": "boolean"
+            },
+            "tags": {
+              "type": "array"
+            }
+          },
+          "required": ["name", "desc", "stage", "si_stage", "bazel", "tests"]
+        }
+      }
+    }
+  }

--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -29,6 +29,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
@@ -54,6 +55,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_normal
@@ -63,6 +65,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_oneshot
@@ -72,6 +75,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -108,6 +108,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_aes_entropy
@@ -176,6 +177,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_force_prng_reseed
@@ -209,6 +211,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_force_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_idle
@@ -300,6 +303,7 @@
       stage: V2S
       si_stage: NA
       tests: ["chip_sw_aes_masking_off"]
+      bazel: []
      }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -43,6 +43,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_escalation"]
+      bazel: []
       otp_mutate: true
       host_support: true
     }
@@ -67,6 +68,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
       otp_mutate: false
     }
     {
@@ -85,6 +87,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_all_escalation_resets
@@ -109,6 +112,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
+      bazel: []
     }
     {
       name: chip_sw_alert_handler_irqs
@@ -139,6 +143,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_alert_handler_entropy"]
+      bazel: []
     }
     {
       name: chip_sw_alert_handler_crashdump
@@ -190,6 +195,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_alerts"]
+      bazel: []
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_pings

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -270,6 +270,7 @@
         "chip_sw_flash_init_reduced_freq",
         "chip_sw_csrng_edn_concurrency_reduced_freq",
       ]
+      bazel: []
     }
     {
       name: chip_sw_clkmgr_deep_sleep_frequency
@@ -357,6 +358,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
+      bazel: []
     }
     {
       name: chip_sw_clkmgr_alert_handler_clock_enables

--- a/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
@@ -53,6 +53,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_csrng_fuse_en_sw_app_read_test"]
+      bazel: []
     }
     {
       name: chip_sw_csrng_lc_hw_debug_en
@@ -83,6 +84,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END"]
       tests: ["chip_sw_csrng_lc_hw_debug_en_test"]
+      bazel: []
     }
     {
       name: chip_sw_csrng_known_answer_tests

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -94,6 +94,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_flash_rma_unlocked"]
+      bazel: []
     }
     {
       name: chip_sw_flash_scramble
@@ -141,6 +142,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_key_derivation"]
+      bazel: []
     }
     {
       name: chip_sw_flash_lc_creator_seed_sw_rw_en
@@ -230,6 +232,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: []
     }
     {
       name: chip_sw_flash_lc_escalate_en
@@ -247,6 +250,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
+      bazel: []
     }
     {
       name: chip_sw_flash_prim_tl_access
@@ -259,6 +263,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_prim_tl_access"]
+      bazel: []
     }
     {
       name: chip_sw_flash_ctrl_clock_freqs
@@ -286,6 +291,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_flash_crash_alert"]
+      bazel: []
     }
     {
       name: chip_sw_flash_ctrl_write_clear

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -98,7 +98,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:i2c_host_override_test"]
+      tests: []
+      bazel: ["//sw/device/tests:i2c_host_override_test"]
     }
     {
       name: chip_sw_i2c_clockstretching
@@ -124,7 +125,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:i2c_target_test", "//sw/device/tests/pmod:i2c_host_clock_stretching_test"]
+      tests: []
+      bazel: ["//sw/device/tests:i2c_target_test", "//sw/device/tests/pmod:i2c_host_clock_stretching_test"]
     }
     {
       name: chip_sw_i2c_nack

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -43,6 +43,7 @@
         "chip_sw_keymgr_key_derivation",
         "chip_sw_keymgr_key_derivation_jitter_en",
       ]
+      bazel: []
     }
     {
       name: chip_sw_keymgr_sideload_kmac_error
@@ -61,6 +62,7 @@
       stage: V3
       si_stage: NA
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_keymgr_sideload_kmac
@@ -160,16 +162,16 @@
             - The test should check for any error or fault code status, to ensure all operations
               executed successfully.
             '''
-            features: [
-              "KEYMGR.DERIVE.ATTESTATION",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-            ]
-            stage: V3
-            si_stage: SV2
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: [
+        "KEYMGR.DERIVE.ATTESTATION",
+        "KEYMGR.GENERATE.OUTPUT",
+        "KEYMGR.GENERATE.IDENTITY",
+      ]
+      stage: V3
+      si_stage: SV2
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
     {
       name: chip_sw_keymgr_derive_sealing
@@ -183,17 +185,17 @@
             - Test a valid and an invalid key version when generating SW and sideload keys.
 
             '''
-            features: [
-              "KEYMGR.DERIVE.SEALING",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-              "KEYMGR.KEY_VERSIONING",
-            ]
-            stage: V3
-            si_stage: SV3
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: [
+        "KEYMGR.DERIVE.SEALING",
+        "KEYMGR.GENERATE.OUTPUT",
+        "KEYMGR.GENERATE.IDENTITY",
+        "KEYMGR.KEY_VERSIONING",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -38,6 +38,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_keymgr_key_derivation"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_app_lc
@@ -52,6 +53,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_app_rom
@@ -68,6 +70,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_kmac_app_rom"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_entropy
@@ -96,6 +99,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_kmac_entropy"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_idle

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -78,7 +78,9 @@
             - Ensure that no interrupts or alerts are triggered.
             '''
       stage: V2
+      si_stage: None
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_transitions
@@ -144,7 +146,9 @@
             - Verify that the keymgr uses the given `key_div_o` value to compute the keys.
             '''
       stage: V2
+      si_stage: None
       tests: ["chip_sw_keymgr_key_derivation_prod"]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_broadcast
@@ -178,6 +182,7 @@
               - lc_escalate_en_o (multiple)
             '''
       stage: V2
+      si_stage: None
       tests: [
         "chip_prim_tl_access",                         // lc_dft_en_o: otp_ctrl
         "chip_tap_straps_dev",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
@@ -202,6 +207,7 @@
         "chip_sw_otp_ctrl_lc_signals_prod",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
         "chip_sw_otp_ctrl_lc_signals_rma",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
       ]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_kmac_error
@@ -215,7 +221,9 @@
             - TBD
             '''
       stage: V3
+      si_stage: None
       tests: []
+      bazel: []
     }
     {
       name: chip_lc_scrap
@@ -284,11 +292,13 @@
              Verify that the features that should indeed be disabled are indeed disabled.
              '''
       stage: V2
+      si_stage: None
       tests: ["chip_sw_lc_walkthrough_dev",
               "chip_sw_lc_walkthrough_prod",
               "chip_sw_lc_walkthrough_prodend",
               "chip_sw_lc_walkthrough_rma",
               "chip_sw_lc_walkthrough_testunlocks"]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -19,6 +19,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_keys
@@ -48,6 +49,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_entropy
@@ -68,6 +70,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program
@@ -90,6 +93,7 @@
       si_stage: SV1
       lc_states: ["PROD"]
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program_error
@@ -111,6 +115,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_lc_ctrl_program_error"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_hw_cfg0
@@ -164,6 +169,7 @@
         "chip_sw_otp_ctrl_lc_signals_prod",
         "chip_sw_otp_ctrl_lc_signals_rma",
         ]
+      bazel: []
     }
     {
       name: chip_sw_otp_prim_tl_access
@@ -180,6 +186,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "RMA"]
       tests: ["chip_prim_tl_access"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_vendor_test_csr_access
@@ -203,6 +210,7 @@
       stage: V3
       si_stage: NA
       tests: ["chip_sw_otp_ctrl_vendor_test_csr_access"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_escalation
@@ -220,6 +228,7 @@
       stage: V3
       si_stage: NA
       tests: ["chip_sw_otp_ctrl_escalation"]
+      bazel: []
     }
     {
       name: otp_ctrl_calibration
@@ -232,6 +241,7 @@
       si_stage: SV1
       lc_states: ["TEST_UNLOCKED"]
       tests: []
+      bazel: []
     }
     {
       name: otp_ctrl_partition_access_locked
@@ -248,6 +258,7 @@
       stage: V3
       si_stage: NA
       tests: []
+      bazel: []
     }
     {
       name: otp_ctrl_check_timeout
@@ -263,6 +274,7 @@
       stage: V3
       si_stage: NA
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -270,6 +270,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_main_power_glitch_reset"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
@@ -292,6 +293,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_random_sleep_power_glitch_reset"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
@@ -311,6 +313,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_deep_sleep_power_glitch_reset"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset
@@ -325,6 +328,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_sleep_power_glitch_reset"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_random_sleep_all_reset_reqs
@@ -389,6 +393,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_b2b_sleep_reset_req"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_disabled
@@ -464,6 +469,7 @@
       si_stage: NA
       features: ["PWRMGR.RESET.ESCALATION_REQUEST"]
       tests: ["chip_sw_all_escalation_resets"]
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -41,6 +41,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_rom_ctrl_integrity_check"]
+      bazel: []
     }
     {
       name: chip_sw_rom_ctrl_kmac_error
@@ -59,6 +60,7 @@
       stage: V3
       si_stage: NA
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_rom_ctrl_digests
@@ -77,6 +79,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -220,6 +220,7 @@
      stage: V2S
      si_stage: None
      tests: ["chip_sw_rv_core_ibex_lockstep_glitch"]
+      bazel: []
     }
     {
       name: chip_sw_rv_core_ibex_alerts
@@ -235,6 +236,7 @@
       stage: V3
       si_stage: NA
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -24,11 +24,12 @@
       tests: ["chip_jtag_csr_rw"]
       bazel: ["//sw/device/tests:rv_dm_csr_rw"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
       ]
+      bazel: []
     }
     {
       name: chip_jtag_mem_access
@@ -55,7 +56,7 @@
       tests: ["chip_jtag_mem_access"]
       bazel: ["//sw/device/tests:rv_dm_mem_access"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -95,7 +96,7 @@
               "rom_e2e_jtag_debug_rma"]
       bazel: ["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -119,7 +120,7 @@
       tests: ["chip_rv_dm_ndm_reset_req"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -151,7 +152,7 @@
       tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -172,7 +173,7 @@
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
       bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -209,7 +210,7 @@
       tests: ["chip_tap_straps_rma"]
       bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -242,7 +243,7 @@
       ],
       lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "RMA", "PROD",
         "PROD_END", "SCRAP"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -262,7 +263,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_jtag"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
       ]
@@ -281,7 +282,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_dtm"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -312,7 +313,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_control_status"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",

--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -56,6 +56,7 @@
       stage: V3
       si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -81,6 +81,7 @@
         "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
       ]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_spi_device_pass_through_collision

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -53,6 +53,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
+      bazel: []
       tests: []
     }
     {
@@ -72,6 +73,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
+      bazel: []
       tests: []
     }
     {
@@ -97,6 +99,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
+      bazel: []
       tests: []
       bazel: ["//sw/device/tests:spi_host_irq_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -127,6 +127,7 @@
       lc_states: ["PROD"]
       tests: ["chip_sw_all_escalation_resets",
               "chip_sw_data_integrity_escalation"]
+      bazel: []
     }
 
     {

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -77,6 +77,7 @@
       si_stage: NA
       features: []
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
+      bazel: []
     }
     {
       name: chip_sw_uart_parity

--- a/util/lint_testplan.py
+++ b/util/lint_testplan.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script lint the various opentitan testplan.hjson
+usage:
+    python3 ./util/lint_testplan.py --schema hw/lint/sival_testplan_schema.json \
+                                    --dir hw/top_earlgrey/data/ip/
+"""
+
+import argparse
+import glob
+import logging
+import sys
+import pathlib
+import hjson
+import json
+import jsonschema
+
+
+def main(args: argparse.Namespace) -> int:
+    files = [f for f in glob.glob(f"{args.dir}/*.hjson")]
+
+    assert args.schema
+    return Linter(args.schema).check(files)
+
+
+class Linter:
+    def __init__(self, schema_file: str):
+        self.schema = json.load(open(schema_file, "r", encoding="utf-8"))
+
+    def check(self, files: str) -> int:
+        res: int = 0
+        for f in files:
+            try:
+                testplan = hjson.load(open(f, "r", encoding="utf-8"))
+                jsonschema.validate(testplan, schema=self.schema)
+
+            except jsonschema.ValidationError as e:
+                logging.info("Validation failed on file %s: %s", f, e)
+                res = -1
+            except hjson.scanner.HjsonDecodeError as e:
+                logging.info("Failed to decode file %s: %s", f, e)
+                res = -1
+                break
+
+        if res == 0:
+            logging.info("No errors found!")
+
+        return res
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--logging",
+        default="info",
+        choices=["debug", "info", "warning", "error", "critical"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--dir",
+        required=True,
+        help="A dir with all the testplan.hjson.",
+    )
+    parser.add_argument(
+        "--schema",
+        required=True,
+        type=pathlib.Path,
+        help="A json file with the linting rules to be used.",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=args.logging.upper())
+    sys.exit(main(args))


### PR DESCRIPTION
Using a json schema with a python library to lint the tesplans.
Usage:
```py
python3 ./util/lint_testplan.py --schema hw/lint/sival_testplan_schema.json --dir hw/top_earlgrey/data/ip/
```

