### PR TITLE
[manuf] add final personalization binary to crank the keymgr and gen attestation keys

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -498,6 +498,13 @@ cc_library(
 )
 
 cc_library(
+    name = "attestation_key_diversifiers",
+    srcs = ["attestation_key_diversifiers.c"],
+    hdrs = ["attestation_key_diversifiers.h"],
+    deps = ["//sw/device/silicon_creator/lib/drivers:keymgr"],
+)
+
+cc_library(
     name = "otbn_boot_services",
     srcs = ["otbn_boot_services.c"],
     hdrs = ["otbn_boot_services.h"],

--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -5,8 +5,6 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ATTESTATION_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ATTESTATION_H_
 
-#include "sw/device/silicon_creator/lib/error.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/attestation_key_diversifiers.c
+++ b/sw/device/silicon_creator/lib/attestation_key_diversifiers.c
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/attestation_key_diversifiers.h"
+
+// UDS (Creator) attestation key diverisfier constants.
+// Note: versions are always set to 0 so these keys are always valid from the
+// perspective of the keymgr hardware.
+const keymgr_diversification_t kUdsKeymgrDiversifier = {
+    .salt =
+        {
+            0xabffa6a9,
+            0xc781f1ad,
+            0x4c1107ad,
+            0xf9210d85,
+            0x0931f555,
+            0x6c5aef5d,
+            0xb9ba4df0,
+            0x77b248d2,
+        },
+    .version = 0,
+};
+
+// CDI_0 (OwnerIntermediate) attestation key diverisfier constants.
+const keymgr_diversification_t kCdi0KeymgrDiversifier = {
+    .salt =
+        {
+            0x3e5913c7,
+            0x41156f1d,
+            0x998ddb9f,
+            0xfa334191,
+            0x8a85380e,
+            0xba76ca1a,
+            0xdb17c4a7,
+            0xfb8852dc,
+        },
+    .version = 0,
+};
+
+// CDI_1 (Owner) attestation key diverisfier constants.
+const keymgr_diversification_t kCdi1KeymgrDiversifier = {
+    .salt =
+        {
+            0x2d12c2e3,
+            0x6acc6876,
+            0x4bfb07ee,
+            0xc45fc414,
+            0x5d4fa9de,
+            0xf295b128,
+            0x50f49882,
+            0xbbdefa29,
+        },
+    .version = 0,
+};

--- a/sw/device/silicon_creator/lib/attestation_key_diversifiers.h
+++ b/sw/device/silicon_creator/lib/attestation_key_diversifiers.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ATTESTATION_KEY_DIVERSIFIERS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ATTESTATION_KEY_DIVERSIFIERS_H_
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Attestation key diversifier constants.
+extern const keymgr_diversification_t kUdsKeymgrDiversifier;
+extern const keymgr_diversification_t kCdi0KeymgrDiversifier;
+extern const keymgr_diversification_t kCdi1KeymgrDiversifier;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ATTESTATION_KEY_DIVERSIFIERS_H_

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -33,15 +33,15 @@ rom_error_t otbn_boot_app_load(void);
  * Generate an attestation public key from a keymgr-derived secret.
  *
  * This routine triggers the key manager to sideload key material into OTBN,
- * and also takes in an extra seed to XOR with the key material. The final
+ * and also loads in an extra seed to XOR with the key material. The final
  * private key is:
  *   d = (additional_seed ^ keymgr_seed) mod n
  * ...where n is the P256 curve order. The public key is d*G, where G is the
  * P256 base point.
  *
- * The `additional_seed` is expected to be the output from a specially seeded
- * DRBG, and is provisioned into flash at manufacturing time. It must be fully
- * independent from the key manager seed.
+ * The extra seed is expected to be the output from a specially seeded DRBG, and
+ * is provisioned into flash at manufacturing time. It must be fully independent
+ * from the key manager seed.
  *
  * Expects the OTBN boot-services program to already be loaded; see
  * `otbn_boot_app_load`.

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -51,21 +51,4 @@ status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
                                      flash_info_field_t field, uint32_t *buf,
                                      size_t len);
 
