### PR TITLE
[dv,dma] Extend DMA DV for interrupt-driven testing and TL-UL error generation

### DIFF
--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -37,6 +37,16 @@ package dma_env_pkg;
   parameter uint DMA_ERROR = 1;
   parameter uint DMA_MEMORY_BUFFER_LIMIT_INTR = 2;
 
+  // Completion status bits (DV-internal)
+  typedef enum {
+    StatusDone,
+    StatusError,
+    StatusAborted,
+    StatusTimeout
+  } status_e;
+  // Bitmask of completion reason(s)
+  typedef uint status_t;
+
   // types
   typedef virtual dma_if dma_vif;
   //typedef virtual clk_if clk_rst_vif;

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -308,7 +308,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
 
     // Check if Data item has an outstanding address item
     `DV_CHECK(got_source_item || got_dest_item,
-              $sformatf("Data item source id doesnt match any outstanding request"))
+              $sformatf("Data item source id doesn't match any outstanding request"))
+
     // Source interface item checks
     if (got_source_item) begin
       src_tl_error_detected = item.d_error;
@@ -436,7 +437,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
         @(posedge cfg.intr_vif.pins[DMA_DONE]);
         if (!cfg.en_scb) continue;
         if (!cfg.under_reset) begin
-          `DV_CHECK_EQ(exp_dma_done_intr, 1, "Unexpected assertion of DMA_DONE interrupt")
+          `DV_CHECK_EQ(exp_dma_done_intr, 1, "Unexpected assertion of dma_done interrupt")
         end
       end
     join_none

--- a/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
@@ -44,7 +44,7 @@ class dma_abort_vseq extends dma_generic_vseq;
 
   // Transaction has ended
   virtual task ending_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config,
-                          int status);
+                          status_t status);
     `DV_CHECK_EQ(operating, 1'b1, "Unexpected end of transaction")
     // Stop our parallel task
     operating = 1'b0;

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -376,6 +376,13 @@ class dma_base_vseq extends cip_base_vseq #(
     csr_wr(ral.handshake_interrupt_enable, 32'd1);
   endtask : enable_handshake_interrupt
 
+  // Enable/disable errors on TL-UL buses with the given percentage probability/word
+  function void enable_bus_errors(int pct);
+    seq_ctn.enable_bus_errors(pct);
+    seq_sys.enable_bus_errors(pct);
+    seq_host.enable_bus_errors(pct);
+  endfunction
+
   function void set_seq_fifo_read_mode(asid_encoding_e asid, bit read_fifo_en);
     case (asid)
       OtInternalAddr: begin

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -14,8 +14,8 @@ class dma_base_vseq extends cip_base_vseq #(
 
   // response sequences
   dma_pull_seq #(.AddrWidth(HOST_ADDR_WIDTH)) seq_host;
-  dma_pull_seq #(.AddrWidth(CTN_ADDR_WIDTH)) seq_ctn;
-  dma_pull_seq #(.AddrWidth(SYS_ADDR_WIDTH)) seq_sys;
+  dma_pull_seq #(.AddrWidth(CTN_ADDR_WIDTH))  seq_ctn;
+  dma_pull_seq #(.AddrWidth(SYS_ADDR_WIDTH))  seq_sys;
 
   // DMA configuration item
   dma_seq_item dma_config;
@@ -33,7 +33,7 @@ class dma_base_vseq extends cip_base_vseq #(
     super.new(name);
     dma_config = dma_seq_item::type_id::create("dma_config");
     // response sequences
-    seq_ctn = dma_pull_seq #(.AddrWidth(CTN_ADDR_WIDTH))::type_id::create("seq_ctn");
+    seq_ctn  = dma_pull_seq #(.AddrWidth(CTN_ADDR_WIDTH))::type_id::create("seq_ctn");
     seq_host = dma_pull_seq #(.AddrWidth(HOST_ADDR_WIDTH))::type_id::create("seq_host");
     seq_sys  = dma_pull_seq #(.AddrWidth(SYS_ADDR_WIDTH))::type_id::create("seq_sys");
     // Create memory models
@@ -648,18 +648,6 @@ class dma_base_vseq extends cip_base_vseq #(
       delay(pollrate);
     end
   endtask : poll_status
-
-  // Monitors busy bit in STATUS register
-  task wait_for_idle();
-    forever begin
-      uvm_reg_data_t data;
-      csr_rd(ral.status, data);
-      if (!get_field_val(ral.status.busy, data)) begin
-        `uvm_info(`gfn, "DMA in Idle state", UVM_MEDIUM)
-        break;
-      end
-    end
-  endtask
 
   // Task: Simulate a clock delay
   virtual task delay(int num = 1);

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -93,6 +93,7 @@ class dma_generic_vseq extends dma_base_vseq;
     `uvm_info(`gfn, $sformatf("%s DMA-enabled memory range randomization", action), UVM_HIGH)
   endfunction
 
+  // Clear the STATUS.error indication after reporting it and vetting the cause of the error.
   task clear_errors(ref dma_seq_item dma_config);
     uvm_reg_data_t status;
     csr_rd(ral.status, status);

--- a/hw/ip/dma/dv/env/seq_lib/dma_memory_region_lock_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_memory_region_lock_vseq.sv
@@ -135,7 +135,7 @@ class dma_memory_region_lock_vseq extends dma_generic_vseq;
 
   // Transaction has ended
   virtual task ending_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config,
