### PR TITLE
[bazel] Create a localtools toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,3 +148,7 @@ hyperdebug_repos()
 # Bazel skylib library
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
+
+register_toolchains(
+    "//rules/opentitan:localtools",
+)

--- a/rules/host.bzl
+++ b/rules/host.bzl
@@ -16,10 +16,22 @@ def _host_tools_transition_impl(settings, attr):
     This transition is used for building host tools, passing through all build
     settings specified on the command line.
     """
-    return {"//command_line_option:platforms": "@local_config_platform//:host"}
+    ret = {
+        "//command_line_option:platforms": "@local_config_platform//:host",
+        "//command_line_option:copt": settings["//command_line_option:copt"],
+        "//command_line_option:features": settings["//command_line_option:features"],
+    }
+    return ret
 
 host_tools_transition = transition(
     implementation = _host_tools_transition_impl,
-    inputs = [],
-    outputs = ["//command_line_option:platforms"],
+    inputs = [
+        "//command_line_option:copt",
+        "//command_line_option:features",
+    ],
+    outputs = [
+        "//command_line_option:platforms",
+        "//command_line_option:copt",
+        "//command_line_option:features",
+    ],
 )

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -16,6 +16,7 @@ load(
 load("@crt//rules:transition.bzl", "platform_target")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//lib:structs.bzl", "structs")
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
 """Rules to build OpenTitan for the RISC-V target"""
 
@@ -651,6 +652,7 @@ gen_sim_dv_logs_db = rule(
 )
 
 def _assemble_flash_image_impl(ctx):
+    tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
     output = ctx.actions.declare_file(ctx.attr.output)
     outputs = [output]
     inputs = []
@@ -672,7 +674,7 @@ def _assemble_flash_image_impl(ctx):
         outputs = outputs,
         inputs = inputs,
         arguments = arguments,
-        executable = ctx.executable._opentitantool,
+        executable = tc.tools.opentitantool,
     )
     return [DefaultInfo(
         files = depset(outputs),
@@ -685,13 +687,8 @@ assemble_flash_image = rv_rule(
         "image_size": attr.int(default = 0, doc = "Size of the assembled image"),
         "output": attr.string(),
         "binaries": attr.label_keyed_string_dict(allow_empty = False),
-        "_opentitantool": attr.label(
-            default = "//sw/host/opentitantool:opentitantool",
-            allow_single_file = True,
-            executable = True,
-            cfg = "exec",
-        ),
     },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def opentitan_binary(

--- a/rules/opentitan/BUILD
+++ b/rules/opentitan/BUILD
@@ -1,3 +1,21 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN", "localtools_toolchain")
+
+localtools_toolchain(
+    name = "localtools_impl",
+)
+
+toolchain_type(
+    name = "localtools_type",
+)
+
+toolchain(
+    name = "localtools",
+    toolchain = ":localtools_impl",
+    toolchain_type = LOCALTOOLS_TOOLCHAIN,
+)

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -197,12 +197,12 @@ def _build_binary(ctx, exec_env, name, deps, kind):
             fail("Signing requires a manifest and an rsa_key, and optionally an spx_key")
         signed = sign_binary(
             ctx,
+            opentitantool = exec_env._opentitantool,
             bin = binary,
             rsa_key = rsa_key,
             spx_key = spx_key,
             manifest = manifest,
             # FIXME: will need to supply hsmtool when we add NitroKey signing.
-            _tool = exec_env._opentitantool,
         )
     else:
         signed = {}

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -30,6 +30,7 @@ load(
     "OPENTITANTOOL_OPENOCD_DATA_DEPS",
     "OPENTITANTOOL_OPENOCD_TEST_CMD",
 )
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
 _TEST_SCRIPT = """#!/bin/bash
 set -e
