### PR TITLE
[ci] Use fpga_pool variable for CI CW310 agent pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -510,7 +510,7 @@ jobs:
 - job: execute_test_rom_fpga_tests_cw310
   displayName: CW310 Test ROM Tests
   pool:
-    name: FPGA
+    name: $(fpga_pool)
     demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
@@ -536,7 +536,7 @@ jobs:
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
   pool:
-    name: FPGA
+    name: $(fpga_pool)
     demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
@@ -562,7 +562,7 @@ jobs:
 - job: execute_hyperdebug_tests_cw310
   displayName: Hyperdebug CW310 Tests (Experimental)
   pool:
-    name: FPGA
+    name: $(fpga_pool)
     demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:
@@ -628,7 +628,7 @@ jobs:
 - job: execute_fpga_manuf_tests_cw310
   displayName: CW310 Manufacturing Tests
   pool:
-    name: FPGA
+    name: $(fpga_pool)
     demands: BOARD -equals cw310
   timeoutInMinutes: 60
   dependsOn:


### PR DESCRIPTION
## Summary

This PR sets the name of the Azure agent pool that we run FPGA jobs on to the `$(fpga_pool)` Azure variable.

The default value for this variable is `FPGA`, so normal runs will be unchanged.

## Details

Making the pool name a variable gives us the ability to trigger manual CI pipeline runs with a different value for that variable.

This is useful because we have a second agent pool called `FPGA Staging` where we put FPGAs that we want to check the hardware configuration of. Previously, we would have to open a new pull request changing `FPGA` to `FPGA Staging` to trigger a run on this pool. With this change, we can avoid creating PRs and trigger them through the Azure interface instead.

This PR leaves the CW340 pool alone for now.