### PR TITLE
[ci] Make hyperdebug tests blocking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -629,7 +629,6 @@ jobs:
       ci/scripts/run-fpga-tests.sh hyper310 hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
-  continueOnError: True
 
 - job: execute_rom_fpga_tests_cw340
   displayName: CW340 ROM Tests


### PR DESCRIPTION
Currently, we set `continueOnError: true` for the HyperDebug test.

That setting allows further jobs in the pipeline to start after this one, even if it has failed. This isn't very useful since the HD tests run at the end of the pipeline anyway.

The flag does prevent us from using the "re-run failed jobs" feature of Azure, though. Azure doesn't seem to think the job failed with `continueOnError: true` set, so we have to force-push to the PR to get it to re-trigger the whole CI pipeline.

Resolves https://github.com/lowRISC/opentitan/issues/17782