### PR TITLE
[sival,clkmgr,pwrmgr] Fix non-existent tests

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -144,12 +144,8 @@
               "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",
               "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
               "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",
-              "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",
-              "manuf_cp_unlock_raw",
-              "manuf_cp_yield_test"]
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma"]
       bazel: [
-        "//sw/device/silicon_creator/manuf/tests:manuf_cp_unlock_raw_functest_fpga_cw310_rom_with_fake_keys",
-        "//sw/device/silicon_creator/manuf/tests:manuf_cp_yield_test_functest_test_unlocked0_fpga_cw310_rom_with_fake_keys",
         "//sw/device/tests:ast_clk_outs_test_cw310_test_rom",
         "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_cw310_test_rom",
         "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_cw310_test_rom",
@@ -172,11 +168,8 @@
         "RAW",
         "TEST_LOCKED0",
       ]
-      tests: [
-        "chip_sw_clkmgr_external_clk_src_for_lc",
-        "manuf_cp_unlock_raw",
-      ]
-      bazel: ["//sw/device/silicon_creator/manuf/tests:manuf_cp_unlock_raw_functest_fpga_cw310_rom_with_fake_keys"]
+      tests: ["chip_sw_clkmgr_external_clk_src_for_lc"]
+      bazel: []
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_sw

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -117,7 +117,7 @@
       bazel: ["//sw/device/tests:pwrmgr_deep_sleep_por_reset_test_fpga_cw310_test_rom"]
     }
     {
-      name: chip_sw_pwrmgr_sleep_por_reset
+      name: chip_sw_pwrmgr_normal_sleep_por_reset
       desc: '''Verify POR in normal sleep mode.
 
             This verifies that the pwrmgr can handle POR in normal sleep. The chip is placed
@@ -139,7 +139,7 @@
         "PWRMGR.LOW_POWER.ENTRY",
         "PWRMGR.RESET.POR_REQUEST",
       ]
-      tests: ["chip_sw_pwrmgr_sleep_por_reset"]
+      tests: ["chip_sw_pwrmgr_normal_sleep_por_reset"]
       bazel: ["//sw/device/tests:pwrmgr_normal_sleep_por_reset_test_fpga_cw310_test_rom"]
     }
     {


### PR DESCRIPTION
Remove manuf_cp* tests since they that code will be run to provision the chips.