-                          int status);
+                          status_t status);
     if (operating) begin
       // Stop our parallel task
       operating = 1'b0;

--- a/hw/ip/dma/dv/env/seq_lib/dma_stress_all_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_stress_all_vseq.sv
@@ -11,11 +11,105 @@ class dma_stress_all_vseq extends dma_generic_vseq;
   constraint transactions_c {num_txns inside {[10:40]};}
   constraint num_iters_c {num_iters inside {[5:20]};}
 
+  bit operating;
+
+  // Inter-task signaling
+  event e_start;
+  event e_stopped;
+
+  // Retain the state of the 'regwen' that determines whether the DMA-enabled memory range has been
+  // locked; modification of the range when writing is still enabled shall be avoid as it is
+  // expected to induce failures.
+  //
+  // PR #20351 aims to protect all configuration throughout the transfer, at which point we shall
+  // be permitted to attack many more registers.
+  mubi4_t range_regwen;
+
+  // Attempt to disrupt the DMA transfer by writing randomized data into the configuration registers
+  virtual task modify_registers();
+    // TODO: extend this to other configuration registers (see above).
+    if (range_regwen != MuBi4True) begin
+      bit [3:0]  range_regwen;  // Randomize as bits rather than enum to test illegal values too.
+      bit        dma_memory_valid;
+      bit [31:0] dma_memory_base;
+      bit [31:0] dma_memory_limit;
+      `DV_CHECK_STD_RANDOMIZE_FATAL(range_regwen)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(dma_memory_valid)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(dma_memory_base)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(dma_memory_limit)
+
+      `uvm_info(`gfn, $sformatf("Setting DMA-enabled base 0x%0x limit 0x%0x valid 0x%0x lock 0x%x",
+                dma_memory_base, dma_memory_limit, dma_memory_valid, range_regwen), UVM_MEDIUM)
+
+      set_dma_enabled_memory_range(.base(dma_memory_base),
+                                   .limit(dma_memory_limit),
+                                   .valid(dma_memory_valid),
+                                   .lock(mubi4_t'(range_regwen)));
+    end
+  endtask
+
+  // Transaction is commencing
+  virtual task starting_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config);
+    int pct = $urandom_range(0, 200);
+    bit [31:0] data;
+
+    super.starting_txn(txn, num_txns, dma_config);
+
+    // Decide whether we want to randomly generate TL-UL bus errors during this transaction.
+    enable_bus_errors((pct > 100) ? 0 : pct);
+
+    // Retain the state of the 'REGWEN' field controlling the DMA-enabled memory range configuration
+    csr_rd(cfg.ral.range_regwen, data);
+    range_regwen = mubi4_t'(get_field_val(ral.range_regwen.regwen, data));
+
+    operating = 1'b1;
+    // Signal to the parallel test task that it should start generating events.
+    ->e_start;
+  endtask
+
+  // Transaction has ended
+  virtual task ending_txn(int unsigned txn, int unsigned num_txns, ref dma_seq_item dma_config,
+                          status_t status);
+    if (operating) begin
+      // Stop our parallel task
+      operating = 1'b0;
+      wait (e_stopped.triggered);
+    end
+  endtask
+
   // The functionality of this vseq is implemented in `dma_generic_vseq` and restricted
   // to 'hardware handshaking' transfers in `dma_handshake_vseq`
   virtual task body();
     `uvm_info(`gfn, "DMA: Starting stress all Sequence", UVM_LOW)
-    super.body();
+    fork
+      // Main test sequence
+      super.body();
+      // Parallel thread generates Aborts and Errors, and attempts to modify registers that should
+      // be locked throughout the transaction.
+      forever begin
+        // Await a signal from the main task, indicating that we should start generating events.
+        wait (e_start.triggered);
+        while (operating) begin
+          // Decide what to do, and when
+          bit [31:0] event_delay = $urandom_range(10, 'h1fff);
+          bit [3:0] event_rsn = $urandom_range(0, 15);
+          while (operating && |event_delay) begin
+            event_delay--;
+            delay(1);
+          end
+          if (operating) begin
+            unique case (event_rsn)
+              2'b00: abort();
+              // Introduce any other stressors here, eg. dynamically varying bus responsiveness.
+              default: modify_registers();
+            endcase
+          end
+        end
+        // Signal to the main task that we have stopped trying to modify the range.
+        ->e_stopped;
+      end
+    join_any
+    disable fork;
     `uvm_info(`gfn, "DMA: Completed stress all Sequence", UVM_LOW)
   endtask : body
 endclass


### PR DESCRIPTION
This PR modifies the DV environment to support interrupt-driven testing/monitoring of the DMA controller, and not just CSR-based polling. It also introduces the ability to generate TL-UL errors to test the error handling and reporting.

**Commit 1:** Trivial tidy ups and removal of unused task. No functional change.
**Commit 2:** Modify scoreboard to have an awareness of the interrupt enable state. Support generation of TL-UL errors.
**Commit 3:** Modify the signaling of test completion, and support either interrupt-driven or CSR-polling on a per-transfer basis.
**Commit 4:** Extend the `dma_stress_all` sequence to embrace the additional testing - interrupts and TL-UL errors - as well as a modified form of the randomized register modification from the `dma_memory_region_lock` sequence.

Further work: any necessary merging with the 'clear interrupt' PR #20341 and additional randomized (attempted) writing of configuration registers mid-transfer a la PR #20351.