### PR TITLE
[hw,dma,rtl] Use the FSM state to lock/unlock the register set

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -319,6 +319,7 @@
             '''
       swaccess: "ro"
       hwaccess: "hwo"
+      hwext: "true"
       fields: [
         { bits: "3:0"
           mubi: "true"

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -102,7 +102,6 @@ module dma
   logic cfg_abort_en;
   assign cfg_abort_en = reg2hw.control.abort.q;
 
-  logic clear_cfg_regwen, set_cfg_regwen;
   logic cfg_handshake_en;
 
   logic [SYS_METADATA_WIDTH-1:0] src_metadata;
@@ -1199,13 +1198,8 @@ module dma
     hw2reg.control.go.de = clear_go || cfg_abort_en;
     hw2reg.control.go.d  = 1'b0;
 
-    // Lock or unlock the regwen when leaving or returning back to DmaIdle
-    clear_cfg_regwen = (ctrl_state_q == DmaIdle) && (ctrl_state_d != DmaIdle);
-    set_cfg_regwen   = hw2reg.control.go.de;
-    // Convert the regwen set/clear signal to the multi bit
-    hw2reg.cfg_regwen.de = set_cfg_regwen | clear_cfg_regwen;
-    hw2reg.cfg_regwen.d  = prim_mubi_pkg::mubi4_bool_to_mubi(set_cfg_regwen);
-
+    // Unlock the register set when we are in the idle state
+    hw2reg.cfg_regwen.d = prim_mubi_pkg::mubi4_bool_to_mubi(ctrl_state_q == DmaIdle);
 
     // If we are in hardware handshake mode with auto-increment increment the corresponding address
     // when finishing a DMA operation when transitioning from a data move state to the idle state

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -234,7 +234,6 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [3:0]  d;
-    logic        de;
   } dma_hw2reg_cfg_regwen_reg_t;
 
   typedef struct packed {
@@ -350,12 +349,12 @@ package dma_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    dma_hw2reg_intr_state_reg_t intr_state; // [702:697]
-    dma_hw2reg_source_address_lo_reg_t source_address_lo; // [696:664]
-    dma_hw2reg_source_address_hi_reg_t source_address_hi; // [663:631]
-    dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [630:598]
-    dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [597:565]
-    dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [564:560]
+    dma_hw2reg_intr_state_reg_t intr_state; // [701:696]
+    dma_hw2reg_source_address_lo_reg_t source_address_lo; // [695:663]
+    dma_hw2reg_source_address_hi_reg_t source_address_hi; // [662:630]
+    dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [629:597]
+    dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [596:564]
+    dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [563:560]
     dma_hw2reg_control_reg_t control; // [559:554]
     dma_hw2reg_status_reg_t status; // [553:544]
     dma_hw2reg_error_code_reg_t error_code; // [543:528]
@@ -436,6 +435,8 @@ package dma_reg_pkg;
   parameter logic [0:0] DMA_INTR_TEST_DMA_MEMORY_BUFFER_LIMIT_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [3:0] DMA_CFG_REGWEN_RESVAL = 4'h 6;
+  parameter logic [3:0] DMA_CFG_REGWEN_REGWEN_RESVAL = 4'h 6;
 
   // Register index
   typedef enum int {

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -173,6 +173,7 @@ module dma_reg_top (
   logic range_regwen_we;
   logic [3:0] range_regwen_qs;
   logic [3:0] range_regwen_wd;
+  logic cfg_regwen_re;
   logic [3:0] cfg_regwen_qs;
   logic total_data_size_we;
   logic [31:0] total_data_size_qs;
@@ -904,30 +905,18 @@ module dma_reg_top (
   );
 
 
-  // R[cfg_regwen]: V(False)
-  prim_subreg #(
-    .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+  // R[cfg_regwen]: V(True)
+  prim_subreg_ext #(
+    .DW    (4)
   ) u_cfg_regwen (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (cfg_regwen_re),
     .we     (1'b0),
     .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.cfg_regwen.de),
     .d      (hw2reg.cfg_regwen.d),
-
-    // to internal hardware
+    .qre    (),
     .qe     (),
     .q      (),
     .ds     (),
-
-    // to register interface (read)
     .qs     (cfg_regwen_qs)
   );
 
@@ -3269,6 +3258,7 @@ module dma_reg_top (
   assign range_regwen_we = addr_hit[12] & reg_we & !reg_error;
 
   assign range_regwen_wd = reg_wdata[3:0];
+  assign cfg_regwen_re = addr_hit[13] & reg_re & !reg_error;
   assign total_data_size_we = addr_hit[14] & reg_we & !reg_error;
 
   assign total_data_size_wd = reg_wdata[31:0];


### PR DESCRIPTION
This breaks a dependency on next state and improves the readability. Instead of having a dedicated register, we make the `CFG_REGWEN` to a `hwext` register and use the control state of the FSM to indicate if we enable writing or not.