### PR TITLE
[bazel] Add execution environment for hyper310 and add hyper310 test ROM tests to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -590,7 +590,7 @@ jobs:
   - template: ci/publish-bazel-test-results.yml
 
 - job: execute_hyperdebug_tests_cw310
-  displayName: Hyperdebug CW310 Tests (Experimental)
+  displayName: Hyperdebug CW310 Test ROM Tests (Experimental)
   pool:
     name: $(fpga_pool)
     demands: BOARD -equals cw310
@@ -626,7 +626,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh hyper310 hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh hyper310 hyper310_test_rom || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
@@ -676,7 +676,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh cw310 manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 manuf,-hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 

--- a/hw/bitstream/hyperdebug/BUILD
+++ b/hw/bitstream/hyperdebug/BUILD
@@ -83,3 +83,25 @@ bitstream_splice(
     for (otp_name, img_target) in get_otp_images()
     for authenticity in KEY_AUTHENTICITY
 ]
+
+# TODO(#20231): Remove once support for new splicing infrastructure is
+# available.
+[
+    bitstream_splice(
+        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
+        testonly = True,
+        src = ":rom_with_{}_keys".format(authenticity),
+        data = img_target,
+        meminfo = ":otp_mmi",
+        tags = ["manual"],
+        update_usr_access = True,
+    )
+    for (otp_name, img_target) in [
+        ("sival_test_locked0", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_post_cp_test_locked0"),
+        ("sival_prod_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized"),
+        ("sival_prod_end_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_personalized"),
+        ("sival_dev_individualized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_individualized"),
+        ("sival_dev_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized"),
+    ]
+    for authenticity in KEY_AUTHENTICITY
+]

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -78,8 +78,8 @@ fpga_cw310(
     rom = "//sw/device/lib/testing/test_rom:test_rom",
     rom_mmi = "//hw/bitstream:rom_mmi",
     test_cmd = """
-        --exec="fpga load-bitstream {bitstream}"
         --exec="transport init"
+        --exec="fpga load-bitstream {bitstream}"
         --exec="bootstrap --clear-uart=true {firmware}"
         --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -147,6 +147,108 @@ fpga_cw310(
 )
 
 ###########################################################################
+# FPGA CW310+Hyperdebug Environments
+###########################################################################
+fpga_cw310(
+    name = "fpga_hyper310",
+    design = "earlgrey",
+    exec_env = "fpga_hyper310",
+    lib = "//sw/device/lib/arch:fpga_cw310",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
+    test_cmd = "testing-not-supported",
+)
+
+fpga_cw310(
+    name = "fpga_hyper310_test_rom",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ],
+    base = ":fpga_hyper310",
+    base_bitstream = "//hw/bitstream/hyperdebug:test_rom",
+    exec_env = "fpga_hyper310_test_rom",
+    otp = "//hw/ip/otp_ctrl/data:img_rma",
+    otp_mmi = "//hw/bitstream/hyperdebug:otp_mmi",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rom = "//sw/device/lib/testing/test_rom:test_rom",
+    rom_mmi = "//hw/bitstream/hyperdebug:rom_mmi",
+    test_cmd = """
+        --exec="transport init"
+        --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
+fpga_cw310(
+    name = "fpga_hyper310_rom_with_fake_keys",
+    testonly = True,
+    base = ":fpga_hyper310_test_rom",
+    exec_env = "fpga_hyper310_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+)
+
+fpga_cw310(
+    name = "fpga_hyper310_rom_ext",
+    testonly = True,
+    base = ":fpga_hyper310_test_rom",
+    exec_env = "fpga_hyper310_rom_ext",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+    manifest = "//sw/device/silicon_owner:manifest_standard",
+    otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@0 {firmware}@0x10000",
+    },
+    rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
+)
+
+# FPGA configuration used to emulate silicon targets. This rule can be used by
+# targets that require executing at the `rom_ext` stage level in flash, as well
+# as SRAM programs. Use the `fpga_hyper310_sival_rom_ext` execution environment
+# to emulate silicon targets containing a `rom_ext` stage.
+fpga_cw310(
+    name = "fpga_hyper310_sival",
+    testonly = True,
+    base = ":fpga_hyper310_rom_with_fake_keys",
+    # TODO(cfrantz): remove in favor of the OTP config.
+    base_bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_sival_prod_personalized",
+    exec_env = "fpga_hyper310_sival",
+
+    # PROD keys are allowed to run across all life cycle stages. This prod key
+    # is used to enable execution across life cycle stages with a single
+    # binary.
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+)
+
+# FPGA configuration used to emulate silicon targets containing a `rom_ext`
+# stage. See `fpga_cw310_sival` for more details.
+fpga_cw310(
+    name = "fpga_hyper310_sival_rom_ext",
+    testonly = True,
+    base = ":fpga_hyper310_rom_ext",
+    # TODO(cfrantz): remove in favor of the OTP config.
+    base_bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_sival_prod_personalized",
+    exec_env = "fpga_hyper310_sival_rom_ext",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_sival_prod_signed_slot_a",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
+)
+
+###########################################################################
 # FPGA CW305 Environments
 #
 # TODO(opentitan#19493): Determine whether the `fpga_cw310` infrastructure

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -20,6 +20,8 @@ load(
     _fpga_cw305 = "fpga_cw305",
     _fpga_cw310 = "fpga_cw310",
     _fpga_cw340 = "fpga_cw340",
+    _hyper310_params = "hyper310_params",
+    _hyper310_jtag_params = "hyper310_jtag_params",
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:silicon.bzl",
@@ -57,6 +59,8 @@ fpga_cw305 = _fpga_cw305
 fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 cw310_jtag_params = _cw310_jtag_params
+hyper310_params = _hyper310_params
+hyper310_jtag_params = _hyper310_jtag_params
 
 silicon = _silicon
 silicon_params = _silicon_params
@@ -75,6 +79,8 @@ rsa_key_by_name = _rsa_key_by_name
 EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    "//hw/top_earlgrey:fpga_hyper310_test_rom": "hyper310",
+    "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": "hyper310",
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,
 }
@@ -100,6 +106,8 @@ def _parameter_name(env, pname):
         (_, suffix) = env.split(":")
         if "cw310" in suffix:
             pname = "cw310"
+        elif "hyper310" in suffix:
+            pname = "hyper310"
         elif "verilator" in suffix:
             pname = "verilator"
         elif "dv" in suffix:
@@ -113,7 +121,8 @@ def _parameter_name(env, pname):
 def _hacky_tags(env):
     (_, suffix) = env.split(":")
     tags = []
-    if suffix.startswith("fpga_cw310_") or suffix.startswith("fpga_cw340_"):
+    if (suffix.startswith("fpga_cw310_") or suffix.startswith("fpga_cw340_") or
+        suffix.startswith("fpga_hyper310_")):
         # We have tags like "cw310_rom_with_real_keys" or "cw310_test_rom"
         # applied to our tests.  Since there is no way to adjust tags in a
         # rule's implementation, we have to infer these tag names from the
@@ -140,6 +149,7 @@ def opentitan_test(
         dv = _dv_params(),
         silicon = _silicon_params(),
         verilator = _verilator_params(),
+        hyper310 = _hyper310_params(),
         **kwargs):
     """Instantiate a test per execution environment.
 
@@ -170,6 +180,7 @@ def opentitan_test(
     """
     test_parameters = {
         "cw310": cw310,
+        "hyper310": hyper310,
         "dv": dv,
         "silicon": silicon,
         "verilator": verilator,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -17,6 +17,7 @@ load(
     "@lowrisc_opentitan//rules/opentitan:fpga_cw310.bzl",
     _cw310_jtag_params = "cw310_jtag_params",
     _cw310_params = "cw310_params",
+    _fpga_cw_params = "fpga_cw_params",
     _fpga_cw305 = "fpga_cw305",
     _fpga_cw310 = "fpga_cw310",
     _fpga_cw340 = "fpga_cw340",
@@ -59,6 +60,7 @@ fpga_cw305 = _fpga_cw305
 fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 cw310_jtag_params = _cw310_jtag_params
+fpga_cw_params = _fpga_cw_params
 hyper310_params = _hyper310_params
 hyper310_jtag_params = _hyper310_jtag_params
 
@@ -146,6 +148,7 @@ def opentitan_test(
         manifest = None,
         exec_env = {},
         cw310 = _cw310_params(),
+        cw340 = _fpga_cw_params(interface = "cw340"),
         dv = _dv_params(),
         silicon = _silicon_params(),
         verilator = _verilator_params(),
@@ -180,6 +183,7 @@ def opentitan_test(
     """
     test_parameters = {
         "cw310": cw310,
+        "cw340": cw340,
         "hyper310": hyper310,
         "dv": dv,
         "silicon": silicon,

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -27,6 +27,8 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:openocd.bzl",
+    "OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS",
+    "OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD",
     "OPENTITANTOOL_OPENOCD_DATA_DEPS",
     "OPENTITANTOOL_OPENOCD_TEST_CMD",
 )
@@ -299,5 +301,108 @@ def cw310_jtag_params(
         bitstream = bitstream,
         test_cmd = OPENTITANTOOL_OPENOCD_TEST_CMD + test_cmd,
         data = OPENTITANTOOL_OPENOCD_DATA_DEPS + data,
+        param = kwargs,
+    )
+
+def hyper310_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = None,
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create CW310 parameters for OpenTitan tests.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      otp: Use an alternate OTP configuration for this test.
+      bitstream: Use an alternate bitstream for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    if bitstream and (rom or otp):
+        fail("Cannot use rom or otp with bitstream.")
+    if not bitstream:
+        bitstream = "@//hw/bitstream/universal:splice"
+    return struct(
+        tags = ["hyper310", "exclusive"] + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = test_cmd,
+        data = data,
+        param = kwargs,
+    )
+
+def hyper310_jtag_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = None,
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create Hyper310 parameters for OpenTitan JTAG tests.
+
+    This creates version of the Hyper310 parameter structure pre-initialized
+    with OpenOCD dependencies and test_cmd parameters.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      otp: Use an alternate OTP configuration for this test.
+      bitstream: Use an alternate bitstream for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    if bitstream and (rom or otp):
+        fail("Cannot use rom or otp with bitstream.")
+    if not bitstream:
+        bitstream = "@//hw/bitstream/universal:splice"
+    return struct(
+        tags = ["hyper310", "exclusive"] + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD + test_cmd,
+        data = OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS + data,
         param = kwargs,
     )

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -406,3 +406,57 @@ def hyper310_jtag_params(
         data = OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS + data,
         param = kwargs,
     )
+
+def fpga_cw_params(
+        interface = None,
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = None,
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create CW310 parameters for OpenTitan tests.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      otp: Use an alternate OTP configuration for this test.
+      bitstream: Use an alternate bitstream for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    fpga_tags = ["exclusive"]
+    if interface != None:
+        fpga_tags.append(interface)
+    if bitstream and (rom or otp):
+        fail("Cannot use rom or otp with bitstream.")
+    if not bitstream:
+        bitstream = "@//hw/bitstream/universal:splice"
+    return struct(
+        tags = fpga_tags + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = test_cmd,
+        data = data,
+        param = kwargs,
+    )

--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -7,12 +7,24 @@ OPENTITANTOOL_OPENOCD_DATA_DEPS = [
     "//third_party/openocd:openocd_bin",
 ]
 
+OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS = [
+    "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+    "//third_party/openocd:openocd_bin",
+]
+
 OPENTITANTOOL_OPENOCD_SI_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
     --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_olimex_cfg)"
 """
 
 OPENTITANTOOL_OPENOCD_TEST_CMD = OPENTITANTOOL_OPENOCD_SI_TEST_CMD + """
+    --clear-bitstream
+    --bitstream={bitstream}
+"""
+
+OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD = """
+    --openocd="$(rootpath //third_party/openocd:openocd_bin)"
+    --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_cmsis_dap_adapter_cfg)"
     --clear-bitstream
     --bitstream={bitstream}
 """

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -232,8 +232,8 @@ def fpga_params(
         tags = _BASE_PARAMS["tags"],
         test_runner = _BASE_PARAMS["test_runner"],
         test_cmds = [
-            "--exec=\"fpga load-bitstream $(location {bitstream})\"",
             "--exec=\"transport init\"",
+            "--exec=\"fpga load-bitstream $(location {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(location {flash})\"",
             "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
             "{clear_bitstream}",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -330,8 +330,8 @@ opentitan_test(
     cw310 = cw310_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """
-            --exec="fpga load-bitstream {bitstream}"
             --exec="transport init"
+            --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -9,6 +9,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "verilator_params",
 )
@@ -100,7 +101,11 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "long",
+    ),
     deps = [
         ":mod_exp_ibex",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -350,7 +355,11 @@ opentitan_test(
     exec_env = {
         # Test set is too large as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "long",
+    ),
     deps = [
         ":sigverify",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -164,6 +164,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat0_header",
@@ -181,6 +182,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat1_header",
@@ -198,6 +200,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat2_header",
@@ -215,6 +218,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat3_header",
@@ -232,6 +236,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat4_header",
@@ -249,6 +254,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat5_header",
@@ -266,6 +272,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat6_header",
@@ -283,6 +290,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat7_header",
@@ -300,6 +308,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat8_header",
@@ -317,6 +326,7 @@ opentitan_test(
     exec_env = {
         # Test set is too large for Verilator or as ROM_EXT
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat9_header",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -8,6 +8,8 @@ load(
     "OPENTITAN_CPU",
     "cw310_jtag_params",
     "cw310_params",
+    "hyper310_jtag_params",
+    "hyper310_params",
     "opentitan_test",
 )
 
@@ -184,7 +186,18 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_test_unlocked1",
+        tags = ["manuf"],
+        test_cmd = """
+        --clear-bitstream
+        --bitstream={bitstream}
+        --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/manuf/individualize_sw_cfg",
+    ),
     deps = [
         ":individualize_sw_cfg_earlgrey_a0_sku_generic",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -241,7 +254,18 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_sival_dev_individualized",
+        data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
+        tags = ["manuf"],
+        test_cmd = """
+            --bootstrap={firmware}
+            --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
+        """,
+        test_harness = "//sw/host/tests/manuf/personalize",
+    ),
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
     deps = [
         ":flash_info_fields",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -10,6 +10,7 @@ load(
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
@@ -111,7 +112,19 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":sram_cp_provision": "sram_cp_provision",
+        },
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_raw",
+        tags = ["manuf"],
+        test_cmd = """
+            --elf={sram_cp_provision}
+        """,
+        test_harness = "//sw/host/tests/manuf/provisioning/cp",
+    ),
 )
 
 opentitan_test(
@@ -131,7 +144,21 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":sram_cp_provision": "sram_cp_provision",
+            ":sram_cp_provision_functest": "sram_cp_provision_functest",
+        },
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_raw",
+        tags = ["manuf"],
+        test_cmd = """
+            --provisioning-sram-elf={sram_cp_provision}
+            --test-sram-elf={sram_cp_provision_functest}
+        """,
+        test_harness = "//sw/host/tests/manuf/provisioning/cp_test",
+    ),
 )
 
 opentitan_binary(
@@ -222,7 +249,25 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":sram_ft_individualize": "sram_ft_individualize",
+            ":ft_personalize_2": "ft_personalize_2",
+        },
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_sival_test_locked0",
+        data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
+        tags = ["manuf"],
+        test_cmd = """
+            --elf={sram_ft_individualize}
+            --bootstrap={firmware}
+            --second-bootstrap={ft_personalize_2}
+            --target-mission-mode-lc-state="prod"
+            --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
+        """,
+        test_harness = "//sw/host/tests/manuf/provisioning/ft",
+    ),
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,
         CONST.LCV.PROD,

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -13,6 +13,7 @@ load("//rules:splice.bzl", "bitstream_splice")
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
@@ -81,7 +82,19 @@ _MANUF_TEST_LOCKED_KEY = None
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_jtag_params(
+            bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_{}".format(lc_state.lower()),
+            lc_state = lc_state,  # will be expanded in test_cmd
+            tags = ["manuf"],
+            test_cmd = (
+                "" if (
+                    (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS
+                ) else "--bootstrap={firmware}"
+            ) + " --initial-lc-state={lc_state}",
+            test_harness = "//sw/host/tests/manuf/manuf_scrap",
+        ),
         rsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else rsa_key_for_lc_state(RSA_ONLY_KEY_STRUCTS, lc_val),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -114,7 +127,13 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_raw",
+        tags = ["manuf"],
+        test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw",
+    ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -134,7 +153,13 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_raw",
+        tags = ["manuf"],
+        test_harness = "//sw/host/tests/manuf/manuf_cp_volatile_unlock_raw",
+    ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -160,6 +185,7 @@ opentitan_test(
 
 # Bitstream with ROM and above OTP image that is in the test_unlocked* LC state
 # with ROM execution disabled.
+# TODO: Add hyper310 targets too?
 [
     bitstream_splice(
         name = "bitstream_rom_exec_disabled_test_unlocked{}".format(i),
@@ -444,6 +470,7 @@ otp_image(
     visibility = ["//visibility:private"],
 )
 
+# TODO: Add hyper310 targets too?
 bitstream_splice(
     name = "bitstream_otp_ctrl_functest",
     src = "//hw/bitstream:rom_with_fake_keys",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -435,8 +435,8 @@ opentitan_functest(
         exit_failure = "(min_security_version_rom_ext:[^01])|(FAIL)|((min_security_version_rom_ext:0(?s:.*)){2,})|(PASS)",
         exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         test_cmds = [
-            "--exec=\"fpga load-bitstream $(rootpath {bitstream})\"",
             "--exec=\"transport init\"",
+            "--exec=\"fpga load-bitstream $(rootpath {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(rootpath {flash})\"",
             "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
             # We clear the bitstream to force any subsequent test to load a

--- a/sw/device/silicon_creator/rom/e2e/address_translation/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/address_translation/BUILD
@@ -4,6 +4,7 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "hyper310_params",
     "opentitan_test",
     new_cw310_params = "cw310_params",
 )
@@ -39,7 +40,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+        },
+        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
+        exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["a"],
+    ),
 )
 
 opentitan_test(
@@ -55,7 +66,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+        },
+        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
+        exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["b"],
+    ),
 )
 
 opentitan_test(
@@ -71,7 +92,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+        },
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        offset = SLOTS["b"],
+    ),
 )
 
 opentitan_test(
@@ -87,7 +118,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+        },
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
+        offset = SLOTS["a"],
+    ),
 )
 
 opentitan_test(
@@ -103,7 +144,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+        },
+        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
+        exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["a"],
+    ),
 )
 
 opentitan_test(
@@ -119,7 +170,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+        },
+        exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
+        exit_success = MSG_STARTING_ROM_EXT,
+        offset = SLOTS["b"],
+    ),
 )
 
 opentitan_test(
@@ -135,7 +196,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        assemble = "{firmware}@{offset}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation": "firmware",
+        },
+        exit_failure = MSG_STARTING_ROM_EXT,
+        exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
+        offset = SLOTS["a"],
+    ),
 )
 
 test_suite(

--- a/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -154,7 +155,19 @@ BOOT_DATA_RECOVERY_MANIFEST = manifest(
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            exit_success = MSG_TEMPLATE_BFV.format(hex_digits(case["expected_bfv"])) if case["expected_bfv"] != None else MSG_PASS,
+            otp = ":otp_img_boot_data_recovery_{}_{}".format(
+                case["lc_state"],
+                case["default_boot_data"],
+            ),
+            tags = maybe_skip_in_ci(getattr(
+                CONST.LCV,
+                case["lc_state"].upper(),
+            )),
+        ),
         manifest = BOOT_DATA_RECOVERY_MANIFEST,
         # PROD keys can sign binaries able to run across all life cycle states.
         rsa_key = rsa_key_for_lc_state(

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -253,6 +253,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
     ]
 ]
 
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_boot_policy_bad_manifest_{}_sec_ver_{}".format(

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_newer/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_newer/BUILD
@@ -128,6 +128,7 @@ BOOT_POLICY_NEWER_CASES = [
 ) for lc_state, _ in get_lc_items()]
 
 # Splice OTP images into bitstreams
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_boot_policy_newer_{}".format(lc_state),

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
@@ -78,6 +78,7 @@ otp_json(
     visibility = ["//visibility:private"],
 ) for lc_state, _ in get_lc_items()]
 
