### PR TITLE
[ot_certs] Add OT certificate template parser

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -465,6 +465,7 @@
     - [Crypto Library Tests](./sw/device/tests/crypto/README.md)
 
 - [Host Software](./sw/host/README.md)
+  - [OpenTitan Certificate Generator](./sw/host/ot_certs/README.md)
   - [Hardware Security Module (HSM) tool](./sw/host/hsmtool/README.md)
     - [Requirements](./sw/host/hsmtool/doc/requirements.md)
   - [OpenTitanLib](./sw/host/opentitanlib/README.md)

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -174,6 +174,7 @@ RUST_TARGETS = [
     "//sw/host/cryptotest:cryptotest_parser_test",
     "//sw/host/hsmtool:hsmlib",
     "//sw/host/hsmtool:hsmlib_test",
+    "//sw/host/ot_certs:ot_certs",
     "//sw/host/opentitanlib:opentitanlib",
     "//sw/host/opentitanlib:opentitanlib_test",
     "//sw/host/opentitansession:opentitansession",

--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -175,6 +175,7 @@ RUST_TARGETS = [
     "//sw/host/hsmtool:hsmlib",
     "//sw/host/hsmtool:hsmlib_test",
     "//sw/host/ot_certs:ot_certs",
+    "//sw/host/ot_certs:ot_certs_test",
     "//sw/host/opentitanlib:opentitanlib",
     "//sw/host/opentitanlib:opentitanlib_test",
     "//sw/host/opentitansession:opentitansession",

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,6 +22,14 @@ rust_library(
         "@crate_index//:serde",
         "@crate_index//:serde_with",
         "@crate_index//:strum",
+    ],
+)
+
+rust_test(
+    name = "ot_certs_test",
+    crate = ":ot_certs",
+    proc_macro_deps = [
+        "@crate_index//:indoc",
     ],
 )
 

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "ot_certs",
+    srcs = [
+        "src/lib.rs",
+        "src/template/hjson.rs",
+        "src/template/mod.rs",
+    ],
+    deps = [
+        "@crate_index//:anyhow",
+        "@crate_index//:deser-hjson",
+        "@crate_index//:hex",
+        "@crate_index//:num-bigint-dig",
+        "@crate_index//:num-traits",
+        "@crate_index//:serde",
+        "@crate_index//:serde_with",
+        "@crate_index//:strum",
+    ],
+)
+
+rust_doc(
+    name = "ot_certs_doc",
+    crate = ":ot_certs",
+)

--- a/sw/host/ot_certs/README.md
+++ b/sw/host/ot_certs/README.md
@@ -1,0 +1,12 @@
+# OpenTitan certificate generator
+
+This crate is capable of generating OpenTitan certificates to be stored on the
+device.
+
+Certificates templates are specified in Hjson format. Fields of the certificate
+can be given literal values in the template, or given the name of a variable.
+These variable values are intended to be set by the OpenTitan device itself.
+This crate will generate code capable of running on the device to get/set these
+fields.
+
+More detailed documentation on OpenTitan certificates will be published soon.

--- a/sw/host/ot_certs/src/lib.rs
+++ b/sw/host/ot_certs/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crate handles generating OpenTitan certificates.
+//!
+//! These certificates are generated from a template and embedded onto an
+//! OpenTitan device.
+//!
+//! Templates may specify that some values are variables, in which case they
+//! will be filled in by the device itself. This crate will generate C code for
+//! setting/getting variable values of templates from OpenTitan firmware.
+//!
+//! Certificates are generated in both X.509 format and CWT (CBOR web token)
+//! format. Details of the certificates will be available in the documentation
+//! in the future.
+
+pub mod template;

