### PR TITLE
[keymgr_dpe, rtl] Fix disable request

### DIFF
--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -133,10 +133,11 @@ module keymgr_dpe_ctrl
   logic fsm_at_disabled;
   logic fsm_at_invalid;
 
-  logic adv_req, gen_req, erase_req;
-  assign adv_req   = op_req & (op_i == OpDpeAdvance);
-  assign gen_req   = op_req & gen_key_op;
-  assign erase_req = op_req & (op_i == OpDpeErase);
+  logic adv_req, gen_req, erase_req, disable_req;
+  assign adv_req     = op_req & (op_i == OpDpeAdvance);
+  assign gen_req     = op_req & gen_key_op;
+  assign erase_req   = op_req & (op_i == OpDpeErase);
+  assign disable_req = op_req & (op_i == OpDpeDisable);
 
   ///////////////////////////
   //  interaction between operation fsm and software
@@ -178,7 +179,7 @@ module keymgr_dpe_ctrl
   logic random_ack;
 
   // wipe and initialize take precedence
-  assign update_sel = wipe_req                         ? SlotQuickWipeAll   :
+  assign update_sel = wipe_req                         ? SlotWipeAll        :
                       (state_q == StCtrlDpeRandom)     ? SlotDestRandomize  :
                       init_o & en_i & root_key_i.valid ? SlotLoadRoot       : op_update_sel;
 
@@ -186,7 +187,8 @@ module keymgr_dpe_ctrl
   // when in invalid state, always update.
   // when in disabled state, always update unless a fault is encountered.
   // op_update marks the clock cycle where KMAC returns the digest. It is the time to latch the key.
-  assign op_update_sel = op_update & op_fault_err               ? SlotQuickWipeAll :
+  assign op_update_sel = op_update & op_fault_err               ? SlotWipeAll :
+                         op_update & disable_req                ? SlotWipeAll :
                          op_update & (op_err | fsm_at_disabled) ? SlotUpdateIdle   :
                          op_update & adv_req                    ? SlotLoadFromKmac :
                          op_update & erase_req                  ? SlotErase        :
@@ -244,7 +246,7 @@ module keymgr_dpe_ctrl
   assign active_slot_policy     = active_key_slot_o.key_policy;
 
   assign data_valid_o = op_ack & gen_key_op;
-  assign wipe_key_o = update_sel == SlotQuickWipeAll;
+  assign wipe_key_o = update_sel == SlotWipeAll;
 
   logic destination_slot_valid;
   assign destination_slot_valid = key_slots_q[slot_dst_sel_i].valid;
@@ -296,7 +298,7 @@ module keymgr_dpe_ctrl
       // 1) Remove DPE contexts that should not be accessible in the later program flow
       // 2) Remove DPE contexts, so that the hardware keymgr slot can be used to derive another DPE
       // context through advance call.
-      // This is different than `SlotQuickWipeAll`, which removes all secrets inside keymgr_DPE when
+      // This is different than `SlotWipeAll`, which removes all secrets inside keymgr_DPE when
       // a fault is observed.
       SlotErase: begin
         for (int j = 0; j < Shares; j++) begin
@@ -306,9 +308,9 @@ module keymgr_dpe_ctrl
         end
       end
 
-      // `SlotQuickWipeAll` is used in a panic/terminal state where keymgr_dpe won't be reused until
-      // next reboot. This is triggered by detection of a fault attack.
-      SlotQuickWipeAll: begin
+      // `SlotWipeAll` is used in a panic/terminal state triggered by FI or during SW-initiated 
+      // transition to disabled where keymgr_dpe's slots will not be reused until next reboot.
+      SlotWipeAll: begin
         for (int i = 0; i < DpeNumSlots; i++) begin
           // Note that '0 for `key_policy` is a safe default, as it is the most restrictive policy
           key_slots_d[i] = '0;
@@ -557,6 +559,7 @@ module keymgr_dpe_ctrl
     .adv_req_i(adv_req),
     .gen_req_i(gen_req),
     .erase_req_i(erase_req),
+    .disable_req_i(disable_req),
     .op_ack_o(op_ack),
     .op_busy_o(op_busy),
     .op_update_o(op_update),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -89,7 +89,7 @@ package keymgr_dpe_pkg;
     SlotLoadRoot,
     SlotLoadFromKmac,
     SlotErase,
-    SlotQuickWipeAll
+    SlotWipeAll
   } keymgr_dpe_key_update_e;
 
   localparam keymgr_dpe_policy_t DEFAULT_UDS_POLICY = '{


### PR DESCRIPTION
#20468 reports that disable has two bugs:
1) it does not clean/erase internal keymgr slots
2) it does not correctly update status after the operation.

This commit adds an internal state to op_state_ctrl, so that disable commands also get a 1 clock cycle delayed handshake signals `op_update_o` and `op_ack_o`. These signals are used to clean keymgr slots and update the operation status.