### PR TITLE
[crypto] Finish ECC top-level hardening.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
@@ -148,10 +148,12 @@ static status_t set_message_digest(const uint32_t digest[kP256ScalarWords]) {
   // architecture than the big-endian form requested by the specification (FIPS
   // 186-5, section B.2.1).
   uint32_t digest_little_endian[kP256ScalarWords];
-  for (size_t i = 0; i < kP256ScalarWords; i++) {
+  size_t i = 0;
+  for (; launder32(i) < kP256ScalarWords; i++) {
     digest_little_endian[i] =
         __builtin_bswap32(digest[kP256ScalarWords - 1 - i]);
   }
+  HARDENED_CHECK_EQ(i, kP256ScalarWords);
   return otbn_dmem_write(kP256ScalarWords, digest_little_endian,
                          kOtbnVarEcdsaMsg);
 }


### PR DESCRIPTION
Add extra hardening measures where needed for P-256 C code (applies to ECDSA and ECDH). The OTBN code has already been hardened. Includes hardening for the keyblob library as well, which P-256 code depends on.

The OTBN driver itself could still use some extra hardening pass, see https://github.com/lowRISC/opentitan/issues/18333, and the `hardened_memory.h` library itself still relies on `random_order.h`, which is a stub without a properly hardened implementation. However, modulo those more library-wide issues, this should fix the P-256 code.