### PR TITLE
[silicon_creator] change format of attestation signature

### DIFF
--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -76,7 +76,8 @@ typedef struct attestation_public_key {
  * Holds an attestation signature (ECDSA-P256).
  */
 typedef struct attestation_signature {
-  uint32_t sig[kAttestationSignatureWords];
+  uint32_t r[kAttestationSignatureWords / 2];
+  uint32_t s[kAttestationSignatureWords / 2];
 } attestation_signature_t;
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -153,12 +153,10 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
 
   // Retrieve the signature (in two parts, r and s).
   size_t half_num_words = kAttestationSignatureWords / 2;
-  uint32_t *r_dest = sig->sig;
-  uint32_t *s_dest = &sig->sig[half_num_words];
   HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_read(half_num_words, kOtbnVarBootR, r_dest));
+      otbn_dmem_read(half_num_words, kOtbnVarBootR, sig->r));
   HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_read(half_num_words, kOtbnVarBootS, s_dest));
+      otbn_dmem_read(half_num_words, kOtbnVarBootS, sig->s));
 
   return kErrorOk;
 }


### PR DESCRIPTION
It is more ergonomical for the certificate templates to have the key represented by its r and s values.

@pamaury I split this up as we discussed last week. Lmk if this is what you were looking for.