### PR TITLE
[dv,dma] Bring up of 'Clear Interrupt' traffic

### DIFF
--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -45,8 +45,8 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
   mem_model#(.AddrWidth(CTN_ADDR_WIDTH), .DataWidth(CTN_DATA_WIDTH)) mem_ctn;
   mem_model#(.AddrWidth(SYS_ADDR_WIDTH), .DataWidth(SYS_DATA_WIDTH)) mem_sys;
 
-  // Associative array with mapping of ASID encoding to interface name
-  string asid_interface_map[asid_encoding_e];
+  // Associative array with mapping of ASID encoding to interface name; for textual output.
+  string asid_names[asid_encoding_e];
 
   // Constraints
   //  TODO
@@ -69,9 +69,9 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
       dma_dir_fifo[fifo_names[i]] = $sformatf("tl_dir_%s_fifo", fifo_names[i]);
     end
     // Initialize mapping
-    asid_interface_map[OtInternalAddr] = "host";
-    asid_interface_map[SocControlAddr] = "ctn";
-    asid_interface_map[SocSystemAddr] = "sys";
+    asid_names[OtInternalAddr] = "host";
+    asid_names[SocControlAddr] = "ctn";
+    asid_names[SocSystemAddr]  = "sys";
 
     // Initialize cip_base_env_cfg
     super.initialize(csr_base_addr);

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -82,7 +82,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
     if (!dma_config.randomize()) begin
       `uvm_fatal(`gfn, "Failed to randomize dma_config")
     end
-  endfunction: build_phase
+  endfunction : build_phase
 
   // Check if address is valid, and indicate whether it's a 'clear interrupt' address.
   // This method is common for both source and destination address.
