### PR TITLE
[sival, rv_dm] add sival test for testing RV_DM JTAG

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -237,6 +237,9 @@
       stage: V2
       si_stage: SV3
       tests: []
+      bazel: [
+        "//sw/device/tests:rv_dm_jtag",
+      ],
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
       host_support: "true"
       features: [

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -182,6 +182,9 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_tap_straps_rma"]
+      bazel: [
+        "//sw/device/tests:rv_dm_jtag_tap_sel",
+      ],
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
       host_support: "true"
       features: [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3049,6 +3049,52 @@ opentitan_test(
     ],
 )
 
+_SIVAL_OTP_IMAGE = {
+    "test_unlocked1": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_unlocked1_manuf_individualized",
+    "test_locked0": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_locked0_manuf_initialized",
+    "dev": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_personalized",
+    "prod": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
+    "prod_end": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_manuf_personalized",
+    "rma": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_rma_manuf_personalized",
+}
+
+_RV_DM_JTAG_LC_STATES = get_lc_items(
+    CONST.LCV.TEST_UNLOCKED1,
+    CONST.LCV.DEV,
+    CONST.LCV.RMA,
+)
+
+[
+    opentitan_test(
+        name = "rv_dm_jtag_tap_sel_{}".format(lc_state),
+        srcs = ["example_test_from_flash.c"],
+        cw310 = cw310_jtag_params(
+            otp = _SIVAL_OTP_IMAGE[lc_state],
+            tags = [
+                "lc_{}".format(lc_state),
+            ],
+            test_harness = "//sw/host/tests/chip/rv_dm:jtag_tap_sel",
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+        deps = [
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for lc_state, _ in _RV_DM_JTAG_LC_STATES
+]
+
+test_suite(
+    name = "rv_dm_jtag_tap_sel",
+    tags = ["manual"],
+    tests = [
+        ":rv_dm_jtag_tap_sel_{}".format(lc_state)
+        for lc_state, _ in _RV_DM_JTAG_LC_STATES
+    ],
+)
+
 # TL tests are done on Ibex, so requires execution to be enabled.
 _RV_DM_LC_DISABLED_TL_LC_STATES = get_lc_items(
     CONST.LCV.TEST_UNLOCKED1,
@@ -3072,15 +3118,6 @@ _LC_STATES_DEBUG_DISALLOWED = [
     CONST.LCV.PROD,
     CONST.LCV.PROD_END,
 ]
-
-_SIVAL_OTP_IMAGE = {
-    "test_unlocked1": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_unlocked1_manuf_individualized",
-    "test_locked0": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_locked0_manuf_initialized",
-    "dev": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_personalized",
-    "prod": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
-    "prod_end": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_manuf_personalized",
-    "rma": "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_rma_manuf_personalized",
-}
 
 [
     opentitan_test(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3066,6 +3066,37 @@ _RV_DM_JTAG_LC_STATES = get_lc_items(
 
 [
     opentitan_test(
+        name = "rv_dm_jtag_{}".format(lc_state),
+        srcs = ["example_test_from_flash.c"],
+        cw310 = cw310_jtag_params(
+            otp = _SIVAL_OTP_IMAGE[lc_state],
+            tags = [
+                "lc_{}".format(lc_state),
+            ],
+            test_harness = "//sw/host/tests/chip/rv_dm:jtag",
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+        deps = [
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for lc_state, _ in _RV_DM_JTAG_LC_STATES
+]
+
+test_suite(
+    name = "rv_dm_jtag",
+    tags = ["manual"],
+    tests = [
+        ":rv_dm_jtag_{}".format(lc_state)
+        for lc_state, _ in _RV_DM_JTAG_LC_STATES
+    ],
+)
+
+[
+    opentitan_test(
         name = "rv_dm_jtag_tap_sel_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
         cw310 = cw310_jtag_params(

--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -106,6 +106,21 @@
       ]
     },
     {
+      "name": "PINMUX_TAP_DFT",
+      "pins": [
+        {
+          "name": "TAP_STRAP0",
+          "mode": "PushPull",
+          "level": true
+        },
+        {
+          "name": "TAP_STRAP1",
+          "mode": "PushPull",
+          "level": true
+        }
+      ]
+    },
+    {
       "name": "RESET",
       "pins": [
         {

--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -53,6 +53,9 @@ impl_serializable_error!(JtagError);
 pub trait JtagChain {
     /// Connect to the given JTAG TAP on this chain.
     fn connect(self: Box<Self>, tap: JtagTap) -> Result<Box<dyn Jtag>>;
+
+    /// Stop further setup and returns raw OpenOCD instance.
+    fn into_raw(self: Box<Self>) -> Result<crate::util::openocd::OpenOcd>;
 }
 
 /// A trait which represents a TAP on a JTAG chain.

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -258,6 +258,10 @@ impl JtagChain for OpenOcdJtagChain {
             jtag_tap: tap,
         }))
     }
+
+    fn into_raw(self: Box<Self>) -> Result<OpenOcd> {
+        Ok(self.openocd)
+    }
 }
 
 /// An JTAG interface driver over OpenOCD.

--- a/sw/host/tests/chip/rv_dm/BUILD
+++ b/sw/host/tests/chip/rv_dm/BUILD
@@ -7,6 +7,22 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 package(default_visibility = ["//visibility:public"])
 
 rust_binary(
+    name = "jtag_tap_sel",
+    srcs = [
+        "src/jtag_tap_sel.rs",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:log",
+        "@crate_index//:once_cell",
+        "@crate_index//:regex",
+    ],
+)
+
+rust_binary(
     name = "lc_disabled",
     srcs = [
         "src/lc_disabled.rs",

--- a/sw/host/tests/chip/rv_dm/BUILD
+++ b/sw/host/tests/chip/rv_dm/BUILD
@@ -7,6 +7,19 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 package(default_visibility = ["//visibility:public"])
 
 rust_binary(
+    name = "jtag",
+    srcs = [
+        "src/jtag.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:log",
+    ],
+)
+
+rust_binary(
     name = "jtag_tap_sel",
     srcs = [
         "src/jtag_tap_sel.rs",

--- a/sw/host/tests/chip/rv_dm/src/jtag.rs
+++ b/sw/host/tests/chip/rv_dm/src/jtag.rs
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+}
+
+// Needs to match util/openocd/target
+const RISCV_IDCODE: u32 = 0x10001cdf;
+
+fn test_jtag(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Avoid watchdog timeout by entering bootstrap mode.
+    transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
+
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    let mut openocd = opts.init.jtag_params.create(transport)?.into_raw()?;
+
+    // Configure OpenOCD to expect RISC-V tap and initialize JTAG.
+    assert_eq!(
+        openocd.execute(&format!(
+            "jtag newtap riscv tap -irlen 5 -expected-id {RISCV_IDCODE:#x}"
+        ))?,
+        ""
+    );
+    assert_eq!(openocd.execute("init")?, "");
+
+    // Read IDCODE register to ensure that it is expected.
+    assert_eq!(openocd.execute("irscan riscv.tap 0x1")?, "");
+    let idcode = u32::from_str_radix(&openocd.execute("drscan riscv.tap 32 0")?, 16)?;
+    assert_eq!(idcode, RISCV_IDCODE);
+
+    // Attempt to write IDCODE
+    assert_eq!(openocd.execute("irscan riscv.tap 0x1")?, "");
+    assert_eq!(
+        openocd.execute("drscan riscv.tap 64 0xdeadbeef")?,
+        format!("deadbeef{RISCV_IDCODE:x}")
+    );
+
+    // Read back IDCODE to ensure that the value remains
+    assert_eq!(openocd.execute("irscan riscv.tap 0x1")?, "");
+    let idcode = u32::from_str_radix(&openocd.execute("drscan riscv.tap 32 0")?, 16)?;
+    assert_eq!(idcode, RISCV_IDCODE);
+
+    // Check functionality of BYPASS
+    assert_eq!(openocd.execute("irscan riscv.tap 0")?, "");
+    assert_eq!(openocd.execute("drscan riscv.tap 1 0")?, "00");
+    let scan = u64::from_str_radix(&openocd.execute("drscan riscv.tap 33 0xdeadbeef")?, 16)?;
+    assert_eq!(scan, 0xdeadbeef << 1);
+
+    // Read DTMCS ensure value is as expected
+    assert_eq!(openocd.execute("irscan riscv.tap 0x10")?, "");
+    let value = u32::from_str_radix(&openocd.execute("drscan riscv.tap 32 0")?, 16)?;
+    // DTMCS.version
+    assert_eq!(value & 0xF, 1);
+    // DTMCS.abits
+    assert_eq!((value >> 4) & 0x3F, 7);
+
+    // Write DTMCS and ensure it's unchanged
+    assert_eq!(openocd.execute("irscan riscv.tap 0x10")?, "");
+    assert_eq!(
+        openocd.execute("drscan riscv.tap 64 0xdeadbeef")?,
+        format!("deadbeef{:08x}", value)
+    );
+    assert_eq!(openocd.execute("irscan riscv.tap 0x10")?, "");
+    let new_value = u32::from_str_radix(&openocd.execute("drscan riscv.tap 32 0")?, 16)?;
+    assert_eq!(new_value, value);
+
+    openocd.shutdown()?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(test_jtag, &opts, &transport);
+
+    Ok(())
+}

--- a/sw/host/tests/chip/rv_dm/src/jtag_tap_sel.rs
+++ b/sw/host/tests/chip/rv_dm/src/jtag_tap_sel.rs
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::JtagTap;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::util::parse_int::ParseInt;
+
+use top_earlgrey::top_earlgrey;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// IDCODE of the DFT TAP. If not specified, the test will check that DFT does not exist.
+    #[arg(long, value_parser = u32::from_str)]
+    dft_idcode: Option<u32>,
+}
+
+fn test_jtag_tap_sel(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Avoid watchdog timeout by entering bootstrap mode.
+    transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
+
+    // Test the LC TAP
+    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::LcTap)?;
+    let lc_state =
+        DifLcCtrlState::from_redundant_encoding(jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?)?;
+
+    jtag.disconnect()?;
+    transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;
+
+    // Test RISC-V TAP
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+    let mut lc_state_rv = 0;
+    jtag.read_memory32(
+        top_earlgrey::LC_CTRL_BASE_ADDR as u32 + LcCtrlReg::LcState as u32,
+        core::slice::from_mut(&mut lc_state_rv),
+    )?;
+    let lc_state_rv = DifLcCtrlState::from_redundant_encoding(lc_state_rv)?;
+    assert_eq!(lc_state, lc_state_rv);
+
+    jtag.disconnect()?;
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
+
+    // Test DFT TAP
+    transport.pin_strapping("PINMUX_TAP_DFT")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    // For DFT test we need to do raw OpenOCD command.
+    let mut openocd = opts.init.jtag_params.create(transport)?.into_raw()?;
+    // Perform JTAG initialisation and capture the result.
+    let init_result = openocd.execute("capture \"jtag init\"")?;
+
+    static ID_REGEX: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"tap/device found: 0x([0-9A-Fa-f]+) \(").unwrap());
+    let idcode = if init_result.contains("JTAG scan chain interrogation failed") {
+        None
+    } else {
+        Some(u32::from_str_radix(
+            ID_REGEX
+                .captures(&init_result)
+                .context("Failed to parse IDCODE from OpenOCD output")?
+                .get(1)
+                .unwrap()
+                .as_str(),
+            16,
+        )?)
+    };
+    assert_eq!(idcode, opts.dft_idcode);
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(test_jtag_tap_sel, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
Fix #19884
Fix #19886 