### PR TITLE
[keymgr_dpe, rtl] Fix invalid data on invalid advance

### DIFF
--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -281,6 +281,7 @@ module keymgr_dpe
   keymgr_dpe_slot_t active_key_slot;
   logic op_start;
   assign op_start = reg2hw.start.q;
+  logic invalid_advance;
   keymgr_dpe_ctrl u_ctrl (
     .clk_i,
     .rst_ni,
@@ -322,6 +323,7 @@ module keymgr_dpe
     .gen_en_o(gen_en),
     .key_o(kmac_key),
     .active_key_slot_o(active_key_slot),
+    .invalid_advance_o(invalid_advance),
     .kmac_done_i(kmac_done),
     .kmac_input_invalid_i(kmac_input_invalid),
     .kmac_fsm_err_i(kmac_fsm_err),
@@ -576,7 +578,8 @@ module keymgr_dpe
   // It does not check the validity of the requested operation, with respect to other inputs
   // such as policy violation etc.
   logic [3:0] invalid_data;
-  assign invalid_data[OpAdvance]  = ~key_vld | ~adv_dvalid[active_key_slot.boot_stage];
+  assign invalid_data[OpAdvance]  = ~key_vld | invalid_advance |
+                                    ~adv_dvalid[active_key_slot.boot_stage];
   // Keymgr_dpe does not have identity generation, therefore `id_en = 0`. The value of
   // `invalid_data[OpGenId] does not matter, but assign it to 0 for the sake of lint.
   assign invalid_data[OpGenId] = 1'b0;

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -66,6 +66,7 @@ module keymgr_dpe_ctrl
   output logic gen_en_o,
   output hw_key_req_t key_o,
   output keymgr_dpe_slot_t active_key_slot_o,
+  output invalid_advance_o,
 
   input kmac_done_i,
   input kmac_input_invalid_i, // asserted when selected data fails criteria check
@@ -620,6 +621,13 @@ module keymgr_dpe_ctrl
   assign invalid_erase = erase_req & ~destination_slot_valid;
 
   assign invalid_gen = gen_req & (~active_key_slot_o.valid | ~key_version_vld_o);
+
+  // This is similar to `invalid_advance` except that it does not depend on a incoming request.
+  // The outer module uses `invalid_advance_o` to invalidate KMAC msg payload, when the advance
+  // operation is not valid. It is better be loose here and ask to invalidate even when there is no
+  // advance request.
+  assign invalid_advance_o = invalid_allow_child | invalid_max_boot_stage |
+                                      invalid_src_slot | invalid_retain_parent;
 
   // Exportable DPE is not yet implemented, so mark it unused for lint.
   logic unused_exportable_bit;


### PR DESCRIPTION
Fixes #20467.

When an advance operation is invalid for various
reasons other than simple key invalidity check,
KMAC msg payload should still be carrying
randomized data.