### PR TITLE
[hw,dma,rtl] Clear STATUS when starting a new transfer

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -576,7 +576,8 @@
         { bits: "0"
           name: "busy"
           resval: 0x0
-          hwaccess: "hwo"
+          hwaccess: "hrw"
+          swaccess: "ro"
           desc: '''
                 DMA operation is active if this bit is set.
                 DMA engine clears this bit when operation is complete.
@@ -587,7 +588,10 @@
           name: "done"
           resval: 0x0
           hwaccess: "hrw"
-          desc: "Configured DMA operation is complete."
+          desc: '''
+                Configured DMA operation is complete.
+                Cleared automatically by the hardware when starting a new transfer.
+                '''
         }
         { bits: "2"
           name: "aborted"

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -166,10 +166,6 @@ class dma_generic_vseq extends dma_base_vseq;
                 // Model the FirmWare running on the OT side, responding to the Done interrupt and
                 // nudging the controller to perform the next chunk of a multi-chunk transfer
 
-                // TODO: clear the Done bit; PR #660 is aimed at obviating this
-                ral.status.done.set(1'b1);
-                csr_update(ral.status);
-
                 // Supply the next chunk of input data
                 void'(configure_mem_model(dma_config, num_bytes_supplied));
                 num_bytes_supplied += dma_config.chunk_size(num_bytes_supplied);

--- a/hw/ip/dma/lint/dma.waiver
+++ b/hw/ip/dma/lint/dma.waiver
@@ -6,3 +6,5 @@
 
 waive -rules {ARITH_CONTEXT} -location {dma.sv} -regexp {.*Bitlength of arithmetic operation.*is self-determined in this context.*} \
       -comment "Carry issue when determining the bit length."
+waive -rules {HIER_NET_NOT_READ} -location {dma_reg_top.sv} -regexp {status_flds_we\[0\]' is not read from in module} \
+      -comment "Internal register is accepted to not be read. Tracked in #702."

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -75,7 +75,7 @@ module dma
 
   logic dma_state_error;
   dma_ctrl_state_e ctrl_state_q, ctrl_state_d;
-  logic clear_go;
+  logic clear_go, clear_status, clear_sha_status;
 
   logic [INT_CLEAR_SOURCES_WIDTH-1:0] clear_index_d, clear_index_q;
   logic                               clear_index_en, int_clear_tlul_rsp_valid;
@@ -386,7 +386,7 @@ module dma
 
   logic use_inline_hashing;
   logic sha2_hash_start, sha2_hash_process;
-  logic sha2_valid, sha2_ready, sha2_digest_set, sha2_digest_clear;
+  logic sha2_valid, sha2_ready, sha2_digest_set;
   sha_fifo32_t sha2_data;
   digest_mode_e sha2_mode;
   sha_word64_t [7:0] sha2_digest;
@@ -603,7 +603,6 @@ module dma
     sha2_hash_start      = 1'b0;
     sha2_valid           = 1'b0;
     sha2_digest_set      = 1'b0;
-    sha2_digest_clear    = 1'b0;
     sha2_consumed_d      = sha2_consumed_q;
 
     // Make SHA2 Done sticky to not miss a single-cycle done event during any outstanding writes
@@ -631,7 +630,6 @@ module dma
             if (reg2hw.control.initial_transfer.q) begin
               transfer_byte_d       = '0;
               capture_transfer_byte = 1'b1;
-              sha2_digest_clear     = 1'b1;
             end
             // if not handshake start transfer
             if (!cfg_handshake_en) begin
@@ -1201,37 +1199,6 @@ module dma
       hw2reg.control.initial_transfer.de = 1'b1;
     end
 
-    // Write digest to CSRs when needed. The digest is an 8-element  64-bit datatype. Depending on
-    // the selected hashing algorithm, the digest is stored differently in the digest datatype:
-    // SHA2-256: digest[0-7][31:0] store the 256-bit digest. The upper 32-bits of all digest
-    //           elements are zero
-    // SHA2-384: digest[0-5][63:0] store the 384-bit digest.
-    // SHA2-512: digest[0-7][63:0] store the 512-bit digest.
-    for (int i = 0; i < NR_SHA_DIGEST_ELEMENTS; i++) begin
-      hw2reg.sha2_digest[i].de = sha2_digest_set | sha2_digest_clear;
-    end
-
-    for (int unsigned i = 0; i < NR_SHA_DIGEST_ELEMENTS / 2; i++) begin
-      unique case (reg2hw.control.opcode.q)
-        OpcSha256: begin
-          hw2reg.sha2_digest[i].d = sha2_digest_clear? '0 : sha2_digest[i][0 +: 32];
-        end
-        OpcSha384: begin
-          if (i < 6) begin
-            hw2reg.sha2_digest[i*2].d     = sha2_digest_clear? '0 : sha2_digest[i][32 +: 32];
-            hw2reg.sha2_digest[(i*2)+1].d = sha2_digest_clear? '0 : sha2_digest[i][0  +: 32];
-          end
-        end
-        default: begin // SHA2-512
-          hw2reg.sha2_digest[i*2].d     = sha2_digest_clear? '0 : sha2_digest[i][32 +: 32];
-          hw2reg.sha2_digest[(i*2)+1].d = sha2_digest_clear? '0 : sha2_digest[i][0  +: 32];
-        end
-      endcase
-    end
-
-    hw2reg.status.sha2_digest_valid.de = sha2_digest_set | sha2_digest_clear;
-    hw2reg.status.sha2_digest_valid.d  = sha2_digest_set;
-
     hw2reg.destination_address_hi.de = update_destination_addr_reg;
     hw2reg.destination_address_hi.d  = new_destination_addr[63:32];
 
@@ -1244,11 +1211,6 @@ module dma
     hw2reg.source_address_lo.de = update_source_addr_reg;
     hw2reg.source_address_lo.d  = new_source_addr[31:0];
 
-    // Clear the go bit if we are in a single transfer and finished the DMA operation,
-    // hardware handshake mode when we finished all transfers, or when aborting the transfer.
-    hw2reg.control.go.de = clear_go;
-    hw2reg.control.go.d  = 1'b0;
-
     // Assert busy write enable on
     // - transitions from IDLE out
     // - clearing the go bit (going back to idle)
@@ -1259,37 +1221,79 @@ module dma
     hw2reg.status.busy.d  = ((ctrl_state_q == DmaIdle) &&
                             (ctrl_state_d != DmaIdle)) ? 1'b1 : 1'b0;
 
+    // Status is cleared when leaving the IDLE state the first time, i.e., when busy is not yet set
+    clear_status = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle) && !reg2hw.status.busy.q;
+    // The SHA digest valid and the digest itself needs to incorporate the initial transfer flag
+    // as busy is deasserted for every chunk in the middle of a multi-chunk memory-to-memory
+    //transfer
+    clear_sha_status = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle) &&
+                       reg2hw.control.initial_transfer.q;
+
     // Set done bit and raise interrupt when we either finished a single transfer or all transfers
-    // in hardware handshake mode.
-    hw2reg.status.done.de = (!cfg_abort_en)     &&
-                             data_move_state    &&
-                             clear_go;
-    hw2reg.status.done.d  = 1'b1;
+    // in hardware handshake mode. Automatically clear the done bit when starting a new transfer
+    hw2reg.status.done.de = ((!cfg_abort_en) && data_move_state && clear_go) | clear_status;
+    hw2reg.status.done.d  = clear_status? 1'b0 : 1'b1;
 
-    hw2reg.status.error.d  = 1'b1;
-    hw2reg.status.error.de = (ctrl_state_d == DmaError);
+    hw2reg.status.error.de = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.status.error.d  = clear_status? 1'b0 : 1'b1;
 
-    hw2reg.status.aborted.de = cfg_abort_en && (ctrl_state_d == DmaIdle);
-    hw2reg.status.aborted.d  = 1'b1;
+    hw2reg.status.aborted.de = (cfg_abort_en && (ctrl_state_d == DmaIdle)) | clear_status;
+    hw2reg.status.aborted.d  = clear_status? 1'b0 : 1'b1;
+
+    hw2reg.status.sha2_digest_valid.de = sha2_digest_set | clear_sha_status;
+    hw2reg.status.sha2_digest_valid.d  = sha2_digest_set;
+
+     // Write digest to CSRs when needed. The digest is an 8-element  64-bit datatype. Depending on
+    // the selected hashing algorithm, the digest is stored differently in the digest datatype:
+    // SHA2-256: digest[0-7][31:0] store the 256-bit digest. The upper 32-bits of all digest
+    //           elements are zero
+    // SHA2-384: digest[0-5][63:0] store the 384-bit digest.
+    // SHA2-512: digest[0-7][63:0] store the 512-bit digest.
+    for (int i = 0; i < NR_SHA_DIGEST_ELEMENTS; i++) begin
+      hw2reg.sha2_digest[i].de = sha2_digest_set | clear_sha_status;
+    end
+
+    for (int unsigned i = 0; i < NR_SHA_DIGEST_ELEMENTS / 2; i++) begin
+      unique case (reg2hw.control.opcode.q)
+        OpcSha256: begin
+          hw2reg.sha2_digest[i].d = clear_sha_status? '0 : sha2_digest[i][0 +: 32];
+        end
+        OpcSha384: begin
+          if (i < 6) begin
+            hw2reg.sha2_digest[i*2].d     = clear_sha_status? '0 : sha2_digest[i][32 +: 32];
+            hw2reg.sha2_digest[(i*2)+1].d = clear_sha_status? '0 : sha2_digest[i][0  +: 32];
+          end
+        end
+        default: begin // SHA2-512
+          hw2reg.sha2_digest[i*2].d     = clear_sha_status? '0 : sha2_digest[i][32 +: 32];
+          hw2reg.sha2_digest[(i*2)+1].d = clear_sha_status? '0 : sha2_digest[i][0  +: 32];
+        end
+      endcase
+    end
+
+    // Clear the go bit if we are in a single transfer and finished the DMA operation,
+    // hardware handshake mode when we finished all transfers, or when aborting the transfer.
+    hw2reg.control.go.de = clear_go;
+    hw2reg.control.go.d  = 1'b0;
 
     // Fiddle out error signals
-    hw2reg.error_code.src_address_error.de = (ctrl_state_d == DmaError);
-    hw2reg.error_code.dst_address_error.de = (ctrl_state_d == DmaError);
-    hw2reg.error_code.opcode_error.de      = (ctrl_state_d == DmaError);
-    hw2reg.error_code.size_error.de        = (ctrl_state_d == DmaError);
-    hw2reg.error_code.bus_error.de         = (ctrl_state_d == DmaError);
-    hw2reg.error_code.base_limit_error.de  = (ctrl_state_d == DmaError);
-    hw2reg.error_code.range_valid_error.de = (ctrl_state_d == DmaError);
-    hw2reg.error_code.asid_error.de        = (ctrl_state_d == DmaError);
+    hw2reg.error_code.src_address_error.de = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.dst_address_error.de = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.opcode_error.de      = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.size_error.de        = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.bus_error.de         = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.base_limit_error.de  = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.range_valid_error.de = (ctrl_state_d == DmaError) | clear_status;
+    hw2reg.error_code.asid_error.de        = (ctrl_state_d == DmaError) | clear_status;
 
-    hw2reg.error_code.src_address_error.d  = next_error[DmaSourceAddrErr];
-    hw2reg.error_code.dst_address_error.d  = next_error[DmaDestinationAddrErr];
-    hw2reg.error_code.opcode_error.d       = next_error[DmaOpcodeErr];
-    hw2reg.error_code.size_error.d         = next_error[DmaSizeErr];
-    hw2reg.error_code.bus_error.d          = next_error[DmaCompletionErr];
-    hw2reg.error_code.base_limit_error.d   = next_error[DmaBaseLimitErr];
-    hw2reg.error_code.range_valid_error.d  = next_error[DmaRangeValidErr];
-    hw2reg.error_code.asid_error.d         = next_error[DmaAsidErr];
+    hw2reg.error_code.src_address_error.d  = clear_status? '0 : next_error[DmaSourceAddrErr];
+    hw2reg.error_code.dst_address_error.d  = clear_status? '0 : next_error[DmaDestinationAddrErr];
+    hw2reg.error_code.opcode_error.d       = clear_status? '0 : next_error[DmaOpcodeErr];
+    hw2reg.error_code.size_error.d         = clear_status? '0 : next_error[DmaSizeErr];
+    hw2reg.error_code.bus_error.d          = clear_status? '0 : next_error[DmaCompletionErr];
+    hw2reg.error_code.base_limit_error.d   = clear_status? '0 : next_error[DmaBaseLimitErr];
+    hw2reg.error_code.range_valid_error.d  = clear_status? '0 : next_error[DmaRangeValidErr];
+    hw2reg.error_code.asid_error.d         = clear_status? '0 : next_error[DmaAsidErr];
 
     // Clear the control.abort bit once we have handled the abort request
     hw2reg.control.abort.de = hw2reg.status.aborted.de;

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -163,6 +163,9 @@ package dma_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } busy;
+    struct packed {
+      logic        q;
     } done;
     struct packed {
       logic        q;
@@ -309,30 +312,30 @@ package dma_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    dma_reg2hw_intr_state_reg_t intr_state; // [1168:1166]
-    dma_reg2hw_intr_enable_reg_t intr_enable; // [1165:1163]
-    dma_reg2hw_intr_test_reg_t intr_test; // [1162:1157]
-    dma_reg2hw_alert_test_reg_t alert_test; // [1156:1155]
-    dma_reg2hw_source_address_lo_reg_t source_address_lo; // [1154:1123]
-    dma_reg2hw_source_address_hi_reg_t source_address_hi; // [1122:1091]
-    dma_reg2hw_destination_address_lo_reg_t destination_address_lo; // [1090:1059]
-    dma_reg2hw_destination_address_hi_reg_t destination_address_hi; // [1058:1027]
-    dma_reg2hw_address_space_id_reg_t address_space_id; // [1026:1019]
-    dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [1018:986]
-    dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [985:953]
-    dma_reg2hw_range_valid_reg_t range_valid; // [952:952]
-    dma_reg2hw_range_regwen_reg_t range_regwen; // [951:948]
-    dma_reg2hw_total_data_size_reg_t total_data_size; // [947:916]
-    dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [915:884]
-    dma_reg2hw_transfer_width_reg_t transfer_width; // [883:882]
-    dma_reg2hw_destination_address_limit_lo_reg_t destination_address_limit_lo; // [881:850]
-    dma_reg2hw_destination_address_limit_hi_reg_t destination_address_limit_hi; // [849:818]
+    dma_reg2hw_intr_state_reg_t intr_state; // [1169:1167]
+    dma_reg2hw_intr_enable_reg_t intr_enable; // [1166:1164]
+    dma_reg2hw_intr_test_reg_t intr_test; // [1163:1158]
+    dma_reg2hw_alert_test_reg_t alert_test; // [1157:1156]
+    dma_reg2hw_source_address_lo_reg_t source_address_lo; // [1155:1124]
+    dma_reg2hw_source_address_hi_reg_t source_address_hi; // [1123:1092]
+    dma_reg2hw_destination_address_lo_reg_t destination_address_lo; // [1091:1060]
+    dma_reg2hw_destination_address_hi_reg_t destination_address_hi; // [1059:1028]
+    dma_reg2hw_address_space_id_reg_t address_space_id; // [1027:1020]
+    dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [1019:987]
+    dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [986:954]
+    dma_reg2hw_range_valid_reg_t range_valid; // [953:953]
+    dma_reg2hw_range_regwen_reg_t range_regwen; // [952:949]
+    dma_reg2hw_total_data_size_reg_t total_data_size; // [948:917]
+    dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [916:885]
+    dma_reg2hw_transfer_width_reg_t transfer_width; // [884:883]
+    dma_reg2hw_destination_address_limit_lo_reg_t destination_address_limit_lo; // [882:851]
+    dma_reg2hw_destination_address_limit_hi_reg_t destination_address_limit_hi; // [850:819]
     dma_reg2hw_destination_address_almost_limit_lo_reg_t
-        destination_address_almost_limit_lo; // [817:786]
+        destination_address_almost_limit_lo; // [818:787]
     dma_reg2hw_destination_address_almost_limit_hi_reg_t
-        destination_address_almost_limit_hi; // [785:754]
-    dma_reg2hw_control_reg_t control; // [753:742]
-    dma_reg2hw_status_reg_t status; // [741:737]
+        destination_address_almost_limit_hi; // [786:755]
+    dma_reg2hw_control_reg_t control; // [754:743]
+    dma_reg2hw_status_reg_t status; // [742:737]
     dma_reg2hw_handshake_interrupt_enable_reg_t handshake_interrupt_enable; // [736:726]
     dma_reg2hw_clear_int_src_reg_t clear_int_src; // [725:715]
     dma_reg2hw_clear_int_bus_reg_t clear_int_bus; // [714:704]

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -212,7 +212,6 @@ module dma_reg_top (
   logic control_go_wd;
   logic status_we;
   logic status_busy_qs;
-  logic status_busy_wd;
   logic status_done_qs;
   logic status_done_wd;
   logic status_aborted_qs;
@@ -1315,13 +1314,13 @@ module dma_reg_top (
   ) u_status0_qe (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .d_i(&status_flds_we),
+    .d_i(&(status_flds_we | 5'h1)),
     .q_o(status_qe)
   );
   //   F[busy]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_status_busy (
@@ -1329,8 +1328,8 @@ module dma_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (status_we),
-    .wd     (status_busy_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.status.busy.de),
@@ -1338,7 +1337,7 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (status_flds_we[0]),
-    .q      (),
+    .q      (reg2hw.status.busy.q),
     .ds     (),
 
     // to register interface (read)
@@ -3094,8 +3093,6 @@ module dma_reg_top (
 
   assign control_go_wd = reg_wdata[31];
   assign status_we = addr_hit[21] & reg_we & !reg_error;
-
-  assign status_busy_wd = reg_wdata[0];
 
   assign status_done_wd = reg_wdata[1];
 


### PR DESCRIPTION
Previously, the FW needs to manually clear the done signal after a transfer, to allow a polling loop to get the fresh data. This PR changes the hardware to automatically clear the done bit on new transfer. This removes the requirement on the FW to clear the DONE bit after a transfer.

Furthermore, it clears also the error and sha2_digest_valid bit when starting a new transfer. 

This PR is pulled over from https://github.com/lowRISC/opentitan-integrated/pull/660

/cc @alees24 