### PR TITLE
[manuf] sram exec test run on all lc unlocked states

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -363,7 +363,7 @@ opentitan_binary(
             binaries = {
                 ":sram_exec_test": "sram_program",
             },
-            bitstream = ":bitstream_rom_exec_disabled_test_unlocked0",
+            bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
             tags = ["manuf"],
             test_cmd = """
                 --elf={sram_program}


### PR DESCRIPTION
The `manuf_cp_ast_test_execution` test was only being run on the unlocked0 lc state. It now runs on all eight unlocked states.