--- a/sw/host/ot_certs/src/template/hjson.rs
+++ b/sw/host/ot_certs/src/template/hjson.rs
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains Hjson-specific encodings of certificate template
+//! components.
+//!
+//! They are kept separated here so that details of the representation of
+//! templates on-disk (in Hjson) can change without the API of the template
+//! structs changing.
+
+use hex::FromHex;
+use num_bigint_dig::BigUint as InnerBigUint;
+use num_traits::{Num, ToPrimitive};
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use serde_with::DeserializeAs;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BigUint {
+    biguint: InnerBigUint,
+}
+
+impl From<BigUint> for InnerBigUint {
+    fn from(value: BigUint) -> InnerBigUint {
+        value.biguint
+    }
+}
+
+// Helper trait to improve error messages for Value<T>.
+pub trait DeserializeAsHelpMsg<T> {
+    fn help_msg() -> &'static str;
+    fn example() -> &'static str;
+}
+
+impl DeserializeAsHelpMsg<String> for String {
+    fn help_msg() -> &'static str {
+        "a string"
+    }
+
+    fn example() -> &'static str {
+        "\"hello world\""
+    }
+}
+
+// Deserialize BigUint as InnerBigUint. This is necessary because the default hjson
+// parser really wants to parse numbers by itself and it won't handle big integers
+// or any customization.
+impl<'de> DeserializeAs<'de, InnerBigUint> for BigUint {
+    fn deserialize_as<D>(deserializer: D) -> Result<InnerBigUint, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_str(BigUintVisitor)
+            .map(InnerBigUint::from)
+    }
+}
+
+impl DeserializeAsHelpMsg<InnerBigUint> for BigUint {
+    fn help_msg() -> &'static str {
+        "a string representing a non-negative integer (you can use the prefix '0x' for hexadecimal)"
+    }
+
+    fn example() -> &'static str {
+        "410983 or 0x64567"
+    }
+}
+
+// Same for u8, derserialize as BigUint and see if it fits.
+impl<'de> DeserializeAs<'de, u8> for BigUint {
+    fn deserialize_as<D>(deserializer: D) -> Result<u8, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner: InnerBigUint = BigUint::deserialize_as(deserializer)?;
+        match inner.to_u8() {
+            Some(x) => Ok(x),
+            None => Err(de::Error::custom(format!(
+                "expected 8-bit integer but {} is too large",
+                inner
+            ))),
+        }
+    }
+}
+
+impl DeserializeAsHelpMsg<u8> for BigUint {
+    fn help_msg() -> &'static str {
+        "a string representing a non-negative 8-bit integer (you can use the prefix '0x' for hexadecimal)"
+    }
+
+    fn example() -> &'static str {
+        "123 or 0x7b"
+    }
+}
+
+struct BigUintVisitor;
+
+impl<'de> serde::de::Visitor<'de> for BigUintVisitor {
+    type Value = BigUint;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a non-negative integer, you can use the prefix '0x' for hexadecimal")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        // Unless the string starts with '0x', expect a decimal string.
+        let (radix, s) = s.strip_prefix("0x").map_or_else(|| (10, s), |s| (16, s));
+        InnerBigUint::from_str_radix(s, radix)
+            .map_err(de::Error::custom)
+            .map(|biguint| BigUint { biguint })
+    }
+}
+
+pub struct HexString;
+
+/// Deserialization of a `Value<Vec<u8>>` from a string of hex digits.
+impl<'de> DeserializeAs<'de, Vec<u8>> for HexString {
+    fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Vec::<u8>::from_hex(s)
+            .map_err(|err| de::Error::custom(format!("could not parse hexstring: {}", err)))
+    }
+}
+
+impl DeserializeAsHelpMsg<Vec<u8>> for HexString {
+    fn help_msg() -> &'static str {
+        "a hexstring (a string of hexadecimal characters representing a byte array)"
+    }
+
+    fn example() -> &'static str {
+        "ff8702"
+    }
+}
+
+impl<T> DeserializeAsHelpMsg<T> for serde_with::Same
+where
+    T: DeserializeAsHelpMsg<T>,
+{
+    fn help_msg() -> &'static str {
+        T::help_msg()
+    }
+
+    fn example() -> &'static str {
+        T::example()
+    }
+}

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -1,0 +1,335 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! OpenTitan certificate template deserialization.
+//!
+//! This module contains structs defining certificate templates.
+//!
+//! These structs are defined in Hjson files and deserialized to here. Any
+//! extra conversion required (beyond simple renaming) is done in the `hjson`
+//! module.
+//!
+//! The format for a template in Hjson looks something like:
+//!
+//! ```hjson
+//! {
+//!   variables: {
+//!     SomeVariableName: {
+//!       type: "byte-array",
+//!       size: 20,
+//!     },
+//!     // ...
+//!   },
+//!
+//!   certificate: {
+//!     // Certificate keys, some making use of variables, others not.
+//!     serial_number: { var: "SomeVariableName" },
+//!     layer: 0,
+//!     // ...
+//!   }
+//! }
+//! ```
+
+use anyhow::Result;
+use num_bigint_dig::BigUint;
+use serde::{Deserialize, Deserializer};
+use serde_with::{serde_as, As, DeserializeAs, Same};
+use std::collections::HashMap;
+
+mod hjson;
+
+/// Full template file, including variable declarations and certificate spec.
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct Template {
+    /// Name of the certificate.
+    pub name: String,
+    /// Variable declarations.
+    pub variables: HashMap<String, VariableType>,
+    /// Certificate specification.
+    pub certificate: Certificate,
+}
+
+/// Certificate specification.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct Certificate {
+    /// X509 certificate's serial number
+    #[serde_as(as = "Value<hjson::BigUint>")]
+    pub serial_number: Value<BigUint>,
+    /// X509 certificate's issuer.
+    pub issuer: HashMap<AttributeType, Value<String>>,
+    /// X509 certificate's subject.
+    pub subject: HashMap<AttributeType, Value<String>>,
+    /// X509 certificate's public key.
+    pub subject_public_key_info: SubjectPublicKeyInfo,
+    /// X509 certificate's authority key identifier.
+    #[serde_as(as = "Value<hjson::HexString>")]
+    pub authority_key_identifier: Value<Vec<u8>>,
+    /// X509 certificate's public key identifier.
+    #[serde_as(as = "Value<hjson::HexString>")]
+    pub subject_key_identifier: Value<Vec<u8>>,
+    /// DICE TCB model.
+    pub model: Option<Value<String>>,
+    /// DICE TCB vendor.
+    pub vendor: Option<Value<String>>,
+    /// DICE TCB version.
+    pub version: Option<Value<String>>,
+    /// DICE TCB security version number.
+    #[serde_as(as = "Option<Value<hjson::BigUint>>")]
+    pub svn: Option<Value<BigUint>>,
+    /// DICE TCB layer.
+    #[serde_as(as = "Option<Value<hjson::BigUint>>")]
+    pub layer: Option<Value<BigUint>>,
+    /// DICE TCB firmware IDs.
+    pub fw_ids: Option<Vec<FirmwareId>>,
+    /// DICE TCB flags.
+    pub flags: Option<Flags>,
+    /// X509 certificate's signature.
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Hash, strum::Display)]
+#[serde(rename_all = "snake_case")]
+pub enum AttributeType {
+    #[serde(alias = "c")]
+    Country,
+    #[serde(alias = "o")]
+    Organization,
+    #[serde(alias = "ou")]
+    OrganizationalUnit,
+    #[serde(alias = "st")]
+    State,
+    #[serde(alias = "cn")]
+    CommonName,
+    #[serde(alias = "sn")]
+    SerialNumber,
+}
+
+/// Value which may either be a variable name or literal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Value<T> {
+    /// This value will be populated on the device when variables are set.
+    Variable {
+        /// Name of the variable.
+        var: String,
+        /// Optional conversion to apply to the variable.
+        convert: Option<Conversion>,
+    },
+    /// Constant literal that will be set when the certificate is generated.
+    Literal(T),
+}
+
+impl<T> Value<T> {
+    /// Create a variable with the given name. No conversion applied.
+    pub fn variable(name: &str) -> Self {
+        Value::Variable {
+            var: name.into(),
+            convert: None,
+        }
+    }
+
+    /// Create a variable with the given name and conversion.
+    pub fn convert(var: &str, conversion: Conversion) -> Self {
+        Value::Variable {
+            var: var.into(),
+            convert: Some(conversion),
+        }
+    }
+
+    /// Create a literal with the given value.
+    pub fn literal(value: impl Into<T>) -> Self {
+        Value::Literal(value.into())
+    }
+
+    /// Return true if the value is a literal
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal(_))
+    }
+}
+
+// Manual implementation of the deserializer since error messages for untagged
+// enumerations are really terrible.
+impl<'de, T, U> DeserializeAs<'de, Value<T>> for Value<U>
+where
+    U: DeserializeAs<'de, T> + hjson::DeserializeAsHelpMsg<T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<Value<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // This is a horrible hack: we redefine a local type where T is now instantiated
+        // and we derive a derserializer using serde but using serde with to override the
+        // deserialize for T so that we can combine with SerializeAs. Since this is a local
+        // type with outer generic types, we need to specify them in the type definition,
+        // but U is not used so we need a phantom data to appease the compiler. We further
+        // need to recall serde that there is a type bound on U.
+        //
+        // FIXME: this works but the error message of serde is still terrible. It might be worth
+        // trying to replacing this with serde_as::PickFirst but this requires more boiler plate.
+        #[derive(Deserialize)]
+        #[serde(bound = "U: DeserializeAs<'de, T> + hjson::DeserializeAsHelpMsg<T>")]
+        #[serde(untagged)]
+        pub enum LocalValue<U, T> {
+            Variable {
+                var: String,
+                convert: Option<Conversion>,
+                #[serde(skip)]
+                _phantom: std::marker::PhantomData<U>,
+            },
+            #[serde(with = "As::<U>")]
+            Literal(T),
+        }
+        match LocalValue::<U, T>::deserialize(deserializer) {
+            Ok(val) => match val {
+                LocalValue::Literal(x) => Ok(Value::<T>::Literal(x)),
+                LocalValue::Variable { var, convert, .. } => {
+                    Ok(Value::<T>::Variable { var, convert })
+                }
+            },
+            Err(_) => {
+                let msg = format!("could not parse value: expected either {} or a variable (use the syntax {{var: \"name\"}}",
+                                  U::help_msg());
+                let example = format!("for example: {}, or {{var: \"my_variabla\"}}", U::example());
+                Err(serde::de::Error::custom(format!("{}\n{}", msg, example)))
+            }
+        }
+    }
+}
+
+// Convenience implementation to avoid using
+// `serde_as(as = "Same<_>)` everywhere.
+impl<'de, T> Deserialize<'de> for Value<T>
+where
+    T: Deserialize<'de> + hjson::DeserializeAsHelpMsg<T>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Value<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        As::<Value<Same>>::deserialize(deserializer)
+    }
+}
+
+/// Conversion to apply to a variable when inserting it into the certificate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Conversion {
+    /// Lower case hex: convert a byte array to a string in lowercase
+    /// hexadecimal form. Every byte is printed using exactly two characters
+    /// and there is no "0x" prefix. Example:
+    /// [42, 53] -> "2a35".
+    LowercaseHex,
+    /// Little endian: convert between a byte array and integer in little endian.
+    LittleEndian,
+    /// Little endian: convert between a byte array and integer in little endian.
+    BigEndian,
+}
+
+/// Representation of the signature of the certificate.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(tag = "algorithm", rename_all = "kebab-case")]
+pub enum Signature {
+    EcdsaWithSha256 { value: Option<EcdsaSignature> },
+}
+
+/// Representation of an ECDSA signature.
+///
+/// The signature consists of two integers "r" and "s".
+/// See X9.62
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct EcdsaSignature {
+    #[serde_as(as = "Value<hjson::BigUint>")]
+    pub r: Value<BigUint>,
+    #[serde_as(as = "Value<hjson::BigUint>")]
+    pub s: Value<BigUint>,
+}
+
+/// Representation of the `SubjectPublicKeyInfo` field.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(tag = "algorithm", rename_all = "kebab-case")]
+pub enum SubjectPublicKeyInfo {
+    EcPublicKey(EcPublicKeyInfo),
+}
+
+/// Representation of an elliptic curve public key information.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct EcPublicKeyInfo {
+    pub curve: EcCurve,
+    pub public_key: EcPublicKey,
+}
+
+/// Representation of an elliptic curve public key in uncompressed
+/// form.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct EcPublicKey {
+    #[serde_as(as = "Value<hjson::BigUint>")]
+    pub x: Value<BigUint>,
+    #[serde_as(as = "Value<hjson::BigUint>")]
+    pub y: Value<BigUint>,
+}
+
+/// List of EC named curves.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub enum EcCurve {
+    #[serde(rename = "prime256v1")]
+    Prime256v1,
+}
+
+/// Flags that can be set for a certificate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
+pub struct Flags {
+    pub not_configured: bool,
+    pub not_secure: bool,
+    pub recovery: bool,
+    pub debug: bool,
+}
+
+/// Firmware ID (fwid) field.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct FirmwareId {
+    /// Algorithm used for the has of the firmware.
+    pub hash_algorithm: HashAlgorithm,
+    /// Raw bytes of the hashed firmware.
+    #[serde_as(as = "Value<hjson::HexString>")]
+    pub digest: Value<Vec<u8>>,
+}
+
+/// Possible algorithms for computing hashes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+pub enum HashAlgorithm {
+    #[serde(rename = "sha256")]
+    Sha256,
+}
+
+/// Declaration of a variable that can be filled into the template.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum VariableType {
+    /// Raw array of bytes.
+    ByteArray {
+        /// Length in bytes for this variable.
+        size: usize,
+    },
+    /// Signed integer: such an integer is represented by an array of
+    /// in big-endian.
+    Integer {
+        /// Maximum size in bytes for this variable.
+        size: usize,
+    },
+    /// UTF-8 encoded String.
+    String {
+        /// Maximum size in bytes for this variable.
+        size: usize,
+    },
+}
+
+impl Template {
+    pub fn from_hjson_str(content: &str) -> Result<Template> {
+        Ok(deser_hjson::from_str(content)?)
+    }
+}

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -91,6 +91,13 @@ crates_vendor(
                 "@//third_party/rust/patches:pqcrypto-sphincsplus-includedir.patch",
             ],
         )],
