### PR TITLE
[sival, rom_ext] Finalize the ePMP configuration 

### DIFF
--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -14,7 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/epmp_defs.h"
 
-void print_integer(unsigned value, bool is_signed) {
+static void print_integer(unsigned value, bool is_signed) {
   char buf[12];
   char *b = buf + sizeof(buf);
   if (is_signed && (int)value < 0) {

--- a/sw/device/silicon_creator/lib/dbg_print.h
+++ b/sw/device/silicon_creator/lib/dbg_print.h
@@ -18,10 +18,10 @@ extern "C" {
  *
  * This function only supports the format specifiers required by the
  * ROM:
- * - %c, which prints a null-terminated string.
+ * - %c, which prints a single character.
  * - %d, which prints a signed int in decimal.
  * - %u, which prints an unsigned int in decimal.
- * - %s, which prints a null-terminated string.
+ * - %s, which prints a nul-terminated string.
  * - %p, which prints pointer in hexadecimal.
  * - %x, which prints an `unsigned int` in hexadecimal using lowercase
  *   characters.

--- a/sw/device/silicon_creator/rom_ext/doc/si_val.md
+++ b/sw/device/silicon_creator/rom_ext/doc/si_val.md
@@ -16,24 +16,23 @@ An example of how the SiVal ROM\_EXT will configure the ePMP:
 ```
  0: 20010400 ----- ---- sz=00000000     ; OWNER code start.
  1: 20013d24   TOR LX-R sz=00003924     ; OWNER code end.
- 2: 00008000 NAPOT L--R sz=00008000     ; ROM data (can be cleared).
+ 2: 00008000 NAPOT L--R sz=00008000     ; OWNER data (if using remap window, else ROM data region)
  3: 20000400 ----- ---- sz=00000000     ; ROM_EXT code start.
- 4: 20004fa0   TOR LX-R sz=00004ba0     ; ROM_EXT code end.
- 5: 20000000 NAPOT L--R sz=00100000     ; FLASH read access.
+ 4: 20004fe8   TOR LX-R sz=00004be8     ; ROM_EXT code end.
+ 5: 20000000 NAPOT L--R sz=00100000     ; FLASH data (1 MB).
+ 6: 40130000 NAPOT L--- sz=00001000     ; OTP MMIO lockout.
  6: 00000000 ----- ---- sz=00000000
  7: 00000000 ----- ---- sz=00000000
  8: 00000000 ----- ---- sz=00000000
  9: 00000000 ----- ---- sz=00000000
-10: 40130000 NAPOT L--- sz=00001000     ; OTP MMIO lockout.
+10: 00000000 ----- ---- sz=00000000
 11: 40000000 NAPOT L-WR sz=10000000     ; MMIO region.
 12: 00000000 ----- ---- sz=00000000
 13: 00010000 NAPOT LXWR sz=00001000     ; RvDM region (not PROD, RMA/DEV only).
 14: 1001c000   NA4 L--- sz=00000004     ; Stack guard.
 15: 10000000 NAPOT L-WR sz=00020000     ; RAM region.
-mseccfg = 00000006                      ; RLB=1, MMWP=1, MML=0.
+mseccfg = 00000002                      ; RLB=0, MMWP=1, MML=0.
 ```
-
-TODO: Clear RLB so ePMP rules can not be overidden by owner code.
 
 ### OTP
 

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -60,3 +60,22 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_test(
+    name = "epmp_rlb_lockdown",
+    srcs = ["epmp_rlb_lockdown.c"],
+    cw310 = cw310_params(
+        exit_failure = "(PASS|FAIL|BFV|FAULT).*\r\n",
+        # Make sure the test program failed to modify the ePMP.
+        exit_success = "6: 40130000 NAPOT L--- sz=00001000\r\n",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:dbg_print",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/epmp_rlb_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/epmp_rlb_lockdown.c
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // Try to overwrite ePMP entry 6 (ie: the otp lockout) by clearing its config
+  // bits.
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff << 16);
+  CSR_WRITE(CSR_REG_PMPADDR6, 0);
+
+  // The test rule in the BUILD file will look for the expected configuration
+  // for ePMP entry 10.
+  dbg_print_epmp();
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.c
@@ -83,7 +83,7 @@ void rom_ext_epmp_mmio_adjust(void) {
 }
 
 void rom_ext_epmp_otp_dai_lockout(void) {
-  const int kEntry = 10;
+  const int kEntry = 6;
   epmp_region_t region = {
       .start = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR,
       .end = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + 0x1000,
@@ -92,19 +92,64 @@ void rom_ext_epmp_otp_dai_lockout(void) {
 
   // Update the hardware configuration (CSRs).
   //
-  // Entry is hardcoded as 10. Make sure to modify hardcoded values if changing
+  // Entry is hardcoded as 6. Make sure to modify hardcoded values if changing
   // kEntry.
   //
-  // The `pmp11cfg` configuration is the third field in `pmpcfg2`.
+  // The `pmp6cfg` configuration is the third field in `pmpcfg1`.
   //
   //            32          24          16           8           0
   //             +-----------+-----------+-----------+-----------+
-  // `pmpcfg2` = | `pmp11cfg`| `pmp10cfg`| `pmp9cfg` | `pmp8cfg` |
+  // `pmpcfg1` = |  `pmp7cfg |  `pmp6cfg`| `pmp5cfg` | `pmp4cfg` |
   //             +-----------+-----------+-----------+-----------+
-  CSR_WRITE(CSR_REG_PMPADDR10,
+  CSR_WRITE(CSR_REG_PMPADDR6,
             (uint32_t)region.start >> 2 |
                 ((uint32_t)region.end - (uint32_t)region.start - 1) >> 3);
-  CSR_CLEAR_BITS(CSR_REG_PMPCFG2, 0xff << 16);
-  CSR_SET_BITS(CSR_REG_PMPCFG2,
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff << 16);
+  CSR_SET_BITS(CSR_REG_PMPCFG1,
                ((kEpmpModeNapot | kEpmpPermLockedNoAccess) << 16));
+}
+
+void rom_ext_epmp_clear_rom_region(void) {
+  const int kEntry = 2;
+  const uint32_t kMask = (0xFF << 16);
+  epmp_state.pmpaddr[kEntry] = 0;
+  epmp_state.pmpcfg[0] &= ~kMask;
+
+  // Update the hardware configuration (CSRs).
+  //
+  // Entry is hardcoded as 2. Make sure to modify hardcoded values if changing
+  // kEntry.
+  //
+  // The `pmp2cfg` configuration is the third field in `pmpcfg0`.
+  //
+  //            32          24          16           8           0
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg0` = |  `pmp3cfg |  `pmp2cfg`| `pmp1cfg` | `pmp0cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  CSR_WRITE(CSR_REG_PMPADDR2, 0);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, kMask);
+}
+
+void rom_ext_epmp_final_cleanup(void) {
+  // We want to clear the L bit from pmp3cfg and pmp4cfg to unlock the
+  // ROM_EXT region for the next stage.
+  //
+  //            32          24          16           8           0
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg0` = |  `pmp3cfg |  `pmp2cfg`| `pmp1cfg` | `pmp0cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg1` = |  `pmp7cfg |  `pmp6cfg`| `pmp5cfg` | `pmp4cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  const uint32_t kMask0 = (uint32_t)(EPMP_CFG_L << 24);
+  const uint32_t kMask1 = (uint32_t)(EPMP_CFG_L << 0);
+  epmp_state.pmpcfg[0] &= ~kMask0;
+  epmp_state.pmpcfg[1] &= ~kMask1;
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, kMask0);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG1, kMask1);
+}
+
+void rom_ext_epmp_clear_rlb(void) {
+  const uint32_t kMask = EPMP_MSECCFG_RLB;
+  epmp_state.mseccfg &= ~kMask;
+  CSR_CLEAR_BITS(CSR_REG_MSECCFG, kMask);
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
@@ -79,6 +79,27 @@ void rom_ext_epmp_mmio_adjust(void);
  */
 void rom_ext_epmp_otp_dai_lockout(void);
 
+/**
+ * Clear the ROM mapping from the ePMP.
+ *
+ * The ROM memory mapping is no longer needed once the ROM_EXT starts.
+ */
+void rom_ext_epmp_clear_rom_region(void);
+
+/**
+ * Perform final cleanups to the ePMP configuration before owner handoff.
+ *
+ * Unlock the ROM_EXT code segments so they can be ovewritten by the next stage.
+ */
+void rom_ext_epmp_final_cleanup(void);
+
+/**
+ * Clear the rule-locking-bypass (RLB) bit.
+ *
+ * Clearing RLB causes the Lock bit in the ePMP to be enforced.
+ */
+void rom_ext_epmp_clear_rlb(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
1. Finalize the ePMP configuration for the SiVal ROM_EXT.
   - Put the OTP DAI lockout in PMP entry 6.
   - Lock all prior ePMP entries to prevent overrding the DAI lockout.
   - Clear RLB to prevent further modification of locked ePMP entries.
2. Add a test to make sure RLB is applied.

NOTE: this PR depends on #20362.  You need only review the last commit.