### PR TITLE
[rv_dm] Implement nextdm register

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
@@ -21,6 +21,7 @@ typedef class jtag_dmi_reg_hartinfo;
 typedef class jtag_dmi_reg_haltsum1;
 typedef class jtag_dmi_reg_abstractcs;
 typedef class jtag_dmi_reg_command;
+typedef class jtag_dmi_reg_nextdm;
 typedef class jtag_dmi_reg_abstractauto;
 typedef class jtag_dmi_reg_progbuf;
 typedef class jtag_dmi_reg_haltsum2;
@@ -805,6 +806,38 @@ class jtag_dmi_reg_command extends dv_base_reg;
   endfunction : build
 endclass : jtag_dmi_reg_command
 
+class jtag_dmi_reg_nextdm extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field address;
+
+  `uvm_object_utils(jtag_dmi_reg_nextdm)
+
+  function new(string       name = "jtag_dmi_reg_nextdm",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build(csr_excl_item csr_excl = null);
+    // create fields
+    address = (dv_base_reg_field::
+               type_id::create("address"));
+    address.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(0));
+
+    address.set_original_access("RO");
+
+  endfunction : build
+endclass : jtag_dmi_reg_nextdm
+
 class jtag_dmi_reg_abstractauto extends dv_base_reg;
   // fields
   rand dv_base_reg_field autoexecdata;
@@ -1519,6 +1552,7 @@ class jtag_dmi_reg_block extends dv_base_reg_block;
   rand jtag_dmi_reg_haltsum1 haltsum1;
   rand jtag_dmi_reg_abstractcs abstractcs;
   rand jtag_dmi_reg_command command;
+  rand jtag_dmi_reg_nextdm nextdm;
   rand jtag_dmi_reg_abstractauto abstractauto;
   rand jtag_dmi_reg_progbuf progbuf[16];
   rand jtag_dmi_reg_haltsum2 haltsum2;
@@ -1679,6 +1713,13 @@ class jtag_dmi_reg_block extends dv_base_reg_block;
     command.build(csr_excl);
     default_map.add_reg(.rg(command),
                         .offset(32'h17));
+
+    nextdm = (jtag_dmi_reg_nextdm::
+              type_id::create("nextdm"));
+    nextdm.configure(.blk_parent(this));
+    nextdm.build(csr_excl);
+    default_map.add_reg(.rg(nextdm),
+                        .offset(32'h1d));
 
     abstractauto = (jtag_dmi_reg_abstractauto::
                     type_id::create("abstractauto"));

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -37,6 +37,16 @@
       desc:    "Number of hardware threads in the system."
       local:   "true"
     },
+    { name:    "NextDmAddr",
+      type:    "logic [31:0]",
+      default: "'0",
+      desc:    '''
+               32bit word address of the next debug module.
+               Set to 0x0 if this is the last debug module in the chain.,
+               '''
+      local:   "false",
+      expose:  "true"
+    },
   ]
   interrupt_list: [
   ],

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -15,7 +15,8 @@
 module rv_dm
   import rv_dm_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter logic [31:0]          NextDmAddr   = '0
 ) (
   input  logic                clk_i,       // clock
   input  logic                rst_ni,      // asynchronous reset active low, connect PoR
@@ -406,7 +407,8 @@ module rv_dm
     // However, we require that the DM can be placed at arbitrary offsets in the system, which
     // requires the generalized debug ROM implementation and two scratch registers. We hence set
     // this parameter to a non-zero value (inside dm_mem, this just feeds into a comparison with 0).
-    .DmBaseAddress  (1)
+    .DmBaseAddress  (1),
+    .NextDmAddr     (NextDmAddr)
   ) u_dm_top (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4231,7 +4231,22 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: NextDmAddr
+          desc:
+            '''
+            32bit word address of the next debug module.
+            Set to 0x0 if this is the last debug module in the chain.,
+            '''
+          type: logic [31:0]
+          default: "'0"
+          expose: "true"
+          name_top: RvDmNextDmAddr
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -48,6 +48,7 @@ module top_darjeeling #(
   // parameters for sram_ctrl_ret_aon
   parameter bit SramCtrlRetAonInstrExec = 0,
   // parameters for rv_dm
+  parameter logic [31:0] RvDmNextDmAddr = '0,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,
@@ -1645,7 +1646,8 @@ module top_darjeeling #(
       .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   rv_dm #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[53:53])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[53:53]),
+    .NextDmAddr(RvDmNextDmAddr)
   ) u_rv_dm (
       // [53]: fatal_fault
       .alert_tx_o  ( alert_tx[53:53] ),

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Fix-lint-errors.patch
@@ -1,7 +1,7 @@
 From aa62d018f46ee0c811045789ac5165521783c9fd Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:28:07 -0700
-Subject: [PATCH 1/4] Fix lint errors
+Subject: [PATCH 1/5] Fix lint errors
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Add-access-error-signal-to-dm_mem.patch
@@ -1,7 +1,7 @@
 From 0fa994dd7783812dd42a7bd6c32f6ca3715723ca Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 19:38:49 -0700
-Subject: [PATCH 2/4] Add access error signal to dm_mem
+Subject: [PATCH 2/5] Add access error signal to dm_mem
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,7 +1,7 @@
 From cb348aa5f31dbf24946f2fd45a9daa27960b231c Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@google.com>
 Date: Tue, 25 Oct 2022 18:27:27 -0700
-Subject: [PATCH 3/4] Use lowrisc instead of PULP primitives
+Subject: [PATCH 3/5] Use lowrisc instead of PULP primitives
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0004-Extend-DMI-address-width.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0004-Extend-DMI-address-width.patch
@@ -1,7 +1,7 @@
 From f2287d1540014435c0ab612fbf69ec5155acc333 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Thu, 17 Aug 2023 10:30:17 -0700
-Subject: [PATCH 4/4] Extend DMI address width
+Subject: [PATCH 4/5] Extend DMI address width
 
 Make the DMI interface address 32bits so that larger
 address ranges can be supported (e.g. to take advantage

--- a/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
@@ -1,0 +1,68 @@
+From f6b2619166ce631d1208fe951249e4e7b341e2fb Mon Sep 17 00:00:00 2001
+From: Michael Schaffner <msf@opentitan.org>
+Date: Tue, 21 Nov 2023 19:40:16 -0800
+Subject: [PATCH 5/5] [dm_csrs] Implement nextdm register
+
+Signed-off-by: Michael Schaffner <msf@opentitan.org>
+
+diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
+index b899b17..f3aa721 100644
+--- a/src/dm_csrs.sv
++++ b/src/dm_csrs.sv
+@@ -18,7 +18,8 @@
+ module dm_csrs #(
+   parameter int unsigned        NrHarts          = 1,
+   parameter int unsigned        BusWidth         = 32,
+-  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
++  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
++  parameter logic [31:0]        NextDmAddr       = '0
+ ) (
+   input  logic                              clk_i,           // Clock
+   input  logic                              rst_ni,          // Asynchronous reset active low
+@@ -307,8 +308,8 @@ module dm_csrs #(
+         dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
+         dm::AbstractCS:   resp_queue_inp.data = abstractcs;
+         dm::AbstractAuto: resp_queue_inp.data = abstractauto_q;
+-        // command is read-only
+-        dm::Command:    resp_queue_inp.data = '0;
++        dm::Command:      resp_queue_inp.data = '0;
++        dm::NextDM:       resp_queue_inp.data = NextDmAddr;
+         [(dm::ProgBuf0):ProgBufEnd]: begin
+           resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
+           if (!cmdbusy_i) begin
+@@ -419,6 +420,7 @@ module dm_csrs #(
+             end
+           end
+         end
++        dm::NextDM:; // nextdm is R/O
+         dm::AbstractAuto: begin
+           // this field can only be written legally when there is no command executing
+           if (!cmdbusy_i) begin
+diff --git a/src/dm_top.sv b/src/dm_top.sv
+index 6188b28..a5bde9f 100644
+--- a/src/dm_top.sv
++++ b/src/dm_top.sv
+@@ -25,7 +25,12 @@ module dm_top #(
+   // that don't use hart numbers in a contiguous fashion.
+   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
+   // toggle new behavior to drive master_be_o during a read
+-  parameter bit                 ReadByteEnable   = 1
++  parameter bit                 ReadByteEnable   = 1,
++  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
++  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
++  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
++  // register is a word address and not a byte address.
++  parameter logic [31:0]        NextDmAddr       = '0
+ ) (
+   input  logic                  clk_i,       // clock
+   // asynchronous reset active low, connect PoR here, not the system reset
+@@ -111,7 +116,8 @@ module dm_top #(
+   dm_csrs #(
+     .NrHarts(NrHarts),
+     .BusWidth(BusWidth),
+-    .SelectableHarts(SelectableHarts)
++    .SelectableHarts(SelectableHarts),
++    .NextDmAddr(NextDmAddr)
+   ) i_dm_csrs (
+     .clk_i,
+     .rst_ni,

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -18,7 +18,8 @@
 module dm_csrs #(
   parameter int unsigned        NrHarts          = 1,
   parameter int unsigned        BusWidth         = 32,
-  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
+  parameter logic [31:0]        NextDmAddr       = '0
 ) (
   input  logic                              clk_i,           // Clock
   input  logic                              rst_ni,          // Asynchronous reset active low
@@ -307,8 +308,8 @@ module dm_csrs #(
         dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
         dm::AbstractCS:   resp_queue_inp.data = abstractcs;
         dm::AbstractAuto: resp_queue_inp.data = abstractauto_q;
-        // command is read-only
-        dm::Command:    resp_queue_inp.data = '0;
+        dm::Command:      resp_queue_inp.data = '0;
+        dm::NextDM:       resp_queue_inp.data = NextDmAddr;
         [(dm::ProgBuf0):ProgBufEnd]: begin
           resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
           if (!cmdbusy_i) begin
@@ -419,6 +420,7 @@ module dm_csrs #(
             end
           end
         end
+        dm::NextDM:; // nextdm is R/O
         dm::AbstractAuto: begin
           // this field can only be written legally when there is no command executing
           if (!cmdbusy_i) begin

--- a/hw/vendor/pulp_riscv_dbg/src/dm_top.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_top.sv
@@ -25,7 +25,12 @@ module dm_top #(
   // that don't use hart numbers in a contiguous fashion.
   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
   // toggle new behavior to drive master_be_o during a read
-  parameter bit                 ReadByteEnable   = 1
+  parameter bit                 ReadByteEnable   = 1,
+  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
+  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
+  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
+  // register is a word address and not a byte address.
+  parameter logic [31:0]        NextDmAddr       = '0
 ) (
   input  logic                  clk_i,       // clock
   // asynchronous reset active low, connect PoR here, not the system reset
@@ -111,7 +116,8 @@ module dm_top #(
   dm_csrs #(
     .NrHarts(NrHarts),
     .BusWidth(BusWidth),
-    .SelectableHarts(SelectableHarts)
+    .SelectableHarts(SelectableHarts),
+    .NextDmAddr(NextDmAddr)
   ) i_dm_csrs (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This also extends the RAL model to model this register (assuming value `0x0`), so the block-level is partially covered.
There is currently however no integration test for this at the top-level.