+        # This is a workaround: presumably because of a rules_rust bug, indexmap 1.9.3 depends
+        # on hashbrown 0.12 with no defaults and the `raw` feature but rules_rust does not add this
+        # feature to crate which prevents the crate from compiling.
+        "hashbrown": [crate.annotation(
+            crate_features = ["raw"],
+            version = "0.12",
+        )],
     },
     cargo_lockfile = "//third_party/rust:Cargo.lock",
     manifests = ["//third_party/rust:Cargo.toml"],

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -180,6 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,8 +276,9 @@ dependencies = [
  "hex",
  "humantime",
  "humantime-serde",
- "indexmap",
+ "indexmap 2.0.0",
  "indicatif",
+ "indoc",
  "libftdi1-sys",
  "log",
  "mdbook",
@@ -303,6 +310,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "serialport",
  "sha2",
  "shellwords",
@@ -341,6 +349,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -525,6 +534,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +584,9 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "deser-hjson"
@@ -725,6 +772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +860,12 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -904,6 +963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,12 +980,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -936,6 +1012,12 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inout"
@@ -1894,6 +1976,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "serialport"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2357,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -53,9 +53,9 @@ rusb = "0.9.3"
 rustix = { version = "0.38", features = ["event", "fs", "net", "process", "stdio", "termios"] }
 scopeguard = "1.2"
 serde = { version = "1.0.188", features = ["derive"] }
-
 serde_bytes = "0.11"
 serde_json = "1.0.69"
+serde_with = "3.4.0"
 serialport = "4.2.2"
 sha2 = { version = "0.10", features = ["oid"] }
 shellwords = "1.1.0"
@@ -98,3 +98,6 @@ tar = "0.4.36"
 elf = "0.7.1"
 ring = "0.16.20"
 rsa-der = "0.3.0"
+
+[dev-dependencies]
+indoc = "2.0.4"

--- a/third_party/rust/crates/BUILD.base64-0.21.5.bazel
+++ b/third_party/rust/crates/BUILD.base64-0.21.5.bazel
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "time",
+    name = "base64",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +28,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=base64",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +72,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
-    deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
-    ],
+    version = "0.21.5",
 )

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -170,6 +170,12 @@ alias(
 )
 
 alias(
+    name = "indoc",
+    actual = "@crate_index__indoc-2.0.4//:indoc",
+    tags = ["manual"],
+)
+
+alias(
     name = "libftdi1-sys",
     actual = "@crate_index__libftdi1-sys-1.1.2//:libftdi1_sys",
     tags = ["manual"],
@@ -352,6 +358,12 @@ alias(
 alias(
     name = "serde_json",
     actual = "@crate_index__serde_json-1.0.107//:serde_json",
+    tags = ["manual"],
+)
+
+alias(
+    name = "serde_with",
+    actual = "@crate_index__serde_with-3.4.0//:serde_with",
     tags = ["manual"],
 )
 

--- a/third_party/rust/crates/BUILD.chrono-0.4.31.bazel
+++ b/third_party/rust/crates/BUILD.chrono-0.4.31.bazel
@@ -88,6 +88,7 @@ rust_library(
     version = "0.4.31",
     deps = [
         "@crate_index__num-traits-0.2.17//:num_traits",
+        "@crate_index__serde-1.0.189//:serde",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "@crate_index__iana-time-zone-0.1.58//:iana_time_zone",  # cfg(unix)

--- a/third_party/rust/crates/BUILD.darling-0.20.3.bazel
+++ b/third_party/rust/crates/BUILD.darling-0.20.3.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # MIT
 # ])
 
 rust_library(
-    name = "time",
+    name = "darling",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,21 +29,18 @@ rust_library(
         ],
     ),
     crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
+        "default",
+        "suggestions",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2018",
     proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
+        "@crate_index__darling_macro-0.20.3//:darling_macro",
     ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=darling",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +79,8 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "0.20.3",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
+        "@crate_index__darling_core-0.20.3//:darling_core",
     ],
 )

--- a/third_party/rust/crates/BUILD.darling_core-0.20.3.bazel
+++ b/third_party/rust/crates/BUILD.darling_core-0.20.3.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # MIT
 # ])
 
 rust_library(
-    name = "time",
+    name = "darling_core",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,21 +29,15 @@ rust_library(
         ],
     ),
     crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
+        "strsim",
+        "suggestions",
     ],
     crate_root = "src/lib.rs",
-    edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=darling_core",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +76,13 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "0.20.3",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
+        "@crate_index__fnv-1.0.7//:fnv",
+        "@crate_index__ident_case-1.0.1//:ident_case",
+        "@crate_index__proc-macro2-1.0.69//:proc_macro2",
+        "@crate_index__quote-1.0.33//:quote",
+        "@crate_index__strsim-0.10.0//:strsim",
+        "@crate_index__syn-2.0.38//:syn",
     ],
 )

