### PR TITLE
[cryptotest] Add NIST ECDSA test vectors and parser

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,6 +114,10 @@ xkcp_repos()
 load("//third_party/hsm:repos.bzl", "hsm_repos")
 hsm_repos()
 
+# NIST CAVP Test Vectors
+load("//third_party/nist_cavp_testvectors:repos.bzl", "nist_cavp_repos")
+nist_cavp_repos()
+
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+genrule(
+    name = "nist_cavp_ecdsa_fips_186_4_sig_ver_json",
+    srcs = [
+        "@nist_cavp_ecdsa_fips_186_4//:SigVer.rsp",
+        "//sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema",
+    ],
+    outs = ["nist_cavp_ecdsa_fips_186_4_sig_ver.json"],
+    cmd = """$(location //sw/host/cryptotest/testvectors/parsers:nist_cavp_ecdsa_parser) \
+            --src $(location @nist_cavp_ecdsa_fips_186_4//:SigVer.rsp) \
+            --dst $(RULEDIR)/nist_cavp_ecdsa_fips_186_4_sig_ver \
+            --schema $(location //sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema)""",
+    message = "Parsing testvector - NIST CAVP Digital Signatures FIPS 186-4 - ECDSA",
+    tools = ["//sw/host/cryptotest/testvectors/parsers:nist_cavp_ecdsa_parser"],
+    visibility = ["//visibility:public"],
+)

--- a/sw/host/cryptotest/testvectors/data/README.md
+++ b/sw/host/cryptotest/testvectors/data/README.md
@@ -1,0 +1,18 @@
+# Cryptotest Test Vectors
+
+## ECDSA
+
+### NIST CAVP ECDSA FIPS 186-4 Test Vectors
+
+Source: [NIST CAVP Digital Signatures Page](https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/digital-signatures)
+
+We are using the following tests:
+
+- Signature Verification (`SigVer.rsp`)
+
+Unused tests:
+
+- Key Pair Generation (`KeyPair.rsp`): cryptolib does not support key generation for a specified private key
+- Public Key Validation Test (`PKV.rsp`): cryptolib does not expose a key validation function
+- Signature Generation (`SigGen.txt`): cryptolib does not allow specifying `k`, the per-message secret number.
+    - The download also includes `SigGen.rsp` which contains the same test vectors but omits `d` (the private key) and `k`.

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -8,3 +8,8 @@ filegroup(
     name = "aes_block_schema",
     srcs = ["aes_block_schema.json"],
 )
+
+filegroup(
+    name = "ecdsa_sig_ver_schema",
+    srcs = ["ecdsa_sig_ver_schema.json"],
+)

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/aes_block_schema.json",
+  "title": "Cryptotest ECDSA Signature Verification Test Vector",
+  "description": "A list of testvectors for ECDSA Signature Verification testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "algorithm": {
+        "description": "Should be ecdsa",
+        "type": "string",
+        "enum": ["ecdsa"]
+      },
+      "operation": {
+        "description": "ECDSA operation",
+        "type": "string",
+        "enum": ["verify"]
+      },
+      "curve": {
+        "description": "Curve type",
+        "type": "string",
+        "enum": ["p-256", "p-384"]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm",
+        "type": "string",
+        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512"]
+      },
+      "message": {
+        "description": "Message to be verified",
+        "$ref": "#/$defs/byte_array"
+      },
+      "qx": {
+        "description": "Qx",
+        "type": "integer"
+      },
+      "qy": {
+        "description": "Qy",
+        "type": "integer"
+      },
+      "r": {
+        "description": "r parameter",
+        "type": "integer"
+      },
+      "s": {
+        "description": "s parameter",
+        "type": "integer"
+      },
+      "result": {
+        "description": "Verification result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -19,3 +19,13 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "nist_cavp_ecdsa_parser",
+    srcs = ["nist_cavp_ecdsa_parser.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP Digital Signatures test vectors to JSON.
+
+"""
+# TODO: Add more detailed docstring
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+SUPPORTED_NIST_CURVES = ["P-256", "P-384"]
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+
+    # NIST splits the rsp files into sections with named after (curve, hash
+    # algorithm) pairs
+    for section_name in raw_testcases.keys():
+        curve, hash_alg = section_name.split(",")
+        if curve not in SUPPORTED_NIST_CURVES:
+            continue
+        for test_vec in raw_testcases[section_name]:
+            test_case = {
+                "algorithm": "ecdsa",
+                "operation": "verify",
+                "curve": curve.lower(),
+                "hash_alg": hash_alg.lower(),
+                "message": str_to_byte_array(test_vec["Msg"]),
+                "qx": int(test_vec["Qx"], 16),
+                "qy": int(test_vec["Qy"], 16),
+                "r": int(test_vec["R"], 16),
+                "s": int(test_vec["S"], 16),
+            }
+
+            # NIST test vectors express the expected result as a string with a
+            # short description of the particular failure mode (if applicable).
+            # We can extract the pass/fail condition by checking the first
+            # character of the result field.
+            # Example passing vector: Result = P (0 )
+            # Example failing vector: Result = F (3 - S Changed)
+            result_str = test_vec["Result"][0]
+            if result_str == "P":
+                test_case["result"] = True
+            elif result_str == "F":
+                test_case["result"] = False
+            else:
+                raise ValueError(f"Unknown verification result value: {result_str}")
+
+            test_cases.append(test_case)
+
+    json_filename = f"{args.dst}.json"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/nist_cavp_testvectors/BUILD
+++ b/third_party/nist_cavp_testvectors/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/nist_cavp_testvectors/BUILD.nist_cavp_common.bazel
+++ b/third_party/nist_cavp_testvectors/BUILD.nist_cavp_common.bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def nist_cavp_repos():
+    http_archive(
+        name = "nist_cavp_ecdsa_fips_186_4",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        strip_prefix = "186-4ecdsatestvectors",
+        sha256 = "fe47cc92b4cee418236125c9ffbcd9bb01c8c34e74a4ba195d954bcb72824752",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-4ecdsatestvectors.zip",
+    )


### PR DESCRIPTION
This PR adds the NIST ECDSA test vectors as a Bazel third-party dependency and adds a parser for them.