### PR TITLE
[ci] Move documentation build from quick-lints to slow-lints

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,8 +105,6 @@ jobs:
   - bash: ci/scripts/whitespace.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check trailing whitespace
-  - bash: ci/scripts/build-docs.sh
-    displayName: Render documentation
   - bash: ci/scripts/check-links.sh
     displayName: Check File Links
   - bash: ci/scripts/check-cmdgen.sh
@@ -153,6 +151,8 @@ jobs:
   - bash:  ci/scripts/check_bazel_target_names.py
     displayName: Check Bazel target names (Experimental)
     continueOnError: True
+  - bash: ci/scripts/build-docs.sh
+    displayName: Render documentation
   # Define OT_DESTRUCTIVE=1 to enable ci/scripts/check-generated.sh to delete
   # uncommitted changes.
   - bash: OT_DESTRUCTIVE=1 ci/scripts/check-generated.sh

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -61,9 +61,6 @@ ci/scripts/rust-format.sh $tgt_branch
 echo -e "\n### Run shellcheck on all shell scripts"
 util/sh/scripts/run-shellcheck.sh
 
-echo -e "\n### Render documentation"
-ci/scripts/build-docs.sh
-
 echo -e "\n### Render landing site"
 ci/scripts/build-site.sh
 

--- a/ci/jobs/slow-lint.sh
+++ b/ci/jobs/slow-lint.sh
@@ -17,6 +17,9 @@ ci/scripts/check-bazel-tags.sh
 echo -e "\n### Ensure bazel doesn't use 'git_repository's"
 ci/scripts/check-bazel-banned-rules.sh
 
+echo -e "\n### Render documentation"
+ci/scripts/build-docs.sh
+
 echo -e "\n### Ensure all generated files are clean and up-to-date"
 ci/scripts/check-generated.sh
 


### PR DESCRIPTION
This step takes ~5 minutes and isn't very quick. All other CI jobs are gated on quick lints, so we do want them to be as fast as possible.