### PR TITLE
[test] Restore ability to add --test_arg

### DIFF
--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -36,8 +36,8 @@ _TEST_SCRIPT = """#!/bin/bash
 set -e
 
 TEST_CMD=({test_cmd})
-echo Invoking test: {test_harness} {args} "${{TEST_CMD[@]}}"
-RUST_BACKTRACE=1 {test_harness} {args} "${{TEST_CMD[@]}}"
+echo Invoking test: {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+RUST_BACKTRACE=1 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
 """
 
 def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -29,8 +29,8 @@ _TEST_SCRIPT = """#!/bin/bash
 set -e
 
 TEST_CMD=({test_cmd})
-echo Invoking test: {test_harness} {args} "${{TEST_CMD[@]}}"
-RUST_BACKTRACE=1 {test_harness} {args} "${{TEST_CMD[@]}}"
+echo Invoking test: {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+RUST_BACKTRACE=1 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
 """
 
 def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -26,7 +26,7 @@ set -e
 readonly DVSIM="util/dvsim/dvsim.py"
 TEST_CMD=({test_cmd})
 echo "At this time, dvsim.py must be run manually (after building SW) via:
-${{DVSIM}} {args} ${{TEST_CMD[@]}}"
+${{DVSIM}} {args} $@ ${{TEST_CMD[@]}}"
 """
 
 def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -22,8 +22,8 @@ _TEST_SCRIPT = """#!/bin/bash
 set -e
 
 TEST_CMD=({test_cmd})
-echo Invoking test: {test_harness} {args} "${{TEST_CMD[@]}}"
-RUST_BACKTRACE=1 {test_harness} {args} "${{TEST_CMD[@]}}"
+echo Invoking test: {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+RUST_BACKTRACE=1 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
 """
 
 def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):


### PR DESCRIPTION
Restore the ability to apply --test_arg to opentitan_test invocations. This is especially useful for extracting waves from Verilator simulations.