### PR TITLE
[opentitantool] Add initial SPI device support for QEMU

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -170,6 +170,8 @@ rust_library(
         "src/transport/proxy/mod.rs",
         "src/transport/proxy/spi.rs",
         "src/transport/proxy/uart.rs",
+        "src/transport/qemu/mod.rs",
+        "src/transport/qemu/spi.rs",
         "src/transport/ti50emulator/emu.rs",
         "src/transport/ti50emulator/gpio.rs",
         "src/transport/ti50emulator/i2c.rs",

--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -73,5 +73,6 @@ static BUILTINS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         "/__builtin__/hyperdebug_cw340.json" => include_str!("hyperdebug_cw340.json"),
         "/__builtin__/opentitan_ultradebug.json" => include_str!("opentitan_ultradebug.json"),
         "/__builtin__/opentitan_verilator.json" => include_str!("opentitan_verilator.json"),
+        "/__builtin__/qemu.json" => include_str!("qemu.json"),
     }
 });

--- a/sw/host/opentitanlib/src/app/config/qemu.json
+++ b/sw/host/opentitanlib/src/app/config/qemu.json
@@ -1,0 +1,12 @@
+{
+    "includes": [
+        "/__builtin__/opentitan.json"
+    ],
+    "interface": "qemu",
+    "spi": [
+        {
+            "name": "BOOTSTRAP",
+            "alias_of": "0"
+        }
+    ]
+}

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -14,6 +14,7 @@ use crate::transport::dediprog::Dediprog;
 use crate::transport::hyperdebug::{
     C2d2Flavor, ChipWhispererFlavor, ServoMicroFlavor, StandardFlavor, Ti50Flavor,
 };
+use crate::transport::qemu::QEMU;
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 
@@ -120,6 +121,10 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
                 args.usb_serial.as_deref(),
             )?);
             (dediprog, Some(Path::new("/__builtin__/dediprog.json")))
+        }
+        "qemu" => {
+            let qemu: Box<dyn Transport> = Box::new(QEMU::new()?);
+            (qemu, Some(Path::new("/__builtin__/qemu.json")))
         }
         _ => return Err(Error::UnknownInterface(interface.to_string()).into()),
     };

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -25,6 +25,7 @@ pub mod dediprog;
 pub mod hyperdebug;
 pub mod ioexpander;
 pub mod proxy;
+pub mod qemu;
 pub mod ti50emulator;
 pub mod ultradebug;
 pub mod verilator;

