### PR TITLE
[manuf/personalize] send attestation TCB measurements to device over console

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
@@ -137,7 +137,8 @@ otp_json(
                 # sw/device/lib/base/hardened.h.
                 "OWNER_SW_CFG_ROM_BOOTSTRAP_DIS": otp_hex(CONST.HARDENED_FALSE),
                 # Set to 0x739 to use the ROM_EXT hash measurement as the key
-                # manager attestation binding value.
+                # manager attestation binding value. Since our attestation
+                # scheme has changed, we keep this as false (disabled).
                 "OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN": otp_hex(0x0),
                 # Report errors without any redaction.
                 "OWNER_SW_CFG_ROM_ERROR_REPORTING": otp_hex(CONST.SHUTDOWN.REDACT.NONE),

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -30,11 +30,27 @@ UJSON_SERDE_STRUCT(EccP256PublicKey, \
  * Data imported during device personalization.
  */
 // clang-format off
-#define STRUCT_MANUF_PERSO_DATA_IN(field, string) \
+#define STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_IN(field, string) \
     field(host_pk, ecc_p256_public_key_t)
-UJSON_SERDE_STRUCT(ManufPersoDataIn, \
-                   manuf_perso_data_in_t, \
-                   STRUCT_MANUF_PERSO_DATA_IN);
+UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataIn, \
+                   manuf_rma_token_perso_data_in_t, \
+                   STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_IN);
+// clang-format on
+
+/**
+ * Data imported during device certificate personalization.
+ */
+// clang-format off
+#define STRUCT_MANUF_CERT_PERSO_DATA_IN(field, string) \
+    field(rom_ext_measurement, uint32_t, 8) \
+    field(rom_ext_measurement_valid, bool) \
+    field(owner_manifest_measurement, uint32_t, 8) \
+    field(owner_manifest_measurement_valid, bool) \
+    field(owner_measurement, uint32_t, 8) \
+    field(owner_measurement_valid, bool)
+UJSON_SERDE_STRUCT(ManufCertPersoDataIn, \
+                   manuf_cert_perso_data_in_t, \
+                   STRUCT_MANUF_CERT_PERSO_DATA_IN);
 // clang-format on
 
 /**
@@ -69,11 +85,11 @@ UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
  * Data exported during device personalization.
  */
 // clang-format off
-#define STRUCT_MANUF_PERSO_DATA_OUT(field, string) \
+#define STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_OUT(field, string) \
     field(wrapped_rma_unlock_token, wrapped_rma_unlock_token_t)
-UJSON_SERDE_STRUCT(ManufPersoDataOut, \
-                   manuf_perso_data_out_t, \
-                   STRUCT_MANUF_PERSO_DATA_OUT);
+UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataOut, \
+                   manuf_rma_token_perso_data_out_t, \
+                   STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_OUT);
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -11,6 +11,9 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
+static_assert(kAttestationSeedWords <= 16,
+              "Additional attestation seed needs must be <= 516 bits.");
+
 OTBN_DECLARE_APP_SYMBOLS(boot);             // The OTBN boot-services app.
 OTBN_DECLARE_SYMBOL_ADDR(boot, mode);       // Application mode.
 OTBN_DECLARE_SYMBOL_ADDR(boot, rsa_mod);    // RSA modulus.

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -334,11 +334,10 @@ static status_t otp_partition_secret2_configure(
   return OK_STATUS();
 }
 
