### PR TITLE
[ci] Add the sival exec_env to the CI nigthly BoB tests

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -142,6 +142,19 @@ jobs:
         --define bitstream=gcp_splice \
         --build_tests_only \
         --test_output=errors \
-        $(bash ./bazelisk.sh query 'attr("tags", "[\[ ]bob[,\]]", attr("tags", "[\[ ]cw310[,\]]", tests(//...)))')
-    displayName: "Run all the SPI and I2C Tests with BoB"
+        --test_tag_filters="cw310_test_rom" \
+        $(bash ./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')
+    displayName: "Run the PMOD tests with Test ROM"
+  - template: ../ci/publish-bazel-test-results.yml
+  - bash: |
+      set -x
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/bazelisk.sh test \
+        --define DISABLE_VERILATOR_BUILD=true \
+        --define bitstream=gcp_splice \
+        --build_tests_only \
+        --test_output=errors \
+        --test_tag_filters="cw310_sival" \
+        $(bash ./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')
+    displayName: "Run the PMOD tests for Sival"
   - template: ../ci/publish-bazel-test-results.yml

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -31,7 +31,7 @@
       tests: ["chip_sw_spi_host_tx_rx"]
       bazel: [
         "//sw/device/tests:spi_host_winbond_flash_test_fpga_cw310_rom_with_fake_keys",
-        "//sw/device/tests/pmod:spi_host_macronix_flash_test_fpga_cw310_rom_with_fake_keys"
+        "//sw/device/tests/pmod:spi_host_macronix_flash_test_fpga_cw310_sival"
       ]
     }
     {

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -15,12 +15,12 @@ opentitan_test(
     srcs = ["spi_host_macronix_flash_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -45,11 +45,12 @@ opentitan_test(
     srcs = ["spi_host_gigadevice256Mb_flash_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -75,11 +76,12 @@ opentitan_test(
     srcs = ["spi_host_gigadevice1Gb_flash_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -105,11 +107,12 @@ opentitan_test(
     srcs = ["spi_host_micron512Mb_flash_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -135,11 +138,12 @@ opentitan_test(
     srcs = ["i2c_host_accelerometer_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -162,11 +166,12 @@ opentitan_test(
     srcs = ["i2c_host_ambient_light_detector_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -189,11 +194,12 @@ opentitan_test(
     srcs = ["i2c_host_hdc1080_humidity_temp_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -216,11 +222,12 @@ opentitan_test(
     srcs = ["i2c_host_clock_stretching_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -245,11 +252,12 @@ opentitan_test(
     srcs = ["i2c_host_compass_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -273,11 +281,12 @@ opentitan_test(
     srcs = ["i2c_host_eeprom_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -300,11 +309,12 @@ opentitan_test(
     srcs = ["i2c_host_fram_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -327,11 +337,12 @@ opentitan_test(
     srcs = ["i2c_host_gas_sensor_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -354,11 +365,12 @@ opentitan_test(
     srcs = ["i2c_host_power_monitor_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -381,11 +393,12 @@ opentitan_test(
     srcs = ["i2c_host_irq_test.c"],
     cw310 = cw310_params(
         tags = [
-            "bob",
             "manual",
-        ],  # Requires the BoB in CI.
+            "pmod",
+        ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [


### PR DESCRIPTION
Add the sival exec_env to the CI nigthly BoB tests.

I broke the tests into two steps to optimize the bitstream load.