### PR TITLE
[sival] Update flash_ctrl_rma_test to use sival infra.

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -349,7 +349,7 @@ otp_json(
             items = {
                 # We aren't testing keymgr for ROM_EXT tests and we want
                 # reproducible bitstreams for all tests.
-                "RMA_TOKEN": "0000000000000005",
+                "RMA_TOKEN": "0x1faf9056acde66561685549803a28bec",
                 "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
                 "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
             },

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic/BUILD
@@ -103,13 +103,12 @@ otp_json(
                 "CREATOR_SW_CFG_DEFAULT_BOOT_DATA_IN_PROD_EN": otp_hex(CONST.HARDENED_TRUE),
                 # Enable AST initialization.
                 "CREATOR_SW_CFG_AST_INIT_EN": otp_hex(CONST.MUBI4_TRUE),
-                # TODO: This enables a busyloop in the ROM to give time to
-                # trigger an RMA lifecycle transition via JTAG.  The current
-                # value of 10 cycles is useful for test code which verifies
-                # the path through the ROM.  This value is not useful for a
-                # real chip.
+                # This enables a busyloop in the ROM to give time to
+                # trigger an RMA lifecycle transition via JTAG.
+                # TODO: The following value needs to be updated once we have an
+                # idea of how many cycles are needed to enter RMA.
                 "CREATOR_SW_CFG_RMA_SPIN_EN": otp_hex(CONST.HARDENED_TRUE),
-                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "10",
+                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": otp_hex(0x2000000),
                 # Entropy source health check default values. This needs to be
                 # populated when `CREATOR_SW_CFG_RNG_EN` is set to true.
                 "CREATOR_SW_CFG_RNG_REPCNT_THRESHOLDS": otp_hex(0xffffffff),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1298,52 +1298,15 @@ opentitan_test(
     ],
 )
 
-# Generate hard coded secret2 partition but unlocked.
-otp_json(
-    name = "otp_json_test_rma",
-    partitions = [
-        otp_partition(
-            name = "CREATOR_SW_CFG",
-            items = {
-                "CREATOR_SW_CFG_RMA_SPIN_EN": otp_hex(CONST.HARDENED_TRUE),
-                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0x2000000",
-            },
-        ),
-        otp_partition(
-            name = "SECRET2",
-            items = {
-                # This RMA token is a cSHAKE128 digest.
-                # Source is hardcoded to host test file.
-                "RMA_TOKEN": "0x1faf9056acde66561685549803a28bec",
-                "CREATOR_ROOT_KEY_SHARE0": "<random>",
-                "CREATOR_ROOT_KEY_SHARE1": "<random>",
-            },
-        ),
-    ],
-    visibility = ["//visibility:private"],
-)
-
-# rom exec is disabled to mitigate sram execution.
-# Without this, it will cause continuous watch dog timeout.
-# secret2 unlocked dev state is required to write secret to all necessary info partitions
-# (creator, owner and isolation partition)
-otp_image(
-    name = "img_dev_exec_disabled",
-    src = "//hw/ip/otp_ctrl/data:otp_json_dev",
-    overlays = STD_OTP_OVERLAYS + [
-        "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
-        ":otp_json_test_rma",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-# This test is fpga only.
 opentitan_test(
     name = "flash_ctrl_rma_test",
     srcs = ["flash_ctrl_rma_test.c"],
     cw310 = cw310_jtag_params(
-        otp = ":img_dev_exec_disabled",
-        tags = ["cw310_rom_with_fake_keys"],
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized",
+        tags = [
+            "fpga_cw310_sival",
+            "lc_dev",
+        ],
         test_cmd = " ".join([
             "--elf=\"{firmware}\"",
             " \"{firmware}\"",
@@ -1351,16 +1314,10 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/flash_ctrl:host_rma_test",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
-    # Test goes from Dev to RMA.
-    # So prod rsa key is required.
-    rsa_key = rsa_key_for_lc_state(
-        RSA_ONLY_KEY_STRUCTS,
-        CONST.LCV.PROD,
-    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",

--- a/sw/device/tests/flash_ctrl_rma_test.c
+++ b/sw/device/tests/flash_ctrl_rma_test.c
@@ -41,10 +41,9 @@ enum {
 };
 
 // Hardcoded secret data for flash info partition.
-static const uint32_t kRandomData[3] = {
+static const uint32_t kRandomData[2] = {
     0xbab0bab1,
     0xdeadbeef,
-    0xcafefeed,
 };
 
 static status_t write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
@@ -84,19 +83,17 @@ static status_t read_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
 }
 
 static status_t read_and_check_info(bool match) {
-  uint32_t readback_data[3];
-  read_info_page(&flash, kFlashInfoPageIdCreatorSecret, readback_data, true);
-  read_info_page(&flash, kFlashInfoPageIdOwnerSecret, readback_data + 1, true);
-  read_info_page(&flash, kFlashInfoPageIdIsoPart, readback_data + 2, true);
+  uint32_t readback_data[2];
+  read_info_page(&flash, kFlashInfoPageIdOwnerSecret, readback_data, true);
+  read_info_page(&flash, kFlashInfoPageIdIsoPart, readback_data + 1, true);
   LOG_INFO("readdata0: %x", *readback_data);
   LOG_INFO("readdata1: %x", *(readback_data + 1));
-  LOG_INFO("readdata2: %x", *(readback_data + 2));
   if (match) {
     // iso partition cannot be accessed in dev state.
-    // check create and owner partition only
-    CHECK_ARRAYS_EQ(readback_data, kRandomData, 2);
+    // check owner partition only
+    CHECK_ARRAYS_EQ(readback_data, kRandomData, 1);
   } else {
-    CHECK_ARRAYS_NE(readback_data, kRandomData, 3);
+    CHECK_ARRAYS_NE(readback_data, kRandomData, 2);
   }
   LOG_INFO("read_and_check is done");
   return OK_STATUS();
@@ -124,10 +121,8 @@ bool sram_main(void) {
   switch (kTestPhase) {
     case kTestPhase0:
       LOG_INFO("testphase0");
-      write_info_page(&flash, kFlashInfoPageIdCreatorSecret, kRandomData, true);
-      write_info_page(&flash, kFlashInfoPageIdOwnerSecret, kRandomData + 1,
-                      true);
-      write_info_page(&flash, kFlashInfoPageIdIsoPart, kRandomData + 2, true);
+      write_info_page(&flash, kFlashInfoPageIdOwnerSecret, kRandomData, true);
+      write_info_page(&flash, kFlashInfoPageIdIsoPart, kRandomData + 1, true);
       read_and_check_info(true);
 
       // After update info partition in flash,


### PR DESCRIPTION
The following changes were made:

1. Use `//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized` to emulate the configuration of a DEV part. DEV parts will be distributed in personalized state.
2. Update `flash_ctrl_rma_test` to skip writing to the creator info page partition. This partition is not available in personalized mode.
3. Force bootstrap before connecting to `rv_dm`. This is to avoid triggering the watchdog during SRAM code execution. The ROM disables the watchdog in bootstrap mode.
4. Update the SiVal `SECRET2` configuration to use a known RMA unlock token.
5. Update exec_env to use `fpga_cw310_sival`. This exec_env is ok to use in this case because the device is in DEV state and code execution is done via SRAM.