### PR TITLE
[sw] Refactor uart_tx_rx_test to use a pinmux testutil

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -458,6 +458,22 @@ cc_library(
 )
 
 cc_library(
+    name = "uart_testutils",
+    srcs = ["uart_testutils.c"],
+    hdrs = ["uart_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/uart/data:uart_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)
+
+cc_library(
     name = "usb_testutils",
     srcs = [
         "usb_testutils.c",

--- a/sw/device/lib/testing/uart_testutils.c
+++ b/sw/device/lib/testing/uart_testutils.c
@@ -1,0 +1,126 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/uart_testutils.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "uart_regs.h"  // Generated.
+
+#define MODULE_ID MAKE_MODULE_ID('u', 't', 'u')
+
+/**
+ * This table stores the pins for all UART instances of Earlgrey.
+ */
+static const pinmux_testutils_peripheral_pin_t kUartPinmuxPins[] = {
+    // UART0.
+    {
+        .peripheral_in = kTopEarlgreyPinmuxPeripheralInUart0Rx,
+        .outsel = kTopEarlgreyPinmuxOutselUart0Tx,
+    },
+    // UART1.
+    {
+        .peripheral_in = kTopEarlgreyPinmuxPeripheralInUart1Rx,
+        .outsel = kTopEarlgreyPinmuxOutselUart1Tx,
+    },
+    // UART2.
+    {
+        .peripheral_in = kTopEarlgreyPinmuxPeripheralInUart2Rx,
+        .outsel = kTopEarlgreyPinmuxOutselUart2Tx,
+    },
+    // UART3.
+    {
+        .peripheral_in = kTopEarlgreyPinmuxPeripheralInUart3Rx,
+        .outsel = kTopEarlgreyPinmuxOutselUart3Tx,
+    },
+};
+
+/**
+ * This table stores UART pin mappings for different platforms.
+ * This is used to connect UART instances to mio pins based on the platform.
+ */
+static const pinmux_testutils_mio_pin_t
+    kUartPlatformPins[UartPinmuxPlatformIdCount][4] = {
+        // Hyper310 bitstream.
+        [UartPinmuxPlatformIdHyper310] =
+            {// UART0.
+             {
+                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                 .insel = kTopEarlgreyPinmuxInselIoc3,
+             },
+             // UART1.
+             {
+                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                 .insel = kTopEarlgreyPinmuxInselIoc3,
+             },
+             // UART2.
+             {
+                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                 .insel = kTopEarlgreyPinmuxInselIoc3,
+             },
+             // UART3.
+             {
+                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                 .insel = kTopEarlgreyPinmuxInselIoc3,
+             }},
+        // DV.
+        [UartPinmuxPlatformIdDvsim] = {
+            // UART0.
+            {
+                .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                .insel = kTopEarlgreyPinmuxInselIoc3,
+            },
+            // UART1.
+            {
+                .mio_out = kTopEarlgreyPinmuxMioOutIob5,
+                .insel = kTopEarlgreyPinmuxInselIob4,
+            },
+            // UART2.
+            {
+                .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
+                .insel = kTopEarlgreyPinmuxInselIoa4,
+            },
+            // UART3.
+            {
+                .mio_out = kTopEarlgreyPinmuxMioOutIoa1,
+                .insel = kTopEarlgreyPinmuxInselIoa0,
+            }}};
+
+status_t uart_testutils_select_pinmux(const dif_pinmux_t *pinmux,
+                                      uint8_t uart_id,
+                                      uart_pinmux_platform_id_t platform) {
+  TRY_CHECK(platform < UartPinmuxPlatformIdCount &&
+                uart_id < ARRAYSIZE(kUartPinmuxPins),
+            "Index out of bounds");
+
+  TRY(dif_pinmux_input_select(pinmux, kUartPinmuxPins[uart_id].peripheral_in,
+                              kUartPlatformPins[platform][uart_id].insel));
+  TRY(dif_pinmux_output_select(pinmux,
+                               kUartPlatformPins[platform][uart_id].mio_out,
+                               kUartPinmuxPins[uart_id].outsel));
+
+  return OK_STATUS();
+}
+
+status_t uart_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
+                                      uint8_t uart_id) {
+  TRY_CHECK(uart_id < ARRAYSIZE(kUartPinmuxPins), "Index out of bounds");
+
+  TRY(dif_pinmux_input_select(pinmux, kUartPinmuxPins[uart_id].peripheral_in,
+                              kTopEarlgreyPinmuxInselConstantZero));
+
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/uart_testutils.h
+++ b/sw/device/lib/testing/uart_testutils.h
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_UART_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_UART_TESTUTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_uart.h"
+
+/**
+ * Define the available platforms which uart is mapped
+ */
+typedef enum uart_pinmux_platform_id {
+  UartPinmuxPlatformIdHyper310 = 0,
+  UartPinmuxPlatformIdDvsim,
+  UartPinmuxPlatformIdCount,
+} uart_pinmux_platform_id_t;
+
+/**
+ * Connect the uart pins to mio pins via pinmux based on the platform the test
+ * is running.
+ *
+ * @param pimmux A pinmux handler.
+ * @param kUartIdx The uart instance identifier.
+ * @param platform The platform which the test is running.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t uart_testutils_select_pinmux(const dif_pinmux_t *pinmux,
+                                      uint8_t kUartIdx,
+                                      uart_pinmux_platform_id_t platform);
+
+/**
+ * Disconnect the uart input pins from mio pads and wire it to zero.
+ *
+ * @param pimmux A pinmux handler.
+ * @param uart_id The uart instance identifier.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t uart_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
+                                      uint8_t uart_id);
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_UART_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -23,6 +23,7 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing:uart_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
This PR:
* Adds a testutil function for selecting a pinmux configuration for each UART on each platform.
  * Based on the i2c testutils.
  * DV maps reflect those used in `uart_tx_rx_test`.
  * Hyper310 UARTs are all mapped to the console pins.
* Refactors `uart_tx_rx_test` to use the new testutil instead of direct memory changes.

Tested in dvsim, but the hyper310 configuration will require porting this to sival before it can be tested.