+# TODO: Add hyper310 targets?
 [bitstream_splice(
     name = "bitstream_boot_policy_rollback_{}".format(
         lc_state,

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_valid/BUILD
@@ -69,6 +69,7 @@ BOOT_POLICY_VALID_CASES = [
 ]
 
 # Splice OTP images into bitstreams
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_boot_policy_valid_{}".format(lc_state),

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -6,6 +6,8 @@ load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
     "cw310_params",
+    "hyper310_jtag_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -83,7 +85,17 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        otp = "otp_img_bootstrap_rma",
+        # We need to clear the bitstream between consecutive runs of this
+        # test since it modifies OTP state (i.e., the LC state).
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/rom/e2e_bootstrap_rma",
+    ),
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,
@@ -115,6 +127,20 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        # Since the bitstream disables bootstrap, there is no firmware to
+        # load into the chip.  However, opentitan_functest wants to build a
+        # binary target.  We'll build an unsigned do-nothing binary.
+        binaries = {
+            "//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware",
+        },
+        otp = "//hw/ip/otp_ctrl/data:img_bootstrap_disabled",
+        test_cmd = """
+            --bitstream="{bitstream}"
+        """,
+        test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
+    ),
     manifest = None,
 )

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -39,7 +40,18 @@ package(default_visibility = ["//visibility:public"])
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            otp = "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+            test_cmd = """
+                --bitstream="{bitstream}"
+                --bootstrap="{firmware}"
+                --otp-unprogrammed
+            """,
+            test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",
+        ),
         manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         rsa_key = rsa_key_for_lc_state(
             RSA_ONLY_KEY_STRUCTS,

--- a/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
     "verilator_params",
@@ -35,8 +36,13 @@ package(default_visibility = ["//visibility:public"])
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_verilator": None,
         },
+        hyper310 = hyper310_params(
+            bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_" + lc_state,
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
         local_defines = [
             "EXPECT_DEBUG={}".format(1 if lc_state_val in [
                 CONST.LCV.TEST_UNLOCKED0,

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -5,14 +5,8 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
     "opentitan_test",
-)
-load(
-    "//rules:opentitan_test.bzl",
-    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
-    "OPENTITANTOOL_OPENOCD_TEST_CMDS",
-    "cw310_params",
-    "opentitan_functest",
 )
 load(
     "//rules:const.bzl",
@@ -108,7 +102,15 @@ LC_STATES_DEBUG_DISALLOWED = [
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_jtag_params(
+            timeout = "moderate",
+            logging = "debug",
+            otp = ":img_{}_exec_disabled".format(lc_state),
+            test_cmd = " --elf={rom:elf}" + (" --expect-fail" if lc_state_val in LC_STATES_DEBUG_DISALLOWED else " "),
+            test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test",
+        ),
         deps = [
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
     "dv_params",
+    "hyper310_params",
     "opentitan_binary",
     "opentitan_test",
     "verilator_params",
@@ -97,9 +98,14 @@ rom_e2e_keymgr_init_configs = [
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
         },
+        hyper310 = hyper310_params(
+            binaries = {":rom_e2e_keymgr_init_test": "firmware"},
+            otp = ":otp_img_keymgr_{}".format(config["name"]),
+        ),
         verilator = verilator_params(
             timeout = "eternal",
             binaries = {":rom_e2e_keymgr_init_test": "firmware"},

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -34,6 +34,7 @@ otp_image(
     visibility = ["//visibility:private"],
 )
 
+# TODO: Add hyper310 targets?
 bitstream_splice(
     name = "bitstream_sigverify_spx_rma",
     src = "//hw/bitstream:rom_with_real_keys",
@@ -78,6 +79,7 @@ opentitan_flash_binary(
     ],
 )
 
+# TODO: Add hyper310 targets?
 bitstream_splice(
     name = "bitstream_rom_self_hash_test_rma_otbn_mod_exp",
     src = "//hw/bitstream:rom_with_real_keys",

--- a/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
 )
 load(
@@ -54,7 +55,12 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        otp = ":otp_img_reset_ret_ram",
+        tags = maybe_skip_in_ci(CONST.LCV.RMA),
+    ),
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:rstmgr",
@@ -73,7 +79,11 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        tags = maybe_skip_in_ci(CONST.LCV.RMA),
+    ),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
         "//sw/device/lib/base:memory",

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
 )
 load(
@@ -47,7 +48,18 @@ package(default_visibility = ["//visibility:public"])
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
+            otp = ":otp_img_e2e_bootstrap_entry_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+            test_cmd = """
+                --bitstream="{bitstream}"
+                --bootstrap="{firmware}"
+            """,
+            test_harness = "//sw/host/tests/rom/e2e_bootstrap_entry",
+        ),
         # We don't want the `empty_test` to run, but we _also_ don't want some
         # leftover flash image from a previous test to run.  So, bootstrap an
         # unsigned image to force a boot failure.

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -74,9 +74,9 @@ otp_json(
             otp = ":otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
             test_cmd = """
