### PR TITLE
[edn] Add transition from boot to SW mode

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -562,7 +562,7 @@
           desc: '''This is the state of the EDN main state machine.
                 See the RTL file `edn_main_sm` for the meaning of the values.
                 '''
-          resval: 0x185
+          resval: 0x0C1
         }
       ]
     },

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -462,4 +462,5 @@ Main state machine state observation register
 |  31:9  |        |         |               | Reserved                                                                                                       |
 |  8:0   |   ro   |  0xc1   | MAIN_SM_STATE | This is the state of the EDN main state machine. See the RTL file `edn_main_sm` for the meaning of the values. |
 
+
 <!-- END CMDGEN -->

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -448,7 +448,7 @@ an interrupt or an alert.
 ## MAIN_SM_STATE
 Main state machine state observation register
 - Offset: `0x40`
-- Reset default: `0x185`
+- Reset default: `0xc1`
 - Reset mask: `0x1ff`
 
 ### Fields
@@ -460,7 +460,6 @@ Main state machine state observation register
 |  Bits  |  Type  |  Reset  | Name          | Description                                                                                                    |
 |:------:|:------:|:-------:|:--------------|:---------------------------------------------------------------------------------------------------------------|
 |  31:9  |        |         |               | Reserved                                                                                                       |
-|  8:0   |   ro   |  0x185  | MAIN_SM_STATE | This is the state of the EDN main state machine. See the RTL file `edn_main_sm` for the meaning of the values. |
-
+|  8:0   |   ro   |  0xc1   | MAIN_SM_STATE | This is the state of the EDN main state machine. See the RTL file `edn_main_sm` for the meaning of the values. |
 
 <!-- END CMDGEN -->

--- a/hw/ip/edn/doc/theory_of_operation.md
+++ b/hw/ip/edn/doc/theory_of_operation.md
@@ -28,8 +28,9 @@ This means, for instance, that no personalization strings or additional data may
 On exiting, the EDN issues an `uninstantiate` command to destroy the associated CSRNG instance.
 
 Once firmware initialization is complete, it is important to exit this mode if the endpoints ever need FIPS-approved random values.
+Should another generate command be needed, it can only be issued after exiting boot mode.
 This is done by either *clearing* the `EDN_ENABLE` field or *clearing* the `BOOT_REQ_MODE` field in [`CTRL`](registers.md#ctrl) to halt the boot-time request state machine.
-Firmware must then wait for successful the shutdown of the state machine by polling the `REQ_MODE_SM_STS` field of the [`MAIN_SM_STATE`](registers.md#main_sm_state) register.
+Firmware must then wait for the transition of the state machine by polling the `CMD_RDY` field of the [`SW_CMD_STS`](registers.md#sw_cmd_sts) register or wait for the state machine to enter the SW mode by polling the [`MAIN_SM_STATE`](registers.md#main_sm_state) register.
 
 It should be noted that when in boot-time request mode, no status will be updated that is used for the software port operation.
 If some hang condition were to occur when in this mode, the main state machine debug register should be read to determine if a hang condition is present.

--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -116,10 +116,10 @@ interface edn_cov_if (
       // Generate commands in auto mode that aren't from the generate register aren't intended
       ignore_bins gen_auto_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::AutoReqMode } &&
                                        ! binsof(cp_cmd_src) intersect { edn_env_pkg::AutoGen };
-      // Generate commands in boot mode that aren't from the bootgen or sw register aren't intended
+      // Generate commands in boot mode that aren't from the bootgen register aren't intended
       ignore_bins gen_boot_wrong_src =
           binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
-          ! binsof(cp_cmd_src) intersect { edn_env_pkg::BootGen, edn_env_pkg::Sw };
+          ! binsof(cp_cmd_src) intersect { edn_env_pkg::BootGen };
       // Generate commands in boot mode that have a clen > 0 aren't intended
       ignore_bins gen_boot_seq_wrong_clen =
           binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
@@ -146,7 +146,7 @@ interface edn_cov_if (
       // Instantiate commands in boot mode that aren't from the BootIns register aren't intended
       ignore_bins ins_boot_wrong_src =
           binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
-          ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw, edn_env_pkg::BootIns };
+          ! binsof(cp_cmd_src) intersect { edn_env_pkg::BootIns };
       // Instantiate commands in boot mode that have a clen > 0 aren't intended
       ignore_bins ins_boot_seq_wrong_clen =
           binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
@@ -170,9 +170,8 @@ interface edn_cov_if (
       // Reseed commands in auto mode that aren't from the autoRes register aren't intended
       ignore_bins res_auto_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::AutoReqMode } &&
                                        ! binsof(cp_cmd_src) intersect { edn_env_pkg::AutoRes };
-      // Reseed commands in boot mode that aren't from the sw register aren't intended
-      ignore_bins res_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
-                                       ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };
+      // Reseed commands in boot mode aren't intended
+      ignore_bins res_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode };
       // Reseed commands in sw mode that aren't from the sw register aren't intended
       ignore_bins res_sw_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::SwMode } &&
                                      ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };
