### PR TITLE
[opentitantool] add top-level command to read current LC state

### DIFF
--- a/sw/host/opentitanlib/src/dif/lc_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/lc_ctrl.rs
@@ -39,6 +39,10 @@ with_unknown! {
 }
 
 impl DifLcCtrlState {
+    pub fn from_redundant_encoding(encoding: u32) -> Result<Self> {
+        Ok(DifLcCtrlState(encoding & 0x1fu32))
+    }
+
     /// Encode the given life cycle state in a redundant format where the
     /// five-bit value is repeated six times.
     pub fn redundant_encoding(&self) -> u32 {

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -19,6 +19,7 @@ rust_binary(
         "src/command/hello.rs",
         "src/command/i2c.rs",
         "src/command/image.rs",
+        "src/command/lc.rs",
         "src/command/load_bitstream.rs",
         "src/command/mod.rs",
         "src/command/otp.rs",

--- a/sw/host/opentitantool/src/command/lc.rs
+++ b/sw/host/opentitantool/src/command/lc.rs
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use humantime::parse_duration;
+use serde_annotate::Annotate;
+use std::any::Any;
+use std::time::Duration;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::io::jtag::{JtagParams, JtagTap};
+
+#[derive(serde::Serialize)]
+pub struct LcStateReadResult {
+    pub lc_state: DifLcCtrlState,
+}
+
+#[derive(Debug, Args)]
+/// Reads the device life cycle state over JTAG.
+pub struct LcStateRead {
+    /// Whether or not to use the externally provided clock.
+    #[arg(long)]
+    pub use_ext_clk: bool,
+
+    /// Reset duration when switching the LC TAP straps.
+    #[arg(long, value_parser = parse_duration, default_value = "100ms")]
+    pub reset_delay: Duration,
+
+    #[command(flatten)]
+    pub jtag_params: JtagParams,
+}
+
+impl CommandDispatch for LcStateRead {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        // Set the TAP straps for the lifecycle controller and reset.
+        transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+        transport.reset_target(self.reset_delay, true)?;
+
+        // Spawn an OpenOCD process and connect to the LC JTAG TAP.
+        let jtag = self.jtag_params.create(transport)?;
+        jtag.connect(JtagTap::LcTap)?;
+
+        // Read and decode the LC state.
+        let lc_state =
+            DifLcCtrlState::from_redundant_encoding(jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?)?;
+        Ok(Some(Box::new(LcStateReadResult { lc_state })))
+    }
+}
+
+#[derive(Debug, Subcommand, CommandDispatch)]
+/// Commands for performing various device life cycle operations.
+pub enum LcCommand {
+    Read(LcStateRead),
+}

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -11,6 +11,7 @@ pub mod gpio;
 pub mod hello;
 pub mod i2c;
 pub mod image;
+pub mod lc;
 pub mod load_bitstream;
 pub mod otp;
 pub mod reset_sam3x;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -40,6 +40,8 @@ enum RootCommandHierarchy {
     I2c(command::i2c::I2cCommand),
     #[command(subcommand)]
     Image(command::image::Image),
+    #[command(subcommand)]
+    LifeCycle(command::lc::LcCommand),
     NoOp(command::NoOp),
     #[command(subcommand)]
     Otp(command::otp::Otp),


### PR DESCRIPTION
[opentitantool] add top-level command to read current LC state

This partially addresses #20211.

Additionally, this updates the lc_ctrl DIF lib to use the (actual) redundant encoding as LC state enum values. Using the actual redundant encoding as the LC state enum values makes checking values on the Rust side easier, and simplifies the code required to implement the top-level opentitantool commands to perform LC reads and the raw unlock operation.