### PR TITLE
[ci] increase CW310 ROM Test timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -568,7 +568,7 @@ jobs:
   pool:
     name: $(fpga_pool)
     demands: BOARD -equals cw310
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build


### PR DESCRIPTION
The tests are hitting the 1hr limit, so bump this to 1hr30min.