### PR TITLE
[test, top] ibex icache invalidation now checked in software

### DIFF
--- a/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
+++ b/sw/device/tests/rv_core_ibex_icache_invalidate_test.c
@@ -23,9 +23,13 @@ bool test_main(void) {
   for (unsigned i = 0; i < kNumIcacheInvals; i++) {
     icache_invalidate();
 
+    uint32_t cpuctrlsts;
+    // Check that the icache scramble key is no longer valid.
+    CSR_READ(CSR_REG_CPUCTRL, &cpuctrlsts);
+    CHECK((cpuctrlsts & (1 << 8)) == 0);
+
     // Wait for the icache scramble key to become valid before requesting the
     // next invalidation.
-    uint32_t cpuctrlsts;
     do {
       CSR_READ(CSR_REG_CPUCTRL, &cpuctrlsts);
     } while ((cpuctrlsts & (1 << 8)) == 0);


### PR DESCRIPTION
The `chip_sw_rv_core_ibex_icache_scrambled_access` test can be run in both a UVM environment with `hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_core_ibex_icache_invalidate_vseq.sv` and on an fpga or in verilator.

The only check that cache invalidations were happening was in the `vseq`.

This commit adds a software check that an invalidation has happened.

Found while looking into https://github.com/lowRISC/opentitan/issues/20028