### PR TITLE
[bazel] Convert gpio_pinmux_test and i2c_target_test

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -86,6 +86,30 @@ fpga_cw310(
     """,
 )
 
+# Hyperdebug + CW310 is a sub-type of CW310.
+# All of the parameters are the same except the `interface` and
+# bitstream-related parameters.
+fpga_cw310(
+    name = "fpga_hyper310_test_rom",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+        # Unlike CW310, we don't need the UART overrides.
+    ],
+    base = ":fpga_cw310_test_rom",
+    base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
+    exec_env = "fpga_hyper310_test_rom",
+    otp_mmi = "//hw/bitstream/hyperdebug:otp_mmi",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rom_mmi = "//hw/bitstream/hyperdebug:rom_mmi",
+)
+
 fpga_cw310(
     name = "fpga_cw310_rom_with_fake_keys",
     testonly = True,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1314,24 +1314,23 @@ opentitan_test(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "gpio_pinmux_test",
     srcs = ["gpio_pinmux_test.c"],
-    cw310 = cw310_params(
-        interface = "hyper310",
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    hyper310 = new_cw310_params(
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
     ),
-    targets = [
-        "verilator",
-        "cw310_test_rom",
-    ],
     test_harness = "//sw/host/tests/chip/gpio",
-    verilator = verilator_params(
+    verilator = new_verilator_params(
         timeout = "eternal",
-        test_cmds = [],
+        test_cmd = " ",
     ),
     deps = [
         "//sw/device/lib/dif:gpio",
@@ -3055,25 +3054,18 @@ opentitan_functest(
     ],
 )
 
-# TODO(#19902): Migrate to `opentitan_test` once there is support for the
-# hyperdebug310 target.
-opentitan_functest(
+opentitan_test(
     name = "i2c_target_test",
-    srcs = [
-        "i2c_target_test.c",
-    ],
-    cw310 = cw310_params(
-        # This test needs hyperdebug to serve as I2C host to OpenTitan's
-        # I2C target device.
-        interface = "hyper310",
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
+    srcs = ["i2c_target_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+    },
+    hyper310 = new_cw310_params(
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
     ),
-    targets = [
-        "cw310_test_rom",
-    ],
     test_harness = "//sw/host/tests/chip/i2c_target",
     deps = [
         "//sw/device/lib/arch:device",


### PR DESCRIPTION
1. Add an exec_env for `fpga_hyper310_test_rom`.
2. Convert `gpio_pinmux_test` and `i2c_target_test` to the new rules.