@@ -170,8 +170,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       // Check if the transaction has correct mask
       `DV_CHECK_EQ($countones(item.a_mask), 4) // Always 4B
       // Check source ASID for read transaction
-      `DV_CHECK_EQ(if_name,
-                   cfg.asid_interface_map[dma_config.src_asid],
+      `DV_CHECK_EQ(if_name, cfg.asid_names[dma_config.src_asid],
                    $sformatf("Unexpected read txn on %s interface with source ASID %s",
                              if_name, dma_config.src_asid.name()))
       // Check if opcode is as expected
@@ -221,8 +220,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
                              item.a_mask, expected_per_txn_bytes, exp_a_mask_count_ones))
 
       // Check destination ASID for write transaction
-      `DV_CHECK_EQ(if_name,
-                   cfg.asid_interface_map[dma_config.dst_asid],
+      `DV_CHECK_EQ(if_name, cfg.asid_names[dma_config.dst_asid],
                    $sformatf("Unexpected write txn on %s interface with destination ASID %s",
                              if_name, dma_config.dst_asid.name()))
       // Check if the transaction address is in destination address range

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -378,8 +378,9 @@ class dma_scoreboard extends cip_base_scoreboard #(
       dst_queue.delete(queue_idx);
     end
 
-    // Errors are expected to raise an interrupt if enabled
-    exp_dma_err_intr = item.d_error & intr_enable_error;
+    // Errors are expected to raise an interrupt if enabled, but we not must forget a configuration
+    // error whilst error-free 'clear interrupt' writes are occurring.
+    exp_dma_err_intr = exp_dma_err_intr | (item.d_error & intr_enable_error);
   endtask
 
   // Method to process requests on TL interfaces
@@ -810,7 +811,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
           dma_config.is_valid_config = dma_config.check_config("scoreboard starting transfer");
           `uvm_info(`gfn, $sformatf("dma_config.is_valid_config = %b",
                                     dma_config.is_valid_config), UVM_MEDIUM)
-          exp_dma_err_intr = !dma_config.is_valid_config;
+          exp_dma_err_intr = !dma_config.is_valid_config & intr_enable_error;
           // Expect digest to be cleared even for rejected configurations
           exp_digest = '{default:0};
           if (cfg.en_cov) begin

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -358,11 +358,13 @@ class dma_base_vseq extends cip_base_vseq #(
                                  dma_config.mem_range_lock);
   endtask : run_common_config
 
-  // Task: Enable Interrupt
-  task enable_interrupt();
-    `uvm_info(`gfn, "DMA: Assert Interrupt Enable", UVM_HIGH)
-    csr_wr(ral.intr_enable, (1 << ral.intr_enable.get_n_bits()) - 1);
-  endtask : enable_interrupt
+  // Task: Enable/Disable Interrupt(s)
+  task enable_interrupts(bit [31:0] interrupts = 32'hFFFF_FFFF, bit enable = 1'b1);
+    string action;
+    action = enable ? "Enable" : "Disable";
+    `uvm_info(`gfn, $sformatf("DMA: %s interrupt(s) 0x%0x", action, interrupts), UVM_HIGH)
+    cfg_interrupts(interrupts, enable);
+  endtask : enable_interrupts
 
   // Clear one or more interrupts
   task clear_interrupts(bit [31:0] clear);
@@ -775,6 +777,6 @@ class dma_base_vseq extends cip_base_vseq #(
   // Body: Need to override for inherited tests
   task body();
     init_model();
-    enable_interrupt();
+    enable_interrupts();
   endtask : body
 endclass

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -426,11 +426,9 @@ class dma_base_vseq extends cip_base_vseq #(
   // Task: Start TLUL Sequences
   virtual task start_device(ref dma_seq_item dma_config);
     if (dma_config.handshake) begin
-      // Assign memory models used in tl_device_vseq instances
+      // Will the test sequence generate any interrupts?
       bit [31:0] fifo_interrupt_mask;
       bit fifo_intr_clear_en;
-      bit [31:0] fifo_intr_clear_reg_addr;
-      bit [31:0] fifo_intr_clear_val;
       // Variable to check if any of the handshake interrupts are asserted
       fifo_interrupt_mask = dma_config.handshake_intr_en & cfg.dma_vif.handshake_i;
       `uvm_info(`gfn, $sformatf("FIFO interrupt enable mask = %0x ", fifo_interrupt_mask),
@@ -439,7 +437,9 @@ class dma_base_vseq extends cip_base_vseq #(
       // Set fifo enable bit
       set_seq_fifo_read_mode(dma_config.src_asid, dma_config.get_read_fifo_en());
       set_seq_fifo_write_mode(dma_config.dst_asid, dma_config.get_write_fifo_en());
-      // Get FIFO register clear enable
+
+      // TODO: there may be some merit at some point to starting handshaking transfers when
+      // interrupts cannot occur, but only if we're expecting to abort transfers, for example.
       if (fifo_intr_clear_en) begin
         // Get FIFO interrupt register address and value
         // Find the interrupt index with both handshake interrupt enable and clear_int_src

--- a/hw/ip/dma/dv/env/seq_lib/dma_handshake_smoke_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_handshake_smoke_vseq.sv
@@ -30,7 +30,6 @@ class dma_handshake_smoke_vseq extends dma_handshake_vseq;
       per_transfer_width == DmaXfer4BperTxn; // Limit to only 4B transfers
       handshake == 1'b1; // Enable hardware handshake mode
       handshake_intr_en != 0; // At least one handshake interrupt signal must be enabled
-      clear_int_src == 0; // Disable clearing of FIFO interrupt
       opcode == OpcCopy;) // Avoid any involved operations such as SHA2 hashing
     `uvm_info(`gfn, $sformatf("DMA: Randomized a new transaction:%s",
                               dma_config.convert2string()), UVM_MEDIUM)


### PR DESCRIPTION
This PR makes the changes necessary to enable the 'Clear Interrupt' write traffic in all sequences/configurations.

**Commit 1:** No functional change

**Commit 2:** Modify the way that the scoreboard differentiates 'Clear Interrupt' traffic from regular bus traffic

**Commit 3:** Restructure the checking of read/write traffic to avoid crosstalk between 'Clear Interrupt' traffic and regular bus traffic. This is mostly code migration, moving into the 'write data' fork checks that shall not be performed on interrupt-clearing write operations.

**Commit 4:** Dynamically enable/disable interrupts according to whether we're using polling or interrupts to mediate/monitor the transfer.

This commit also removes the DV constraints that prevented interrupts from being cleared previously, now that the DV work has been done. It also supports arbitrary mapping of interrupts to buses and any number of configured interrupt sources.


~~The changes in this PR impact only 'hardware handshaking' sequences, but~~ the pass rates should be unaffected. It is just that they now exercise the extra functionality.