### PR TITLE
[dma] Fix STATUS.busy reset logic

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -1215,8 +1215,7 @@ module dma
     // - transitions from IDLE out
     // - clearing the go bit (going back to idle)
     // - abort               (going back to idle)
-    hw2reg.status.busy.de = ((ctrl_state_q  == DmaIdle) && (ctrl_state_d != DmaIdle)) ||
-                            hw2reg.control.go.de;
+    hw2reg.status.busy.de = ((ctrl_state_q  == DmaIdle) && (ctrl_state_d != DmaIdle)) || clear_go;
     // If transitioning from IDLE, set busy, otherwise clear it
     hw2reg.status.busy.d  = ((ctrl_state_q == DmaIdle) &&
                             (ctrl_state_d != DmaIdle)) ? 1'b1 : 1'b0;


### PR DESCRIPTION
Reset STATUS.busy bit when the CONTROL.go bit is cleared.

The previous expression used a forwards reference to `hw2reg.control.go.de` (blocking assignment in always_comb block), and thus never cleared the busy bit except at IP block reset.

This is important in that recent changes rely upon '...status.busy.q' to ascertain whether the DMA controller is truly idle (ie. between transfers). Firmware will likely also depend upon this status bit indicator.