### PR TITLE
[top_level,dpi] Fix C and SV code errors

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -5,6 +5,7 @@
 #include "gpiodpi.h"
 
 #ifdef __linux__
+#include <linux/limits.h>
 #include <pty.h>
 #elif __APPLE__
 #include <util.h>
@@ -14,6 +15,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/hw/dv/dpi/gpiodpi/gpiodpi.h
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.h
@@ -7,7 +7,9 @@
 
 #include <svdpi.h>
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 /**
  * Allocate a new GPIO DPI interface, returned as an opaque pointer.
@@ -47,5 +49,7 @@ uint32_t gpiodpi_host_to_device_tick(void *ctx_void, svBitVecVal *gpio_oe,
  */
 void gpiodpi_close(void *ctx_void);
 
+#ifdef __cplusplus
 }  // extern "C"
+#endif
 #endif  // OPENTITAN_HW_DV_DPI_GPIODPI_GPIODPI_H_

--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -5,7 +5,7 @@
 module gpiodpi
 #(
   parameter string NAME = "gpio0",
-  parameter        N_GPIO = 32
+  parameter int    N_GPIO = 32
 )(
   input  logic              clk_i,
   input  logic              rst_ni,
@@ -20,17 +20,17 @@ module gpiodpi
      chandle gpiodpi_create(input string name, input int n_bits);
 
    import "DPI-C" function
-     void gpiodpi_device_to_host(input chandle ctx, input [N_GPIO-1:0] gpio_d2p,
-                                 input [N_GPIO-1:0] gpio_en_d2p);
+     void gpiodpi_device_to_host(input chandle ctx, input logic [N_GPIO-1:0] gpio_d2p,
+                                 input logic [N_GPIO-1:0] gpio_en_d2p);
 
    import "DPI-C" function
      void gpiodpi_close(input chandle ctx);
 
    import "DPI-C" function
      int gpiodpi_host_to_device_tick(input chandle ctx,
-                                     input [N_GPIO-1:0] gpio_en_d2p,
-                                     input [N_GPIO-1:0] gpio_pull_en,
-                                     input [N_GPIO-1:0] gpio_pull_sel);
+                                     input logic [N_GPIO-1:0] gpio_en_d2p,
+                                     input logic [N_GPIO-1:0] gpio_pull_en,
+                                     input logic [N_GPIO-1:0] gpio_pull_sel);
 
    chandle ctx;
 

--- a/hw/dv/dpi/spidpi/spidpi.c
+++ b/hw/dv/dpi/spidpi/spidpi.c
@@ -20,7 +20,9 @@
 #include <unistd.h>
 
 #include "spidpi.h"
+#ifdef VERILATOR
 #include "verilator_sim_ctrl.h"
+#endif
 
 // Enable this define to stop tracing at cycle 4
 // and resume at the first SPI packet
@@ -102,10 +104,12 @@ char spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data) {
   // Will tick at the host clock
   ctx->tick++;
 
+#ifdef VERILATOR
 #ifdef CONTROL_TRACE
   if (ctx->tick == 4) {
     VerilatorSimCtrl::GetInstance().TraceOff();
   }
+#endif
 #endif
 
   monitor_spi(ctx->mon, ctx->mon_file, ctx->loglevel, ctx->tick, ctx->driving,
@@ -126,8 +130,10 @@ char spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data) {
         ctx->bin = ctx->msbfirst ? 0x80 : 0x01;
         ctx->din = 0;
         ctx->state = SP_CSFALL;
+#ifdef VERILATOR
 #ifdef CONTROL_TRACE
         VerilatorSimCtrl::GetInstance().TraceOn();
+#endif
 #endif
       }
     }
