### PR TITLE
[otbn,doc] Extract list of ISRs into YAML files

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -111,6 +111,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
 
 <!-- This list of CSRs is replicated in otbn_env_cov.sv, wsr.py, the
      RTL and in rig/model.py. If editing one, edit the other four as well. -->
+<!-- BEGIN CMDGEN ./hw/ip/otbn/util/docs/md_isrs.py hw/ip/otbn/data/csr.yml -->
 <table>
   <thead>
     <tr>
@@ -128,16 +129,16 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         Wide arithmetic flag group 0.
         This CSR provides access to flag group 0 used by wide integer arithmetic.
-        <strong>FLAGS</strong>, <strong>FG0</strong> and <strong>FG1</strong> provide different views on the same underlying bits.
+        *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of Flag Group 0</td></tr>
-            <tr><td>1</td><td>MSb of Flag Group 0</td></tr>
-            <tr><td>2</td><td>LSb of Flag Group 0</td></tr>
-            <tr><td>3</td><td>Zero of Flag Group 0</td></tr>
+            <tr><td>0</td><td>Carry of flag group 0</td></tr>
+            <tr><td>1</td><td>MSb of flag group 0</td></tr>
+            <tr><td>2</td><td>LSb of flag group 0</td></tr>
+            <tr><td>3</td><td>Zero of flag group 0</td></tr>
           </tbody>
         </table>
       </td>
@@ -149,16 +150,16 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         Wide arithmetic flag group 1.
         This CSR provides access to flag group 1 used by wide integer arithmetic.
-        <strong>FLAGS</strong>, <strong>FG0</strong> and <strong>FG1</strong> provide different views on the same underlying bits.
+        *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of Flag Group 1</td></tr>
-            <tr><td>1</td><td>MSb of Flag Group 1</td></tr>
-            <tr><td>2</td><td>LSb of Flag Group 1</td></tr>
-            <tr><td>3</td><td>Zero of Flag Group 1</td></tr>
+            <tr><td>0</td><td>Carry of flag group 1</td></tr>
+            <tr><td>1</td><td>MSb of flag group 1</td></tr>
+            <tr><td>2</td><td>LSb of flag group 1</td></tr>
+            <tr><td>3</td><td>Zero of flag group 1</td></tr>
           </tbody>
         </table>
       </td>
@@ -169,21 +170,21 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>FLAGS</td>
       <td>
         Wide arithmetic flag groups.
-        This CSR provides access to both flags groups used by wide integer arithmetic.
-        <strong>FLAGS</strong>, <strong>FG0</strong> and <strong>FG1</strong> provide different views on the same underlying bits.
+        This CSR provides access to both flag groups used by wide integer arithmetic.
+        *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
         <table>
           <thead>
             <tr><th>Bit</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td>0</td><td>Carry of Flag Group 0</td></tr>
-            <tr><td>1</td><td>MSb of Flag Group 0</td></tr>
-            <tr><td>2</td><td>LSb of Flag Group 0</td></tr>
-            <tr><td>3</td><td>Zero of Flag Group 0</td></tr>
-            <tr><td>4</td><td>Carry of Flag Group 1</td></tr>
-            <tr><td>5</td><td>MSb of Flag Group 1</td></tr>
-            <tr><td>6</td><td>LSb of Flag Group 1</td></tr>
-            <tr><td>7</td><td>Zero of Flag Group 1</td></tr>
+            <tr><td>0</td><td>Carry of flag group 0</td></tr>
+            <tr><td>1</td><td>MSb of flag group 0</td></tr>
+            <tr><td>2</td><td>LSb of flag group 0</td></tr>
+            <tr><td>3</td><td>Zero of flag group 0</td></tr>
+            <tr><td>4</td><td>Carry of flag group 1</td></tr>
+            <tr><td>5</td><td>MSb of flag group 1</td></tr>
+            <tr><td>6</td><td>LSb of flag group 1</td></tr>
+            <tr><td>7</td><td>Zero of flag group 1</td></tr>
           </tbody>
         </table>
       </td>
@@ -274,11 +275,11 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>RO</td>
       <td>RND</td>
       <td>
