### PR TITLE
[flash_ctrl,sival] flash_ctrl rma test for fpga target

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -22,6 +22,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
     new_cw310_params = "cw310_params",
@@ -29,7 +30,7 @@ load(
     new_verilator_params = "verilator_params",
 )
 load("//rules:splice.bzl", "bitstream_splice")
-load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_image", "otp_json", "otp_partition")
+load("//rules:otp.bzl", "STD_OTP_OVERLAYS", "otp_hex", "otp_image", "otp_json", "otp_partition")
 load(
     "//rules:const.bzl",
     "CONST",
@@ -1295,6 +1296,99 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+# Generate hard coded secret2 partition but unlocked.
+otp_json(
+    name = "otp_json_test_rma",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_RMA_SPIN_EN": otp_hex(CONST.HARDENED_TRUE),
+                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0x2000000",
+            },
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                # This RMA token is a cSHAKE128 digest.
+                # Source is hardcoded to host test file.
+                "RMA_TOKEN": "0x1faf9056acde66561685549803a28bec",
+                "CREATOR_ROOT_KEY_SHARE0": "<random>",
+                "CREATOR_ROOT_KEY_SHARE1": "<random>",
+            },
+        ),
+    ],
+    visibility = ["//visibility:private"],
+)
+
+# rom exec is disabled to mitigate sram execution.
+# Without this, it will cause continuous watch dog timeout.
+# secret2 unlocked dev state is required to write secret to all necessary info partitions
+# (creator, owner and isolation partition)
+otp_image(
+    name = "img_dev_exec_disabled",
+    src = "//hw/ip/otp_ctrl/data:otp_json_dev",
+    overlays = STD_OTP_OVERLAYS + [
+        "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
+        ":otp_json_test_rma",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+bitstream_splice(
+    name = "rom_with_fake_keys_otp_dev_exec_disabled",
+    src = "//hw/bitstream:rom_with_fake_keys",
+    data = "img_dev_exec_disabled",
+    meminfo = "//hw/bitstream:otp_mmi",
+    update_usr_access = True,
+    visibility = ["//visibility:private"],
+)
+
+# This test is fpga only.
+opentitan_test(
+    name = "flash_ctrl_rma_test",
+    srcs = ["flash_ctrl_rma_test.c"],
+    cw310 = cw310_jtag_params(
+        bitstream = ":rom_with_fake_keys_otp_dev_exec_disabled",
+        test_cmd = " ".join([
+            "--elf=\"{firmware}\"",
+            " \"{firmware}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/flash_ctrl:host",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    kind = "ram",
+    linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    # Test goes from Dev to RMA.
+    # So prod rsa key is required.
+    rsa_key = rsa_key_for_lc_state(
+        RSA_ONLY_KEY_STRUCTS,
+        CONST.LCV.PROD,
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
+        "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )
 

--- a/sw/device/tests/flash_ctrl_rma_test.c
+++ b/sw/device/tests/flash_ctrl_rma_test.c
@@ -1,0 +1,213 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/mem.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf_commands.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+volatile uint32_t kTestPhase;
+volatile uint32_t kEndTest;
+
+static dif_uart_t uart;
+static dif_pinmux_t pinmux;
+static dif_flash_ctrl_state_t flash;
+static dif_otp_ctrl_t otp_ctrl;
+
+enum {
+  kFlashInfoBankId = 0,
+  kFlashInfoPartitionId = 0,
+  kFlashInfoPageIdCreatorSecret = 1,
+  kFlashInfoPageIdOwnerSecret = 2,
+  kFlashInfoPageIdIsoPart = 3,
+  kTestPhase0 = 0,
+  kTestPhase1 = 1,
+  kTestPhaseInit = 2,
+};
+
+// Hardcoded secret data for flash info partition.
+static const uint32_t kRandomData[3] = {
+    0xbab0bab1,
+    0xdeadbeef,
+    0xcafefeed,
+};
+
+status_t command_processor(ujson_t *uj) {
+  while (!kEndTest) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    status_t status = ujson_ottf_dispatch(uj, command);
+    if (status_err(status) == kUnimplemented) {
+      RESP_ERR(uj, status);
+    } else if (status_err(status) != kOk) {
+      return status;
+    }
+  }
+  return OK_STATUS();
+}
+#define EXECUTE_TEST(result_, test_function_, ...)                       \
+  do {                                                                   \
+    LOG_INFO("Starting test " #test_function_ "...");                    \
+    uint64_t t_start_ = ibex_mcycle_read();                              \
+    status_t local_status = INTO_STATUS(test_function_(__VA_ARGS__));    \
+    uint64_t cycles_ = ibex_mcycle_read() - t_start_;                    \
+    CHECK(kClockFreqCpuHz <= UINT32_MAX, "");                            \
+    uint32_t clock_mhz = (uint32_t)kClockFreqCpuHz / 1000000;            \
+    if (status_ok(local_status)) {                                       \
+      if (cycles_ <= UINT32_MAX) {                                       \
+        uint32_t micros = (uint32_t)cycles_ / clock_mhz;                 \
+        LOG_INFO("Successfully finished test " #test_function_           \
+                 " in %u cycles or %u us @ %u MHz.",                     \
+                 (uint32_t)cycles_, micros, clock_mhz);                  \
+      } else {                                                           \
+        uint32_t cycles_lower_ = (uint32_t)(cycles_ & UINT32_MAX);       \
+        uint32_t cycles_upper_ = (uint32_t)(cycles_ >> 32);              \
+        LOG_INFO("Successfully finished test " #test_function_           \
+                 " in 0x%08x%08x cycles.",                               \
+                 cycles_upper_, cycles_lower_);                          \
+      }                                                                  \
+    } else {                                                             \
+      result_ = local_status;                                            \
+      LOG_ERROR("Finished test " #test_function_ ": %r.", local_status); \
+    }                                                                    \
+  } while (0)
+
+static status_t write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
+                                const uint32_t *data, bool scramble) {
+  uint32_t address = 0;
+  if (scramble) {
+    TRY(flash_ctrl_testutils_info_region_scrambled_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
+  } else {
+    TRY(flash_ctrl_testutils_info_region_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
+  }
+
+  TRY(flash_ctrl_testutils_erase_and_write_page(
+      flash, address, kFlashInfoPartitionId, data,
+      kDifFlashCtrlPartitionTypeInfo, 1));
+
+  LOG_INFO("wr_info: data:0x%x", *data);
+  return OK_STATUS();
+}
+
+static status_t read_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
+                               uint32_t *data, bool scramble) {
+  uint32_t address = 0;
+  if (scramble) {
+    TRY(flash_ctrl_testutils_info_region_scrambled_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
+  } else {
+    TRY(flash_ctrl_testutils_info_region_setup(
+        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
+  }
+
+  TRY(flash_ctrl_testutils_read(flash, address, kFlashInfoPartitionId, data,
+                                kDifFlashCtrlPartitionTypeInfo, 1, 1));
+
+  return OK_STATUS();
+}
+
+static status_t read_and_check_info(bool match) {
+  uint32_t readback_data[3];
+  read_info_page(&flash, kFlashInfoPageIdCreatorSecret, readback_data, true);
+  read_info_page(&flash, kFlashInfoPageIdOwnerSecret, readback_data + 1, true);
+  read_info_page(&flash, kFlashInfoPageIdIsoPart, readback_data + 2, true);
+  LOG_INFO("readdata0: %x", *readback_data);
+  LOG_INFO("readdata1: %x", *(readback_data + 1));
+  LOG_INFO("readdata2: %x", *(readback_data + 2));
+  if (match) {
+    // iso partition cannot be accessed in dev state.
+    // check create and owner partition only
+    CHECK_ARRAYS_EQ(readback_data, kRandomData, 2);
+  } else {
+    CHECK_ARRAYS_NE(readback_data, kRandomData, 3);
+  }
+  LOG_INFO("read_and_check is done");
+  return OK_STATUS();
+}
+
+bool sram_main(void) {
+  // Initialize UART console.
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+
+  CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK_DIF_OK(dif_uart_configure(
+      &uart, (dif_uart_config_t){
+                 .baudrate = (uint32_t)kUartBaudrate,
+                 .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                 .parity_enable = kDifToggleDisabled,
+                 .parity = kDifUartParityEven,
+                 .tx_enable = kDifToggleEnabled,
+                 .rx_enable = kDifToggleEnabled,
+             }));
+  ottf_console_init();
+
+  kEndTest = 0;
+  kTestPhase = kTestPhaseInit;
+
+  ujson_t uj = ujson_ottf_console();
+
+  status_t result = OK_STATUS();
+  // Waiting for uart input from the host.
+  EXECUTE_TEST(result, command_processor, &uj);
+
+  switch (kTestPhase) {
+    case kTestPhase0:
+      LOG_INFO("testphase0");
+      write_info_page(&flash, kFlashInfoPageIdCreatorSecret, kRandomData, true);
+      write_info_page(&flash, kFlashInfoPageIdOwnerSecret, kRandomData + 1,
+                      true);
+      write_info_page(&flash, kFlashInfoPageIdIsoPart, kRandomData + 2, true);
+      read_and_check_info(true);
+
+      // After update info partition in flash,
+      // lock secret2 partition in otp.
+      CHECK_STATUS_OK(otp_ctrl_testutils_lock_partition(
+          &otp_ctrl, kDifOtpCtrlPartitionSecret2, 0));
+      break;
+    case kTestPhase1:
+      LOG_INFO("testphase1");
+      // After RMA, all contents in flash info partition are scrapped.
+      // So expecting read data mismatch.
+      read_and_check_info(false);
+      break;
+    default:
+      LOG_ERROR("unexpected test phase : %d", kTestPhase);
+      break;
+  }
+
+  // This print is required for host hand shake.
+  LOG_INFO("test_end");
+  return status_ok(result);
+}

--- a/sw/host/tests/chip/flash_ctrl/BUILD
+++ b/sw/host/tests/chip/flash_ctrl/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "host",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/flash_ctrl/src/main.rs
+++ b/sw/host/tests/chip/flash_ctrl/src/main.rs
@@ -1,0 +1,293 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+
+use std::iter;
+use anyhow::Context;
+use opentitanlib::test_utils::lc_transition;
+use opentitanlib::chip::boolean::MultiBitBool8;
+use opentitanlib::dif::lc_ctrl::{
+    DifLcCtrlState, DifLcCtrlToken, LcCtrlReg, LcCtrlStatus, LcCtrlTransitionCmd,
+    LcCtrlTransitionRegwen,
+};
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use object::{Object, ObjectSymbol};
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::mem::{MemRead32Req, MemWrite32Req};
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::io::jtag::JtagTap;
+use opentitanlib::test_utils::load_sram_program::{ExecutionMode, SramProgramParams
+};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+
+    #[command(flatten)]
+    sram_program: SramProgramParams,
+
+}
+
+fn test_update_phase(
+    _opts: &Opts,
+    test_word_address: u32,
+    transport: &TransportWrapper,
+    value: u32,
+) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Starting [^\r\n]*", _opts.timeout)?;
+    let _ = uart.clear_rx_buffer();
+    MemWrite32Req::execute(&*uart, test_word_address, value)?;
+    Ok(())
+}
+
+fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
+    assert!(end_test_value == 0);
+    MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;
+    let _ = UartConsole::wait_for(&*uart, r"test_end[^\r\n]*", opts.timeout)?;
+    Ok(())
+}
+
+fn test_sram_load(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    //
+    // Connect to the RISC-V TAP
+    //
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    log::info!("Connecting to RISC-V TAP");
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+
+    log::info!("Halting core");
+    jtag.halt()?;
+
+    opts.sram_program
+        .load_and_execute(&mut *jtag, ExecutionMode::Jump)?;
+
+    jtag.disconnect()?;
+    Ok(())
+}
+
+fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result<()> {
+    let rma_bootstrap_strapping = transport.pin_strapping("RMA_BOOTSTRAP")?;
+    let tap_strapping = transport.pin_strapping("PINMUX_TAP_LC")?;
+
+    // Need to reset with `RMA_BOOTSTRAP` set.
+    rma_bootstrap_strapping
+        .apply()
+        .context("failed to apply RMA_BOOTSTRAP strapping")?;
+
+    // We keep `PINMUX_TAP_LC` set so that resets due to transition don't
+    // disconnect us from the LC TAP.
+    tap_strapping
+        .apply()
+        .context("failed to apply PINMUX_TAP_LC strapping")?;
+
+    transport
+        .reset_target(opts.init.bootstrap.options.reset_delay, true)
+        .context("failed to reset target")?;
+
+    log::info!("Connecting to JTAG interface");
+
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::LcTap)
+        .context("failed to connect to JTAG")?;
+
+    // Wait for the lifecycle controller to enter the `READY` state from
+    // which it accepts transition commands.
+    lc_transition::wait_for_status(&mut *jtag, Duration::from_secs(3), LcCtrlStatus::READY)
+        .context("failed to wait for lifecycle controller to be ready")?;
+
+    // Check we're in the `DEV` state with 5 transitions registered.
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?,
+        DifLcCtrlState::Dev.redundant_encoding()
+    );
+    assert_eq!(jtag.read_lc_ctrl_reg(&LcCtrlReg::LcTransitionCnt)?, 5);
+
+    // Attempt to claim the transition mutex.
+    jtag.write_lc_ctrl_reg(
+        &LcCtrlReg::ClaimTransitionIf,
+        u8::from(MultiBitBool8::True) as u32,
+    )?;
+    // Will be true if the transition was successful.
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::ClaimTransitionIf)?,
+        u8::from(MultiBitBool8::True) as u32
+    );
+    // And hardware will enable writing to transition registers.
+    let regwen = jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionRegwen)?;
+    let regwen = LcCtrlTransitionRegwen::from_bits(regwen)
+        .context("TRANSITION_REGWEN has invalid bits set")?;
+    assert_eq!(regwen, LcCtrlTransitionRegwen::TRANSITION_REGWEN);
+
+    // Multi-reg registers for the transition token.
+    let token_regs = [
+        &LcCtrlReg::TransitionToken0,
+        &LcCtrlReg::TransitionToken1,
+        &LcCtrlReg::TransitionToken2,
+        &LcCtrlReg::TransitionToken3,
+    ];
+    // This is the preimage of the RMA token, randomly generated. The postimage
+    // is was generated using the `gen_rma_token.py` script and embedded in the
+    // OTP's SECRET2 partition.
+    let token = DifLcCtrlToken::from([
+        0x53, 0xa3, 0x81, 0x2b, 0x5a, 0x4c, 0x04, 0xa4, //
+        0x85, 0xda, 0xac, 0x25, 0x2d, 0x14, 0x5c, 0xaf,
+    ]);
+    let token_words = token.into_register_values();
+
+    // Write token to the multi-register.
+    for (reg, value) in iter::zip(token_regs, token_words) {
+        jtag.write_lc_ctrl_reg(reg, value)?;
+    }
+
+    // Read back the values to confirm the write.
+    for (reg, value) in iter::zip(token_regs, token_words) {
+        assert_eq!(jtag.read_lc_ctrl_reg(reg)?, value);
+    }
+
+    // Set the transition target to `RMA` and read back to confirm.
+    jtag.write_lc_ctrl_reg(
+        &LcCtrlReg::TransitionTarget,
+        DifLcCtrlState::Rma.redundant_encoding(),
+    )?;
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionTarget)?,
+        DifLcCtrlState::Rma.redundant_encoding(),
+    );
+
+    log::info!("Initiating lifecycle transition");
+
+    // Write `START` to the `TRANSITION_CMD` register.
+    jtag.write_lc_ctrl_reg(&LcCtrlReg::TransitionCmd, LcCtrlTransitionCmd::START.bits())?;
+
+    assert_eq!(jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionRegwen)?, 0);
+
+    let status = jtag.read_lc_ctrl_reg(&LcCtrlReg::Status)?;
+    let status = LcCtrlStatus::from_bits(status).context("invalid status bits")?;
+    assert_eq!(status, LcCtrlStatus::INITIALIZED);
+
+    // Poll until status register reports a successful transition.
+    lc_transition::wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(3),
+        LcCtrlStatus::TRANSITION_SUCCESSFUL,
+    )
+    .context("failed to wait for LC to report TRANSITION_SUCCESSFUL status")?;
+
+    // Lifecycle controller should now be in the POST_TRANSITION state.
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?,
+        DifLcCtrlState::PostTransition.redundant_encoding()
+    );
+
+    log::info!("Lifecycle transition complete");
+
+    // No longer need the JTAG interface, shut down gracefully.
+    jtag.disconnect()
+        .context("failed to disconnect from JTAG")?;
+
+    transport
+        .reset_target(opts.init.bootstrap.options.reset_delay, true)
+        .context("failed to reset target")?;
+
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::LcTap)
+        .context("failed to connect to JTAG")?;
+
+    // Wait for the lifecycle controller to enter the `READY` state from
+    // which it accepts transition commands.
+    lc_transition::wait_for_status(&mut *jtag, Duration::from_secs(3), LcCtrlStatus::READY)
+        .context("failed to wait for lifecycle controller to be ready")?;
+
+    // Check we're in the `RMA` state
+    assert_eq!(
+        jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?,
+        DifLcCtrlState::Rma.redundant_encoding()
+    );
+
+    jtag.disconnect()
+        .context("failed to disconnect from JTAG")?;
+
+    // Remove the RMA strapping so that future resets bring up normally.
+    rma_bootstrap_strapping
+        .remove()
+        .context("failed to remove strapping RMA_BOOTSTRAP")?;
+
+    // Remove the strapping in case this state survives to another test.
+    tap_strapping
+        .remove()
+        .context("failed to remove strapping PINMUX_TAP_LC")?;
+
+    Ok(())
+ }
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let elf_file = object::File::parse(&*elf_binary)?;
+    let mut symbols = HashMap::<String, u32>::new();
+    for sym in elf_file.symbols() {
+        symbols.insert(sym.name()?.to_owned(), sym.address() as u32);
+    }
+    let end_test_address = symbols
+        .get("kEndTest")
+        .expect("Provided ELF missing 'kEndTest' symbol");
+    let test_word_address = symbols
+        .get("kTestPhase")
+        .expect("Provided ELF missing 'kTestWord' symbol");
+
+    // 1st sram execution:
+    // Upload c test to sram and update kTestPhase to kTestPhase0
+    log::info!("host: round1");
+    execute_test!(test_sram_load, &opts, &transport);
+    execute_test!(test_update_phase, &opts, *test_word_address, &transport, 0);
+    execute_test!(test_end, &opts, *end_test_address, &transport);
+
+    // rma entry start by JtagTap::LcTap
+    execute_test!(test_rma_command, &opts, &transport);
+
+    // 2nd sram execution
+    // Upload c test to sram and update kTestPhase to kTestPhase1
+    log::info!("host: round2");
+    execute_test!(test_sram_load, &opts, &transport);
+    execute_test!(test_update_phase, &opts, *test_word_address, &transport, 1);
+    execute_test!(test_end, &opts, *end_test_address, &transport);
+    Ok(())
+}


### PR DESCRIPTION
Flash ctrl rma entry test
- Test starts from unpersonalized dev state.
- It programs fixed patterns to each info partition and execute otp secret2 partition lock
- After reboot, host triggers rma entry process with rma_unlock token provisioning.
- After rma process is finished in flash device, test does another reboot.
- After reboot, test read back info partition to make sure the data in the info partition no longer available.