### PR TITLE
[opentitantool] Avoid orphaned OpenOCD processes

### DIFF
--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -15,6 +15,7 @@ def openocd_repos(local = None):
         sha256 = "bb367fd19ab96a65ee5b269b60326d9f36bca1c64d9865cc36985d3651aba563",
         # See Issue(#18087)
         patches = [
+            Label("//third_party/openocd:terminate_on_parent_death.patch"),
             Label("//third_party/openocd:reset_on_dmi_op_error.patch"),
             Label("//third_party/openocd:string_truncate_build_error.patch"),
         ],

--- a/third_party/openocd/terminate_on_parent_death.patch
+++ b/third_party/openocd/terminate_on_parent_death.patch
@@ -1,0 +1,26 @@
+diff --git a/src/server/server.c b/src/server/server.c
+index 1569f5a2c..aa7921903 100644
+--- a/src/server/server.c
++++ b/src/server/server.c
+@@ -43,6 +43,7 @@
+ 
+ #ifndef _WIN32
+ #include <netinet/tcp.h>
++#include <sys/prctl.h>
+ #endif
+ 
+ static struct service *services;
+@@ -670,7 +671,12 @@ int server_preinit(void)
+ 	signal(SIGBREAK, sig_handler);
+ 	signal(SIGINT, sig_handler);
+ #else
+-	signal(SIGHUP, sig_handler);
++        /*
++         * Ask Linux kernel to send SIGHUP to this process, in case its parent dies.
++         */
++        prctl(PR_SET_PDEATHSIG, SIGHUP);
++
++        signal(SIGHUP, sig_handler);
+ 	signal(SIGPIPE, sig_handler);
+ 	signal(SIGQUIT, sigkey_handler);
+ 	signal(SIGINT, sigkey_handler);


### PR DESCRIPTION
If a opentitantool or other process invokes `Jtag.connect()` but terminates for any reason before invoking `Jtag.disconnect()`, the current code may leave an orphaned openocd process, which may hold on to USB resources.

The stock OpenOCD code does not seem to have provisions to terminate e.g. when stdin closes.  This CL insteads patches OpenOCD to have it request a SIGHUP from the Linux kernel, whenever its parent terminates for any reason.