### PR TITLE
[dv,dma] Randomized Aborting of DMA transfers

### DIFF
--- a/hw/ip/dma/dv/dma_sim_cfg.hjson
+++ b/hw/ip/dma/dv/dma_sim_cfg.hjson
@@ -69,6 +69,12 @@
       reseed: 5
     }
     {
+      name: dma_abort
+      uvm_test_seq: dma_abort_vseq
+      run_opts: ["+dma_dv_waive_system_bus=1"]
+      reseed: 5
+    }
+    {
       name: dma_generic_stress
       uvm_test_seq: dma_generic_stress_vseq
       run_opts: ["+dma_dv_waive_system_bus=1", "+test_timeout_ns=300_000_000_000"]

--- a/hw/ip/dma/dv/env/dma_env.core
+++ b/hw/ip/dma/dv/env/dma_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/dma_memory_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/dma_handshake_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/dma_memory_region_lock_vseq.sv: {is_include_file: true}
+      - seq_lib/dma_abort_vseq.sv: {is_include_file: true}
       - seq_lib/dma_short_transfer_vseq.sv: {is_include_file: true}
       - seq_lib/dma_intr_vseq.sv: {is_include_file: true}
       - seq_lib/dma_generic_stress_vseq.sv: {is_include_file: true}

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -814,7 +814,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       end
       "status": begin
         bit busy, done, aborted, error, sha2_digest_valid;
-        bit [7:0] error_code;
+        bit [DmaErrLast-1:0] error_code;
         bit exp_aborted = abort_via_reg_write;
         bit bus_error;
 
@@ -823,18 +823,18 @@ class dma_scoreboard extends cip_base_scoreboard #(
         done = get_field_val(ral.status.done, item.d_data);
         aborted = get_field_val(ral.status.aborted, item.d_data);
         error = get_field_val(ral.status.error, item.d_data);
-        error_code[0] = get_field_val(ral.error_code.src_address_error, item.d_data);
-        error_code[1] = get_field_val(ral.error_code.dst_address_error, item.d_data);
-        error_code[2] = get_field_val(ral.error_code.opcode_error, item.d_data);
-        error_code[3] = get_field_val(ral.error_code.size_error, item.d_data);
-        error_code[4] = get_field_val(ral.error_code.bus_error, item.d_data);
-        error_code[5] = get_field_val(ral.error_code.base_limit_error, item.d_data);
-        error_code[6] = get_field_val(ral.error_code.range_valid_error, item.d_data);
-        error_code[7] = get_field_val(ral.error_code.asid_error, item.d_data);
+        error_code[DmaSourceAddrErr] = get_field_val(ral.error_code.src_address_error, item.d_data);
+        error_code[DmaDestAddrErr]   = get_field_val(ral.error_code.dst_address_error, item.d_data);
+        error_code[DmaOpcodeErr]     = get_field_val(ral.error_code.opcode_error, item.d_data);
+        error_code[DmaSizeErr]       = get_field_val(ral.error_code.size_error, item.d_data);
+        error_code[DmaBusErr]        = get_field_val(ral.error_code.bus_error, item.d_data);
+        error_code[DmaBaseLimitErr]  = get_field_val(ral.error_code.base_limit_error, item.d_data);
+        error_code[DmaRangeValidErr] = get_field_val(ral.error_code.range_valid_error, item.d_data);
+        error_code[DmaAsidErr]       = get_field_val(ral.error_code.asid_error, item.d_data);
         sha2_digest_valid = get_field_val(ral.status.sha2_digest_valid, item.d_data);
 
         // Bus errors are distinct from configuration errors.
-        bus_error = error_code[4];
+        bus_error = error_code[DmaBusErr];
 
         if (done || aborted || error) begin
           string reasons;

--- a/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Aborting of both 'memory-to-memory' and 'hardware handshaking' DMA transfers
+class dma_abort_vseq extends dma_generic_vseq;
+  `uvm_object_utils(dma_abort_vseq)
+  `uvm_object_new
+
+  // Constrain number of iterations and transactions in each iteration; since aborting shall also
+  // be exercised in the stress tests, keep this as a fairly short test of functionality.
+  constraint transactions_c {num_txns inside {[4:12]};}
+  constraint num_iters_c {num_iters inside {[2:4]};}
+
+  bit operating;
+
+  // Inter-task signaling
+  event e_start;
+  event e_stopped;
+
+  // Permit only valid configurations for this test; with this sequence we're interested in Aborting
+  // transfers, so generate only configurations that will not be immediately rejected.
+  virtual function bit pick_if_config_valid();
+    return 1'b1;
+  endfunction
+
+  // Choose whether to raise an Abort and, if so, after how many cycles.
+  virtual function bit [15:0] choose_abort_delay();
+    bit raise_abort;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(raise_abort, raise_abort dist { 0 := 20, 1 := 80};)
+    return raise_abort ? $urandom_range(1, 16'h3FF) : 16'b0;
+  endfunction
+
+  // Transaction is commencing
+  virtual task starting_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config);
+    `DV_CHECK_EQ(operating, 1'b0, "Unexpected start of transaction")
+
+    super.starting_txn(txn, num_txns, dma_config);
+
+    operating = 1'b1;
+    // Signal to the parallel test task it should start attempting to Abort the transfer.
+    ->e_start;
+  endtask
+
+  // Transaction has ended
+  virtual task ending_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config,
+                          int status);
+    `DV_CHECK_EQ(operating, 1'b1, "Unexpected end of transaction")
+    // Stop our parallel task
+    operating = 1'b0;
+    wait (e_stopped.triggered);
+  endtask
+
+  // The functionality of this vseq is implemented in `dma_generic_vseq` and restricted
+  // to 'memory-to-memory' transfers in `dma_memory_vseq`
+  virtual task body();
+    // Activate the generation of randomized Abort requests
+    `uvm_info(`gfn, "DMA: Starting Abort Sequence", UVM_LOW)
+    operating = 1'b0;
+    fork
+      // Run generic test body
+      super.body();
+      // Parallel task exercises aborting of DMA transfers
+      forever begin
+        bit [15:0] abort_delay;
+        // Await a signal from the main task, indicating that the range should be locked.
+        wait (e_start.triggered);
+        `DV_CHECK_EQ(operating, 1'b1, "Abort thread triggered unexpectedly")
+        // Decide whether or not to raise an Abort during this transfer and, if so, after how long.
+        abort_delay = choose_abort_delay();
+        if (|abort_delay) begin
+          bit [8:0] abort_timeout = 0;
+          while (operating && abort_delay > 0) begin
+            abort_delay--;
+            if (~|abort_delay) begin
+              // Abort the transfer, and await below to be notified of its completion.
+              abort();
+            end
+            delay(1);
+          end
+          // Aborts shall always be actioned, never ignored.
+          // So, if completion does not occur within a small, finite time period (dominated by
+          // the frequency of DV completion polling), this implies a failure.
+          while (operating) begin
+            abort_timeout++;
+            `DV_CHECK(abort_timeout < 'h100, "Timeout responding to Abort request")
+            delay(1);
+          end
+        end else begin
+          // We've decided not to interrupt this transfer.
+          while (operating) begin
+            delay(100);
+          end
+        end
+        ->e_stopped;
+      end
+    join_any
+    `uvm_info(`gfn, "DMA: Completed Abort Sequence", UVM_LOW)
+  endtask : body
+endclass

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -132,13 +132,8 @@ class dma_generic_vseq extends dma_base_vseq;
         // and programmed into the DMA controller, but before the transfer has commenced.
         starting_txn(j, num_txns, dma_config);
 
-        set_control_register(dma_config.opcode, // OPCODE
-                             1'b1,              // Initial transfer
-                             dma_config.handshake, // Handshake Enable
-                             dma_config.auto_inc_buffer, // Auto-increment Buffer Address
-                             dma_config.auto_inc_fifo, // Auto-increment FIFO Address
-                             dma_config.direction, // Direction
-                             1'b1); // Go
+        // Start the Initial chunk of the transfer.
+        start_chunk(dma_config, 1'b1);
 
         // Keep track of the number of bytes that we've supplied to the DMA controller
         num_bytes_supplied = dma_config.chunk_size(0);
@@ -171,9 +166,7 @@ class dma_generic_vseq extends dma_base_vseq;
                 num_bytes_supplied += dma_config.chunk_size(num_bytes_supplied);
 
                 // Nudge the DMA controller to start processing the next chunk of data
-                ral.control.initial_transfer.set(1'b0);
-                ral.control.go.set(1'b1);
-                csr_update(ral.control);
+                start_chunk(dma_config, 1'b0);
               end else begin
                 `uvm_fatal(`gfn,
                       $sformatf("STATUS.done bit set prematurely (0x%x byte(s) of 0x%x transferred",

--- a/hw/ip/dma/dv/env/seq_lib/dma_vseq_list.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_vseq_list.sv
@@ -11,6 +11,7 @@
 `include "dma_handshake_vseq.sv"
 `include "dma_handshake_smoke_vseq.sv"
 `include "dma_memory_region_lock_vseq.sv"
+`include "dma_abort_vseq.sv"
 `include "dma_generic_stress_vseq.sv"
 `include "dma_memory_stress_vseq.sv"
 `include "dma_handshake_stress_vseq.sv"

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -815,7 +815,7 @@ module dma
           end
           if (reg2hw.transfer_width.q == DmaXfer4BperTxn &&
             (|reg2hw.destination_address_lo.q[1:0])) begin
-            next_error[DmaDestinationAddrErr] = 1'b1;
+            next_error[DmaDestAddrErr] = 1'b1;
           end
 
           // In 2-byte transfers, source and destination address must be 2-byte aligned
@@ -824,13 +824,13 @@ module dma
           end
           if (reg2hw.transfer_width.q == DmaXfer2BperTxn &&
               reg2hw.destination_address_lo.q[0]) begin
-            next_error[DmaDestinationAddrErr] = 1'b1;
+            next_error[DmaDestAddrErr] = 1'b1;
           end
 
           // Source and destination must have the same alignment
           if (reg2hw.source_address_lo.q[1:0] != reg2hw.destination_address_lo.q[1:0]) begin
             next_error[DmaSourceAddrErr] = 1'b1;
-            next_error[DmaDestinationAddrErr] = 1'b1;
+            next_error[DmaDestAddrErr] = 1'b1;
           end
           // If data from the SOC system bus or the control bus is transferred
           // to the OT internal memory, we must check if the destination address range falls into
@@ -844,7 +844,7 @@ module dma
                 ((SYS_ADDR_WIDTH'(reg2hw.destination_address_lo.q) +
                   SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) >
                   SYS_ADDR_WIDTH'(reg2hw.enabled_memory_range_limit.q)))) begin
-            next_error[DmaDestinationAddrErr] = 1'b1;
+            next_error[DmaDestAddrErr] = 1'b1;
           end
 
           // If data from the OT internal memory is transferred  to the SOC system bus or the
@@ -875,7 +875,7 @@ module dma
           if (((reg2hw.address_space_id.destination_asid.q == SocControlAddr) ||
               (reg2hw.address_space_id.destination_asid.q == OtInternalAddr)) &&
               (|reg2hw.destination_address_hi.q)) begin
-            next_error[DmaDestinationAddrErr] = 1'b1;
+            next_error[DmaDestAddrErr] = 1'b1;
           end
 
           if (!reg2hw.range_valid.q) begin
@@ -902,8 +902,8 @@ module dma
         DmaWaitReadResponse: begin
           if (read_rsp_valid) begin
             if (read_rsp_error) begin
-              next_error[DmaCompletionErr] = 1'b1;
-              ctrl_state_d                 = DmaError;
+              next_error[DmaBusErr] = 1'b1;
+              ctrl_state_d          = DmaError;
             end else begin
               capture_return_data = 1'b1;
               // We received data, feed it into the SHA2 engine
@@ -929,8 +929,8 @@ module dma
 
           if (write_rsp_valid) begin
             if (write_rsp_error) begin
-              next_error[DmaCompletionErr] = 1'b1;
-              ctrl_state_d                 = DmaError;
+              next_error[DmaBusErr] = 1'b1;
+              ctrl_state_d          = DmaError;
             end else begin
               // Advance by the number of bytes just transferred
               transfer_byte_d       = transfer_byte_q + TRANSFER_BYTES_WIDTH'(transfer_width_q);
@@ -1287,10 +1287,10 @@ module dma
     hw2reg.error_code.asid_error.de        = (ctrl_state_d == DmaError) | clear_status;
 
     hw2reg.error_code.src_address_error.d  = clear_status? '0 : next_error[DmaSourceAddrErr];
-    hw2reg.error_code.dst_address_error.d  = clear_status? '0 : next_error[DmaDestinationAddrErr];
+    hw2reg.error_code.dst_address_error.d  = clear_status? '0 : next_error[DmaDestAddrErr];
     hw2reg.error_code.opcode_error.d       = clear_status? '0 : next_error[DmaOpcodeErr];
     hw2reg.error_code.size_error.d         = clear_status? '0 : next_error[DmaSizeErr];
-    hw2reg.error_code.bus_error.d          = clear_status? '0 : next_error[DmaCompletionErr];
+    hw2reg.error_code.bus_error.d          = clear_status? '0 : next_error[DmaBusErr];
     hw2reg.error_code.base_limit_error.d   = clear_status? '0 : next_error[DmaBaseLimitErr];
     hw2reg.error_code.range_valid_error.d  = clear_status? '0 : next_error[DmaRangeValidErr];
     hw2reg.error_code.asid_error.d         = clear_status? '0 : next_error[DmaAsidErr];

--- a/hw/ip/dma/rtl/dma_pkg.sv
+++ b/hw/ip/dma/rtl/dma_pkg.sv
@@ -10,10 +10,10 @@ package dma_pkg;
   // Possible error bits the DMA can raise
   typedef enum logic [3:0] {
     DmaSourceAddrErr,
-    DmaDestinationAddrErr,
+    DmaDestAddrErr,
     DmaOpcodeErr,
     DmaSizeErr,
-    DmaCompletionErr,
+    DmaBusErr,
     DmaBaseLimitErr,
     DmaRangeValidErr,
     DmaAsidErr,


### PR DESCRIPTION
This PR introduces a further DMA vseq to abort DMA transfers randomly.

Deriving from the 'generic' sequence, it can abort DMA transfers having any valid configuration, ie. memory-to-memory and hardware handshaking operations, with or without inline SHA digest calculations.

The vseq uses a parallel thread that executes concurrently with the FW-mimic/transfer control, and a semaphore is therefore introduced to control multithreaded access to the CONTROL register, preventing races in the RAL modifications. The logic in 'set_control' is re-expressed to reduce contention/conflict between the two threads, the scoreboard logic is modified with an awareness that Aborting overrides the starting of chunks/transfers.

It's also important to note that requesting Abort does not guarantee that test completion will report 'aborted' status because the DMA controller could have been on the verge of completing the transfer.

The vseq has an apparent 100% pass rate without further RTL changes (issues observed during its development have already been resolved and merged).