### PR TITLE
[cryptotest] Make sure to init the entropy complex

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -38,6 +38,8 @@ opentitan_binary(
     deps = [
         ":aes",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
@@ -35,6 +37,7 @@ status_t process_cmd(ujson_t *uj) {
 }
 
 bool test_main(void) {
+  CHECK_STATUS_OK(entropy_complex_init());
   ujson_t uj = ujson_ottf_console();
   return status_ok(process_cmd(&uj));
 }


### PR DESCRIPTION
The entropy complex starts with a fixed amount of entropy and does not generate more in the default configuration. Initialize the complex in auto mode, so long-running tests don't run out.

Fixes #20277