### PR TITLE
[test] clear bitstream after rom_ext_upgrade_interrupt

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -100,6 +100,7 @@ otp_json(
                 --exec="transport init"
                 --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                --exec="fpga clear-bitstream"
                 no-op
             """,
         ),


### PR DESCRIPTION
Fix #20289 

The CI issue appears to be caused by bitstream not cleared after the ROM_EXT upgrade interrupt test. This causes the subsequent test to think that the bitstream does not require reload and fail since manifest version is being rolled back.