### PR TITLE
 [hw,dma,rtl] Lock configuration registers during an operation

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -314,7 +314,7 @@
     }
     { name: "CFG_REGWEN"
       desc: '''
-            Indicates whether the configuration registers are locked because the DMA controller is operating. 
+            Indicates whether the configuration registers are locked because the DMA controller is operating.
             The CONTROL, STATUS, and CLEAR_STATE registers remain usable.
             '''
       swaccess: "ro"
@@ -612,6 +612,7 @@
           resval: 0x0
           hwaccess: "hrw"
           swaccess: "ro"
+          hwaccess: "hrw"
           desc: '''
                 DMA operation is active if this bit is set.
                 DMA engine clears this bit when operation is complete.
@@ -644,10 +645,12 @@
         }
         { bits: "4"
           name: "sha2_digest_valid"
+          swaccess: "ro"
           resval: 0x0
           hwaccess: "hrw"
           hwqe: "true"
-          desc: '''Indicates whether the SHA2_DIGEST register contains a valid digest.
+          desc: '''
+                Indicates whether the SHA2_DIGEST register contains a valid digest.
                 This value is cleared on the initial transfer and set when the digest is written.
                 '''
         }
@@ -789,7 +792,7 @@
         ]
       }
     }
-    { skipto: "0x128" }
+    { skipto: "0x12C" }
     { multireg: {
         name: "INT_SOURCE_WR_VAL"
         desc: "Write value for interrupt clearing write."

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -128,6 +128,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hrw"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "source_address_lo"
@@ -145,6 +146,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hrw"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "source_address_hi"
@@ -167,6 +169,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hrw"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "destination_address_lo"
@@ -185,6 +188,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hrw"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "destination_address_hi"
@@ -201,6 +205,7 @@
       desc: "Address space that source and destination pointers refer to."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "3:0"
           name: "source_asid"
@@ -307,10 +312,33 @@
       // writing to other registers, which the automated tests are not aware of.
       tags: ["excl:CsrAllTests:CsrExclWrite"]
     }
+    { name: "CFG_REGWEN"
+      desc: '''
+            Indicates whether the configuration registers are locked because the DMA controller is operating. 
+            The CONTROL, STATUS, and CLEAR_STATE registers remain usable.
+            '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      fields: [
+        { bits: "3:0"
+          mubi: "true"
+          resval: true
+          name: "regwen"
+          desc: '''
+                Used by hardware to lock the DMA configuration registers.
+                This register is purely managed by hardware and only software readable.
+                '''
+        }
+      ]
+      // Don't let automated CSR tests write random values to this register, as it could lock
+      // writing to other registers, which the automated tests are not aware of.
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
+    }
     { name: "TOTAL_DATA_SIZE"
       desc: "Total size of the data blob involved in DMA movement."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "data_size"
@@ -329,6 +357,7 @@
       desc: "Total size of the data blob involved in DMA movement."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "data_size"
@@ -349,6 +378,7 @@
       desc: "Denotes the width of each transaction that the DMA shall issue."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "1:0"
           name: "transaction_width"
@@ -385,6 +415,7 @@
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "address_limit_lo"
@@ -404,6 +435,7 @@
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "address_limit_hi"
@@ -423,6 +455,7 @@
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "address_limit_lo"
@@ -442,6 +475,7 @@
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
           name: "address_limit_hi"
@@ -695,6 +729,7 @@
       desc: "Enable bits for incoming handshake interrupt wires."
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { bits: "NumIntClearSources-1:0"
           name: "mask"
@@ -712,6 +747,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { name: "source"
           desc: "Source N needs interrupt cleared"
@@ -727,6 +763,7 @@
             '''
       swaccess: "rw"
       hwaccess: "hro"
+      regwen: "CFG_REGWEN"
       fields: [
         { name: "bus"
           desc: "Bus selection bit for source N."
@@ -742,6 +779,7 @@
         cname: "ADDR"
         swaccess: "rw"
         hwaccess: "hro"
+        regwen: "CFG_REGWEN"
         fields: [
           { name: "addr"
             desc: "Destination address for interrupt source clearing write."
@@ -759,6 +797,7 @@
         cname: "WRVAL"
         swaccess: "rw"
         hwaccess: "hro"
+        regwen: "CFG_REGWEN"
         fields: [
           { name: "wr_val"
             desc: "Write value for interrupt clearing write."

--- a/hw/ip/dma/lint/dma.waiver
+++ b/hw/ip/dma/lint/dma.waiver
@@ -6,5 +6,5 @@
 
 waive -rules {ARITH_CONTEXT} -location {dma.sv} -regexp {.*Bitlength of arithmetic operation.*is self-determined in this context.*} \
       -comment "Carry issue when determining the bit length."
-waive -rules {HIER_NET_NOT_READ} -location {dma_reg_top.sv} -regexp {status_flds_we\[0\]' is not read from in module} \
+waive -rules {HIER_NET_NOT_READ} -location {dma_reg_top.sv} -regexp {status_flds_we\[0|4\]' is not read from in module} \
       -comment "Internal register is accepted to not be read. Tracked in #702."

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -99,13 +99,11 @@ module dma
   //   (Note: in use `write_rsp_error` must be qualified with `write_rsp_valid`)
   logic write_rsp_error;
 
-  logic cfg_handshake_en;
-  logic cfg_fifo_auto_increment_en;
-  logic cfg_memory_buffer_auto_increment_en;
-  logic cfg_data_direction;
   logic cfg_abort_en;
+  assign cfg_abort_en = reg2hw.control.abort.q;
 
   logic clear_cfg_regwen, set_cfg_regwen;
+  logic cfg_handshake_en;
 
   logic [SYS_METADATA_WIDTH-1:0] src_metadata;
   assign src_metadata = SYS_METADATA_WIDTH'(1'b1) << OtAgentId;
@@ -258,27 +256,37 @@ module dma
   logic [$bits(dma_ctrl_state_e)-1:0] ctrl_state_logic;
   assign ctrl_state_q = dma_ctrl_state_e'(ctrl_state_logic);
 
-  // Captured state that we cannot lock with a REGWEN
-  logic [31:0] enabled_memory_range_base_q, enabled_memory_range_limit_q;
-  logic        capture_enabled_memory_range;
+  // During the active DMA operation, most of the DMA registers are locked with a hardware-
+  // controlled REGWEN. However, this mechanism is not possible for all registers. For example,
+  // some registers already have a different REGWEn attached (range locking) or the CONTROL
+  // register, which needs to be partly writable. To lock those registers, we capture their value
+  // during the start of the operation and, further on, only use the captured value in the state
+  // machine. The captured state is stored in control_q.
+  control_state_t control_d, control_q;
+  logic           capture_state;
+
+  // Fiddle out control bits into captured state
+  always_comb begin
+    control_d.opcode                     = opcode_e'(reg2hw.control.opcode.q);
+    control_d.cfg_handshake_en           = reg2hw.control.hardware_handshake_enable.q;
+    control_d.cfg_data_direction         = reg2hw.control.data_direction.q;
+    control_d.cfg_fifo_auto_increment_en = reg2hw.control.fifo_auto_increment_enable.q;
+    control_d.range_valid                = reg2hw.range_valid.q;
+    control_d.enabled_memory_range_base  = reg2hw.enabled_memory_range_base.q;
+    control_d.enabled_memory_range_limit = reg2hw.enabled_memory_range_limit.q;
+
+    control_d.cfg_memory_buffer_auto_increment_en =
+      reg2hw.control.memory_buffer_auto_increment_enable.q;
+  end
 
   prim_generic_flop_en #(
-    .Width(32)
-  ) u_enabled_memory_base (
-    .clk_i  ( gated_clk                           ),
-    .rst_ni ( rst_ni                              ),
-    .en_i   ( capture_enabled_memory_range        ),
-    .d_i    ( reg2hw.enabled_memory_range_base.q  ),
-    .q_o    ( enabled_memory_range_base_q         )
-  );
-  prim_generic_flop_en #(
-    .Width(32)
-  ) u_enabled_memory_limit (
-    .clk_i  ( gated_clk                           ),
-    .rst_ni ( rst_ni                              ),
-    .en_i   ( capture_enabled_memory_range        ),
-    .d_i    ( reg2hw.enabled_memory_range_limit.q ),
-    .q_o    ( enabled_memory_range_limit_q        )
+    .Width($bits(control_state_t))
+  ) u_opcode (
+    .clk_i  ( gated_clk     ),
+    .rst_ni ( rst_ni        ),
+    .en_i   ( capture_state ),
+    .d_i    ( control_d     ),
+    .q_o    ( control_q     )
   );
 
   prim_flop #(
@@ -393,7 +401,7 @@ module dma
   digest_mode_e sha2_mode;
   sha_word64_t [7:0] sha2_digest;
 
-  assign use_inline_hashing = reg2hw.control.opcode.q inside {OpcSha256,  OpcSha384, OpcSha512};
+  assign use_inline_hashing = control_q.opcode inside {OpcSha256,  OpcSha384, OpcSha512};
   // When reaching DmaShaFinalize, we are consuming data and start computing the digest value
   assign sha2_hash_process = (ctrl_state_q == DmaShaFinalize);
 
@@ -424,7 +432,7 @@ module dma
 
   // Translate the DMA opcode to the SHA2 digest mode
   always_comb begin
-    unique case (reg2hw.control.opcode.q)
+    unique case (control_q.opcode)
       OpcSha256: sha2_mode = SHA2_256;
       OpcSha384: sha2_mode = SHA2_384;
       OpcSha512: sha2_mode = SHA2_512;
@@ -573,14 +581,14 @@ module dma
   always_comb begin
     ctrl_state_d = ctrl_state_q;
 
-    capture_transfer_byte        = 1'b0;
-    transfer_byte_d              = transfer_byte_q;
-    capture_chunk_byte           = 1'b0;
-    chunk_byte_d                 = chunk_byte_q;
-    capture_transfer_width       = 1'b0;
-    transfer_width_d             = '0;
-    capture_return_data          = 1'b0;
-    capture_enabled_memory_range = 1'b0;
+    capture_transfer_byte  = 1'b0;
+    transfer_byte_d        = transfer_byte_q;
+    capture_chunk_byte     = 1'b0;
+    chunk_byte_d           = chunk_byte_q;
+    capture_transfer_width = 1'b0;
+    transfer_width_d       = '0;
+    capture_return_data    = 1'b0;
+    capture_state          = 1'b0;
 
     next_error   = '0;
     capture_addr = 1'b0;
@@ -617,6 +625,9 @@ module dma
       sha2_hash_done_d = sha2_hash_done_q | sha2_hash_done;
     end
 
+    // Default assignments for the muxed config signals for the idle state
+    cfg_handshake_en = control_q.cfg_handshake_en;
+
     // Abort has the highest priority in the state machine. In all cases, if the abort is raised,
     // the DMA is reset to the idle state. This includes the error state and the default state,
     // which should never be reached during the normal operation. The abort condition has precedence
@@ -629,19 +640,30 @@ module dma
         DmaIdle: begin
           chunk_byte_d       = '0;
           capture_chunk_byte = 1'b1;
+
+          // In DmaIdle we need to determine if we are really idling or, we are doing a roundtrip
+          // via idle. If we are really idling, we need to take the config from the register
+          // interface otherwise, we need to take the captured data
+          if (!reg2hw.status.busy.q) begin
+            // We are idling
+            cfg_handshake_en = reg2hw.control.hardware_handshake_enable.q;
+          end
+          // else, we are doing a roundtrip, which signaling is covered by the default assignment
+
           // Wait for go bit to be set to proceed with data movement
-          if (reg2hw.control.go.q) begin
+          if (reg2hw.control.go.q || reg2hw.status.busy.q) begin
             // Clear the transferred bytes only on the very first iteration
-            if (reg2hw.control.initial_transfer.q) begin
+            if (reg2hw.control.initial_transfer.q && !reg2hw.status.busy.q) begin
               transfer_byte_d       = '0;
               capture_transfer_byte = 1'b1;
               // Capture unlocked state  when starting the transfer.
-              capture_enabled_memory_range = 1'b1;
+              capture_state = 1'b1;
             end
             // if not handshake start transfer
             if (!cfg_handshake_en) begin
               ctrl_state_d = DmaAddrSetup;
-            end else if (cfg_handshake_en && |lsio_trigger) begin // if handshake wait for interrupt
+            end else if (cfg_handshake_en && |lsio_trigger) begin
+              // if handshake wait for interrupt
               if (|reg2hw.clear_int_src.q) begin
                 clear_index_en = 1'b1;
                 clear_index_d  = '0;
@@ -714,11 +736,12 @@ module dma
           endcase
 
           if ((transfer_byte_q == '0) ||
-              (cfg_handshake_en &&
+              (control_q.cfg_handshake_en &&
               // Does the source address need resetting to the configured base address?
-              ((cfg_data_direction && chunk_byte_q == '0 &&
-                !cfg_memory_buffer_auto_increment_en) ||
-               (!cfg_data_direction && (chunk_byte_q == '0 || !cfg_fifo_auto_increment_en))))) begin
+              ((control_q.cfg_data_direction && chunk_byte_q == '0 &&
+                !control_q.cfg_memory_buffer_auto_increment_en) ||
+               (!control_q.cfg_data_direction &&
+               (chunk_byte_q == '0 || !control_q.cfg_fifo_auto_increment_en))))) begin
             src_addr_d = {reg2hw.source_address_hi.q, reg2hw.source_address_lo.q};
           end else begin
             // Advance from the previous transaction within this chunk
@@ -726,11 +749,12 @@ module dma
           end
 
           if ((transfer_byte_q == '0) ||
-              (cfg_handshake_en    &&
+              (control_q.cfg_handshake_en    &&
               // Does the destination address need resetting to the configured base address?
-              ((!cfg_data_direction && chunk_byte_q == '0 &&
-                !cfg_memory_buffer_auto_increment_en) ||
-               ( cfg_data_direction && (chunk_byte_q == '0 || !cfg_fifo_auto_increment_en))))) begin
+              ((!control_q.cfg_data_direction && chunk_byte_q == '0 &&
+                !control_q.cfg_memory_buffer_auto_increment_en) ||
+               (control_q.cfg_data_direction &&
+               (chunk_byte_q == '0 || !control_q.cfg_fifo_auto_increment_en))))) begin
             dst_addr_d = {reg2hw.destination_address_hi.q, reg2hw.destination_address_lo.q};
           end else begin
             // Advance from the previous transaction within this chunk
@@ -800,7 +824,7 @@ module dma
 
           // Check the validity of the restricted DMA-enabled memory range
           // Note: both the base and the limit addresses are inclusive
-          if (enabled_memory_range_limit_q < enabled_memory_range_base_q) begin
+          if (control_q.enabled_memory_range_limit < control_q.enabled_memory_range_base) begin
             next_error[DmaBaseLimitErr] = 1'b1;
           end
 
@@ -834,11 +858,11 @@ module dma
 
           if ((src_asid inside {SocControlAddr, SocSystemAddr}) && (dst_asid == OtInternalAddr) &&
               // Out-of-bound check
-              ((reg2hw.destination_address_lo.q > enabled_memory_range_limit_q) ||
-                (reg2hw.destination_address_lo.q < enabled_memory_range_base_q) ||
+              ((reg2hw.destination_address_lo.q > control_q.enabled_memory_range_limit) ||
+                (reg2hw.destination_address_lo.q < control_q.enabled_memory_range_base) ||
                 ((SYS_ADDR_WIDTH'(reg2hw.destination_address_lo.q) +
                   SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) >
-                  SYS_ADDR_WIDTH'(enabled_memory_range_limit_q)))) begin
+                  SYS_ADDR_WIDTH'(control_q.enabled_memory_range_limit)))) begin
             next_error[DmaDestAddrErr] = 1'b1;
           end
 
@@ -847,11 +871,11 @@ module dma
           // DMA enabled memory region.
           if ((dst_asid inside {SocControlAddr, SocSystemAddr}) && (src_asid == OtInternalAddr) &&
                 // Out-of-bound check
-                ((reg2hw.source_address_lo.q > enabled_memory_range_limit_q) ||
-                (reg2hw.source_address_lo.q < enabled_memory_range_base_q)   ||
+                ((reg2hw.source_address_lo.q > control_q.enabled_memory_range_limit) ||
+                (reg2hw.source_address_lo.q < control_q.enabled_memory_range_base)   ||
                 ((SYS_ADDR_WIDTH'(reg2hw.source_address_lo.q) +
                   SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) >
-                  SYS_ADDR_WIDTH'(enabled_memory_range_limit_q)))) begin
+                  SYS_ADDR_WIDTH'(control_q.enabled_memory_range_limit)))) begin
             next_error[DmaSourceAddrErr] = 1'b1;
           end
 
@@ -869,7 +893,7 @@ module dma
             next_error[DmaDestAddrErr] = 1'b1;
           end
 
-          if (!reg2hw.range_valid.q) begin
+          if (!control_q.range_valid) begin
             next_error[DmaRangeValidErr] = 1'b1;
           end
 
@@ -877,10 +901,9 @@ module dma
           if (|next_error) begin
             ctrl_state_d = DmaError;
           end else begin
-            // Start the inline hashing if we are in the very first transfer. If we are in the first
-            // iteration of a transfer, which is not the very first transfer, only capture the
-            // transfer length to compute the final message length
-            if (reg2hw.control.initial_transfer.q) begin
+            // Start the inline hashing if we are in the very first transfer. This is indicated
+            // when transfer_byte_q is still 0
+            if (transfer_byte_q == '0) begin
               if (use_inline_hashing) begin
                 sha2_hash_start = 1'b1;
               end
@@ -941,7 +964,7 @@ module dma
                 // Conditionally clear the go bit when not being in hardware handshake mode.
                 // In non-hardware handshake mode, finishing one chunk should raise the done IRQ
                 // and done bit, and release the go bit for the next FW-controlled chunk.
-                clear_go     = !cfg_handshake_en;
+                clear_go     = !control_q.cfg_handshake_en;
                 ctrl_state_d = DmaIdle;
               end else begin
                 ctrl_state_d = DmaAddrSetup;
@@ -973,7 +996,7 @@ module dma
               // Conditionally clear the go bit when not being in hardware handshake mode.
               // In non-hardware handshake mode, finishing one chunk should raise the done IRQ
               // and done bit, and release the go bit for the next FW-controlled chunk.
-              clear_go     = !cfg_handshake_en;
+              clear_go     = !control_q.cfg_handshake_en;
               ctrl_state_d = DmaIdle;
             end else begin
               ctrl_state_d = DmaAddrSetup;
@@ -1101,9 +1124,9 @@ module dma
   assign send_almost_limit_interrupt =
     (!sent_almost_limit_interrupt_q)    &&  // only want to send once
     data_move_state_valid               &&  // only trigger for single cycle when data has moved
-    cfg_handshake_en                    &&
-    cfg_memory_buffer_auto_increment_en &&
-    (!cfg_data_direction)               &&
+    control_q.cfg_handshake_en          &&
+    control_q.cfg_memory_buffer_auto_increment_en &&
+    (!control_q.cfg_data_direction)     &&
     (dst_addr_q >= {reg2hw.destination_address_almost_limit_hi.q,
                     reg2hw.destination_address_almost_limit_lo.q});
 
@@ -1129,9 +1152,9 @@ module dma
   assign send_limit_interrupt =
     (!sent_limit_interrupt_q)           &&  // only want to send once
     data_move_state_valid               &&  // only trigger for single cycle when data has moved
-    cfg_handshake_en                    &&
-    cfg_memory_buffer_auto_increment_en &&
-    (!cfg_data_direction)               &&
+    control_q.cfg_handshake_en          &&
+    control_q.cfg_memory_buffer_auto_increment_en &&
+    (!control_q.cfg_data_direction)     &&
     (dst_addr_q >= {reg2hw.destination_address_limit_hi.q,
                     reg2hw.destination_address_limit_lo.q});
 
@@ -1147,13 +1170,13 @@ module dma
                            (ctrl_state_q == DmaShaWait)           ||
                            (ctrl_state_q == DmaShaFinalize);
 
-  assign new_destination_addr = cfg_data_direction ?
+  assign new_destination_addr = control_q.cfg_data_direction ?
     ({reg2hw.destination_address_hi.q, reg2hw.destination_address_lo.q} +
      SYS_ADDR_WIDTH'(transfer_width_q)) :
     ({reg2hw.destination_address_hi.q, reg2hw.destination_address_lo.q} +
      SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q));
 
-  assign new_source_addr = cfg_data_direction ?
+  assign new_source_addr = control_q.cfg_data_direction ?
     ({reg2hw.source_address_hi.q, reg2hw.source_address_lo.q} +
       SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) :
     ({reg2hw.source_address_hi.q, reg2hw.source_address_lo.q} +
@@ -1171,9 +1194,14 @@ module dma
   always_comb begin
     hw2reg = '0;
 
+    // Clear the go bit if we are in a single transfer and finished the DMA operation,
+    // hardware handshake mode when we finished all transfers, or when aborting the transfer.
+    hw2reg.control.go.de = clear_go || cfg_abort_en;
+    hw2reg.control.go.d  = 1'b0;
+
     // Lock or unlock the regwen when leaving or returning back to DmaIdle
     clear_cfg_regwen = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle);
-    set_cfg_regwen   = (ctrl_state_d == DmaIdle);
+    set_cfg_regwen   = hw2reg.control.go.de;
     // Convert the regwen set/clear signal to the multi bit
     hw2reg.cfg_regwen.de = set_cfg_regwen | clear_cfg_regwen;
     hw2reg.cfg_regwen.d  = prim_mubi_pkg::mubi4_bool_to_mubi(set_cfg_regwen);
@@ -1183,18 +1211,18 @@ module dma
     // when finishing a DMA operation when transitioning from a data move state to the idle state
     update_destination_addr_reg = 1'b0;
     update_source_addr_reg      = 1'b0;
-    if (cfg_handshake_en && cfg_memory_buffer_auto_increment_en &&
+    if (control_q.cfg_handshake_en && control_q.cfg_memory_buffer_auto_increment_en &&
         data_move_state && (ctrl_state_d == DmaIdle)) begin
-      if (cfg_data_direction) begin
+      if (control_q.cfg_data_direction) begin
         update_source_addr_reg = 1'b1;
       end else begin
         update_destination_addr_reg = 1'b1;
       end
     end
 
-    // Clear the inline initial transfer flag starting flag when leaving the
-    // DmaAddrSetup the first time
-    if ((ctrl_state_q == DmaAddrSetup) & reg2hw.control.initial_transfer.q) begin
+    // Clear the inline initial transfer flag starting flag when leaving the DmaIdle the first time
+    if ((ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle) &&
+        reg2hw.control.initial_transfer.q) begin
       hw2reg.control.initial_transfer.de = 1'b1;
     end
 
@@ -1214,16 +1242,16 @@ module dma
     // - transitions from IDLE out
     // - clearing the go bit (going back to idle)
     // - abort               (going back to idle)
-    hw2reg.status.busy.de = ((ctrl_state_q  == DmaIdle) && (ctrl_state_d != DmaIdle)) || clear_go;
+    hw2reg.status.busy.de = ((ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle)) ||
+                            clear_go                                                 ||
+                            cfg_abort_en;
     // If transitioning from IDLE, set busy, otherwise clear it
-    hw2reg.status.busy.d  = ((ctrl_state_q == DmaIdle) &&
-                            (ctrl_state_d != DmaIdle)) ? 1'b1 : 1'b0;
+    hw2reg.status.busy.d  = ((ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle)) ? 1'b1 : 1'b0;
 
     // Status is cleared when leaving the IDLE state the first time, i.e., when busy is not yet set
     clear_status = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle) && !reg2hw.status.busy.q;
-    // The SHA digest valid and the digest itself needs to incorporate the initial transfer flag
-    // as busy is deasserted for every chunk in the middle of a multi-chunk memory-to-memory
-    //transfer
+    // The SHA digest valid and the digest itself needs to incorporate the initial transfer flag as
+    // busy is deasserted for every chunk in the middle of a multi-chunk memory-to-memory transfer
     clear_sha_status = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle) &&
                        reg2hw.control.initial_transfer.q;
 
@@ -1235,7 +1263,7 @@ module dma
     hw2reg.status.error.de = (ctrl_state_d == DmaError) | clear_status;
     hw2reg.status.error.d  = clear_status? 1'b0 : 1'b1;
 
-    hw2reg.status.aborted.de = (cfg_abort_en && (ctrl_state_d == DmaIdle)) | clear_status;
+    hw2reg.status.aborted.de = cfg_abort_en | clear_status;
     hw2reg.status.aborted.d  = clear_status? 1'b0 : 1'b1;
 
     hw2reg.status.sha2_digest_valid.de = sha2_digest_set | clear_sha_status;
@@ -1268,11 +1296,6 @@ module dma
         end
       endcase
     end
-
-    // Clear the go bit if we are in a single transfer and finished the DMA operation,
-    // hardware handshake mode when we finished all transfers, or when aborting the transfer.
-    hw2reg.control.go.de = clear_go;
-    hw2reg.control.go.d  = 1'b0;
 
     // Fiddle out error signals
     hw2reg.error_code.src_address_error.de = (ctrl_state_d == DmaError) | clear_status;
@@ -1337,14 +1360,6 @@ module dma
       hw2reg.error_code.range_valid_error.d  = 1'b0;
       hw2reg.error_code.asid_error.d         = 1'b0;
     end
-  end
-
-  always_comb begin
-    cfg_handshake_en                    = reg2hw.control.hardware_handshake_enable.q;
-    cfg_data_direction                  = reg2hw.control.data_direction.q;
-    cfg_fifo_auto_increment_en          = reg2hw.control.fifo_auto_increment_enable.q;
-    cfg_memory_buffer_auto_increment_en = reg2hw.control.memory_buffer_auto_increment_enable.q;
-    cfg_abort_en                        = reg2hw.control.abort.q;
   end
 
   //////////////////////////////////////////////////////////////////////////////

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -105,6 +105,8 @@ module dma
   logic cfg_data_direction;
   logic cfg_abort_en;
 
+  logic clear_cfg_regwen, set_cfg_regwen;
+
   logic [SYS_METADATA_WIDTH-1:0] src_metadata;
   assign src_metadata = SYS_METADATA_WIDTH'(1'b1) << OtAgentId;
 
@@ -256,6 +258,29 @@ module dma
   logic [$bits(dma_ctrl_state_e)-1:0] ctrl_state_logic;
   assign ctrl_state_q = dma_ctrl_state_e'(ctrl_state_logic);
 
+  // Captured state that we cannot lock with a REGWEN
+  logic [31:0] enabled_memory_range_base_q, enabled_memory_range_limit_q;
+  logic        capture_enabled_memory_range;
+
+  prim_generic_flop_en #(
+    .Width(32)
+  ) u_enabled_memory_base (
+    .clk_i  ( gated_clk                           ),
+    .rst_ni ( rst_ni                              ),
+    .en_i   ( capture_enabled_memory_range        ),
+    .d_i    ( reg2hw.enabled_memory_range_base.q  ),
+    .q_o    ( enabled_memory_range_base_q         )
+  );
+  prim_generic_flop_en #(
+    .Width(32)
+  ) u_enabled_memory_limit (
+    .clk_i  ( gated_clk                           ),
+    .rst_ni ( rst_ni                              ),
+    .en_i   ( capture_enabled_memory_range        ),
+    .d_i    ( reg2hw.enabled_memory_range_limit.q ),
+    .q_o    ( enabled_memory_range_limit_q        )
+  );
+
   prim_flop #(
     .Width($bits(dma_ctrl_state_e)),
     .ResetValue({DmaIdle})
@@ -329,15 +354,14 @@ module dma
   );
 
   logic                  capture_asid;
-  logic [ASID_WIDTH-1:0] src_asid_q, src_asid_d;
-  logic [ASID_WIDTH-1:0] dst_asid_q, dst_asid_d;
+  logic [ASID_WIDTH-1:0] src_asid_q, dst_asid_q;
   prim_generic_flop_en #(
     .Width(ASID_WIDTH)
   ) aff_src_asid (
     .clk_i ( gated_clk    ),
     .rst_ni( rst_ni       ),
     .en_i  ( capture_asid ),
-    .d_i   ( src_asid_d   ),
+    .d_i   ( reg2hw.address_space_id.source_asid.q ),
     .q_o   ( src_asid_q   )
   );
 
@@ -347,7 +371,7 @@ module dma
     .clk_i ( gated_clk    ),
     .rst_ni( rst_ni       ),
     .en_i  ( capture_asid ),
-    .d_i   ( dst_asid_d   ),
+    .d_i   ( reg2hw.address_space_id.destination_asid.q ),
     .q_o   ( dst_asid_q   )
   );
 
@@ -566,21 +590,20 @@ module dma
   always_comb begin
     ctrl_state_d = ctrl_state_q;
 
-    capture_transfer_byte  = 1'b0;
-    transfer_byte_d        = transfer_byte_q;
-    capture_chunk_byte     = 1'b0;
-    chunk_byte_d           = chunk_byte_q;
-    capture_transfer_width = 1'b0;
-    transfer_width_d       = '0;
-    capture_return_data    = 1'b0;
+    capture_transfer_byte        = 1'b0;
+    transfer_byte_d              = transfer_byte_q;
+    capture_chunk_byte           = 1'b0;
+    chunk_byte_d                 = chunk_byte_q;
+    capture_transfer_width       = 1'b0;
+    transfer_width_d             = '0;
+    capture_return_data          = 1'b0;
+    capture_enabled_memory_range = 1'b0;
 
     next_error   = '0;
     capture_addr = 1'b0;
     src_addr_d   = '0;
     dst_addr_d   = '0;
     capture_asid = 1'b0;
-    src_asid_d   = '0;
-    dst_asid_d   = '0;
 
     capture_be   = '0;
     req_src_be_d = '0;
@@ -630,6 +653,9 @@ module dma
             if (reg2hw.control.initial_transfer.q) begin
               transfer_byte_d       = '0;
               capture_transfer_byte = 1'b1;
+              // Capture unlocked state  when starting the transfer.
+              capture_enabled_memory_range = 1'b1;
+              capture_asid                 = 1'b1;
             end
             // if not handshake start transfer
             if (!cfg_handshake_en) begin
@@ -733,8 +759,6 @@ module dma
           // Capture ASID values for use throughout the transfer.
           if (transfer_byte_q == '0) begin
             capture_asid = 1'b1;
-            src_asid_d = reg2hw.address_space_id.source_asid.q;
-            dst_asid_d = reg2hw.address_space_id.destination_asid.q;
           end
 
           unique case (transfer_width_d)
@@ -804,7 +828,7 @@ module dma
 
           // Check the validity of the restricted DMA-enabled memory range
           // Note: both the base and the limit addresses are inclusive
-          if (reg2hw.enabled_memory_range_limit.q < reg2hw.enabled_memory_range_base.q) begin
+          if (enabled_memory_range_limit_q < enabled_memory_range_base_q) begin
             next_error[DmaBaseLimitErr] = 1'b1;
           end
 
@@ -839,11 +863,11 @@ module dma
               (reg2hw.address_space_id.source_asid.q == SocSystemAddr)) &&
               (reg2hw.address_space_id.destination_asid.q == OtInternalAddr) &&
               // Out-of-bound check
-              ((reg2hw.destination_address_lo.q > reg2hw.enabled_memory_range_limit.q) ||
-                (reg2hw.destination_address_lo.q < reg2hw.enabled_memory_range_base.q)  ||
+              ((reg2hw.destination_address_lo.q > enabled_memory_range_limit_q) ||
+                (reg2hw.destination_address_lo.q < enabled_memory_range_base_q) ||
                 ((SYS_ADDR_WIDTH'(reg2hw.destination_address_lo.q) +
                   SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) >
-                  SYS_ADDR_WIDTH'(reg2hw.enabled_memory_range_limit.q)))) begin
+                  SYS_ADDR_WIDTH'(enabled_memory_range_limit_q)))) begin
             next_error[DmaDestAddrErr] = 1'b1;
           end
 
@@ -854,11 +878,11 @@ module dma
               (reg2hw.address_space_id.destination_asid.q == SocSystemAddr)) &&
               (reg2hw.address_space_id.source_asid.q == OtInternalAddr) &&
                 // Out-of-bound check
-                ((reg2hw.source_address_lo.q > reg2hw.enabled_memory_range_limit.q) ||
-                (reg2hw.source_address_lo.q < reg2hw.enabled_memory_range_base.q)  ||
+                ((reg2hw.source_address_lo.q > enabled_memory_range_limit_q) ||
+                (reg2hw.source_address_lo.q < enabled_memory_range_base_q)   ||
                 ((SYS_ADDR_WIDTH'(reg2hw.source_address_lo.q) +
                   SYS_ADDR_WIDTH'(reg2hw.chunk_data_size.q)) >
-                  SYS_ADDR_WIDTH'(reg2hw.enabled_memory_range_limit.q)))) begin
+                  SYS_ADDR_WIDTH'(enabled_memory_range_limit_q)))) begin
             next_error[DmaSourceAddrErr] = 1'b1;
           end
 
@@ -1179,6 +1203,14 @@ module dma
 
   always_comb begin
     hw2reg = '0;
+
+    // Lock or unlock the regwen when leaving or returning back to DmaIdle
+    clear_cfg_regwen = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle);
+    set_cfg_regwen   = (ctrl_state_d == DmaIdle);
+    // Convert the regwen set/clear signal to the multi bit
+    hw2reg.cfg_regwen.de = set_cfg_regwen | clear_cfg_regwen;
+    hw2reg.cfg_regwen.d  = prim_mubi_pkg::mubi4_bool_to_mubi(set_cfg_regwen);
+
 
     // If we are in hardware handshake mode with auto-increment increment the corresponding address
     // when finishing a DMA operation when transitioning from a data move state to the idle state

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -353,28 +353,6 @@ module dma
     .q_o   ( dst_addr_q   )
   );
 
-  logic                  capture_asid;
-  logic [ASID_WIDTH-1:0] src_asid_q, dst_asid_q;
-  prim_generic_flop_en #(
-    .Width(ASID_WIDTH)
-  ) aff_src_asid (
-    .clk_i ( gated_clk    ),
-    .rst_ni( rst_ni       ),
-    .en_i  ( capture_asid ),
-    .d_i   ( reg2hw.address_space_id.source_asid.q ),
-    .q_o   ( src_asid_q   )
-  );
-
-  prim_generic_flop_en #(
-    .Width(ASID_WIDTH)
-  ) aff_dst_asid (
-    .clk_i ( gated_clk    ),
-    .rst_ni( rst_ni       ),
-    .en_i  ( capture_asid ),
-    .d_i   ( reg2hw.address_space_id.destination_asid.q ),
-    .q_o   ( dst_asid_q   )
-  );
-
   logic                       capture_be;
   logic [top_pkg::TL_DBW-1:0] req_src_be_q, req_src_be_d;
   logic [top_pkg::TL_DBW-1:0] req_dst_be_q, req_dst_be_d;
@@ -473,13 +451,18 @@ module dma
     .idle             (                       )
   );
 
+  // Fiddle ASIDs out for better readability during the rest of the code
+  logic [ASID_WIDTH-1:0] src_asid, dst_asid;
+  assign src_asid = reg2hw.address_space_id.source_asid.q;
+  assign dst_asid = reg2hw.address_space_id.destination_asid.q;
+
   // Note: bus signals shall be asserted only when configured and active, to ensure
   // that address and - especially - data are not leaked to other buses.
 
   // Host interface to OT Internal address space
   always_comb begin
-    dma_host_write = (ctrl_state_q == DmaSendWrite) & (dst_asid_q == OtInternalAddr);
-    dma_host_read  = (ctrl_state_q == DmaSendRead)  & (src_asid_q == OtInternalAddr);
+    dma_host_write = (ctrl_state_q == DmaSendWrite) & (dst_asid == OtInternalAddr);
+    dma_host_read  = (ctrl_state_q == DmaSendRead)  & (src_asid == OtInternalAddr);
 
     dma_host_tlul_req_valid = dma_host_write | dma_host_read | dma_host_clear_int;
     // TLUL 4B aligned
@@ -496,8 +479,8 @@ module dma
 
   // Host interface to SoC CTN address space
   always_comb begin
-    dma_ctn_write = (ctrl_state_q == DmaSendWrite) & (dst_asid_q == SocControlAddr);
-    dma_ctn_read  = (ctrl_state_q == DmaSendRead)  & (src_asid_q == SocControlAddr);
+    dma_ctn_write = (ctrl_state_q == DmaSendWrite) & (dst_asid == SocControlAddr);
+    dma_ctn_read  = (ctrl_state_q == DmaSendRead)  & (src_asid == SocControlAddr);
 
     dma_ctn_tlul_req_valid = dma_ctn_write | dma_ctn_read | dma_ctn_clear_int;
     // TLUL 4B aligned
@@ -513,8 +496,8 @@ module dma
 
   // Host interface to SoC SYS address space
   always_comb begin
-    dma_sys_write = (ctrl_state_q == DmaSendWrite) & (dst_asid_q == SocSystemAddr);
-    dma_sys_read  = (ctrl_state_q == DmaSendRead)  & (src_asid_q == SocSystemAddr);
+    dma_sys_write = (ctrl_state_q == DmaSendWrite) & (dst_asid == SocSystemAddr);
+    dma_sys_read  = (ctrl_state_q == DmaSendRead)  & (src_asid  == SocSystemAddr);
 
     sys_req_d.vld_vec     [SysCmdWrite] = dma_sys_write;
     sys_req_d.metadata_vec[SysCmdWrite] = src_metadata;
@@ -537,7 +520,7 @@ module dma
 
   // Write response muxing
   always_comb begin
-    unique case (dst_asid_q)
+    unique case (dst_asid)
       OtInternalAddr: begin
         // Write request grant
         write_gnt       = dma_host_tlul_gnt;
@@ -563,7 +546,7 @@ module dma
 
   // Read response muxing
   always_comb begin
-    unique case (src_asid_q)
+    unique case (src_asid)
       OtInternalAddr: begin
         // Read request grant
         read_gnt       = dma_host_tlul_gnt;
@@ -603,7 +586,6 @@ module dma
     capture_addr = 1'b0;
     src_addr_d   = '0;
     dst_addr_d   = '0;
-    capture_asid = 1'b0;
 
     capture_be   = '0;
     req_src_be_d = '0;
@@ -655,7 +637,6 @@ module dma
               capture_transfer_byte = 1'b1;
               // Capture unlocked state  when starting the transfer.
               capture_enabled_memory_range = 1'b1;
-              capture_asid                 = 1'b1;
             end
             // if not handshake start transfer
             if (!cfg_handshake_en) begin
@@ -756,11 +737,6 @@ module dma
             dst_addr_d = dst_addr_q + SYS_ADDR_WIDTH'(transfer_width_d);
           end
 
-          // Capture ASID values for use throughout the transfer.
-          if (transfer_byte_q == '0) begin
-            capture_asid = 1'b1;
-          end
-
           unique case (transfer_width_d)
             3'b001: begin
               req_dst_be_d = top_pkg::TL_DBW'('b0001) << dst_addr_d[1:0];
@@ -815,14 +791,10 @@ module dma
 
           // Ensure that ASIDs have valid values
           // SEC_CM: ASID.INTERSIG.MUBI
-          if (!(reg2hw.address_space_id.source_asid.q inside {OtInternalAddr,
-                                                              SocControlAddr,
-                                                              SocSystemAddr})) begin
+          if (!(src_asid inside {OtInternalAddr, SocControlAddr, SocSystemAddr})) begin
             next_error[DmaAsidErr] = 1'b1;
           end
-          if (!(reg2hw.address_space_id.destination_asid.q inside {OtInternalAddr,
-                                                                  SocControlAddr,
-                                                                  SocSystemAddr})) begin
+          if (!(dst_asid inside {OtInternalAddr, SocControlAddr, SocSystemAddr})) begin
             next_error[DmaAsidErr] = 1'b1;
           end
 
@@ -859,9 +831,8 @@ module dma
           // If data from the SOC system bus or the control bus is transferred
           // to the OT internal memory, we must check if the destination address range falls into
           // the DMA enabled memory region.
-          if (((reg2hw.address_space_id.source_asid.q == SocControlAddr) ||
-              (reg2hw.address_space_id.source_asid.q == SocSystemAddr)) &&
-              (reg2hw.address_space_id.destination_asid.q == OtInternalAddr) &&
+
+          if ((src_asid inside {SocControlAddr, SocSystemAddr}) && (dst_asid == OtInternalAddr) &&
               // Out-of-bound check
               ((reg2hw.destination_address_lo.q > enabled_memory_range_limit_q) ||
                 (reg2hw.destination_address_lo.q < enabled_memory_range_base_q) ||
@@ -874,9 +845,7 @@ module dma
           // If data from the OT internal memory is transferred  to the SOC system bus or the
           // control bus, we must check if the source address range falls into the
           // DMA enabled memory region.
-          if (((reg2hw.address_space_id.destination_asid.q == SocControlAddr) ||
-              (reg2hw.address_space_id.destination_asid.q == SocSystemAddr)) &&
-              (reg2hw.address_space_id.source_asid.q == OtInternalAddr) &&
+          if ((dst_asid inside {SocControlAddr, SocSystemAddr}) && (src_asid == OtInternalAddr) &&
                 // Out-of-bound check
                 ((reg2hw.source_address_lo.q > enabled_memory_range_limit_q) ||
                 (reg2hw.source_address_lo.q < enabled_memory_range_base_q)   ||
@@ -888,16 +857,14 @@ module dma
 
           // If the source ASID is the SOC control port or the OT internal port, we are accessing a
           // 32-bit address space. Thus the upper bits of the source address must be zero
-          if (((reg2hw.address_space_id.source_asid.q == SocControlAddr) ||
-              (reg2hw.address_space_id.source_asid.q == OtInternalAddr)) &&
+          if ((src_asid inside {SocControlAddr, OtInternalAddr}) &&
               (|reg2hw.source_address_hi.q)) begin
             next_error[DmaSourceAddrErr] = 1'b1;
           end
 
           // If the destination ASID is the SOC control por or the OT internal port we are accessing
           // a 32-bit address space. Thus the upper bits of the destination address must be zero
-          if (((reg2hw.address_space_id.destination_asid.q == SocControlAddr) ||
-              (reg2hw.address_space_id.destination_asid.q == OtInternalAddr)) &&
+          if ((dst_asid inside {SocControlAddr, OtInternalAddr}) &&
               (|reg2hw.destination_address_hi.q)) begin
             next_error[DmaDestAddrErr] = 1'b1;
           end
@@ -1041,7 +1008,7 @@ module dma
 
   // Collect read data from the appropriate port.
   always_comb begin
-    unique case (src_asid_q)
+    unique case (src_asid)
       OtInternalAddr: dma_rsp_data = dma_host_tlul_rsp_data;
       SocControlAddr: dma_rsp_data = dma_ctn_tlul_rsp_data;
       default:        dma_rsp_data = sys_resp_q.read_data;

--- a/hw/ip/dma/rtl/dma_pkg.sv
+++ b/hw/ip/dma/rtl/dma_pkg.sv
@@ -44,6 +44,21 @@ package dma_pkg;
     OpcSha512 = 4'h3
   } opcode_e;
 
+  // Control state captured during the operation
+  typedef struct packed {
+    // Control register
+    opcode_e    opcode;
+    logic       cfg_handshake_en;
+    logic       cfg_memory_buffer_auto_increment_en;
+    logic       cfg_fifo_auto_increment_en;
+    logic       cfg_data_direction;
+    logic       range_valid;
+    // Enabled memory base register
+    logic [31:0] enabled_memory_range_base;
+    // Enabled memory limit register
+    logic [31:0] enabled_memory_range_limit;
+  } control_state_t;
+
   typedef enum logic [3:0] {
     DmaIdle                  = 4'b0000,
     DmaClearIntrSrc          = 4'b0001,

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -417,17 +417,17 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_8_OFFSET = 9'h cc;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_9_OFFSET = 9'h d0;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_10_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_0_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_1_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_2_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_3_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_4_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_5_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_6_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_7_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_8_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_9_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_10_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_0_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_1_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_2_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_3_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_4_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_5_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_6_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_7_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_8_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_9_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_10_OFFSET = 9'h 154;
 
   // Reset values for hwext registers and their fields
   parameter logic [2:0] DMA_INTR_TEST_RESVAL = 3'h 0;

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -233,6 +233,11 @@ package dma_reg_pkg;
   } dma_hw2reg_destination_address_hi_reg_t;
 
   typedef struct packed {
+    logic [3:0]  d;
+    logic        de;
+  } dma_hw2reg_cfg_regwen_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -345,11 +350,12 @@ package dma_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    dma_hw2reg_intr_state_reg_t intr_state; // [697:692]
-    dma_hw2reg_source_address_lo_reg_t source_address_lo; // [691:659]
-    dma_hw2reg_source_address_hi_reg_t source_address_hi; // [658:626]
-    dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [625:593]
-    dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [592:560]
+    dma_hw2reg_intr_state_reg_t intr_state; // [702:697]
+    dma_hw2reg_source_address_lo_reg_t source_address_lo; // [696:664]
+    dma_hw2reg_source_address_hi_reg_t source_address_hi; // [663:631]
+    dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [630:598]
+    dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [597:565]
+    dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [564:560]
     dma_hw2reg_control_reg_t control; // [559:554]
     dma_hw2reg_status_reg_t status; // [553:544]
     dma_hw2reg_error_code_reg_t error_code; // [543:528]
@@ -370,46 +376,47 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_ENABLED_MEMORY_RANGE_LIMIT_OFFSET = 9'h 28;
   parameter logic [BlockAw-1:0] DMA_RANGE_VALID_OFFSET = 9'h 2c;
   parameter logic [BlockAw-1:0] DMA_RANGE_REGWEN_OFFSET = 9'h 30;
-  parameter logic [BlockAw-1:0] DMA_TOTAL_DATA_SIZE_OFFSET = 9'h 34;
-  parameter logic [BlockAw-1:0] DMA_CHUNK_DATA_SIZE_OFFSET = 9'h 38;
-  parameter logic [BlockAw-1:0] DMA_TRANSFER_WIDTH_OFFSET = 9'h 3c;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_LO_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_HI_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] DMA_CONTROL_OFFSET = 9'h 50;
-  parameter logic [BlockAw-1:0] DMA_STATUS_OFFSET = 9'h 54;
-  parameter logic [BlockAw-1:0] DMA_ERROR_CODE_OFFSET = 9'h 58;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_0_OFFSET = 9'h 5c;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_1_OFFSET = 9'h 60;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_2_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_3_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_4_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_5_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_6_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_7_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_8_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_9_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_10_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_11_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_12_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_13_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_14_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_15_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] DMA_HANDSHAKE_INTERRUPT_ENABLE_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_SRC_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_BUS_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_0_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_1_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_2_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_3_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_4_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_5_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_6_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_7_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_8_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_9_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_10_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] DMA_CFG_REGWEN_OFFSET = 9'h 34;
+  parameter logic [BlockAw-1:0] DMA_TOTAL_DATA_SIZE_OFFSET = 9'h 38;
+  parameter logic [BlockAw-1:0] DMA_CHUNK_DATA_SIZE_OFFSET = 9'h 3c;
+  parameter logic [BlockAw-1:0] DMA_TRANSFER_WIDTH_OFFSET = 9'h 40;
+  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_LO_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_HI_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] DMA_CONTROL_OFFSET = 9'h 54;
+  parameter logic [BlockAw-1:0] DMA_STATUS_OFFSET = 9'h 58;
+  parameter logic [BlockAw-1:0] DMA_ERROR_CODE_OFFSET = 9'h 5c;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_0_OFFSET = 9'h 60;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_1_OFFSET = 9'h 64;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_2_OFFSET = 9'h 68;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_3_OFFSET = 9'h 6c;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_4_OFFSET = 9'h 70;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_5_OFFSET = 9'h 74;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_6_OFFSET = 9'h 78;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_7_OFFSET = 9'h 7c;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_8_OFFSET = 9'h 80;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_9_OFFSET = 9'h 84;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_10_OFFSET = 9'h 88;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_11_OFFSET = 9'h 8c;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_12_OFFSET = 9'h 90;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_13_OFFSET = 9'h 94;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_14_OFFSET = 9'h 98;
+  parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_15_OFFSET = 9'h 9c;
+  parameter logic [BlockAw-1:0] DMA_HANDSHAKE_INTERRUPT_ENABLE_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_SRC_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_BUS_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_0_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_1_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_2_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_3_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_4_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_5_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_6_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_7_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_8_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_9_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_10_OFFSET = 9'h d4;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_0_OFFSET = 9'h 128;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_1_OFFSET = 9'h 12c;
   parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_2_OFFSET = 9'h 130;
@@ -445,6 +452,7 @@ package dma_reg_pkg;
     DMA_ENABLED_MEMORY_RANGE_LIMIT,
     DMA_RANGE_VALID,
     DMA_RANGE_REGWEN,
+    DMA_CFG_REGWEN,
     DMA_TOTAL_DATA_SIZE,
     DMA_CHUNK_DATA_SIZE,
     DMA_TRANSFER_WIDTH,
@@ -499,7 +507,7 @@ package dma_reg_pkg;
   } dma_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] DMA_PERMIT [64] = '{
+  parameter logic [3:0] DMA_PERMIT [65] = '{
     4'b 0001, // index[ 0] DMA_INTR_STATE
     4'b 0001, // index[ 1] DMA_INTR_ENABLE
     4'b 0001, // index[ 2] DMA_INTR_TEST
@@ -513,57 +521,58 @@ package dma_reg_pkg;
     4'b 1111, // index[10] DMA_ENABLED_MEMORY_RANGE_LIMIT
     4'b 0001, // index[11] DMA_RANGE_VALID
     4'b 0001, // index[12] DMA_RANGE_REGWEN
-    4'b 1111, // index[13] DMA_TOTAL_DATA_SIZE
-    4'b 1111, // index[14] DMA_CHUNK_DATA_SIZE
-    4'b 0001, // index[15] DMA_TRANSFER_WIDTH
-    4'b 1111, // index[16] DMA_DESTINATION_ADDRESS_LIMIT_LO
-    4'b 1111, // index[17] DMA_DESTINATION_ADDRESS_LIMIT_HI
-    4'b 1111, // index[18] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO
-    4'b 1111, // index[19] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI
-    4'b 1111, // index[20] DMA_CONTROL
-    4'b 0001, // index[21] DMA_STATUS
-    4'b 0001, // index[22] DMA_ERROR_CODE
-    4'b 1111, // index[23] DMA_SHA2_DIGEST_0
-    4'b 1111, // index[24] DMA_SHA2_DIGEST_1
-    4'b 1111, // index[25] DMA_SHA2_DIGEST_2
-    4'b 1111, // index[26] DMA_SHA2_DIGEST_3
-    4'b 1111, // index[27] DMA_SHA2_DIGEST_4
-    4'b 1111, // index[28] DMA_SHA2_DIGEST_5
-    4'b 1111, // index[29] DMA_SHA2_DIGEST_6
-    4'b 1111, // index[30] DMA_SHA2_DIGEST_7
-    4'b 1111, // index[31] DMA_SHA2_DIGEST_8
-    4'b 1111, // index[32] DMA_SHA2_DIGEST_9
-    4'b 1111, // index[33] DMA_SHA2_DIGEST_10
-    4'b 1111, // index[34] DMA_SHA2_DIGEST_11
-    4'b 1111, // index[35] DMA_SHA2_DIGEST_12
-    4'b 1111, // index[36] DMA_SHA2_DIGEST_13
-    4'b 1111, // index[37] DMA_SHA2_DIGEST_14
-    4'b 1111, // index[38] DMA_SHA2_DIGEST_15
-    4'b 0011, // index[39] DMA_HANDSHAKE_INTERRUPT_ENABLE
-    4'b 0011, // index[40] DMA_CLEAR_INT_SRC
-    4'b 0011, // index[41] DMA_CLEAR_INT_BUS
-    4'b 1111, // index[42] DMA_INT_SOURCE_ADDR_0
-    4'b 1111, // index[43] DMA_INT_SOURCE_ADDR_1
-    4'b 1111, // index[44] DMA_INT_SOURCE_ADDR_2
-    4'b 1111, // index[45] DMA_INT_SOURCE_ADDR_3
-    4'b 1111, // index[46] DMA_INT_SOURCE_ADDR_4
-    4'b 1111, // index[47] DMA_INT_SOURCE_ADDR_5
-    4'b 1111, // index[48] DMA_INT_SOURCE_ADDR_6
-    4'b 1111, // index[49] DMA_INT_SOURCE_ADDR_7
-    4'b 1111, // index[50] DMA_INT_SOURCE_ADDR_8
-    4'b 1111, // index[51] DMA_INT_SOURCE_ADDR_9
-    4'b 1111, // index[52] DMA_INT_SOURCE_ADDR_10
-    4'b 1111, // index[53] DMA_INT_SOURCE_WR_VAL_0
-    4'b 1111, // index[54] DMA_INT_SOURCE_WR_VAL_1
-    4'b 1111, // index[55] DMA_INT_SOURCE_WR_VAL_2
-    4'b 1111, // index[56] DMA_INT_SOURCE_WR_VAL_3
-    4'b 1111, // index[57] DMA_INT_SOURCE_WR_VAL_4
-    4'b 1111, // index[58] DMA_INT_SOURCE_WR_VAL_5
-    4'b 1111, // index[59] DMA_INT_SOURCE_WR_VAL_6
-    4'b 1111, // index[60] DMA_INT_SOURCE_WR_VAL_7
-    4'b 1111, // index[61] DMA_INT_SOURCE_WR_VAL_8
-    4'b 1111, // index[62] DMA_INT_SOURCE_WR_VAL_9
-    4'b 1111  // index[63] DMA_INT_SOURCE_WR_VAL_10
+    4'b 0001, // index[13] DMA_CFG_REGWEN
+    4'b 1111, // index[14] DMA_TOTAL_DATA_SIZE
+    4'b 1111, // index[15] DMA_CHUNK_DATA_SIZE
+    4'b 0001, // index[16] DMA_TRANSFER_WIDTH
+    4'b 1111, // index[17] DMA_DESTINATION_ADDRESS_LIMIT_LO
+    4'b 1111, // index[18] DMA_DESTINATION_ADDRESS_LIMIT_HI
+    4'b 1111, // index[19] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO
+    4'b 1111, // index[20] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI
+    4'b 1111, // index[21] DMA_CONTROL
+    4'b 0001, // index[22] DMA_STATUS
+    4'b 0001, // index[23] DMA_ERROR_CODE
+    4'b 1111, // index[24] DMA_SHA2_DIGEST_0
+    4'b 1111, // index[25] DMA_SHA2_DIGEST_1
+    4'b 1111, // index[26] DMA_SHA2_DIGEST_2
+    4'b 1111, // index[27] DMA_SHA2_DIGEST_3
+    4'b 1111, // index[28] DMA_SHA2_DIGEST_4
+    4'b 1111, // index[29] DMA_SHA2_DIGEST_5
+    4'b 1111, // index[30] DMA_SHA2_DIGEST_6
+    4'b 1111, // index[31] DMA_SHA2_DIGEST_7
+    4'b 1111, // index[32] DMA_SHA2_DIGEST_8
+    4'b 1111, // index[33] DMA_SHA2_DIGEST_9
+    4'b 1111, // index[34] DMA_SHA2_DIGEST_10
+    4'b 1111, // index[35] DMA_SHA2_DIGEST_11
+    4'b 1111, // index[36] DMA_SHA2_DIGEST_12
+    4'b 1111, // index[37] DMA_SHA2_DIGEST_13
+    4'b 1111, // index[38] DMA_SHA2_DIGEST_14
+    4'b 1111, // index[39] DMA_SHA2_DIGEST_15
+    4'b 0011, // index[40] DMA_HANDSHAKE_INTERRUPT_ENABLE
+    4'b 0011, // index[41] DMA_CLEAR_INT_SRC
+    4'b 0011, // index[42] DMA_CLEAR_INT_BUS
+    4'b 1111, // index[43] DMA_INT_SOURCE_ADDR_0
+    4'b 1111, // index[44] DMA_INT_SOURCE_ADDR_1
+    4'b 1111, // index[45] DMA_INT_SOURCE_ADDR_2
+    4'b 1111, // index[46] DMA_INT_SOURCE_ADDR_3
+    4'b 1111, // index[47] DMA_INT_SOURCE_ADDR_4
+    4'b 1111, // index[48] DMA_INT_SOURCE_ADDR_5
+    4'b 1111, // index[49] DMA_INT_SOURCE_ADDR_6
+    4'b 1111, // index[50] DMA_INT_SOURCE_ADDR_7
+    4'b 1111, // index[51] DMA_INT_SOURCE_ADDR_8
+    4'b 1111, // index[52] DMA_INT_SOURCE_ADDR_9
+    4'b 1111, // index[53] DMA_INT_SOURCE_ADDR_10
+    4'b 1111, // index[54] DMA_INT_SOURCE_WR_VAL_0
+    4'b 1111, // index[55] DMA_INT_SOURCE_WR_VAL_1
+    4'b 1111, // index[56] DMA_INT_SOURCE_WR_VAL_2
+    4'b 1111, // index[57] DMA_INT_SOURCE_WR_VAL_3
+    4'b 1111, // index[58] DMA_INT_SOURCE_WR_VAL_4
+    4'b 1111, // index[59] DMA_INT_SOURCE_WR_VAL_5
+    4'b 1111, // index[60] DMA_INT_SOURCE_WR_VAL_6
+    4'b 1111, // index[61] DMA_INT_SOURCE_WR_VAL_7
+    4'b 1111, // index[62] DMA_INT_SOURCE_WR_VAL_8
+    4'b 1111, // index[63] DMA_INT_SOURCE_WR_VAL_9
+    4'b 1111  // index[64] DMA_INT_SOURCE_WR_VAL_10
   };
 
 endpackage

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -220,7 +220,6 @@ module dma_reg_top (
   logic status_error_qs;
   logic status_error_wd;
   logic status_sha2_digest_valid_qs;
-  logic status_sha2_digest_valid_wd;
   logic error_code_src_address_error_qs;
   logic error_code_dst_address_error_qs;
   logic error_code_opcode_error_qs;
@@ -1403,7 +1402,7 @@ module dma_reg_top (
   ) u_status0_qe (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .d_i(&(status_flds_we | 5'h1)),
+    .d_i(&(status_flds_we | 5'h11)),
     .q_o(status_qe)
   );
   //   F[busy]: 0:0
@@ -1518,7 +1517,7 @@ module dma_reg_top (
   //   F[sha2_digest_valid]: 4:4
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_status_sha2_digest_valid (
@@ -1526,8 +1525,8 @@ module dma_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (status_we),
-    .wd     (status_sha2_digest_valid_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.status.sha2_digest_valid.de),
@@ -3315,8 +3314,6 @@ module dma_reg_top (
   assign status_aborted_wd = reg_wdata[2];
 
   assign status_error_wd = reg_wdata[3];
-
-  assign status_sha2_digest_valid_wd = reg_wdata[4];
   assign handshake_interrupt_enable_we = addr_hit[40] & reg_we & !reg_error;
 
   assign handshake_interrupt_enable_wd = reg_wdata[10:0];


### PR DESCRIPTION
This PR implements a hardware managed REGWEN, that locks up the configuration registers of the DMA during an operation. When the DMA leaves the `DmaIdle` state, the hardware locks the following registers:

|  Register| Description |
| ------------- | ------------- |
| `SOURCE_ADDRESS_LO` | Locked  |
| `SOURCE_ADDRESS_HI` | Locked  |
| `DESTINATION_ADDRESS_LO` | Locked  |
| `DESTINATION_ADDRESS_HI` | Locked  |
| `ADDRESS_SPACE_ID` | Locked  |
| `ENABLED_MEMORY_RANGE_BASE` | Not locked but captured in the DMA since it already has a REGWEN  |
| `ENABLED_MEMORY_RANGE_LIMIT` | Not locked but captured in the DMA since it already has a REGWEN  |
| `RANGE_VALID` | Not locked but captured in the DMA since it already has a REGWEN  |
| `RANGE_REGWEN` | Not Locked  |
| `CFG_REGWEN` | Register that implements that lock.  |
| `TOTAL_DATA_SIZE` | Locked  |
| `CHUNK_DATA_SIZE` | Locked  |
| `TRANSFER_WIDTH` | Locked  |
| `DESTINATION_ADDRESS_LIMIT_LO` | Locked  |
| `DESTINATION_ADDRESS_LIMIT_HI` | Locked  |
| `DESTINATION_ADDRESS_ALMOST_LIMIT_LO` | Locked  |
| `DESTINATION_ADDRESS_ALMOST_LIMIT_HI` | Locked  |
| `CONTROL` | Opcode, HW handshake, *increment_enable, direction captured.  |
| `STATUS` | Not locked  |
| `SHA2_DIGEST` | Not locked, read only  |
| `HANDSHAKE_INTERRUPT_ENABLE` | Locked  |
| `CLEAR_INT_SRC` | Locked  |
| `CLEAR_INT_BUS` | Locked  |
| `INT_SOURCE_ADDR` | Locked  |
| `INT_SOURCE_WR_VAL` | Locked  |