--- a/sw/host/opentitanlib/src/transport/qemu/mod.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/mod.rs
@@ -1,0 +1,110 @@
+#![allow(unused)]
+
+use anyhow::{bail, ensure, Context, Result};
+use once_cell::sync::Lazy;
+use std::any::Any;
+use std::cell::{Cell, RefCell};
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::rc::Rc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::io::spi::Target;
+//use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
+//use crate::transport::common::uart::SerialPortUart;
+use crate::transport::{
+    Capabilities, Capability, Transport, TransportError, TransportInterfaceType,
+};
+//use crate::util::parse_int::ParseInt;
+
+pub mod spi;
+
+pub struct Inner {
+    spi: Option<Rc<dyn Target>>,
+    stream: TcpStream,
+}
+
+impl Inner {
+    fn new(stream: TcpStream) -> Self {
+        Self {
+            spi: None,
+            stream: stream
+        }
+    }
+}
+
+pub struct QEMU {
+    inner: Rc<RefCell<Inner>>,
+}
+
+impl QEMU {
+    const POLL_DELAY: Duration = Duration::from_millis(250);
+    const CONN_DELAY: Duration = Duration::from_secs(2);
+
+    pub fn new() -> anyhow::Result<Self> {
+        let addr = format!("localhost:{}", 8004);
+        let stream = Self::wait_for_socket(addr, QEMU::CONN_DELAY)
+            .context("failed to connect to QEMU SPI_device socket")?;
+        stream.set_read_timeout(Some(QEMU::POLL_DELAY))?;
+        stream.set_write_timeout(Some(QEMU::POLL_DELAY))?;
+        let inner = Inner::new(stream);
+        let board = Self {
+            inner: Rc::new(RefCell::new(inner)),
+        };
+        Ok(board)
+    }
+
+    /// Poll `addr` until it is bound and a socket can connect.
+    fn wait_for_socket<A: ToSocketAddrs>(addr: A, timeout: Duration) -> io::Result<TcpStream> {
+        let start = Instant::now();
+        loop {
+            log::info!("Attempting to make tcp connection...");
+            match TcpStream::connect(&addr) {
+                // This is the error for addresses that aren't bound
+                Err(e) if e.kind() == ErrorKind::ConnectionRefused => (),
+                // This is error has been observed in CQ.
+                Err(e) if e.kind() == ErrorKind::AddrNotAvailable => {
+                    log::warn!("Got ErrorKind::AddrInUse on client socket, odd...");
+                }
+                // All other errors (and `Ok`s) we want to know about
+                Err(e) => {
+                    log::warn!("Error: {:?}", e.kind());
+
+                    return Err(e);
+                }
+                socket => {
+                    log::info!("Connected");
+                    return socket 
+                }
+            }
+
+            // Delay between loops if there's enough time before timeout.
+            if start.elapsed() + Self::POLL_DELAY < timeout {
+                thread::sleep(Self::POLL_DELAY);
+            } else {
+                log::warn!("timeout");
+                return Err(ErrorKind::TimedOut.into());
+            }
+        }
+    }
+
+}
+
+impl Transport for QEMU {
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(Capability::SPI))
+    }
+
+    fn spi(&self, instance: &str) -> Result<Rc<dyn Target>> {
+        ensure!(
+            instance == "0",
+            TransportError::InvalidInstance(TransportInterfaceType::Spi, instance.to_string())
+        );
+        if self.inner.borrow().spi.is_none() {
+            self.inner.borrow_mut().spi =
+                Some(Rc::new(spi::QEMUSpi::open(Rc::clone(&self.inner))?));
+        }
+        Ok(Rc::clone(self.inner.borrow().spi.as_ref().unwrap()))
+    }
+}

