### PR TITLE
[opentitanlib] Fix up instance names and ensure TAP straps have default values

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -78,8 +78,8 @@ fpga_cw310(
     rom = "//sw/device/lib/testing/test_rom:test_rom",
     rom_mmi = "//hw/bitstream:rom_mmi",
     test_cmd = """
-        --exec="fpga load-bitstream {bitstream}"
         --exec="transport init"
+        --exec="fpga load-bitstream {bitstream}"
         --exec="bootstrap --clear-uart=true {firmware}"
         --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
         no-op

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -232,8 +232,8 @@ def fpga_params(
         tags = _BASE_PARAMS["tags"],
         test_runner = _BASE_PARAMS["test_runner"],
         test_cmds = [
-            "--exec=\"fpga load-bitstream $(location {bitstream})\"",
             "--exec=\"transport init\"",
+            "--exec=\"fpga load-bitstream $(location {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(location {flash})\"",
             "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
             "{clear_bitstream}",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -330,8 +330,8 @@ opentitan_test(
     cw310 = cw310_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """
-            --exec="fpga load-bitstream {bitstream}"
             --exec="transport init"
+            --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --quiet --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -435,8 +435,8 @@ opentitan_functest(
         exit_failure = "(min_security_version_rom_ext:[^01])|(FAIL)|((min_security_version_rom_ext:0(?s:.*)){2,})|(PASS)",
         exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         test_cmds = [
-            "--exec=\"fpga load-bitstream $(rootpath {bitstream})\"",
             "--exec=\"transport init\"",
+            "--exec=\"fpga load-bitstream $(rootpath {bitstream})\"",
             "--exec=\"bootstrap --clear-uart=true $(rootpath {flash})\"",
             "--exec=\"console --exit-success={exit_success} --exit-failure={exit_failure}\"",
             # We clear the bitstream to force any subsequent test to load a

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -74,9 +74,9 @@ otp_json(
             otp = ":otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
             test_cmd = """
+                --exec="transport init"
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
-                --exec="transport init"
                 --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 --exec="fpga clear-bitstream"

--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -27,10 +27,16 @@
     },
     {
       "name": "TAP_STRAP0",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
       "alias_of": "IOC8"
     },
     {
       "name": "TAP_STRAP1",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
       "alias_of": "IOC5"
     }
   ],

--- a/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_yield_test/src/main.rs
@@ -97,7 +97,6 @@ fn manuf_cp_yield_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
 fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
-    opts.init.init_target()?;
     let transport = opts.init.init_target()?;
 
     execute_test!(manuf_cp_yield_test, &opts, &transport);

--- a/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_disabled/src/main.rs
@@ -48,7 +48,7 @@ fn test_bootstrap_disabled_requested(opts: &Opts, transport: &TransportWrapper) 
     };
     // Now check whether the SPI device is responding to status messages
     log::info!("Issuing SPI READ_STATUS");
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
     Ok(())
 }
@@ -77,7 +77,7 @@ fn test_bootstrap_disabled_not_requested(opts: &Opts, transport: &TransportWrapp
     };
     // Now check whether the SPI device is responding to status messages
     log::info!("Issuing SPI READ_STATUS");
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0xFF);
     Ok(())
 }

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -66,7 +66,7 @@ impl<'a> BootstrapTest<'a> {
         };
         transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
         transport.reset_target(b.reset_delay, true)?;
-        let spi = transport.spi("0").unwrap();
+        let spi = transport.spi("BOOTSTRAP").unwrap();
         SpiFlash::from_spi(&*spi)
             .unwrap()
             .chip_erase(&*spi)
@@ -81,7 +81,7 @@ impl<'a> Drop for BootstrapTest<'a> {
         let bootstrapping = self.transport.pin_strapping("ROM_BOOTSTRAP").unwrap();
         bootstrapping.apply().unwrap();
         self.transport.reset_target(self.reset_delay, true).unwrap();
-        let spi = self.transport.spi("0").unwrap();
+        let spi = self.transport.spi("BOOTSTRAP").unwrap();
         SpiFlash::from_spi(&*spi)
             .unwrap()
             .chip_erase(&*spi)
@@ -114,7 +114,7 @@ fn test_bootstrap_enabled_requested(opts: &Opts, transport: &TransportWrapper) -
         bail!("FAIL: {:?}", result);
     };
     // Now check whether the SPI device is responding to status messages
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x00);
 
     Ok(())
@@ -144,7 +144,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
     // Note: CIPO line is in high-z state when CMD_INFO registers are not configured.
     // Use READ_SFDP instead of READ_STATUS to avoid false negatives when bootstrap is not
     // requested
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     assert!(matches!(
         SpiFlash::read_sfdp(&*spi)
             .unwrap_err()
@@ -158,7 +158,7 @@ fn test_bootstrap_enabled_not_requested(opts: &Opts, transport: &TransportWrappe
 fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let id = SpiFlash::read_jedec_id(&*spi, 16)?;
     log::info!("Read jedec id: {:x?}", id);
     let mut index = 0;
@@ -180,7 +180,7 @@ fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
 
     assert_eq!(SpiFlash::read_status(&*spi)?, 0x0);
 
@@ -196,7 +196,7 @@ fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Resul
 fn test_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let sfdp = SpiFlash::read_sfdp(&*spi)?;
     log::info!("SFDP: {:#x?}", sfdp);
 
@@ -297,7 +297,7 @@ fn test_bootstrap_shutdown(
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(2, 0)),
@@ -335,7 +335,7 @@ fn test_bootstrap_shutdown(
 fn test_bootstrap_phase1_reset(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     // RESET should be ignored and we should not see any messages.
     let mut console = UartConsole {
@@ -357,7 +357,7 @@ fn test_bootstrap_phase1_reset(opts: &Opts, transport: &TransportWrapper) -> Res
 fn test_bootstrap_phase1_page_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -390,7 +390,7 @@ fn test_bootstrap_phase1_erase(
     erase_cmd: u8,
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let mut console = UartConsole {
@@ -438,7 +438,7 @@ fn test_bootstrap_phase1_erase(
 
 fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -475,7 +475,7 @@ fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Resu
 fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
 
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
@@ -508,7 +508,7 @@ fn test_bootstrap_phase2_reset(opts: &Opts, transport: &TransportWrapper) -> Res
 
 fn test_bootstrap_phase2_page_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     SpiFlash::from_spi(&*spi)?
         // Send CHIP_ERASE to transition to phase 2.
@@ -539,7 +539,7 @@ fn test_bootstrap_phase2_erase(
     erase_cmd: u8,
 ) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let spiflash = SpiFlash::from_spi(&*spi)?;
     let erase = || match erase_cmd {
@@ -575,7 +575,7 @@ fn test_bootstrap_phase2_erase(
 
 fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
     let uart = transport.uart("console")?;
     let mut read_buf = [0u8; 8];
 
@@ -609,8 +609,8 @@ fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Resu
 
 fn test_bootstrap_watchdog_check(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let _bs = BootstrapTest::start(transport, opts.init.bootstrap.options.reset_delay)?;
-    let spi = transport.spi("0")?;
-    let uart = transport.uart("0")?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let uart = transport.uart("console")?;
     let mut console = UartConsole {
         timeout: Some(Duration::new(2, 0)),
         exit_success: Some(Regex::new(r".+")?),


### PR DESCRIPTION
Fix up IDs for UART and SPI instances. Some tests were still using "0" as the identifier for UART and SPI devices, but these are not supported across all transports. The correct identifiers are "console" for the UART console and "BOOTSTRAP" for Earl Grey's spi_device IP. The transport will convert these to the correct internal devices that interface with them.

Adjust FPGA flows to perform transport init before FPGA programming. Because the FPGA programming flow interacts with any currently-loaded OpenTitan, the host transport must be set up correctly first.

Ensure TAP straps have default values. The TAP straps should default to setting OT to have no TAP selected. Change the configs to reflect this.