### PR TITLE
[ci] Update Vivado to 2021.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   TOOLCHAIN_VERSION: 20220210-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.2"
+  VIVADO_VERSION: "2021.1"
 
 trigger:
   batch: true

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -28,7 +28,7 @@ variables:
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.2"
+  VIVADO_VERSION: "2021.1"
 
 jobs:
 - job: checkout

--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -29,7 +29,7 @@ variables:
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.2"
+  VIVADO_VERSION: "2021.1"
 
 jobs:
 - job: checkout

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -38,7 +38,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'vivado': {
-        'min_version': '2020.2',
+        'min_version': '2021.1',
         'as_needed': True
     },
 }


### PR DESCRIPTION
This PR updates the Vivado version we use in CI from 2020.2 to 2021.1.

We're seeing some issues with the CW340 bitstream in 2020.2. CI does have licenses for 2021.1, so perhaps this version will fix the issue.

I have left the minimum Vivado version requirement in [tool_requirements.py](https://github.com/lowRISC/opentitan/blob/master/tool_requirements.py), but perhaps we should keep this up to date with the CI version to ensure some guarantee of support.
**EDIT**: this is now updated.