### PR TITLE
[dv,csr] Support non-HRO REGWEN fields

### DIFF
--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -115,13 +115,17 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
   % for hro_reg in hro_regs_list:
 <%
      regwen = hro_reg.regwen
+     hidden_regwen = True
      mubi_regwen = False
      mubi_width = 4
      # Locate the REGWEN register and determine its type.
      for reg in hro_regs_list:
-       if reg.name == regwen and reg.fields[0].mubi:
-         mubi_regwen = True
-         mubi_width = reg.fields[0].bits.width()
+       if reg.name == regwen:
+         hidden_regwen = False
+         if reg.fields[0].mubi:
+           mubi_regwen = True
+           mubi_width = reg.fields[0].bits.width()
+         endif
        endif
      endfor
 %>\
@@ -130,6 +134,9 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
     % elif mubi_regwen:
       assign regwen[${hro_map.get(hro_reg.offset)[0]}] =
                       mubi${mubi_width}_test_true_strict(mubi${mubi_width}_t'(`REGWEN_PATH.${regwen.lower()}_qs));
+    % elif hidden_regwen:
+      // Register is controlled by a REGWEN that is not 'hwo' and not supported in fpv_csr
+      assign regwen[${hro_map.get(hro_reg.offset)[0]}] = 1;
     % else:
       assign regwen[${hro_map.get(hro_reg.offset)[0]}] = `REGWEN_PATH.${regwen.lower()}_qs;
     % endif


### PR DESCRIPTION
REGWEN fields may exist in CSRs that are non-HRO, but those registers must not be modified indirectly by CSR testing, so it will be necessary to exclude those registers which may lead to the internal HW state changing and resetting the REGWEN.

(Background: The DMA block has acquired a 'CFG_REGWEN' field that the DMA controller uses to protect its registers during a transfer. This REGWEN-containing register is not 'HRO' since it is the hardware side that sets/clears the REGWEN.)

Provided that the register(s) which can lead to the lock being changed are excluded from CSR write testing (the CONTROL register in the case of DMA), it is then possible to test all of the registers controlled by such a lock rather than exclude all of them too. (In the case of DMA, almost all registers would have to be excluded from testing.)

The change made in the PR cannot prevent the CSR tests failing if such a REGWEN field is present in a design but the appropriate exclusions are absent, but those CSR tests would be failing already on account of making incorrect predictions about writeability. The PR introduces an annotation in the auto-generated SV code marking any registers which are controlled by non-HRO locks to aid in diagnosis of a failing CSR test.