--- a/third_party/rust/crates/BUILD.darling_macro-0.20.3.bazel
+++ b/third_party/rust/crates/BUILD.darling_macro-0.20.3.bazel
@@ -6,16 +6,16 @@
 #     bazel run @//third_party/rust:crate_index
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # MIT
 # ])
 
-rust_library(
-    name = "time",
+rust_proc_macro(
+    name = "darling_macro",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +28,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
+    edition = "2018",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=darling_macro",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +72,10 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "0.20.3",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
+        "@crate_index__darling_core-0.20.3//:darling_core",
+        "@crate_index__quote-1.0.33//:quote",
+        "@crate_index__syn-2.0.38//:syn",
     ],
 )

--- a/third_party/rust/crates/BUILD.deranged-0.3.8.bazel
+++ b/third_party/rust/crates/BUILD.deranged-0.3.8.bazel
@@ -77,4 +77,7 @@ rust_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     version = "0.3.8",
+    deps = [
+        "@crate_index__serde-1.0.189//:serde",
+    ],
 )

--- a/third_party/rust/crates/BUILD.fnv-1.0.7.bazel
+++ b/third_party/rust/crates/BUILD.fnv-1.0.7.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # Apache-2.0 / MIT
 # ])
 
 rust_library(
-    name = "time",
+    name = "fnv",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,21 +29,15 @@ rust_library(
         ],
     ),
     crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
