### PR TITLE
[Sival, rv core ibex] Double fault 

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -101,6 +101,7 @@
        stage: V2
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
+       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_rom_with_fake_keys"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"
@@ -118,6 +119,7 @@
        stage: V2
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
+       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_rom_with_fake_keys"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"

--- a/sw/device/lib/testing/rv_core_ibex_testutils.h
+++ b/sw/device/lib/testing/rv_core_ibex_testutils.h
@@ -39,4 +39,23 @@ status_t rv_core_ibex_testutils_get_rnd_data(
     const dif_rv_core_ibex_t *rv_core_ibex, uint32_t timeout_usec,
     uint32_t *rnd);
 
+#define RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_DUMP(dump) \
+  LOG_INFO(                                           \
+      "\n%s = {"                                      \
+      "\n\tmtval=%08x"                                \
+      "\n\tmpec=%08x,"                                \
+      "\n\tmdaa=%08x,"                                \
+      "\n\tmnpc=%08x,"                                \
+      "\n\tmcpc=%08x,"                                \
+      "\n}\n",                                        \
+      #dump, dump.mtval, dump.mpec, dump.mdaa, dump.mnpc, dump.mcpc)
+
+#define RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_PREVIOUS_DUMP(dump) \
+  LOG_INFO(                                                    \
+      "\n%s = {"                                               \
+      "\n\tmtval=%08x"                                         \
+      "\n\tmpec=%08x,"                                         \
+      "\n}\n",                                                 \
+      #dump, dump.mtval, dump.mpec)
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_RV_CORE_IBEX_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2106,6 +2106,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2090,11 +2090,7 @@ opentitan_test(
 opentitan_test(
     name = "rstmgr_cpu_info_test",
     srcs = ["rstmgr_cpu_info_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = EARLGREY_TEST_ENVS,
     verilator = new_verilator_params(
         timeout = "long",
         tags = ["broken"],

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -230,7 +230,7 @@ bool test_main(void) {
       addr_val = mmio_region_read32(mmio_region_from_addr(kIllegalAddr0), 0);
       OT_ADDRESSABLE_LABEL(kSingleFaultAddrUpper);
       CHECK(false,
-            "This should be unreachable; a single fault should have occured.");
+            "This should be unreachable; a single fault should have occurred.");
       break;
 
     case kDifRstmgrResetInfoSw:  // The power-up after the single fault.
@@ -255,9 +255,12 @@ bool test_main(void) {
                   kDifToggleDisabled);
 
       LOG_INFO("Setting up watch dog and triggering a double fault.");
+      // When we boot through the ROM the watchdog is configured to generate an
+      // NMI on barking, so we want the watchdog to bark before the first
+      // exception to avoid the NMI messing with the fault dump.
       uint32_t bark_cycles = 0;
       CHECK_STATUS_OK(
-          aon_timer_testutils_get_aon_cycles_from_us(100, &bark_cycles));
+          aon_timer_testutils_get_aon_cycles_from_us(1, &bark_cycles));
       uint32_t bite_cycles = 0;
       CHECK_STATUS_OK(
           aon_timer_testutils_get_aon_cycles_from_us(100, &bite_cycles));

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/aon_timer_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_isrs.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -130,11 +131,12 @@ static dif_rv_core_ibex_crash_dump_info_t get_dump(
 static void check_state(dif_rv_core_ibex_crash_dump_state_t obs_state,
                         dif_rv_core_ibex_crash_dump_state_t exp_state,
                         dif_toggle_t double_fault) {
+  RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_DUMP(obs_state);
+  RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_DUMP(exp_state);
+
   CHECK(exp_state.mtval == obs_state.mtval,
         "Last Exception Access Addr: Expected 0x%x != Observed 0x%x",
         exp_state.mtval, obs_state.mtval);
-  LOG_INFO("exp_mcpc=0x%x, exp_mnpc=0x%x, obs_mcpc=0x%x, obs_mnpc=0x%x",
-           exp_state.mcpc, exp_state.mnpc, obs_state.mcpc, obs_state.mnpc);
   // Check the current pc is either the expected or expected + 4, since the
   // pipeline may have stalled.
   CHECK(exp_state.mcpc == obs_state.mcpc ||
@@ -163,6 +165,8 @@ static void check_state(dif_rv_core_ibex_crash_dump_state_t obs_state,
 static void check_prev_state(
     dif_rv_core_ibex_previous_crash_dump_state_t obs_prev_state,
     dif_rv_core_ibex_previous_crash_dump_state_t exp_prev_state) {
+  RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_PREVIOUS_DUMP(obs_prev_state);
+  RV_CORE_IBEX_TESTUTILS_PRINT_CRASH_PREVIOUS_DUMP(exp_prev_state);
   CHECK(exp_prev_state.mtval == obs_prev_state.mtval,
         "Last Exception Access Addr: Expected 0x%x != Observed 0x%x",
         exp_prev_state.mtval, obs_prev_state.mtval);


### PR DESCRIPTION
## Bug with ROM
The test `rstmgr_cpu_info_test` was failing with ROM.
See [comment](https://github.com/lowRISC/opentitan/issues/20030#issuecomment-1808126208)

## Root cause
The ROM enables the watchdog to generate a NMI at bark, as this test uses the watchdog bite to reset Ibex after the second fault, the NMI generated was messing with the fault dump.

## Solution
This commit makes the watchdog to bark even before the first fault, avoiding a NMI in between the faults.

Fix: https://github.com/lowRISC/opentitan/issues/20029
Fix: https://github.com/lowRISC/opentitan/issues/20030
