### PR TITLE
[rom_ext, si_val] Lock out the AST register space

### DIFF
--- a/sw/device/silicon_creator/rom_ext/doc/si_val.md
+++ b/sw/device/silicon_creator/rom_ext/doc/si_val.md
@@ -21,8 +21,7 @@ An example of how the SiVal ROM\_EXT will configure the ePMP:
  4: 20004fe8   TOR LX-R sz=00004be8     ; ROM_EXT code end.
  5: 20000000 NAPOT L--R sz=00100000     ; FLASH data (1 MB).
  6: 40130000 NAPOT L--- sz=00001000     ; OTP MMIO lockout.
- 6: 00000000 ----- ---- sz=00000000
- 7: 00000000 ----- ---- sz=00000000
+ 7: 40480000 NAPOT L--- sz=00000400     ; AST MMIO lockout.
  8: 00000000 ----- ---- sz=00000000
  9: 00000000 ----- ---- sz=00000000
 10: 00000000 ----- ---- sz=00000000

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -67,7 +67,10 @@ opentitan_test(
     cw310 = cw310_params(
         exit_failure = "(PASS|FAIL|BFV|FAULT).*\r\n",
         # Make sure the test program failed to modify the ePMP.
-        exit_success = "6: 40130000 NAPOT L--- sz=00001000\r\n",
+        exit_success = (
+            "6: 40130000 NAPOT L--- sz=00001000\r\n" +
+            "7: 40480000 NAPOT L--- sz=00000400\r\n"
+        ),
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -206,6 +206,10 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   // controller doesn't have a per-boot register lockout, we'll use the ePMP to
   // disable access to the programming interface.
   rom_ext_epmp_otp_dai_lockout();
+  // TODO(cfrantz): This lockout is for silicon validation testing.
+  // We want to prevent access to the AST by test programs before we commit
+  // to a finalized AST configuration set in OTP.
+  rom_ext_epmp_ast_lockout();
 
   // Configure address translation, compute the epmp regions and the entry
   // point for the virtual address in case the address translation is enabled.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
@@ -80,6 +80,15 @@ void rom_ext_epmp_mmio_adjust(void);
 void rom_ext_epmp_otp_dai_lockout(void);
 
 /**
+ * Lock out access to the AST registers.
+ *
+ * The AST peripheral contains all of the low-level analog configuration
+ * registers (sensors, clock trimming, etc).  After ROM_EXT completes,
+ * the ePMP will forbid access to the AST register space.
+ */
+void rom_ext_epmp_ast_lockout(void);
+
+/**
  * Clear the ROM mapping from the ePMP.
  *
  * The ROM memory mapping is no longer needed once the ROM_EXT starts.


### PR DESCRIPTION
1. Use the ePMP to forbid access to the AST register space from OWNER code.