+        "default",
         "std",
     ],
-    crate_root = "src/lib.rs",
-    edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
+    crate_root = "lib.rs",
+    edition = "2015",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=fnv",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +76,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
-    deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
-    ],
+    version = "1.0.7",
 )

--- a/third_party/rust/crates/BUILD.hashbrown-0.12.3.bazel
+++ b/third_party/rust/crates/BUILD.hashbrown-0.12.3.bazel
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "time",
+    name = "hashbrown",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -29,21 +29,14 @@ rust_library(
         ],
     ),
     crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
+        "raw",
     ],
     crate_root = "src/lib.rs",
     edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=hashbrown",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +75,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
-    deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
-    ],
+    version = "0.12.3",
 )

--- a/third_party/rust/crates/BUILD.ident_case-1.0.1.bazel
+++ b/third_party/rust/crates/BUILD.ident_case-1.0.1.bazel
@@ -11,11 +11,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # MIT/Apache-2.0
 # ])
 
 rust_library(
-    name = "time",
+    name = "ident_case",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +28,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
-    edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
+    edition = "2015",
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=ident_case",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +72,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
-    deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
-    ],
+    version = "1.0.1",
 )

--- a/third_party/rust/crates/BUILD.indexmap-1.9.3.bazel
+++ b/third_party/rust/crates/BUILD.indexmap-1.9.3.bazel
@@ -6,16 +6,17 @@
 #     bazel run @//third_party/rust:crate_index
 ###############################################################################
 