-status_t manuf_personalize_device_secrets(dif_flash_ctrl_state_t *flash_state,
-                                          const dif_lc_ctrl_t *lc_ctrl,
-                                          const dif_otp_ctrl_t *otp_ctrl,
-                                          manuf_perso_data_in_t *in_data,
-                                          manuf_perso_data_out_t *out_data) {
+status_t manuf_personalize_device_secrets(
+    dif_flash_ctrl_state_t *flash_state, const dif_lc_ctrl_t *lc_ctrl,
+    const dif_otp_ctrl_t *otp_ctrl, manuf_rma_token_perso_data_in_t *in_data,
+    manuf_rma_token_perso_data_out_t *out_data) {
   // Check life cycle in either PROD, PROD_END, or DEV.
   TRY(lc_ctrl_testutils_operational_state_check(lc_ctrl));
 

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -73,11 +73,10 @@ status_t manuf_personalize_device_secret1_check(const dif_otp_ctrl_t *otp_ctrl);
  * @param[out] out_data UJSON struct of data to export from the device.
  * @return OK_STATUS on success.
  */
-status_t manuf_personalize_device_secrets(dif_flash_ctrl_state_t *flash_state,
-                                          const dif_lc_ctrl_t *lc_ctrl,
-                                          const dif_otp_ctrl_t *otp_ctrl,
-                                          manuf_perso_data_in_t *in_data,
-                                          manuf_perso_data_out_t *out_data);
+status_t manuf_personalize_device_secrets(
+    dif_flash_ctrl_state_t *flash_state, const dif_lc_ctrl_t *lc_ctrl,
+    const dif_otp_ctrl_t *otp_ctrl, manuf_rma_token_perso_data_in_t *in_data,
+    manuf_rma_token_perso_data_out_t *out_data);
 
 /**
  * Checks the device personalization end state.

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -58,8 +58,8 @@ static void sw_reset(void) {
 }
 
 status_t export_data_over_console(ujson_t *uj,
-                                  manuf_perso_data_out_t *out_data) {
-  RESP_OK(ujson_serialize_manuf_perso_data_out_t, uj, out_data);
+                                  manuf_rma_token_perso_data_out_t *out_data) {
+  RESP_OK(ujson_serialize_manuf_rma_token_perso_data_out_t, uj, out_data);
   return OK_STATUS();
 }
 
@@ -95,8 +95,8 @@ bool test_main(void) {
   // retention SRAM (namely in the creator partition) as it is faster than
   // storing it in flash, and still persists across a SW initiated reset.
   retention_sram_t *ret_sram_data = retention_sram_get();
-  manuf_perso_data_out_t *out_data =
-      (manuf_perso_data_out_t *)&ret_sram_data->creator.reserved;
+  manuf_rma_token_perso_data_out_t *out_data =
+      (manuf_rma_token_perso_data_out_t *)&ret_sram_data->creator.reserved;
 
   dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
   if (info & kDifRstmgrResetInfoPor) {
@@ -117,8 +117,9 @@ bool test_main(void) {
       // Wait for host ECC pubkey, used to generate a shared AES key to export
       // the RMA unlock token, to arrive over the console.
       LOG_INFO("Ready to receive host ECC pubkey ...");
-      manuf_perso_data_in_t in_data;
-      CHECK_STATUS_OK(ujson_deserialize_manuf_perso_data_in_t(&uj, &in_data));
+      manuf_rma_token_perso_data_in_t in_data;
+      CHECK_STATUS_OK(
+          ujson_deserialize_manuf_rma_token_perso_data_in_t(&uj, &in_data));
 
       // Perform OTP and flash info writes.
       LOG_INFO("Provisioning OTP SECRET2 flash info pages 1, 2, & 4 ...");

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_2.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/ft_personalize_2.c
@@ -25,8 +25,8 @@ static dif_lc_ctrl_t lc_ctrl;
 static dif_otp_ctrl_t otp_ctrl;
 static dif_rstmgr_t rstmgr;
 
-static manuf_perso_data_in_t in_data;
-static manuf_perso_data_out_t out_data;
+static manuf_rma_token_perso_data_in_t in_data;
+static manuf_rma_token_perso_data_out_t out_data;
 
 /**
  * Initializes all DIF handles used in this program.
@@ -59,11 +59,11 @@ static void sw_reset(void) {
 static status_t personalize(ujson_t *uj) {
   if (!status_ok(manuf_personalize_device_secrets_check(&otp_ctrl))) {
     LOG_INFO("Waiting for FT provisioning data ...");
-    TRY(ujson_deserialize_manuf_perso_data_in_t(uj, &in_data));
+    TRY(ujson_deserialize_manuf_rma_token_perso_data_in_t(uj, &in_data));
     TRY(manuf_personalize_device_secrets(&flash_ctrl_state, &lc_ctrl, &otp_ctrl,
                                          &in_data, &out_data));
     LOG_INFO("Exporting FT provisioning data ...");
-    RESP_OK(ujson_serialize_manuf_perso_data_out_t, uj, &out_data);
+    RESP_OK(ujson_serialize_manuf_rma_token_perso_data_out_t, uj, &out_data);
     // We need to reset the chip here to activate the keymgr seeds.
     sw_reset();
   }

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -22,7 +22,7 @@ use opentitanlib::test_utils::load_sram_program::{
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
 use ujson_lib::provisioning_data::{
-    EccP256PublicKey, ManufFtIndividualizeData, ManufPersoDataIn, ManufPersoDataOut,
+    EccP256PublicKey, ManufFtIndividualizeData, ManufRmaTokenPersoDataIn, ManufRmaTokenPersoDataOut,
 };
 
 pub fn test_unlock(
@@ -189,7 +189,7 @@ pub fn run_ft_personalize(
         .collect::<ArrayVec<u32, 8>>();
     host_pk_x.reverse();
     host_pk_y.reverse();
-    let in_data = ManufPersoDataIn {
+    let in_data = ManufRmaTokenPersoDataIn {
         host_pk: EccP256PublicKey {
             x: host_pk_x,
             y: host_pk_y,
@@ -206,7 +206,7 @@ pub fn run_ft_personalize(
     // Wait until device exports provisioning data, including the wrapped RMA unlock token and
     // device certificates.
     let _ = UartConsole::wait_for(&*uart, r"Exporting FT provisioning data ...", timeout)?;
-    let out_data = ManufPersoDataOut::recv(&*uart, timeout, false)?;
+    let out_data = ManufRmaTokenPersoDataOut::recv(&*uart, timeout, false)?;
     // TODO(#19455): write the wrapped RMA unlock token to a file.
     log::info!("{:x?}", out_data);
     let _ = UartConsole::wait_for(&*uart, r"PASS.*\n", timeout)?;

--- a/sw/host/tests/manuf/personalize/src/main.rs
+++ b/sw/host/tests/manuf/personalize/src/main.rs
@@ -26,7 +26,7 @@ use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
 
 mod provisioning_data;
-use provisioning_data::{EccP256PublicKey, ManufPersoDataIn, ManufPersoDataOut};
+use provisioning_data::{EccP256PublicKey, ManufRmaTokenPersoDataIn, ManufRmaTokenPersoDataOut};
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -60,7 +60,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
         .collect::<ArrayVec<u32, 8>>();
     host_pk_x.reverse();
     host_pk_y.reverse();
-    let in_data = ManufPersoDataIn {
+    let in_data = ManufRmaTokenPersoDataIn {
         host_pk: EccP256PublicKey {
             x: host_pk_x,
             y: host_pk_y,
@@ -92,7 +92,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
 
     // Wait for output data to be transimitted over the console.
     let _ = UartConsole::wait_for(&*uart, r"Exporting RMA unlock token ...", opts.timeout)?;
-    let export_data = ManufPersoDataOut::recv(&*uart, opts.timeout, false)?;
+    let export_data = ManufRmaTokenPersoDataOut::recv(&*uart, opts.timeout, false)?;
     log::info!("{:x?}", export_data);
 
     // Load device-generated EC public key.


### PR DESCRIPTION
This updates the certificate personalization flow to write the attestation measurements for the desired ROM_EXT + Owner firmware transport image into the device over the ujson console. These measurements will be written to the SW binding registers prior to cranking the keymgr when generating the various attestation keys.

This partially addresses https://github.com/lowRISC/opentitan/issues/19455.

**Note: this depends on #20394, only review the last two commits.**