### PR TITLE
[silicon_creator/lib] auto-load attestation keygen seed from flash info

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -508,6 +508,7 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:otbn",

--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -51,12 +51,20 @@ enum {
   kAttestationSignatureWords = kAttestationSignatureBytes / sizeof(uint32_t),
 };
 
-/**
- * Holds an additional seed for use in attestation key generation.
- */
-typedef struct attestation_seed {
-  uint32_t seed[kAttestationSeedWords];
-} attestation_seed_t;
+typedef enum {
+  /**
+   * The UDS attestation key seed.
+   */
+  kUdsAttestationKeySeed = 0,
+  /**
+   * The CDI_0 attestation key seed.
+   */
+  kCdi0AttestationKeySeed = 1,
+  /**
+   * The CDI_1 attestation key seed.
+   */
+  kCdi1AttestationKeySeed = 2,
+} attestation_key_seed_t;
 
 /**
  * Holds an attestation public key (ECDSA-P256).

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -677,9 +677,9 @@ void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
  */
 static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
     &kFlashCtrlInfoPageCreatorSecret,   &kFlashCtrlInfoPageOwnerSecret,
-    &kFlashCtrlInfoPageWaferAuthSecret, &kFlashCtrlInfoPageBootData0,
-    &kFlashCtrlInfoPageBootData1,       &kFlashCtrlInfoPageOwnerSlot0,
-    &kFlashCtrlInfoPageOwnerSlot1,
+    &kFlashCtrlInfoPageWaferAuthSecret, &kFlashCtrlInfoPageAttestationKeySeeds,
+    &kFlashCtrlInfoPageBootData0,       &kFlashCtrlInfoPageBootData1,
+    &kFlashCtrlInfoPageOwnerSlot0,      &kFlashCtrlInfoPageOwnerSlot1,
 };
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -165,7 +165,7 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * ```
  */
 enum {
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 14,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -628,10 +628,14 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 7> no_owner_access = {
-      &kFlashCtrlInfoPageCreatorSecret,   &kFlashCtrlInfoPageOwnerSecret,
-      &kFlashCtrlInfoPageWaferAuthSecret, &kFlashCtrlInfoPageBootData0,
-      &kFlashCtrlInfoPageBootData1,       &kFlashCtrlInfoPageOwnerSlot0,
+  std::array<const flash_ctrl_info_page_t *, 8> no_owner_access = {
+      &kFlashCtrlInfoPageCreatorSecret,
+      &kFlashCtrlInfoPageOwnerSecret,
+      &kFlashCtrlInfoPageWaferAuthSecret,
+      &kFlashCtrlInfoPageAttestationKeySeeds,
+      &kFlashCtrlInfoPageBootData0,
+      &kFlashCtrlInfoPageBootData1,
+      &kFlashCtrlInfoPageOwnerSlot0,
       &kFlashCtrlInfoPageOwnerSlot1,
   };
   for (auto page : no_owner_access) {

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -40,19 +40,20 @@ rom_error_t otbn_boot_app_load(void);
  * P256 base point.
  *
  * The `additional_seed` is expected to be the output from a specially seeded
- * DRBG. It must be fully independent from the key manager seed.
+ * DRBG, and is provisioned into flash at manufacturing time. It must be fully
+ * independent from the key manager seed.
  *
  * Expects the OTBN boot-services program to already be loaded; see
  * `otbn_boot_app_load`.
  *
- * @param additional_seed Seed material from DRBG.
+ * @param additional_seed The attestation key generation seed to load.
  * @param diversification Salt and version information for key manager.
  * @param[out] public_key Attestation public key.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_attestation_keygen(
-    const attestation_seed_t *additional_seed,
+    attestation_key_seed_t additional_seed,
     keymgr_diversification_t diversification,
     attestation_public_key_t *public_key);
 
@@ -66,13 +67,13 @@ rom_error_t otbn_boot_attestation_keygen(
  * Expects the OTBN boot-services program to already be loaded; see
  * `otbn_boot_app_load`.
  *
- * @param additional_seed Seed material from DRBG.
+ * @param additional_seed The attestation key generation seed to load.
  * @param diversification Salt and version information for key manager.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_attestation_key_save(
-    const attestation_seed_t *additional_seed,
+    attestation_key_seed_t additional_seed,
     keymgr_diversification_t diversification);
 
 /**


### PR DESCRIPTION
The current OTBN boot services API requires the user to input the additional DRBG seed manually. Since this seed is provisioned into a flash info page at manufacturing time, this updates the code to automatically load the specified seed from the flash instead. This simplifies the user experience of driving this library.

Additionally, this adds the flash info page that holds such seeds to the list of pages that are to be locked down by the ROM_EXT upon transition to the owner stage.

**Note: this depends on #20328.**