### PR TITLE
[test] Enable SRAM execution in sram_ctrl for its test

### DIFF
--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -85,6 +85,7 @@ bool test_main(void) {
   // execution is unconditionally enabled for the main SRAM in the RMA life
   // cycle state.
   sram_ret_neg_test();
+  CHECK_DIF_OK(dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled));
   sram_function_test();
 
   return true;


### PR DESCRIPTION
sram_ctrl_execution_test was missing a configuration that ensured execution was enabled in sram_ctrl's CSR. When the default OTP settings for tests changed to have EN_SRAM_IFETCH set to mubi true, SRAM execution was no longer enabled simply from being in the RMA state. This fixes the test so it also enables execution in the CSR.