### PR TITLE
[chip-level/sival] Change comment for configure entropy complex function

### DIFF
--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -215,8 +215,7 @@ static void ibex_task(void *task_parameters) {
 }
 
 /**
- * Verifies that the entropy req interrupt is triggered on EDN instantiate and
- * reseed commands.
+ * Configures the entropy complex and starts both EDNs in auto mode.
  */
 static void entropy_config(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());


### PR DESCRIPTION
This commit changes the comment describing a function that configures the entropy complex and starts both EDNs in auto mode.

This PR resolves #20054.