+                --exec="transport init"
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
-                --exec="transport init"
                 --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 --exec="fpga clear-bitstream"

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -85,7 +86,21 @@ otp_json(
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            otp = ":otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga clear-bitstream"
+                --exec="fpga load-bitstream {bitstream}"
+                --exec="bootstrap --clear-uart=true {firmware}"
+                --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                --exec="fpga clear-bitstream"
+                no-op
+            """,
+        ),
         manifest = ":manifest_rom_ext_upgrade_interrupt",
         rsa_key = rsa_key_for_lc_state(
             RSA_ONLY_KEY_STRUCTS,

--- a/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
@@ -63,6 +63,7 @@ ALERT_LC_STATES = get_lc_items(
     overlays = STD_OTP_OVERLAYS,
 ) for lc_state, _ in ALERT_LC_STATES]
 
+# TODO: Add hyper310 targets?
 [bitstream_splice(
     name = "bitstream_alert_{}".format(lc_state),
     src = "//hw/bitstream:rom_with_fake_keys",
@@ -199,6 +200,7 @@ otp_alert_digest(
     ],
 ) for lc_state, _ in ALERT_LC_STATES]
 
+# TODO: Add hyper310 targets?
 [bitstream_splice(
     name = "bitstream_shutdown_alert_{}".format(lc_state),
     src = "//hw/bitstream:rom_with_fake_keys",

--- a/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
     "dv_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -78,8 +79,19 @@ manifest(
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_dv": None,
         },
+        hyper310 = hyper310_params(
+            binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
+            exit_failure = MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV_LCV.format(
+                hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
+                hex_digits(lc_state_val),
+            ),
+            otp = ":otp_img_shutdown_output_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
         manifest = ":manifest_bad_identifier",
         rsa_key = rsa_key_for_lc_state(
             RSA_ONLY_KEY_STRUCTS,

--- a/sw/device/silicon_creator/rom/e2e/shutdown_redact/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_redact/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
 )
 load(
@@ -98,7 +99,24 @@ REDACT.update({"INVALID": 0x0})
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            binaries = {
+                "//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware",
+            },
+            exit_failure = MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV.format(hex_digits(error_redact(
+                CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER,
+                lc_state_val,
+                redact_val,
+            ))),
+            otp = ":img_{}_{}".format(
+                lc_state,
+                redact.lower(),
+            ),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
         # Skip signing by clearing the manifest configuration.
         manifest = None,
     )

--- a/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -118,7 +119,19 @@ SHUTDOWN_WATCHDOG_CASES = [
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            exit_success = t["exit_success"],
+            otp = ":otp_img_shutdown_watchdog_{}_{}".format(
+                t["lc_state"],
+                t["bite_threshold"],
+            ),
+            tags = maybe_skip_in_ci(getattr(
+                CONST.LCV,
+                t["lc_state"].upper(),
+            )),
+        ),
         local_defines = [
             "HANG_SECS=2",
         ],

--- a/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_params",
+    "hyper310_params",
     "opentitan_binary",
     "opentitan_test",
 )
@@ -103,7 +104,31 @@ SIGVERIFY_BAD_CASES = [
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            assemble = " ".join([
+                "{{slot_{}}}@{}".format(slot, addr)
+                for (slot, addr) in SLOTS.items()
+                if case[slot] == "bad"
+            ]),
+            binaries = {
+                "//sw/device/silicon_creator/rom/e2e:empty_test_slot_{}_{}_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin"
+                    .format(
+                    slot,
+                    filter_key_structs_for_lc_state(RSA_ONLY_KEY_STRUCTS, lc_state_val)[0].rsa.name,
+                ): "slot_{}".format(slot)
+                for (slot, addr) in SLOTS.items()
+                if case[slot] == "bad"
+            },
+            exit_failure = MSG_PASS,
+            exit_success = MSG_TEMPLATE_BFV_LCV.format(
+                case["expected_bfv"],
+                hex_digits(lc_state_val),
+            ),
+            otp = ":otp_img_sigverify_always_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
     )
     for case in SIGVERIFY_BAD_CASES
     for lc_state, lc_state_val in get_lc_items()

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
@@ -51,6 +51,7 @@ package(default_visibility = ["//visibility:public"])
     for lc_state, _ in get_lc_items()
 ]
 
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_sigverify_key_type_{}".format(

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
@@ -74,6 +74,7 @@ otp_json(
     for lc_state, _ in get_lc_items()
 ]
 
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_sigverify_key_validity_{}".format(

--- a/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_mod_exp/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -93,7 +94,16 @@ SIGVERIFY_MOD_EXP_CASES = [
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            exit_success = t["exit_success"][lc_state],
+            otp = ":otp_img_sigverify_mod_exp_{}_{}".format(
+                lc_state,
+                t["name"],
+            ),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
         manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         rsa_key = rsa_key_for_lc_state(
             RSA_ONLY_KEY_STRUCTS,

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
@@ -174,6 +174,7 @@ opentitan_flash_binary(
     for t in SIGVERIFY_SPX_CASES
 ]
 
+# TODO: Add hyper310 targets?
 [
     bitstream_splice(
         name = "bitstream_sigverify_spx_{}_{}".format(

--- a/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_SUCCESS_MSG",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
 )
@@ -284,7 +285,14 @@ test_cases = device_id_test_cases + lc_state_test_cases + manuf_state_test_cases
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
+        hyper310 = hyper310_params(
+            exit_failure = t["exit_failure"],
+            exit_success = t["exit_success"],
+            otp = t["otp"],
+            tags = maybe_skip_in_ci(t["lc_state_val"]),
+        ),
         manifest = manifest(
             dict(
                 t["manifest"],

--- a/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
@@ -139,8 +140,19 @@ WATCHDOG_OTP = {
         ),
         exec_env = {
             "@//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "@//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "@//hw/top_earlgrey:sim_verilator": None,
         },
+        hyper310 = hyper310_params(
+            binaries = {
+                ":test_watchdog_{}_{}".format(
+                    WATCHDOG_TEST_CASES[watchdog_config][lc_state],
+                    lc_state,
+                ): "firmware",
+            },
+            otp = WATCHDOG_OTP[watchdog_config].format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
         verilator = verilator_params(
             timeout = "eternal",
             binaries = {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -22,6 +22,8 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
+    "hyper310_params",
     "opentitan_test",
     "rsa_key_for_lc_state",
     new_cw310_params = "cw310_params",
@@ -76,6 +78,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_sival": None,
+        "//hw/top_earlgrey:fpga_hyper310_sival_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -144,6 +150,7 @@ opentitan_test(
     srcs = ["alert_handler_ping_timeout_test.c"],
     cw310 = new_cw310_params(timeout = "moderate"),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(timeout = "moderate"),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
@@ -330,6 +337,7 @@ opentitan_test(
     srcs = ["aon_timer_irq_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -533,8 +541,10 @@ opentitan_test(
     name = "clkmgr_external_clk_src_for_sw_slow_test",
     srcs = ["clkmgr_external_clk_src_for_sw_slow_test.c"],
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+    # The measurement for clk_main is failing
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(tags = ["broken"]),
     verilator = new_verilator_params(tags = ["broken"]),
     deps = [
         ":clkmgr_external_clk_src_for_sw_impl",
@@ -912,6 +922,7 @@ opentitan_test(
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(tags = ["broken"]),
     verilator = new_verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -1067,6 +1078,14 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/mem",
     ),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+            "\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/mem",
+    ),
     verilator = new_verilator_params(
         timeout = "eternal",
         tags = ["manual"],
@@ -1127,6 +1146,7 @@ opentitan_test(
     srcs = ["flash_ctrl_idle_low_power_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -1289,8 +1309,10 @@ opentitan_test(
     name = "flash_ctrl_clock_freqs_test",
     srcs = ["flash_ctrl_clock_freqs_test.c"],
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+    # Various ECC / integrity errors ostensibly coming from the underlying flash macro
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(tags = ["broken"]),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//sw/device/lib/base:mmio",
@@ -1367,6 +1389,7 @@ opentitan_test(
     exec_env = {
         # Not compatible with the verilated top level.
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
     deps = [
@@ -1561,6 +1584,7 @@ opentitan_test(
     # TODO(#15530): EDN doesn't timeout on FPGA
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -1690,8 +1714,10 @@ opentitan_test(
     name = "otbn_mem_scramble_test",
     srcs = ["otbn_mem_scramble_test.c"],
     # TODO(#12486) [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+    # SecureIbex parameter not set on FPGA, so ECC / integrity errors will not occur.
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(tags = ["broken"]),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -1882,8 +1908,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -1913,8 +1947,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -1944,8 +1986,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -1975,8 +2025,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -2006,8 +2064,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -2036,8 +2102,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -2066,8 +2140,16 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
+    ),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2286,7 +2368,9 @@ opentitan_test(
     cw310 = new_cw310_params(timeout = "moderate"),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
+    hyper310 = hyper310_params(timeout = "moderate"),
     deps = [
         ":spi_host_flash_test_impl",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2309,6 +2393,7 @@ opentitan_test(
     srcs = ["spi_host_winbond_flash_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         ":spi_host_flash_test_impl",
@@ -2332,6 +2417,7 @@ opentitan_test(
     srcs = ["spi_host_irq_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2436,6 +2522,8 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_sival": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2561,6 +2649,7 @@ opentitan_test(
     srcs = ["usbdev_pincfg_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -2583,6 +2672,7 @@ opentitan_test(
     srcs = ["usbdev_vbus_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -2602,6 +2692,7 @@ opentitan_test(
     srcs = ["usbdev_pullup_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -2621,6 +2712,7 @@ opentitan_test(
     srcs = ["usbdev_setuprx_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -2641,10 +2733,12 @@ opentitan_test(
     cw310 = new_cw310_params(tags = ["manual"]),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
     verilator = new_verilator_params(timeout = "long"),
+    hyper310 = hyper310_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -2667,9 +2761,14 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2692,9 +2791,14 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2716,10 +2820,15 @@ opentitan_test(
         tags = ["manual"],
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2738,6 +2847,7 @@ opentitan_test(
     srcs = ["rstmgr_alert_info_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
@@ -2972,19 +3082,15 @@ opentitan_test(
 opentitan_test(
     name = "spi_passthru_test",
     srcs = ["spi_passthru_test.c"],
-    cw310 = new_cw310_params(
-        # TODO: This test will need hyperdebug once we start using multi-lane
-        # SPI modes.
-        # interface = "hyper310",
-        # tags = ["manual"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+    },
+    hyper310 = hyper310_params(
         test_cmd = """
             --bootstrap="{firmware}"
         """,
         test_harness = "//sw/host/tests/chip/spi_passthru",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:gpio",
@@ -3044,28 +3150,28 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_jtag_params(
+        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
+        tags = ["flaky"],
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/jtag:openocd_test",
+    ),
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 
-# TODO(#19902): Migrate to `opentitan_test` once there is support for the
-# hyperdebug310 target. #19903 covers support for hyperdebug340, and #19901
+# TODO(#19903): Migrate to `opentitan_test` once there is support for the
+# hyperdebug340 target. #19903 covers support for hyperdebug340, and #19901
 # covers support for cw340_params.
 opentitan_functest(
-    name = "openocd_hyperdebug_test",
+    name = "openocd_hyper340_test",
     srcs = ["example_test_from_flash.c"],
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
-        interface = "hyper310",
-        tags = ["flaky"],
-        test_cmds = [
-            "--bitstream=\"$(rootpath {bitstream})\"",
-            "--bootstrap=\"$(rootpath {flash})\"",
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
-    ),
     cw340 = cw340_params(
         bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
         interface = "hyper340",
@@ -3118,26 +3224,21 @@ opentitan_functest(
     ],
 )
 
-# TODO(#19902): Migrate to `opentitan_test` once there is support for the
-# hyperdebug310 target.
-opentitan_functest(
+opentitan_test(
     name = "i2c_target_test",
     srcs = [
         "i2c_target_test.c",
     ],
-    cw310 = cw310_params(
-        # This test needs hyperdebug to serve as I2C host to OpenTitan's
-        # I2C target device.
-        interface = "hyper310",
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+    },
+    hyper310 = hyper310_params(
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/i2c_target",
     ),
-    targets = [
-        "cw310_test_rom",
-    ],
-    test_harness = "//sw/host/tests/chip/i2c_target",
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:gpio",
@@ -3174,7 +3275,12 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
+    hyper310 = hyper310_params(
+        exit_failure = "PASS!",
+        exit_success = _STATUS_REPORT_TEST_MSG,
+    ),
     deps = [
         "//sw/device/lib/base:status_report_unittest_c",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -3199,7 +3305,12 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
     },
+    hyper310 = hyper310_params(
+        exit_failure = "PASS!",
+        exit_success = _STATUS_REPORT_OVERFLOW_TEST_MSG,
+    ),
     deps = [
         "//sw/device/lib/base:status_report_unittest_c",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -3218,6 +3329,14 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/example_sival",
     ),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+            "\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/example_sival",
+    ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ottf_utils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -22,6 +22,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "fpga_cw_params",
     "hyper310_jtag_params",
     "hyper310_params",
     "opentitan_test",
@@ -3147,6 +3148,17 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     ),
+    cw340 = fpga_cw_params(
+        bitstream = "//hw/bitstream/cw340:rom_with_fake_keys_otp_test_unlocked0",
+        data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
+        interface = "hyper340",
+        tags = ["flaky"],
+        test_cmd = " ".join(OPENTITANTOOL_OPENOCD_TEST_CMDS) + """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/jtag:openocd_test",
+    ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
@@ -3165,56 +3177,30 @@ opentitan_test(
     ],
 )
 