-An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
-Primarily intended to be used for key generation.
+        An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
+        Primarily intended to be used for key generation.
 
-The number is sourced from the EDN via a single-entry cache.
-Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
+        The number is sourced from the EDN via a single-entry cache.
+        Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
       </td>
     </tr>
     <tr>
@@ -286,16 +287,18 @@ Reads when the cache is empty will cause OTBN to be stalled until a new random n
       <td>RO</td>
       <td>URND</td>
       <td>
-A random number without guaranteed secrecy properties or specific statistical properties.
-Intended for use in masking and blinding schemes.
-Use RND for high-quality randomness.
+        A random number without guaranteed secrecy properties or specific statistical properties.
+        Intended for use in masking and blinding schemes.
+        Use RND for high-quality randomness.
 
-The number is sourced from an local PRNG.
-Reads never stall.
+        The number is sourced from an local PRNG.
+        Reads never stall.
       </td>
     </tr>
   </tbody>
 </table>
+
+<!-- END CMDGEN -->
 
 ### Wide Data Registers (WDRs)
 
@@ -324,6 +327,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
 
 <!-- This list of WSRs is replicated in otbn_env_cov.sv, wsr.py, the
      RTL and in rig/model.py. If editing one, edit the other four as well. -->
+<!-- BEGIN CMDGEN ./hw/ip/otbn/util/docs/md_isrs.py --add-anchors hw/ip/otbn/data/wsr.yml -->
 <table>
   <thead>
     <tr>
@@ -337,43 +341,41 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
     <tr>
       <td>0x0</td>
       <td>RW</td>
