### PR TITLE
[manuf] add silicon exec_env to CP provisioning program

### DIFF
--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -7,12 +7,19 @@ OPENTITANTOOL_OPENOCD_DATA_DEPS = [
     "//third_party/openocd:openocd_bin",
 ]
 
-OPENTITANTOOL_OPENOCD_SI_TEST_CMD = """
+OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS = [
+    "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+    "//third_party/openocd:openocd_bin",
+]
+
+OPENTITANTOOL_OPENOCD_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
     --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_olimex_cfg)"
-"""
-
-OPENTITANTOOL_OPENOCD_TEST_CMD = OPENTITANTOOL_OPENOCD_SI_TEST_CMD + """
     --clear-bitstream
     --bitstream={bitstream}
+"""
+
+OPENTITANTOOL_OPENOCD_CMSIS_SI_TEST_CMD = """
+    --openocd="$(rootpath //third_party/openocd:openocd_bin)"
+    --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_cmsis_dap_adapter_cfg)"
 """

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -20,8 +20,8 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:openocd.bzl",
-    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
-    "OPENTITANTOOL_OPENOCD_SI_TEST_CMD",
+    "OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS",
+    "OPENTITANTOOL_OPENOCD_CMSIS_SI_TEST_CMD",
 )
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
@@ -212,7 +212,7 @@ def silicon_jtag_params(
         rom_ext = rom_ext,
         otp = None,
         bitstream = None,
-        test_cmd = OPENTITANTOOL_OPENOCD_SI_TEST_CMD + test_cmd,
-        data = OPENTITANTOOL_OPENOCD_DATA_DEPS + data,
+        test_cmd = OPENTITANTOOL_OPENOCD_CMSIS_SI_TEST_CMD + test_cmd,
+        data = OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS + data,
         param = kwargs,
     )

--- a/sw/device/silicon_creator/manuf/lib/otp_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/otp_fields.h
@@ -41,12 +41,16 @@ enum {
   kSecret0TestUnlockTokenOffset =
       OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_OFFSET - OTP_CTRL_PARAM_SECRET0_OFFSET,
   kSecret0TestUnlockTokenSizeInBytes = OTP_CTRL_PARAM_TEST_UNLOCK_TOKEN_SIZE,
+  kSecret0TestUnlockTokenSizeIn32BitWords =
+      kSecret0TestUnlockTokenSizeInBytes / sizeof(uint32_t),
   kSecret0TestUnlockTokenSizeIn64BitWords =
       kSecret0TestUnlockTokenSizeInBytes / sizeof(uint64_t),
 
   kSecret0TestExitTokenOffset =
       OTP_CTRL_PARAM_TEST_EXIT_TOKEN_OFFSET - OTP_CTRL_PARAM_SECRET0_OFFSET,
   kSecret0TestExitTokenSizeInBytes = OTP_CTRL_PARAM_TEST_EXIT_TOKEN_SIZE,
+  kSecret0TestExitTokenSizeIn32BitWords =
+      kSecret0TestExitTokenSizeInBytes / sizeof(uint32_t),
   kSecret0TestExitTokenSizeIn64BitWords =
       kSecret0TestExitTokenSizeInBytes / sizeof(uint64_t),
 

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -13,6 +13,7 @@ load(
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
+    "silicon_jtag_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -29,6 +30,7 @@ opentitan_binary(
     srcs = ["sram_cp_provision.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -111,7 +113,18 @@ opentitan_test(
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
+    silicon = silicon_jtag_params(
+        binaries = {
+            ":sram_cp_provision": "sram_cp_provision",
+        },
+        interface = "hyper310",
+        test_cmd = """
+            --elf={sram_cp_provision}
+        """,
+        test_harness = "//sw/host/tests/manuf/provisioning/cp",
+    ),
 )
 
 opentitan_test(

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/sram_cp_provision.c
@@ -116,6 +116,23 @@ static status_t wafer_auth_secret_flash_info_page_write(
   return OK_STATUS();
 }
 
+static status_t print_tokens_to_console(
+    manuf_cp_provisioning_data_t *provisioning_data) {
+  LOG_INFO("Device ID:");
+  for (size_t i = 0; i < kHwCfgDeviceIdSizeIn32BitWords; ++i) {
+    LOG_INFO("0x%x", provisioning_data->device_id[i]);
+  }
+  LOG_INFO("Test Unlock Token:");
+  for (size_t i = 0; i < kSecret0TestUnlockTokenSizeIn32BitWords; ++i) {
+    LOG_INFO("0x%x", provisioning_data->test_unlock_token[i]);
+  }
+  LOG_INFO("Test Exit Token:");
+  for (size_t i = 0; i < kSecret0TestExitTokenSizeIn32BitWords; ++i) {
+    LOG_INFO("0x%x", provisioning_data->test_exit_token[i]);
+  }
+  return OK_STATUS();
+}
+
 /**
  * Provision flash info pages 0 and 3, and OTP Secret0 partition.
  */
@@ -123,6 +140,7 @@ static status_t provision(ujson_t *uj) {
   LOG_INFO("Waiting for CP provisioning data ...");
   manuf_cp_provisioning_data_t provisioning_data;
   TRY(ujson_deserialize_manuf_cp_provisioning_data_t(uj, &provisioning_data));
+  TRY(print_tokens_to_console(&provisioning_data));
   TRY(device_id_and_manuf_state_flash_info_page_erase(&provisioning_data));
   TRY(wafer_auth_secret_flash_info_page_erase(&provisioning_data));
   TRY(device_id_and_manuf_state_flash_info_page_write(&provisioning_data));

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -235,6 +235,7 @@ cc_library(
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
         silicon = silicon_jtag_params(
+            interface = "hyper310",
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
         ),


### PR DESCRIPTION
This enables the CP provisioning program to run on the silicon target. The CP provisioning binary is also updated to print the device ID and test unlock tokens provisioned to the console so they can be tracked / saved. This prepares the CP provisioning program to be on silicon targets.