### PR TITLE
[rom_ext, sival] Build & Sign configuration for SiVAL ROM_EXT

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
@@ -9,9 +9,11 @@ load(
 )
 load(
     "//rules:otp.bzl",
+    "otp_hex",
     "otp_image",
     "otp_image_consts",
     "otp_json",
+    "otp_partition",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -42,6 +44,7 @@ MANUF_INITIALIZED = [
 MANUF_SW_INITIALIZED = [
     "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:alert_digest_cfg",
     "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_creator_sw_cfg",
+    "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_json_manuf_state_creator_sival",
     "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/generic:otp_json_owner_sw_cfg",
 ]
 
@@ -57,6 +60,18 @@ MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
     "//hw/ip/otp_ctrl/data:otp_json_secret1",
     "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
+
+otp_json(
+    name = "otp_json_manuf_state_creator_sival",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
+            },
+        ),
+    ],
+)
 
 # OTP SW Configuration. Used to generate a configuration program used during
 # manufacturing. The `MANUF_SW_INITIALIZED` OTP profile is also used to derive

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -144,7 +144,7 @@ fpga_cw310(
     base = ":fpga_cw310_rom_ext",
     exec_env = "fpga_cw310_sival_rom_ext",
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_sival_prod_signed_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
     tags = ["cw310_sival_rom_ext"],
 )

--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -112,6 +112,9 @@ CONST = struct(
         ESC_PHASE_2 = 0x25,
         ESC_PHASE_3 = 0x76,
     ),
+    MANUF_STATE = struct(
+        SIVAL = 0x30305653,  # ASCII `SV00`.
+    ),
 )
 
 _DEFAULT_LC_STATES = [

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -262,23 +262,6 @@ opentitan_binary(
 )
 
 opentitan_binary(
-    name = "rom_ext_sival_prod_signed_slot_a",
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:sim_dv_base",
-        "//hw/top_earlgrey:sim_verilator_base",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
-    deps = [
-        ":rom_ext",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-    ],
-)
-
-opentitan_binary(
     name = "rom_ext_slot_b",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
@@ -288,23 +271,6 @@ opentitan_binary(
     linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
     rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
-    deps = [
-        ":rom_ext",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-    ],
-)
-
-opentitan_binary(
-    name = "rom_ext_sival_prod_signed_slot_b",
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:sim_dv_base",
-        "//hw/top_earlgrey:sim_verilator_base",
-    ],
-    linker_script = ":ld_slot_b",
-    manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -1,0 +1,129 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
+load("//rules:signing.bzl", "offline_fake_rsa_sign", "offline_presigning_artifacts", "offline_signature_attach")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+# In order to prevent the linker from prematurely discarding symbols, we
+# need to give the CRT library last.
+LINK_ORDER = [
+    "$(location //sw/device/silicon_creator/rom_ext)",
+    "$(location //sw/device/lib/crt)",
+]
+
+manifest({
+    "name": "manifest_sival",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.ROM_EXT),
+    "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
+    "visibility": ["//visibility:public"],
+})
+
+# To test that the fake-signed SiVAL ROM_EXT can boot, you need a bitstream
+# with the OTP word CREATOR_SW_CCFG_MANUF_STATE set to `SIVAL` (as above
+# in the manifest definition).  You can manually create such a bitstream with:
+#
+# bazel build //hw/bitstream/universal:splice --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_cw310_sival
+opentitan_binary(
+    name = "rom_ext_fake_prod_signed_slot_a",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
+    linkopts = LINK_ORDER,
+    manifest = ":manifest_sival",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    deps = [
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/rom_ext",
+    ],
+)
+
+opentitan_binary(
+    name = "rom_ext_fake_prod_signed_slot_b",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
+    linkopts = LINK_ORDER,
+    manifest = ":manifest_sival",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    deps = [
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/rom_ext",
+    ],
+)
+
+opentitan_binary(
+    name = "rom_ext_real_prod_signed_slot_a",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+    ],
+    linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
+    linkopts = LINK_ORDER,
+    deps = [
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/rom_ext",
+    ],
+)
+
+opentitan_binary(
+    name = "rom_ext_real_prod_signed_slot_b",
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+    ],
+    linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
+    linkopts = LINK_ORDER,
+    deps = [
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/rom_ext",
+    ],
+)
+
+offline_presigning_artifacts(
+    name = "presigning",
+    testonly = True,
+    srcs = [
+        ":rom_ext_real_prod_signed_slot_a",
+        ":rom_ext_real_prod_signed_slot_b",
+    ],
+    manifest = ":manifest_sival",
+    rsa_key = {
+        "//sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_prod_0": "ealrgrey_a0_prod_0",
+    },
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "digests",
+    testonly = True,
+    srcs = [":presigning"],
+    mode = "0644",
+    tags = ["manual"],
+)
+
+offline_signature_attach(
+    name = "signed",
+    testonly = True,
+    srcs = [
+        ":presigning",
+    ],
+    rsa_signatures = [
+        "//sw/device/silicon_creator/rom_ext/sival/signatures:rsa_signatures",
+    ],
+    tags = ["manual"],
+)

--- a/sw/device/silicon_creator/rom_ext/sival/signatures/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/signatures/BUILD
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "rsa_signatures",
+    srcs = glob(["*.rsa_sig"]),
+)
+
+filegroup(
+    name = "spx_signatures",
+    srcs = glob(["*.spx_sig"]),
+)


### PR DESCRIPTION
1. Move SiVAL ROM_EXT build rules to their own subdirectory.
2. Add rules for building and signing with reak keys.
3. Set CREATOR_SW_CFG_MANUF_STATE to `SiVL` for SiVAL OTP configurations.  Constrain the SiVAL ROM_EXT to run only on devices with that OTP configuration.