### PR TITLE
[Sival, i2c] chip_sw_i2c_device_tx_rx

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -49,6 +49,7 @@
       features: ["I2C.MODE.TARGET", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
       si_stage: SV2
+      bazel: ["//sw/device/tests:i2c_target_test_cw310_test_rom"]
       tests: ["chip_sw_i2c_device_tx_rx"]
     }
     {

--- a/sw/device/lib/testing/json/i2c_target.h
+++ b/sw/device/lib/testing/json/i2c_target.h
@@ -13,6 +13,7 @@ extern "C" {
 #define MODULE_ID MAKE_MODULE_ID('j', 'i', 'i')
 
 #define STRUCT_I2C_TARGET_ADDRESS(field, string) \
+    field(instance, uint8_t) \
     field(id0, uint8_t) \
     field(mask0, uint8_t) \
     field(id1, uint8_t) \


### PR DESCRIPTION

Changes the existing i2c_target_test to run against all the i2c instances and links it to the sival test chip_sw_i2c_device_tx_rx.

Fix https://github.com/lowRISC/opentitan/issues/19835