-/**
- * Reads info flash page field.
- *
- * Assumes the page containing the field has already been configured for read
- * access.
- *
- * @param flash_state Flash controller instance.
- * @param field Flash info field information.
- * @param[out] data_out Output buffer.
- * @param num_words Number of words to read from flash and write to `data_out`.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
-                                     flash_info_field_t field, uint32_t *buf,
-                                     size_t len);
-
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_FLASH_INFO_FIELDS_H_

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -162,10 +162,8 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/device/silicon_creator/manuf/lib:individualize",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_generic",
-        "//sw/device/silicon_creator/manuf/lib:otp_fields",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )
@@ -200,6 +198,36 @@ opentitan_binary(
     ],
 )
 
+opentitan_binary(
+    name = "ft_personalize_3",
+    testonly = True,
+    srcs = ["ft_personalize_3.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rsa_key = rsa_key_for_lc_state(
+        RSA_ONLY_KEY_STRUCTS,
+        CONST.LCV.PROD,
+    ),
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:otbn_boot_services",
+        "//sw/device/silicon_creator/lib/drivers:keymgr",
+        "//sw/otbn/crypto:boot",
+    ],
+)
+
 opentitan_test(
     name = "ft_provision",
     srcs = ["ft_personalize_1.c"],
@@ -207,6 +235,7 @@ opentitan_test(
         binaries = {
             ":sram_ft_individualize": "sram_ft_individualize",
             ":ft_personalize_2": "ft_personalize_2",
+            ":ft_personalize_3": "ft_personalize_3",
         },
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_test_locked0",
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
@@ -215,6 +244,7 @@ opentitan_test(
             --elf={sram_ft_individualize}
             --bootstrap={firmware}
             --second-bootstrap={ft_personalize_2}
+            --third-bootstrap={ft_personalize_3}
             --target-mission-mode-lc-state="prod"
             --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
         """,

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_3.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_3.c
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/silicon_creator/lib/attestation.h"
+#include "sw/device/silicon_creator/lib/attestation_key_diversifiers.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+/**
+ * Crank the keymgr to produce the attestation keys and certificates.
+ */
+static status_t personalize(ujson_t *uj) {
+  // Advance keymgr to Initialized state.
+  TRY(entropy_complex_init());
+  keymgr_advance_state();
+  TRY(keymgr_state_check(kKeymgrStateInit));
+
+  // Load OTBN attestation keygen program.
+  attestation_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
+  TRY(otbn_boot_app_load());
+
+  // Advance keymgr and generate UDS attestation keys / cert.
+  // TODO(#19455): set attestation binding to OTP *Cfg partition measurements.
+  keymgr_advance_state();
+  TRY(keymgr_state_check(kKeymgrStateCreatorRootKey));
+  TRY(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
+                                   kUdsKeymgrDiversifier, &curr_pubkey));
+  // TODO(#19455): create certificate and self-sign it. While it will be
+  // endorsed off-device, i.e., the signature will be replaced, the self-sign
+  // will be used to gaurantee the integrity of the cert to the host.
+  //
+  // Note: the offline endorsement will take place in a secure environment,
+  // hence we are not taking any measure to authenticate the device to the host.
+  TRY(otbn_boot_attestation_key_save(kUdsAttestationKeySeed,
+                                     kCdi0KeymgrDiversifier));
+
+  // TODO(#19455): only advance keymgr further if firmware measurements have
+  // been provided as an input. Advance keymgr and generate CDI_0 attestation
+  // keys / cert.
+  // TODO(#19455): set attestation binding to ROM_EXT / Ownership Manifest
+  // measurements.
+  keymgr_advance_state();
+  TRY(keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
+  TRY(otbn_boot_attestation_keygen(kCdi0AttestationKeySeed,
+                                   kCdi0KeymgrDiversifier, &curr_pubkey));
+  // TODO(#19455): create certificate with key, endorse it, and write it to
+  // flash info.
+  TRY(otbn_boot_attestation_key_save(kCdi0AttestationKeySeed,
+                                     kCdi0KeymgrDiversifier));
+
+  // Advance keymgr and generate CDI_1 attestation keys / cert.
+  // TODO(#19455): set attestation binding to OWNER measurement.
+  keymgr_advance_state();
+  TRY(keymgr_state_check(kKeymgrStateOwnerKey));
+  TRY(otbn_boot_attestation_keygen(kCdi1AttestationKeySeed,
+                                   kCdi1KeymgrDiversifier, &curr_pubkey));
+  // TODO(#19455): create certificate with key, endorse it, and write it to
+  // flash info.
+  TRY(otbn_boot_attestation_key_save(kCdi1AttestationKeySeed,
+                                     kCdi1KeymgrDiversifier));
+
+  LOG_INFO("Exporting attestation certificates ...");
+  // TODO(#19455): export certificates.
+  LOG_INFO("Wait for UDS attestation certificate endorsement ...");
+  // TODO(#19455): update UDS certificate signature field and commit to flash.
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  ujson_t uj = ujson_ottf_console();
+
+  CHECK_STATUS_OK(personalize(&uj));
+
+  return true;
+}

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_ft_individualize.c
@@ -18,10 +18,8 @@
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
-#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
-#include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
 #include "sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/flash_info_permissions.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -445,7 +445,6 @@ cc_test(
 [pkg_files(
     name = "package_{}".format(authenticity),
     testonly = testonly,
-    #srcs = [":pre_package_{}".format(authenticity)],
     srcs = [":pre_package_{}".format(authenticity)],
     prefix = "earlgrey/rom",
 ) for authenticity, testonly in (

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run_ft_personalize(
     transport: &TransportWrapper,
     init: &InitializeTest,
     second_bootstrap: PathBuf,
+    third_bootstrap: PathBuf,
     host_ecc_sk: PathBuf,
     timeout: Duration,
 ) -> Result<()> {
@@ -208,6 +209,11 @@ pub fn run_ft_personalize(
     let out_data = ManufPersoDataOut::recv(&*uart, timeout, false)?;
     // TODO(#19455): write the wrapped RMA unlock token to a file.
     log::info!("{:x?}", out_data);
+    let _ = UartConsole::wait_for(&*uart, r"PASS.*\n", timeout)?;
+
+    // Bootstrap third personalization binary into flash.
+    uart.clear_rx_buffer()?;
+    init.bootstrap.load(transport, &third_bootstrap)?;
     let _ = UartConsole::wait_for(&*uart, r"PASS.*\n", timeout)?;
 
     Ok(())

--- a/sw/host/tests/manuf/provisioning/ft/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/ft/src/main.rs
@@ -60,6 +60,10 @@ struct Opts {
     #[arg(long)]
     second_bootstrap: PathBuf,
 
+    /// Third personalization binary to bootstrap.
+    #[arg(long)]
+    third_bootstrap: PathBuf,
+
     /// Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
@@ -111,6 +115,7 @@ fn main() -> Result<()> {
         &transport,
         &opts.init,
         opts.second_bootstrap,
+        opts.third_bootstrap,
         opts.provisioning_data.host_ecc_sk,
         opts.timeout,
     )?;


### PR DESCRIPTION
This adds a third (and final) personalization binary to advance the keymgr and generate attestation keys / certificates. This code was placed in a separate binary as a short term fix to name collisions between functions in the silicon_creator OTBN driver (used by the `otbn_boot_services` lib that generates the attestation keys), and the cryptolib OTBN driver (used in the `personalization` lib that provisions OTB Secret2 partition and the keymgr flash info pages).

Additionally, this:
1. adds attestation keymgr diversifiers,
2. fix bugs in otbn_boot_services lib that were causing errors when generating the attestation keys.

This partially addresses #19455.