### PR TITLE
[crypto] Add entropy complex checks to key drivers.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -17,6 +17,7 @@ cc_library(
     srcs = ["aes.c"],
     hdrs = ["aes.h"],
     deps = [
+        ":entropy",
         "//hw/ip/aes/data:aes_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -88,6 +89,7 @@ cc_library(
         "//sw/device/lib/crypto/include:datatypes.h",
     ],
     deps = [
+        ":entropy",
         "//hw/ip/kmac/data:kmac_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -176,6 +178,7 @@ cc_library(
     srcs = ["otbn.c"],
     hdrs = ["otbn.h"],
     deps = [
+        ":entropy",
         "//hw/ip/otbn/data:otbn_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",

--- a/sw/device/lib/crypto/drivers/aes_test.c
+++ b/sw/device/lib/crypto/drivers/aes_test.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/aes.h"
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -113,6 +114,7 @@ static status_t run_aes_test(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
+  CHECK_STATUS_OK(entropy_complex_init());
   CHECK_STATUS_OK(run_aes_test());
 
   return true;

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -138,6 +138,8 @@ static status_t keymgr_wait_until_done(void) {
 
 status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
                                 keymgr_output_t *key) {
+  // Ensure that the entropy complex has been initialized and keymgr is idle.
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(keymgr_is_idle());
 
   // Set the control register to generate a software-visible key.
@@ -164,6 +166,8 @@ status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
 }
 
 status_t keymgr_generate_key_aes(keymgr_diversification_t diversification) {
+  // Ensure that the entropy complex has been initialized and keymgr is idle.
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(keymgr_is_idle());
 
   // Set the control register to generate an AES key.
@@ -175,6 +179,8 @@ status_t keymgr_generate_key_aes(keymgr_diversification_t diversification) {
 }
 
 status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
+  // Ensure that the entropy complex has been initialized and keymgr is idle.
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(keymgr_is_idle());
 
   // Set the control register to generate a KMAC key.
@@ -186,6 +192,8 @@ status_t keymgr_generate_key_kmac(keymgr_diversification_t diversification) {
 }
 
 status_t keymgr_generate_key_otbn(keymgr_diversification_t diversification) {
+  // Ensure that the entropy complex has been initialized and keymgr is idle.
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(keymgr_is_idle());
 
   // Set the control register to generate an OTBN key.
@@ -207,10 +215,9 @@ status_t keymgr_generate_key_otbn(keymgr_diversification_t diversification) {
  * @param slot Value to write to the SIDELOAD_CLEAR register.
  */
 static status_t keymgr_sideload_clear(uint32_t slot) {
-  HARDENED_TRY(keymgr_is_idle());
-
-  // Ensure that the entropy complex has been initialized.
+  // Ensure that the entropy complex has been initialized and keymgr is idle.
   HARDENED_TRY(entropy_complex_check());
+  HARDENED_TRY(keymgr_is_idle());
 
   // Set SIDELOAD_CLEAR to begin continuously clearing the requested slot.
   abs_mmio_write32(

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -179,6 +180,10 @@ status_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest) {
 }
 
 status_t otbn_execute(void) {
+  // Ensure that the entropy complex is in a good state (for the RND
+  // instruction and data wiping).
+  HARDENED_TRY(entropy_complex_check());
+
   // Ensure OTBN is idle before attempting to run a command.
   HARDENED_TRY(otbn_assert_idle());
 
@@ -228,6 +233,7 @@ uint32_t otbn_instruction_count_get(void) {
 }
 
 status_t otbn_imem_sec_wipe(void) {
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(otbn_assert_idle());
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeImem);
   HARDENED_TRY(otbn_busy_wait_for_done());
@@ -235,6 +241,7 @@ status_t otbn_imem_sec_wipe(void) {
 }
 
 status_t otbn_dmem_sec_wipe(void) {
+  HARDENED_TRY(entropy_complex_check());
   HARDENED_TRY(otbn_assert_idle());
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdSecWipeDmem);
   HARDENED_TRY(otbn_busy_wait_for_done());

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -23,6 +23,7 @@ opentitan_test(
     ),
     deps = [
         ":aes_testvectors",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -574,6 +575,7 @@ opentitan_test(
         timeout = "long",
     ),
     deps = [
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:kdf",
         "//sw/device/lib/crypto/impl:keyblob",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/aes.h"
@@ -250,6 +251,9 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
+
+  // Start the entropy complex.
+  CHECK_STATUS_OK(entropy_complex_init());
 
   for (size_t i = 0; i < ARRAYSIZE(kAesTests); i++) {
     LOG_INFO("Starting AES test %d of %d...", i + 1, ARRAYSIZE(kAesTests));

--- a/sw/device/tests/crypto/aes_gcm_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_functest.c
@@ -5,6 +5,7 @@
 #include <stddef.h>
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/tests/crypto/aes_gcm_testutils.h"
@@ -33,6 +34,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
+
+  CHECK_STATUS_OK(entropy_complex_init());
 
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     LOG_INFO("Starting AES-GCM test %d of %d...", i + 1,

--- a/sw/device/tests/crypto/aes_gcm_timing_test.c
+++ b/sw/device/tests/crypto/aes_gcm_timing_test.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/aes_gcm/aes_gcm.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -71,6 +72,7 @@ static status_t test_decrypt_timing(void) {
 OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result;
+  CHECK_STATUS_OK(entropy_complex_init());
   for (size_t i = 0; i < ARRAYSIZE(kAesGcmTestvectors); i++) {
     current_test = &kAesGcmTestvectors[i];
     LOG_INFO("Key length = %d", current_test->key_len * sizeof(uint32_t));

--- a/sw/device/tests/crypto/aes_kwp_kat_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_kat_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/runtime/log.h"
@@ -150,6 +151,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
 
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(result, no_padding_test);
   EXECUTE_TEST(result, needs_padding_test);
 

--- a/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_verify_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/ecc/ecdsa_p256.h"
@@ -51,6 +52,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   // Stays true only if all tests pass.
   bool result = true;
+
+  CHECK_STATUS_OK(entropy_complex_init());
 
   // The definition of `RULE_NAME` comes from the autogen Bazel rule.
   LOG_INFO("Starting ecdsa_p256_verify_test:%s", RULE_NAME);

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -370,6 +371,9 @@ static status_t rfc_test3(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
+  // Start the entropy complex.
+  CHECK_STATUS_OK(entropy_complex_init());
+
   status_t test_result = OK_STATUS();
   EXECUTE_TEST(test_result, rfc_test1);
   EXECUTE_TEST(test_result, rfc_test2);

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -145,6 +146,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -153,6 +154,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -162,6 +163,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, long_key_test);

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hash.h"
@@ -177,6 +178,7 @@ bool test_main(void) {
   LOG_INFO("Testing cryptolib KMAC driver.");
 
   // Initialize the core with default parameters
+  CHECK_STATUS_OK(entropy_complex_init());
   CHECK_STATUS_OK(kmac_hwip_default_configure());
 
   status_t test_result = OK_STATUS();

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hash.h"
@@ -170,6 +171,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, simple_test);
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, one_update_streaming_test);

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/runtime/log.h"
@@ -134,6 +135,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, empty_test);
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/runtime/log.h"
@@ -123,6 +124,7 @@ static volatile status_t test_result;
 
 bool test_main(void) {
   test_result = OK_STATUS();
+  CHECK_STATUS_OK(entropy_complex_init());
   EXECUTE_TEST(test_result, one_block_test);
   EXECUTE_TEST(test_result, two_block_test);
   EXECUTE_TEST(test_result, streaming_test);


### PR DESCRIPTION
After reviewing the documentation of hardware used by the cryptolib, I found that most of them require input from EDN at least for masking. This PR updates all applicable cryptolib drivers to check the state of the entropy complex before running a routine that might consume entropy. Afterwards, I had to add entropy initialization to several crypto tests.