### PR TITLE
[mbx,dif] Initial implementation of the mailbox DIF

### DIFF
--- a/sw/ip/mbx/dif/dif_mbx.c
+++ b/sw/ip/mbx/dif/dif_mbx.c
@@ -4,6 +4,7 @@
 
 #include "sw/ip/mbx/dif/dif_mbx.h"
 
+#include "sw/lib/sw/device/base/abs_mmio.h"
 #include "sw/lib/sw/device/base/memory.h"
 #include "sw/lib/sw/device/base/mmio.h"
 
@@ -55,5 +56,58 @@ dif_result_t dif_mbx_range_get(const dif_mbx_t *mbx,
       mmio_region_read32(mbx->base_addr, MBX_OUTBOUND_BASE_ADDRESS_REG_OFFSET);
   config->ombx_limit_addr =
       mmio_region_read32(mbx->base_addr, MBX_OUTBOUND_LIMIT_ADDRESS_REG_OFFSET);
+  return kDifOk;
+}
+
+dif_result_t dif_mbx_is_busy(const dif_mbx_t *mbx, bool *is_busy) {
+  if (mbx == NULL || is_busy == NULL) {
+    return kDifBadArg;
+  }
+
+  *is_busy = bitfield_bit32_read(
+      mmio_region_read32(mbx->base_addr, MBX_STATUS_REG_OFFSET),
+      MBX_STATUS_BUSY_BIT);
+  return kDifOk;
+}
+
+dif_result_t dif_mbx_process_request(const dif_mbx_t *mbx,
+                                     dif_mbx_transaction_t *request) {
+  if (mbx == NULL || request == NULL || request->data_dwords == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t curr_ptr =
+      mmio_region_read32(mbx->base_addr, MBX_INBOUND_BASE_ADDRESS_REG_OFFSET);
+  uint32_t imbx_wr_ptr =
+      mmio_region_read32(mbx->base_addr, MBX_INBOUND_WRITE_PTR_REG_OFFSET);
+
+  // Read from base until the write pointer.
+  request->nr_dwords = 0;
+  while (curr_ptr < imbx_wr_ptr) {
+    request->data_dwords[request->nr_dwords++] = abs_mmio_read32(curr_ptr);
+    curr_ptr += sizeof(uint32_t);
+  }
+  return kDifOk;
+}
+
+dif_result_t dif_mbx_generate_response(const dif_mbx_t *mbx,
+                                       const dif_mbx_transaction_t response) {
+  uint32_t curr_ptr;
+
+  if (mbx == NULL || response.data_dwords == NULL ||
+      response.nr_dwords > DOE_MAILBOX_MAX_OBJECT_SIZE) {
+    return kDifBadArg;
+  }
+
+  curr_ptr =
+      mmio_region_read32(mbx->base_addr, MBX_OUTBOUND_READ_PTR_REG_OFFSET);
+  for (uint32_t i = 0; i < response.nr_dwords; ++i) {
+    abs_mmio_write32(curr_ptr, response.data_dwords[i]);
+    curr_ptr += sizeof(uint32_t);
+  }
+
+  mmio_region_write32(mbx->base_addr, MBX_OUTBOUND_OBJECT_SIZE_REG_OFFSET,
+                      response.nr_dwords);
+
   return kDifOk;
 }

--- a/sw/ip/mbx/dif/dif_mbx.c
+++ b/sw/ip/mbx/dif/dif_mbx.c
@@ -3,3 +3,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/ip/mbx/dif/dif_mbx.h"
+
+#include "sw/lib/sw/device/base/memory.h"
+#include "sw/lib/sw/device/base/mmio.h"
+
+#include "mbx_regs.h"  // Generated.
+
+dif_result_t dif_mbx_range_set(const dif_mbx_t *mbx,
+                               dif_mbx_range_config_t config) {
+  if (mbx == NULL) {
+    return kDifBadArg;
+  }
+  if (config.imbx_base_addr >= config.imbx_limit_addr) {
+    return kDifBadArg;
+  }
+  if (config.ombx_base_addr >= config.ombx_limit_addr) {
+    return kDifBadArg;
+  }
+  // Check that the inbound mailbox and outbound mailbox memory ranges collide
+  // with each other.
+  if ((config.imbx_base_addr < config.ombx_limit_addr) &&
+      (config.ombx_base_addr < config.imbx_limit_addr)) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(mbx->base_addr, MBX_INBOUND_BASE_ADDRESS_REG_OFFSET,
+                      config.imbx_base_addr);
+  mmio_region_write32(mbx->base_addr, MBX_INBOUND_LIMIT_ADDRESS_REG_OFFSET,
+                      config.imbx_limit_addr);
+  mmio_region_write32(mbx->base_addr, MBX_OUTBOUND_BASE_ADDRESS_REG_OFFSET,
+                      config.ombx_base_addr);
+  mmio_region_write32(mbx->base_addr, MBX_OUTBOUND_LIMIT_ADDRESS_REG_OFFSET,
+                      config.ombx_limit_addr);
+  // Indicate the range configuration to be valid.
+  mmio_region_write32(mbx->base_addr, MBX_ADDRESS_RANGE_VALID_REG_OFFSET, 1);
+
+  return kDifOk;
+}
+
+dif_result_t dif_mbx_range_get(const dif_mbx_t *mbx,
+                               dif_mbx_range_config_t *config) {
+  if (mbx == NULL || config == NULL) {
+    return kDifBadArg;
+  }
+
+  config->imbx_base_addr =
+      mmio_region_read32(mbx->base_addr, MBX_INBOUND_BASE_ADDRESS_REG_OFFSET);
+  config->imbx_limit_addr =
+      mmio_region_read32(mbx->base_addr, MBX_INBOUND_LIMIT_ADDRESS_REG_OFFSET);
+  config->ombx_base_addr =
+      mmio_region_read32(mbx->base_addr, MBX_OUTBOUND_BASE_ADDRESS_REG_OFFSET);
+  config->ombx_limit_addr =
+      mmio_region_read32(mbx->base_addr, MBX_OUTBOUND_LIMIT_ADDRESS_REG_OFFSET);
+  return kDifOk;
+}

--- a/sw/ip/mbx/dif/dif_mbx.h
+++ b/sw/ip/mbx/dif/dif_mbx.h
@@ -30,6 +30,20 @@ typedef struct dif_mbx_range_config {
 } dif_mbx_range_config_t;
 
 /**
+ * A DOE transaction is allowed to have at maximum 1024 double words (32-bit
+ * each)
+ */
+#define DOE_MAILBOX_MAX_OBJECT_SIZE 1024
+
+/**
+ * DOE object transferred on the inbound or outbound mailbox.
+ */
+typedef struct dif_mbx_transaction {
+  uint32_t *data_dwords;
+  uint32_t nr_dwords;
+} dif_mbx_transaction_t;
+
+/**
  * Configures the mailbox inbound and outbound ranges and validates them.
  *
  * @param mbx A DOE Mailbox handle.
@@ -41,6 +55,16 @@ dif_result_t dif_mbx_range_set(const dif_mbx_t *mbx,
                                dif_mbx_range_config_t config);
 
 /**
+ * Returns whether the mailbox is busy or not.
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param[out] is_busy True if the mailbox is busy, false if not.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_is_busy(const dif_mbx_t *mbx, bool *is_busy);
+
+/**
  * Reads the mailbox range configuration.
  *
  * @param mbx A DOE Mailbox handle.
@@ -50,6 +74,28 @@ dif_result_t dif_mbx_range_set(const dif_mbx_t *mbx,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_mbx_range_get(const dif_mbx_t *mbx,
                                dif_mbx_range_config_t *config);
+
+/**
+ * Host reads the DoE Mailbox request from internal SRAM
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param[out] request DOE object read from the internal SRAM.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_process_request(const dif_mbx_t *mbx_host,
+                                     dif_mbx_transaction_t *request);
+
+/**
+ * Host writes the DoE Mailbox response to the internal SRAM
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param response DOE object written to the the internal SRAM.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_generate_response(const dif_mbx_t *mbx,
+                                       const dif_mbx_transaction_t response);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/ip/mbx/dif/dif_mbx.h
+++ b/sw/ip/mbx/dif/dif_mbx.h
@@ -5,6 +5,54 @@
 #ifndef OPENTITAN_SW_IP_MBX_DIF_DIF_MBX_H_
 #define OPENTITAN_SW_IP_MBX_DIF_DIF_MBX_H_
 
+/**
+ * @file
+ * @brief <a href="/hw/ip/mbx/doc/">DOE Mailbox</a> Device Interface
+ * Functions
+ */
+#include <stdint.h>
+
 #include "sw/ip/mbx/dif/autogen/dif_mbx_autogen.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Inbound and outbound range for DOE Mailbox.
+ */
+typedef struct dif_mbx_range_config {
+  // Fields, if necessary.
+  uint32_t imbx_base_addr;
+  uint32_t imbx_limit_addr;
+  uint32_t ombx_base_addr;
+  uint32_t ombx_limit_addr;
+} dif_mbx_range_config_t;
+
+/**
+ * Configures the mailbox inbound and outbound ranges and validates them.
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param config Mailbox inbound and outbound range configuration.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_range_set(const dif_mbx_t *mbx,
+                               dif_mbx_range_config_t config);
+
+/**
+ * Reads the mailbox range configuration.
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param[out] config Mailbox inbound and outbound range configuration.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_range_get(const dif_mbx_t *mbx,
+                               dif_mbx_range_config_t *config);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_IP_MBX_DIF_DIF_MBX_H_

--- a/sw/ip/mbx/dif/dif_mbx_unittest.cc
+++ b/sw/ip/mbx/dif/dif_mbx_unittest.cc
@@ -1,0 +1,131 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/ip/mbx/dif/dif_mbx.h"
+
+#include "gtest/gtest.h"
+#include "sw/ip/base/dif/dif_test_base.h"
+#include "sw/lib/sw/device/base/mmio.h"
+#include "sw/lib/sw/device/base/mock_mmio.h"
+
+extern "C" {
+#include "mbx_regs.h"  // Generated.
+}  // extern "C"
+
+namespace dif_mbx_test {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Test;
+
+// Base class for the rest fixtures in this file.
+class MbxTest : public testing::Test, public mock_mmio::MmioTest {};
+
+// Base class for the rest of the tests in this file, provides a
+// `dif_mbx_t` instance.
+class MbxTestInitialized : public MbxTest {
+ protected:
+  dif_mbx_t mbx_;
+
+  MbxTestInitialized() { EXPECT_DIF_OK(dif_mbx_init(dev().region(), &mbx_)); }
+};
+
+class MemoryRangeSuccessTests
+    : public MbxTestInitialized,
+      public testing::WithParamInterface<dif_mbx_range_config_t> {};
+
+TEST_P(MemoryRangeSuccessTests, SetSuccess) {
+  dif_mbx_range_config_t range = GetParam();
+
+  EXPECT_WRITE32(MBX_INBOUND_BASE_ADDRESS_REG_OFFSET, range.imbx_base_addr);
+  EXPECT_WRITE32(MBX_INBOUND_LIMIT_ADDRESS_REG_OFFSET, range.imbx_limit_addr);
+  EXPECT_WRITE32(MBX_OUTBOUND_BASE_ADDRESS_REG_OFFSET, range.ombx_base_addr);
+  EXPECT_WRITE32(MBX_OUTBOUND_LIMIT_ADDRESS_REG_OFFSET, range.ombx_limit_addr);
+  EXPECT_WRITE32(MBX_ADDRESS_RANGE_VALID_REG_OFFSET, 1);
+
+  EXPECT_DIF_OK(dif_mbx_range_set(&mbx_, range));
+}
+
+INSTANTIATE_TEST_SUITE_P(MemoryRangeSuccessTests, MemoryRangeSuccessTests,
+                         testing::ValuesIn(std::vector<dif_mbx_range_config_t>{{
+                             {.imbx_base_addr = 0xD0CF2C50,
+                              .imbx_limit_addr = 0xD1CF2C0F,
+                              .ombx_base_addr = 0xD1CF3C0F,
+                              .ombx_limit_addr = 0xD1CF3C10},
+                             {.imbx_base_addr = 0x1000,
+                              .imbx_limit_addr = 0x2000,
+                              .ombx_base_addr = 0x3000,
+                              .ombx_limit_addr = 0x4000},
+                             {.imbx_base_addr = 0x1000,
+                              .imbx_limit_addr = 0x1001,
+                              .ombx_base_addr = 0x1001,
+                              .ombx_limit_addr = 0x1002},
+                         }}));
+
+class MemoryRangeBadArgTests
+    : public MbxTestInitialized,
+      public testing::WithParamInterface<dif_mbx_range_config_t> {};
+
+TEST_P(MemoryRangeBadArgTests, SetBadArg) {
+  dif_mbx_range_config_t range = GetParam();
+
+  EXPECT_DIF_BADARG(dif_mbx_range_set(&mbx_, range));
+}
+
+INSTANTIATE_TEST_SUITE_P(MemoryRangeBadArgTests, MemoryRangeBadArgTests,
+                         testing::ValuesIn(std::vector<dif_mbx_range_config_t>{{
+                             {.imbx_base_addr = 0x1000,
+                              .imbx_limit_addr = 0,
+                              .ombx_base_addr = 0x2000,
+                              .ombx_limit_addr = 0x4000},
+                             {.imbx_base_addr = 0x1000,
+                              .imbx_limit_addr = 0x5000,
+                              .ombx_base_addr = 0x4000,
+                              .ombx_limit_addr = 0x4000},
+                             {.imbx_base_addr = 0x1000,
+                              .imbx_limit_addr = 0x2000,
+                              .ombx_base_addr = 0x1500,
+                              .ombx_limit_addr = 0x2500},
+                             {.imbx_base_addr = 0x1500,
+                              .imbx_limit_addr = 0x2500,
+                              .ombx_base_addr = 0x1000,
+                              .ombx_limit_addr = 0x2000},
+                         }}));
+
+TEST_F(MemoryRangeBadArgTests, GetBadArg) {
+  dif_mbx_range_config_t range;
+
+  EXPECT_DIF_BADARG(dif_mbx_range_set(nullptr, range));
+}
+
+class MemoryRangeTests : public MbxTestInitialized {};
+
+TEST_F(MemoryRangeTests, GetSuccess) {
+  dif_mbx_range_config_t range = {.imbx_base_addr = 0xD0CF2C50,
+                                  .imbx_limit_addr = 0xD1CF2C0F,
+                                  .ombx_base_addr = 0xD1CF3C0F,
+                                  .ombx_limit_addr = 0xD1CF3C19};
+
+  EXPECT_READ32(MBX_INBOUND_BASE_ADDRESS_REG_OFFSET, range.imbx_base_addr);
+  EXPECT_READ32(MBX_INBOUND_LIMIT_ADDRESS_REG_OFFSET, range.imbx_limit_addr);
+  EXPECT_READ32(MBX_OUTBOUND_BASE_ADDRESS_REG_OFFSET, range.ombx_base_addr);
+  EXPECT_READ32(MBX_OUTBOUND_LIMIT_ADDRESS_REG_OFFSET, range.ombx_limit_addr);
+
+  dif_mbx_range_config_t read_range;
+  EXPECT_DIF_OK(dif_mbx_range_get(&mbx_, &read_range));
+
+  EXPECT_EQ(read_range.imbx_base_addr, range.imbx_base_addr);
+  EXPECT_EQ(read_range.imbx_limit_addr, range.imbx_limit_addr);
+  EXPECT_EQ(read_range.ombx_base_addr, range.ombx_base_addr);
+  EXPECT_EQ(read_range.ombx_limit_addr, range.ombx_limit_addr);
+}
+
+TEST_F(MemoryRangeTests, GetBadArg) {
+  dif_mbx_range_config_t range;
+
+  EXPECT_DIF_BADARG(dif_mbx_range_get(nullptr, &range));
+  EXPECT_DIF_BADARG(dif_mbx_range_get(&mbx_, nullptr));
+}
+
+
+}  // namespace dif_mbx_test

--- a/sw/ip/mbx/dif/dif_mbx_unittest.cc
+++ b/sw/ip/mbx/dif/dif_mbx_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/ip/base/dif/dif_test_base.h"
 #include "sw/lib/sw/device/base/mmio.h"
+#include "sw/lib/sw/device/base/mock_abs_mmio.h"
 #include "sw/lib/sw/device/base/mock_mmio.h"
 
 extern "C" {
@@ -26,6 +27,7 @@ class MbxTest : public testing::Test, public mock_mmio::MmioTest {};
 class MbxTestInitialized : public MbxTest {
  protected:
   dif_mbx_t mbx_;
+  rom_test::MockAbsMmio mmio_;
 
   MbxTestInitialized() { EXPECT_DIF_OK(dif_mbx_init(dev().region(), &mbx_)); }
 };
@@ -127,5 +129,100 @@ TEST_F(MemoryRangeTests, GetBadArg) {
   EXPECT_DIF_BADARG(dif_mbx_range_get(&mbx_, nullptr));
 }
 
+typedef struct status_reg {
+  uint32_t reg;
+  bool is_busy;
+} status_reg_t;
+
+class ProcessBusyTests : public MbxTestInitialized,
+                         public testing::WithParamInterface<status_reg_t> {};
+
+TEST_P(ProcessBusyTests, GetSuccess) {
+  status_reg_t status_arg = GetParam();
+
+  EXPECT_READ32(MBX_STATUS_REG_OFFSET, status_arg.reg);
+
+  bool is_busy = !status_arg.is_busy;
+
+  EXPECT_DIF_OK(dif_mbx_is_busy(&mbx_, &is_busy));
+  EXPECT_EQ(is_busy, status_arg.is_busy);
+}
+
+INSTANTIATE_TEST_SUITE_P(ProcessBusyTests, ProcessBusyTests,
+                         testing::ValuesIn(std::vector<status_reg_t>{{
+                             {0, false},
+                             {1 << MBX_STATUS_BUSY_BIT, true},
+                         }}));
+
+TEST_F(ProcessBusyTests, GetBadArg) {
+  bool is_busy;
+  EXPECT_DIF_BADARG(dif_mbx_is_busy(nullptr, &is_busy));
+  EXPECT_DIF_BADARG(dif_mbx_is_busy(&mbx_, nullptr));
+}
+
+class ProcessRequestTests : public MbxTestInitialized {};
+
+TEST_F(ProcessRequestTests, Success) {
+  dif_mbx_transaction_t request;
+  uint32_t data[4];
+  request.data_dwords = data;
+
+  EXPECT_READ32(MBX_INBOUND_BASE_ADDRESS_REG_OFFSET, 0x1000);
+  EXPECT_READ32(MBX_INBOUND_WRITE_PTR_REG_OFFSET, 0x1010);
+
+  EXPECT_ABS_READ32(0x1000, 0x123456);
+  EXPECT_ABS_READ32(0x1004, 0x456789);
+  EXPECT_ABS_READ32(0x1008, 0xDEADBEEF);
+  EXPECT_ABS_READ32(0x100C, 0xCAFEDEAD);
+
+  EXPECT_DIF_OK(dif_mbx_process_request(&mbx_, &request));
+
+  EXPECT_EQ(request.nr_dwords, 4);
+  EXPECT_EQ(request.data_dwords[0], 0x123456);
+  EXPECT_EQ(request.data_dwords[1], 0x456789);
+  EXPECT_EQ(request.data_dwords[2], 0xDEADBEEF);
+  EXPECT_EQ(request.data_dwords[3], 0xCAFEDEAD);
+}
+
+TEST_F(ProcessRequestTests, BadArg) {
+  dif_mbx_transaction_t request;
+  request.data_dwords = nullptr;
+  request.nr_dwords = 1;
+
+  EXPECT_DIF_BADARG(dif_mbx_process_request(nullptr, &request));
+  EXPECT_DIF_BADARG(dif_mbx_process_request(&mbx_, nullptr));
+  EXPECT_DIF_BADARG(dif_mbx_process_request(&mbx_, &request));
+}
+
+class ProcessResponseTests : public MbxTestInitialized {};
+
+TEST_F(ProcessResponseTests, Success) {
+  dif_mbx_transaction_t response;
+  std::array<uint32_t, 4> data = {0x123456, 0x456789, 0xDEADBEEF, 0xCAFEDEAD};
+  response.nr_dwords = data.size();
+  response.data_dwords = data.data();
+
+  EXPECT_READ32(MBX_OUTBOUND_READ_PTR_REG_OFFSET, 0x1000);
+  EXPECT_ABS_WRITE32(0x1000, data[0]);
+  EXPECT_ABS_WRITE32(0x1004, data[1]);
+  EXPECT_ABS_WRITE32(0x1008, data[2]);
+  EXPECT_ABS_WRITE32(0x100C, data[3]);
+  EXPECT_WRITE32(MBX_OUTBOUND_OBJECT_SIZE_REG_OFFSET, response.nr_dwords);
+
+  EXPECT_DIF_OK(dif_mbx_generate_response(&mbx_, response));
+}
+
+TEST_F(ProcessResponseTests, BadArg) {
+  dif_mbx_transaction_t response1;
+  response1.nr_dwords = DOE_MAILBOX_MAX_OBJECT_SIZE + 1;
+
+  dif_mbx_transaction_t response2;
+  response2.data_dwords = nullptr;
+  response2.nr_dwords = 1;
+
+  EXPECT_DIF_BADARG(dif_mbx_generate_response(nullptr, response1));
+  EXPECT_DIF_BADARG(dif_mbx_generate_response(&mbx_, response1));
+  EXPECT_DIF_BADARG(dif_mbx_generate_response(&mbx_, response2));
+}
 
 }  // namespace dif_mbx_test

--- a/sw/top_darjeeling/sw/dif/BUILD
+++ b/sw/top_darjeeling/sw/dif/BUILD
@@ -581,6 +581,7 @@ cc_library(
     deps = [
         "//hw/ip/mbx/data:mbx_regs",
         "//sw/ip/base/dif:base",
+        "//sw/lib/sw/device/base:abs_mmio",
         "//sw/lib/sw/device/base:bitfield",
         "//sw/lib/sw/device/base:macros",
         "//sw/lib/sw/device/base:mmio",


### PR DESCRIPTION
This PR adds the initial DIF implementation for the mailbox for the host side.

This PR is a copy-over from https://github.com/lowRISC/opentitan-integrated/pull/642 and incorporates the review.

@engdoreis Can you take a look again and approve if its ok?