### PR TITLE
[opentitantool] add sanity check to manifest updater

### DIFF
--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -94,6 +94,24 @@ impl ToWriter for Image {
 
 impl Image {
     pub const MAX_SIZE: usize = 512 * 1024;
+
+    /// Perform a sanity check to ensure that the image comes with manifest.
+    ///
+    /// Note that passing the sanity check doesn't guarantee that the manifest is valid.
+    pub fn manifest_sanity_check(&self) -> Result<()> {
+        let manifest = self.borrow_manifest()?;
+        let len = self.data.bytes.len() as u32;
+
+        ensure!(manifest.signed_region_end < len);
+        ensure!(manifest.length < len);
+        ensure!(manifest.code_start < len);
+        ensure!(manifest.code_end < len);
+        ensure!(manifest.entry_point < len);
+        ensure!(manifest.extensions.entries.iter().all(|x| x.offset < len));
+
+        Ok(())
+    }
+
     /// Overwrites all fields in the image's manifest that are defined in `other`.
     pub fn overwrite_manifest(&mut self, other: ManifestSpec) -> Result<()> {
         let manifest = self.borrow_manifest_mut()?;

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use clap::{Args, Subcommand};
 use serde_annotate::Annotate;
 use std::any::Any;
@@ -133,6 +133,11 @@ impl CommandDispatch for ManifestUpdateCommand {
     ) -> Result<Option<Box<dyn Annotate>>> {
         let mut image = image::Image::read_from_file(&self.image)?;
         let mut update_length = self.update_length;
+
+        // Some sanity check
+        image
+            .manifest_sanity_check()
+            .context("Image doesn't appear to contain a manifest, or the manifest is corrupted")?;
 
         // Load the manifest HJSON definition and update the image.
         if let Some(manifest) = &self.manifest {


### PR DESCRIPTION
SRAM programs don't have manifests, but we currently are still signing them with opentitantool. It happens to work for all tests *by luck*, but @HU90m is having issues when creating new tests.

This PR adds a sanity check so that OT-tool will fail when it is asked to update manifest of a binary that doesn't have one. The bazel rule is changed so SRAM programs are not signed.