### PR TITLE
[fi] Add Ibex FI command handlers

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -47,6 +47,22 @@ cc_library(
 )
 
 cc_library(
+    name = "ibex_fi",
+    srcs = ["ibex_fi.c"],
+    hdrs = ["ibex_fi.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
+    ],
+)
+
+cc_library(
     name = "prng_sca",
     srcs = ["prng_sca.c"],
     hdrs = ["prng_sca.h"],
@@ -71,6 +87,7 @@ opentitan_binary(
     deps = [
         ":aes",
         ":aes_sca",
+        ":ibex_fi",
         ":prng_sca",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
@@ -80,5 +97,6 @@ opentitan_binary(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -14,11 +14,13 @@
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
 
 // Include handlers
 #include "aes.h"
 #include "aes_sca.h"
+#include "ibex_fi.h"
 #include "prng_sca.h"
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
@@ -33,6 +35,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));
+        break;
+      case kCryptotestCommandIbexFi:
+        RESP_ERR(uj, handle_ibex_fi(uj));
         break;
       case kCryptotestCommandPrngSca:
         RESP_ERR(uj, handle_prng_sca(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define NOP1 "addi x0, x0, 0\n"
+#define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
+#define NOP100 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10
+
+#define INITX5 "addi x5, x0, 0"
+
+#define ADDI1 "addi x5, x5, 1\n"
+#define ADDI10 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1
+#define ADDI100 \
+  ADDI10 ADDI10 ADDI10 ADDI10 ADDI10 ADDI10 ADDI10 ADDI10 ADDI10 ADDI10
+#define ADDI1000                                                          \
+  ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 \
+      ADDI100
+
+/**
+ * Initializes the SCA trigger.
+ *
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4);
+  return OK_STATUS(0);
+}
+
+/**
+ * ibex.char.unrolled_reg_op_loop command handler.
+ *
+ * This FI penetration tests executes the following instructions:
+ * - Initialize register x5=0
+ * - Add 100 NOPs to delay the trigger
+ * - Perform 10000 x5 = x5 + 1 additions
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
+  // Configure Ibex to allow reading ERR_STATUS register.
+  dif_rv_core_ibex_t rv_core_ibex;
+  if (dif_rv_core_ibex_init(
+          mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+          &rv_core_ibex) != kDifOk) {
+    return ABORTED();
+  }
+
+  // FI code target.
+  uint32_t loop_counter = 0;
+  sca_set_trigger_high();
+  asm volatile(INITX5);
+  asm volatile(NOP100);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile(ADDI1000);
+  asm volatile("mv %0, x5" : "=r"(loop_counter));
+  sca_set_trigger_low();
+
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  if (dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes) != kDifOk) {
+    return ABORTED();
+  }
+
+  // Send loop counter & ERR_STATUS to host.
+  ibex_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * Ibex FI command handler.
+ *
+ * Command handler for the Ibex FI command.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi(ujson_t *uj) {
+  ibex_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_ibex_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kIbexFiSubcommandInitTrigger:
+      return handle_ibex_fi_init_trigger(uj);
+    case kIbexFiSubcommandCharUnrolledRegOpLoop:
+      return handle_ibex_fi_char_unrolled_reg_op_loop(uj);
+    default:
+      LOG_ERROR("Unrecognized IBEX FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_IBEX_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_IBEX_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj);
+status_t handle_ibex_fi_init_trigger(ujson_t *uj);
+status_t handle_ibex_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_IBEX_FI_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -26,6 +26,13 @@ cc_library(
 )
 
 cc_library(
+    name = "ibex_fi_commands",
+    srcs = ["ibex_fi_commands.c"],
+    hdrs = ["ibex_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "prng_sca_commands",
     srcs = ["prng_sca_commands.c"],
     hdrs = ["prng_sca_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -13,8 +13,9 @@ extern "C" {
 
 #define COMMAND(_, value) \
     value(_, Aes) \
-    value(_, PrngSca) \
-    value(_, AesSca)
+    value(_, AesSca) \
+    value(_, IbexFi) \
+    value(_, PrngSca)
 UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
 
 // clang-format on

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "ibex_fi_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_IBEX_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_IBEX_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define IBEXFI_SUBCOMMAND(_, value) \
+    value(_, InitTrigger) \
+    value(_, CharUnrolledRegOpLoop)
+UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
+
+#define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
+    field(loop_counter, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_IBEX_FI_COMMANDS_H_


### PR DESCRIPTION
This PR adds first FI command handlers for the first Ibex penetration testto the codebase.

The host code is located in the ot-sca repository
([PR#224](https://github.com/lowRISC/ot-sca/pull/224)).

@milesdai please let me know whether I can keep these fils here or where to move them.