### PR TITLE
[bazel] make tests runnable with `bazel run`

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -81,7 +81,7 @@ fpga_cw310(
         --exec="transport init"
         --exec="fpga load-bitstream {bitstream}"
         --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
 )
@@ -205,7 +205,7 @@ fpga_cw340(
     test_cmd = """
         --exec="fpga load-bitstream {bitstream}"
         --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
 )
@@ -236,7 +236,7 @@ silicon(
     test_cmd = """
         --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
 )
@@ -282,7 +282,7 @@ sim_verilator(
     },
     rom = "//sw/device/lib/testing/test_rom:test_rom",
     test_cmd = """
-        --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op
     """,
 )

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -235,7 +235,7 @@ def fpga_params(
             "--exec=\"transport init\"",
             "--exec=\"fpga load-bitstream $(location {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(location {flash})\"",
-            "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
+            "--exec=\"console --non-interactive --exit-success={exit_success} --exit-failure={exit_failure}\"",
             "{clear_bitstream}",
         ],
         # CW-specific Parameters

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -333,7 +333,7 @@ opentitan_test(
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
+            --exec="console --non-interactive --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console
             --flow-control
             --send="{flow_control_message}\n"
@@ -348,7 +348,7 @@ opentitan_test(
     verilator = verilator_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """
-            --exec "console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
+            --exec "console --non-interactive --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console
             --flow-control
             --send="{flow_control_message}\n"

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -438,7 +438,7 @@ opentitan_functest(
             "--exec=\"transport init\"",
             "--exec=\"fpga load-bitstream $(rootpath {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(rootpath {flash})\"",
-            "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
+            "--exec=\"console --non-interactive --exit-success={exit_success} --exit-failure={exit_failure}\"",
             # We clear the bitstream to force any subsequent test to load a
             # fresh bitstream and clear all memories (ie: flash-based boot policy).
             "--exec=\"fpga clear-bitstream\"",

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -78,7 +78,7 @@ otp_json(
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 --exec="fpga clear-bitstream"
                 no-op
             """,

--- a/sw/device/silicon_creator/rom/e2e/weak_straps/gpio.bzl
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/gpio.bzl
@@ -46,7 +46,7 @@ def strap_combination(strap):
 def strap_combination_test(name, rom, value, evaluator = None, tags = [], extra_verilator_args = ""):
     settings = strap_combination(value)
     if evaluator == None:
-        evaluator = "console --exit-success=\"{pass}\" --exit-failure=\"{fail}\""
+        evaluator = "console --non-interactive --exit-success=\"{pass}\" --exit-failure=\"{fail}\""
     settings["evaluator"] = evaluator.format(**settings)
 
     opentitan_test(


### PR DESCRIPTION
Currently if you try to run tests with `bazel run`, you'll end up in a state where the execution doesn't stop and you can't use Ctrl-C to kill it.

It turns out it's due to we use `console` command in OT-tool which, when stdin is TTY, switch it to raw mode and forward stdin to FPGA uart. This is useful for debugging but not what we want for the tests.

So instead, pipe /dev/null to stdin and make `bazel run` consistent with `bazel test` for OT tests.