### PR TITLE
[manuf] add device ID parameter to HwCfg individualize function

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -91,6 +91,17 @@ UJSON_SERDE_STRUCT(ManufCpProvisioningData, \
                    STRUCT_MANUF_CP_PROVISIONING_DATA);
 // clang-format on
 
+/**
+ * Provisioning data imported onto the device in FT during individualization.
+ */
+// clang-format off
+#define STRUCT_MANUF_FT_INDIVIDUALIZE_DATA(field, string) \
+    field(device_id, uint32_t, 8)
+UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
+                   manuf_ft_individualize_data_t, \
+                   STRUCT_MANUF_FT_INDIVIDUALIZE_DATA);
+// clang-format on
+
 #undef MODULE_ID
 // clang-format on
 

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -111,6 +111,7 @@ cc_library(
         "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/lib/testing/test_framework:check",
     ],
 )
 
@@ -127,6 +128,7 @@ opentitan_test(
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
     deps = [
         ":individualize",
+        ":otp_fields",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:flash_ctrl",

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -21,7 +21,10 @@
  * - Various digital logic configuration settings.
  *
  * Preconditions:
- * - DeviceId & ManufState are pre-populated in the appropriate flash info page.
+ * - ManufState is pre-populated in the appropriate flash info page.
+ * - If DeviceId is already written to flash, the device ID provided must match.
+ *   If the DeviceId slot in flash is all 0s, then the provided DeviceId will be
+ *   what is written to OTP.
  *
  * Note: The test will skip all programming steps and succeed if the HW_CFG
  * parition is already locked. This is to facilitate test re-runs.
@@ -35,11 +38,14 @@
  * @param flash_info_page_0_permissions Access permissions to set on flash info
  *                                      page 0 (which temporarily holds
  *                                      device_id and manuf_state).
+ * @param device_id DeviceId to check exists in flash, or inject in into OTP if
+ *                  running in a test environment.
  * @return OK_STATUS on success.
  */
 status_t manuf_individualize_device_hw_cfg(
     dif_flash_ctrl_state_t *flash_state, const dif_otp_ctrl_t *otp_ctrl,
-    dif_flash_ctrl_region_properties_t flash_info_page_0_permissions);
+    dif_flash_ctrl_region_properties_t flash_info_page_0_permissions,
+    uint32_t *device_id);
 
 /**
  * Checks the HW_CFG OTP partition end state.

--- a/sw/device/silicon_creator/manuf/lib/individualize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_functest.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -65,8 +66,11 @@ bool test_main(void) {
         .prog_en = kMultiBitBool4True,
         .rd_en = kMultiBitBool4True,
         .scramble_en = kMultiBitBool4False};
+    uint32_t device_id[kHwCfgDeviceIdSizeIn32BitWords] = {
+        0xAAAAAAAA, 0xBBBBBBBB, 0xAAAAAAAA, 0xBBBBBBBB,
+        0xAAAAAAAA, 0xBBBBBBBB, 0xAAAAAAAA, 0xBBBBBBBB};
     CHECK_STATUS_OK(manuf_individualize_device_hw_cfg(
-        &flash_state, &otp_ctrl, kFlashInfoPage0Permissions));
+        &flash_state, &otp_ctrl, kFlashInfoPage0Permissions, device_id));
     sw_reset();
   }
 

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -163,6 +163,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:ottf_console",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/device/silicon_creator/manuf/lib:individualize",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_generic",
@@ -233,7 +234,7 @@ opentitan_test(
         test_cmd = """
             --elf={sram_ft_individualize}
             --bootstrap={firmware}
-            --secondary-bootstrap={ft_personalize_2}
+            --second-bootstrap={ft_personalize_2}
             --target-mission-mode-lc-state="prod"
             --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
         """,

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_1.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_1.c
@@ -21,7 +21,7 @@ static dif_lc_ctrl_t lc_ctrl;
 static dif_otp_ctrl_t otp_ctrl;
 
 /**
- * Initializes all DIF handles used in this SRAM program.
+ * Initializes all DIF handles used in this program.
  */
 static status_t peripheral_handles_init(void) {
   TRY(dif_lc_ctrl_init(mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR),

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_2.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_2.c
@@ -29,7 +29,7 @@ static manuf_perso_data_in_t in_data;
 static manuf_perso_data_out_t out_data;
 
 /**
- * Initializes all DIF handles used in this SRAM program.
+ * Initializes all DIF handles used in this program.
  */
 static status_t peripheral_handles_init(void) {
   TRY(dif_flash_ctrl_init_state(

--- a/sw/host/provisioning/cp_lib/src/lib.rs
+++ b/sw/host/provisioning/cp_lib/src/lib.rs
@@ -28,7 +28,7 @@ pub struct ManufCpProvisioningDataInput {
     /// Device ID to provision.
     #[arg(
         long,
-        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+        default_value = "0xCAFEBABE_11112222_33334444_55556666_77778888_9999AAAA_BBBBCCCC_DEADBEEF"
     )]
     pub device_id: String,
 
@@ -47,11 +47,11 @@ pub struct ManufCpProvisioningDataInput {
     pub wafer_auth_secret: String,
 
     /// TestUnlock token to provision.
-    #[arg(long, default_value = "0x00000000_00000000_00000000_00000000")]
+    #[arg(long, default_value = "0x11111111_11111111_11111111_11111111")]
     pub test_unlock_token: String,
 
     /// TestExit token to provision.
-    #[arg(long, default_value = "0x00000000_00000000_00000000_00000000")]
+    #[arg(long, default_value = "0x11111111_11111111_11111111_11111111")]
     pub test_exit_token: String,
 }
 

--- a/sw/host/tests/manuf/provisioning/ft/BUILD
+++ b/sw/host/tests/manuf/provisioning/ft/BUILD
@@ -12,6 +12,7 @@ rust_binary(
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ft_lib",
+        "//sw/host/provisioning/ujson_lib",
         "//sw/host/provisioning/util_lib",
         "@crate_index//:anyhow",
         "@crate_index//:clap",


### PR DESCRIPTION
During individualization, the device ID is copied from flash info page 0 to the HwCfg OTP partition. However, the device ID in flash is not checked, and blindly copying it makes it difficult to test both CP and FT stages individually, since to test FT provisioning would require setting up flash info pages before test execution. Moreover, if the device ID is not checked for all 0s, it will cause the keymgr to lock up later during the provisioning flow.

This adds a device ID parameter to the HwCfg individualization function to override the device ID stored in flash (if it is all 0s, i.e., it is missing), or to check against what is already in flash to ensure the provisioning payload is the one expected.