### PR TITLE
[edn/doc] Update sum_sts strings to main_sm_state

### DIFF
--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -39,7 +39,7 @@
             Verify BOOT_INS_CMD/BOOT_GEN_CMD registers.
             Verify auto request mode behaves as predicted.
             Verify RESEED_CMD/GENERATE_CMD/MAX_NUM_REQS_BETWEEN_RESEEDS registers.
-            Verify SUM_STS register bits behave as predicted.
+            Verify MAIN_SM_STATE register bits behave as predicted.
             Verify all csrng commands (clen = 0-12, sw_mode, boot/auto_req_mode).
             Verify with ready randomly asserting/deasserting
             '''

--- a/hw/ip/edn/doc/theory_of_operation.md
+++ b/hw/ip/edn/doc/theory_of_operation.md
@@ -29,7 +29,7 @@ On exiting, the EDN issues an `uninstantiate` command to destroy the associated 
 
 Once firmware initialization is complete, it is important to exit this mode if the endpoints ever need FIPS-approved random values.
 This is done by either *clearing* the `EDN_ENABLE` field or *clearing* the `BOOT_REQ_MODE` field in [`CTRL`](registers.md#ctrl) to halt the boot-time request state machine.
-Firmware must then wait for successful the shutdown of the state machine by polling the `REQ_MODE_SM_STS` field of the [`SUM_STS`](registers.md#sum_sts) register.
+Firmware must then wait for successful the shutdown of the state machine by polling the `REQ_MODE_SM_STS` field of the [`MAIN_SM_STATE`](registers.md#main_sm_state) register.
 
 It should be noted that when in boot-time request mode, no status will be updated that is used for the software port operation.
 If some hang condition were to occur when in this mode, the main state machine debug register should be read to determine if a hang condition is present.

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -250,8 +250,6 @@ class edn_scoreboard extends cip_base_scoreboard #(
           boot_gen_cmd_comp = item.a_data;
         end
       end
-      "sum_sts": begin
-      end
       "generate_cmd": begin
         if (addr_phase_write) begin
           generate_cmd_q.push_back(item.a_data);


### PR DESCRIPTION
This commit removes some leftovers from when the main_sm_state register used to be called sum_sts.

This PR resolves #18469