### PR TITLE
[hw,mbx,rtl] Raise error if SOC writes out-of-bounds

### DIFF
--- a/hw/ip/mbx/data/mbx.hjson
+++ b/hw/ip/mbx/data/mbx.hjson
@@ -60,6 +60,9 @@
     { name: "mbx_abort"
       desc: "An abort request was received from the requester."
     }
+    { name: "mbx_error"
+      desc: "The mailbox instance generated an error."
+    }
   ]
   alert_list: [
     { name: "fatal_fault"

--- a/hw/ip/mbx/dv/env/mbx_env_pkg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_pkg.sv
@@ -37,7 +37,8 @@ package mbx_env_pkg;
   } reg_op_e;
   typedef enum {
     MbxCoreReady,
-    MbxCoreAbort
+    MbxCoreAbort,
+    MbxCoreError
   } mbx_core_intr_e;
 
   // functions

--- a/hw/ip/mbx/dv/tb.sv
+++ b/hw/ip/mbx/dv/tb.sv
@@ -19,6 +19,7 @@ module tb;
   wire intr_doe;
   wire intr_ready;
   wire intr_abort;
+  wire intr_error;
 
   clk_rst_if i_clk_rst_if(.clk(clk), .rst_n(rst_n));
   tl_if i_tl_scxb_mbx_core_if(.clk(clk), .rst_n(rst_n));
@@ -37,6 +38,7 @@ module tb;
     .doe_intr_support_o(),
     .doe_intr_en_o(),
     .doe_intr_o(intr_doe),
+    .doe_async_msg_support_o(),
     // various tlul interfaces
     .core_tl_d_o(i_tl_agxb_mbx_core_if.d2h),
     .core_tl_d_i(i_tl_agxb_mbx_core_if.h2d),
@@ -47,6 +49,7 @@ module tb;
     // alerts and interrupts
     .intr_mbx_ready_o(intr_ready),
     .intr_mbx_abort_o(intr_abort),
+    .intr_mbx_error_o(intr_error),
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx)
   );
@@ -54,6 +57,7 @@ module tb;
   // Connect the interrupts
   assign interrupts[MbxCoreReady] = intr_ready;
   assign interrupts[MbxCoreAbort] = intr_abort;
+  assign interrupts[MbxCoreError] = intr_error;
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -20,6 +20,7 @@ module mbx
   // Comportable interrupt to the OT
   output logic                                      intr_mbx_ready_o,
   output logic                                      intr_mbx_abort_o,
+  output logic                                      intr_mbx_error_o,
   // Custom straps for capability register implementation
   output logic                                      doe_intr_support_o,
   output logic                                      doe_intr_en_o,
@@ -59,6 +60,7 @@ module mbx
   logic hostif_address_range_valid, hostif_address_range_valid_write;
   logic sysif_control_abort_set;
   logic doe_async_msg_en;
+  logic imbx_overflow_error_set;
 
   // Status signal inputs from the sysif to the hostif
   logic sysif_status_busy, sysif_status_error;
@@ -101,8 +103,10 @@ module mbx
     .tl_host_o                           ( core_tl_d_o                        ),
     .event_intr_ready_i                  ( hostif_event_intr_ready            ),
     .event_intr_abort_i                  ( hostif_event_intr_abort            ),
+    .event_intr_error_i                  ( imbx_overflow_error_set            ),
     .intr_ready_o                        ( intr_mbx_ready_o                   ),
     .intr_abort_o                        ( intr_mbx_abort_o                   ),
+    .intr_error_o                        ( intr_mbx_error_o                   ),
     .intg_err_i                          ( alert_signal                       ),
     .sram_err_i                          ( sram_err                           ),
     .alert_rx_i                          ( alert_rx_i                         ),
@@ -176,7 +180,7 @@ module mbx
 
   // Combine error outputs of all modules and distribute back error to them to bring all
   // modules to the error state if needed
-  logic mbx_error_set, imbx_overflow_error_set;
+  logic mbx_error_set;
   assign mbx_error_set = hostif_control_error_set | imbx_overflow_error_set;
 
   mbx_sysif #(

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -174,6 +174,11 @@ module mbx
   logic [CfgSramDataWidth-1:0] ombx_sram_read_data, sysif_read_data;
   logic sysif_read_data_read_valid, sysif_read_data_write_valid;
 
+  // Combine error outputs of all modules and distribute back error to them to bring all
+  // modules to the error state if needed
+  logic mbx_error_set, imbx_overflow_error_set;
+  assign mbx_error_set = hostif_control_error_set | imbx_overflow_error_set;
+
   mbx_sysif #(
     .CfgSramAddrWidth   ( CfgSramAddrWidth   ),
     .CfgSramDataWidth   ( CfgSramDataWidth   ),
@@ -202,7 +207,7 @@ module mbx
     .sysif_status_busy_i                 ( imbx_status_busy                   ),
     .sysif_status_busy_o                 ( sysif_status_busy                  ),
     .sysif_status_doe_intr_ready_set_i   ( ombx_doe_intr_ready_set            ),
-    .sysif_status_error_set_i            ( hostif_control_error_set           ),
+    .sysif_status_error_set_i            ( mbx_error_set                      ),
     .sysif_status_error_o                ( sysif_status_error                 ),
     .sysif_status_ready_valid_i          ( ombx_status_ready_valid            ),
     .sysif_status_ready_i                ( ombx_status_ready                  ),
@@ -234,9 +239,10 @@ module mbx
     .imbx_irq_ready_o            ( hostif_event_intr_ready          ),
     .imbx_irq_abort_o            ( hostif_event_intr_abort          ),
     .imbx_status_busy_update_o   ( imbx_status_busy_valid           ),
+    .imbx_overflow_error_set_o   ( imbx_overflow_error_set          ),
     .imbx_status_busy_o          ( imbx_status_busy                 ),
     .hostif_control_abort_clear_i( hostif_control_abort_clear       ),
-    .hostif_control_error_set_i  ( hostif_control_error_set         ),
+    .mbx_error_set_i             ( mbx_error_set                    ),
     .sys_read_all_i              ( sys_read_all                     ),
     // SRAM range configuration
     .hostif_range_valid_write_i  ( hostif_address_range_valid_write ),
@@ -279,7 +285,7 @@ module mbx
     .sysif_status_ready_i            ( sysif_status_ready               ),
     // Writing a 1 to control.abort register clears the abort condition
     .hostif_control_abort_clear_i    ( hostif_control_abort_clear       ),
-    .hostif_control_error_set_i      ( hostif_control_error_set         ),
+    .mbx_error_set_i                 ( mbx_error_set                    ),
     .sysif_control_abort_set_i       ( sysif_control_abort_set          ),
     .sysif_read_data_read_valid_i    ( sysif_read_data_read_valid       ),
     .sysif_read_data_write_valid_i   ( sysif_read_data_write_valid      ),

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -129,14 +129,19 @@ module mbx_core_reg_top (
   logic intr_state_mbx_ready_wd;
   logic intr_state_mbx_abort_qs;
   logic intr_state_mbx_abort_wd;
+  logic intr_state_mbx_error_qs;
+  logic intr_state_mbx_error_wd;
   logic intr_enable_we;
   logic intr_enable_mbx_ready_qs;
   logic intr_enable_mbx_ready_wd;
   logic intr_enable_mbx_abort_qs;
   logic intr_enable_mbx_abort_wd;
+  logic intr_enable_mbx_error_qs;
+  logic intr_enable_mbx_error_wd;
   logic intr_test_we;
   logic intr_test_mbx_ready_wd;
   logic intr_test_mbx_abort_wd;
+  logic intr_test_mbx_error_wd;
   logic alert_test_we;
   logic alert_test_fatal_fault_wd;
   logic alert_test_recov_fault_wd;
@@ -238,6 +243,33 @@ module mbx_core_reg_top (
     .qs     (intr_state_mbx_abort_qs)
   );
 
+  //   F[mbx_error]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_intr_state_mbx_error (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_state_we),
+    .wd     (intr_state_mbx_error_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.mbx_error.de),
+    .d      (hw2reg.intr_state.mbx_error.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.mbx_error.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (intr_state_mbx_error_qs)
+  );
+
 
   // R[intr_enable]: V(False)
   //   F[mbx_ready]: 0:0
@@ -294,10 +326,37 @@ module mbx_core_reg_top (
     .qs     (intr_enable_mbx_abort_qs)
   );
 
+  //   F[mbx_error]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_intr_enable_mbx_error (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_enable_we),
+    .wd     (intr_enable_mbx_error_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.mbx_error.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (intr_enable_mbx_error_qs)
+  );
+
 
   // R[intr_test]: V(True)
   logic intr_test_qe;
-  logic [1:0] intr_test_flds_we;
+  logic [2:0] intr_test_flds_we;
   assign intr_test_qe = &intr_test_flds_we;
   //   F[mbx_ready]: 0:0
   prim_subreg_ext #(
@@ -330,6 +389,22 @@ module mbx_core_reg_top (
     .qs     ()
   );
   assign reg2hw.intr_test.mbx_abort.qe = intr_test_qe;
+
+  //   F[mbx_error]: 2:2
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_mbx_error (
+    .re     (1'b0),
+    .we     (intr_test_we),
+    .wd     (intr_test_mbx_error_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (intr_test_flds_we[2]),
+    .q      (reg2hw.intr_test.mbx_error.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.intr_test.mbx_error.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
@@ -841,16 +916,22 @@ module mbx_core_reg_top (
   assign intr_state_mbx_ready_wd = reg_wdata[0];
 
   assign intr_state_mbx_abort_wd = reg_wdata[1];
+
+  assign intr_state_mbx_error_wd = reg_wdata[2];
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
   assign intr_enable_mbx_ready_wd = reg_wdata[0];
 
   assign intr_enable_mbx_abort_wd = reg_wdata[1];
+
+  assign intr_enable_mbx_error_wd = reg_wdata[2];
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
   assign intr_test_mbx_ready_wd = reg_wdata[0];
 
   assign intr_test_mbx_abort_wd = reg_wdata[1];
+
+  assign intr_test_mbx_error_wd = reg_wdata[2];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
   assign alert_test_fatal_fault_wd = reg_wdata[0];
@@ -920,16 +1001,19 @@ module mbx_core_reg_top (
       addr_hit[0]: begin
         reg_rdata_next[0] = intr_state_mbx_ready_qs;
         reg_rdata_next[1] = intr_state_mbx_abort_qs;
+        reg_rdata_next[2] = intr_state_mbx_error_qs;
       end
 
       addr_hit[1]: begin
         reg_rdata_next[0] = intr_enable_mbx_ready_qs;
         reg_rdata_next[1] = intr_enable_mbx_abort_qs;
+        reg_rdata_next[2] = intr_enable_mbx_error_qs;
       end
 
       addr_hit[2]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
+        reg_rdata_next[2] = '0;
       end
 
       addr_hit[3]: begin

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -18,8 +18,10 @@ module mbx_hostif
   // Generated interrupt event
   input  logic                          event_intr_ready_i,
   input  logic                          event_intr_abort_i,
+  input  logic                          event_intr_error_i,
   output logic                          intr_ready_o,
   output logic                          intr_abort_o,
+  output logic                          intr_error_o,
   // External errors
   input  logic                          intg_err_i,
   input  logic                          sram_err_i,
@@ -131,6 +133,19 @@ module mbx_hostif
     .hw2reg_intr_state_de_o ( hw2reg.intr_state.mbx_abort.de ),
     .hw2reg_intr_state_d_o  ( hw2reg.intr_state.mbx_abort.d  ),
     .intr_o                 ( intr_abort_o                   )
+  );
+
+  prim_intr_hw #(.Width(1)) u_intr_error (
+    .clk_i                  ( clk_i                          ),
+    .rst_ni                 ( rst_ni                         ),
+    .event_intr_i           ( event_intr_error_i             ),
+    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.mbx_error.q ),
+    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.mbx_error.q   ),
+    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.mbx_error.qe  ),
+    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.mbx_error.q  ),
+    .hw2reg_intr_state_de_o ( hw2reg.intr_state.mbx_error.de ),
+    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.mbx_error.d  ),
+    .intr_o                 ( intr_error_o                   )
   );
 
   // Control Register

--- a/hw/ip/mbx/rtl/mbx_ombx.sv
+++ b/hw/ip/mbx/rtl/mbx_ombx.sv
@@ -25,7 +25,7 @@ module mbx_ombx #(
   // Writing a 1 to control.abort register clears the abort condition
   input  logic                          sysif_status_ready_i,
   input  logic                          hostif_control_abort_clear_i,
-  input  logic                          hostif_control_error_set_i,
+  input  logic                          mbx_error_set_i,
   input  logic                          sysif_control_abort_set_i,
   input  logic                          sysif_read_data_read_valid_i,
   input  logic                          sysif_read_data_write_valid_i,
@@ -106,6 +106,7 @@ module mbx_ombx #(
                           sysif_read_data_write_valid_i  &
                           (sram_read_ptr_q == sram_read_ptr_limit_q);
 
+  // The abort requestet was handled by the host. This re-initialzes the read pointer
   logic host_clear_abort;
   assign host_clear_abort = hostif_control_abort_clear_i & mbx_sys_abort;
 
@@ -147,7 +148,7 @@ module mbx_ombx #(
   // or the requester aborts the transaction
   logic clear_read_data;
   assign clear_read_data = sys_read_all_o             |
-                           hostif_control_error_set_i |
+                           mbx_error_set_i            |
                            sysif_control_abort_set_i;
   // Advance the SRAM read response to read data
   prim_generic_flop_en #(
@@ -239,7 +240,7 @@ module mbx_ombx #(
     .rst_ni                    ( rst_ni                       ),
     .mbx_range_valid_i         ( hostif_range_valid_i         ),
     .hostif_abort_ack_i        ( hostif_control_abort_clear_i ),