--- a/sw/host/opentitanlib/src/transport/qemu/spi.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/spi.rs
@@ -1,0 +1,259 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Context, Result};
+use std::cell::RefCell;
+use std::io::{self, Error, ErrorKind, Read, Write};
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use crate::io::eeprom;
+use crate::io::eeprom::Transaction::{Read as SpiRead, WaitForBusyClear, Write as SpiWrite};
+use crate::io::spi::{AssertChipSelect, MaxSizes, SpiError, Target, Transfer, TransferMode};
+use crate::spiflash::flash::SpiFlash;
+use crate::transport::qemu::Inner;
+use crate::util::voltage::Voltage;
+
+pub struct QEMUSpi {
+    inner: Rc<RefCell<Inner>>,
+    buffer: Rc<RefCell<Vec<u8>>>,
+    max_chunk_size: usize,
+    spi_mode: u8,
+    addr4b_enable: bool,
+}
+
+impl QEMUSpi {
+    const MAX_FLASH_DATA_LEN: usize = 65536;
+    const COMM_TIMEOUT: Duration = Duration::from_millis(2000);
+
+    pub fn open(inner: Rc<RefCell<Inner>>) -> Result<Self> {
+        let this = Self {
+            inner,
+            buffer: Rc::new(RefCell::new(Vec::new())),
+            max_chunk_size: 65535 * 256,
+            spi_mode: 0,
+            addr4b_enable: false,
+        };
+        Ok(this)
+    }
+
+    fn eeprom_read_transaction(&self, cmd: &eeprom::Cmd, rbuf: &mut [u8]) -> Result<()> {
+        let cmdbuf = cmd.to_bytes()?;
+        self.transmit(cmdbuf, rbuf, true)
+    }
+
+    fn eeprom_write_transaction(&self, cmd: &eeprom::Cmd, wbuf: &[u8],
+                                _wait_for_busy_clear: bool) -> Result<()> {
+        let cmdbuf = cmd.to_bytes()?;
+        let mut rbuf = [0u8; 0];
+        self.transmit(cmdbuf, &mut rbuf, false)?;
+        self.transmit(wbuf, &mut rbuf, true)
+    }
+
+    fn do_run_eeprom_transactions(
+        &self,
+        mut transactions: &mut [eeprom::Transaction],
+    ) -> Result<()> {
+        loop {
+            match transactions {
+                [eeprom::Transaction::Command(pre_cmd), SpiWrite(cmd, wbuf), WaitForBusyClear, rest @ ..] =>
+                {
+                    transactions = rest;
+                    if pre_cmd.get_opcode() == [SpiFlash::WRITE_ENABLE] {
+                        // Write enable is done by eeprom_write_transaction()
+                    } else {
+                        self.run_transaction(&mut [Transfer::Write(cmd.to_bytes()?)])?
+                    }
+                    self.eeprom_write_transaction(cmd, wbuf, true)?;
+                }
+                [eeprom::Transaction::Command(cmd), rest @ ..] => {
+                    transactions = rest;
+                    self.run_transaction(&mut [Transfer::Write(cmd.to_bytes()?)])?
+                }
+                [SpiRead(cmd, ref mut rbuf), rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_read_transaction(cmd, rbuf)?;
+                }
+                [SpiWrite(cmd, wbuf), WaitForBusyClear, rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_write_transaction(cmd, wbuf, true)?;
+                }
+                [SpiWrite(cmd, wbuf), rest @ ..] => {
+                    transactions = rest;
+                    self.eeprom_write_transaction(cmd, wbuf, false)?;
+                }
+                [WaitForBusyClear, rest @ ..] => {
+                    transactions = rest;
+                    let mut status = eeprom::STATUS_WIP;
+                    while status & eeprom::STATUS_WIP != 0 {
+                        self.run_transaction(&mut [
+                            Transfer::Write(&[eeprom::READ_STATUS]),
+                            Transfer::Read(std::slice::from_mut(&mut status)),
+                        ])?;
+                    }
+                }
+                [] => return Ok(()),
+            }
+        }
+        Ok(())
+    }
+
+    fn build_cs_header(&self, size: usize, release: bool) -> [u8; 8] {
+        let mut mode = self.spi_mode & 0xf;
+        if !release {
+            mode |= 0x80;
+        }
+        let mut header = [0u8; 8];
+        header[0..3].clone_from_slice(b"/CS");
+        header[3] = 0; // version
+        header[4] = mode;
+        header[6..8].clone_from_slice(&(size as u16).to_le_bytes());
+        header
+    }
+
+    fn send(&self, txbuf: &[u8], release: bool) -> Result<()> {
+        let size = txbuf.len();
+        let header = self.build_cs_header(size, release);
+        {
+            let stream = &mut self.inner.borrow_mut().stream;
+            stream.write_all(&header[..])
+                .with_context(|| "Cannot send SPI CS header")?;
+            stream.write_all(txbuf)
+                .with_context(|| "Cannot send SPI TX data")
+        }
+    }
+
+    fn receive(&self, rxbuf: &mut [u8]) -> Result<()> {
+        let length = rxbuf.len();
+        let mut rx_len = 0usize;
+        let timeout = Instant::now() + QEMUSpi::COMM_TIMEOUT;
+        while rx_len < length {
+            match self.inner.borrow_mut().stream.read(&mut rxbuf[rx_len..length]) {
+                Ok(0) => (),
+                Ok(n) => { rx_len += n; continue; },
+                Err(err) => match err.kind() {
+                    ErrorKind::TimedOut | ErrorKind::WouldBlock => (),
+                    _ => {
+                        return Err(err).with_context(|| "Cannot receive SPI RX data");
+                    }
+                }
+            }
+            if Instant::now() > timeout {
+                return Err(Error::new(ErrorKind::TimedOut, ""))
+                    .with_context(|| "Timeout on SPI RX data");
+            }
+        }
+        Ok(())
+    }
+
+    fn transmit(&self, txbuf: &[u8], rxbuf: &mut [u8], release: bool) -> Result<()> {
+        let txlen = txbuf.len();
+        let rxlen = rxbuf.len();
+        let length = txlen+rxlen;
+        let mut buffer = self.buffer.borrow_mut();
+        buffer.resize(length, 0xffu8);
+        buffer[..txlen].clone_from_slice(txbuf);
+        log::debug!("TX: {:x?}", buffer);
+        self.send(&buffer, release)?;
+        buffer.resize(length, 0xffu8);
+        self.receive(&mut buffer)?;
+        log::debug!("RX: {:x?}", buffer);
+        rxbuf.clone_from_slice(&buffer[txlen..]);
+        if rxlen != rxbuf.len() {
+            return Err(Error::new(ErrorKind::TimedOut, ""))
+                .with_context(|| format!("Response truncated {}/{}", rxlen, txlen))
+        }
+        Ok(())
+    }
+}
+
+impl Target for QEMUSpi {
+    fn get_transfer_mode(&self) -> Result<TransferMode> {
+        unimplemented!();
+    }
+    fn set_transfer_mode(&self, _mode: TransferMode) -> Result<()> {
+        unimplemented!();
+    }
+
+    fn get_bits_per_word(&self) -> Result<u32> {
+        Ok(8)
+    }
+    fn set_bits_per_word(&self, bits_per_word: u32) -> Result<()> {
+        match bits_per_word {
+            8 => Ok(()),
+            _ => Err(SpiError::InvalidWordSize(bits_per_word).into()),
+        }
+    }
+
+    fn get_max_speed(&self) -> Result<u32> {
+        Ok(10_000_000)
+    }
+    fn set_max_speed(&self, frequency: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_max_transfer_count(&self) -> Result<usize> {
+        // Arbitrary value
+        Ok(42)
+    }
+
+    fn get_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        Ok(MaxSizes {
+            read: Self::MAX_FLASH_DATA_LEN,
+            write: Self::MAX_FLASH_DATA_LEN,
+        })
+    }
+
+    fn set_voltage(&self, voltage: Voltage) -> Result<()> {
+        Ok(())
+    }
+
+    fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
+        match transaction {
+            [] => (),
+            [Transfer::Write(wbuf), Transfer::Read(rbuf)] => {
+                ensure!(
+                    wbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                ensure!(
+                    rbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(rbuf.len())
+                );
+                self.transmit(wbuf, rbuf, true)?;
+            }
+            [Transfer::Write(wbuf)] => {
+                ensure!(
+                    wbuf.len() <= Self::MAX_FLASH_DATA_LEN,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                let mut rbuf = [0u8; 0];
+                self.transmit(wbuf, &mut rbuf, true)?;
+            }
+            _ => bail!(SpiError::InvalidTransferMode(
+                "Unsupported combination".to_string()
+            )),
+        }
+        Ok(())
+    }
+
+    fn get_eeprom_max_transfer_sizes(&self) -> Result<MaxSizes> {
+        Ok(MaxSizes {
+            read: self.max_chunk_size,
+            write: self.max_chunk_size,
+        })
+    }
+
+    fn run_eeprom_transactions(&self, transactions: &mut [eeprom::Transaction]) -> Result<()> {
+        self.do_run_eeprom_transactions(transactions)
+    }
+
+    fn assert_cs(self: Rc<Self>) -> Result<AssertChipSelect> {
+        unimplemented!();
+    }
+
+    fn supports_bidirectional_transfer(&self) -> Result<bool> {
+        Ok(true)
+    }
+}


### PR DESCRIPTION
This PR adds QEMU connectivity for SPI device to `opentitanlib` / `opentitantool`.

It can be tested with https://github.com/lowRISC/qemu/commit/335013f072c6c587d2b703a10339e0d24cd731fd & https://github.com/lowRISC/qemu/pull/38

To enable SPI dev support on Earlgrey, two options should be defined:
````sh
./qemu-system-riscv32 -M ot-earlgrey,no_epmp_cfg=true -nographic
-chardev socket,id=spidev,host=localhost,port=8004,server=on,wait=off \
-global ot-spi_device.chardev=spidev \
-kernel spidev-flash-test
````

Test example:
````sh
bazel-out/k8-fastbuild/bin/sw/host/opentitantool/opentitantool --logging info --interface qemu spi sfdp
bazel-out/k8-fastbuild/bin/sw/host/opentitantool/opentitantool --logging info --interface qemu spi program LICENSE
````