@@ -185,9 +184,8 @@ interface edn_cov_if (
       ignore_bins not_upd = ! binsof(cp_acmd) intersect { csrng_pkg::UPD };
       // Update commands in auto mode aren't intended
       ignore_bins upd_auto_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::AutoReqMode };
-      // Update commands in boot mode that aren't from the sw register aren't intended
-      ignore_bins upd_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
-                                       ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };
+      // Update commands in boot mode aren't intended
+      ignore_bins upd_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode };
       // Update commands in sw mode that aren't from the sw register aren't intended
       ignore_bins upd_sw_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::SwMode } &&
                                      ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };
@@ -199,9 +197,8 @@ interface edn_cov_if (
       ignore_bins not_uni = ! binsof(cp_acmd) intersect { csrng_pkg::UNI };
       // Uninstantiate commands in auto mode aren't intended
       ignore_bins uni_auto_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::AutoReqMode };
-      // Uninstantiate commands in boot mode that aren't from the sw register aren't intended
-      ignore_bins uni_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode } &&
-                                       ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };
+      // Uninstantiate commands in boot mode are always the same.
+      ignore_bins uni_boot_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::BootReqMode };
       // Uninstantiate commands in sw mode that aren't from the sw register aren't intended
       ignore_bins uni_sw_wrong_src = binsof(cp_mode) intersect { edn_env_pkg::SwMode } &&
                                      ! binsof(cp_cmd_src) intersect { edn_env_pkg::Sw };

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -383,6 +383,11 @@ class edn_scoreboard extends cip_base_scoreboard #(
                                        " CSRNG instance. the value from generate fifo 0x%h."},
                                       cs_cmd))
 
+            // Instantiate not allowed if EDN is in boot_req_mode and boot sequence is done.
+            `DV_CHECK_FATAL(boot_mode -> !boot_gen_cmd_sent,
+                            $sformatf({"Instantiate command not allowed in boot_req_mode after",
+                                       " boot sequence is done. cmd: 0x%h"}, cs_cmd))
+
             // Determine whether the instantiate only consists of the header
             // and set flags accordingly
             if (clen_cntr == 0) begin
@@ -404,7 +409,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
                                          " has to match the value in sw_cmd_req register 0x%h."},
                                         cs_cmd, sw_cmd_req_comp))
 
-            // If EDN is in sw mode or boot_gen command has been sent
+            // If EDN is in sw mode check if the received command is correct.
             end else begin
               sw_cmd_req_comp = sw_cmd_req_q.pop_front();
               `DV_CHECK_FATAL(cs_cmd == sw_cmd_req_comp,
@@ -419,8 +424,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
                             $sformatf({"Reseed command not allowed without instantiated",
                                        " CSRNG instance. cmd: 0x%h"}, cs_cmd))
 
-            // If EDN is in boot_req_mode and boot sequence is not done
-            `DV_CHECK_FATAL(boot_mode -> boot_gen_cmd_sent,
+            // Reseed not allowed if EDN is in boot_req_mode.
+            `DV_CHECK_FATAL(!boot_mode,
                             $sformatf({"Reseed command not allowed in boot_req_mode.",
                                        " cmd: 0x%h"}, cs_cmd))
 
@@ -494,8 +499,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
                             $sformatf({"Update command not allowed without instantiated",
                                        " CSRNG instance. cmd: 0x%h"}, cs_cmd))
 