-    .hostif_control_error_set_i( hostif_control_error_set_i   ),
+    .mbx_error_set_i           ( mbx_error_set_i              ),
     .sysif_control_abort_set_i ( sysif_control_abort_set_i    ),
     .sys_read_all_i            ( sys_read_all_o               ),
     .writer_close_mbx_i        ( writer_close_mbx             ),

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -24,6 +24,9 @@ package mbx_reg_pkg;
     struct packed {
       logic        q;
     } mbx_abort;
+    struct packed {
+      logic        q;
+    } mbx_error;
   } mbx_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -33,6 +36,9 @@ package mbx_reg_pkg;
     struct packed {
       logic        q;
     } mbx_abort;
+    struct packed {
+      logic        q;
+    } mbx_error;
   } mbx_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -44,6 +50,10 @@ package mbx_reg_pkg;
       logic        q;
       logic        qe;
     } mbx_abort;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } mbx_error;
   } mbx_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -107,6 +117,10 @@ package mbx_reg_pkg;
       logic        d;
       logic        de;
     } mbx_abort;
+    struct packed {
+      logic        d;
+      logic        de;
+    } mbx_error;
   } mbx_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -156,9 +170,9 @@ package mbx_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    mbx_reg2hw_intr_state_reg_t intr_state; // [151:150]
-    mbx_reg2hw_intr_enable_reg_t intr_enable; // [149:148]
-    mbx_reg2hw_intr_test_reg_t intr_test; // [147:144]
+    mbx_reg2hw_intr_state_reg_t intr_state; // [155:153]
+    mbx_reg2hw_intr_enable_reg_t intr_enable; // [152:150]
+    mbx_reg2hw_intr_test_reg_t intr_test; // [149:144]
     mbx_reg2hw_alert_test_reg_t alert_test; // [143:140]
     mbx_reg2hw_control_reg_t control; // [139:134]
     mbx_reg2hw_address_range_valid_reg_t address_range_valid; // [133:132]
@@ -171,7 +185,7 @@ package mbx_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    mbx_hw2reg_intr_state_reg_t intr_state; // [145:142]
+    mbx_hw2reg_intr_state_reg_t intr_state; // [147:142]
     mbx_hw2reg_control_reg_t control; // [141:140]
     mbx_hw2reg_status_reg_t status; // [139:136]
     mbx_hw2reg_inbound_write_ptr_reg_t inbound_write_ptr; // [135:106]
@@ -201,9 +215,10 @@ package mbx_reg_pkg;
   parameter logic [CoreAw-1:0] MBX_DOE_INTR_MSG_DATA_OFFSET = 7'h 40;
 
   // Reset values for hwext registers and their fields for core interface
-  parameter logic [1:0] MBX_INTR_TEST_RESVAL = 2'h 0;
+  parameter logic [2:0] MBX_INTR_TEST_RESVAL = 3'h 0;
   parameter logic [0:0] MBX_INTR_TEST_MBX_READY_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_INTR_TEST_MBX_ABORT_RESVAL = 1'h 0;
