### PR TITLE
[spi_passthru] Support READ_4B and FAST_READ_4B

### DIFF
--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -118,6 +118,24 @@ status_t spi_device_testutils_configure_passthrough(
           .payload_io_type = kDifSpiDevicePayloadIoQuad,
           .payload_dir_to_host = true,
       },
+      {
+          // Slot 9: Read4b
+          .opcode = kSpiDeviceFlashOpRead4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 10: ReadFast4b
+          .opcode = kSpiDeviceFlashOpReadFast4b,
+          .address_type = kDifSpiDeviceFlashAddr4Byte,
+          .passthrough_swap_address = true,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
   };
   static_assert(ARRAYSIZE(read_commands) <= UINT8_MAX,
                 "Length of read_commands must fit in uint8_t or we must change "

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -19,7 +19,9 @@ typedef enum spi_device_flash_opcode {
   kSpiDeviceFlashOpReadJedec = 0x9f,
   kSpiDeviceFlashOpReadSfdp = 0x5a,
   kSpiDeviceFlashOpReadNormal = 0x03,
+  kSpiDeviceFlashOpRead4b = 0x13,
   kSpiDeviceFlashOpReadFast = 0x0b,
+  kSpiDeviceFlashOpReadFast4b = 0x0c,
   kSpiDeviceFlashOpReadDual = 0x3b,
   kSpiDeviceFlashOpReadQuad = 0x6b,
   kSpiDeviceFlashOpWriteEnable = 0x06,
@@ -59,7 +61,9 @@ enum spi_device_command_slot {
  *  - ReadJedec
  *  - ReadSfdp
  *  - ReadNormal
+ *  - Read4b
  *  - ReadFast
+ *  - ReadFast4b
  *  - ReadDual
  *  - ReadQuad
  *  - WriteEnable

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2993,6 +2993,7 @@ opentitan_test(
         # interface = "hyper310",
         # tags = ["manual"],
         test_cmd = """
+            --bitstream={bitstream}
             --bootstrap="{firmware}"
         """,
         test_harness = "//sw/host/tests/chip/spi_passthru",

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -136,6 +136,8 @@ pub struct SpiRead {
         default_value = "standard"
     )]
     pub mode: ReadMode,
+    #[arg(short = '4', long, default_value = "false")]
+    pub use_4b_opcodes: bool,
     /// Hexdump the data.
     #[arg(long)]
     hexdump: bool,
@@ -175,7 +177,13 @@ impl CommandDispatch for SpiRead {
 
         let mut buffer = vec![0u8; self.length];
         let progress = StagedProgressBar::new();
-        flash.read_with_progress(&*spi, self.start, &mut buffer, &progress)?;
+        flash.read_with_progress(
+            &*spi,
+            self.start,
+            &mut buffer,
+            &progress,
+            self.use_4b_opcodes,
+        )?;
 
         if self.filename.to_str() == Some("-") {
             self.write_file(io::stdout(), &buffer)?;


### PR DESCRIPTION
The default SPI eeprom on the CW310 board is an ISSI25WP016 and it does not support any 4-byte commands.  We do, however, want to support the explict 4-byte opcodes in the passthru implementation and they can be tested in an ad-hoc fashion by connecting a different eeprom to the CW310 board via `USR_SPI0` header `P1`.

1. Fix an error in the spi_passthru_test definition: explicitly load a bitstream so that we make sure we're testing with the expected configuration.
2. Add READ_4B and FAST_READ_4B to the spi device configuration.
3. Support explicit 4-byte opcodes in opentitanlib/tool.  I don't believe the SFDP does a good job of encoding wither or not these opcodes are supported, so they need to be enabled via a command line flag.