-            // If EDN is in boot_req_mode and boot sequence is not done
-            `DV_CHECK_FATAL(boot_mode -> boot_gen_cmd_sent,
+            // Update not allowed if EDN is in boot_req_mode.
+            `DV_CHECK_FATAL(!boot_mode,
                             $sformatf({"Update command not allowed in boot_req_mode.",
                                        " cmd: 0x%h"}, cs_cmd))
 
@@ -522,17 +527,27 @@ class edn_scoreboard extends cip_base_scoreboard #(
                             $sformatf("clen must be 0 for uninstantiate command. cmd: 0x%h",
                                       cs_cmd))
 
-            `DV_CHECK_FATAL(!auto_mode || (boot_mode -> boot_gen_cmd_sent),
+            `DV_CHECK_FATAL((!auto_mode || !boot_mode),
                             $sformatf({"Uninstantiate command not allowed in auto mode or",
-                                       " before boot gen command has been sent."}))
+                                       " boot mode."}))
 
-            if ((!auto_mode && !boot_mode) || (boot_mode && boot_gen_cmd_sent)) begin
+            if (!auto_mode && !boot_mode && !boot_gen_cmd_sent) begin
               sw_cmd_req_comp = sw_cmd_req_q.pop_front();
               `DV_CHECK_FATAL(cs_cmd == sw_cmd_req_comp,
                               $sformatf({"Uninstantiate command 0x%h has to match",
                                          " the value from sw_cmd_req register 0x%h."},
                                         cs_cmd, sw_cmd_req_comp))
             end
+
+            if (boot_gen_cmd_sent) begin
+              boot_gen_cmd_sent = 1'b0;
+              boot_mode = 1'b0;
+              `DV_CHECK_FATAL(cs_cmd == edn_pkg::BOOT_UNINSTANTIATE,
+                              $sformatf({"Uninstantiate command 0x%h has to match",
+                                         " the boot mode uninstantiate command 0x%h."},
+                                        cs_cmd, edn_pkg::BOOT_UNINSTANTIATE))
+            end
+
             instantiated = 1'b0;
           end
           default: begin

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -75,8 +75,10 @@ class edn_genbits_vseq extends edn_base_vseq;
 
     // set generate length and num_reqs_between_reseeds depending on the operational mode
     if (cfg.boot_req_mode == MuBi4True) begin
-      mode = edn_env_pkg::BootReqMode;
       glen = total_glen - cfg.num_boot_reqs;
+      // Disable boot mode to enter sw mode which enables sw commands.
+      ral.ctrl.boot_req_mode.set(prim_mubi_pkg::MuBi4False);
+      csr_update(.csr(ral.ctrl));
     end
 
     if (cfg.auto_req_mode == MuBi4True) begin
@@ -93,16 +95,14 @@ class edn_genbits_vseq extends edn_base_vseq;
       glen = total_glen;
     end
 