+  parameter logic [0:0] MBX_INTR_TEST_MBX_ERROR_RESVAL = 1'h 0;
   parameter logic [1:0] MBX_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] MBX_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] MBX_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -15598,6 +15598,12 @@
       module_name: mbx0
     }
     {
+      name: mbx0_mbx_error
+      width: 1
+      type: interrupt
+      module_name: mbx0
+    }
+    {
       name: mbx1_mbx_ready
       width: 1
       type: interrupt
@@ -15605,6 +15611,12 @@
     }
     {
       name: mbx1_mbx_abort
+      width: 1
+      type: interrupt
+      module_name: mbx1
+    }
+    {
+      name: mbx1_mbx_error
       width: 1
       type: interrupt
       module_name: mbx1
@@ -15622,6 +15634,12 @@
       module_name: mbx2
     }
     {
+      name: mbx2_mbx_error
+      width: 1
+      type: interrupt
+      module_name: mbx2
+    }
+    {
       name: mbx3_mbx_ready
       width: 1
       type: interrupt
@@ -15629,6 +15647,12 @@
     }
     {
       name: mbx3_mbx_abort
+      width: 1
+      type: interrupt
+      module_name: mbx3
+    }
+    {
+      name: mbx3_mbx_error
       width: 1
       type: interrupt
       module_name: mbx3
@@ -15646,6 +15670,12 @@
       module_name: mbx4
     }
     {
+      name: mbx4_mbx_error
+      width: 1
+      type: interrupt
+      module_name: mbx4
+    }
+    {
       name: mbx5_mbx_ready
       width: 1
       type: interrupt
@@ -15653,6 +15683,12 @@
     }
     {
       name: mbx5_mbx_abort
+      width: 1
+      type: interrupt
+      module_name: mbx5
+    }
+    {
+      name: mbx5_mbx_error
       width: 1
       type: interrupt
       module_name: mbx5
@@ -15670,6 +15706,12 @@
       module_name: mbx6
     }
     {
+      name: mbx6_mbx_error
+      width: 1
+      type: interrupt
+      module_name: mbx6
+    }
+    {
       name: mbx_jtag_mbx_ready
       width: 1
       type: interrupt
@@ -15677,6 +15719,12 @@
     }
     {
       name: mbx_jtag_mbx_abort
+      width: 1
+      type: interrupt
+      module_name: mbx_jtag
+    }
+    {
+      name: mbx_jtag_mbx_error
       width: 1
       type: interrupt
       module_name: mbx_jtag
@@ -15694,6 +15742,12 @@
       module_name: mbx_pcie0
     }
     {
+      name: mbx_pcie0_mbx_error
+      width: 1
+      type: interrupt
+      module_name: mbx_pcie0
+    }
+    {
       name: mbx_pcie1_mbx_ready
       width: 1
       type: interrupt
@@ -15701,6 +15755,12 @@
     }
     {
       name: mbx_pcie1_mbx_abort
+      width: 1
+      type: interrupt
+      module_name: mbx_pcie1
+    }
+    {
+      name: mbx_pcie1_mbx_error
       width: 1
       type: interrupt
       module_name: mbx_pcie1

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -37,7 +37,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "153",
+      default: "163",
       local: "true"
     },
     { name: "NumTarget",
@@ -1316,6 +1316,86 @@
     }
     { name: "PRIO152",
       desc: "Interrupt Source 152 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO153",
+      desc: "Interrupt Source 153 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO154",
+      desc: "Interrupt Source 154 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO155",
+      desc: "Interrupt Source 155 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO156",
+      desc: "Interrupt Source 156 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO157",
+      desc: "Interrupt Source 157 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO158",
+      desc: "Interrupt Source 158 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO159",
+      desc: "Interrupt Source 159 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO160",
+      desc: "Interrupt Source 160 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO161",
+      desc: "Interrupt Source 161 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO162",
+      desc: "Interrupt Source 162 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -5,7 +5,7 @@
   instance_name: top_darjeeling_rv_plic
   param_values:
   {
-    src: 153
+    src: 163
     target: 1
     prio: 3
     top_name: darjeeling

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -251,11 +251,21 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[150] = reg2hw.prio150.q;
   assign prio[151] = reg2hw.prio151.q;
   assign prio[152] = reg2hw.prio152.q;
+  assign prio[153] = reg2hw.prio153.q;
+  assign prio[154] = reg2hw.prio154.q;
+  assign prio[155] = reg2hw.prio155.q;
+  assign prio[156] = reg2hw.prio156.q;
+  assign prio[157] = reg2hw.prio157.q;
+  assign prio[158] = reg2hw.prio158.q;
+  assign prio[159] = reg2hw.prio159.q;
+  assign prio[160] = reg2hw.prio160.q;
+  assign prio[161] = reg2hw.prio161.q;
+  assign prio[162] = reg2hw.prio162.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 153; s++) begin : gen_ie0
+  for (genvar s = 0; s < 163; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -281,7 +291,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 153; s++) begin : gen_ip
+  for (genvar s = 0; s < 163; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 153;
+  parameter int NumSrc = 163;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
   parameter int NumAlerts = 1;
@@ -632,6 +632,46 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio152_reg_t;
 
   typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio153_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio154_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio155_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio156_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio157_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio158_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio159_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio160_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio161_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio162_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -665,160 +705,170 @@ package rv_plic_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    rv_plic_reg2hw_prio0_reg_t prio0; // [473:472]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [471:470]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [469:468]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [467:466]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [465:464]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [463:462]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [461:460]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [459:458]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [457:456]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [455:454]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [453:452]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [451:450]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [449:448]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [447:446]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [445:444]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [443:442]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [441:440]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [439:438]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [437:436]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [435:434]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [433:432]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [431:430]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [429:428]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [427:426]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [425:424]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [423:422]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [421:420]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [419:418]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [417:416]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [415:414]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [413:412]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [411:410]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [409:408]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [407:406]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [405:404]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [403:402]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [401:400]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [399:398]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [397:396]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [395:394]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [393:392]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [391:390]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [389:388]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [387:386]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [385:384]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [383:382]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [381:380]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [379:378]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [377:376]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [375:374]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [373:372]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [371:370]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [369:368]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [367:366]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [365:364]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [363:362]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [361:360]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [359:358]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [357:356]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [355:354]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [353:352]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [351:350]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [349:348]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [347:346]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [345:344]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [343:342]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [341:340]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [339:338]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [337:336]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [335:334]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [333:332]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [331:330]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [329:328]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [327:326]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [325:324]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [323:322]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [321:320]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [319:318]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [317:316]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [315:314]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [313:312]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [311:310]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [309:308]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [307:306]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [305:304]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [303:302]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [301:300]
-    rv_plic_reg2hw_prio87_reg_t prio87; // [299:298]
-    rv_plic_reg2hw_prio88_reg_t prio88; // [297:296]
-    rv_plic_reg2hw_prio89_reg_t prio89; // [295:294]
-    rv_plic_reg2hw_prio90_reg_t prio90; // [293:292]
-    rv_plic_reg2hw_prio91_reg_t prio91; // [291:290]
-    rv_plic_reg2hw_prio92_reg_t prio92; // [289:288]
-    rv_plic_reg2hw_prio93_reg_t prio93; // [287:286]
-    rv_plic_reg2hw_prio94_reg_t prio94; // [285:284]
-    rv_plic_reg2hw_prio95_reg_t prio95; // [283:282]
-    rv_plic_reg2hw_prio96_reg_t prio96; // [281:280]
-    rv_plic_reg2hw_prio97_reg_t prio97; // [279:278]
-    rv_plic_reg2hw_prio98_reg_t prio98; // [277:276]
-    rv_plic_reg2hw_prio99_reg_t prio99; // [275:274]
-    rv_plic_reg2hw_prio100_reg_t prio100; // [273:272]
-    rv_plic_reg2hw_prio101_reg_t prio101; // [271:270]
-    rv_plic_reg2hw_prio102_reg_t prio102; // [269:268]
-    rv_plic_reg2hw_prio103_reg_t prio103; // [267:266]
-    rv_plic_reg2hw_prio104_reg_t prio104; // [265:264]
-    rv_plic_reg2hw_prio105_reg_t prio105; // [263:262]
-    rv_plic_reg2hw_prio106_reg_t prio106; // [261:260]
-    rv_plic_reg2hw_prio107_reg_t prio107; // [259:258]
-    rv_plic_reg2hw_prio108_reg_t prio108; // [257:256]
-    rv_plic_reg2hw_prio109_reg_t prio109; // [255:254]
-    rv_plic_reg2hw_prio110_reg_t prio110; // [253:252]
-    rv_plic_reg2hw_prio111_reg_t prio111; // [251:250]
-    rv_plic_reg2hw_prio112_reg_t prio112; // [249:248]
-    rv_plic_reg2hw_prio113_reg_t prio113; // [247:246]
-    rv_plic_reg2hw_prio114_reg_t prio114; // [245:244]
-    rv_plic_reg2hw_prio115_reg_t prio115; // [243:242]
-    rv_plic_reg2hw_prio116_reg_t prio116; // [241:240]
-    rv_plic_reg2hw_prio117_reg_t prio117; // [239:238]
-    rv_plic_reg2hw_prio118_reg_t prio118; // [237:236]
-    rv_plic_reg2hw_prio119_reg_t prio119; // [235:234]
-    rv_plic_reg2hw_prio120_reg_t prio120; // [233:232]
-    rv_plic_reg2hw_prio121_reg_t prio121; // [231:230]
-    rv_plic_reg2hw_prio122_reg_t prio122; // [229:228]
-    rv_plic_reg2hw_prio123_reg_t prio123; // [227:226]
-    rv_plic_reg2hw_prio124_reg_t prio124; // [225:224]
-    rv_plic_reg2hw_prio125_reg_t prio125; // [223:222]
-    rv_plic_reg2hw_prio126_reg_t prio126; // [221:220]
-    rv_plic_reg2hw_prio127_reg_t prio127; // [219:218]
-    rv_plic_reg2hw_prio128_reg_t prio128; // [217:216]
-    rv_plic_reg2hw_prio129_reg_t prio129; // [215:214]
-    rv_plic_reg2hw_prio130_reg_t prio130; // [213:212]
-    rv_plic_reg2hw_prio131_reg_t prio131; // [211:210]
-    rv_plic_reg2hw_prio132_reg_t prio132; // [209:208]
-    rv_plic_reg2hw_prio133_reg_t prio133; // [207:206]
-    rv_plic_reg2hw_prio134_reg_t prio134; // [205:204]
-    rv_plic_reg2hw_prio135_reg_t prio135; // [203:202]
-    rv_plic_reg2hw_prio136_reg_t prio136; // [201:200]
-    rv_plic_reg2hw_prio137_reg_t prio137; // [199:198]
-    rv_plic_reg2hw_prio138_reg_t prio138; // [197:196]
-    rv_plic_reg2hw_prio139_reg_t prio139; // [195:194]
-    rv_plic_reg2hw_prio140_reg_t prio140; // [193:192]
-    rv_plic_reg2hw_prio141_reg_t prio141; // [191:190]
-    rv_plic_reg2hw_prio142_reg_t prio142; // [189:188]
-    rv_plic_reg2hw_prio143_reg_t prio143; // [187:186]
-    rv_plic_reg2hw_prio144_reg_t prio144; // [185:184]
-    rv_plic_reg2hw_prio145_reg_t prio145; // [183:182]
-    rv_plic_reg2hw_prio146_reg_t prio146; // [181:180]
-    rv_plic_reg2hw_prio147_reg_t prio147; // [179:178]
-    rv_plic_reg2hw_prio148_reg_t prio148; // [177:176]
-    rv_plic_reg2hw_prio149_reg_t prio149; // [175:174]
-    rv_plic_reg2hw_prio150_reg_t prio150; // [173:172]
-    rv_plic_reg2hw_prio151_reg_t prio151; // [171:170]
-    rv_plic_reg2hw_prio152_reg_t prio152; // [169:168]
-    rv_plic_reg2hw_ie0_mreg_t [152:0] ie0; // [167:15]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [503:502]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [501:500]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [499:498]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [497:496]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [495:494]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [493:492]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [491:490]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [489:488]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [487:486]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [485:484]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [483:482]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [481:480]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [479:478]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [477:476]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [475:474]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [473:472]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [471:470]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [469:468]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [467:466]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [465:464]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [463:462]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [461:460]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [459:458]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [457:456]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [455:454]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [453:452]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [451:450]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [449:448]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [447:446]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [445:444]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [443:442]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [441:440]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [439:438]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [437:436]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [435:434]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [433:432]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [431:430]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [429:428]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [427:426]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [425:424]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [423:422]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [421:420]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [419:418]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [417:416]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [415:414]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [413:412]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [411:410]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [409:408]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [407:406]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [405:404]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [403:402]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [401:400]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [399:398]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [397:396]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [395:394]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [393:392]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [391:390]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [389:388]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [387:386]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [385:384]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [383:382]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [381:380]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [379:378]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [377:376]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [375:374]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [373:372]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [371:370]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [369:368]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [367:366]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [365:364]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [363:362]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [361:360]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [359:358]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [357:356]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [355:354]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [353:352]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [351:350]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [349:348]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [347:346]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [345:344]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [343:342]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [341:340]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [339:338]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [337:336]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [335:334]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [333:332]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [331:330]
+    rv_plic_reg2hw_prio87_reg_t prio87; // [329:328]
+    rv_plic_reg2hw_prio88_reg_t prio88; // [327:326]
+    rv_plic_reg2hw_prio89_reg_t prio89; // [325:324]
+    rv_plic_reg2hw_prio90_reg_t prio90; // [323:322]
+    rv_plic_reg2hw_prio91_reg_t prio91; // [321:320]
+    rv_plic_reg2hw_prio92_reg_t prio92; // [319:318]
+    rv_plic_reg2hw_prio93_reg_t prio93; // [317:316]
+    rv_plic_reg2hw_prio94_reg_t prio94; // [315:314]
+    rv_plic_reg2hw_prio95_reg_t prio95; // [313:312]
+    rv_plic_reg2hw_prio96_reg_t prio96; // [311:310]
+    rv_plic_reg2hw_prio97_reg_t prio97; // [309:308]
+    rv_plic_reg2hw_prio98_reg_t prio98; // [307:306]
+    rv_plic_reg2hw_prio99_reg_t prio99; // [305:304]
+    rv_plic_reg2hw_prio100_reg_t prio100; // [303:302]
+    rv_plic_reg2hw_prio101_reg_t prio101; // [301:300]
+    rv_plic_reg2hw_prio102_reg_t prio102; // [299:298]
+    rv_plic_reg2hw_prio103_reg_t prio103; // [297:296]
+    rv_plic_reg2hw_prio104_reg_t prio104; // [295:294]
+    rv_plic_reg2hw_prio105_reg_t prio105; // [293:292]
+    rv_plic_reg2hw_prio106_reg_t prio106; // [291:290]
+    rv_plic_reg2hw_prio107_reg_t prio107; // [289:288]
+    rv_plic_reg2hw_prio108_reg_t prio108; // [287:286]
+    rv_plic_reg2hw_prio109_reg_t prio109; // [285:284]
+    rv_plic_reg2hw_prio110_reg_t prio110; // [283:282]
+    rv_plic_reg2hw_prio111_reg_t prio111; // [281:280]
+    rv_plic_reg2hw_prio112_reg_t prio112; // [279:278]
+    rv_plic_reg2hw_prio113_reg_t prio113; // [277:276]
+    rv_plic_reg2hw_prio114_reg_t prio114; // [275:274]
+    rv_plic_reg2hw_prio115_reg_t prio115; // [273:272]
+    rv_plic_reg2hw_prio116_reg_t prio116; // [271:270]
+    rv_plic_reg2hw_prio117_reg_t prio117; // [269:268]
+    rv_plic_reg2hw_prio118_reg_t prio118; // [267:266]
+    rv_plic_reg2hw_prio119_reg_t prio119; // [265:264]
+    rv_plic_reg2hw_prio120_reg_t prio120; // [263:262]
+    rv_plic_reg2hw_prio121_reg_t prio121; // [261:260]
+    rv_plic_reg2hw_prio122_reg_t prio122; // [259:258]
+    rv_plic_reg2hw_prio123_reg_t prio123; // [257:256]
+    rv_plic_reg2hw_prio124_reg_t prio124; // [255:254]
+    rv_plic_reg2hw_prio125_reg_t prio125; // [253:252]
+    rv_plic_reg2hw_prio126_reg_t prio126; // [251:250]
+    rv_plic_reg2hw_prio127_reg_t prio127; // [249:248]
+    rv_plic_reg2hw_prio128_reg_t prio128; // [247:246]
+    rv_plic_reg2hw_prio129_reg_t prio129; // [245:244]
+    rv_plic_reg2hw_prio130_reg_t prio130; // [243:242]
+    rv_plic_reg2hw_prio131_reg_t prio131; // [241:240]
+    rv_plic_reg2hw_prio132_reg_t prio132; // [239:238]
+    rv_plic_reg2hw_prio133_reg_t prio133; // [237:236]
+    rv_plic_reg2hw_prio134_reg_t prio134; // [235:234]
+    rv_plic_reg2hw_prio135_reg_t prio135; // [233:232]
+    rv_plic_reg2hw_prio136_reg_t prio136; // [231:230]
+    rv_plic_reg2hw_prio137_reg_t prio137; // [229:228]
+    rv_plic_reg2hw_prio138_reg_t prio138; // [227:226]
+    rv_plic_reg2hw_prio139_reg_t prio139; // [225:224]
+    rv_plic_reg2hw_prio140_reg_t prio140; // [223:222]
+    rv_plic_reg2hw_prio141_reg_t prio141; // [221:220]
+    rv_plic_reg2hw_prio142_reg_t prio142; // [219:218]
+    rv_plic_reg2hw_prio143_reg_t prio143; // [217:216]
+    rv_plic_reg2hw_prio144_reg_t prio144; // [215:214]
+    rv_plic_reg2hw_prio145_reg_t prio145; // [213:212]
+    rv_plic_reg2hw_prio146_reg_t prio146; // [211:210]
+    rv_plic_reg2hw_prio147_reg_t prio147; // [209:208]
+    rv_plic_reg2hw_prio148_reg_t prio148; // [207:206]
+    rv_plic_reg2hw_prio149_reg_t prio149; // [205:204]
+    rv_plic_reg2hw_prio150_reg_t prio150; // [203:202]
+    rv_plic_reg2hw_prio151_reg_t prio151; // [201:200]
+    rv_plic_reg2hw_prio152_reg_t prio152; // [199:198]
+    rv_plic_reg2hw_prio153_reg_t prio153; // [197:196]
+    rv_plic_reg2hw_prio154_reg_t prio154; // [195:194]
+    rv_plic_reg2hw_prio155_reg_t prio155; // [193:192]
+    rv_plic_reg2hw_prio156_reg_t prio156; // [191:190]
+    rv_plic_reg2hw_prio157_reg_t prio157; // [189:188]
+    rv_plic_reg2hw_prio158_reg_t prio158; // [187:186]
+    rv_plic_reg2hw_prio159_reg_t prio159; // [185:184]
+    rv_plic_reg2hw_prio160_reg_t prio160; // [183:182]
+    rv_plic_reg2hw_prio161_reg_t prio161; // [181:180]
+    rv_plic_reg2hw_prio162_reg_t prio162; // [179:178]
+    rv_plic_reg2hw_ie0_mreg_t [162:0] ie0; // [177:15]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [14:13]
     rv_plic_reg2hw_cc0_reg_t cc0; // [12:3]
     rv_plic_reg2hw_msip0_reg_t msip0; // [2:2]
@@ -827,7 +877,7 @@ package rv_plic_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [152:0] ip; // [313:8]
+    rv_plic_hw2reg_ip_mreg_t [162:0] ip; // [333:8]
     rv_plic_hw2reg_cc0_reg_t cc0; // [7:0]
   } rv_plic_hw2reg_t;
 
@@ -985,16 +1035,28 @@ package rv_plic_reg_pkg;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO150_OFFSET = 27'h 258;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO151_OFFSET = 27'h 25c;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO152_OFFSET = 27'h 260;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO153_OFFSET = 27'h 264;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO154_OFFSET = 27'h 268;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO155_OFFSET = 27'h 26c;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO156_OFFSET = 27'h 270;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO157_OFFSET = 27'h 274;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO158_OFFSET = 27'h 278;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO159_OFFSET = 27'h 27c;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO160_OFFSET = 27'h 280;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO161_OFFSET = 27'h 284;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO162_OFFSET = 27'h 288;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_0_OFFSET = 27'h 1000;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_1_OFFSET = 27'h 1004;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_2_OFFSET = 27'h 1008;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_3_OFFSET = 27'h 100c;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_4_OFFSET = 27'h 1010;
+  parameter logic [BlockAw-1:0] RV_PLIC_IP_5_OFFSET = 27'h 1014;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_0_OFFSET = 27'h 2000;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_1_OFFSET = 27'h 2004;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_2_OFFSET = 27'h 2008;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_3_OFFSET = 27'h 200c;
   parameter logic [BlockAw-1:0] RV_PLIC_IE0_4_OFFSET = 27'h 2010;
+  parameter logic [BlockAw-1:0] RV_PLIC_IE0_5_OFFSET = 27'h 2014;
   parameter logic [BlockAw-1:0] RV_PLIC_THRESHOLD0_OFFSET = 27'h 200000;
   parameter logic [BlockAw-1:0] RV_PLIC_CC0_OFFSET = 27'h 200004;
   parameter logic [BlockAw-1:0] RV_PLIC_MSIP0_OFFSET = 27'h 4000000;
@@ -1159,16 +1221,28 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO150,
     RV_PLIC_PRIO151,
     RV_PLIC_PRIO152,
+    RV_PLIC_PRIO153,
+    RV_PLIC_PRIO154,
+    RV_PLIC_PRIO155,
+    RV_PLIC_PRIO156,
+    RV_PLIC_PRIO157,
+    RV_PLIC_PRIO158,
+    RV_PLIC_PRIO159,
+    RV_PLIC_PRIO160,
+    RV_PLIC_PRIO161,
+    RV_PLIC_PRIO162,
     RV_PLIC_IP_0,
     RV_PLIC_IP_1,
     RV_PLIC_IP_2,
     RV_PLIC_IP_3,
     RV_PLIC_IP_4,
+    RV_PLIC_IP_5,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
     RV_PLIC_IE0_3,
     RV_PLIC_IE0_4,
+    RV_PLIC_IE0_5,
     RV_PLIC_THRESHOLD0,
     RV_PLIC_CC0,
     RV_PLIC_MSIP0,
@@ -1176,7 +1250,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [167] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [179] = '{
     4'b 0001, // index[  0] RV_PLIC_PRIO0
     4'b 0001, // index[  1] RV_PLIC_PRIO1
     4'b 0001, // index[  2] RV_PLIC_PRIO2
@@ -1330,20 +1404,32 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[150] RV_PLIC_PRIO150
     4'b 0001, // index[151] RV_PLIC_PRIO151
     4'b 0001, // index[152] RV_PLIC_PRIO152
-    4'b 1111, // index[153] RV_PLIC_IP_0
-    4'b 1111, // index[154] RV_PLIC_IP_1
-    4'b 1111, // index[155] RV_PLIC_IP_2
-    4'b 1111, // index[156] RV_PLIC_IP_3
-    4'b 1111, // index[157] RV_PLIC_IP_4
-    4'b 1111, // index[158] RV_PLIC_IE0_0
-    4'b 1111, // index[159] RV_PLIC_IE0_1
-    4'b 1111, // index[160] RV_PLIC_IE0_2
-    4'b 1111, // index[161] RV_PLIC_IE0_3
-    4'b 1111, // index[162] RV_PLIC_IE0_4
-    4'b 0001, // index[163] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[164] RV_PLIC_CC0
-    4'b 0001, // index[165] RV_PLIC_MSIP0
-    4'b 0001  // index[166] RV_PLIC_ALERT_TEST
+    4'b 0001, // index[153] RV_PLIC_PRIO153
+    4'b 0001, // index[154] RV_PLIC_PRIO154
+    4'b 0001, // index[155] RV_PLIC_PRIO155
+    4'b 0001, // index[156] RV_PLIC_PRIO156
+    4'b 0001, // index[157] RV_PLIC_PRIO157
+    4'b 0001, // index[158] RV_PLIC_PRIO158
+    4'b 0001, // index[159] RV_PLIC_PRIO159
+    4'b 0001, // index[160] RV_PLIC_PRIO160
+    4'b 0001, // index[161] RV_PLIC_PRIO161
+    4'b 0001, // index[162] RV_PLIC_PRIO162
+    4'b 1111, // index[163] RV_PLIC_IP_0
+    4'b 1111, // index[164] RV_PLIC_IP_1
+    4'b 1111, // index[165] RV_PLIC_IP_2
+    4'b 1111, // index[166] RV_PLIC_IP_3
+    4'b 1111, // index[167] RV_PLIC_IP_4
+    4'b 0001, // index[168] RV_PLIC_IP_5
+    4'b 1111, // index[169] RV_PLIC_IE0_0
+    4'b 1111, // index[170] RV_PLIC_IE0_1
+    4'b 1111, // index[171] RV_PLIC_IE0_2
+    4'b 1111, // index[172] RV_PLIC_IE0_3
+    4'b 1111, // index[173] RV_PLIC_IE0_4
+    4'b 0001, // index[174] RV_PLIC_IE0_5
+    4'b 0001, // index[175] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[176] RV_PLIC_CC0
+    4'b 0001, // index[177] RV_PLIC_MSIP0
+    4'b 0001  // index[178] RV_PLIC_ALERT_TEST
   };
 
 endpackage

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -55,9 +55,9 @@ module rv_plic_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [166:0] reg_we_check;
+  logic [178:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(167)
+    .OneHotWidth(179)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -583,6 +583,36 @@ module rv_plic_reg_top (
   logic prio152_we;
   logic [1:0] prio152_qs;
   logic [1:0] prio152_wd;
+  logic prio153_we;
+  logic [1:0] prio153_qs;
+  logic [1:0] prio153_wd;
+  logic prio154_we;
+  logic [1:0] prio154_qs;
+  logic [1:0] prio154_wd;
+  logic prio155_we;
+  logic [1:0] prio155_qs;
+  logic [1:0] prio155_wd;
+  logic prio156_we;
+  logic [1:0] prio156_qs;
+  logic [1:0] prio156_wd;
+  logic prio157_we;
+  logic [1:0] prio157_qs;
+  logic [1:0] prio157_wd;
+  logic prio158_we;
+  logic [1:0] prio158_qs;
+  logic [1:0] prio158_wd;
+  logic prio159_we;
+  logic [1:0] prio159_qs;
+  logic [1:0] prio159_wd;
+  logic prio160_we;
+  logic [1:0] prio160_qs;
+  logic [1:0] prio160_wd;
+  logic prio161_we;
+  logic [1:0] prio161_qs;
+  logic [1:0] prio161_wd;
+  logic prio162_we;
+  logic [1:0] prio162_qs;
+  logic [1:0] prio162_wd;
   logic ip_0_p_0_qs;
   logic ip_0_p_1_qs;
   logic ip_0_p_2_qs;
@@ -736,6 +766,16 @@ module rv_plic_reg_top (
   logic ip_4_p_150_qs;
   logic ip_4_p_151_qs;
   logic ip_4_p_152_qs;
+  logic ip_4_p_153_qs;
+  logic ip_4_p_154_qs;
+  logic ip_4_p_155_qs;
+  logic ip_4_p_156_qs;
+  logic ip_4_p_157_qs;
+  logic ip_4_p_158_qs;
+  logic ip_4_p_159_qs;
+  logic ip_5_p_160_qs;
+  logic ip_5_p_161_qs;
+  logic ip_5_p_162_qs;
   logic ie0_0_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
@@ -1047,6 +1087,27 @@ module rv_plic_reg_top (
   logic ie0_4_e_151_wd;
   logic ie0_4_e_152_qs;
   logic ie0_4_e_152_wd;
+  logic ie0_4_e_153_qs;
+  logic ie0_4_e_153_wd;
+  logic ie0_4_e_154_qs;
+  logic ie0_4_e_154_wd;
+  logic ie0_4_e_155_qs;
+  logic ie0_4_e_155_wd;
+  logic ie0_4_e_156_qs;
+  logic ie0_4_e_156_wd;
+  logic ie0_4_e_157_qs;
+  logic ie0_4_e_157_wd;
+  logic ie0_4_e_158_qs;
+  logic ie0_4_e_158_wd;
+  logic ie0_4_e_159_qs;
+  logic ie0_4_e_159_wd;
+  logic ie0_5_we;
+  logic ie0_5_e_160_qs;
+  logic ie0_5_e_160_wd;
+  logic ie0_5_e_161_qs;
+  logic ie0_5_e_161_wd;
+  logic ie0_5_e_162_qs;
+  logic ie0_5_e_162_wd;
   logic threshold0_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
@@ -5345,6 +5406,286 @@ module rv_plic_reg_top (
   );
 
 
+  // R[prio153]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio153 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio153_we),
+    .wd     (prio153_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio153.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio153_qs)
+  );
+
+
+  // R[prio154]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio154 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio154_we),
+    .wd     (prio154_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio154.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio154_qs)
+  );
+
+
+  // R[prio155]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio155 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio155_we),
+    .wd     (prio155_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio155.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio155_qs)
+  );
+
+
+  // R[prio156]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio156 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio156_we),
+    .wd     (prio156_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio156.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio156_qs)
+  );
+
+
+  // R[prio157]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio157 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio157_we),
+    .wd     (prio157_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio157.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio157_qs)
+  );
+
+
+  // R[prio158]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio158 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio158_we),
+    .wd     (prio158_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio158.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio158_qs)
+  );
+
+
+  // R[prio159]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio159_we),
+    .wd     (prio159_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio159.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio159_qs)
+  );
+
+
+  // R[prio160]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio160 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio160_we),
+    .wd     (prio160_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio160.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio160_qs)
+  );
+
+
+  // R[prio161]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio161 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio161_we),
+    .wd     (prio161_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio161.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio161_qs)
+  );
+
+
+  // R[prio162]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio162 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio162_we),
+    .wd     (prio162_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio162.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio162_qs)
+  );
+
+
   // Subregister 0 of Multireg ip
   // R[ip_0]: V(False)
   //   F[p_0]: 0:0