-# TODO(#19903): Migrate to `opentitan_test` once there is support for the
-# hyperdebug340 target. #19903 covers support for hyperdebug340, and #19901
-# covers support for cw340_params.
-opentitan_functest(
-    name = "openocd_hyper340_test",
-    srcs = ["example_test_from_flash.c"],
-    cw340 = cw340_params(
-        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
-        interface = "hyper340",
-        tags = ["flaky"],
-        test_cmds = [
-            "--bitstream=\"$(rootpath {bitstream})\"",
-            "--bootstrap=\"$(rootpath {flash})\"",
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
-    ),
-    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    targets = ["cw310_rom_with_fake_keys"],
-    test_harness = "//sw/host/tests/chip/jtag:openocd_test",
-    deps = [
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
-
-# TODO(#19902): Migrate to `opentitan_test` once there is support for the
-# hyperdebug310 target. #19903 covers support for hyperdebug340, and #19901
-# covers support for cw340_params.
-opentitan_functest(
+opentitan_test(
     name = "spi_device_ottf_console_test",
     srcs = ["spi_device_ottf_console_test.c"],
-    cw310 = cw310_params(
-        interface = "hyper310",
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
-    ),
-    cw340 = cw340_params(
+    cw340 = fpga_cw_params(
         interface = "hyper340",
         tags = ["manual"],
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
     ),
-    targets = [
-        "cw310_test_rom",
-        "cw340_test_rom",
-    ],
-    test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw340_test_rom": "cw340",
+    },
+    hyper310 = hyper310_params(
+        interface = "hyper310",
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:spi_device",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1400,24 +1400,23 @@ opentitan_test(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "gpio_pinmux_test",
     srcs = ["gpio_pinmux_test.c"],
-    cw310 = cw310_params(
-        interface = "hyper310",
-        test_cmds = [
-            "--bitstream=\"$(location {bitstream})\"",
-            "--bootstrap=\"$(location {flash})\"",
-        ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    hyper310 = hyper310_params(
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/gpio",
     ),
-    targets = [
-        "verilator",
-        "cw310_test_rom",
-    ],
-    test_harness = "//sw/host/tests/chip/gpio",
-    verilator = verilator_params(
+    verilator = new_verilator_params(
         timeout = "eternal",
-        test_cmds = [],
+        test_harness = "//sw/host/tests/chip/gpio",
     ),
     deps = [
         "//sw/device/lib/dif:gpio",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -7,6 +7,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_params",
+    "hyper310_params",
     "opentitan_test",
     "verilator_params",
 )
@@ -148,6 +149,11 @@ opentitan_test(
         # [test-triage] test not constant time with icache enabled
     ),
     exec_env = EARLGREY_TEST_ENVS,
+    hyper310 = hyper310_params(
+        timeout = "long",
+        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
+        # [test-triage] test not constant time with icache enabled
+    ),
     verilator = verilator_params(
         timeout = "long",
         tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/15788
@@ -311,7 +317,12 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "long",
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -349,7 +360,12 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "long",
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -387,7 +403,12 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "long",
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -432,8 +453,12 @@ opentitan_test(
     # we have to restrict the environments to run with the test_rom.
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
+    hyper310 = hyper310_params(
+        timeout = "moderate",
+    ),
     verilator = verilator_params(
         timeout = "eternal",
     ),

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -4,6 +4,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "hyper310_params",
     "opentitan_binary",
     "opentitan_test",
 )
@@ -38,7 +39,18 @@ package(default_visibility = ["//visibility:public"])
 #     ),
 #     exec_env = {
 #         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+#         "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
 #     },
+#     hyper310 = hyper310_params(
+#         timeout = "long",
+#         binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+#         data = testvector_targets,
+#         test_cmd = """
+#             --bootstrap={firmware}
+#             --bitstream={bitstream}
+#         """ + testvector_args,
+#         test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+#     ),
 # )
 
 KAT_TYPE = [
@@ -112,6 +124,16 @@ TESTVECTOR_ARGS = {
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         },
+        hyper310 = hyper310_params(
+            timeout = "long",
+            binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+            data = TESTVECTOR_TARGETS[mode],
+            test_cmd = """
+                --bootstrap={firmware}
+                --bitstream={bitstream}
+            """ + TESTVECTOR_ARGS[mode],
+            test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+        ),
     )
     for mode in [
         "cbc",

--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -27,10 +27,16 @@
     },
     {
       "name": "TAP_STRAP0",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
       "alias_of": "IOC8"
     },
     {
       "name": "TAP_STRAP1",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
       "alias_of": "IOC5"
     }
   ],

--- a/sw/host/opentitanlib/src/util/openocd.rs
+++ b/sw/host/opentitanlib/src/util/openocd.rs
@@ -252,6 +252,11 @@ impl JtagChain for OpenOcdJtagChain {
         if resp.contains("JTAG scan chain interrogation failed") {
             bail!(OpenOcdError::InitializeFailure(resp));
         }
+        static CONNECT_FAILED_REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"target \S+ examination failed").unwrap());
+        if CONNECT_FAILED_REGEX.is_match(&resp) {
+            bail!(OpenOcdError::InitializeFailure(resp));
+        }
 
         Ok(Box::new(OpenOcdJtagTap {
             openocd: self.openocd,

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -97,7 +97,6 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
 fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
-    opts.init.init_target()?;
     let transport = opts.init.init_target()?;
 
     execute_test!(manuf_cp_yield_test, &opts, &transport);

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
@@ -48,7 +48,7 @@ fn test_bootstrap_disabled_requested(opts: &Opts, transport: &TransportWrapper) 
     };
     // Now check whether the SPI device is responding to status messages
     log::info!("Issuing SPI READ_STATUS");
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
     Ok(())
 }
@@ -77,7 +77,7 @@ fn test_bootstrap_disabled_not_requested(opts: &Opts, transport: &TransportWrapp
     };
     // Now check whether the SPI device is responding to status messages
     log::info!("Issuing SPI READ_STATUS");
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
     Ok(())
 }

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -66,7 +66,7 @@ impl<'a> BootstrapTest<'a> {
         };
         transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
         transport.reset_target(b.reset_delay, true)?;
-        let spi = transport.spi("0").unwrap();
+        let spi = transport.spi("BOOTSTRAP").unwrap();
         SpiFlash::from_spi(&*spi)
             .unwrap()
             .chip_erase(&*spi)
@@ -81,7 +81,7 @@ impl<'a> Drop for BootstrapTest<'a> {
         let bootstrapping = self.transport.pin_strapping("ROM_BOOTSTRAP").unwrap();
         bootstrapping.apply().unwrap();
         self.transport.reset_target(self.reset_delay, true).unwrap();
-        let spi = self.transport.spi("0").unwrap();
+        let spi = self.transport.spi("BOOTSTRAP").unwrap();
         SpiFlash::from_spi(&*spi)
             .unwrap()
             .chip_erase(&*spi)
@@ -114,7 +114,7 @@ fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -
         bail!("FAIL: {:?}", result);
     };
     // Now check whether the SPI device is responding to status messages
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x00);
 
     Ok(())
@@ -144,7 +144,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
     // Note: CIPO line is in high-z state when CMD_INFO registers are not configured.
     // Use READ_SFDP instead of READ_STATUS to avoid false negatives when bootstrap is not
     // requested
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert!(matches!(
         SpiFlash::read_sfdp(&*spi)
             .unwrap_err()
@@ -158,7 +158,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
 fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let id = SpiFlash::read_jedec_id(&*spi, 16)?;
     log::info!("Read jedec id: {:x?}", id);
     let mut index = 0;
@@ -180,7 +180,7 @@ fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
 
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x0);
 
@@ -196,7 +196,7 @@ fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Resul
 fn test_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let sfdp = SpiFlash::read_sfdp(&*spi)?;
     log::info!("SFDP: {:#x?}", sfdp);
 
@@ -297,7 +297,7 @@ fn test_bootstrap_shutdown(
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(2, 0)),
@@ -335,7 +335,7 @@ fn test_bootstrap_shutdown(
 fn test_bootstrap_phase1_reset(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     // RESET should be ignored and we should not see any messages.
     let mut console = UartConsole {
@@ -357,7 +357,7 @@ fn test_bootstrap_phase1_reset(opts: &Opts, transport: &TransportWrapper) -> Res
 fn test_bootstrap_phase1_page_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -390,7 +390,7 @@ fn test_bootstrap_phase1_erase(
     erase_cmd: u8,
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let mut console = UartConsole {
@@ -438,7 +438,7 @@ fn test_bootstrap_phase1_erase(
 
 fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -475,7 +475,7 @@ fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Resu
 fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -508,7 +508,7 @@ fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Res
 
 fn test_bootstrap_phase2_page_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     SpiFlash::from_spi(&*spi)?
         // Send CHIP_ERASE to transition to phase 2.
@@ -539,7 +539,7 @@ fn test_bootstrap_phase2_erase(
     erase_cmd: u8,
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let erase = || match erase_cmd {
@@ -575,7 +575,7 @@ fn test_bootstrap_phase2_erase(
 
 fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut read_buf = [0u8; 8];
 
@@ -609,8 +609,8 @@ fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Resu
 
 fn test_bootstrap_watchdog_check(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(2, 0)),
         exit_success: Some(Regex::new(r".+")?),

--- a/third_party/riscv-compliance/defs.bzl
+++ b/third_party/riscv-compliance/defs.bzl
@@ -4,7 +4,12 @@
 
 """Helper macros for generating RISC-V compliance test targets."""
 
-load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
+load(
+    "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
+    "opentitan_test",
+    "verilator_params",
+)
 
 def rv_compliance_test(name, arch):
     test_file = "@riscv-compliance//:riscv-test-suite/{}/src/{}.S".format(arch, name)
@@ -24,7 +29,7 @@ def rv_compliance_test(name, arch):
         """.format(reference_output),
     )
 
-    opentitan_functest(
+    opentitan_test(
         name = name,
         srcs = [
             test_file,
@@ -32,6 +37,7 @@ def rv_compliance_test(name, arch):
             "compliance_main.c",
             "compliance_main.S",
         ],
+        exec_env = EARLGREY_TEST_ENVS,
         verilator = verilator_params(
             timeout = "long",
         ),


### PR DESCRIPTION
Create an execution environment for hyper310. Duplicate virtually everything from the cw310 environments, and add hyper310 variants to many tests.

-  Creates distinct tags for cw310 vs. hyper310 for tag filtering, without relying on specially-named environment targets (via `hacky_tags()`)
- This method makes adding new classes of execution environment very painful, though!

Should we lean into `hacky_tags()` to preserve tag filtering and create the distinct environments instead? When tags are defined, we only have the execution environment's label to work with for adding anything under the hood: Tags are set outside the rule's implementation function, but Labels can't become Targets with more useful structured data until bazel gets _into_ the rule implementation function.

Or do we give up tag filtering for execution environments altogether? ...or is there another way?