-    if (cfg.boot_req_mode != MuBi4True) begin
-      // Send instantiate cmd
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
-      `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
-      wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(clen), .flags(flags),
-             .glen(glen), .mode(mode));
-      for (int i = 0; i < clen; i++) begin
-        `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
-        wr_cmd(.cmd_type(edn_env_pkg::Sw), .cmd_data(cmd_data), .mode(mode));
-      end
+    // Send instantiate cmd
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(clen, clen dist { 0 :/ 20, [1:12] :/ 80 };)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
+    wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(clen), .flags(flags),
+            .glen(glen), .mode(mode));
+    for (int i = 0; i < clen; i++) begin
+      `DV_CHECK_STD_RANDOMIZE_FATAL(cmd_data)
+      wr_cmd(.cmd_type(edn_env_pkg::Sw), .cmd_data(cmd_data), .mode(mode));
     end
 
     if (cfg.auto_req_mode != MuBi4True) begin

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -125,6 +125,7 @@ module edn_core import edn_pkg::*;
   logic                      boot_req_mode_pfa;
   logic                      boot_wr_cmd_reg;
   logic                      boot_wr_cmd_genfifo;
+  logic                      boot_wr_cmd_uni;
   logic                      auto_first_ack_wait;
   logic                      auto_req_mode_busy;
   logic                      auto_set_intr_gate;
@@ -477,11 +478,12 @@ module edn_core import edn_pkg::*;
          (!edn_enable_fo[CsrngCmdReq]) ? '0 :
          boot_wr_cmd_reg ? boot_ins_cmd :
          sw_cmd_req_load ? sw_cmd_req_bus :
+         boot_wr_cmd_uni ? edn_pkg::BOOT_UNINSTANTIATE :
          cs_cmd_req_q;
 
   assign cs_cmd_req_vld_d =
          (!edn_enable_fo[CsrngCmdReqValid]) ? '0 :
-         (sw_cmd_req_load || boot_wr_cmd_reg); // cmd reg write
+         (sw_cmd_req_load || boot_wr_cmd_reg || boot_wr_cmd_uni); // cmd reg write
 
   assign cs_cmd_req_out_d =
          (!edn_enable_fo[CsrngCmdReqOut]) ? '0 :
@@ -651,6 +653,7 @@ module edn_core import edn_pkg::*;
     .sw_cmd_valid_o         (sw_cmd_valid),
     .boot_wr_cmd_reg_o      (boot_wr_cmd_reg),
     .boot_wr_cmd_genfifo_o  (boot_wr_cmd_genfifo),
+    .boot_wr_cmd_uni_o      (boot_wr_cmd_uni),
     .auto_set_intr_gate_o   (auto_set_intr_gate),
     .auto_clr_intr_gate_o   (auto_clr_intr_gate),
     .auto_first_ack_wait_o  (auto_first_ack_wait),

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -81,7 +81,7 @@ module edn_main_sm import edn_pkg::*; #(
     send_rescmd_o          = 1'b0;
     main_sm_done_pulse_o   = 1'b0;
     main_sm_err_o          = 1'b0;
-    sw_cmd_valid_o         = 1'b1;
+    sw_cmd_valid_o         = 1'b0;
     unique case (state_q)
       Idle: begin
         if (boot_req_mode_i && edn_enable_i) begin
@@ -129,6 +129,7 @@ module edn_main_sm import edn_pkg::*; #(
       end
       //-----------------------------------
       AutoLoadIns: begin
+        sw_cmd_valid_o = 1'b1;
         auto_set_intr_gate_o = 1'b1;
         auto_first_ack_wait_o = 1'b1;
         if (sw_cmd_req_load_i) begin
@@ -136,6 +137,7 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoFirstAckWait: begin
+        sw_cmd_valid_o = 1'b1;
         auto_first_ack_wait_o = 1'b1;
         if (csrng_cmd_ack_i) begin
           auto_clr_intr_gate_o = 1'b1;
@@ -143,7 +145,6 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoAckWait: begin
-        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         if (csrng_cmd_ack_i) begin
           state_d = AutoDispatch;
@@ -151,7 +152,6 @@ module edn_main_sm import edn_pkg::*; #(
       end
       AutoDispatch: begin
         auto_req_mode_busy_o = 1'b1;
-        sw_cmd_valid_o = 1'b0;
         if (!auto_req_mode_i) begin
           main_sm_done_pulse_o = 1'b1;
           state_d = Idle;
@@ -164,13 +164,11 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoCaptGenCnt: begin
-        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         capt_gencmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendGenCmd;
       end
       AutoSendGenCmd: begin
-        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         send_gencmd_o = 1'b1;
         if (cmd_sent_i) begin
@@ -178,13 +176,11 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       AutoCaptReseedCnt: begin
-        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         capt_rescmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendReseedCmd;
       end
       AutoSendReseedCmd: begin
-        sw_cmd_valid_o = 1'b0;
         auto_req_mode_busy_o = 1'b1;
         send_rescmd_o = 1'b1;
         if (cmd_sent_i) begin
@@ -192,6 +188,7 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       SWPortMode: begin
+        sw_cmd_valid_o = 1'b1;
       end
       Error: begin
         main_sm_err_o = 1'b1;

--- a/hw/ip/edn/rtl/edn_pkg.sv
+++ b/hw/ip/edn/rtl/edn_pkg.sv
@@ -25,6 +25,7 @@ package edn_pkg;
 
   parameter edn_req_t EDN_REQ_DEFAULT = '0;
   parameter edn_rsp_t EDN_RSP_DEFAULT = '0;
+  parameter csrng_pkg::csrng_cmd_t BOOT_UNINSTANTIATE = 32'h5;
 
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 3 -m 21 -n 9 \

--- a/hw/ip/edn/rtl/edn_pkg.sv
+++ b/hw/ip/edn/rtl/edn_pkg.sv
@@ -26,26 +26,50 @@ package edn_pkg;
   parameter edn_req_t EDN_REQ_DEFAULT = '0;
   parameter edn_rsp_t EDN_RSP_DEFAULT = '0;
 
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 21 -n 9 \
+  //     -s 2596398066 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||| (20.00%)
+  //  4: |||||||||||||||||||| (31.43%)
+  //  5: ||||||||||||||| (23.81%)
+  //  6: ||||||||| (14.76%)
+  //  7: |||| (7.62%)
+  //  8: | (2.38%)
+  //  9: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 8
+  // Minimum Hamming weight: 2
+  // Maximum Hamming weight: 7
+  //
   typedef enum logic [8:0] {
-    Idle              = 9'b110000101, // idle
-    BootLoadIns       = 9'b110110111, // boot: load the instantiate command
-    BootLoadGen       = 9'b000000011, // boot: load the generate command
-    BootInsAckWait    = 9'b011010010, // boot: wait for instantiate command ack
-    BootCaptGenCnt    = 9'b010111010, // boot: capture the gen fifo count
-    BootSendGenCmd    = 9'b011100100, // boot: send the generate command
-    BootGenAckWait    = 9'b101101100, // boot: wait for generate command ack
-    BootPulse         = 9'b100001010, // boot: signal a done pulse
-    BootDone          = 9'b011011111, // boot: stay in done state until reset
-    AutoLoadIns       = 9'b001110000, // auto: load the instantiate command
-    AutoFirstAckWait  = 9'b001001101, // auto: wait for first instantiate command ack
-    AutoAckWait       = 9'b101100011, // auto: wait for instantiate command ack
-    AutoDispatch      = 9'b110101110, // auto: determine next command to be sent
-    AutoCaptGenCnt    = 9'b000110101, // auto: capture the gen fifo count
-    AutoSendGenCmd    = 9'b111111000, // auto: send the generate command
-    AutoCaptReseedCnt = 9'b000100110, // auto: capture the reseed fifo count
-    AutoSendReseedCmd = 9'b101010110, // auto: send the reseed command
-    SWPortMode        = 9'b100111001, // swport: no hw request mode
-    Error             = 9'b010010001  // illegal state reached and hang
+    Idle              = 9'b011000001, // idle
+    BootLoadIns       = 9'b111000111, // boot: load the instantiate command
+    BootLoadGen       = 9'b001111001, // boot: load the generate command
+    BootInsAckWait    = 9'b000000011, // boot: wait for instantiate command ack
+    BootCaptGenCnt    = 9'b001110111, // boot: capture the gen fifo count
+    BootSendGenCmd    = 9'b010101001, // boot: send the generate command
+    BootGenAckWait    = 9'b011110000, // boot: wait for generate command ack
+    BootPulse         = 9'b100110101, // boot: signal a done pulse
+    BootDone          = 9'b000101100, // boot: stay in done state until reset
+    BootLoadUni       = 9'b110111100, // boot: load the uninstantiate command
+    BootUniAckWait    = 9'b110100011, // boot: wait for uninstantiate command ack
+    AutoLoadIns       = 9'b010010010, // auto: load the instantiate command
+    AutoFirstAckWait  = 9'b101100001, // auto: wait for first instantiate command ack
+    AutoAckWait       = 9'b100001110, // auto: wait for instantiate command ack
+    AutoDispatch      = 9'b111011101, // auto: determine next command to be sent
+    AutoCaptGenCnt    = 9'b010111111, // auto: capture the gen fifo count
+    AutoSendGenCmd    = 9'b001101010, // auto: send the generate command
+    AutoCaptReseedCnt = 9'b010010101, // auto: capture the reseed fifo count
+    AutoSendReseedCmd = 9'b000011000, // auto: send the reseed command
+    SWPortMode        = 9'b101111110, // swport: no hw request mode
+    Error             = 9'b001000100  // illegal state reached and hang
   } state_e;
 
 endpackage : edn_pkg

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -1160,7 +1160,7 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (9'h185),
+    .RESVAL  (9'hc1),
     .Mubi    (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -141,79 +141,87 @@ typedef enum dif_edn_sm_state {
   /**
    * Device is idle.
    */
-  kDifEdnSmStateIdle = 389,
+  kDifEdnSmStateIdle = 193,
   /**
    * Boot mode: load the instantiate command.
    */
-  kDifEdnSmStateBootLoadIns = 439,
+  kDifEdnSmStateBootLoadIns = 455,
   /**
    * Boot mode: load the generate command.
    */
-  kDifEdnSmStateBootLoadGen = 3,
+  kDifEdnSmStateBootLoadGen = 121,
   /**
    * Boot mode: wait for instantiate command ack.
    */
-  kDifEdnSmStateBootInsAckWait = 210,
+  kDifEdnSmStateBootInsAckWait = 3,
   /**
    * Boot mode: capture the gen fifo count.
    */
-  kDifEdnSmStateBootCaptGenCnt = 186,
+  kDifEdnSmStateBootCaptGenCnt = 119,
   /**
    * Boot mode: send the generate command.
    */
-  kDifEdnSmStateBootSendGenCmd = 228,
+  kDifEdnSmStateBootSendGenCmd = 169,
   /**
    * Boot mode: wait for generate command ack.
    */
-  kDifEdnSmStateBootGenAckWait = 364,
+  kDifEdnSmStateBootGenAckWait = 240,
   /**
    * Boot mode: signal a done pulse.
    */
-  kDifEdnSmStateBootPulse = 266,
+  kDifEdnSmStateBootPulse = 309,
   /**
    * Boot mode: stay in done state until reset.
    */
-  kDifEdnSmStateBootDone = 223,
+  kDifEdnSmStateBootDone = 44,
+  /**
+   * Boot mode: load the uninstantiate command.
+   */
+  kDifEdnSmStateBootLoadUni = 444,
+  /**
+   * Boot mode: wait for uninstantiate command ack.
+   */
+  kDifEdnSmStateBootUniAckWait = 419,
   /**
    * Auto mode: load the instantiate command.
    */
-  kDifEdnSmStateAutoLoadIns = 112,
+  kDifEdnSmStateAutoLoadIns = 146,
   /**
    * Auto mode: wait for first instantiate command ack.
    */
-  kDifEdnSmStateAutoFirstAckWait = 77,
+  kDifEdnSmStateAutoFirstAckWait = 353,
   /**
    * Auto mode: wait for instantiate command ack.
    */
-  kDifEdnSmStateAutoAckWait = 355,
+  kDifEdnSmStateAutoAckWait = 270,
   /**
    * Auto mode: determine next command to be sent.
    */
-  kDifEdnSmStateAutoDispatch = 430,
+  kDifEdnSmStateAutoDispatch = 477,
   /**
    * Auto mode: capture the gen fifo count.
    */
-  kDifEdnSmStateAutoCaptGenCnt = 53,
+  kDifEdnSmStateAutoCaptGenCnt = 191,
   /**
    * Auto mode: send the generate command.
    */
-  kDifEdnSmStateAutoSendGenCmd = 504,
+  kDifEdnSmStateAutoSendGenCmd = 106,
   /**
    * Auto mode: capture the reseed fifo count.
    */
-  kDifEdnSmStateAutoCaptReseedCnt = 38,
+  kDifEdnSmStateAutoCaptReseedCnt = 149,
   /**
    * Auto mode: send the reseed command.
    */
-  kDifEdnSmStateAutoSendReseedCmd = 342,
+  kDifEdnSmStateAutoSendReseedCmd = 24,
   /**
    * Sw port: no hw request mode.
    */
-  kDifEdnSmStateSWPortMode = 313,
+  kDifEdnSmStateSWPortMode = 382,
   /**
    * Illegal state reached and hang.
    */
-  kDifEdnSmStateError = 145,
+  kDifEdnSmStateError = 68,
 } dif_edn_sm_state_t;
 
 /**


### PR DESCRIPTION
This commit adds a transition from boot to SW mode after the
boot sequence is done and the ctrl.boot_req_mode flag is disabled.

For further information have a look at the individual commit messages.

This PR resolves #19655 
This PR resolves #19037