@@ -9488,6 +9829,279 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_4_p_152_qs)
+  );
+
+  //   F[p_153]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_153 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[153].de),
+    .d      (hw2reg.ip[153].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_153_qs)
+  );
+
+  //   F[p_154]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_154 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[154].de),
+    .d      (hw2reg.ip[154].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_154_qs)
+  );
+
+  //   F[p_155]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_155 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[155].de),
+    .d      (hw2reg.ip[155].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_155_qs)
+  );
+
+  //   F[p_156]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_156 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[156].de),
+    .d      (hw2reg.ip[156].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_156_qs)
+  );
+
+  //   F[p_157]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_157 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[157].de),
+    .d      (hw2reg.ip[157].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_157_qs)
+  );
+
+  //   F[p_158]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_158 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[158].de),
+    .d      (hw2reg.ip[158].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_158_qs)
+  );
+
+  //   F[p_159]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[159].de),
+    .d      (hw2reg.ip[159].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_159_qs)
+  );
+
+
+  // Subregister 5 of Multireg ip
+  // R[ip_5]: V(False)
+  //   F[p_160]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_5_p_160 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[160].de),
+    .d      (hw2reg.ip[160].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_5_p_160_qs)
+  );
+
+  //   F[p_161]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_5_p_161 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[161].de),
+    .d      (hw2reg.ip[161].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_5_p_161_qs)
+  );
+
+  //   F[p_162]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_5_p_162 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[162].de),
+    .d      (hw2reg.ip[162].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_5_p_162_qs)
   );
 
 
@@ -13636,6 +14250,279 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_152_qs)
   );
 
+  //   F[e_153]: 25:25
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_153 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_153_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[153].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_153_qs)
+  );
+
+  //   F[e_154]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_154 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_154_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[154].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_154_qs)
+  );
+
+  //   F[e_155]: 27:27
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_155 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_155_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[155].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_155_qs)
+  );
+
+  //   F[e_156]: 28:28
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_156 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_156_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[156].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_156_qs)
+  );
+
+  //   F[e_157]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_157 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_157_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[157].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_157_qs)
+  );
+
+  //   F[e_158]: 30:30
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_158 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_158_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[158].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_158_qs)
+  );
+
+  //   F[e_159]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_159_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[159].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_159_qs)
+  );
+
+
+  // Subregister 5 of Multireg ie0
+  // R[ie0_5]: V(False)
+  //   F[e_160]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_5_e_160 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_5_we),
+    .wd     (ie0_5_e_160_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[160].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_5_e_160_qs)
+  );
+
+  //   F[e_161]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_5_e_161 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_5_we),
+    .wd     (ie0_5_e_161_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[161].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_5_e_161_qs)
+  );
+
+  //   F[e_162]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_5_e_162 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_5_we),
+    .wd     (ie0_5_e_162_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[162].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_5_e_162_qs)
+  );
+
 
   // R[threshold0]: V(False)
   prim_subreg #(
