### PR TITLE
[rv_dm,dv] fix regression failure

### DIFF
--- a/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
@@ -41,6 +41,14 @@ class tl_device_seq #(type REQ = tl_seq_item) extends dv_base_seq #(
     };
   }
 
+  // In case this seq start in the middle of other body.
+  // If we set `stop` at the beginning of this body, then
+  // there is a risk to get the race when start and stop are called
+  // at the same time.
+  virtual task pre_body();
+    stop = 0;
+  endtask
+
   virtual task body();
     fork
       begin: isolation_thread

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -18,6 +18,13 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
 
   `uvm_object_new
 
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
   task body();
     // Read the JTAG IDCODE register and verify that it matches the expected value.
     jtag_item req;


### PR DESCRIPTION
Discovered from darjeeling debug.
- fix rv_dm_fsm_vseq test to use constant scanmode and lc_hw_debug_en value
- Add explicit stop = 0 in case we want to reuse tl_device_sequence in the middle of the body.
  