### PR TITLE
[mbx] Improve Abort handling, and recovery from communications failure.

### DIFF
--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -314,24 +314,26 @@ module mbx
     .CfgSramAddrWidth( CfgSramAddrWidth ),
     .CfgSramDataWidth( CfgSramDataWidth )
   ) u_sramrwarb (
-    .clk_i                     ( clk_i                    ),
-    .rst_ni                    ( rst_ni                   ),
-    .tl_host_o                 ( sram_tl_h_o              ),
-    .tl_host_i                 ( sram_tl_h_i              ),
-    .intg_err_o                ( tl_sram_intg_err         ),
-    .sram_err_o                ( sram_err                 ),
+    .clk_i                        ( clk_i                      ),
+    .rst_ni                       ( rst_ni                     ),
+    .tl_host_o                    ( sram_tl_h_o                ),
+    .tl_host_i                    ( sram_tl_h_i                ),
+    .intg_err_o                   ( tl_sram_intg_err           ),
+    .sram_err_o                   ( sram_err                   ),
+    // Host-side acknowledgement of an Abort operation
+    .hostif_control_abort_clear_i ( hostif_control_abort_clear ),
     // Interface to the inbound mailbox
-    .imbx_sram_write_req_i     ( imbx_sram_write_req      ),
-    .imbx_sram_write_gnt_o     ( imbx_sram_write_gnt      ),
-    .imbx_sram_write_ptr_i     ( imbx_sram_write_ptr      ),
-    .imbx_sram_all_vld_rcvd_o  ( imbx_sram_all_vld_rcvd   ),
-    .imbx_write_data_i         ( sysif_write_data         ),
+    .imbx_sram_write_req_i        ( imbx_sram_write_req        ),
+    .imbx_sram_write_gnt_o        ( imbx_sram_write_gnt        ),
+    .imbx_sram_write_ptr_i        ( imbx_sram_write_ptr        ),
+    .imbx_sram_all_vld_rcvd_o     ( imbx_sram_all_vld_rcvd     ),
+    .imbx_write_data_i            ( sysif_write_data           ),
     // Interface to the outbound mailbox
-    .ombx_sram_read_req_i      ( ombx_sram_read_req       ),
-    .ombx_sram_read_gnt_o      ( ombx_sram_read_gnt       ),
-    .ombx_sram_read_ptr_i      ( ombx_sram_read_ptr       ),
-    .ombx_sram_read_resp_vld_o ( ombx_sram_read_resp_vld  ),
-    .ombx_sram_read_resp_o     ( ombx_sram_read_data      )
+    .ombx_sram_read_req_i         ( ombx_sram_read_req         ),
+    .ombx_sram_read_gnt_o         ( ombx_sram_read_gnt         ),
+    .ombx_sram_read_ptr_i         ( ombx_sram_read_ptr         ),
+    .ombx_sram_read_resp_vld_o    ( ombx_sram_read_resp_vld    ),
+    .ombx_sram_read_resp_o        ( ombx_sram_read_data        )
   );
 
   // Assertions


### PR DESCRIPTION
This PR implements a FW-initiated reset of the Inbound and Outbound data paths in the event of a communications failure within the SoC<->mailbox<->TL-UL chain and improves the Abort handling.

_Mailbox operation is critical to all communication between the SoC and RoT, and use of the asynchronous reset of the IP block is considered infeasible because it is common to many other IP blocks._


The logic is currently reliant upon everything completing as expected (whether successfully or by an error being indicated by the TL-UL device/bus), but is not robust against potential design flaws nor against any reliability issues with the specific physical device. Further, the current Error and Abort handling mechanisms do not have the capacity to reset fully the internal state of the mailbox logic. ([Issue detailed here](https://github.com/lowRISC/opentitan-integrated/issues/708).)

To help with understanding this PR, the Abort mechanism is described below:

- in the event of a failure in the Request/Response mechanism, the SoC side has the capacity to request that an operation be Aborted and it is expected that this mechanism be used in response to a communications timeout (of the order of > 1 second).
- the Abort request is signaled to the RoT via an interrupt.
- the RoT firmware acknowledges the Abort condition.

It is worth noting that the SoC side itself may become stalled and unable to employ the Abort mechanism, since a Write Data access from the SoC when sending the Request may cause the SoC to be blocked upon completion of the previous write. Similarly, a Read Data access from the SoC when fetching the Response will block until the read data is retrieved from the mailbox SRAM.

It is therefore proposed that the Abort acknowledgment should be available as a RoT FW-initiated reset of the mailbox logic, for use even if there has been no explicit Abort request from the SoC side.

This PR consists of two commits:

**Commit 1:** Introduces a reset of the following internal state when the RoT FW ('host') acknowledges an Abort condition.

- u_ombx.u_req_state <- TL-UL read request
- u_ombx.u_pop_entry <- ditto
- u_ombx.u_pending <- SoC side Write Data Register stall
- u_imbx.u_req_state <- TL-UL write request
- u_imbx.u_pending <- ditto

It also clears down the count of outstanding TL-UL bus requests (`u_sramrwarb.u_outstanding_req_cnt`) and suppresses any subsequent TL-UL read response from being propagated into the Outbound mailbox logic, because that previously would result in the logic re-entering an active state as if starting to send a fresh Response to the SoC side.

**Commit 2:** Prioritizes the host-side Abort acknowledgement over all FSM states such that it may be used as a FW-initiated reset at any time, and not just when handling an explicit Abort request from the SoC. This would be used after a timeout in the communications from/to the SoC side. (Apologies: This changes the FSM identation and confuses diff tools.)

This should address [issue 708](https://github.com/lowRISC/opentitan-integrated/issues/708) although DV is currently unable to verify the existing Abort handling or the complete efficacy of this change. The smoke test still passes as expected.