@@ -13734,7 +14621,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [166:0] addr_hit;
+  logic [178:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_PRIO0_OFFSET);
@@ -13890,20 +14777,32 @@ module rv_plic_reg_top (
     addr_hit[150] = (reg_addr == RV_PLIC_PRIO150_OFFSET);
     addr_hit[151] = (reg_addr == RV_PLIC_PRIO151_OFFSET);
     addr_hit[152] = (reg_addr == RV_PLIC_PRIO152_OFFSET);
-    addr_hit[153] = (reg_addr == RV_PLIC_IP_0_OFFSET);
-    addr_hit[154] = (reg_addr == RV_PLIC_IP_1_OFFSET);
-    addr_hit[155] = (reg_addr == RV_PLIC_IP_2_OFFSET);
-    addr_hit[156] = (reg_addr == RV_PLIC_IP_3_OFFSET);
-    addr_hit[157] = (reg_addr == RV_PLIC_IP_4_OFFSET);
-    addr_hit[158] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[159] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[160] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[161] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
-    addr_hit[162] = (reg_addr == RV_PLIC_IE0_4_OFFSET);
-    addr_hit[163] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[164] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[165] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
-    addr_hit[166] = (reg_addr == RV_PLIC_ALERT_TEST_OFFSET);
+    addr_hit[153] = (reg_addr == RV_PLIC_PRIO153_OFFSET);
+    addr_hit[154] = (reg_addr == RV_PLIC_PRIO154_OFFSET);
+    addr_hit[155] = (reg_addr == RV_PLIC_PRIO155_OFFSET);
+    addr_hit[156] = (reg_addr == RV_PLIC_PRIO156_OFFSET);
+    addr_hit[157] = (reg_addr == RV_PLIC_PRIO157_OFFSET);
+    addr_hit[158] = (reg_addr == RV_PLIC_PRIO158_OFFSET);
+    addr_hit[159] = (reg_addr == RV_PLIC_PRIO159_OFFSET);
+    addr_hit[160] = (reg_addr == RV_PLIC_PRIO160_OFFSET);
+    addr_hit[161] = (reg_addr == RV_PLIC_PRIO161_OFFSET);
+    addr_hit[162] = (reg_addr == RV_PLIC_PRIO162_OFFSET);
+    addr_hit[163] = (reg_addr == RV_PLIC_IP_0_OFFSET);
+    addr_hit[164] = (reg_addr == RV_PLIC_IP_1_OFFSET);
+    addr_hit[165] = (reg_addr == RV_PLIC_IP_2_OFFSET);
+    addr_hit[166] = (reg_addr == RV_PLIC_IP_3_OFFSET);
+    addr_hit[167] = (reg_addr == RV_PLIC_IP_4_OFFSET);
+    addr_hit[168] = (reg_addr == RV_PLIC_IP_5_OFFSET);
+    addr_hit[169] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[170] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[171] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[172] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
+    addr_hit[173] = (reg_addr == RV_PLIC_IE0_4_OFFSET);
+    addr_hit[174] = (reg_addr == RV_PLIC_IE0_5_OFFSET);
+    addr_hit[175] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[176] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[177] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[178] = (reg_addr == RV_PLIC_ALERT_TEST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -14077,7 +14976,19 @@ module rv_plic_reg_top (
                (addr_hit[163] & (|(RV_PLIC_PERMIT[163] & ~reg_be))) |
                (addr_hit[164] & (|(RV_PLIC_PERMIT[164] & ~reg_be))) |
                (addr_hit[165] & (|(RV_PLIC_PERMIT[165] & ~reg_be))) |
-               (addr_hit[166] & (|(RV_PLIC_PERMIT[166] & ~reg_be)))));
+               (addr_hit[166] & (|(RV_PLIC_PERMIT[166] & ~reg_be))) |
+               (addr_hit[167] & (|(RV_PLIC_PERMIT[167] & ~reg_be))) |
+               (addr_hit[168] & (|(RV_PLIC_PERMIT[168] & ~reg_be))) |
+               (addr_hit[169] & (|(RV_PLIC_PERMIT[169] & ~reg_be))) |
+               (addr_hit[170] & (|(RV_PLIC_PERMIT[170] & ~reg_be))) |
+               (addr_hit[171] & (|(RV_PLIC_PERMIT[171] & ~reg_be))) |
+               (addr_hit[172] & (|(RV_PLIC_PERMIT[172] & ~reg_be))) |
+               (addr_hit[173] & (|(RV_PLIC_PERMIT[173] & ~reg_be))) |
+               (addr_hit[174] & (|(RV_PLIC_PERMIT[174] & ~reg_be))) |
+               (addr_hit[175] & (|(RV_PLIC_PERMIT[175] & ~reg_be))) |
+               (addr_hit[176] & (|(RV_PLIC_PERMIT[176] & ~reg_be))) |
+               (addr_hit[177] & (|(RV_PLIC_PERMIT[177] & ~reg_be))) |
+               (addr_hit[178] & (|(RV_PLIC_PERMIT[178] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -14540,7 +15451,37 @@ module rv_plic_reg_top (
   assign prio152_we = addr_hit[152] & reg_we & !reg_error;
 
   assign prio152_wd = reg_wdata[1:0];
-  assign ie0_0_we = addr_hit[158] & reg_we & !reg_error;
+  assign prio153_we = addr_hit[153] & reg_we & !reg_error;
+
+  assign prio153_wd = reg_wdata[1:0];
+  assign prio154_we = addr_hit[154] & reg_we & !reg_error;
+
+  assign prio154_wd = reg_wdata[1:0];
+  assign prio155_we = addr_hit[155] & reg_we & !reg_error;
+
+  assign prio155_wd = reg_wdata[1:0];
+  assign prio156_we = addr_hit[156] & reg_we & !reg_error;
+
+  assign prio156_wd = reg_wdata[1:0];
+  assign prio157_we = addr_hit[157] & reg_we & !reg_error;
+
+  assign prio157_wd = reg_wdata[1:0];
+  assign prio158_we = addr_hit[158] & reg_we & !reg_error;
+
+  assign prio158_wd = reg_wdata[1:0];
+  assign prio159_we = addr_hit[159] & reg_we & !reg_error;
+
+  assign prio159_wd = reg_wdata[1:0];
+  assign prio160_we = addr_hit[160] & reg_we & !reg_error;
+
+  assign prio160_wd = reg_wdata[1:0];
+  assign prio161_we = addr_hit[161] & reg_we & !reg_error;
+
+  assign prio161_wd = reg_wdata[1:0];
+  assign prio162_we = addr_hit[162] & reg_we & !reg_error;
+
+  assign prio162_wd = reg_wdata[1:0];
+  assign ie0_0_we = addr_hit[169] & reg_we & !reg_error;
 
   assign ie0_0_e_0_wd = reg_wdata[0];
 
@@ -14605,7 +15546,7 @@ module rv_plic_reg_top (
   assign ie0_0_e_30_wd = reg_wdata[30];
 
   assign ie0_0_e_31_wd = reg_wdata[31];
-  assign ie0_1_we = addr_hit[159] & reg_we & !reg_error;
+  assign ie0_1_we = addr_hit[170] & reg_we & !reg_error;
 
   assign ie0_1_e_32_wd = reg_wdata[0];
 
@@ -14670,7 +15611,7 @@ module rv_plic_reg_top (
   assign ie0_1_e_62_wd = reg_wdata[30];
 
   assign ie0_1_e_63_wd = reg_wdata[31];
-  assign ie0_2_we = addr_hit[160] & reg_we & !reg_error;
+  assign ie0_2_we = addr_hit[171] & reg_we & !reg_error;
 
   assign ie0_2_e_64_wd = reg_wdata[0];
 
@@ -14735,7 +15676,7 @@ module rv_plic_reg_top (
   assign ie0_2_e_94_wd = reg_wdata[30];
 
   assign ie0_2_e_95_wd = reg_wdata[31];
-  assign ie0_3_we = addr_hit[161] & reg_we & !reg_error;
+  assign ie0_3_we = addr_hit[172] & reg_we & !reg_error;
 
   assign ie0_3_e_96_wd = reg_wdata[0];
 
@@ -14800,7 +15741,7 @@ module rv_plic_reg_top (
   assign ie0_3_e_126_wd = reg_wdata[30];
 
   assign ie0_3_e_127_wd = reg_wdata[31];
-  assign ie0_4_we = addr_hit[162] & reg_we & !reg_error;
+  assign ie0_4_we = addr_hit[173] & reg_we & !reg_error;
 
   assign ie0_4_e_128_wd = reg_wdata[0];
 
@@ -14851,17 +15792,38 @@ module rv_plic_reg_top (
   assign ie0_4_e_151_wd = reg_wdata[23];
 
   assign ie0_4_e_152_wd = reg_wdata[24];
-  assign threshold0_we = addr_hit[163] & reg_we & !reg_error;
+
+  assign ie0_4_e_153_wd = reg_wdata[25];
+
+  assign ie0_4_e_154_wd = reg_wdata[26];
+
+  assign ie0_4_e_155_wd = reg_wdata[27];
+
+  assign ie0_4_e_156_wd = reg_wdata[28];
+
+  assign ie0_4_e_157_wd = reg_wdata[29];
+
+  assign ie0_4_e_158_wd = reg_wdata[30];
+
+  assign ie0_4_e_159_wd = reg_wdata[31];
+  assign ie0_5_we = addr_hit[174] & reg_we & !reg_error;
+
+  assign ie0_5_e_160_wd = reg_wdata[0];
+
+  assign ie0_5_e_161_wd = reg_wdata[1];
+
+  assign ie0_5_e_162_wd = reg_wdata[2];
+  assign threshold0_we = addr_hit[175] & reg_we & !reg_error;
 
   assign threshold0_wd = reg_wdata[1:0];
-  assign cc0_re = addr_hit[164] & reg_re & !reg_error;
-  assign cc0_we = addr_hit[164] & reg_we & !reg_error;
+  assign cc0_re = addr_hit[176] & reg_re & !reg_error;
+  assign cc0_we = addr_hit[176] & reg_we & !reg_error;
 
   assign cc0_wd = reg_wdata[7:0];
-  assign msip0_we = addr_hit[165] & reg_we & !reg_error;
+  assign msip0_we = addr_hit[177] & reg_we & !reg_error;
 
   assign msip0_wd = reg_wdata[0];
-  assign alert_test_we = addr_hit[166] & reg_we & !reg_error;
+  assign alert_test_we = addr_hit[178] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
 
@@ -15021,20 +15983,32 @@ module rv_plic_reg_top (
     reg_we_check[150] = prio150_we;
     reg_we_check[151] = prio151_we;
     reg_we_check[152] = prio152_we;
-    reg_we_check[153] = 1'b0;
-    reg_we_check[154] = 1'b0;
-    reg_we_check[155] = 1'b0;
-    reg_we_check[156] = 1'b0;
-    reg_we_check[157] = 1'b0;
-    reg_we_check[158] = ie0_0_we;
-    reg_we_check[159] = ie0_1_we;
-    reg_we_check[160] = ie0_2_we;
-    reg_we_check[161] = ie0_3_we;
-    reg_we_check[162] = ie0_4_we;
-    reg_we_check[163] = threshold0_we;
-    reg_we_check[164] = cc0_we;
-    reg_we_check[165] = msip0_we;
-    reg_we_check[166] = alert_test_we;
+    reg_we_check[153] = prio153_we;
+    reg_we_check[154] = prio154_we;
+    reg_we_check[155] = prio155_we;
+    reg_we_check[156] = prio156_we;
+    reg_we_check[157] = prio157_we;
+    reg_we_check[158] = prio158_we;
+    reg_we_check[159] = prio159_we;
+    reg_we_check[160] = prio160_we;
+    reg_we_check[161] = prio161_we;
+    reg_we_check[162] = prio162_we;
+    reg_we_check[163] = 1'b0;
+    reg_we_check[164] = 1'b0;
+    reg_we_check[165] = 1'b0;
+    reg_we_check[166] = 1'b0;
+    reg_we_check[167] = 1'b0;
+    reg_we_check[168] = 1'b0;
+    reg_we_check[169] = ie0_0_we;
+    reg_we_check[170] = ie0_1_we;
+    reg_we_check[171] = ie0_2_we;
+    reg_we_check[172] = ie0_3_we;
+    reg_we_check[173] = ie0_4_we;
+    reg_we_check[174] = ie0_5_we;
+    reg_we_check[175] = threshold0_we;
+    reg_we_check[176] = cc0_we;
+    reg_we_check[177] = msip0_we;
+    reg_we_check[178] = alert_test_we;
   end
 
   // Read data return
@@ -15654,6 +16628,46 @@ module rv_plic_reg_top (
       end
 
       addr_hit[153]: begin
+        reg_rdata_next[1:0] = prio153_qs;
+      end
+
+      addr_hit[154]: begin
+        reg_rdata_next[1:0] = prio154_qs;
+      end
+
+      addr_hit[155]: begin
+        reg_rdata_next[1:0] = prio155_qs;
+      end
+
+      addr_hit[156]: begin
+        reg_rdata_next[1:0] = prio156_qs;
+      end
+
+      addr_hit[157]: begin
+        reg_rdata_next[1:0] = prio157_qs;
+      end
+
+      addr_hit[158]: begin
+        reg_rdata_next[1:0] = prio158_qs;
+      end
+
+      addr_hit[159]: begin
+        reg_rdata_next[1:0] = prio159_qs;
+      end
+
+      addr_hit[160]: begin
+        reg_rdata_next[1:0] = prio160_qs;
+      end
+
+      addr_hit[161]: begin
+        reg_rdata_next[1:0] = prio161_qs;
+      end
+
+      addr_hit[162]: begin
+        reg_rdata_next[1:0] = prio162_qs;
+      end
+
+      addr_hit[163]: begin
         reg_rdata_next[0] = ip_0_p_0_qs;
         reg_rdata_next[1] = ip_0_p_1_qs;
         reg_rdata_next[2] = ip_0_p_2_qs;
@@ -15688,7 +16702,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_0_p_31_qs;
       end
 
-      addr_hit[154]: begin
+      addr_hit[164]: begin
         reg_rdata_next[0] = ip_1_p_32_qs;
         reg_rdata_next[1] = ip_1_p_33_qs;
         reg_rdata_next[2] = ip_1_p_34_qs;
@@ -15723,7 +16737,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_1_p_63_qs;
       end
 
-      addr_hit[155]: begin
+      addr_hit[165]: begin
         reg_rdata_next[0] = ip_2_p_64_qs;
         reg_rdata_next[1] = ip_2_p_65_qs;
         reg_rdata_next[2] = ip_2_p_66_qs;
@@ -15758,7 +16772,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_2_p_95_qs;
       end
 
-      addr_hit[156]: begin
+      addr_hit[166]: begin
         reg_rdata_next[0] = ip_3_p_96_qs;
         reg_rdata_next[1] = ip_3_p_97_qs;
         reg_rdata_next[2] = ip_3_p_98_qs;
@@ -15793,7 +16807,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_3_p_127_qs;
       end
 
-      addr_hit[157]: begin
+      addr_hit[167]: begin
         reg_rdata_next[0] = ip_4_p_128_qs;
         reg_rdata_next[1] = ip_4_p_129_qs;
         reg_rdata_next[2] = ip_4_p_130_qs;
@@ -15819,9 +16833,22 @@ module rv_plic_reg_top (
         reg_rdata_next[22] = ip_4_p_150_qs;
         reg_rdata_next[23] = ip_4_p_151_qs;
         reg_rdata_next[24] = ip_4_p_152_qs;
+        reg_rdata_next[25] = ip_4_p_153_qs;
+        reg_rdata_next[26] = ip_4_p_154_qs;
+        reg_rdata_next[27] = ip_4_p_155_qs;
+        reg_rdata_next[28] = ip_4_p_156_qs;
+        reg_rdata_next[29] = ip_4_p_157_qs;
+        reg_rdata_next[30] = ip_4_p_158_qs;
+        reg_rdata_next[31] = ip_4_p_159_qs;
       end
 
-      addr_hit[158]: begin
+      addr_hit[168]: begin
+        reg_rdata_next[0] = ip_5_p_160_qs;
+        reg_rdata_next[1] = ip_5_p_161_qs;
+        reg_rdata_next[2] = ip_5_p_162_qs;
+      end
+
+      addr_hit[169]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -15856,7 +16883,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[159]: begin
+      addr_hit[170]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -15891,7 +16918,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[160]: begin
+      addr_hit[171]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -15926,7 +16953,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_2_e_95_qs;
       end
 
-      addr_hit[161]: begin
+      addr_hit[172]: begin
         reg_rdata_next[0] = ie0_3_e_96_qs;
         reg_rdata_next[1] = ie0_3_e_97_qs;
         reg_rdata_next[2] = ie0_3_e_98_qs;
@@ -15961,7 +16988,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_3_e_127_qs;
       end
 
-      addr_hit[162]: begin
+      addr_hit[173]: begin
         reg_rdata_next[0] = ie0_4_e_128_qs;
         reg_rdata_next[1] = ie0_4_e_129_qs;
         reg_rdata_next[2] = ie0_4_e_130_qs;
@@ -15987,21 +17014,34 @@ module rv_plic_reg_top (
         reg_rdata_next[22] = ie0_4_e_150_qs;
         reg_rdata_next[23] = ie0_4_e_151_qs;
         reg_rdata_next[24] = ie0_4_e_152_qs;
+        reg_rdata_next[25] = ie0_4_e_153_qs;
+        reg_rdata_next[26] = ie0_4_e_154_qs;
+        reg_rdata_next[27] = ie0_4_e_155_qs;
+        reg_rdata_next[28] = ie0_4_e_156_qs;
+        reg_rdata_next[29] = ie0_4_e_157_qs;
+        reg_rdata_next[30] = ie0_4_e_158_qs;
+        reg_rdata_next[31] = ie0_4_e_159_qs;
       end
 
-      addr_hit[163]: begin
+      addr_hit[174]: begin
+        reg_rdata_next[0] = ie0_5_e_160_qs;
+        reg_rdata_next[1] = ie0_5_e_161_qs;
+        reg_rdata_next[2] = ie0_5_e_162_qs;
+      end
+
+      addr_hit[175]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[164]: begin
+      addr_hit[176]: begin
         reg_rdata_next[7:0] = cc0_qs;
       end
 
-      addr_hit[165]: begin
+      addr_hit[177]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 
-      addr_hit[166]: begin
+      addr_hit[178]: begin
         reg_rdata_next[0] = '0;
       end
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -345,7 +345,7 @@ module top_darjeeling #(
   // rv_core_ibex
 
 
-  logic [152:0]  intr_vector;
+  logic [162:0]  intr_vector;
   // Interrupt source list
   logic intr_uart0_tx_watermark;
   logic intr_uart0_rx_watermark;
@@ -419,24 +419,34 @@ module top_darjeeling #(
   logic intr_dma_dma_memory_buffer_limit;
   logic intr_mbx0_mbx_ready;
   logic intr_mbx0_mbx_abort;
+  logic intr_mbx0_mbx_error;
   logic intr_mbx1_mbx_ready;
   logic intr_mbx1_mbx_abort;
+  logic intr_mbx1_mbx_error;
   logic intr_mbx2_mbx_ready;
   logic intr_mbx2_mbx_abort;
+  logic intr_mbx2_mbx_error;
   logic intr_mbx3_mbx_ready;
   logic intr_mbx3_mbx_abort;
+  logic intr_mbx3_mbx_error;
   logic intr_mbx4_mbx_ready;
   logic intr_mbx4_mbx_abort;
+  logic intr_mbx4_mbx_error;
   logic intr_mbx5_mbx_ready;
   logic intr_mbx5_mbx_abort;
+  logic intr_mbx5_mbx_error;
   logic intr_mbx6_mbx_ready;
   logic intr_mbx6_mbx_abort;
+  logic intr_mbx6_mbx_error;
   logic intr_mbx_jtag_mbx_ready;
   logic intr_mbx_jtag_mbx_abort;
+  logic intr_mbx_jtag_mbx_error;
   logic intr_mbx_pcie0_mbx_ready;
   logic intr_mbx_pcie0_mbx_abort;
+  logic intr_mbx_pcie0_mbx_error;
   logic intr_mbx_pcie1_mbx_ready;
   logic intr_mbx_pcie1_mbx_abort;
+  logic intr_mbx_pcie1_mbx_error;
 
   // Alert list
   prim_alert_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
@@ -2113,6 +2123,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx0_mbx_ready),
       .intr_mbx_abort_o (intr_mbx0_mbx_abort),
+      .intr_mbx_error_o (intr_mbx0_mbx_error),
       // [75]: fatal_fault
       // [76]: recov_fault
       .alert_tx_o  ( alert_tx[76:75] ),
@@ -2141,6 +2152,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx1_mbx_ready),
       .intr_mbx_abort_o (intr_mbx1_mbx_abort),
+      .intr_mbx_error_o (intr_mbx1_mbx_error),
       // [77]: fatal_fault
       // [78]: recov_fault
       .alert_tx_o  ( alert_tx[78:77] ),
@@ -2169,6 +2181,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx2_mbx_ready),
       .intr_mbx_abort_o (intr_mbx2_mbx_abort),
+      .intr_mbx_error_o (intr_mbx2_mbx_error),
       // [79]: fatal_fault
       // [80]: recov_fault
       .alert_tx_o  ( alert_tx[80:79] ),
@@ -2197,6 +2210,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx3_mbx_ready),
       .intr_mbx_abort_o (intr_mbx3_mbx_abort),
+      .intr_mbx_error_o (intr_mbx3_mbx_error),
       // [81]: fatal_fault
       // [82]: recov_fault
       .alert_tx_o  ( alert_tx[82:81] ),
@@ -2225,6 +2239,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx4_mbx_ready),
       .intr_mbx_abort_o (intr_mbx4_mbx_abort),
+      .intr_mbx_error_o (intr_mbx4_mbx_error),
       // [83]: fatal_fault
       // [84]: recov_fault
       .alert_tx_o  ( alert_tx[84:83] ),
@@ -2253,6 +2268,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx5_mbx_ready),
       .intr_mbx_abort_o (intr_mbx5_mbx_abort),
+      .intr_mbx_error_o (intr_mbx5_mbx_error),
       // [85]: fatal_fault
       // [86]: recov_fault
       .alert_tx_o  ( alert_tx[86:85] ),
@@ -2281,6 +2297,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx6_mbx_ready),
       .intr_mbx_abort_o (intr_mbx6_mbx_abort),
+      .intr_mbx_error_o (intr_mbx6_mbx_error),
       // [87]: fatal_fault
       // [88]: recov_fault
       .alert_tx_o  ( alert_tx[88:87] ),
@@ -2309,6 +2326,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx_jtag_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_jtag_mbx_abort),
+      .intr_mbx_error_o (intr_mbx_jtag_mbx_error),
       // [89]: fatal_fault
       // [90]: recov_fault
       .alert_tx_o  ( alert_tx[90:89] ),
@@ -2337,6 +2355,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx_pcie0_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_pcie0_mbx_abort),
+      .intr_mbx_error_o (intr_mbx_pcie0_mbx_error),
       // [91]: fatal_fault
       // [92]: recov_fault
       .alert_tx_o  ( alert_tx[92:91] ),
@@ -2365,6 +2384,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_mbx_ready_o (intr_mbx_pcie1_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_pcie1_mbx_abort),
+      .intr_mbx_error_o (intr_mbx_pcie1_mbx_error),
       // [93]: fatal_fault
       // [94]: recov_fault
       .alert_tx_o  ( alert_tx[94:93] ),
@@ -2463,24 +2483,34 @@ module top_darjeeling #(
   );
   // interrupt assignments
   assign intr_vector = {
-      intr_mbx_pcie1_mbx_abort, // IDs [152 +: 1]
-      intr_mbx_pcie1_mbx_ready, // IDs [151 +: 1]
-      intr_mbx_pcie0_mbx_abort, // IDs [150 +: 1]
-      intr_mbx_pcie0_mbx_ready, // IDs [149 +: 1]
-      intr_mbx_jtag_mbx_abort, // IDs [148 +: 1]
-      intr_mbx_jtag_mbx_ready, // IDs [147 +: 1]
-      intr_mbx6_mbx_abort, // IDs [146 +: 1]
-      intr_mbx6_mbx_ready, // IDs [145 +: 1]
-      intr_mbx5_mbx_abort, // IDs [144 +: 1]
-      intr_mbx5_mbx_ready, // IDs [143 +: 1]
-      intr_mbx4_mbx_abort, // IDs [142 +: 1]
-      intr_mbx4_mbx_ready, // IDs [141 +: 1]
-      intr_mbx3_mbx_abort, // IDs [140 +: 1]
-      intr_mbx3_mbx_ready, // IDs [139 +: 1]
-      intr_mbx2_mbx_abort, // IDs [138 +: 1]
-      intr_mbx2_mbx_ready, // IDs [137 +: 1]
-      intr_mbx1_mbx_abort, // IDs [136 +: 1]
-      intr_mbx1_mbx_ready, // IDs [135 +: 1]
+      intr_mbx_pcie1_mbx_error, // IDs [162 +: 1]
+      intr_mbx_pcie1_mbx_abort, // IDs [161 +: 1]
+      intr_mbx_pcie1_mbx_ready, // IDs [160 +: 1]
+      intr_mbx_pcie0_mbx_error, // IDs [159 +: 1]
+      intr_mbx_pcie0_mbx_abort, // IDs [158 +: 1]
+      intr_mbx_pcie0_mbx_ready, // IDs [157 +: 1]
+      intr_mbx_jtag_mbx_error, // IDs [156 +: 1]
+      intr_mbx_jtag_mbx_abort, // IDs [155 +: 1]
+      intr_mbx_jtag_mbx_ready, // IDs [154 +: 1]
+      intr_mbx6_mbx_error, // IDs [153 +: 1]
+      intr_mbx6_mbx_abort, // IDs [152 +: 1]
+      intr_mbx6_mbx_ready, // IDs [151 +: 1]
+      intr_mbx5_mbx_error, // IDs [150 +: 1]
+      intr_mbx5_mbx_abort, // IDs [149 +: 1]
+      intr_mbx5_mbx_ready, // IDs [148 +: 1]
+      intr_mbx4_mbx_error, // IDs [147 +: 1]
+      intr_mbx4_mbx_abort, // IDs [146 +: 1]
+      intr_mbx4_mbx_ready, // IDs [145 +: 1]
+      intr_mbx3_mbx_error, // IDs [144 +: 1]
+      intr_mbx3_mbx_abort, // IDs [143 +: 1]
+      intr_mbx3_mbx_ready, // IDs [142 +: 1]
+      intr_mbx2_mbx_error, // IDs [141 +: 1]
+      intr_mbx2_mbx_abort, // IDs [140 +: 1]
+      intr_mbx2_mbx_ready, // IDs [139 +: 1]
+      intr_mbx1_mbx_error, // IDs [138 +: 1]
+      intr_mbx1_mbx_abort, // IDs [137 +: 1]
+      intr_mbx1_mbx_ready, // IDs [136 +: 1]
+      intr_mbx0_mbx_error, // IDs [135 +: 1]
       intr_mbx0_mbx_abort, // IDs [134 +: 1]
       intr_mbx0_mbx_ready, // IDs [133 +: 1]
       intr_dma_dma_memory_buffer_limit, // IDs [132 +: 1]

--- a/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
@@ -1125,42 +1125,62 @@ pub enum TopDarjeelingPlicIrqId {
     Mbx0MbxReady = 133,
     /// mbx0_mbx_abort
     Mbx0MbxAbort = 134,
+    /// mbx0_mbx_error
+    Mbx0MbxError = 135,
     /// mbx1_mbx_ready
-    Mbx1MbxReady = 135,
+    Mbx1MbxReady = 136,
     /// mbx1_mbx_abort
-    Mbx1MbxAbort = 136,
+    Mbx1MbxAbort = 137,
+    /// mbx1_mbx_error
+    Mbx1MbxError = 138,
     /// mbx2_mbx_ready
-    Mbx2MbxReady = 137,
+    Mbx2MbxReady = 139,
     /// mbx2_mbx_abort
-    Mbx2MbxAbort = 138,
+    Mbx2MbxAbort = 140,
+    /// mbx2_mbx_error
+    Mbx2MbxError = 141,
     /// mbx3_mbx_ready
-    Mbx3MbxReady = 139,
+    Mbx3MbxReady = 142,
     /// mbx3_mbx_abort
-    Mbx3MbxAbort = 140,
+    Mbx3MbxAbort = 143,
+    /// mbx3_mbx_error
+    Mbx3MbxError = 144,
     /// mbx4_mbx_ready
-    Mbx4MbxReady = 141,
+    Mbx4MbxReady = 145,
     /// mbx4_mbx_abort
-    Mbx4MbxAbort = 142,
+    Mbx4MbxAbort = 146,
+    /// mbx4_mbx_error
+    Mbx4MbxError = 147,
     /// mbx5_mbx_ready
-    Mbx5MbxReady = 143,
+    Mbx5MbxReady = 148,
     /// mbx5_mbx_abort
-    Mbx5MbxAbort = 144,
+    Mbx5MbxAbort = 149,
+    /// mbx5_mbx_error
+    Mbx5MbxError = 150,
     /// mbx6_mbx_ready
-    Mbx6MbxReady = 145,
+    Mbx6MbxReady = 151,
     /// mbx6_mbx_abort
-    Mbx6MbxAbort = 146,
+    Mbx6MbxAbort = 152,
+    /// mbx6_mbx_error
+    Mbx6MbxError = 153,
     /// mbx_jtag_mbx_ready
-    MbxJtagMbxReady = 147,
+    MbxJtagMbxReady = 154,
     /// mbx_jtag_mbx_abort
-    MbxJtagMbxAbort = 148,
+    MbxJtagMbxAbort = 155,
+    /// mbx_jtag_mbx_error
+    MbxJtagMbxError = 156,
     /// mbx_pcie0_mbx_ready
-    MbxPcie0MbxReady = 149,
+    MbxPcie0MbxReady = 157,
     /// mbx_pcie0_mbx_abort
-    MbxPcie0MbxAbort = 150,
+    MbxPcie0MbxAbort = 158,
+    /// mbx_pcie0_mbx_error
+    MbxPcie0MbxError = 159,
     /// mbx_pcie1_mbx_ready
-    MbxPcie1MbxReady = 151,
+    MbxPcie1MbxReady = 160,
     /// mbx_pcie1_mbx_abort
-    MbxPcie1MbxAbort = 152,
+    MbxPcie1MbxAbort = 161,
+    /// mbx_pcie1_mbx_error
+    MbxPcie1MbxError = 162,
 }
 
 impl TryFrom<u32> for TopDarjeelingPlicIrqId {
@@ -1302,24 +1322,34 @@ impl TryFrom<u32> for TopDarjeelingPlicIrqId {
             132 => Ok(Self::DmaDmaMemoryBufferLimit),
             133 => Ok(Self::Mbx0MbxReady),
             134 => Ok(Self::Mbx0MbxAbort),
-            135 => Ok(Self::Mbx1MbxReady),
-            136 => Ok(Self::Mbx1MbxAbort),
-            137 => Ok(Self::Mbx2MbxReady),
-            138 => Ok(Self::Mbx2MbxAbort),
-            139 => Ok(Self::Mbx3MbxReady),
-            140 => Ok(Self::Mbx3MbxAbort),
-            141 => Ok(Self::Mbx4MbxReady),
-            142 => Ok(Self::Mbx4MbxAbort),
-            143 => Ok(Self::Mbx5MbxReady),
-            144 => Ok(Self::Mbx5MbxAbort),
-            145 => Ok(Self::Mbx6MbxReady),
-            146 => Ok(Self::Mbx6MbxAbort),
-            147 => Ok(Self::MbxJtagMbxReady),
-            148 => Ok(Self::MbxJtagMbxAbort),
-            149 => Ok(Self::MbxPcie0MbxReady),
-            150 => Ok(Self::MbxPcie0MbxAbort),
-            151 => Ok(Self::MbxPcie1MbxReady),
-            152 => Ok(Self::MbxPcie1MbxAbort),
+            135 => Ok(Self::Mbx0MbxError),
+            136 => Ok(Self::Mbx1MbxReady),
+            137 => Ok(Self::Mbx1MbxAbort),
+            138 => Ok(Self::Mbx1MbxError),
+            139 => Ok(Self::Mbx2MbxReady),
+            140 => Ok(Self::Mbx2MbxAbort),
+            141 => Ok(Self::Mbx2MbxError),
+            142 => Ok(Self::Mbx3MbxReady),
+            143 => Ok(Self::Mbx3MbxAbort),
+            144 => Ok(Self::Mbx3MbxError),
+            145 => Ok(Self::Mbx4MbxReady),
+            146 => Ok(Self::Mbx4MbxAbort),
+            147 => Ok(Self::Mbx4MbxError),
+            148 => Ok(Self::Mbx5MbxReady),
+            149 => Ok(Self::Mbx5MbxAbort),
+            150 => Ok(Self::Mbx5MbxError),
+            151 => Ok(Self::Mbx6MbxReady),
+            152 => Ok(Self::Mbx6MbxAbort),
+            153 => Ok(Self::Mbx6MbxError),
+            154 => Ok(Self::MbxJtagMbxReady),
+            155 => Ok(Self::MbxJtagMbxAbort),
+            156 => Ok(Self::MbxJtagMbxError),
+            157 => Ok(Self::MbxPcie0MbxReady),
+            158 => Ok(Self::MbxPcie0MbxAbort),
+            159 => Ok(Self::MbxPcie0MbxError),
+            160 => Ok(Self::MbxPcie1MbxReady),
+            161 => Ok(Self::MbxPcie1MbxAbort),
+            162 => Ok(Self::MbxPcie1MbxError),
             _ => Err(val),
         }
     }
@@ -1745,7 +1775,7 @@ impl TryFrom<u32> for TopDarjeelingAlertId {
 ///
 /// This array is a mapping from `TopDarjeelingPlicIrqId` to
 /// `TopDarjeelingPlicPeripheral`.
-pub const TOP_DARJEELING_PLIC_INTERRUPT_FOR_PERIPHERAL: [TopDarjeelingPlicPeripheral; 153] = [
+pub const TOP_DARJEELING_PLIC_INTERRUPT_FOR_PERIPHERAL: [TopDarjeelingPlicPeripheral; 163] = [
     // None -> TopDarjeelingPlicPeripheral::Unknown
     TopDarjeelingPlicPeripheral::Unknown,
     // Uart0TxWatermark -> TopDarjeelingPlicPeripheral::Uart0
@@ -2016,41 +2046,61 @@ pub const TOP_DARJEELING_PLIC_INTERRUPT_FOR_PERIPHERAL: [TopDarjeelingPlicPeriph
     TopDarjeelingPlicPeripheral::Mbx0,
     // Mbx0MbxAbort -> TopDarjeelingPlicPeripheral::Mbx0
     TopDarjeelingPlicPeripheral::Mbx0,
+    // Mbx0MbxError -> TopDarjeelingPlicPeripheral::Mbx0
+    TopDarjeelingPlicPeripheral::Mbx0,
     // Mbx1MbxReady -> TopDarjeelingPlicPeripheral::Mbx1
     TopDarjeelingPlicPeripheral::Mbx1,
     // Mbx1MbxAbort -> TopDarjeelingPlicPeripheral::Mbx1
+    TopDarjeelingPlicPeripheral::Mbx1,
+    // Mbx1MbxError -> TopDarjeelingPlicPeripheral::Mbx1
     TopDarjeelingPlicPeripheral::Mbx1,
     // Mbx2MbxReady -> TopDarjeelingPlicPeripheral::Mbx2
     TopDarjeelingPlicPeripheral::Mbx2,
     // Mbx2MbxAbort -> TopDarjeelingPlicPeripheral::Mbx2
     TopDarjeelingPlicPeripheral::Mbx2,
+    // Mbx2MbxError -> TopDarjeelingPlicPeripheral::Mbx2
+    TopDarjeelingPlicPeripheral::Mbx2,
     // Mbx3MbxReady -> TopDarjeelingPlicPeripheral::Mbx3
     TopDarjeelingPlicPeripheral::Mbx3,
     // Mbx3MbxAbort -> TopDarjeelingPlicPeripheral::Mbx3
+    TopDarjeelingPlicPeripheral::Mbx3,
+    // Mbx3MbxError -> TopDarjeelingPlicPeripheral::Mbx3
     TopDarjeelingPlicPeripheral::Mbx3,
     // Mbx4MbxReady -> TopDarjeelingPlicPeripheral::Mbx4
     TopDarjeelingPlicPeripheral::Mbx4,
     // Mbx4MbxAbort -> TopDarjeelingPlicPeripheral::Mbx4
     TopDarjeelingPlicPeripheral::Mbx4,
+    // Mbx4MbxError -> TopDarjeelingPlicPeripheral::Mbx4
+    TopDarjeelingPlicPeripheral::Mbx4,
     // Mbx5MbxReady -> TopDarjeelingPlicPeripheral::Mbx5
     TopDarjeelingPlicPeripheral::Mbx5,
     // Mbx5MbxAbort -> TopDarjeelingPlicPeripheral::Mbx5
+    TopDarjeelingPlicPeripheral::Mbx5,
+    // Mbx5MbxError -> TopDarjeelingPlicPeripheral::Mbx5
     TopDarjeelingPlicPeripheral::Mbx5,
     // Mbx6MbxReady -> TopDarjeelingPlicPeripheral::Mbx6
     TopDarjeelingPlicPeripheral::Mbx6,
     // Mbx6MbxAbort -> TopDarjeelingPlicPeripheral::Mbx6
     TopDarjeelingPlicPeripheral::Mbx6,
+    // Mbx6MbxError -> TopDarjeelingPlicPeripheral::Mbx6
+    TopDarjeelingPlicPeripheral::Mbx6,
     // MbxJtagMbxReady -> TopDarjeelingPlicPeripheral::MbxJtag
     TopDarjeelingPlicPeripheral::MbxJtag,
     // MbxJtagMbxAbort -> TopDarjeelingPlicPeripheral::MbxJtag
+    TopDarjeelingPlicPeripheral::MbxJtag,
+    // MbxJtagMbxError -> TopDarjeelingPlicPeripheral::MbxJtag
     TopDarjeelingPlicPeripheral::MbxJtag,
     // MbxPcie0MbxReady -> TopDarjeelingPlicPeripheral::MbxPcie0
     TopDarjeelingPlicPeripheral::MbxPcie0,
     // MbxPcie0MbxAbort -> TopDarjeelingPlicPeripheral::MbxPcie0
     TopDarjeelingPlicPeripheral::MbxPcie0,
+    // MbxPcie0MbxError -> TopDarjeelingPlicPeripheral::MbxPcie0
+    TopDarjeelingPlicPeripheral::MbxPcie0,
     // MbxPcie1MbxReady -> TopDarjeelingPlicPeripheral::MbxPcie1
     TopDarjeelingPlicPeripheral::MbxPcie1,
     // MbxPcie1MbxAbort -> TopDarjeelingPlicPeripheral::MbxPcie1
+    TopDarjeelingPlicPeripheral::MbxPcie1,
+    // MbxPcie1MbxError -> TopDarjeelingPlicPeripheral::MbxPcie1
     TopDarjeelingPlicPeripheral::MbxPcie1,
 ];
 

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.c
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.c
@@ -11,7 +11,7 @@
  * `top_darjeeling_plic_peripheral_t`.
  */
 const top_darjeeling_plic_peripheral_t
-    top_darjeeling_plic_interrupt_for_peripheral[153] = {
+    top_darjeeling_plic_interrupt_for_peripheral[163] = {
   [kTopDarjeelingPlicIrqIdNone] = kTopDarjeelingPlicPeripheralUnknown,
   [kTopDarjeelingPlicIrqIdUart0TxWatermark] = kTopDarjeelingPlicPeripheralUart0,
   [kTopDarjeelingPlicIrqIdUart0RxWatermark] = kTopDarjeelingPlicPeripheralUart0,
@@ -147,24 +147,34 @@ const top_darjeeling_plic_peripheral_t
   [kTopDarjeelingPlicIrqIdDmaDmaMemoryBufferLimit] = kTopDarjeelingPlicPeripheralDma,
   [kTopDarjeelingPlicIrqIdMbx0MbxReady] = kTopDarjeelingPlicPeripheralMbx0,
   [kTopDarjeelingPlicIrqIdMbx0MbxAbort] = kTopDarjeelingPlicPeripheralMbx0,
+  [kTopDarjeelingPlicIrqIdMbx0MbxError] = kTopDarjeelingPlicPeripheralMbx0,
   [kTopDarjeelingPlicIrqIdMbx1MbxReady] = kTopDarjeelingPlicPeripheralMbx1,
   [kTopDarjeelingPlicIrqIdMbx1MbxAbort] = kTopDarjeelingPlicPeripheralMbx1,
+  [kTopDarjeelingPlicIrqIdMbx1MbxError] = kTopDarjeelingPlicPeripheralMbx1,
   [kTopDarjeelingPlicIrqIdMbx2MbxReady] = kTopDarjeelingPlicPeripheralMbx2,
   [kTopDarjeelingPlicIrqIdMbx2MbxAbort] = kTopDarjeelingPlicPeripheralMbx2,
+  [kTopDarjeelingPlicIrqIdMbx2MbxError] = kTopDarjeelingPlicPeripheralMbx2,
   [kTopDarjeelingPlicIrqIdMbx3MbxReady] = kTopDarjeelingPlicPeripheralMbx3,
   [kTopDarjeelingPlicIrqIdMbx3MbxAbort] = kTopDarjeelingPlicPeripheralMbx3,
+  [kTopDarjeelingPlicIrqIdMbx3MbxError] = kTopDarjeelingPlicPeripheralMbx3,
   [kTopDarjeelingPlicIrqIdMbx4MbxReady] = kTopDarjeelingPlicPeripheralMbx4,
   [kTopDarjeelingPlicIrqIdMbx4MbxAbort] = kTopDarjeelingPlicPeripheralMbx4,
+  [kTopDarjeelingPlicIrqIdMbx4MbxError] = kTopDarjeelingPlicPeripheralMbx4,
   [kTopDarjeelingPlicIrqIdMbx5MbxReady] = kTopDarjeelingPlicPeripheralMbx5,
   [kTopDarjeelingPlicIrqIdMbx5MbxAbort] = kTopDarjeelingPlicPeripheralMbx5,
+  [kTopDarjeelingPlicIrqIdMbx5MbxError] = kTopDarjeelingPlicPeripheralMbx5,
   [kTopDarjeelingPlicIrqIdMbx6MbxReady] = kTopDarjeelingPlicPeripheralMbx6,
   [kTopDarjeelingPlicIrqIdMbx6MbxAbort] = kTopDarjeelingPlicPeripheralMbx6,
+  [kTopDarjeelingPlicIrqIdMbx6MbxError] = kTopDarjeelingPlicPeripheralMbx6,
   [kTopDarjeelingPlicIrqIdMbxJtagMbxReady] = kTopDarjeelingPlicPeripheralMbxJtag,
   [kTopDarjeelingPlicIrqIdMbxJtagMbxAbort] = kTopDarjeelingPlicPeripheralMbxJtag,
+  [kTopDarjeelingPlicIrqIdMbxJtagMbxError] = kTopDarjeelingPlicPeripheralMbxJtag,
   [kTopDarjeelingPlicIrqIdMbxPcie0MbxReady] = kTopDarjeelingPlicPeripheralMbxPcie0,
   [kTopDarjeelingPlicIrqIdMbxPcie0MbxAbort] = kTopDarjeelingPlicPeripheralMbxPcie0,
+  [kTopDarjeelingPlicIrqIdMbxPcie0MbxError] = kTopDarjeelingPlicPeripheralMbxPcie0,
   [kTopDarjeelingPlicIrqIdMbxPcie1MbxReady] = kTopDarjeelingPlicPeripheralMbxPcie1,
   [kTopDarjeelingPlicIrqIdMbxPcie1MbxAbort] = kTopDarjeelingPlicPeripheralMbxPcie1,
+  [kTopDarjeelingPlicIrqIdMbxPcie1MbxError] = kTopDarjeelingPlicPeripheralMbxPcie1,
 };
 
 

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.h
@@ -1218,25 +1218,35 @@ typedef enum top_darjeeling_plic_irq_id {
   kTopDarjeelingPlicIrqIdDmaDmaMemoryBufferLimit = 132, /**< dma_dma_memory_buffer_limit */
   kTopDarjeelingPlicIrqIdMbx0MbxReady = 133, /**< mbx0_mbx_ready */
   kTopDarjeelingPlicIrqIdMbx0MbxAbort = 134, /**< mbx0_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx1MbxReady = 135, /**< mbx1_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx1MbxAbort = 136, /**< mbx1_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx2MbxReady = 137, /**< mbx2_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx2MbxAbort = 138, /**< mbx2_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx3MbxReady = 139, /**< mbx3_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx3MbxAbort = 140, /**< mbx3_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx4MbxReady = 141, /**< mbx4_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx4MbxAbort = 142, /**< mbx4_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx5MbxReady = 143, /**< mbx5_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx5MbxAbort = 144, /**< mbx5_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbx6MbxReady = 145, /**< mbx6_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbx6MbxAbort = 146, /**< mbx6_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbxJtagMbxReady = 147, /**< mbx_jtag_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbxJtagMbxAbort = 148, /**< mbx_jtag_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbxPcie0MbxReady = 149, /**< mbx_pcie0_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbxPcie0MbxAbort = 150, /**< mbx_pcie0_mbx_abort */
-  kTopDarjeelingPlicIrqIdMbxPcie1MbxReady = 151, /**< mbx_pcie1_mbx_ready */
-  kTopDarjeelingPlicIrqIdMbxPcie1MbxAbort = 152, /**< mbx_pcie1_mbx_abort */
-  kTopDarjeelingPlicIrqIdLast = 152, /**< \internal The Last Valid Interrupt ID. */
+  kTopDarjeelingPlicIrqIdMbx0MbxError = 135, /**< mbx0_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx1MbxReady = 136, /**< mbx1_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx1MbxAbort = 137, /**< mbx1_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx1MbxError = 138, /**< mbx1_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx2MbxReady = 139, /**< mbx2_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx2MbxAbort = 140, /**< mbx2_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx2MbxError = 141, /**< mbx2_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx3MbxReady = 142, /**< mbx3_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx3MbxAbort = 143, /**< mbx3_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx3MbxError = 144, /**< mbx3_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx4MbxReady = 145, /**< mbx4_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx4MbxAbort = 146, /**< mbx4_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx4MbxError = 147, /**< mbx4_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx5MbxReady = 148, /**< mbx5_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx5MbxAbort = 149, /**< mbx5_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx5MbxError = 150, /**< mbx5_mbx_error */
+  kTopDarjeelingPlicIrqIdMbx6MbxReady = 151, /**< mbx6_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbx6MbxAbort = 152, /**< mbx6_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbx6MbxError = 153, /**< mbx6_mbx_error */
+  kTopDarjeelingPlicIrqIdMbxJtagMbxReady = 154, /**< mbx_jtag_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbxJtagMbxAbort = 155, /**< mbx_jtag_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbxJtagMbxError = 156, /**< mbx_jtag_mbx_error */
+  kTopDarjeelingPlicIrqIdMbxPcie0MbxReady = 157, /**< mbx_pcie0_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbxPcie0MbxAbort = 158, /**< mbx_pcie0_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbxPcie0MbxError = 159, /**< mbx_pcie0_mbx_error */
+  kTopDarjeelingPlicIrqIdMbxPcie1MbxReady = 160, /**< mbx_pcie1_mbx_ready */
+  kTopDarjeelingPlicIrqIdMbxPcie1MbxAbort = 161, /**< mbx_pcie1_mbx_abort */
+  kTopDarjeelingPlicIrqIdMbxPcie1MbxError = 162, /**< mbx_pcie1_mbx_error */
+  kTopDarjeelingPlicIrqIdLast = 162, /**< \internal The Last Valid Interrupt ID. */
 } top_darjeeling_plic_irq_id_t;
 
 /**
@@ -1246,7 +1256,7 @@ typedef enum top_darjeeling_plic_irq_id {
  * `top_darjeeling_plic_peripheral_t`.
  */
 extern const top_darjeeling_plic_peripheral_t
-    top_darjeeling_plic_interrupt_for_peripheral[153];
+    top_darjeeling_plic_interrupt_for_peripheral[163];
 
 /**
  * PLIC Interrupt Target.

--- a/sw/device/tests/autogen/top_darjeeling/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/top_darjeeling/plic_all_irqs_test.c
@@ -1224,7 +1224,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx0;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx0, irq, true));
@@ -1237,7 +1237,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx1;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx1, irq, true));
@@ -1250,7 +1250,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx2;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx2 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx2, irq, true));
@@ -1263,7 +1263,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx3;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx3 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx3, irq, true));
@@ -1276,7 +1276,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx4;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx4 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx4, irq, true));
@@ -1289,7 +1289,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx5;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx5 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx5, irq, true));
@@ -1302,7 +1302,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbx6;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx6 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx6, irq, true));
@@ -1315,7 +1315,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbxJtag;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx_jtag IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx_jtag, irq, true));
@@ -1328,7 +1328,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbxPcie0;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx_pcie0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx_pcie0, irq, true));
@@ -1341,7 +1341,7 @@ static void peripheral_irqs_trigger(void) {
 
   peripheral_expected = kTopDarjeelingPlicPeripheralMbxPcie1;
   for (dif_mbx_irq_t irq = kDifMbxIrqMbxReady;
-       irq <= kDifMbxIrqMbxAbort; ++irq) {
+       irq <= kDifMbxIrqMbxError; ++irq) {
     mbx_irq_expected = irq;
     LOG_INFO("Triggering mbx_pcie1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_mbx_irq_force(&mbx_pcie1, irq, true));

--- a/sw/ip/mbx/dif/autogen/dif_mbx_autogen.c
+++ b/sw/ip/mbx/dif/autogen/dif_mbx_autogen.c
@@ -60,6 +60,9 @@ static bool mbx_get_irq_bit_index(dif_mbx_irq_t irq,
     case kDifMbxIrqMbxAbort:
       *index_out = MBX_INTR_COMMON_MBX_ABORT_BIT;
       break;
+    case kDifMbxIrqMbxError:
+      *index_out = MBX_INTR_COMMON_MBX_ERROR_BIT;
+      break;
     default:
       return false;
   }
@@ -70,12 +73,13 @@ static bool mbx_get_irq_bit_index(dif_mbx_irq_t irq,
 static dif_irq_type_t irq_types[] = {
     kDifIrqTypeEvent,
     kDifIrqTypeEvent,
+    kDifIrqTypeEvent,
 };
 
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_mbx_irq_get_type(const dif_mbx_t *mbx, dif_mbx_irq_t irq,
                                   dif_irq_type_t *type) {
-  if (mbx == NULL || type == NULL || irq == kDifMbxIrqMbxAbort + 1) {
+  if (mbx == NULL || type == NULL || irq == kDifMbxIrqMbxError + 1) {
     return kDifBadArg;
   }
 

--- a/sw/ip/mbx/dif/autogen/dif_mbx_autogen.h
+++ b/sw/ip/mbx/dif/autogen/dif_mbx_autogen.h
@@ -87,6 +87,10 @@ typedef enum dif_mbx_irq {
    * An abort request was received from the requester.
    */
   kDifMbxIrqMbxAbort = 1,
+  /**
+   * The mailbox instance generated an error.
+   */
+  kDifMbxIrqMbxError = 2,
 } dif_mbx_irq_t;
 
 /**

--- a/sw/ip/mbx/dif/autogen/dif_mbx_autogen_unittest.cc
+++ b/sw/ip/mbx/dif/autogen/dif_mbx_autogen_unittest.cc
@@ -75,7 +75,7 @@ TEST_F(IrqGetTypeTest, BadIrq) {
   dif_irq_type_t type;
 
   EXPECT_DIF_BADARG(dif_mbx_irq_get_type(
-      &mbx_, static_cast<dif_mbx_irq_t>(kDifMbxIrqMbxAbort + 1), &type));
+      &mbx_, static_cast<dif_mbx_irq_t>(kDifMbxIrqMbxError + 1), &type));
 }
 
 TEST_F(IrqGetTypeTest, Success) {
@@ -148,8 +148,8 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(MBX_INTR_STATE_REG_OFFSET,
-                {{MBX_INTR_STATE_MBX_ABORT_BIT, false}});
-  EXPECT_DIF_OK(dif_mbx_irq_is_pending(&mbx_, kDifMbxIrqMbxAbort, &irq_state));
+                {{MBX_INTR_STATE_MBX_ERROR_BIT, false}});
+  EXPECT_DIF_OK(dif_mbx_irq_is_pending(&mbx_, kDifMbxIrqMbxError, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
@@ -161,7 +161,7 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  const uint32_t num_irqs = 2;
+  const uint32_t num_irqs = 3;
   const uint32_t irq_mask = (1u << num_irqs) - 1;
   dif_mbx_irq_state_snapshot_t irq_snapshot = 1;
 
@@ -214,8 +214,8 @@ TEST_F(IrqAcknowledgeTest, Success) {
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(MBX_INTR_STATE_REG_OFFSET,
-                 {{MBX_INTR_STATE_MBX_ABORT_BIT, true}});
-  EXPECT_DIF_OK(dif_mbx_irq_acknowledge(&mbx_, kDifMbxIrqMbxAbort));
+                 {{MBX_INTR_STATE_MBX_ERROR_BIT, true}});
+  EXPECT_DIF_OK(dif_mbx_irq_acknowledge(&mbx_, kDifMbxIrqMbxError));
 }
 
 class IrqForceTest : public MbxTest {};
@@ -237,8 +237,8 @@ TEST_F(IrqForceTest, Success) {
 
   // Force last IRQ.
   EXPECT_WRITE32(MBX_INTR_TEST_REG_OFFSET,
-                 {{MBX_INTR_TEST_MBX_ABORT_BIT, true}});
-  EXPECT_DIF_OK(dif_mbx_irq_force(&mbx_, kDifMbxIrqMbxAbort, true));
+                 {{MBX_INTR_TEST_MBX_ERROR_BIT, true}});
+  EXPECT_DIF_OK(dif_mbx_irq_force(&mbx_, kDifMbxIrqMbxError, true));
 }
 
 class IrqGetEnabledTest : public MbxTest {};
@@ -276,8 +276,8 @@ TEST_F(IrqGetEnabledTest, Success) {
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(MBX_INTR_ENABLE_REG_OFFSET,
-                {{MBX_INTR_ENABLE_MBX_ABORT_BIT, false}});
-  EXPECT_DIF_OK(dif_mbx_irq_get_enabled(&mbx_, kDifMbxIrqMbxAbort, &irq_state));
+                {{MBX_INTR_ENABLE_MBX_ERROR_BIT, false}});
+  EXPECT_DIF_OK(dif_mbx_irq_get_enabled(&mbx_, kDifMbxIrqMbxError, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -309,8 +309,8 @@ TEST_F(IrqSetEnabledTest, Success) {
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(MBX_INTR_ENABLE_REG_OFFSET,
-                {{MBX_INTR_ENABLE_MBX_ABORT_BIT, 0x1, false}});
-  EXPECT_DIF_OK(dif_mbx_irq_set_enabled(&mbx_, kDifMbxIrqMbxAbort, irq_state));
+                {{MBX_INTR_ENABLE_MBX_ERROR_BIT, 0x1, false}});
+  EXPECT_DIF_OK(dif_mbx_irq_set_enabled(&mbx_, kDifMbxIrqMbxError, irq_state));
 }
 
 class IrqDisableAllTest : public MbxTest {};

--- a/sw/ip/rv_plic/dif/dif_rv_plic_unittest.cc
+++ b/sw/ip/rv_plic/dif/dif_rv_plic_unittest.cc
@@ -21,7 +21,7 @@ using testing::Test;
 
 // If either of these static assertions fail, then the unit-tests for related
 // API should be revisited.
-static_assert(RV_PLIC_PARAM_NUM_SRC == 153 ||    // Darjeeling
+static_assert(RV_PLIC_PARAM_NUM_SRC == 163 ||    // Darjeeling
                   RV_PLIC_PARAM_NUM_SRC == 185,  // Earlgrey
               "PLIC instantiation parameters have changed.");
 static_assert(RV_PLIC_PARAM_NUM_TARGET == 1,
@@ -50,6 +50,7 @@ class ResetTest : public PlicTest {
     EXPECT_WRITE32(RV_PLIC_IE0_2_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_IE0_3_REG_OFFSET, 0);
     EXPECT_WRITE32(RV_PLIC_IE0_4_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_5_REG_OFFSET, 0);
 
     // Target threshold registers.
     EXPECT_WRITE32(RV_PLIC_THRESHOLD0_REG_OFFSET, 0);
@@ -99,7 +100,8 @@ class IrqTest : public PlicTest {
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
           {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_95_BIT},
           {RV_PLIC_IE0_3_REG_OFFSET, RV_PLIC_IE0_3_E_127_BIT},
-          {RV_PLIC_IE0_4_REG_OFFSET, RV_PLIC_IE0_4_E_152_BIT},
+          {RV_PLIC_IE0_4_REG_OFFSET, RV_PLIC_IE0_4_E_159_BIT},
+          {RV_PLIC_IE0_5_REG_OFFSET, RV_PLIC_IE0_5_E_162_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
@@ -107,7 +109,8 @@ class IrqTest : public PlicTest {
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
           {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_95_BIT},
           {RV_PLIC_IP_3_REG_OFFSET, RV_PLIC_IP_3_P_127_BIT},
-          {RV_PLIC_IP_4_REG_OFFSET, RV_PLIC_IP_4_P_152_BIT},
+          {RV_PLIC_IP_4_REG_OFFSET, RV_PLIC_IP_4_P_159_BIT},
+          {RV_PLIC_IP_5_REG_OFFSET, RV_PLIC_IP_5_P_162_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.


### PR DESCRIPTION
This PR implements the error mechanism in case there requester tries to write out of the limit bounds of the mailbox. Compared to the HOST-generated error by Ibex, this error is generated by the mailbox hardware itself. 

* For a better readability, there is a new error state in the FSM. Whenever an error is triggered, the FSM transfers to that state. The error is cleared by the abort mechanism. The requester initiated an abort request, the FSM transfers to the abort state, and finally the HOST acknowledges the abort, such that the mailbox transfers back to idle.
* A hardware generated error triggers a new error interrupt to the host, so it can take any measures that are needed.

Closes https://github.com/lowRISC/opentitan-integrated/issues/443