+load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # Apache-2.0 OR MIT
 # ])
 
 rust_library(
-    name = "time",
+    name = "indexmap",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +29,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=indexmap",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +73,50 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "1.9.3",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
+        "@crate_index__hashbrown-0.12.3//:hashbrown",
+        "@crate_index__indexmap-1.9.3//:build_script_build",
         "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
     ],
+)
+
+cargo_build_script(
+    name = "indexmap_build_script",
+    srcs = glob(["**/*.rs"]),
+    crate_name = "build_script_build",
+    crate_root = "build.rs",
+    data = glob(
+        include = ["**"],
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
+    edition = "2021",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-bazel",
+        "crate-name=indexmap",
+        "manual",
+        "noclippy",
+        "norustfmt",
+    ],
+    version = "1.9.3",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@crate_index__autocfg-1.1.0//:autocfg",
+    ],
+)
+
+alias(
+    name = "build_script_build",
+    actual = "indexmap_build_script",
+    tags = ["manual"],
 )

--- a/third_party/rust/crates/BUILD.indoc-2.0.4.bazel
+++ b/third_party/rust/crates/BUILD.indoc-2.0.4.bazel
@@ -6,7 +6,7 @@
 #     bazel run @//third_party/rust:crate_index
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
 #     "TODO",  # MIT OR Apache-2.0
 # ])
 
