### PR TITLE
[sival, spi_host] chip_sw_spi_host_tx_rx

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -29,6 +29,10 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_sw_spi_host_tx_rx"]
+      bazel: [
+        "//sw/device/tests:spi_host_winbond_flash_test_fpga_cw310_rom_with_fake_keys",
+        "//sw/device/tests/pmod:spi_host_macronix_flash_test_fpga_cw310_rom_with_fake_keys"
+      ]
     }
     {
       name: chip_sw_spi_host_pass_through

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2285,6 +2285,7 @@ opentitan_test(
     name = "spi_host_winbond_flash_test",
     srcs = ["spi_host_winbond_flash_test.c"],
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -20,6 +20,7 @@ opentitan_test(
         ],  # Requires the BoB in CI.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [


### PR DESCRIPTION
This PR only links the spi_flash tests to the spi_host_tx_rx test in the testplan.

Fix https://github.com/lowRISC/opentitan/issues/19842