### PR TITLE
[util/topgen] Dynamic chip_info section generation

### DIFF
--- a/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.ld
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling_memory.ld
@@ -33,11 +33,13 @@ _stack_start = _stack_end - _stack_size;
 _static_critical_size = 8136;
 
 /**
- * `.chip_info` at the top of ROM0.
+ * `.chip_info` at the top of each ROM.
  */
 _chip_info_size = 128;
-_chip_info_end   = ORIGIN(rom0) + LENGTH(rom0);
-_chip_info_start = _chip_info_end - _chip_info_size;
+_rom0_chip_info_end = ORIGIN(rom0) + LENGTH(rom0);
+_rom0_chip_info_start = _rom0_chip_info_end - _chip_info_size;
+_rom1_chip_info_end = ORIGIN(rom1) + LENGTH(rom1);
+_rom1_chip_info_start = _rom1_chip_info_end - _chip_info_size;
 
 /**
  * Size of the initial ePMP RX region at reset (in bytes). This region must be

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -30,11 +30,11 @@ _stack_start = _stack_end - _stack_size;
 _static_critical_size = 8136;
 
 /**
- * `.chip_info` at the top of ROM0.
+ * `.chip_info` at the top of each ROM.
  */
 _chip_info_size = 128;
-_chip_info_end   = ORIGIN(rom0) + LENGTH(rom0);
-_chip_info_start = _chip_info_end - _chip_info_size;
+_rom0_chip_info_end = ORIGIN(rom0) + LENGTH(rom0);
+_rom0_chip_info_start = _rom0_chip_info_end - _chip_info_size;
 
 /**
  * Size of the initial ePMP RX region at reset (in bytes). This region must be

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_self_hash_test.c
@@ -47,7 +47,7 @@ const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
     0xe3a7c719, 0x6875c88c, 0xbf1c08b4, 0xad5fd883,
 };
 
-extern const char _chip_info_start[];
+extern const char _rom0_chip_info_start[];
 
 // We hash the ROM using the SHA256 algorithm and print the hash to the console.
 status_t hash_rom(void) {
@@ -63,7 +63,7 @@ status_t hash_rom(void) {
 
   TRY(otcrypto_hash(input, kHashModeSha256, &output));
   LOG_INFO("ROM Hash: 0x%!x", kSha256HashSizeInBytes, rom_hash);
-  chip_info_t *rom_chip_info = (chip_info_t *)_chip_info_start;
+  chip_info_t *rom_chip_info = (chip_info_t *)_rom0_chip_info_start;
   LOG_INFO("rom_chip_info @ %p:", rom_chip_info);
   LOG_INFO("scm_revision = %08x%08x",
            rom_chip_info->scm_revision.scm_revision_high,

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -185,7 +185,7 @@ SECTIONS {
    *
    * This is the last thing in rom.
    */
-  .chip_info _chip_info_start : ALIGN(4) {
+  .chip_info _rom0_chip_info_start : ALIGN(4) {
     KEEP(*(.chip_info))
   } > rom0
 

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -96,11 +96,19 @@ _stack_start = _stack_end - _stack_size;
 _static_critical_size = 8136;
 
 /**
- * `.chip_info` at the top of ROM0.
+ * `.chip_info` at the top of each ROM.
  */
 _chip_info_size = 128;
-_chip_info_end   = ORIGIN(rom0) + LENGTH(rom0);
-_chip_info_start = _chip_info_end - _chip_info_size;
+% for m in top["module"]:
+  % if "memory" in m:
+    % for key, mem in m["memory"].items():
+      % if key == "rom":
+_${mem["label"]}_chip_info_end = ORIGIN(${mem["label"]}) + LENGTH(${mem["label"]});
+_${mem["label"]}_chip_info_start = _${mem["label"]}_chip_info_end - _chip_info_size;
+      % endif
+    % endfor
+  % endif
+% endfor
 
 /**
  * Size of the initial ePMP RX region at reset (in bytes). This region must be


### PR DESCRIPTION
Add a per-ROM chip_info section dynamically, based on the TOP hjson ROM controllers.