-rust_library(
-    name = "time",
+rust_proc_macro(
+    name = "indoc",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +28,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=indoc",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +72,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
-    deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
-    ],
+    version = "2.0.4",
 )

--- a/third_party/rust/crates/BUILD.serde_with-3.4.0.bazel
+++ b/third_party/rust/crates/BUILD.serde_with-3.4.0.bazel
@@ -15,8 +15,14 @@ package(default_visibility = ["//visibility:public"])
 # ])
 
 rust_library(
-    name = "time",
+    name = "serde_with",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+        "@crate_index__chrono-0.4.31//:chrono": "chrono_0_4",
+        "@crate_index__indexmap-1.9.3//:indexmap": "indexmap_1",
+        "@crate_index__indexmap-2.0.0//:indexmap": "indexmap_2",
+        "@crate_index__time-0.3.28//:time": "time_0_3",
+    },
     compile_data = glob(
         include = ["**"],
         exclude = [
@@ -30,20 +36,19 @@ rust_library(
     ),
     crate_features = [
         "alloc",
-        "formatting",
+        "default",
         "macros",
-        "parsing",
         "std",
     ],
     crate_root = "src/lib.rs",
     edition = "2021",
     proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
+        "@crate_index__serde_with_macros-3.4.0//:serde_with_macros",
     ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=serde_with",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +87,12 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "3.4.0",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
+        "@crate_index__chrono-0.4.31//:chrono",
+        "@crate_index__indexmap-1.9.3//:indexmap",
+        "@crate_index__indexmap-2.0.0//:indexmap",
         "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
+        "@crate_index__time-0.3.28//:time",
     ],
 )

--- a/third_party/rust/crates/BUILD.serde_with_macros-3.4.0.bazel
+++ b/third_party/rust/crates/BUILD.serde_with_macros-3.4.0.bazel
@@ -6,7 +6,7 @@
 #     bazel run @//third_party/rust:crate_index
 ###############################################################################
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
 #     "TODO",  # MIT OR Apache-2.0
 # ])
 