@@ -145,7 +146,7 @@ def _test_dispatch(ctx, exec_env, firmware):
     ctx.actions.write(
         script,
         _TEST_SCRIPT.format(
-            test_harness = test_harness.short_path,
+            test_harness = test_harness.executable.short_path,
             args = args,
             test_cmd = test_cmd,
         ),
@@ -165,6 +166,7 @@ def _fpga_cw310(ctx):
 fpga_cw310 = rule(
     implementation = _fpga_cw310,
     attrs = exec_env_common_attrs(),
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def _fpga_cw305(ctx):
@@ -179,6 +181,7 @@ def _fpga_cw305(ctx):
 fpga_cw305 = rule(
     implementation = _fpga_cw305,
     attrs = exec_env_common_attrs(),
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def _fpga_cw340(ctx):
@@ -193,6 +196,7 @@ def _fpga_cw340(ctx):
 fpga_cw340 = rule(
     implementation = _fpga_cw340,
     attrs = exec_env_common_attrs(),
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def cw310_params(

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -18,6 +18,7 @@ load(
     "extract_software_logs",
     "scramble_flash",
 )
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
 _TEST_SCRIPT = """#!/bin/bash
 set -e
@@ -135,7 +136,7 @@ def _test_dispatch(ctx, exec_env, firmware):
     ctx.actions.write(
         script,
         _TEST_SCRIPT.format(
-            test_harness = test_harness.short_path,
+            test_harness = test_harness.executable.short_path,
             args = args,
             test_cmd = test_cmd,
             data_files = " ".join([f.path for f in data_files]),
@@ -156,6 +157,7 @@ def _sim_dv(ctx):
 sim_dv = rule(
     implementation = _sim_dv,
     attrs = exec_env_common_attrs(),
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def dv_params(

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -16,6 +16,7 @@ load(
     "convert_to_scrambled_rom_vmem",
     "convert_to_vmem",
 )
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
 _TEST_SCRIPT = """#!/bin/bash
 set -e
@@ -133,7 +134,7 @@ def _test_dispatch(ctx, exec_env, firmware):
     ctx.actions.write(
         script,
         _TEST_SCRIPT.format(
-            test_harness = test_harness.short_path,
+            test_harness = test_harness.executable.short_path,
             args = args,
             test_cmd = test_cmd,
         ),
@@ -153,6 +154,7 @@ def _sim_verilator(ctx):
 sim_verilator = rule(
     implementation = _sim_verilator,
     attrs = exec_env_common_attrs(),
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )
 
 def verilator_params(

--- a/rules/opentitan/toolchain.bzl
+++ b/rules/opentitan/toolchain.bzl
@@ -1,0 +1,43 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:host.bzl", "host_tools_transition")
+
+LOCALTOOLS_TOOLCHAIN = "@lowrisc_opentitan//rules/opentitan:localtools_type"
+
+LocalToolInfo = provider(fields = [
+    "opentitantool",
+    "gen_mem_image",
+])
+
+def _localtools_toolchain(ctx):
+    tools = LocalToolInfo(
+        opentitantool = ctx.attr.opentitantool[0].files_to_run,
+        gen_mem_image = ctx.attr.gen_mem_image[0].files_to_run,
+    )
+    return platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        tools = tools,
+    )
+
+localtools_toolchain = rule(
+    implementation = _localtools_toolchain,
+    attrs = {
+        "opentitantool": attr.label(
+            default = "//sw/host/opentitantool:opentitantool",
+            executable = True,
+            cfg = host_tools_transition,
+        ),
+        "gen_mem_image": attr.label(
+            default = "//hw/ip/rom_ctrl/util:gen_vivado_mem_image",
+            executable = True,
+            cfg = host_tools_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    doc = "Toolchain for local in-tree tools",
+    provides = [platform_common.ToolchainInfo],
+)


### PR DESCRIPTION
1. Create a localtools toolchain that transitions to a "golden" host configuration.  This is done so that we have exactly one configuration for tools and we wont have to worry about build flags propagating into `cfg=exec` dependencies.
2. Move opentitantool into the toolchain definition.
3. Move gen_vivado_mem_image into the toolchain definition.