### PR TITLE
[rv_dm,dv] move stop=0 to pre_body

### DIFF
--- a/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
@@ -41,8 +41,11 @@ class tl_device_seq #(type REQ = tl_seq_item, int unsigned AddrWidth = 32) exten
     };
   }
 
-  virtual task body();
+  virtual task pre_body();
     stop = 0; // Allow sequence to restart after stop
+  endtask
+
+  virtual task body();
     fork
       begin: isolation_thread
         fork


### PR DESCRIPTION
Address race condition discussed in #20417 

In earlgrey, it replies on default initialization but from 
[here](https://github.com/lowRISC/opentitan/commit/db92b366ee79fd2b2cb1fce8f2769ba3e9f24bb7)
it is added on purpose. So I move this to pre_body.