### PR TITLE
[edn] Clear auto cmd FIFOs after edn disable

### DIFF
--- a/hw/ip/edn/doc/theory_of_operation.md
+++ b/hw/ip/edn/doc/theory_of_operation.md
@@ -76,6 +76,8 @@ Note that if BOOT_REQ_MODE is asserted the state machine will enter boot-time re
 To issue any new commands other than those stored in the generate or reseed FIFOs, it is important to disable auto request mode, by deasserting the `AUTO_REQ_MODE` field in the [`CTRL`](registers.md#ctrl) register.
 Firmware must then wait until the current command is completed by polling the [`MAIN_SM_STATE`](registers.md#main_sm_state) register.
 Once the state machine returns to the `Idle` or `SWPortMode` states, new firmware-driven commands can be passed to the CSRNG via the [`SW_CMD_REQ`](registers.md#sw_cmd_req) register.
+The generate and reseed FIFOs are reset under four circumstances.
+These circumstances are (a) when the EDN is disabled, (b) when the `SWPortMode` state is entered, (c) when the boot sequence has completed, or (d) when the EDN enters the `Idle` state after it finishes operation in auto mode.
 
 It should be noted that when in auto request mode, no status will be updated that is used for the software port operation once the `instantiate` command has completed.
 If some hang condition were to occur when in this mode, the main state machine debug register should be read to determine if a hang condition is present.

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -27,6 +27,7 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
 
   bit abort_sw_cmd = 0;
   bit backdoor_disable = 1'b0;
+  bit base_vseq_edn_enabled = 1'b0;
 
   int min_auto_reseeds = 2;
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -117,6 +117,8 @@ class edn_base_vseq extends cip_base_vseq #(
     ral.ctrl.boot_req_mode.set(cfg.boot_req_mode);
     ral.ctrl.auto_req_mode.set(cfg.auto_req_mode);
     csr_update(.csr(ral.ctrl));
+    // Signal that the EDN has been enabled for the first time.
+    cfg.base_vseq_edn_enabled = 1'b1;
 
     // If set_regwen is set, write random value to the EDN, and expect the write won't be taken.
     if (set_regwen) begin

--- a/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_disable_auto_req_mode_vseq.sv
@@ -82,6 +82,8 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
         bit unused;
         // Wait for EDN to come out of reset.
         wait(cfg.clk_rst_vif.rst_n);
+        // Wait for the EDN to be enabled.
+        wait(cfg.base_vseq_edn_enabled);
         // Disable EDN after a random number of cycles or in a random state.
         randomly_disable_edn();
         // Abort any open SW commands and wait for CSR accesses to complete, as simply killing their
@@ -91,10 +93,6 @@ class edn_disable_auto_req_mode_vseq extends edn_base_vseq;
         // Kill EDN initialization and endpoint requests if necessary.
         mbox_kill_edn_init.put(1'b1);
         mbox_kill_endpoint_reqs.put(1'b1);
-        // TODO: Remove the following lines resetting the FIFOs based on decision in #19653.
-        // Reset cmd FIFO to prevent FIFO from overflowing after re-enabling EDN.
-        csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4True));
-        csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(MuBi4False));
         // Wait before re-enabling EDN.
         `uvm_info(`gfn, $sformatf("Waiting before re-enabling EDN"), UVM_LOW)
         cfg.clk_rst_vif.wait_n_clks($urandom_range(1, 1000));

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -239,7 +239,7 @@ module edn_main_sm import edn_pkg::*; #(
       send_gencmd_o          = 1'b0;
       capt_rescmd_fifo_cnt_o = 1'b0;
       send_rescmd_o          = 1'b0;
-      main_sm_done_pulse_o   = 1'b0;
+      main_sm_done_pulse_o   = 1'b1;
     end
   end
 


### PR DESCRIPTION
This PR clears the auto cmd FIFOs after the edn is disabled.
For more precise information check out the individual commit messages.

This PR resolves #19653 