### PR TITLE
[hw,dma,rtl] Fix enable signal for sys_req_.read_be

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -1484,7 +1484,7 @@ module dma
   ) u_sys_read_be (
     .clk_i ( gated_clk                      ),
     .rst_ni( rst_ni                         ),
-    .en_i  ( sys_req_d.vld_vec[SysCmdWrite] ),
+    .en_i  ( sys_req_d.vld_vec[SysCmdRead ] ),
     .d_i   ( sys_req_d.read_be              ),
     .q_o   ( sys_o.read_be                  )
   );


### PR DESCRIPTION
Read BE signal was using the write channel for its enable signal