### PR TITLE
Ibex ISA Smoke Test

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -19,6 +19,8 @@ load(
     "silicon_jtag_params",
 )
 
+package(default_visibility = ["//visibility:public"])
+
 _TEST_UNLOCKED_LC_ITEMS = get_lc_items(
     CONST.LCV.TEST_UNLOCKED0,
     CONST.LCV.TEST_UNLOCKED1,
@@ -167,7 +169,7 @@ opentitan_test(
         data = ":otp_img_rom_exec_disabled_test_unlocked{}".format(i),
         meminfo = "//hw/bitstream:otp_mmi",
         update_usr_access = True,
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
     )
     for i in range(0, 8)
 ]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -22,8 +22,10 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
+    "silicon_jtag_params",
     new_cw310_params = "cw310_params",
     new_dv_params = "dv_params",
     new_verilator_params = "verilator_params",
@@ -3252,5 +3254,53 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+opentitan_test(
+    name = "rv_core_ibex_isa_test_functest",
+    srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
+    cw310 = cw310_jtag_params(
+        binaries = {
+            ":rv_core_ibex_isa_test": "sram_program",
+        },
+        bitstream =
+            "//sw/device/silicon_creator/manuf/tests:bitstream_rom_exec_disabled_test_unlocked0",
+        tags = ["manual"],
+        test_cmd = "--elf={sram_program}",
+        test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
+    },
+    silicon = silicon_jtag_params(
+        tags = ["manual"],
+        test_cmd = "--elf={firmware}",
+        test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
+    ),
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_binary(
+    name = "rv_core_ibex_isa_test",
+    testonly = True,
+    srcs = [
+        "rv_core_ibex_isa_test.S",
+        "rv_core_ibex_isa_test.c",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    kind = "ram",
+    linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )

--- a/sw/device/tests/rv_core_ibex_isa_test.S
+++ b/sw/device/tests/rv_core_ibex_isa_test.S
@@ -1,0 +1,518 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Checks the given value is equal to zero or a second given value.
+ * If they are not equal,
+ * a0 is set to a unique value and returns early from sram_main.
+ *
+ * @param actual The value to check.
+ * @param[opt] expected The value to check against. Defaults to zero.
+ */
+.macro check actual, expected=zero
+  beq \actual, \expected, 1f
+  li a0, \@+1
+  jr s1
+  1:
+.endm
+
+.section .text
+
+/**
+ * Runs every instruction that is available to the ibex.
+ *
+ * @param[out] a0 error code, will be non-zero if a check fails.
+ */
+  .balign 4
+  .global sram_main
+  .type sram_main, @function
+sram_main:
+  mv s1, ra
+  li a0, -1
+
+  jal smoke_branch
+  jal smoke_auipc
+  jal smoke_load_store
+  jal smoke_alu_i
+  jal smoke_alu_i_imm
+  jal smoke_alu_m
+  jal smoke_alu_zba
+  jal smoke_alu_zbb
+  jal smoke_alu_zbc
+  jal smoke_alu_zbf
+  jal smoke_alu_zbp
+  jal smoke_alu_zbr
+  jal smoke_alu_zbs
+  jal smoke_alu_b_misc
+  jal smoke_alu_zbt
+  jal smoke_alu_b_imm
+  jal smoke_csr
+  jal smoke_fence
+  c.jal smoke_c_sp
+  la t0, smoke_c
+  c.jalr t0
+
+  mv a0, zero
+  jr s1
+
+/**
+ * Check the RV32I branch instructions
+ */
+smoke_branch:
+  li t0, 0x8e9c1d0d
+  li t1, 0x3610897a
+  mv t2, t1
+  bne t0, t1, smoke_beq
+  check t0
+  smoke_beq:
+  beq t1, t2, smoke_blt
+  check t0
+  smoke_blt:
+  blt t0, t1, smoke_bge
+  check t0
+  smoke_bge:
+  bge t2, t1, smoke_bltu
+  check t0
+  smoke_bltu:
+  bltu t1, t0, smoke_bgeu
+  check t0
+  smoke_bgeu:
+  bgeu t2, t1, smoke_branch_ret
+  check t0
+  smoke_branch_ret:
+  ret
+
+/**
+ * Check the `auipc` instruction.
+ */
+smoke_auipc:
+  auipc t0, 0xA
+  auipc t1, 0xA
+  addi  t0, t0, 4
+  check t0, t1
+  ret
+
+/**
+ * Checks the RV32I load and store instructions
+ */
+smoke_load_store:
+  li t1, 0x2d3eae8c
+
+  sb t1, -4(sp)
+  lb t2, -4(sp)
+  li t3, 0xffffff8c
+  check t2, t3
+
+  lbu t2, -4(sp)
+  li t3, 0x0000008c
+  check t2, t3
+
+  sh  t1, -8(sp)
+  lh  t2, -8(sp)
+  li t3, 0xffffae8c
+  check t2, t3
+
+  lhu t2, -8(sp)
+  li t3, 0x0000ae8c
+  check t2, t3
+
+  sw t1, -12(sp)
+  lw t2, -12(sp)
+  check t2, t1
+
+  ret
+
+/**
+ * Checks the RV32I non-immediate ALU instructions
+ */
+smoke_alu_i:
+  li   t0, 0x3217ab08
+  li   t1, 0x24e6a04f
+
+  add  t2, t1, t0
+  slt  t1, t0, t2
+  sll  t0, t2, t1
+  sra  t1, t0, t2
+  and  t2, t1, t0
+  xor  t0, t2, t1
+  sub  t1, t0, t2
+  or   t2, t1, t0
+  sltu t0, t1, t2
+  srl  t1, t2, t0
+
+  li t0, 0x7b03fdab
+  check t1, t0
+  ret
+
+/**
+ * Checks the RV32I immediate ALU instructions
+ */
+smoke_alu_i_imm:
+  li    t0, 0xfcec24cf
+
+  .option push
+  .option norvc
+  slti  t0, t0, 0x37e
+  ori   t0, t0, 0x13b
+  sltiu t0, t0, 0x23e
+  addi  t0, t0, 0x7c4
+  srli  t0, t0, 3
+  xori  t0, t0, 0x4f1
+  slli  t0, t0, 28
+  srai  t0, t0, 30
+  andi  t0, t0, 0x76b
+  .option pop
+
+  li t1, 0x76a
+  check t1, t0
+  ret
+
+/**
+ * Checks the RV32M instructions
+ */
+smoke_alu_m:
+  li      t0, 144
+  li      t1, 0x61a061b6
+  div     t2, t1, t0
+  divu    t2, t2, t0
+  rem     t2, t1, t2
+  remu    t2, t1, t2
+  mulh    t0, t2, t1
+  mulhsu  t2, t1, t0
+  mul     t0, t2, t1
+  mulhu   t2, t1, t0
+
+  # check result
+  li t0, 0x25f7c073
+  check t2, t0
+  ret
+
+/**
+ * Checks the instructions from the zba extension
+ */
+smoke_alu_zba:
+  addi t0, zero, 0x2f7
+  addi t1, zero, 0x7ce
+  sh1add t0, t0, t1
+  sh2add t0, t0, t1
+  sh3add t0, t0, t1
+
+  li t2, 0x0001fdbe
+  check t2, t0
+  ret
+
+/**
+ * Checks the instructions from the zbb extension
+ *
+ * Note: rev8, orc.b, and zext.h are pseudo instructions
+ * for grevi, gorci, and pack respectively,
+ * which are tested in `smoke_alu_b_imm` and `smoke_alu_zbp`.
+ */
+smoke_alu_zbb:
+  li   t0, 3
+  li   t1, 0x2bb36000
+  ctz  t2, t1
+  clz  t2, t2
+  cpop t2, t2
+  check  t0, t2
+
+  li t3, 0x151a2a2a
+  andn   t0, t3, t1
+  rol    t0, t0, t2
+  orn    t0, t3, t0
+  sext.h t0, t0
+  ror    t0, t0, t2
+  xnor   t0, t1, t0
+  li  t1, 0x2bb36a2a
+  check t0, t1
+
+  sext.b t0, t0
+  li  t1, 0x0000002a
+  check t0, t1
+
+  max  t2, t1, t3
+  check  t2, t3
+  min  t2, t1, t3
+  check  t2, t1
+  maxu t2, t1, t3
+  check  t2, t3
+  minu t2, t1, t3
+  check  t2, t1
+
+  ret
+
+/**
+ * Checks the instructions from the zbc extension
+ */
+smoke_alu_zbc:
+  addi t0, zero, 0x395
+  li t1, 0x6ac8234c
+  clmul   t0, t0, t1
+  clmulr  t0, t0, t1
+  clmulh  t0, t0, t1
+
+  li t1, 0x08810f55
+  check t0, t1
+  ret
+
+/**
+ * Checks the instructions from the zbf extension
+ *
+ * Note: pack and packh are not checked here
+ * but in covered in `smoke_alu_zbp`.
+ */
+smoke_alu_zbf:
+  li t0, 0x0e0a47f3
+  li t1, 0x0e1fcff3
+  .option push
+  .option arch, +zbf0p93
+  bfp t0, t0, t0
+  .option pop
+  check t0, t1
+  ret
+
+/**
+ * Checks the instructions from the zbp extension
+ *
+ * Note: andn, orn, xnor, rol, and ror are not checked here
+ * but in `smoke_alu_zbb`.
+ */
+smoke_alu_zbp:
+  .option push
+  .option arch, +zbp0p93
+  li t0, 0xcc9fd6b6
+  li t1, 0x7ce71003
+  pack    t2, t0, t1
+  packu   t3, t0, t1
+  packh   t2, t2, t3
+
+  li t0, 0x00009fb6
+  check t0, t2
+
+  li t2, 0x04030001
+  xperm.n t3, t3, t2
+  xperm.b t3, t3, t2
+  xperm.h t3, t3, t2
+  li t0, 0x000000f7
+  check t3, t0
+
+  li t0, 4
+  grev    t1, t1, t0
+  shfl    t1, t1, t0
+  gorc    t1, t1, t0
+  unshfl  t1, t1, t0
+  .option pop
+
+  li t0, 0xffff3131
+  check t0, t1
+  ret
+
+/**
+ * Checks the instructions from the zbr extension
+ */
+smoke_alu_zbr:
+  li t0, 0xabdca651
+  li t1, 0xac605e47
+  .option push
+  .option arch, +zbr0p93
+  crc32.b  t0, t0
+  crc32.h  t0, t0
+  crc32.w  t0, t0
+  crc32c.b t0, t0
+  crc32c.h t0, t0
+  crc32c.w t0, t0
+  .option pop
+  check t1, t0
+  ret
+
+/**
+ * Checks the instructions from the zbs extension
+ */
+smoke_alu_zbs:
+  addi t0, zero, 0x3
+  addi t1, zero, 0x4
+  bclr t0, t0, 0
+  binv t0, t0, 1
+  bset t0, t0, 2
+  check t0, t1
+
+  bext t1, t0, 1
+  check t1
+
+  ret
+
+/**
+ * Checks the instructions from the zbt extension
+ */
+smoke_alu_zbt:
+  .option push
+  .option arch, +zbt0p93
+  li t0, 7
+  li t1, 4
+  li t2, 0x5d76fb6b
+  li t3, 0xe5693902
+  fsl t2, t2, t3, t0
+  fsr t2, t2, t3, t1
+  cmix t2, t0, t2, t3
+
+  li   t1, 0xe5693907
+  check  t1, t2
+
+  cmov t2, t0, t3, t2
+  check  t2, t3
+  .option pop
+
+  ret
+
+/**
+ * Checks the `slo` and `sro` instructions
+ */
+smoke_alu_b_misc:
+  li t0, 0x9bfae1bb
+  li t1, 8
+  li t2, 4
+  //slo t0, t0, t1
+  .insn r OP, 0b001, 0b0010000, t0, t0, t1
+  //sro t0, t0, t2
+  .insn r OP, 0b101, 0b0010000, t0, t0, t2
+
+  li t1, 0xffae1bbf
+  check t0, t1
+  ret
+
+/**
+ * Checks the immediate bitmanip instructions.
+ *
+ * This is a superset of RV32B's immediate instructions.
+ */
+smoke_alu_b_imm:
+  li    t0, 0xfcec24cf
+  //sloi  t0, t0, 7
+  .insn i OP_IMM, 0b001, t0, t0, 0x207
+  // zbs
+  bclri t0, t0, 3
+  bseti t0, t0, 31
+  binvi t0, t0, 19
+  bexti t1, t0, 8
+  // zbt
+  .option push
+  .option arch, +zbt0p93
+  fsri  t0, t0, t1, 4
+  .option pop
+  //sroi  t0, t0, 5
+  .insn i OP_IMM, 0b101, t0, t0, 0x205
+  // zbb
+  rori  t0, t0, 16
+  // zbp
+  .option push
+  .option arch, +zbp0p93
+  grevi   t0, t0, 4
+  shfli   t0, t0, 4
+  gorci   t0, t0, 2
+  unshfli t0, t0, 4
+  .option pop
+
+  li t1, 0xf0ffafff
+  check t0, t1
+  ret
+
+/**
+ * Checks the RV32I CSR instructions.
+ *
+ * Note: This routine clobbers counters
+ * and so inhibits all counters before returning.
+ */
+smoke_csr:
+  li t0, 0b11100
+  li t1, 0b00001
+  li t2, 0b01000
+  li t3, 0b10101
+  csrw mcountinhibit, t0
+  csrs mcountinhibit, t1
+  csrc mcountinhibit, t2
+  csrr t0, mcountinhibit
+  check t0, t3
+
+  csrwi mcountinhibit, 0b11100
+  csrsi mcountinhibit, 0b00001
+  csrci mcountinhibit, 0b01000
+  csrr t0, mcountinhibit
+  check t0, t3
+
+  // Inhibit all counters
+  csrw mcountinhibit, zero
+  ret
+
+/**
+ * Runs the fence instructions.
+ *
+ * No checks are performed.
+ */
+smoke_fence:
+  fence
+  fence.i
+  ret
+
+/**
+ * Checks the compressed 'add immediate to sp' instructions.
+ */
+smoke_c_sp:
+  c.addi16sp sp, -64
+  c.addi4spn a5, sp, 64
+  c.addi16sp sp, 64
+  check a5, sp
+
+
+/**
+ * Checks the RV32C instructions.
+ *
+ * Notes: `c.ebreak` and those within `smoke_c_sp` are not checked.
+ */
+smoke_c:
+  c.lui  a5, 0x1b
+  c.bnez a5, 2f
+  check  ra
+  2:
+  c.sub  a5, a5
+  c.beqz a5, 2f
+  check  ra
+  2:
+  c.j 2f
+  check  ra
+  2:
+
+  c.li   a5, 0x1b
+  c.andi a5, 0x1e
+  c.addi a5, 0x1a
+  c.slli a5, 26
+  c.srai a5, 4
+  c.srli a5, 2
+
+  li a3, 0x3f400000
+  check a5, a3
+
+  li a4, 0x37a
+  c.xor a5, a4
+  c.add a5, a4
+  c.and a5, a4
+  c.or  a5, a3
+
+  addi a3, a3, 0x270
+  check a5, a3
+
+  c.mv a5, a4
+  check a5, a4
+
+  addi a5, sp, -8
+  c.sw a4, 4(a5)
+  c.lw a5, 4(a5)
+  check a4, a5
+
+  addi sp, sp, -12
+  c.swsp a3, 8(sp)
+  c.lwsp a4, 8(sp)
+  addi sp, sp, 12
+  check a4, a3
+
+  c.jr ra

--- a/sw/device/tests/rv_core_ibex_isa_test.c
+++ b/sw/device/tests/rv_core_ibex_isa_test.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+OTTF_DEFINE_TEST_CONFIG();

--- a/sw/host/tests/chip/rv_core_ibex_isa/BUILD
+++ b/sw/host/tests/chip/rv_core_ibex_isa/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "rv_core_ibex_isa",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)

--- a/sw/host/tests/chip/rv_core_ibex_isa/src/main.rs
+++ b/sw/host/tests/chip/rv_core_ibex_isa/src/main.rs
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use clap::Parser;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::{JtagTap, RiscvReg, RiscvGpr};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::load_sram_program::{
+    ExecutionMode, ExecutionResult, SramProgramParams,
+};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    #[command(flatten)]
+    sram_program: SramProgramParams,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+fn ibex_isa_smoke_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+
+    log::info!("Connecting to RISC-V TAP");
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+    log::info!("Halting core");
+    jtag.halt()?;
+
+    // Make sure to remove any messages from the ROM.
+    let uart = transport.uart("console")?;
+    uart.clear_rx_buffer()?;
+
+    // Load SRAM program
+    match opts
+        .sram_program
+        .load_and_execute(&mut *jtag, ExecutionMode::JumpAndWait(Duration::from_secs(5)))?
+    {
+        ExecutionResult::ExecutionDone => log::info!("program successfully ran"),
+        res => bail!("program execution failed: {:?}", res),
+    }
+    let a0 = jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::A0))?;
+    log::info!("Return Value (a0): {a0}");
+    // Disconnect JTAG.
+    jtag.halt()?;
+    jtag.disconnect()?;
+
+    assert_eq!(a0, 0, "An instruction failed");
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    execute_test!(ibex_isa_smoke_test, &opts, &transport);
+
+    Ok(())
+}


### PR DESCRIPTION
Initial parts of the Ibex ISA smoke test.

Instructions that are not yet checked but will be in a future PR:
- `c.ebreak`
- `ecall`
- `mret`
- `wfi`

*`ebreak` is tested in sram_start and `dret` will never be covered see https://github.com/lowRISC/opentitan/issues/20031#issuecomment-1780850909*

Covers most of https://github.com/lowRISC/opentitan/issues/20031