### PR TITLE
[sval] Remove prebuilt-sival bitstreams.

### DIFF
--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -133,28 +133,6 @@ bitstream_splice(
     for authenticity in KEY_AUTHENTICITY
 ]
 
-# TODO(#20231): Remove once support for new splicing infrastructure is
-# available.
-[
-    bitstream_splice(
-        name = "rom_with_{}_keys_otp_{}".format(authenticity, otp_name),
-        testonly = True,
-        src = ":rom_with_{}_keys".format(authenticity),
-        data = img_target,
-        meminfo = ":otp_mmi",
-        tags = ["manual"],
-        update_usr_access = True,
-    )
-    for (otp_name, img_target) in [
-        ("sival_test_locked0", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_post_cp_test_locked0"),
-        ("sival_prod_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized"),
-        ("sival_prod_end_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_end_personalized"),
-        ("sival_dev_individualized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_individualized"),
-        ("sival_dev_personalized", "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_personalized"),
-    ]
-    for authenticity in KEY_AUTHENTICITY
-]
-
 # Create manifest fragments for all the cached bitstreams
 bitstream_fragment_from_manifest(
     name = "chip_earlgrey_cw310_cached_fragment",

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -123,9 +123,8 @@ fpga_cw310(
     name = "fpga_cw310_sival",
     testonly = True,
     base = ":fpga_cw310_rom_with_fake_keys",
-    # TODO(cfrantz): remove in favor of the OTP config.
-    base_bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_prod_personalized",
     exec_env = "fpga_cw310_sival",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized",
 
     # PROD keys are allowed to run across all life cycle stages. This prod key
     # is used to enable execution across life cycle stages with a single
@@ -139,9 +138,8 @@ fpga_cw310(
     name = "fpga_cw310_sival_rom_ext",
     testonly = True,
     base = ":fpga_cw310_rom_ext",
-    # TODO(cfrantz): remove in favor of the OTP config.
-    base_bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_prod_personalized",
     exec_env = "fpga_cw310_sival_rom_ext",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_sival_prod_signed_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
 )

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -230,9 +230,12 @@ opentitan_test(
     name = "personalize_functest",
     srcs = ["personalize_functest.c"],
     cw310 = cw310_jtag_params(
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_dev_individualized",
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
-        tags = ["manuf"],
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_individualized",
+        tags = [
+            "lc_dev",
+            "manuf",
+        ],
         test_cmd = """
             --bootstrap={firmware}
             --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
@@ -240,7 +243,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/manuf/personalize",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
     },
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0": "dev_key_0"},
     deps = [

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -208,9 +208,12 @@ opentitan_test(
             ":sram_ft_individualize": "sram_ft_individualize",
             ":ft_personalize_2": "ft_personalize_2",
         },
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_test_locked0",
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
-        tags = ["manuf"],
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_post_cp_test_locked0",
+        tags = [
+            "lc_test_locked0",
+            "manuf",
+        ],
         test_cmd = """
             --elf={sram_ft_individualize}
             --bootstrap={firmware}
@@ -221,7 +224,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/manuf/provisioning/ft",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
     },
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1219,7 +1219,7 @@ test_suite(
         name = "flash_ctrl_info_access_lc_{}_personalized".format(lc_state),
         srcs = ["flash_ctrl_info_access_lc.c"],
         cw310 = new_cw310_params(
-            bitstream = "//hw/bitstream:rom_with_fake_keys_otp_sival_{}_personalized".format(lc_state),
+            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_{}_personalized".format(lc_state),
         ),
         dv = new_dv_params(
             otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_{}_personalized".format(lc_state),


### PR DESCRIPTION
Update test targets using sival OTP dependencies to use the new universal bitstream flow. The universal bitstream flow relies on Bazel to maintain a cache of bitstreams built with different `rom` and `otp` images.