### PR TITLE
[chip-level/sival] Add test to testplan

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -17,7 +17,8 @@
             '''
       stage: V2
       tests: ["chip_sw_edn_entropy_reqs",
-              "chip_sw_csrng_edn_concurrency"]
+              "chip_sw_csrng_edn_concurrency",
+              "chip_sw_entropy_src_ast_rng_req",]
     },
     {
       name: chip_sw_edn_boot_mode

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -238,10 +238,6 @@ status_t execute_test(void) {
   return OK_STATUS();
 }
 
-/**
- * TODO: Run the test entropy src end reqs in continuous mode
- * (https://github.com/lowRISC/opentitan/issues/13393)
- */
 bool test_main(void) {
   test_initialize();
 


### PR DESCRIPTION
This PR adds another test to the chip_sw_edn_entropy_reqs test
point in the edn test plan. The added test is a pre existing test
called chip_sw_entropy_src_ast_rng_req_test. This test is added since
chip_sw_entropy_src_edn_reqs_test only tests 7 out of the 8 EDN endpoints.
The endpoint for the AST is now also covered.

This PR resolves #20054 