### PR TITLE
[hw,spi_host,dif] Split the configuration and FIFO read in different functions

### DIFF
--- a/sw/ip/spi_host/dif/dif_spi_host.c
+++ b/sw/ip/spi_host/dif/dif_spi_host.c
@@ -375,10 +375,14 @@ static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,
   return kDifOk;
 }
 
-dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
-                                      uint32_t csid,
-                                      dif_spi_host_segment_t *segments,
-                                      size_t length) {
+dif_result_t dif_spi_host_start_transaction(const dif_spi_host_t *spi_host,
+                                            uint32_t csid,
+                                            dif_spi_host_segment_t *segments,
+                                            size_t length) {
+  if (spi_host == NULL || segments == NULL) {
+    return kDifBadArg;
+  }
+
   // Write to chip select ID.
   mmio_region_write32(spi_host->base_addr, SPI_HOST_CSID_REG_OFFSET, csid);
 
@@ -411,6 +415,15 @@ dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
         return kDifBadArg;
     }
   }
+  return kDifOk;
+}
+
+dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
+                                      uint32_t csid,
+                                      dif_spi_host_segment_t *segments,
+                                      size_t length) {
+  DIF_RETURN_IF_ERROR(
+      dif_spi_host_start_transaction(spi_host, csid, segments, length));
 
   // For each segment which receives data, read from the receive FIFO.
   for (size_t i = 0; i < length; ++i) {

--- a/sw/ip/spi_host/dif/dif_spi_host.h
+++ b/sw/ip/spi_host/dif/dif_spi_host.h
@@ -195,6 +195,21 @@ dif_result_t dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
                                     uint16_t len);
 
 /**
+ * Begins a SPI Host transaction without reading the FIFOs.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param csid The chip-select ID of the SPI target.
+ * @param segments The SPI segments to send in this transaction.
+ * @param length The number of SPI segments in this transaction.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_start_transaction(const dif_spi_host_t *spi_host,
+                                            uint32_t csid,
+                                            dif_spi_host_segment_t *segments,
+                                            size_t length);
+
+/**
  * Begins a SPI Host transaction.
  *
  * @param spi_host A SPI Host handle.

--- a/sw/ip/spi_host/dif/dif_spi_host_unittest.cc
+++ b/sw/ip/spi_host/dif/dif_spi_host_unittest.cc
@@ -278,13 +278,13 @@ TEST_F(ConfigTest, SpiTxRxWatermark) {
   EXPECT_DIF_OK(dif_spi_host_configure(&spi_host_, config_));
 }
 
-class TransactionTest : public SpiHostTest {
+class TransactionStartTest : public SpiHostTest {
  protected:
   MockFifo fifo_;
 };
 
 // Checks that an opcode segment is sent correctly.
-TEST_F(TransactionTest, IssueOpcode) {
+TEST_F(TransactionStartTest, IssueOpcode) {
   dif_spi_host_segment segment;
   segment.type = kDifSpiHostSegmentTypeOpcode;
   segment.opcode = 0x5a;
@@ -301,7 +301,7 @@ TEST_F(TransactionTest, IssueOpcode) {
 }
 
 // Checks that an address segment is sent correctly in 3-byte mode.
-TEST_F(TransactionTest, IssueAddressMode3b) {
+TEST_F(TransactionStartTest, IssueAddressMode3b) {
   dif_spi_host_segment segment;
   segment.type = kDifSpiHostSegmentTypeAddress;
   segment.address.width = kDifSpiHostWidthStandard;
@@ -320,7 +320,7 @@ TEST_F(TransactionTest, IssueAddressMode3b) {
 }
 
 // Checks that an address segment is sent correctly in 4-byte mode.
-TEST_F(TransactionTest, IssueAddressMode4b) {
+TEST_F(TransactionStartTest, IssueAddressMode4b) {
   dif_spi_host_segment segment;
   segment.type = kDifSpiHostSegmentTypeAddress;
   segment.address.width = kDifSpiHostWidthStandard;
@@ -339,7 +339,7 @@ TEST_F(TransactionTest, IssueAddressMode4b) {
 }
 
 // Checks that a dummy segment is sent correctly.
-TEST_F(TransactionTest, IssueDummy) {
+TEST_F(TransactionStartTest, IssueDummy) {
   dif_spi_host_segment segment;
   segment.type = kDifSpiHostSegmentTypeDummy;
   segment.dummy.width = kDifSpiHostWidthStandard;
@@ -352,6 +352,11 @@ TEST_F(TransactionTest, IssueDummy) {
 
   EXPECT_DIF_OK(dif_spi_host_transaction(&spi_host_, 0, &segment, 1));
 }
+
+class TransactionTest : public SpiHostTest {
+ protected:
+  MockFifo fifo_;
+};
 
 // Checks that a transmit segment is sent correctly.
 TEST_F(TransactionTest, TransmitDual) {


### PR DESCRIPTION
When using the DMA in hardware handshake mode, we need to configure the SPI host first and then let the DMA read or write the FIFOs. This PR splits up the single function that configures the DMA and accesses the FIFOs into two, without changing the API of this DIF.