### PR TITLE
[chip-test,si-val] chip_sw_rom_access

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -12,7 +12,7 @@
             '''
       features: ["ROM_CTRL.SCRAMBLED"]
       stage: V2
-      si_stage: SV2
+      si_stage: SV1
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -13,6 +13,8 @@
       features: ["ROM_CTRL.SCRAMBLED"]
       stage: V2
       si_stage: SV1
+      bazel:["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"]
+      lc_states: ["TEST_UNLOCKED0", "DEV", "RMA", "PROD", "PROD_END"]
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -115,24 +115,23 @@ LC_STATES_DEBUG_DISALLOWED = [
 ]
 
 [
-    opentitan_functest(
+    opentitan_test(
         name = "openocd_debug_test_otp_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = cw310_params(
+        cw310 = cw310_jtag_params(
             timeout = "moderate",
+            binaries = {
+                "//sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_elf": "rom",
+            },
             bitstream = ":rom_with_fake_keys_otp_{}_exec_disabled".format(lc_state),
-            test_cmds = [
-                "--bitstream=\"$(rootpath {bitstream})\"",
-                "--elf=\"$(rootpath //sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_elf)\"",
-            ] + (
-                ["--expect-fail"] if lc_state_val in LC_STATES_DEBUG_DISALLOWED else []
-            ) + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+            logging = "debug",
+            tags = ["cw310_rom_with_fake_keys"],
+            test_cmd = " --elf={rom}" + (" --expect-fail" if lc_state_val in LC_STATES_DEBUG_DISALLOWED else " "),
+            test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test",
         ),
-        data = [
-            "//sw/device/silicon_creator/rom:rom_with_fake_keys_fpga_cw310_elf",
-        ] + OPENTITANTOOL_OPENOCD_DATA_DEPS,
-        targets = ["cw310_rom_with_fake_keys"],
-        test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test",
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
         deps = [
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing/test_framework:ottf_main",


### PR DESCRIPTION
## This PR implements the test chip_sw_rom_access by
- Migrating the rom_e2e_openocd_debug_test to use the new bazel rules.
- Linking the chip_sw_rom_access to rom_e2e_openocd_debug_test.


Relates to https://github.com/lowRISC/opentitan/issues/19939