### PR TITLE
[bazel] Convert sigverify_key_validity to the new rules. 

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -9,7 +9,6 @@ load(
     "RSA_ONLY_KEY_STRUCTS",
 )
 load("//rules:otp.bzl", "otp_image")
-load("//rules:splice.bzl", "bitstream_splice")
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
@@ -160,27 +159,13 @@ opentitan_test(
     for i in range(0, 8)
 ]
 
-# Bitstream with ROM and above OTP image that is in the test_unlocked* LC state
-# with ROM execution disabled.
-[
-    bitstream_splice(
-        name = "bitstream_rom_exec_disabled_test_unlocked{}".format(i),
-        src = "//hw/bitstream:rom_with_fake_keys",
-        data = ":otp_img_rom_exec_disabled_test_unlocked{}".format(i),
-        meminfo = "//hw/bitstream:otp_mmi",
-        update_usr_access = True,
-        visibility = ["//visibility:public"],
-    )
-    for i in range(0, 8)
-]
-
 [
     opentitan_test(
         name = "manuf_cp_yield_test_functest_{}".format(lc_state.lower()),
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
         cw310 = cw310_jtag_params(
-            bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
             lc_state = lc_state,  # will be expanded in test_cmd
+            otp = ":otp_img_rom_exec_disabled_{}".format(lc_state.lower()),
             tags = ["manuf"],
             test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
@@ -218,7 +203,7 @@ cc_library(
 )
 
 # We are using a bitstream with ROM execution disabled so the contents of flash
-# does not matter but opentitan_functest() is unhappy if we don't provide one.
+# does not matter but opentitan_test() is unhappy if we don't provide one.
 # Additionally, ROM execution is disabled in the OTP image we use so we do not
 # attempt to bootstrap.
 [
@@ -226,7 +211,7 @@ cc_library(
         name = "manuf_sram_program_crc_{}_functest".format(lc_state.lower()),
         srcs = ["sram_empty_functest.c"],
         cw310 = cw310_jtag_params(
-            bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            otp = ":otp_img_rom_exec_disabled_{}".format(lc_state.lower()),
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
         ),
@@ -310,7 +295,7 @@ opentitan_binary(
             binaries = {
                 ":sram_device_info_flash_wr_functest": "sram_program",
             },
-            bitstream = "bitstream_rom_exec_disabled_{}".format(init_lc_state.lower()),
+            otp = ":otp_img_rom_exec_disabled_{}".format(init_lc_state.lower()),
             tags = ["manuf"],
             target_lc_state = target_lc_state,  # will be expanded in test_cmd
             test_cmd = """
@@ -381,7 +366,7 @@ opentitan_binary(
 )
 
 # We are using a bitstream with disabled execution so the content of the flash
-# does not matter but opentitan_functest() is unhappy if we don't provide one.
+# does not matter but opentitan_test() is unhappy if we don't provide one.
 # Additionally, ROM execution is disabled in the OTP image we use so we do not
 # attempt to bootstrap.
 [
@@ -392,7 +377,7 @@ opentitan_binary(
             binaries = {
                 ":sram_exec_test": "sram_program",
             },
-            bitstream = ":bitstream_rom_exec_disabled_{}".format(lc_state.lower()),
+            otp = ":otp_img_rom_exec_disabled_{}".format(lc_state.lower()),
             tags = ["manuf"],
             test_cmd = """
                 --elf={sram_program}
@@ -425,7 +410,7 @@ opentitan_test(
     name = "manuf_cp_test_lock_functest",
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     cw310 = cw310_jtag_params(
-        bitstream = ":bitstream_otp_ctrl_functest",
+        otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_test_lock",
     ),
@@ -447,20 +432,11 @@ otp_image(
     visibility = ["//visibility:private"],
 )
 
-bitstream_splice(
-    name = "bitstream_otp_ctrl_functest",
-    src = "//hw/bitstream:rom_with_fake_keys",
-    data = ":otp_img_otp_ctrl_functest",
-    meminfo = "//hw/bitstream:otp_mmi",
-    update_usr_access = True,
-    visibility = ["//visibility:private"],
-)
-
 opentitan_test(
     name = "otp_ctrl_functest",
     srcs = [":empty_functest.c"],
     cw310 = cw310_jtag_params(
-        bitstream = ":bitstream_otp_ctrl_functest",
+        otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/otp_ctrl:otp_ctrl",
     ),

--- a/sw/device/silicon_creator/rom/e2e/empty_test.c
+++ b/sw/device/silicon_creator/rom/e2e/empty_test.c
@@ -4,11 +4,11 @@
 
 #include <stdbool.h>
 
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
 #ifdef EMPTY_TEST_MSG
+#include "sw/device/lib/runtime/log.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/sigverify/spx_verify.h"

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
     "cw310_params",
-    "opentitan_functest",
+    "opentitan_test",
 )
 load(
     "//rules:const.bzl",
@@ -75,30 +75,13 @@ otp_json(
 ]
 
 [
-    bitstream_splice(
-        name = "bitstream_sigverify_key_validity_{}".format(
-            lc_state,
-        ),
-        src = "//hw/bitstream:rom_with_fake_keys",
-        data = ":otp_img_sigverify_key_validity_{}".format(
-            lc_state,
-        ),
-        meminfo = "//hw/bitstream:otp_mmi",
-        tags = maybe_skip_in_ci(lc_state_val),
-        update_usr_access = True,
-        visibility = ["//visibility:private"],
-    )
-    for lc_state, lc_state_val in get_lc_items()
-]
-
-[
-    opentitan_functest(
+    opentitan_test(
         name = "sigverify_key_validity_{}_{}".format(
             lc_state,
             key.rsa.name,
         ),
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
         cw310 = cw310_params(
-            bitstream = ":bitstream_sigverify_key_validity_{}".format(lc_state),
             exit_failure = MSG_PASS if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else MSG_TEMPLATE_BFV_LCV.format(
                 hex_digits(CONST.BFV.SIGVERIFY.BAD_RSA_KEY),
                 hex_digits(lc_state_val),
@@ -107,12 +90,15 @@ otp_json(
                 hex_digits(CONST.BFV.SIGVERIFY.BAD_RSA_KEY),
                 hex_digits(lc_state_val),
             ) if lc_state_val != CONST.LCV.TEST_UNLOCKED0 else MSG_PASS,
+            otp = ":otp_img_sigverify_key_validity_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        key_struct = key,
-        ot_flash_binary = "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a",
-        targets = [
-            "cw310_rom_with_fake_keys",
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        rsa_key = {key.rsa.label: key.rsa.name},
+        deps = [
+            "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
     for lc_state, lc_state_val in get_lc_items()

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4250,8 +4250,7 @@ opentitan_test(
         binaries = {
             ":rv_core_ibex_isa_test": "sram_program",
         },
-        bitstream =
-            "//sw/device/silicon_creator/manuf/tests:bitstream_rom_exec_disabled_test_unlocked0",
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
@@ -4300,17 +4299,17 @@ opentitan_test(
         binaries = {
             ":rv_core_ibex_epmp_test": "sram_program",
         },
-        bitstream =
-            "//sw/device/silicon_creator/manuf/tests:bitstream_rom_exec_disabled_test_unlocked0",
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
     exec_env = {
+        # This test is not compatible with the test_rom because the test_rom
+        # does not respect the exec_disabled OTP config word.
         "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
         "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     hyper310 = hyper310_jtag_params(
         binaries = {
@@ -4421,8 +4420,7 @@ opentitan_test(
         binaries = {
             ":rv_core_ibex_mem_test": "sram_program",
         },
-        bitstream =
-            "//sw/device/silicon_creator/manuf/tests:bitstream_rom_exec_disabled_test_unlocked0",
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         tags = [
             "broken",
             "manual",


### PR DESCRIPTION
Also cleans up some comment references to `opentitan_functest()`.

Fixes: #20098