-rust_library(
-    name = "time",
+rust_proc_macro(
+    name = "serde_with_macros",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(
         include = ["**"],
@@ -28,22 +28,12 @@ rust_library(
             "WORKSPACE.bazel",
         ],
     ),
-    crate_features = [
-        "alloc",
-        "formatting",
-        "macros",
-        "parsing",
-        "std",
-    ],
     crate_root = "src/lib.rs",
     edition = "2021",
-    proc_macro_deps = [
-        "@crate_index__time-macros-0.2.14//:time_macros",
-    ],
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
-        "crate-name=time",
+        "crate-name=serde_with_macros",
         "manual",
         "noclippy",
         "norustfmt",
@@ -82,11 +72,11 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.28",
+    version = "3.4.0",
     deps = [
-        "@crate_index__deranged-0.3.8//:deranged",
-        "@crate_index__itoa-1.0.9//:itoa",
-        "@crate_index__serde-1.0.189//:serde",
-        "@crate_index__time-core-0.1.1//:time_core",
+        "@crate_index__darling-0.20.3//:darling",
+        "@crate_index__proc-macro2-1.0.69//:proc_macro2",
+        "@crate_index__quote-1.0.33//:quote",
+        "@crate_index__syn-2.0.38//:syn",
     ],
 )

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -349,6 +349,7 @@ _NORMAL_DEPENDENCIES = {
             "serde": "@crate_index__serde-1.0.189//:serde",
             "serde_bytes": "@crate_index__serde_bytes-0.11.12//:serde_bytes",
             "serde_json": "@crate_index__serde_json-1.0.107//:serde_json",
+            "serde_with": "@crate_index__serde_with-3.4.0//:serde_with",
             "serialport": "@crate_index__serialport-4.2.2//:serialport",
             "sha2": "@crate_index__sha2-0.10.7//:sha2",
             "shellwords": "@crate_index__shellwords-1.1.0//:shellwords",
@@ -390,11 +391,16 @@ _PROC_MACRO_DEPENDENCIES = {
 
 _PROC_MACRO_ALIASES = {
     "third_party/rust": {
+        _COMMON_CONDITION: {
+        },
     },
 }
 
 _PROC_MACRO_DEV_DEPENDENCIES = {
     "third_party/rust": {
+        _COMMON_CONDITION: {
+            "indoc": "@crate_index__indoc-2.0.4//:indoc",
+        },
     },
 }
 
@@ -668,6 +674,16 @@ def crate_repositories():
         urls = ["https://crates.io/api/v1/crates/base16ct/0.2.0/download"],
         strip_prefix = "base16ct-0.2.0",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.base16ct-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__base64-0.21.5",
+        sha256 = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/base64/0.21.5/download"],
+        strip_prefix = "base64-0.21.5",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.base64-0.21.5.bazel"),
     )
 
     maybe(
@@ -978,6 +994,36 @@ def crate_repositories():
 
     maybe(
         http_archive,
+        name = "crate_index__darling-0.20.3",
+        sha256 = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/darling/0.20.3/download"],
+        strip_prefix = "darling-0.20.3",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.darling-0.20.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__darling_core-0.20.3",
+        sha256 = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/darling_core/0.20.3/download"],
+        strip_prefix = "darling_core-0.20.3",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.darling_core-0.20.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__darling_macro-0.20.3",
+        sha256 = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/darling_macro/0.20.3/download"],
+        strip_prefix = "darling_macro-0.20.3",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.darling_macro-0.20.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "crate_index__der-0.7.8",
         sha256 = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c",
         type = "tar.gz",
@@ -1178,6 +1224,16 @@ def crate_repositories():
 
     maybe(
         http_archive,
+        name = "crate_index__fnv-1.0.7",
+        sha256 = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/fnv/1.0.7/download"],
+        strip_prefix = "fnv-1.0.7",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.fnv-1.0.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "crate_index__form_urlencoded-1.2.0",
         sha256 = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
         type = "tar.gz",
@@ -1264,6 +1320,16 @@ def crate_repositories():
         urls = ["https://crates.io/api/v1/crates/handlebars/4.3.7/download"],
         strip_prefix = "handlebars-4.3.7",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.handlebars-4.3.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__hashbrown-0.12.3",
+        sha256 = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/hashbrown/0.12.3/download"],
+        strip_prefix = "hashbrown-0.12.3",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.hashbrown-0.12.3.bazel"),
     )
 
     maybe(
@@ -1378,12 +1444,32 @@ def crate_repositories():
 
     maybe(
         http_archive,
+        name = "crate_index__ident_case-1.0.1",
+        sha256 = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/ident_case/1.0.1/download"],
+        strip_prefix = "ident_case-1.0.1",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.ident_case-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "crate_index__idna-0.4.0",
         sha256 = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
         type = "tar.gz",
         urls = ["https://crates.io/api/v1/crates/idna/0.4.0/download"],
         strip_prefix = "idna-0.4.0",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.idna-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__indexmap-1.9.3",
+        sha256 = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/indexmap/1.9.3/download"],
+        strip_prefix = "indexmap-1.9.3",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.indexmap-1.9.3.bazel"),
     )
 
     maybe(
@@ -1404,6 +1490,16 @@ def crate_repositories():
         urls = ["https://crates.io/api/v1/crates/indicatif/0.17.6/download"],
         strip_prefix = "indicatif-0.17.6",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.indicatif-0.17.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__indoc-2.0.4",
+        sha256 = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/indoc/2.0.4/download"],
+        strip_prefix = "indoc-2.0.4",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.indoc-2.0.4.bazel"),
     )
 
     maybe(
@@ -2412,6 +2508,26 @@ def crate_repositories():
         urls = ["https://crates.io/api/v1/crates/serde_json/1.0.107/download"],
         strip_prefix = "serde_json-1.0.107",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.serde_json-1.0.107.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__serde_with-3.4.0",
+        sha256 = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/serde_with/3.4.0/download"],
+        strip_prefix = "serde_with-3.4.0",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.serde_with-3.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "crate_index__serde_with_macros-3.4.0",
+        sha256 = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788",
+        type = "tar.gz",
+        urls = ["https://crates.io/api/v1/crates/serde_with_macros/3.4.0/download"],
+        strip_prefix = "serde_with_macros-3.4.0",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.serde_with_macros-3.4.0.bazel"),
     )
 
     maybe(


### PR DESCRIPTION
This is the first in a series of PRs that will build up the `ot_certs` crate.

This crate is for reading templates that define the variable and literal values of a certificate that will be installed on an OpenTitan. It will generate:

* Certificates based on a template in X.509 and CWT binary format (with holes where variable data is to be inserted).
* C code for the device to use to fill in the variable values of a certificate with concrete values.

This first PR adds the crate and some code for parsing a template. There is a unit test containing an example template.

The template is written in JSON5/Hjson and specifies various fields needed for an X.509 or CWT certificate. This certificate will live in binary format on the device's flash.

A detailed spec of how these certificates work needs to be released once the details are finalised.