### PR TITLE
[pwrmgr/dv] Minor fixes to increase pass rate to V2 levels

### DIFF
--- a/hw/ip/pwrmgr/dv/cov/pwrmgr_rom_ctrl_mubi_cov_if.sv
+++ b/hw/ip/pwrmgr/dv/cov/pwrmgr_rom_ctrl_mubi_cov_if.sv
@@ -6,7 +6,7 @@
 // Adaptor to bind vector of rom_ctrl mubi fields
 
 interface pwrmgr_rom_ctrl_mubi_cov_if #(
-  parameter int Width
+  parameter int Width = 8
 ) (
   input rom_ctrl_pkg::pwrmgr_data_t [Width-1:0] rom_ctrl_i,
   input logic rst_ni

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -93,12 +93,12 @@ interface pwrmgr_if (
   always_comb wakeup_en = `PATH_TO_DUT.reg2hw.wakeup_en;
 
   // Wakeup_status ro CSR.
-  // the multireg is an array of interleaved d / de fields. taking every second bit starting from 0
+  // the multireg is an array of interleaved d / de fields. taking every second bit starting from 1
   // will extract all d fields.
   always_comb begin
     logic [2*pwrmgr_reg_pkg::NumWkups-1:0] wakeup_status_raw;
     wakeup_status_raw = `PATH_TO_DUT.hw2reg.wake_status;
-    for (int k = 0; k < pwrmgr_reg_pkg::NumWkups; k++) wakeup_status[k] = wakeup_status_raw[k*2];
+    for (int k = 0; k < pwrmgr_reg_pkg::NumWkups; k++) wakeup_status[k] = wakeup_status_raw[k*2+1];
   end
 
   always_comb wakeup_capture_en = !`PATH_TO_DUT.u_reg.wake_info_capture_dis_qs;
@@ -170,7 +170,7 @@ interface pwrmgr_if (
     if (!internal_assertion_disabled) begin
       internal_assertion_disabled = 1'b1;
       `uvm_info("pwrmgr_if", "disabling power glitch related SVA", UVM_MEDIUM)
-      $assertoff(1, dut.u_slow_fsm.IntRstReq_A);
+      $assertoff(1, tb.dut.u_slow_fsm.IntRstReq_A);
     end
     repeat (2) @(posedge clk_slow);
     rst_main_n = 1'b1;

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -70,17 +70,17 @@
     {
       name: pwrmgr_lowpower_wakeup_race
       uvm_test_seq: pwrmgr_lowpower_wakeup_race_vseq
-      run_opts: ["+test_timeout_ns=1000000"]
+      run_opts: ["+test_timeout_ns=3000000"]
     }
     {
       name: pwrmgr_wakeup
       uvm_test_seq: pwrmgr_wakeup_vseq
-      run_opts: ["+test_timeout_ns=1000000"]
+      run_opts: ["+test_timeout_ns=3000000"]
     }
     {
       name: pwrmgr_wakeup_reset
       uvm_test_seq: pwrmgr_wakeup_reset_vseq
-      run_opts: ["+test_timeout_ns=1000000"]
+      run_opts: ["+test_timeout_ns=3000000"]
     }
     {
       name: pwrmgr_aborted_low_power
@@ -89,7 +89,7 @@
     {
       name: pwrmgr_sec_cm_lc_ctrl_intersig_mubi
       uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
-      run_opts: ["+test_timeout_ns=3000000", "+pwrmgr_mubi_mode=PwrmgrMubiLcCtrl"]
+      run_opts: ["+test_timeout_ns=4000000", "+pwrmgr_mubi_mode=PwrmgrMubiLcCtrl"]
     }
     {
       name: pwrmgr_sec_cm_rom_ctrl_intersig_mubi

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -107,7 +107,7 @@ module pwrmgr_sec_cm_checker_assert
 // sec_cm_main_pd_rst_local_esc
 // if power is up and rst_main_ni goes low, pwr_rst_o.rstreqs[ResetMainPwrIdx] should be asserted
   `ASSERT(RstreqChkMainpd_A,
-          slow_mp_rst_req && slow_fsm_idle |-> ##[0:5] pwr_rst_o.rstreqs[ResetMainPwrIdx], clk_i,
+          slow_mp_rst_req |-> ##[0:5] pwr_rst_o.rstreqs[ResetMainPwrIdx], clk_i,
           reset_or_disable)
 
 endmodule // pwrmgr_sec_cm_checker_assert


### PR DESCRIPTION
This fixes a few minor issues in the testbench and increases a couple of timeouts so that the pass rate is close to 100%.

The SVA precondition for RstreqChkMainpd_A has been corrected on master, so this patch just aligns the assertion with master.

This closes https://github.com/lowRISC/opentitan-integrated/issues/605.