### PR TITLE
[sival] Add `sv1_test` test_suite.

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -131,6 +131,7 @@ fpga_cw310(
     # is used to enable execution across life cycle stages with a single
     # binary.
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    tags = ["cw310_sival"],
 )
 
 # FPGA configuration used to emulate silicon targets containing a `rom_ext`
@@ -145,6 +146,7 @@ fpga_cw310(
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_sival_prod_signed_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
+    tags = ["cw310_sival_rom_ext"],
 )
 
 ###########################################################################

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -47,7 +47,7 @@
       features: [
         "RV_CORE_IBEX.RND"
       ]
-      bazel: ["//sw/device/tests:rv_core_ibex_rnd_test_fpga_cw310_rom_with_fake_keys"]
+      bazel: ["//sw/device/tests:rv_core_ibex_rnd_test_fpga_cw310_sival"]
     }
     {
       name: chip_sw_rv_core_ibex_address_translation
@@ -123,7 +123,7 @@
        stage: V2
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
-       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_rom_with_fake_keys"]
+       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_sival"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2153,7 +2153,14 @@ opentitan_test(
 opentitan_test(
     name = "rstmgr_cpu_info_test",
     srcs = ["rstmgr_cpu_info_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
     verilator = new_verilator_params(
         timeout = "long",
         tags = ["broken"],
@@ -2783,7 +2790,14 @@ opentitan_test(
         "rv_core_ibex_rnd_test.S",
         "rv_core_ibex_rnd_test.c",
     ],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",

--- a/sw/device/tests/doc/sival/README.md
+++ b/sw/device/tests/doc/sival/README.md
@@ -157,6 +157,22 @@ PROD, PROD\_END | N              | Y               | Y
 :-------------- | :------------: | :-------------: | :---------------:
 PROD, PROD\_END | N              | Y               | Y
 
+## Running Test Suites
+
+### FPGA example
+
+The following command runs the `SV1` test suite on `fpga_cw310_sival` and
+`fpga_cw310_sival_rom_ext` execution environments.
+
+```console
+bazel test   --define DISABLE_VERILATOR_BUILD=true   \
+    --test_tag_filters=cw310_sival,cw310_sival_rom_ext   \
+    --test_output=streamed   \
+    --define bitstream=gcp_splice   \
+    --cache_test_results=no \
+    //sw/device/tests/sival:sv1_tests
+```
+
 ## Read More
 
 *  [SiVal Developer Guide](./devguide.md)

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# See sw/device/tests/doc/sival/README.md#running-test-suites for details on
+# how to run SV test suites across execution environments.
+
+test_suite(
+    name = "sv1_tests",
+    tests = [
+        "//sw/device/tests:rstmgr_cpu_info_test",
+        "//sw/device/tests:rv_core_ibex_rnd_test",
+    ],
+)


### PR DESCRIPTION
1. Add `cw310_sival` and `cw310_sival_rom_ext` tags to respective targets in //hw/top_earlgrey. This is to allow filtering test execution by execution environment.
2. Add //sw/device/tests/sival/BUILD to maintain test suites for various SiVal stages.
3. Update a couple of SV1 test cases to enable support for `sival` execution environments.