### PR TITLE
[csrng/dv] Clean up CSRNG fips coverage

### DIFF
--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -392,6 +392,7 @@ interface csrng_cov_if (
       // Ignore invalid MuBi values for flags.
       ignore_bins ignore_invalid_mubi = !binsof(cp_flags) intersect { MuBi4True, MuBi4False };
     }
+    cmd_flag0_transition_app_cross: cross cp_flags_transition, cp_app;
   endgroup : csrng_cmds_cg
 
   // Covergroup to sample otp_en_cs_sw_app_read feature
@@ -475,6 +476,8 @@ interface csrng_cov_if (
       bins valid = { 1'b1 };
       bins invalid = { 1'b0 };
     }
+
+    genbits_fips_transition_app_cross: cross cp_genbits_fips_transition, cp_genbits_app;
   endgroup
 
   // This covergroup tracks the compliance bit in the CSRNG state_db.

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -265,7 +265,7 @@ interface csrng_cov_if (
     option.name         = "csrng_err_code_test_cg";
     option.per_instance = 1;
 
-    err_code_test_cp: coverpoint err_test;
+    cp_err_code_test: coverpoint err_test;
 
   endgroup : csrng_err_code_test_cg
 
@@ -273,7 +273,7 @@ interface csrng_cov_if (
     option.name         = "csrng_recov_alert_sts_cg";
     option.per_instance = 1;
 
-    recov_alert_sts_cp: coverpoint recov_alert;
+    cp_recov_alert_sts: coverpoint recov_alert;
   endgroup : csrng_recov_alert_sts_cg
 
   covergroup csrng_cmds_cg with function sample(bit [NUM_HW_APPS-1:0] app,

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -596,6 +596,14 @@ class csrng_scoreboard extends cip_base_scoreboard #(
             `DV_CHECK_EQ_FATAL(cs_item[app].genbits_q[i], prd_genbits_q[app][i])
             // Check if the FIPS compliance bit is set correctly.
             `DV_CHECK_EQ_FATAL(cs_item[app].fips_q[i], cfg.compliance[app])
+            cov_vif.cg_csrng_genbits_sample(
+                .genbits_fips(cs_item[app].fips_q[i]),
+                .genbits_fips_previous(genbits_fips_previous[app]),
+                .app(app),
+                .valid(1'b1),
+                .record_transition(genbits_fips_received[app]));
+            genbits_fips_previous[SW_APP] = cs_item[app].fips_q[i];
+            genbits_fips_received[SW_APP] = 1'b1;
           end
           // Deletes the predicted genbits before the next comparison.
           prd_genbits_q[app].delete();


### PR DESCRIPTION
This PR cleans up the code that makes up the fips coverage.
For a more detailed explanation please see the individual commit messages.

Most of this PR is already included in #20475.