### PR TITLE
[sival] Define set of OTP profiles.

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -147,8 +147,10 @@ bitstream_splice(
         update_usr_access = True,
     )
     for (otp_name, img_target) in [
+        ("sival_test_locked0", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_post_cp_test_locked0"),
         ("sival_prod_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized"),
         ("sival_prod_end_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_personalized"),
+        ("sival_dev_individualized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_individualized"),
         ("sival_dev_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized"),
     ]
     for authenticity in KEY_AUTHENTICITY

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -509,16 +509,6 @@ otp_image(
     ],
 )
 
-# Represents a device in DEV state with the SECRET0 partition in the locked
-# state. SECRET1 and SECRET2 partitions are in the unlocked state.
-otp_image(
-    name = "img_dev_individualized",
-    src = ":otp_json_dev",
-    overlays = [
-        ":otp_json_secret0",
-    ] + STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS,
-)
-
 otp_image(
     name = "img_dev",
     src = ":otp_json_dev",
@@ -581,7 +571,6 @@ filegroup(
     name = "otp_imgs",
     srcs = [
         ":img_dev",
-        ":img_dev_individualized",
         ":img_prod",
         ":img_raw",
         ":img_rma",

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:const.bzl", "CONST", "EARLGREY_ALERTS", "EARLGREY_LOC_ALERTS")
 load(
     "//rules:otp.bzl",
     "otp_alert_classification",
@@ -15,7 +16,6 @@ load(
     "otp_per_class_ints",
     "otp_per_class_lists",
 )
-load("//rules:const.bzl", "CONST", "EARLGREY_ALERTS", "EARLGREY_LOC_ALERTS")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "//rules:const.bzl",
+    "CONST",
+    "get_lc_items",
+)
+load(
     "//rules:otp.bzl",
     "otp_image",
     "otp_image_consts",
@@ -11,21 +16,58 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-# Dummy partition used in `otp_image_consts` targets.
+# Partition used to set a fixed seed value in `otp_image_consts` targets.
 otp_json(
     name = "otp_json_baseline",
     seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
 )
 
-# OTP SW Configuration for Test SKU.
+# The `LC_MISSION_STATES` object contains the set of mission mode life cycle
+# states. A device is considered to be mission mode configured if it has a
+# matching `MANUF_PERSONALIZED` OTP configuration.
+LC_MISSION_STATES = get_lc_items(
+    CONST.LCV.DEV,
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+)
+
+# The `MANUF_INITIALIZED` OTP profile configures the SECRET0 partition to
+# enable the device to transition between test_unlock and test_locked states,
+# as well as to transition out of test_unlock into any of the
+# `LC_MISSION_STATES`.
+MANUF_INITIALIZED = [
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
+]
+
+MANUF_SW_INITIALIZED = [
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
+]
+
+# The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG, CREATOR_SW and
+# OWNER_SW OTP partitions. It also includes the `MANUF_INITIALIZED`.
+MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + [
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
+]
+
+# The `MANUF_PERSONALIZED` OTP profile configures the SECRET1 and SECRET2 OTP
+# partitions. It also includes the `MANUF_INDIVIDUALIZED` profile.
+MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
+    "//hw/ip/otp_ctrl/data:otp_json_secret1",
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
+]
+
+# OTP SW Configuration. Used to generate a configuration program used during
+# manufacturing. The `MANUF_SW_INITIALIZED` OTP profile is also used to derive
+# OTP profiles representing the state of the device after running manufacturing
+# steps consuming this dependency.
 otp_image_consts(
     name = "otp_sw_cfg_c_file",
     src = ":otp_json_baseline",
-    overlays = [
-        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
-        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
-        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
-    ],
+    # Do not add additional overlays here. Update the `MANUF_SW_INITIALIZED`
+    # OTP profile instead.
+    overlays = MANUF_SW_INITIALIZED,
 )
 
 cc_library(
@@ -37,30 +79,68 @@ cc_library(
     ],
 )
 
-MISSION_MODE_OVERLAYS = [
-    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg",
-    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
-    "//hw/ip/otp_ctrl/data:otp_json_secret1",
-    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
-    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
-    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
-    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
+# Initial test_unlocked state. Only applicable for test_unlocked0. All other
+# test states required the SECRET0 partition to be configured.
+# In this configuration, ROM execution is disabled by default. JTAG should be
+# used to bootstrap code into SRAM or FLASH.
+otp_image(
+    name = "otp_img_test_unlocked0_manuf_empty",
+    src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
+    overlays = [
+        "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+# `MANUF_INITIALIZED` configuration. This configuration will be generally used
+# to lock the chips before shipping to the Final-Test test house.
+otp_image(
+    name = "otp_img_post_cp_test_locked0",
+    src = "//hw/ip/otp_ctrl/data:otp_json_test_locked0",
+    overlays = MANUF_INITIALIZED,
+)
+
+# `MANUF_INITIALIZED` OTP configuration. Available on TEST_UNLOCK states 1-7.
+[
+    otp_image(
+        name = "otp_img_test_unlocked{}_manuf_initialized".format(i),
+        src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked{}".format(i),
+        overlays = MANUF_INITIALIZED,
+    )
+    for i in range(1, 8)
 ]
 
-otp_image(
-    name = "otp_img_prod_personalized",
-    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
-    overlays = MISSION_MODE_OVERLAYS,
-)
+# `MANUF_INDIVIDUALIZED` configuration. Available on TEST_UNLOCK states 1-7, as
+# well as dev, prod, prod_end and rma. This configuration has flash scrambling
+# disabled. See the personalized OTP configuration for targets requiring flash
+# scrambling enabled.
+[
+    otp_image(
+        name = "otp_img_{}_individualized".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+        overlays = MANUF_INDIVIDUALIZED,
+    )
+    for lc_state, _ in get_lc_items(
+        CONST.LCV.TEST_UNLOCKED1,
+        CONST.LCV.TEST_UNLOCKED2,
+        CONST.LCV.TEST_UNLOCKED3,
+        CONST.LCV.TEST_UNLOCKED4,
+        CONST.LCV.TEST_UNLOCKED5,
+        CONST.LCV.TEST_UNLOCKED6,
+        CONST.LCV.TEST_UNLOCKED7,
+        CONST.LCV.DEV,
+        CONST.LCV.PROD,
+        CONST.LCV.PROD_END,
+    )
+]
 
-otp_image(
-    name = "otp_img_prod_end_personalized",
-    src = "//hw/ip/otp_ctrl/data:otp_json_prod_end",
-    overlays = MISSION_MODE_OVERLAYS,
-)
-
-otp_image(
-    name = "otp_img_dev_personalized",
-    src = "//hw/ip/otp_ctrl/data:otp_json_dev",
-    overlays = MISSION_MODE_OVERLAYS,
-)
+# `MANUF_PERSONALIZED` configuration. Available on `LC_MISSION_STATES` life
+# cycle states.
+[
+    otp_image(
+        name = "otp_img_{}_personalized".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+        overlays = MANUF_PERSONALIZED,
+    )
+    for lc_state, _ in LC_MISSION_STATES
+]

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -51,7 +51,6 @@ def get_otp_images():
 
     img_targets = [
         "//hw/ip/otp_ctrl/data:img_dev",
-        "//hw/ip/otp_ctrl/data:img_dev_individualized",
         "//hw/ip/otp_ctrl/data:img_rma",
         "//hw/ip/otp_ctrl/data:img_test_locked0",
         "//hw/ip/otp_ctrl/data:img_test_locked1",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -228,7 +228,7 @@ opentitan_test(
     name = "personalize_functest",
     srcs = ["personalize_functest.c"],
     cw310 = cw310_jtag_params(
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_dev_individualized",
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_dev_individualized",
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         tags = ["manuf"],
         test_cmd = """

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -104,12 +104,14 @@ bool test_main(void) {
     if (!status_ok(manuf_personalize_device_secret1_check(&otp_ctrl))) {
       LOG_INFO("Provisioning OTP SECRET1 ...");
       CHECK_STATUS_OK(manuf_personalize_device_secret1(&lc_ctrl, &otp_ctrl));
+      // Wait in a loop so that the test harness can trigger a second bootstrap
+      // operation. This is required because the flash scrambling setting may
+      // have changed in OTP.
+      // The following log message is polled in the host side of this test.
+      LOG_INFO("Provisioning OTP SECRET1 Done ...");
+      abort();
     }
-    // We move the SW reset outside the above if-clause so the next block of the
-    // outter conditional (the block executed under a soft reset condition) is
-    // always executed. This facilitates test-reruns.
-    sw_reset();
-  } else if (info == kDifRstmgrResetInfoSw) {
+
     // Provision the OTP SECRET2 partition and flash info pages.
     if (!status_ok(manuf_personalize_device_secrets_check(&otp_ctrl))) {
       // Wait for host ECC pubkey, used to generate a shared AES key to export
@@ -146,7 +148,7 @@ bool test_main(void) {
       // Reset the chip to activate the OTP partitions and flash pages.
       sw_reset();
     }
-
+  } else if (info == kDifRstmgrResetInfoSw) {
     // Send the RMA unlock token data (stored in the retention SRAM) over the
     // console using ujson framework.
     LOG_INFO("Exporting RMA unlock token ...");

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -7,8 +7,6 @@ load(
     "//rules:opentitan.bzl",
     "RSA_ONLY_KEY_STRUCTS",
 )
-load("//rules:otp.bzl", "otp_image")
-load("//rules:splice.bzl", "bitstream_splice")
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
@@ -201,24 +199,6 @@ opentitan_binary(
     ],
 )
 
-# This is the same as //hw/ip/otp_ctrl/data:img_test_locked* but with *_SW_CFG
-# partitions unprovisioned (and as a result, ROM execution also disabled).
-otp_image(
-    name = "otp_img_post_cp_test_locked0",
-    src = "//hw/ip/otp_ctrl/data:otp_json_test_locked0",
-    overlays = ["//hw/ip/otp_ctrl/data:otp_json_fixed_secret0"],
-    visibility = ["//visibility:private"],
-)
-
-bitstream_splice(
-    name = "bitstream_post_cp_test_locked0",
-    src = "//hw/bitstream:rom_with_fake_keys",
-    data = ":otp_img_post_cp_test_locked0",
-    meminfo = "//hw/bitstream:otp_mmi",
-    update_usr_access = True,
-    visibility = ["//visibility:private"],
-)
-
 opentitan_test(
     name = "ft_provision",
     srcs = ["ft_personalize_1.c"],
@@ -227,7 +207,7 @@ opentitan_test(
             ":sram_ft_individualize": "sram_ft_individualize",
             ":ft_personalize_2": "ft_personalize_2",
         },
-        bitstream = ":bitstream_post_cp_test_locked0",
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_test_locked0",
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         tags = ["manuf"],
         test_cmd = """

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -2,10 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:const.bzl", "CONST", "get_lc_items")
+load("//rules:lc.bzl", "lc_raw_unlock_token")
 load(
     "//rules:opentitan.bzl",
     "RSA_ONLY_KEY_STRUCTS",
 )
+load("//rules:otp.bzl", "otp_image")
+load("//rules:splice.bzl", "bitstream_splice")
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
@@ -13,10 +17,6 @@ load(
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
-load("//rules:const.bzl", "CONST", "get_lc_items")
-load("//rules:lc.bzl", "lc_raw_unlock_token")
-load("//rules:otp.bzl", "otp_image")
-load("//rules:splice.bzl", "bitstream_splice")
 
 _TEST_UNLOCKED_LC_ITEMS = get_lc_items(
     CONST.LCV.TEST_UNLOCKED0,


### PR DESCRIPTION
This change introduces a list of OTP profiles to be used during Silicon Validation enablement. The current profile definitions ommit OTP permutations that are not planned for end use cases.