### PR TITLE
[bazel] add exec_env for the silicon platform

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -203,6 +203,7 @@ fpga_cw340(
 ###########################################################################
 # Silicon Environments
 ###########################################################################
+# This exec_env targets running software at the ROM_EXT stage on silicon.
 silicon(
     name = "silicon_creator",
     testonly = True,
@@ -210,10 +211,7 @@ silicon(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
-    ] + select({
-        "@//ci:lowrisc_fpga_cw310": ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
-        "//conditions:default": [],
-    }),
+    ],
     design = "earlgrey",
     exec_env = "silicon_creator",
     lib = "//sw/device/lib/arch:silicon",

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -10,6 +10,7 @@ load(
     "fpga_cw305",
     "fpga_cw310",
     "fpga_cw340",
+    "silicon",
     "sim_dv",
     "sim_verilator",
 )
@@ -193,6 +194,39 @@ fpga_cw340(
     },
     test_cmd = """
         --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
+###########################################################################
+# Silicon Environments
+###########################################################################
+silicon(
+    name = "silicon_creator",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ] + select({
+        "@//ci:lowrisc_fpga_cw310": ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
+        "//conditions:default": [],
+    }),
+    design = "earlgrey",
+    exec_env = "silicon_creator",
+    lib = "//sw/device/lib/arch:silicon",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    test_cmd = """
+        --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"
         --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -22,6 +22,12 @@ load(
     _fpga_cw340 = "fpga_cw340",
 )
 load(
+    "@lowrisc_opentitan//rules/opentitan:silicon.bzl",
+    _silicon = "silicon",
+    _silicon_jtag_params = "silicon_jtag_params",
+    _silicon_params = "silicon_params",
+)
+load(
     "@lowrisc_opentitan//rules/opentitan:sim_verilator.bzl",
     _sim_verilator = "sim_verilator",
     _verilator_params = "verilator_params",
@@ -50,6 +56,10 @@ fpga_cw305 = _fpga_cw305
 fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 cw310_jtag_params = _cw310_jtag_params
+
+silicon = _silicon
+silicon_params = _silicon_params
+silicon_jtag_params = _silicon_jtag_params
 
 sim_verilator = _sim_verilator
 verilator_params = _verilator_params
@@ -92,6 +102,8 @@ def _parameter_name(env, pname):
             pname = "verilator"
         elif "dv" in suffix:
             pname = "dv"
+        elif "silicon" in suffix:
+            pname = "silicon"
         else:
             fail("Unable to identify parameter block name:", env)
     return pname
@@ -124,6 +136,7 @@ def opentitan_test(
         exec_env = {},
         cw310 = _cw310_params(),
         dv = _dv_params(),
+        silicon = _silicon_params(),
         verilator = _verilator_params(),
         **kwargs):
     """Instantiate a test per execution environment.
@@ -146,15 +159,17 @@ def opentitan_test(
       exec_env: A dictionary of execution environments.  The keys are labels to
                 execution environments.  The values are the kwargs parameter names
                 of the exec_env override or None.  If None, the default parameter
-                names of `cw310`, `dv` or `verilator` will be guessed.
+                names of `cw310`, `dv`, `silicon`, or `verilator` will be guessed.
       cw310: Execution overrides for a CW310-based test.
       dv: Execution overrides for a DV-based test.
+      silicon: Execution overrides for a silicon-based test.
       verilator: Execution overrides for a verilator-based test.
       kwargs: Additional execution overrides identified by the `exec_env` dict.
     """
     test_parameters = {
         "cw310": cw310,
         "dv": dv,
+        "silicon": silicon,
         "verilator": verilator,
     }
     test_parameters.update(kwargs)

--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -7,9 +7,12 @@ OPENTITANTOOL_OPENOCD_DATA_DEPS = [
     "//third_party/openocd:openocd_bin",
 ]
 
-OPENTITANTOOL_OPENOCD_TEST_CMD = """
+OPENTITANTOOL_OPENOCD_SI_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
     --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_olimex_cfg)"
+"""
+
+OPENTITANTOOL_OPENOCD_TEST_CMD = OPENTITANTOOL_OPENOCD_SI_TEST_CMD + """
     --clear-bitstream
     --bitstream={bitstream}
 """

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -16,6 +16,10 @@ Cw340BinaryInfo = provider(
     doc = "CW340 Binary Info",
 )
 
+SiliconBinaryInfo = provider(
+    doc = "Silicon Binary Info",
+)
+
 SimDvBinaryInfo = provider(
     doc = "Dv Binary Info",
 )
@@ -27,6 +31,7 @@ SimVerilatorBinaryInfo = provider(
 ALL_BINARY_PROVIDERS = [
     Cw310BinaryInfo,
     Cw340BinaryInfo,
+    SiliconBinaryInfo,
     SimDvBinaryInfo,
     SimVerilatorBinaryInfo,
 ]

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -1,0 +1,216 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@lowrisc_opentitan//rules/opentitan:providers.bzl",
+    "SiliconBinaryInfo",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:util.bzl",
+    "assemble_for_test",
+    "get_fallback",
+)
+load(
+    "//rules/opentitan:exec_env.bzl",
+    "ExecEnvInfo",
+    "common_test_setup",
+    "exec_env_as_dict",
+    "exec_env_common_attrs",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:openocd.bzl",
+    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
+    "OPENTITANTOOL_OPENOCD_SI_TEST_CMD",
+)
+
+_TEST_SCRIPT = """#!/bin/bash
+set -e
+
+TEST_CMD=({test_cmd})
+echo Invoking test: {test_harness} {args} "${{TEST_CMD[@]}}"
+RUST_BACKTRACE=1 {test_harness} {args} "${{TEST_CMD[@]}}"
+"""
+
+def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):
+    """Transform binaries into the preferred forms for silicon.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      name: The rule name/basename.
+      elf: The compiled elf program.
+      binary: The raw binary of the compiled program.
+      signed_bin: The signed binary (if available).
+      disassembly: A disassembly listing.
+      mapfile: The linker-created mapfile.
+    Returns:
+      dict: A dict of fields to create in the provider.
+    """
+    if ctx.attr.kind == "ram":
+        default = elf
+    elif ctx.attr.kind == "flash":
+        default = signed_bin if signed_bin else binary
+    else:
+        fail("Not implemented: kind ==", ctx.attr.kind)
+
+    return {
+        "elf": elf,
+        "binary": binary,
+        "default": default,
+        "signed_bin": signed_bin,
+        "disassembly": disassembly,
+        "mapfile": mapfile,
+    }
+
+def _test_dispatch(ctx, exec_env, firmware):
+    """Dispatch a test for the silicon environment.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      firmware: A label with a SiliconBinaryInfo provider attached.
+    Returns:
+      (File, List[File]) The test script and needed runfiles.
+    """
+    if ctx.attr.kind == "rom":
+        fail("Silicon is not capable of executing ROM tests")
+
+    test_harness, data_labels, data_files, param, action_param = common_test_setup(ctx, exec_env, firmware)
+
+    # If the test requested an assembled image, then use opentitantool to
+    # assemble the image.  Replace the firmware param with the newly assembled
+    # image.
+    if "assemble" in param:
+        assemble = param["assemble"].format(**action_param)
+        assemble = ctx.expand_location(assemble, data_labels)
+        image = assemble_for_test(
+            ctx,
+            name = ctx.attr.name,
+            spec = assemble.split(" "),
+            data_files = data_files,
+            opentitantool = exec_env._opentitantool,
+        )
+        param["firmware"] = image.short_path
+        action_param["firmware"] = image.path
+        data_files.append(image)
+
+    # Perform all relevant substitutions on the test_cmd.
+    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
+    test_cmd = test_cmd.format(**param)
+    test_cmd = ctx.expand_location(test_cmd, data_labels)
+
+    # Get the pre-test_cmd args.
+    args = get_fallback(ctx, "attr.args", exec_env)
+    args = " ".join(args).format(**param)
+    args = ctx.expand_location(args, data_labels)
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+    ctx.actions.write(
+        script,
+        _TEST_SCRIPT.format(
+            test_harness = test_harness.short_path,
+            args = args,
+            test_cmd = test_cmd,
+        ),
+        is_executable = True,
+    )
+    return script, data_files
+
+def _silicon(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        provider = SiliconBinaryInfo,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        **fields
+    )
+
+silicon = rule(
+    implementation = _silicon,
+    attrs = exec_env_common_attrs(),
+)
+
+def silicon_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        rom_ext = None,
+        test_harness = None,
+        binaries = {},
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create Silicon parameters for OpenTitan tests.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    return struct(
+        tags = ["silicon", "exclusive"] + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = None,
+        rom_ext = rom_ext,
+        otp = None,
+        bitstream = None,
+        test_cmd = test_cmd,
+        data = data,
+        param = kwargs,
+    )
+
+def silicon_jtag_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        rom_ext = None,
+        test_harness = None,
+        binaries = {},
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create Silicon parameters for OpenTitan JTAG tests.
+
+    This creates version of the Silicon parameter structure pre-initialized
+    with OpenOCD dependencies and test_cmd parameters.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    return struct(
+        tags = ["silicon", "exclusive"] + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = None,
+        rom_ext = rom_ext,
+        otp = None,
+        bitstream = None,
+        test_cmd = OPENTITANTOOL_OPENOCD_SI_TEST_CMD + test_cmd,
+        data = OPENTITANTOOL_OPENOCD_DATA_DEPS + data,
+        param = kwargs,
+    )

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -46,6 +46,16 @@ cc_library(
 )
 
 cc_library(
+    name = "silicon",
+    srcs = ["device_silicon.c"],
+    deps = [
+        ":device",
+        "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    ],
+)
+
+cc_library(
     name = "sim_dv",
     srcs = ["device_sim_dv.c"],
     deps = [

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -61,6 +61,11 @@ typedef enum device_type {
    * FPGA board blessed for OpenTitan development, containing a Xilinx FPGA.
    */
   kDeviceFpgaCw340 = 4,
+  /**
+   * Represents the "Silicon" device, i.e., an instantiation of OpenTitan in
+   * Silicon.
+   */
+  kDeviceSilicon = 5,
 } device_type_t;
 
 /**

--- a/sw/device/lib/arch/device_silicon.c
+++ b/sw/device/lib/arch/device_silicon.c
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+/**
+ * Device-specific symbol definitions for the Silicon device.
+ */
+
+const device_type_t kDeviceType = kDeviceSilicon;
+
+const uint64_t kClockFreqCpuMhz = 100;
+
+const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
+
+uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
+
+const uint64_t kClockFreqHiSpeedPeripheralHz = 96 * 1000 * 1000;  // 96MHz
+
+const uint64_t kClockFreqPeripheralHz = 24 * 1000 * 1000;  // 24MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
+
+const uint64_t kClockFreqAonHz = 200 * 1000;  // 200kHz
+
+const uint64_t kUartBaudrate = 115200;
+
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
+const uint32_t kUartTxFifoCpuCycles =
+    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+
+const uint32_t kAstCheckPollCpuCycles =
+    CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
+
+const uintptr_t kDeviceTestStatusAddress = 0;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+void device_fpga_version_print(void) {}

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -12,6 +12,7 @@ load(
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
+    "silicon_jtag_params",
 )
 load("//rules:const.bzl", "CONST", "get_lc_items")
 load("//rules:lc.bzl", "lc_raw_unlock_token")
@@ -229,9 +230,14 @@ cc_library(
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:silicon_creator": None,
         },
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+        silicon = silicon_jtag_params(
+            test_cmd = "--elf={firmware}",
+            test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
+        ),
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/arch:device",

--- a/sw/device/silicon_creator/manuf/tests/sram_empty_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_empty_functest.c
@@ -41,7 +41,7 @@ void sram_main(void) {
              }));
   base_uart_stdout(&uart);
 
-  LOG_INFO("hello");
+  LOG_INFO("Hello OpenTitan! We are executing from SRAM.");
 
   // Make sure that the function returns so that the CRT can notify the host.
 }

--- a/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
+++ b/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
@@ -86,19 +86,19 @@ fn test_sram_load(opts: &Opts, transport: &TransportWrapper, corrupt: bool) -> R
         }
     }
 
+    jtag.halt()?;
+    jtag.disconnect()?;
+
     // If the program was not corrupted, make sure that it printed the expected message.
     if !corrupt {
         const CONSOLE_TIMEOUT: Duration = Duration::from_secs(1);
         let _ = UartConsole::wait_for(
             &*uart,
-            r"sram_empty_functest\.c:\d+\] hello.",
+            r"Hello OpenTitan! We are executing from SRAM.",
             CONSOLE_TIMEOUT,
         )
         .context("SRAM program did not print 'hello' in time")?;
     }
-
-    jtag.halt()?;
-    jtag.disconnect()?;
 
     Ok(())
 }


### PR DESCRIPTION
This adds the exec_env for the silicon platform. Additionally, this adds this exec_env to a manuf test that simply loads and executes an SRAM program. SRAM program can be run with:

```
bazel test --test_output=streamed --cache_test_results=no //sw/device/silicon_creator/manuf/tests:manuf_sram_program_crc_test_unlocked0_functest_silicon_creator
```