-      <td>MOD</td>
-<td>
-
-The modulus used by the {{#otbn-insn-ref BN.ADDM}} and {{#otbn-insn-ref BN.SUBM}} instructions.
-This WSR is also visible as CSRs `MOD0` through to `MOD7`.
-
-</td>
+      <td><a name="mod">MOD</a></td>
+      <td>
+        The modulus used by the {{#otbn-insn-ref BN.ADDM}} and {{#otbn-insn-ref BN.SUBM}} instructions.
+        This WSR is also visible as CSRs `MOD0` through to `MOD7`.
+      </td>
     </tr>
     <tr>
       <td>0x1</td>
       <td>RO</td>
-      <td>RND</td>
+      <td><a name="rnd">RND</a></td>
       <td>
-An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
-Primarily intended to be used for key generation.
+        An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
+        Primarily intended to be used for key generation.
 
-The number is sourced from the EDN via a single-entry cache.
-Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
+        The number is sourced from the EDN via a single-entry cache.
+        Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
       </td>
     </tr>
     <tr>
       <td>0x2</td>
       <td>RO</td>
-      <td>URND</td>
+      <td><a name="urnd">URND</a></td>
       <td>
-A random number without guaranteed secrecy properties or specific statistical properties.
-Intended for use in masking and blinding schemes.
-Use RND for high-quality randomness.
+        A random number without guaranteed secrecy properties or specific statistical properties.
+        Intended for use in masking and blinding schemes.
+        Use RND for high-quality randomness.
 
-The number is sourced from a local PRNG.
-Reads never stall.
+        The number is sourced from an local PRNG.
+        Reads never stall.
       </td>
     </tr>
     <tr>
       <td>0x3</td>
       <td>RW</td>
-      <td>ACC</td>
+      <td><a name="acc">ACC</a></td>
       <td>
         The accumulator register used by the {{#otbn-insn-ref BN.MULQACC}} instruction.
       </td>
@@ -383,9 +385,9 @@ Reads never stall.
       <td>RO</td>
       <td><a name="key-s0-l">KEY_S0_L</a></td>
       <td>
-Bits [255:0] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+        Bits [255:0] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
 
-A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a key.
+        A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
     <tr>
@@ -393,10 +395,10 @@ A `KEY_INVALID` software error is raised on read if the Key Manager has not prov
       <td>RO</td>
       <td><a name="key-s0-h">KEY_S0_H</a></td>
       <td>
-Bits [255:128] of this register are always zero.
-Bits [127:0] contain bits [383:256] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+        Bits [255:128] of this register are always zero.
+        Bits [127:0] contain bits [383:256] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
 
-A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+        A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
     <tr>
@@ -404,9 +406,9 @@ A `KEY_INVALID` software error is raised on read if the Key Manager has not prov
       <td>RO</td>
       <td><a name="key-s1-l">KEY_S1_L</a></td>
       <td>
-Bits [255:0] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+        Bits [255:0] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
 
-A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+        A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
     <tr>
@@ -414,14 +416,16 @@ A `KEY_INVALID` software error is raised on read if the Key Manager has not prov
       <td>RO</td>
       <td><a name="key-s1-h">KEY_S1_H</a></td>
       <td>
-Bits [255:128] of this register are always zero.
-Bits [127:0] contain bits [383:256] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+        Bits [255:128] of this register are always zero.
+        Bits [127:0] contain bits [383:256] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
 
-A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+        A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
   </tbody>
 </table>
+
+<!-- END CMDGEN -->
 
 ### Flags
 

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -1,0 +1,118 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: fg0
+  address: 0x7c0
+  doc: |
+    Wide arithmetic flag group 0.
+    This CSR provides access to flag group 0 used by wide integer arithmetic.
+    *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
+  bits:
+    0: Carry of flag group 0
+    1: MSb of flag group 0
+    2: LSb of flag group 0
+    3: Zero of flag group 0
+
+- name: fg1
+  address: 0x7c1
+  doc: |
+    Wide arithmetic flag group 1.
+    This CSR provides access to flag group 1 used by wide integer arithmetic.
+    *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
+  bits:
+    0: Carry of flag group 1
+    1: MSb of flag group 1
+    2: LSb of flag group 1
+    3: Zero of flag group 1
+
+- name: flags
+  address: 0x7c8
+  doc: |
+    Wide arithmetic flag groups.
+    This CSR provides access to both flag groups used by wide integer arithmetic.
+    *FLAGS*, *FG0* and *FG1* provide different views on the same underlying bits.
+  bits:
+    0: Carry of flag group 0
+    1: MSb of flag group 0
+    2: LSb of flag group 0
+    3: Zero of flag group 0
+    4: Carry of flag group 1
+    5: MSb of flag group 1
+    6: LSb of flag group 1
+    7: Zero of flag group 1
+
+- name: mod0
+  address: 0x7d0
+  doc: |
+    Bits [31:0] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod1
+  address: 0x7d1
+  doc: |
+    Bits [63:32] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod2
+  address: 0x7d2
+  doc: |
+    Bits [95:64] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod3
+  address: 0x7d3
+  doc: |
+    Bits [127:96] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod4
+  address: 0x7d4
+  doc: |
+    Bits [159:128] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod5
+  address: 0x7d5
+  doc: |
+    Bits [191:160] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod6
+  address: 0x7d6
+  doc: |
+    Bits [223:192] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: mod7
+  address: 0x7d7
+  doc: |
+    Bits [255:224] of the modulus operand, used in the {{#otbn-insn-ref BN.ADDM}}/{{#otbn-insn-ref BN.SUBM}} instructions.
+    This CSR is mapped to the MOD WSR.
+
+- name: rnd_prefetch
+  address: 0x7d8
+  doc: |
+    Write to this CSR to begin a request to fill the RND cache.
+    Always reads as 0.
+
+- name: rnd
+  address: 0xfc0
+  read-only: true
+  doc: |
+    An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
+    Primarily intended to be used for key generation.
+
+    The number is sourced from the EDN via a single-entry cache.
+    Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
+
+- name: urnd
+  address: 0xfc1
+  read-only: true
+  doc: |
+    A random number without guaranteed secrecy properties or specific statistical properties.
+    Intended for use in masking and blinding schemes.
+    Use RND for high-quality randomness.
+
+    The number is sourced from an local PRNG.
+    Reads never stall.

--- a/hw/ip/otbn/data/wsr.yml
+++ b/hw/ip/otbn/data/wsr.yml
@@ -1,0 +1,69 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: mod
+  address: 0
+  doc: |
+    The modulus used by the {{#otbn-insn-ref BN.ADDM}} and {{#otbn-insn-ref BN.SUBM}} instructions.
+    This WSR is also visible as CSRs `MOD0` through to `MOD7`.
+
+- name: rnd
+  address: 1
+  read-only: true
+  doc: |
+    An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
+    Primarily intended to be used for key generation.
+
+    The number is sourced from the EDN via a single-entry cache.
+    Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
+
+- name: urnd
+  address: 2
+  read-only: true
+  doc: |
+    A random number without guaranteed secrecy properties or specific statistical properties.
+    Intended for use in masking and blinding schemes.
+    Use RND for high-quality randomness.
+
+    The number is sourced from an local PRNG.
+    Reads never stall.
+
+- name: acc
+  address: 3
+  doc: |
+    The accumulator register used by the {{#otbn-insn-ref BN.MULQACC}} instruction.
+
+- name: key_s0_l
+  address: 4
+  read-only: true
+  doc: |
+    Bits [255:0] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+
+    A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+
+- name: key_s0_h
+  address: 5
+  read-only: true
+  doc: |
+    Bits [255:128] of this register are always zero.
+    Bits [127:0] contain bits [383:256] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+
+    A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+
+- name: key_s1_l
+  address: 6
+  read-only: true
+  doc: |
+    Bits [255:0] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+
+    A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+
+- name: key_s1_h
+  address: 7
+  read-only: true
+  doc: |
+    Bits [255:128] of this register are always zero.
+    Bits [127:0] contain bits [383:256] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
+
+    A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.

--- a/hw/ip/otbn/util/Makefile
+++ b/hw/ip/otbn/util/Makefile
@@ -16,11 +16,12 @@ $(build-dir) $(lint-build-dir):
 	mkdir -p $@
 
 pylibs := $(wildcard shared/*.py docs/*.py)
-pyscripts := yaml_to_doc.py otbn_as.py otbn_ld.py otbn_objdump.py
+pyscripts := yaml_to_doc.py otbn_as.py otbn_ld.py otbn_objdump.py docs/md_isrs.py
 
 lint-stamps := $(foreach s,$(pyscripts),$(lint-build-dir)/$(s).stamp)
 $(lint-build-dir)/%.stamp: % $(pylibs) | $(lint-build-dir)
 	mypy --strict --config-file=mypy.ini $<
+	mkdir -p $(@D)
 	touch $@
 
 .PHONY: lint

--- a/hw/ip/otbn/util/docs/md_isrs.py
+++ b/hw/ip/otbn/util/docs/md_isrs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# A tool for generating the CSR and WSR documentation (for use in README.md)
+# from the yaml files that contain it.
+
+import argparse
+import os
+import sys
+from typing import List
+
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                              '../../util')))
+
+from shared.isr import Isr, read_isrs  # noqa: E402
+
+
+def print_thead(indent: str, columns: List[str]) -> None:
+    print(f'{indent}<thead>')
+    print(f'{indent}  <tr>')
+    for column in columns:
+        print(f'{indent}    <th>{column}</th>')
+    print(f'{indent}  </tr>')
+    print(f'{indent}</thead>')
+
+
+def print_isr(indent: str, isr: Isr, add_anchors: bool) -> None:
+    uc_name = isr.name.upper()
+    lc_key = isr.name.lower().replace('_', '-')
+
+    print(f'{indent}<tr>')
+    print(f'{indent}  <td>0x{isr.address:X}</td>')
+    print(f'{indent}  <td>{isr.access_str()}</td>')
+    if add_anchors:
+        print(f'{indent}  <td><a name="{lc_key}">{uc_name}</a></td>')
+    else:
+        print(f'{indent}  <td>{uc_name}</td>')
+    print(f'{indent}  <td>')
+
+    doc_lines = isr.doc.splitlines()
+    if isr.bits:
+        doc_lines += ['<table>',
+                      '  <thead>',
+                      '    <tr><th>Bit</th><th>Description</th></tr>',
+                      '  </thead>',
+                      '  <tbody>']
+        for k, v in isr.bits.items():
+            doc_lines.append(f'    <tr><td>{k}</td><td>{v}</td></tr>')
+        doc_lines += ['  </tbody>', '</table>']
+
+    for line in doc_lines:
+        if line:
+            line = indent + ' ' * 4 + line
+        print(line)
+
+    print(f'{indent}  </td>')
+    print(f'{indent}</tr>')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--add-anchors', action='store_true')
+    parser.add_argument('yml')
+
+    args = parser.parse_args()
+
+    print('<table>')
+    print_thead(' ' * 2, ['Number', 'Access', 'Name', 'Description'])
+    print('  <tbody>')
+    for isr in read_isrs(args.yml):
+        print_isr('  ' * 2, isr, args.add_anchors)
+
+    print('  </tbody>')
+    print('</table>')
+
+
+if __name__ == '__main__':
+    main()

--- a/hw/ip/otbn/util/shared/isr.py
+++ b/hw/ip/otbn/util/shared/isr.py
@@ -1,0 +1,54 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Iterable
+from serialize.parse_helpers import (check_keys, check_str, check_list,
+                                     check_int, check_bool, load_yaml)
+
+
+class Isr:
+    def __init__(self, name: str, address: int,
+                 doc: str, read_only: bool, bits: Dict[int, str]) -> None:
+        self.name = name
+        self.address = address
+        self.doc = doc
+        self.read_only = read_only
+        self.bits = bits
+
+    def access_str(self) -> str:
+        return 'RO' if self.read_only else 'RW'
+
+    @staticmethod
+    def from_yml(yml: object) -> 'Isr':
+        yd = check_keys(yml, 'isr',
+                        ['name', 'address', 'doc'],
+                        ['read-only', 'bits'])
+        name = check_str(yd['name'], 'name')
+        address = check_int(yd['address'], 'index/address')
+        if address < 0:
+            raise ValueError(f'Address of ISR {name:!r} is negative.')
+        read_only = check_bool(yd.get('read-only', False), 'read-only flag')
+        doc = check_str(yd['doc'], 'documentation')
+        pre_bits = yd.get('bits', {})
+        if not isinstance(pre_bits, dict):
+            raise ValueError(f'bits field of ISR {name:!r} is not a dict.')
+        bits = {}  # type: Dict[int, str]
+        for k, v in pre_bits.items():
+            k_int = check_int(k, 'address of ISR bit')
+            v_str = check_str(v, f'description of ISR bit {k}')
+            bits[k_int] = v_str
+
+        return Isr(name, address, doc, read_only, bits)
+
+
+def read_isrs(path: str) -> Iterable[Isr]:
+    isrs = {}  # type: Dict[int, Isr]
+    yml = load_yaml(path, None)
+    for isr_yml in check_list(yml, 'contents of ISR file'):
+        isr = Isr.from_yml(isr_yml)
+        if isr.address in isrs:
+            raise ValueError(f'Multiple ISRs at address {isr.address}')
+        isrs[isr.address] = isr
+
+    return isrs.values()


### PR DESCRIPTION
No functional change, except that the lists of CSRs/WSRs in the documentation are now auto-generated from a big YAML file.

The plan is to use that YAML file for the other lists that you see mentioned in e.g. otbn/README.md. But I grabbed the initial list from the documentation, so "generating itself" seemed like the obvious first step.

This should be the first step to sorting out issue #3323, which tracks whether the toolchain can support named CSRs and WSRs in OTBN assembly code.

If reviewing this PR:

 - You can mostly ignore the .yml files: the contents get used to generate README.md, which is also checked in.

 - The script in isr.py is the thing that does the easy job of parsing the yaml.

 - The script in md_isrs.py is the thing that converts the parsed yaml into a markdown table.

 - README.md is now auto-generated, and is intended to be mostly unchanged.

Note that I haven't quite managed to auto-generate the same README.md as was there before. The changes are:

 - Using *bold* instead of <strong>bold</strong>

 - Avoiding some stray capitals in Flag Group

 - Indenting everything more uniformly. For example, see the RND WSR.

 - Adding anchor tags to all WSRs. We needed this for WSRs like KEY_S0_L, and I thought it seemed cleaner to do it uniformly instead of adding a flag to the YML to determine whether the WSR needed an anchor tag.