### PR TITLE
[crypto]  Adjust RSA implementation to remove specialized structs.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -300,8 +300,6 @@ Always ensure that you fully understand the security implications of the padding
 
 ### RSA Synchronous API
 
-{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_public_key_length }}
-{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_private_key_length }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_public_key_construct }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_private_key_from_exponents }}

--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -150,9 +150,7 @@ Data structures for key types and modes help the cryptolib recognize and prevent
 #### RSA data structures
 
 {{#header-snippet sw/device/lib/crypto/include/rsa.h rsa_padding }}
-{{#header-snippet sw/device/lib/crypto/include/rsa.h rsa_private_key }}
-{{#header-snippet sw/device/lib/crypto/include/rsa.h rsa_key_size }}
-{{#header-snippet sw/device/lib/crypto/include/rsa.h rsa_public_key }}
+{{#header-snippet sw/device/lib/crypto/include/rsa.h rsa_size }}
 
 ### Private data structures
 
@@ -302,7 +300,11 @@ Always ensure that you fully understand the security implications of the padding
 
 ### RSA Synchronous API
 
+{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_public_key_length }}
+{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_private_key_length }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_keygen }}
+{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_public_key_construct }}
+{{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_private_key_from_exponents }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_sign }}
 {{#header-snippet sw/device/lib/crypto/include/rsa.h otcrypto_rsa_verify }}
 

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -44,38 +44,38 @@ typedef enum rsa_size {
   kRsaSize4096 = 0x8da,
 } rsa_size_t;
 
-/**
- * Get the length of an RSA public key.
- *
- * The internal representation of RSA public keys is implementation-specific;
- * this function will return the expected key length for a given RSA size.
- *
- * @param size RSA size parameter.
- * @param[out] key_length Key length in bytes.
- * @return Result of the operation.
- */
-crypto_status_t otcrypto_rsa_public_key_length(rsa_size_t size,
-                                               size_t *key_length);
-
-/**
- * Get the length of an RSA private key.
- *
- * The internal representation of RSA private keys is implementation-specific;
- * this function will return the expected key and keyblob length for a given
- * RSA size. The `key_length` output parameter represents the unmasked form of
- * the private key and is intended for the `key_length` field of
- * `crypto_key_config_t`, while the `keyblob_length` parameter represents the
- * blinded form and is intended for the `keyblob_length` field of
- * `crypto_unblinded_key_t`.
- *
- * @param size RSA size parameter.
- * @param[out] key_length Unblinded key length in bytes.
- * @param[out] keyblob_length Blinded keyblob length in bytes.
- * @return Result of the operation.
- */
-crypto_status_t otcrypto_rsa_private_key_length(rsa_size_t size,
-                                                size_t *key_length,
-                                                size_t *keyblob_length);
+enum {
+  /**
+   * Number of bytes needed for RSA public keys.
+   *
+   * The exact representation is an implementation-specific detail and subject
+   * to change. This is the length that the caller should set as `key_length`
+   * and allocate for the `key` buffer in unblinded keys.
+   */
+  kRsa2048PublicKeyBytes = 260,
+  kRsa3072PublicKeyBytes = 388,
+  kRsa4096PublicKeyBytes = 516,
+  /**
+   * Number of bytes needed for RSA private keys.
+   *
+   * The exact representation is an implementation-specific detail and subject
+   * to change. This is the length that the caller should set in `key_length`
+   * for the blinded key configuration (NOT the blinded keyblob length).
+   */
+  kRsa2048PrivateKeyBytes = 256,
+  kRsa3072PrivateKeyBytes = 384,
+  kRsa4096PrivateKeyBytes = 512,
+  /**
+   * Number of bytes needed for RSA private keyblobs.
+   *
+   * The exact representation is an implementation-specific detail and subject
+   * to change. This is the length that the caller should set in
+   * `keyblob_length` and allocate for the `keyblob` buffer in blinded keys.
+   */
+  kRsa2048PrivateKeyblobBytes = 512,
+  kRsa3072PrivateKeyblobBytes = 768,
+  kRsa4096PrivateKeyblobBytes = 1024,
+};
 
 /**
  * Performs the RSA key generation.
@@ -84,13 +84,11 @@ crypto_status_t otcrypto_rsa_private_key_length(rsa_size_t size,
  * modulus (n).
  *
  * The caller should allocate space for the public key and set the `key` and
- * `key_length` fields accordingly. Use `otcrypto_rsa_public_key_length` to get
- * the expected length.
+ * `key_length` fields accordingly.
  *
  * The caller should fully populate the blinded key configuration and allocate
  * space for the keyblob, setting `config.key_length` and `keyblob_length`
- * accordingly. Use `otcrypto_rsa_private_key_length` to get the expected
- * lengths.
+ * accordingly.
  *
  * The value in the `checksum` field of key structs is not checked here and
  * will be populated by the key generation function.
@@ -108,8 +106,7 @@ crypto_status_t otcrypto_rsa_keygen(rsa_size_t size,
  * Constructs an RSA public key from the modulus and public exponent.
  *
  * The caller should allocate space for the public key and set the `key` and
- * `key_length` fields accordingly. Use `otcrypto_rsa_public_key_length` to get
- * the expected length.
+ * `key_length` fields accordingly.
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
@@ -125,8 +122,7 @@ crypto_status_t otcrypto_rsa_public_key_construct(
  * Constructs an RSA private key from the modulus and public/private exponents.
  *
  * The caller should allocate space for the private key and set the `keyblob`,
- * `keyblob_length`, and `key_length` fields accordingly. Use
- * `otcrypto_rsa_private_key_length` to get the expected length.
+ * `keyblob_length`, and `key_length` fields accordingly.
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -31,38 +31,51 @@ typedef enum rsa_padding {
 } rsa_padding_t;
 
 /**
- * Struct to handle the RSA private exponent and modulus.
- */
-typedef struct rsa_private_key {
-  // Unblinded key struct with RSA modulus.
-  crypto_unblinded_key_t n;
-  // Blinded key struct with RSA private exponent.
-  crypto_blinded_key_t d;
-} rsa_private_key_t;
-
-/**
  * Enum to define possible lengths of RSA (public) keys.
  *
  * Values are hardened.
  */
-typedef enum rsa_key_size {
-  // 2048-bit RSA key.
-  kRsaKeySize2048 = 0x5d1,
-  // 3072-bit RSA key.
-  kRsaKeySize3072 = 0xc35,
-  // 4096-bit RSA key.
-  kRsaKeySize4096 = 0x8da,
-} rsa_key_size_t;
+typedef enum rsa_size {
+  // 2048-bit RSA.
+  kRsaSize2048 = 0x5d1,
+  // 3072-bit RSA.
+  kRsaSize3072 = 0xc35,
+  // 4096-bit RSA.
+  kRsaSize4096 = 0x8da,
+} rsa_size_t;
 
 /**
- * Struct to handle the RSA public exponent and modulus.
+ * Get the length of an RSA public key.
+ *
+ * The internal representation of RSA public keys is implementation-specific;
+ * this function will return the expected key length for a given RSA size.
+ *
+ * @param size RSA size parameter.
+ * @param[out] key_length Key length in bytes.
+ * @return Result of the operation.
  */
-typedef struct rsa_public_key {
-  // Unblinded key struct with RSA modulus.
-  crypto_unblinded_key_t n;
-  // Blinded key struct with RSA public exponent.
-  crypto_unblinded_key_t e;
-} rsa_public_key_t;
+crypto_status_t otcrypto_rsa_public_key_length(rsa_size_t size,
+                                               size_t *key_length);
+
+/**
+ * Get the length of an RSA private key.
+ *
+ * The internal representation of RSA private keys is implementation-specific;
+ * this function will return the expected key and keyblob length for a given
+ * RSA size. The `key_length` output parameter represents the unmasked form of
+ * the private key and is intended for the `key_length` field of
+ * `crypto_key_config_t`, while the `keyblob_length` parameter represents the
+ * blinded form and is intended for the `keyblob_length` field of
+ * `crypto_unblinded_key_t`.
+ *
+ * @param size RSA size parameter.
+ * @param[out] key_length Unblinded key length in bytes.
+ * @param[out] keyblob_length Blinded keyblob length in bytes.
+ * @return Result of the operation.
+ */
+crypto_status_t otcrypto_rsa_private_key_length(rsa_size_t size,
+                                                size_t *key_length,
+                                                size_t *keyblob_length);
 
 /**
  * Performs the RSA key generation.
@@ -70,49 +83,79 @@ typedef struct rsa_public_key {
  * Computes RSA private key (d) and RSA public key exponent (e) and
  * modulus (n).
  *
- * The caller should allocate and partially populate all blinded and unblinded
- * key structs underneath `rsa_private_key` and `rsa_public_key`.
+ * The caller should allocate space for the public key and set the `key` and
+ * `key_length` fields accordingly. Use `otcrypto_rsa_public_key_length` to get
+ * the expected length.
  *
- * For unblinded keys, this means setting the key mode, allocating a buffer for
- * the key material, and recording the length of the allocated buffer in
- * `key_length`. If the buffer size does not match expectations, this function
- * will return an error. RSA public key exponents should always have 32 bits (4
- * bytes) allocated for them.
- *
- * For blinded key structs, the caller should fully populate the key
- * configuration and allocate space for the keyblob. As for unblinded keys, the
- * caller should record the allocated buffer length and this function will
- * return an error if the keyblob length does not match expectations. The
- * keyblob should be twice the length of the key.
+ * The caller should fully populate the blinded key configuration and allocate
+ * space for the keyblob, setting `config.key_length` and `keyblob_length`
+ * accordingly. Use `otcrypto_rsa_private_key_length` to get the expected
+ * lengths.
  *
  * The value in the `checksum` field of key structs is not checked here and
  * will be populated by the key generation function.
  *
- * @param required_key_len Requested key length.
- * @param[out] rsa_public_key Pointer to RSA public exponent struct.
- * @param[out] rsa_private_key Pointer to RSA private exponent struct.
+ * @param size RSA size parameter.
+ * @param[out] public_key Pointer to public key struct.
+ * @param[out] private_key Pointer to blinded private key struct.
  * @return Result of the RSA key generation.
  */
-crypto_status_t otcrypto_rsa_keygen(rsa_key_size_t required_key_len,
-                                    rsa_public_key_t *rsa_public_key,
-                                    rsa_private_key_t *rsa_private_key);
+crypto_status_t otcrypto_rsa_keygen(rsa_size_t size,
+                                    crypto_unblinded_key_t *public_key,
+                                    crypto_blinded_key_t *private_key);
+
+/**
+ * Constructs an RSA public key from the modulus and public exponent.
+ *
+ * The caller should allocate space for the public key and set the `key` and
+ * `key_length` fields accordingly. Use `otcrypto_rsa_public_key_length` to get
+ * the expected length.
+ *
+ * @param size RSA size parameter.
+ * @param modulus RSA modulus (n).
+ * @param exponent RSA public exponent (e).
+ * @param[out] public_key Destination public key struct.
+ * @return Result of the RSA key construction.
+ */
+crypto_status_t otcrypto_rsa_public_key_construct(
+    rsa_size_t size, crypto_const_word32_buf_t modulus, uint32_t exponent,
+    crypto_unblinded_key_t *public_key);
+
+/**
+ * Constructs an RSA private key from the modulus and public/private exponents.
+ *
+ * The caller should allocate space for the private key and set the `keyblob`,
+ * `keyblob_length`, and `key_length` fields accordingly. Use
+ * `otcrypto_rsa_private_key_length` to get the expected length.
+ *
+ * @param size RSA size parameter.
+ * @param modulus RSA modulus (n).
+ * @param exponent RSA public exponent (e).
+ * @param d_share0 First share of the RSA private exponent d.
+ * @param d_share1 Second share of the RSA private exponent d.
+ * @param[out] public_key Destination public key struct.
+ * @return Result of the RSA key construction.
+ */
+crypto_status_t otcrypto_rsa_private_key_from_exponents(
+    rsa_size_t size, crypto_const_word32_buf_t modulus, uint32_t e,
+    crypto_const_word32_buf_t d_share0, crypto_const_word32_buf_t d_share1,
+    crypto_blinded_key_t *private_key);
 
 /**
  * Computes the digital signature on the input message data.
  *
- * The caller should allocate space for the `signature` buffer,
- * (expected length same as modulus length from `rsa_private_key`),
+ * The caller should allocate space for the `signature` buffer
  * and set the length of expected output in the `len` field of
  * `signature`. If the user-set length and the output length does not
  * match, an error message will be returned.
  *
- * @param rsa_private_key Pointer to RSA private exponent struct.
+ * @param private_key Pointer to blinded private key struct.
  * @param message_digest Message digest to be signed (pre-hashed).
  * @param padding_mode Padding scheme to be used for the data.
  * @param[out] signature Pointer to the generated signature struct.
  * @return The result of the RSA signature generation.
  */
-crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
+crypto_status_t otcrypto_rsa_sign(const crypto_blinded_key_t *private_key,
                                   const hash_digest_t *message_digest,
                                   rsa_padding_t padding_mode,
                                   crypto_word32_buf_t *signature);
@@ -120,18 +163,18 @@ crypto_status_t otcrypto_rsa_sign(const rsa_private_key_t *rsa_private_key,
 /**
  * Verifies the authenticity of the input signature.
  *
- * The generated signature is compared against the input signature and
- * PASS / FAIL is returned.
+ * An "OK" status code does not mean that the signature passed verification;
+ * the caller must check both the returned status and `verification_result`
+ * before trusting the signature.
  *
- * @param rsa_public_key Pointer to RSA public exponent struct.
+ * @param public_key Pointer to public key struct.
  * @param message_digest Message digest to be verified (pre-hashed).
  * @param padding_mode Padding scheme to be used for the data.
  * @param signature Pointer to the input signature to be verified.
- * @param[out] verification_result Result of signature verification
- * (Pass/Fail).
+ * @param[out] verification_result Result of signature verification.
  * @return Result of the RSA verify operation.
  */
-crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
+crypto_status_t otcrypto_rsa_verify(const crypto_unblinded_key_t *public_key,
                                     const hash_digest_t *message_digest,
                                     rsa_padding_t padding_mode,
                                     crypto_const_word32_buf_t signature,
@@ -147,26 +190,23 @@ crypto_status_t otcrypto_rsa_verify(const rsa_public_key_t *rsa_public_key,
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param required_key_len Requested key length.
+ * @param size RSA size parameter.
  * @return Result of async RSA keygen start operation.
  */
-crypto_status_t otcrypto_rsa_keygen_async_start(
-    rsa_key_size_t required_key_len);
+crypto_status_t otcrypto_rsa_keygen_async_start(rsa_size_t size);
 
 /**
  * Finalizes the asynchronous RSA key generation function.
  *
- * Returns `kCryptoStatusOK` and copies the RSA private key (d), RSA
- * public key exponent (e) and modulus (n) if the OTBN status is done,
- * or `kCryptoStatusAsyncIncomplete` if the OTBN is busy or
- * `kCryptoStatusInternalError` if there is an error.
+ * See `otcrypto_rsa_keygen` for details on the requirements for `public_key`
+ * and `private_key`.
  *
- * @param[out] rsa_public_key Pointer to RSA public exponent struct.
- * @param[out] rsa_private_key Pointer to RSA private exponent struct.
+ * @param[out] public_key Pointer to public key struct.
+ * @param[out] private_key Pointer to blinded private key struct.
  * @return Result of asynchronous RSA keygen finalize operation.
  */
 crypto_status_t otcrypto_rsa_keygen_async_finalize(
-    rsa_public_key_t *rsa_public_key, rsa_private_key_t *rsa_private_key);
+    crypto_unblinded_key_t *public_key, crypto_blinded_key_t *private_key);
 
 /**
  * Starts the asynchronous digital signature generation function.
@@ -178,27 +218,19 @@ crypto_status_t otcrypto_rsa_keygen_async_finalize(
  * started, or`kCryptoStatusInternalError` if the operation cannot be
  * started.
  *
- * @param rsa_private_key Pointer to RSA private exponent struct.
+ * @param private_key Pointer to blinded private key struct.
  * @param message_digest Message digest to be signed (pre-hashed).
  * @param padding_mode Padding scheme to be used for the data.
  * @return Result of async RSA sign start operation.
  */
 crypto_status_t otcrypto_rsa_sign_async_start(
-    const rsa_private_key_t *rsa_private_key,
+    const crypto_blinded_key_t *private_key,
     const hash_digest_t *message_digest, rsa_padding_t padding_mode);
 
 /**
  * Finalizes the asynchronous digital signature generation function.
  *
- * Returns `kCryptoStatusOK` and copies the signature if the OTBN
- * status is done, or `kCryptoStatusAsyncIncomplete` if the OTBN is
- * busy or `kCryptoStatusInternalError` if there is an error.
- *
- * The caller should allocate space for the `signature` buffer,
- * (expected length same as modulus length from `rsa_private_key`),
- * and set the length of expected output in the `len` field of
- * `signature`. If the user-set length and the output length does not
- * match, an error message will be returned.
+ * See `otcrypto_rsa_sign` for details on the requirements for `signature`.
  *
  * @param[out] signature Pointer to generated signature struct.
  * @return Result of async RSA sign finalize operation.
@@ -212,27 +244,24 @@ crypto_status_t otcrypto_rsa_sign_async_finalize(
  * Initializes OTBN and starts the OTBN routine to recover the message
  * from the input signature.
  *
- * @param rsa_public_key Pointer to RSA public exponent struct.
+ * @param public_key Pointer to public key struct.
  * @param signature Pointer to the input signature to be verified.
  * @return Result of async RSA verify start operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_start(
-    const rsa_public_key_t *rsa_public_key,
+    const crypto_unblinded_key_t *public_key,
     crypto_const_word32_buf_t signature);
 
 /**
  * Finalizes the asynchronous signature verification function.
  *
- * Returns `kCryptoStatusOK` and populates the `verification result`
- * if the OTBN status is done, or `kCryptoStatusAsyncIncomplete` if
- * OTBN is busy or `kCryptoStatusInternalError` if there is an error.
- * The (hash of) recovered message is compared against the input
- * message and a PASS or FAIL is returned.
+ * An "OK" status code does not mean that the signature passed verification;
+ * the caller must check both the returned status and `verification_result`
+ * before trusting the signature.
  *
  * @param message_digest Message digest to be verified (pre-hashed).
  * @param padding_mode Padding scheme to be used for the data.
- * @param[out] verification_result Result of signature verification
- * (Pass/Fail).
+ * @param[out] verification_result Result of signature verification.
  * @return Result of async RSA verify finalize operation.
  */
 crypto_status_t otcrypto_rsa_verify_async_finalize(

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -316,6 +316,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
+        "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",
@@ -354,6 +355,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
+        "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",
@@ -392,6 +394,7 @@ opentitan_test(
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
+        "//sw/device/lib/crypto/impl/rsa:rsa_datatypes",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:profile",

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -29,36 +29,30 @@ static const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 static const key_mode_t kTestKeyMode = kKeyModeRsaSignPkcs;
 
 status_t keygen_then_sign_test(void) {
-  // Get the key lengths from the size.
-  size_t public_key_length;
-  TRY(otcrypto_rsa_public_key_length(kRsaSize2048, &public_key_length));
-  size_t private_key_length;
-  size_t private_keyblob_length;
-  TRY(otcrypto_rsa_private_key_length(kRsaSize2048, &private_key_length,
-                                      &private_keyblob_length));
-
   // Allocate buffer for the public key.
-  uint32_t public_key_data[ceil_div(public_key_length, sizeof(uint32_t))];
+  uint32_t public_key_data[ceil_div(kRsa2048PublicKeyBytes, sizeof(uint32_t))];
   memset(public_key_data, 0, sizeof(public_key_data));
   crypto_unblinded_key_t public_key = {
       .key_mode = kTestKeyMode,
-      .key_length = public_key_length,
+      .key_length = kRsa2048PublicKeyBytes,
       .key = public_key_data,
   };
 
   // Allocate buffers for the private key.
-  uint32_t keyblob[ceil_div(private_keyblob_length, sizeof(uint32_t))];
+  size_t keyblob_words =
+      ceil_div(kRsa2048PrivateKeyblobBytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
   memset(keyblob, 0, sizeof(keyblob));
   crypto_blinded_key_t private_key = {
       .config =
           {
               .version = kCryptoLibVersion1,
               .key_mode = kTestKeyMode,
-              .key_length = private_key_length,
+              .key_length = kRsa2048PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
               .security_level = kSecurityLevelLow,
           },
-      .keyblob_length = private_keyblob_length,
+      .keyblob_length = kRsa2048PrivateKeyblobBytes,
       .keyblob = keyblob,
   };
 
@@ -69,11 +63,11 @@ status_t keygen_then_sign_test(void) {
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 
   // Interpret public key using internal RSA datatype.
-  TRY_CHECK(public_key_length == sizeof(rsa_2048_public_key_t));
+  TRY_CHECK(public_key.key_length == sizeof(rsa_2048_public_key_t));
   rsa_2048_public_key_t *pk = (rsa_2048_public_key_t *)public_key.key;
 
   // Interpret private key using internal RSA datatype.
-  TRY_CHECK(private_keyblob_length == sizeof(rsa_2048_private_key_t));
+  TRY_CHECK(private_key.keyblob_length == sizeof(rsa_2048_private_key_t));
   rsa_2048_private_key_t *sk = (rsa_2048_private_key_t *)private_key.keyblob;
 
   // Check that the key uses the F4 exponent.

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -128,22 +128,20 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
   };
 
   // Construct the private key.
-  size_t key_length;
-  size_t keyblob_length;
-  TRY(otcrypto_rsa_private_key_length(kRsaSize2048, &key_length,
-                                      &keyblob_length));
   crypto_key_config_t private_key_config = {
       .version = kCryptoLibVersion1,
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kSecurityLevelLow,
   };
-  uint32_t keyblob[ceil_div(keyblob_length, sizeof(uint32_t))];
+  size_t keyblob_words =
+      ceil_div(kRsa2048PrivateKeyblobBytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
   crypto_blinded_key_t private_key = {
       .config = private_key_config,
       .keyblob = keyblob,
-      .keyblob_length = keyblob_length,
+      .keyblob_length = kRsa2048PrivateKeyblobBytes,
   };
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -204,19 +202,15 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
-  // Get the public key length from the size.
-  size_t key_length;
-  TRY(otcrypto_rsa_public_key_length(kRsaSize2048, &key_length));
-
   // Construct the public key.
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  uint32_t public_key_data[ceil_div(key_length, sizeof(uint32_t))];
+  uint32_t public_key_data[ceil_div(kRsa2048PublicKeyBytes, sizeof(uint32_t))];
   crypto_unblinded_key_t public_key = {
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa2048PublicKeyBytes,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kRsaSize2048, modulus,

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -18,81 +19,75 @@
 enum {
   /* Number of words for a SHA-512 digest. */
   kSha512DigestWords = 512 / 32,
-  /* Number of bytes for RSA-3072 modulus and private exponent. */
-  kRsa3072NumBytes = 3072 / 8,
-  /* Number of words for RSA-3072 modulus and private exponent. */
-  kRsa3072NumWords = kRsa3072NumBytes / sizeof(uint32_t),
 };
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
 static const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 
-// Configuration for the private exponent.
-static const crypto_key_config_t kRsaPrivateKeyConfig = {
-    .version = kCryptoLibVersion1,
-    .key_mode = kKeyModeRsaSignPkcs,
-    .key_length = kRsa3072NumBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kSecurityLevelLow,
-};
+// RSA key mode for testing.
+static const key_mode_t kTestKeyMode = kKeyModeRsaSignPkcs;
 
 status_t keygen_then_sign_test(void) {
-  // Allocate buffers for the public key.
-  uint32_t pub_n[kRsa3072NumWords] = {0};
-  uint32_t pub_e = 0;
-  rsa_public_key_t public_key = {
-      .n =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = kRsa3072NumBytes,
-              .key = pub_n,
-              .checksum = 0,
-          },
-      .e =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = sizeof(uint32_t),
-              .key = &pub_e,
-              .checksum = 0,
-          },
+  // Get the key lengths from the size.
+  size_t public_key_length;
+  TRY(otcrypto_rsa_public_key_length(kRsaSize3072, &public_key_length));
+  size_t private_key_length;
+  size_t private_keyblob_length;
+  TRY(otcrypto_rsa_private_key_length(kRsaSize3072, &private_key_length,
+                                      &private_keyblob_length));
+
+  // Allocate buffer for the public key.
+  uint32_t public_key_data[ceil_div(public_key_length, sizeof(uint32_t))];
+  memset(public_key_data, 0, sizeof(public_key_data));
+  crypto_unblinded_key_t public_key = {
+      .key_mode = kTestKeyMode,
+      .key_length = public_key_length,
+      .key = public_key_data,
   };
 
   // Allocate buffers for the private key.
-  uint32_t priv_n[kRsa3072NumWords] = {0};
-  uint32_t priv_d[kRsa3072NumWords] = {0};
-  rsa_private_key_t private_key = {
-      .n =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = kRsa3072NumBytes,
-              .key = priv_n,
-              .checksum = 0,
+  uint32_t keyblob[ceil_div(private_keyblob_length, sizeof(uint32_t))];
+  memset(keyblob, 0, sizeof(keyblob));
+  crypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kCryptoLibVersion1,
+              .key_mode = kTestKeyMode,
+              .key_length = private_key_length,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kSecurityLevelLow,
           },
-      .d =
-          (crypto_blinded_key_t){
-              .config = kRsaPrivateKeyConfig,
-              .keyblob_length = kRsa3072NumBytes,
-              .keyblob = priv_d,
-              .checksum = 0,
-          },
+      .keyblob_length = private_keyblob_length,
+      .keyblob = keyblob,
   };
 
   // Generate the key pair.
   LOG_INFO("Starting keypair generation...");
-  TRY(otcrypto_rsa_keygen(kRsaKeySize3072, &public_key, &private_key));
+  TRY(otcrypto_rsa_keygen(kRsaSize3072, &public_key, &private_key));
   LOG_INFO("Keypair generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 
+  // Interpret public key using internal RSA datatype.
+  TRY_CHECK(public_key_length == sizeof(rsa_3072_public_key_t));
+  rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key.key;
+
+  // Interpret private key using internal RSA datatype.
+  TRY_CHECK(private_keyblob_length == sizeof(rsa_3072_private_key_t));
+  rsa_3072_private_key_t *sk = (rsa_3072_private_key_t *)private_key.keyblob;
+
   // Check that the key uses the F4 exponent.
-  TRY_CHECK(public_key.e.key_length == sizeof(uint32_t));
-  TRY_CHECK(public_key.e.key[0] == 65537);
+  TRY_CHECK(pk->e == 65537);
+
+  // Check that the moduli match.
+  TRY_CHECK(ARRAYSIZE(pk->n.data) == ARRAYSIZE(sk->n.data));
+  TRY_CHECK_ARRAYS_EQ(pk->n.data, sk->n.data, ARRAYSIZE(pk->n.data));
 
   // Check that d is at least 2^(len(n) / 2) (this is a FIPS requirement) by
   // ensuring that the most significant half is nonzero.
   bool d_large_enough = false;
   for (size_t i = kRsa3072NumWords / 2; i < kRsa3072NumWords; i++) {
-    if (private_key.d.keyblob[i] != 0) {
+    if (sk->d.data[i] != 0) {
       d_large_enough = true;
     }
   }

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -29,36 +29,30 @@ static const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 static const key_mode_t kTestKeyMode = kKeyModeRsaSignPkcs;
 
 status_t keygen_then_sign_test(void) {
-  // Get the key lengths from the size.
-  size_t public_key_length;
-  TRY(otcrypto_rsa_public_key_length(kRsaSize3072, &public_key_length));
-  size_t private_key_length;
-  size_t private_keyblob_length;
-  TRY(otcrypto_rsa_private_key_length(kRsaSize3072, &private_key_length,
-                                      &private_keyblob_length));
-
   // Allocate buffer for the public key.
-  uint32_t public_key_data[ceil_div(public_key_length, sizeof(uint32_t))];
+  uint32_t public_key_data[ceil_div(kRsa3072PublicKeyBytes, sizeof(uint32_t))];
   memset(public_key_data, 0, sizeof(public_key_data));
   crypto_unblinded_key_t public_key = {
       .key_mode = kTestKeyMode,
-      .key_length = public_key_length,
+      .key_length = kRsa3072PublicKeyBytes,
       .key = public_key_data,
   };
 
   // Allocate buffers for the private key.
-  uint32_t keyblob[ceil_div(private_keyblob_length, sizeof(uint32_t))];
+  size_t keyblob_words =
+      ceil_div(kRsa3072PrivateKeyblobBytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
   memset(keyblob, 0, sizeof(keyblob));
   crypto_blinded_key_t private_key = {
       .config =
           {
               .version = kCryptoLibVersion1,
               .key_mode = kTestKeyMode,
-              .key_length = private_key_length,
+              .key_length = kRsa3072PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
               .security_level = kSecurityLevelLow,
           },
-      .keyblob_length = private_keyblob_length,
+      .keyblob_length = kRsa3072PrivateKeyblobBytes,
       .keyblob = keyblob,
   };
 
@@ -69,11 +63,11 @@ status_t keygen_then_sign_test(void) {
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 
   // Interpret public key using internal RSA datatype.
-  TRY_CHECK(public_key_length == sizeof(rsa_3072_public_key_t));
+  TRY_CHECK(public_key.key_length == sizeof(rsa_3072_public_key_t));
   rsa_3072_public_key_t *pk = (rsa_3072_public_key_t *)public_key.key;
 
   // Interpret private key using internal RSA datatype.
-  TRY_CHECK(private_keyblob_length == sizeof(rsa_3072_private_key_t));
+  TRY_CHECK(private_key.keyblob_length == sizeof(rsa_3072_private_key_t));
   rsa_3072_private_key_t *sk = (rsa_3072_private_key_t *)private_key.keyblob;
 
   // Check that the key uses the F4 exponent.

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -154,23 +154,20 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(share1),
   };
 
-  // Construct the private key.
-  size_t key_length;
-  size_t keyblob_length;
-  TRY(otcrypto_rsa_private_key_length(kRsaSize3072, &key_length,
-                                      &keyblob_length));
   crypto_key_config_t private_key_config = {
       .version = kCryptoLibVersion1,
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa3072PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kSecurityLevelLow,
   };
-  uint32_t keyblob[ceil_div(keyblob_length, sizeof(uint32_t))];
+  size_t keyblob_words =
+      ceil_div(kRsa3072PrivateKeyblobBytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
   crypto_blinded_key_t private_key = {
       .config = private_key_config,
       .keyblob = keyblob,
-      .keyblob_length = keyblob_length,
+      .keyblob_length = kRsa3072PrivateKeyblobBytes,
   };
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -232,19 +229,15 @@ static status_t run_rsa_3072_verify(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
-  // Get the public key length from the size.
-  size_t key_length;
-  TRY(otcrypto_rsa_public_key_length(kRsaSize3072, &key_length));
-
   // Construct the public key.
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  uint32_t public_key_data[ceil_div(key_length, sizeof(uint32_t))];
+  uint32_t public_key_data[ceil_div(kRsa3072PublicKeyBytes, sizeof(uint32_t))];
   crypto_unblinded_key_t public_key = {
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa3072PublicKeyBytes,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kRsaSize3072, modulus,

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -143,27 +143,42 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
+  // Create two shares for the private exponent (second share is all-zero).
+  crypto_const_word32_buf_t d_share0 = {
+      .data = kTestPrivateExponent,
+      .len = ARRAYSIZE(kTestPrivateExponent),
+  };
+  uint32_t share1[ARRAYSIZE(kTestPrivateExponent)] = {0};
+  crypto_const_word32_buf_t d_share1 = {
+      .data = share1,
+      .len = ARRAYSIZE(share1),
+  };
+
+  // Construct the private key.
+  size_t key_length;
+  size_t keyblob_length;
+  TRY(otcrypto_rsa_private_key_length(kRsaSize3072, &key_length,
+                                      &keyblob_length));
   crypto_key_config_t private_key_config = {
       .version = kCryptoLibVersion1,
       .key_mode = key_mode,
-      .key_length = kRsa3072NumBytes,
+      .key_length = key_length,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kSecurityLevelLow,
   };
-
-  rsa_private_key_t private_key = {
-      .n = {.key_mode = key_mode,
-            .key_length = sizeof(kTestModulus),
-            .key = kTestModulus,
-            .checksum = 0},
-      .d = {.config = private_key_config,
-            .keyblob = kTestPrivateExponent,
-            .keyblob_length = sizeof(kTestPrivateExponent),
-            .checksum = 0},
+  uint32_t keyblob[ceil_div(keyblob_length, sizeof(uint32_t))];
+  crypto_blinded_key_t private_key = {
+      .config = private_key_config,
+      .keyblob = keyblob,
+      .keyblob_length = keyblob_length,
   };
-
-  private_key.n.checksum = integrity_unblinded_checksum(&private_key.n);
-  private_key.d.checksum = integrity_blinded_checksum(&private_key.d);
+  crypto_const_word32_buf_t modulus = {
+      .data = kTestModulus,
+      .len = ARRAYSIZE(kTestModulus),
+  };
+  TRY(otcrypto_rsa_private_key_from_exponents(kRsaSize3072, modulus,
+                                              kTestPublicExponent, d_share0,
+                                              d_share1, &private_key));
 
   // Hash the message.
   crypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
@@ -217,19 +232,23 @@ static status_t run_rsa_3072_verify(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
-  rsa_public_key_t public_key = {
-      .n = {.key_mode = key_mode,
-            .key_length = sizeof(kTestModulus),
-            .key = kTestModulus,
-            .checksum = 0},
-      .e = {.key_mode = key_mode,
-            .key_length = sizeof(kTestPublicExponent),
-            .key = &kTestPublicExponent,
-            .checksum = 0},
-  };
+  // Get the public key length from the size.
+  size_t key_length;
+  TRY(otcrypto_rsa_public_key_length(kRsaSize3072, &key_length));
 
-  public_key.n.checksum = integrity_unblinded_checksum(&public_key.n);
-  public_key.e.checksum = integrity_unblinded_checksum(&public_key.e);
+  // Construct the public key.
+  crypto_const_word32_buf_t modulus = {
+      .data = kTestModulus,
+      .len = ARRAYSIZE(kTestModulus),
+  };
+  uint32_t public_key_data[ceil_div(key_length, sizeof(uint32_t))];
+  crypto_unblinded_key_t public_key = {
+      .key_mode = key_mode,
+      .key_length = key_length,
+      .key = public_key_data,
+  };
+  TRY(otcrypto_rsa_public_key_construct(kRsaSize3072, modulus,
+                                        kTestPublicExponent, &public_key));
 
   // Hash the message.
   crypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -18,81 +19,75 @@
 enum {
   /* Number of words for a SHA-512 digest. */
   kSha512DigestWords = 512 / 32,
-  /* Number of bytes for RSA-4096 modulus and private exponent. */
-  kRsa4096NumBytes = 4096 / 8,
-  /* Number of words for RSA-4096 modulus and private exponent. */
-  kRsa4096NumWords = kRsa4096NumBytes / sizeof(uint32_t),
 };
 
 // Message data for testing.
 static const unsigned char kTestMessage[] = "Test message.";
 static const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 
-// Configuration for the private exponent.
-static const crypto_key_config_t kRsaPrivateKeyConfig = {
-    .version = kCryptoLibVersion1,
-    .key_mode = kKeyModeRsaSignPkcs,
-    .key_length = kRsa4096NumBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kSecurityLevelLow,
-};
+// RSA key mode for testing.
+static const key_mode_t kTestKeyMode = kKeyModeRsaSignPkcs;
 
 status_t keygen_then_sign_test(void) {
-  // Allocate buffers for the public key.
-  uint32_t pub_n[kRsa4096NumWords] = {0};
-  uint32_t pub_e = 0;
-  rsa_public_key_t public_key = {
-      .n =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = kRsa4096NumBytes,
-              .key = pub_n,
-              .checksum = 0,
-          },
-      .e =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = sizeof(uint32_t),
-              .key = &pub_e,
-              .checksum = 0,
-          },
+  // Get the key lengths from the size.
+  size_t public_key_length;
+  TRY(otcrypto_rsa_public_key_length(kRsaSize4096, &public_key_length));
+  size_t private_key_length;
+  size_t private_keyblob_length;
+  TRY(otcrypto_rsa_private_key_length(kRsaSize4096, &private_key_length,
+                                      &private_keyblob_length));
+
+  // Allocate buffer for the public key.
+  uint32_t public_key_data[ceil_div(public_key_length, sizeof(uint32_t))];
+  memset(public_key_data, 0, sizeof(public_key_data));
+  crypto_unblinded_key_t public_key = {
+      .key_mode = kTestKeyMode,
+      .key_length = public_key_length,
+      .key = public_key_data,
   };
 
   // Allocate buffers for the private key.
-  uint32_t priv_n[kRsa4096NumWords] = {0};
-  uint32_t priv_d[kRsa4096NumWords] = {0};
-  rsa_private_key_t private_key = {
-      .n =
-          (crypto_unblinded_key_t){
-              .key_mode = kRsaPrivateKeyConfig.key_mode,
-              .key_length = kRsa4096NumBytes,
-              .key = priv_n,
-              .checksum = 0,
+  uint32_t keyblob[ceil_div(private_keyblob_length, sizeof(uint32_t))];
+  memset(keyblob, 0, sizeof(keyblob));
+  crypto_blinded_key_t private_key = {
+      .config =
+          {
+              .version = kCryptoLibVersion1,
+              .key_mode = kTestKeyMode,
+              .key_length = private_key_length,
+              .hw_backed = kHardenedBoolFalse,
+              .security_level = kSecurityLevelLow,
           },
-      .d =
-          (crypto_blinded_key_t){
-              .config = kRsaPrivateKeyConfig,
-              .keyblob_length = kRsa4096NumBytes,
-              .keyblob = priv_d,
-              .checksum = 0,
-          },
+      .keyblob_length = private_keyblob_length,
+      .keyblob = keyblob,
   };
 
   // Generate the key pair.
   LOG_INFO("Starting keypair generation...");
-  TRY(otcrypto_rsa_keygen(kRsaKeySize4096, &public_key, &private_key));
+  TRY(otcrypto_rsa_keygen(kRsaSize4096, &public_key, &private_key));
   LOG_INFO("Keypair generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 
+  // Interpret public key using internal RSA datatype.
+  TRY_CHECK(public_key_length == sizeof(rsa_4096_public_key_t));
+  rsa_4096_public_key_t *pk = (rsa_4096_public_key_t *)public_key.key;
+
+  // Interpret private key using internal RSA datatype.
+  TRY_CHECK(private_keyblob_length == sizeof(rsa_4096_private_key_t));
+  rsa_4096_private_key_t *sk = (rsa_4096_private_key_t *)private_key.keyblob;
+
   // Check that the key uses the F4 exponent.
-  TRY_CHECK(public_key.e.key_length == sizeof(uint32_t));
-  TRY_CHECK(public_key.e.key[0] == 65537);
+  TRY_CHECK(pk->e == 65537);
+
+  // Check that the moduli match.
+  TRY_CHECK(ARRAYSIZE(pk->n.data) == ARRAYSIZE(sk->n.data));
+  TRY_CHECK_ARRAYS_EQ(pk->n.data, sk->n.data, ARRAYSIZE(pk->n.data));
 
   // Check that d is at least 2^(len(n) / 2) (this is a FIPS requirement) by
   // ensuring that the most significant half is nonzero.
   bool d_large_enough = false;
   for (size_t i = kRsa4096NumWords / 2; i < kRsa4096NumWords; i++) {
-    if (private_key.d.keyblob[i] != 0) {
+    if (sk->d.data[i] != 0) {
       d_large_enough = true;
     }
   }

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -183,22 +183,20 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
   };
 
   // Construct the private key.
-  size_t key_length;
-  size_t keyblob_length;
-  TRY(otcrypto_rsa_private_key_length(kRsaSize4096, &key_length,
-                                      &keyblob_length));
   crypto_key_config_t private_key_config = {
       .version = kCryptoLibVersion1,
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kSecurityLevelLow,
   };
-  uint32_t keyblob[ceil_div(keyblob_length, sizeof(uint32_t))];
+  size_t keyblob_words =
+      ceil_div(kRsa4096PrivateKeyblobBytes, sizeof(uint32_t));
+  uint32_t keyblob[keyblob_words];
   crypto_blinded_key_t private_key = {
       .config = private_key_config,
       .keyblob = keyblob,
-      .keyblob_length = keyblob_length,
+      .keyblob_length = kRsa4096PrivateKeyblobBytes,
   };
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -260,19 +258,15 @@ static status_t run_rsa_4096_verify(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
-  // Get the public key length from the size.
-  size_t key_length;
-  TRY(otcrypto_rsa_public_key_length(kRsaSize4096, &key_length));
-
   // Construct the public key.
   crypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
       .len = ARRAYSIZE(kTestModulus),
   };
-  uint32_t public_key_data[ceil_div(key_length, sizeof(uint32_t))];
+  uint32_t public_key_data[ceil_div(kRsa4096PublicKeyBytes, sizeof(uint32_t))];
   crypto_unblinded_key_t public_key = {
       .key_mode = key_mode,
-      .key_length = key_length,
+      .key_length = kRsa4096PublicKeyBytes,
       .key = public_key_data,
   };
   TRY(otcrypto_rsa_public_key_construct(kRsaSize4096, modulus,

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -171,27 +171,42 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
+  // Create two shares for the private exponent (second share is all-zero).
+  crypto_const_word32_buf_t d_share0 = {
+      .data = kTestPrivateExponent,
+      .len = ARRAYSIZE(kTestPrivateExponent),
+  };
+  uint32_t share1[ARRAYSIZE(kTestPrivateExponent)] = {0};
+  crypto_const_word32_buf_t d_share1 = {
+      .data = share1,
+      .len = ARRAYSIZE(share1),
+  };
+
+  // Construct the private key.
+  size_t key_length;
+  size_t keyblob_length;
+  TRY(otcrypto_rsa_private_key_length(kRsaSize4096, &key_length,
+                                      &keyblob_length));
   crypto_key_config_t private_key_config = {
       .version = kCryptoLibVersion1,
       .key_mode = key_mode,
-      .key_length = kRsa4096NumBytes,
+      .key_length = key_length,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kSecurityLevelLow,
   };
-
-  rsa_private_key_t private_key = {
-      .n = {.key_mode = key_mode,
-            .key_length = sizeof(kTestModulus),
-            .key = kTestModulus,
-            .checksum = 0},
-      .d = {.config = private_key_config,
-            .keyblob = kTestPrivateExponent,
-            .keyblob_length = sizeof(kTestPrivateExponent),
-            .checksum = 0},
+  uint32_t keyblob[ceil_div(keyblob_length, sizeof(uint32_t))];
+  crypto_blinded_key_t private_key = {
+      .config = private_key_config,
+      .keyblob = keyblob,
+      .keyblob_length = keyblob_length,
   };
-
-  private_key.n.checksum = integrity_unblinded_checksum(&private_key.n);
-  private_key.d.checksum = integrity_blinded_checksum(&private_key.d);
+  crypto_const_word32_buf_t modulus = {
+      .data = kTestModulus,
+      .len = ARRAYSIZE(kTestModulus),
+  };
+  TRY(otcrypto_rsa_private_key_from_exponents(kRsaSize4096, modulus,
+                                              kTestPublicExponent, d_share0,
+                                              d_share1, &private_key));
 
   // Hash the message.
   crypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};
@@ -245,19 +260,23 @@ static status_t run_rsa_4096_verify(const uint8_t *msg, size_t msg_len,
       return INVALID_ARGUMENT();
   };
 
-  rsa_public_key_t public_key = {
-      .n = {.key_mode = key_mode,
-            .key_length = sizeof(kTestModulus),
-            .key = kTestModulus,
-            .checksum = 0},
-      .e = {.key_mode = key_mode,
-            .key_length = sizeof(kTestPublicExponent),
-            .key = &kTestPublicExponent,
-            .checksum = 0},
-  };
+  // Get the public key length from the size.
+  size_t key_length;
+  TRY(otcrypto_rsa_public_key_length(kRsaSize4096, &key_length));
 
-  public_key.n.checksum = integrity_unblinded_checksum(&public_key.n);
-  public_key.e.checksum = integrity_unblinded_checksum(&public_key.e);
+  // Construct the public key.
+  crypto_const_word32_buf_t modulus = {
+      .data = kTestModulus,
+      .len = ARRAYSIZE(kTestModulus),
+  };
+  uint32_t public_key_data[ceil_div(key_length, sizeof(uint32_t))];
+  crypto_unblinded_key_t public_key = {
+      .key_mode = key_mode,
+      .key_length = key_length,
+      .key = public_key_data,
+  };
+  TRY(otcrypto_rsa_public_key_construct(kRsaSize4096, modulus,
+                                        kTestPublicExponent, &public_key));
 
   // Hash the message.
   crypto_const_byte_buf_t msg_buf = {.data = msg, .len = msg_len};


### PR DESCRIPTION
Use normal key and word-buffer structs for RSA keys and signatures instead of specialized multi-level structs. This is more convenient for the caller and also will make it easier to adjust the representation of RSA datatypes under the hood (for example if we wanted to switch to a faster CRT-based RSA, which would represent d differently).

Part of https://github.com/lowRISC/opentitan/issues/19549
Related: https://github.com/lowRISC/opentitan/pull/20262 was essentially the same change for ECC