@@ -196,7 +202,9 @@ char spidpi_tick(void *ctx_void, const svLogicVecVal *d2p_data) {
         ctx->state = SP_IDLE;
         break;
       case SP_FINISH:
+#ifdef VERILATOR
         VerilatorSimCtrl::GetInstance().RequestStop(true);
+#endif
         break;
       default:
         ctx->driving = set_sck | (ctx->driving & ~P2D_SCK);

--- a/hw/dv/dpi/spidpi/spidpi.c
+++ b/hw/dv/dpi/spidpi/spidpi.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #ifdef __linux__
+#include <linux/limits.h>
 #include <pty.h>
 #elif __APPLE__
 #include <util.h>
@@ -15,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <svdpi.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -23,6 +25,39 @@
 #ifdef VERILATOR
 #include "verilator_sim_ctrl.h"
 #endif
+
+// This holds the necessary SPI state.
+#define MAX_TRANSACTION 4
+struct spidpi_ctx {
+  int loglevel;
+  char ptyname[64];
+  int host;
+  int device;
+  FILE *mon_file;
+  char mon_pathname[PATH_MAX];
+  void *mon;
+  int tick;
+  int cpol;
+  int cpha;
+  int msbfirst;  // shift direction
+  int nout;
+  int bout;
+  int nin;
+  int bin;
+  int din;
+  int nmax;
+  char driving;
+  int state;
+  char buf[MAX_TRANSACTION];
+};
+
+// SPI Host States
+#define SP_IDLE 0
+#define SP_CSFALL 1
+#define SP_DMOVE 2
+#define SP_LASTBIT 3
+#define SP_CSRISE 4
+#define SP_FINISH 99
 
 // Enable this define to stop tracing at cycle 4
 // and resume at the first SPI packet

--- a/hw/dv/dpi/spidpi/spidpi.h
+++ b/hw/dv/dpi/spidpi/spidpi.h
@@ -5,10 +5,16 @@
 #ifndef OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 #define OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+
 #include <limits.h>
 #include <svdpi.h>
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 #define MAX_TRANSACTION 4
 struct spidpi_ctx {
@@ -59,5 +65,9 @@ void spidpi_close(void *ctx_void);
 void monitor_spi(void *mon_void, FILE *mon_file, int loglevel, int tick,
                  int p2d, int d2p);
 void *monitor_spi_init(int mode);
-}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
 #endif  // OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_

--- a/hw/dv/dpi/spidpi/spidpi.h
+++ b/hw/dv/dpi/spidpi/spidpi.h
@@ -5,48 +5,11 @@
 #ifndef OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 #define OPENTITAN_HW_DV_DPI_SPIDPI_SPIDPI_H_
 
-#ifdef __linux__
-#include <linux/limits.h>
-#endif
-
-#include <limits.h>
 #include <svdpi.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define MAX_TRANSACTION 4
-struct spidpi_ctx {
-  int loglevel;
-  char ptyname[64];
-  int host;
-  int device;
-  FILE *mon_file;
-  char mon_pathname[PATH_MAX];
-  void *mon;
-  int tick;
-  int cpol;
-  int cpha;
-  int msbfirst;  // shift direction
-  int nout;
-  int bout;
-  int nin;
-  int bin;
-  int din;
-  int nmax;
-  char driving;
-  int state;
-  char buf[MAX_TRANSACTION];
-};
-
-// SPI Host States
-#define SP_IDLE 0
-#define SP_CSFALL 1
-#define SP_DMOVE 2
-#define SP_LASTBIT 3
-#define SP_CSRISE 4
-#define SP_FINISH 99
 
 // Bits in data to C
 #define D2P_SDO 0x2

--- a/hw/dv/dpi/spidpi/spidpi.sv
+++ b/hw/dv/dpi/spidpi/spidpi.sv
@@ -11,8 +11,8 @@
 module spidpi
   #(
   parameter string NAME = "spi0",
-  parameter MODE = 0,
-  parameter LOG_LEVEL = 9
+  parameter int MODE = 0,
+  parameter int LOG_LEVEL = 9
   )(
   input  logic clk_i,
   input  logic rst_ni,
@@ -30,7 +30,7 @@ module spidpi
     void spidpi_close(input chandle ctx);
 
   import "DPI-C" function
-    byte spidpi_tick(input chandle ctx_void, input [1:0] d2p_data);
+    byte spidpi_tick(input chandle ctx_void, input logic [1:0] d2p_data);
 
   chandle ctx;
 

--- a/hw/dv/dpi/uartdpi/uartdpi.c
+++ b/hw/dv/dpi/uartdpi/uartdpi.c
@@ -19,6 +19,15 @@
 #include <string.h>
 #include <unistd.h>
 
+// This keeps the necessary uart state.
+struct uartdpi_ctx {
+  char ptyname[64];
+  int host;
+  int device;
+  char tmp_read;
+  FILE *log_file;
+};
+
 void *uartdpi_create(const char *name, const char *log_file_path) {
   struct uartdpi_ctx *ctx =
       (struct uartdpi_ctx *)malloc(sizeof(struct uartdpi_ctx));

--- a/hw/dv/dpi/uartdpi/uartdpi.h
+++ b/hw/dv/dpi/uartdpi/uartdpi.h
@@ -5,7 +5,9 @@
 #ifndef OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
 #define OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 #include <stdio.h>
 
@@ -22,5 +24,7 @@ void uartdpi_close(void *ctx_void);
 int uartdpi_can_read(void *ctx_void);
 char uartdpi_read(void *ctx_void);
 void uartdpi_write(void *ctx_void, char c);
-}
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 #endif  // OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_

--- a/hw/dv/dpi/uartdpi/uartdpi.h
+++ b/hw/dv/dpi/uartdpi/uartdpi.h
@@ -9,21 +9,12 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
-
-struct uartdpi_ctx {
-  char ptyname[64];
-  int host;
-  int device;
-  char tmp_read;
-  FILE *log_file;
-};
-
 void *uartdpi_create(const char *name, const char *log_file_path);
 void uartdpi_close(void *ctx_void);
 int uartdpi_can_read(void *ctx_void);
 char uartdpi_read(void *ctx_void);
 void uartdpi_write(void *ctx_void, char c);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module uartdpi #(
-  parameter BAUD = 'x,
-  parameter FREQ = 'x,
+  parameter integer BAUD = 'x,
+  parameter integer FREQ = 'x,
   parameter string NAME = "uart0"
 )(
   input  logic clk_i,

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -430,7 +430,7 @@ uint32_t CRC5(uint32_t dwInput, int iBitcnt);
 uint32_t CRC16(const uint8_t *data, int bytes);
 
 #ifdef __cplusplus
-}
+}  // extern "C"
 #endif
 
 #endif  // OPENTITAN_HW_DV_DPI_USBDPI_USBDPI_H_


### PR DESCRIPTION
In order to use these DPI code in the regular sim_dv environment they need to pass more stringent linters and compilers.
The prior versions were only used in the verilator flow.

The first two commits, one for C and the other for SV files, deal with this.

The third commit removes implementation details from the C header files..