### PR TITLE
[opentitantool] Add ability to "transport init" with strap

### DIFF
--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -67,7 +67,7 @@ impl<'a> TransportCommandHandler<'a> {
                 Ok(Response::GetCapabilities(self.transport.capabilities()?))
             }
             Request::ApplyDefaultConfiguration => {
-                self.transport.apply_default_configuration()?;
+                self.transport.apply_default_configuration(None)?;
                 Ok(Response::ApplyDefaultConfiguration)
             }
             Request::Gpio { id, command } => {
@@ -391,6 +391,13 @@ impl<'a> TransportCommandHandler<'a> {
                 ProxyRequest::RemovePinStrapping { strapping_name } => {
                     self.transport.pin_strapping(strapping_name)?.remove()?;
                     Ok(Response::Proxy(ProxyResponse::RemovePinStrapping))
+                }
+                ProxyRequest::ApplyDefaultConfigurationWithStrapping { strapping_name } => {
+                    self.transport
+                        .apply_default_configuration(Some(strapping_name))?;
+                    Ok(Response::Proxy(
+                        ProxyResponse::ApplyDefaultConfigurationWithStrapping,
+                    ))
                 }
             },
         }

--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -78,9 +78,6 @@ impl<'a> SessionHandler<'a> {
             NonblockingUartRegistry::new(),
             socket,
         )?;
-        // Configure all GPIO pins to default direction and level, according to
-        // configuration files provided, and configures SPI port mode/speed, etc.
-        transport.apply_default_configuration()?;
         Ok(Self {
             port,
             socket_server,

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -280,6 +280,9 @@ pub enum ProxyRequest {
     RemovePinStrapping {
         strapping_name: String,
     },
+    ApplyDefaultConfigurationWithStrapping {
+        strapping_name: String,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -290,4 +293,5 @@ pub enum ProxyResponse {
     Bootstrap,
     ApplyPinStrapping,
     RemovePinStrapping,
+    ApplyDefaultConfigurationWithStrapping,
 }

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -136,7 +136,7 @@ impl InitializeTest {
         let transport = backend::create(&self.backend_opts)?;
 
         // Set up the default pin configurations as specified in the transport's config file.
-        transport.apply_default_configuration()?;
+        transport.apply_default_configuration(None)?;
 
         // Create the UART first to initialize the desired parameters.
         let _uart = self.bootstrap.options.uart_params.create(&transport)?;

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -169,6 +169,9 @@ pub trait ProxyOps {
     fn bootstrap(&self, options: &BootstrapOptions, payload: &[u8]) -> Result<()>;
     fn apply_pin_strapping(&self, strapping_name: &str) -> Result<()>;
     fn remove_pin_strapping(&self, strapping_name: &str) -> Result<()>;
+
+    /// Applies the default transport init configuration expect with the specify strap applied.
+    fn apply_default_configuration_with_strap(&self, strapping_name: &str) -> Result<()>;
 }
 
 /// Used by Transport implementations dealing with emulated OpenTitan

--- a/sw/host/opentitanlib/src/transport/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/mod.rs
@@ -281,6 +281,15 @@ impl ProxyOps for ProxyOpsImpl {
             _ => bail!(ProxyError::UnexpectedReply()),
         }
     }
+
+    fn apply_default_configuration_with_strap(&self, strapping_name: &str) -> Result<()> {
+        match self.execute_command(ProxyRequest::ApplyDefaultConfigurationWithStrapping {
+            strapping_name: strapping_name.to_string(),
+        })? {
+            ProxyResponse::ApplyDefaultConfigurationWithStrapping => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
 }
 
 impl Transport for Proxy {

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -21,7 +21,11 @@ use opentitanlib::transport::UpdateFirmware;
 /// typically involves setting pins as input/output, open drain, etc. according to configuration
 /// files.
 #[derive(Debug, Args)]
-pub struct TransportInit {}
+pub struct TransportInit {
+    /// Optional gpio strap to apply during transport initialization.
+    #[arg(short, long)]
+    pub gpio_strap: Option<String>,
+}
 
 impl CommandDispatch for TransportInit {
     fn run(
@@ -31,7 +35,8 @@ impl CommandDispatch for TransportInit {
     ) -> Result<Option<Box<dyn Annotate>>> {
         // Configure all GPIO pins to default direction and level, according to
         // configuration files provided, and configures SPI port mode/speed, etc.
-        transport.apply_default_configuration()?;
+        // Also apply an optional, named gpio strap while performing pin initialization.
+        transport.apply_default_configuration(self.gpio_strap.as_deref())?;
         Ok(None)
     }
 }

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -147,7 +147,7 @@ fn main() -> Result<()> {
     // We call the below functions, instead of calling `opts.init.init_target()` since we do not
     // want to perform bootstrap yet.
     let transport = backend::create(&opts.init.backend_opts)?;
-    transport.apply_default_configuration()?;
+    transport.apply_default_configuration(None)?;
     InitializeTest::print_result("load_bitstream", opts.init.load_bitstream.init(&transport))?;
 
     execute_test!(manuf_cp_device_info_flash_wr, &opts, &transport);

--- a/sw/host/tests/manuf/provisioning/ft/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/ft/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
     // We call the below functions, instead of calling `opts.init.init_target()` since we do not
     // want to perform bootstrap yet.
     let transport = backend::create(&opts.init.backend_opts)?;
-    transport.apply_default_configuration()?;
+    transport.apply_default_configuration(None)?;
     InitializeTest::print_result("load_bitstream", opts.init.load_bitstream.init(&transport))?;
 
     // Format test tokens.


### PR DESCRIPTION
It is desirable to perform the transport initialization with an optional named gpio strap to use when initializing pins. This is especially useful if one wants to perform initialization with the target being held in reset without any glitches on the reset line.