### PR TITLE
[chip, darjeeling, clkmgr, rstmgr] clkmgr rstmgr wdog fix

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1344,13 +1344,14 @@
       sw_images: ["//sw/device/tests:plic_sw_irq_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_clkmgr_off_peri
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:clkmgr_off_peri_test:6"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=30_000_000"]
-    }
+// Refactor test to remove flash dependency
+//    {
+//      name: chip_sw_clkmgr_off_peri
+//      uvm_test_seq: chip_sw_base_vseq
+//      sw_images: ["//sw/device/tests:clkmgr_off_peri_test:6"]
+//      en_run_modes: ["sw_test_mode_test_rom"]
+//      run_opts: ["+sw_test_timeout_ns=30_000_000"]
+//    }
     {
       name: chip_sw_clkmgr_off_aes_trans
       uvm_test_seq: chip_sw_base_vseq

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -93,7 +93,7 @@ static void test_gateable_clocks_off(const dif_clkmgr_t *clkmgr,
       dif_clkmgr_gateable_clock_set_enabled(clkmgr, clock, kDifToggleEnabled));
   // Enable watchdog bite reset.
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifPwrmgrResetRequestSourceOne,
                                               kDifToggleEnabled));
   LOG_INFO("Testing peripheral clock %d", clock);
 

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -161,7 +161,7 @@ bool execute_off_trans_test(dif_clkmgr_hintable_clock_t clock) {
   if (UNWRAP(rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor))) {
     // Enable watchdog bite reset.
     CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                                kDifPwrmgrResetRequestSourceTwo,
+                                                kDifPwrmgrResetRequestSourceOne,
                                                 kDifToggleEnabled));
     CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
 

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -193,7 +193,7 @@ static test_alert_info_t kExpectedInfo[kRoundTotal] = {
             .test_name = "Single class(ClassA)",
             .alert_info =
                 {
-                    .class_accum_cnt = {3, 0, 0, 0},
+                    .class_accum_cnt = {1, 0, 0, 0},  // Single i2c fatal alert
                     .class_esc_state = {kCstatePhase0, kCstateIdle, kCstateIdle,
                                         kCstateIdle},
                 },
@@ -203,7 +203,7 @@ static test_alert_info_t kExpectedInfo[kRoundTotal] = {
             .test_name = "Multi classes(ClassB,C)",
             .alert_info =
                 {
-                    .class_accum_cnt = {0, 1, 4, 0},
+                    .class_accum_cnt = {0, 1, 1, 0},  // otp and uart
                     .class_esc_state = {kCstateIdle, kCstatePhase1,
                                         kCstatePhase0, kCstateIdle},
                 },
@@ -524,7 +524,7 @@ static void peripheral_init(void) {
 
   // Set pwrmgr reset_en
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifPwrmgrResetRequestSourceOne,
                                               kDifToggleEnabled));
 }
 


### PR DESCRIPTION
Follwing tests are fixed.

- clkmgr_off_peri_test.c   // It is disabled from chip_sim_cfg due to flash dependency.
- clkmgr_off_trans_impl.c
- rstmgr_alert_info_test.c