### PR TITLE
[chip,darjeeling, aon_timer, sram_ret] wdog reset fix

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1263,14 +1263,15 @@
       sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_execution_main_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    {
-      name: chip_sw_sleep_sram_ret_contents
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_test:6"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
-                 "+bypass_alert_ready_to_end_check=1"]
-    }
+// Refactor test to remove flash dependency
+//    {
+//      name: chip_sw_sleep_sram_ret_contents
+//      uvm_test_seq: chip_sw_base_vseq
+//      sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_test:6"]
+//      en_run_modes: ["sw_test_mode_test_rom"]
+//      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
+//                 "+bypass_alert_ready_to_end_check=1"]
+//    }
     {
       name: chip_sw_sensor_ctrl_alert
       uvm_test_seq: chip_sw_base_vseq

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -40,7 +40,7 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
 
   // Set wdog as a reset source.
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifPwrmgrResetRequestSourceOne,
                                               kDifToggleEnabled));
 
   // Setup the wdog bark and bite timeouts.
@@ -89,7 +89,7 @@ static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
 
   // Program the pwrmgr to go to deep sleep state (clocks off).
   CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, 0));
+      pwrmgr, kDifPwrmgrWakeupRequestSourceOne, 0));
   // Enter in low power mode.
   wait_for_interrupt();
   // If we arrive here the test must fail.

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_test.c
@@ -156,7 +156,7 @@ void set_up_reset_request(void) {
   // Prepare rstmgr for a reset.
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
+                                              kDifPwrmgrResetRequestSourceOne,
                                               kDifToggleEnabled));
 
   CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));


### PR DESCRIPTION
Fix part of #20415 

- aon_timer_wdog_bite_reset_test.
- sram_ctrl_sleep_sram_ret_contents_test : commented out due to flash dependency