### PR TITLE
[ci] add third_party/rust to bitstream exclusion list

### DIFF
--- a/ci/fpga-template.yml
+++ b/ci/fpga-template.yml
@@ -15,6 +15,7 @@ steps:
 - template: ./install-package-dependencies.yml
 - bash: |
     ci/scripts/get-bitstream-strategy.sh "chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}" \
+      ':!/third_party/rust/' \
       ':!/sw/' \
       ':!/*.hjson' \
       ':!/*.tpl' \


### PR DESCRIPTION
Temporary solution to lighten some CI load by avoiding bitstream rebuilds when third_party/rust is updated.