### PR TITLE
[dv/pwrmgr] Add escalation_timeout test

### DIFF
--- a/hw/ip_templates/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr_testplan.hjson
@@ -245,6 +245,25 @@
       tests: ["pwrmgr_disable_rom_integrity_check"]
     }
     {
+      name: escalation_timeout
+      desc: '''This tests the escalation timeout feature.
+
+            If the escalation network doesn't respond to an outgoing "health"
+            requests within 128 cycles pwrmgr should issue an escalation reset
+            request.
+
+            **Stimulus**:
+            - Cause the external escalation network to stop responding, either
+              disabling the clock or jamming the differential pairs.
+
+            **Check**:
+            - After 128 cycles of inactivity an escalation reset should be
+              triggered.
+            '''
+      stage: V3
+      tests: ["pwrmgr_escalation_timeout"]
+    }
+    {
       name: stress_all
       desc: '''This runs random sequences in succession.
 

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_global_esc_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_escalation_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_reset_invalid_vseq.sv: {is_include_file: true}

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Description:
+// This test checks that an escalation reset is generated when the escalation clock stops for
+// enough cycles.
+class pwrmgr_escalation_timeout_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_escalation_timeout_vseq)
+
+  `uvm_object_new
+
+  localparam int TIMEOUT_THRESHOLD = 128;
+
+  int trans_cnt = 0;
+  constraint num_trans_c {num_trans inside {[1 : 5]};}
+
+  task check_stopped_esc_clk(int stop_cycles, bit expect_reset);
+    fork
+      begin
+        `uvm_info(`gfn, $sformatf("Stopping escalation clock for %0d cycles", stop_cycles),
+                  UVM_MEDIUM)
+        cfg.esc_clk_rst_vif.stop_clk();
+        cfg.clk_rst_vif.wait_clks(stop_cycles);
+        cfg.esc_clk_rst_vif.start_clk();
+        cfg.esc_clk_rst_vif.wait_clks(10000);
+      end
+      begin
+        cfg.clk_rst_vif.wait_clks(TIMEOUT_THRESHOLD);
+        if (expect_reset) begin
+          `DV_WAIT(cfg.pwrmgr_vif.fetch_en != lc_ctrl_pkg::On,
+                   "Timeout waiting for cpu fetch disable", 4000)
+          `uvm_info(`gfn, "cpu fetch disabled, indicating a reset", UVM_MEDIUM)
+          `DV_WAIT(cfg.pwrmgr_vif.pwr_rst_req.rstreqs[pwrmgr_reg_pkg::ResetEscIdx] == 1'b1 &&
+                   cfg.pwrmgr_vif.pwr_rst_req.reset_cause == pwrmgr_pkg::HwReq,
+                   "Timeout waiting for outgoing escalation reset", 40000)
+          `uvm_info(`gfn, "Outgoing escalation reset", UVM_MEDIUM)
+        end else begin
+          repeat (8000) begin
+            cfg.clk_rst_vif.wait_clks(1);
+            if (cfg.pwrmgr_vif.fetch_en != lc_ctrl_pkg::On) begin
+              `uvm_error(`gfn, "Unexpected cpu fetch disable, indicating a reset")
+            end
+          end
+        end
+      end
+    join
+  endtask
+
+  virtual task body();
+    wait_for_fast_fsm_active();
+    cfg.slow_clk_rst_vif.set_freq_mhz(1);
+    cfg.esc_clk_rst_vif.wait_clks(200);
+    check_stopped_esc_clk(120, 1'b0);
+    check_stopped_esc_clk(2000, 1'b1);
+    wait_for_fast_fsm_active();
+    // This fails to generate a reset, so the test fails. It should pass once
+    // lowrisc/opentitan#20516 is addressed.
+    check_stopped_esc_clk(136, 1'b1);
+  endtask : body
+
+endclass

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -16,6 +16,7 @@
 `include "pwrmgr_esc_clk_rst_malfunc_vseq.sv"
 `include "pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv"
 `include "pwrmgr_global_esc_vseq.sv"
+`include "pwrmgr_escalation_timeout_vseq.sv"
 `include "pwrmgr_glitch_vseq.sv"
 `include "pwrmgr_disable_rom_integrity_check_vseq.sv"
 `include "pwrmgr_reset_invalid_vseq.sv"

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -120,6 +120,10 @@
       run_opts: ["+test_timeout_ns=1000000000"]
     }
     {
+      name: pwrmgr_escalation_timeout
+      uvm_test_seq: pwrmgr_escalation_timeout_vseq
+    }
+    {
       name: pwrmgr_glitch
       uvm_test_seq: pwrmgr_glitch_vseq
       run_opts: ["+test_timeout_ns=1000000"]

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_testplan.hjson
@@ -245,6 +245,25 @@
       tests: ["pwrmgr_disable_rom_integrity_check"]
     }
     {
+      name: escalation_timeout
+      desc: '''This tests the escalation timeout feature.
+
+            If the escalation network doesn't respond to an outgoing "health"
+            requests within 128 cycles pwrmgr should issue an escalation reset
+            request.
+
+            **Stimulus**:
+            - Cause the external escalation network to stop responding, either
+              disabling the clock or jamming the differential pairs.
+
+            **Check**:
+            - After 128 cycles of inactivity an escalation reset should be
+              triggered.
+            '''
+      stage: V3
+      tests: ["pwrmgr_escalation_timeout"]
+    }
+    {
       name: stress_all
       desc: '''This runs random sequences in succession.
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_global_esc_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_escalation_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_reset_invalid_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Description:
+// This test checks that an escalation reset is generated when the escalation clock stops for
+// enough cycles.
+class pwrmgr_escalation_timeout_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_escalation_timeout_vseq)
+
+  `uvm_object_new
+
+  localparam int TIMEOUT_THRESHOLD = 128;
+
+  int trans_cnt = 0;
+  constraint num_trans_c {num_trans inside {[1 : 5]};}
+
+  task check_stopped_esc_clk(int stop_cycles, bit expect_reset);
+    fork
+      begin
+        `uvm_info(`gfn, $sformatf("Stopping escalation clock for %0d cycles", stop_cycles),
+                  UVM_MEDIUM)
+        cfg.esc_clk_rst_vif.stop_clk();
+        cfg.clk_rst_vif.wait_clks(stop_cycles);
+        cfg.esc_clk_rst_vif.start_clk();
+        cfg.esc_clk_rst_vif.wait_clks(10000);
+      end
+      begin
+        cfg.clk_rst_vif.wait_clks(TIMEOUT_THRESHOLD);
+        if (expect_reset) begin
+          `DV_WAIT(cfg.pwrmgr_vif.fetch_en != lc_ctrl_pkg::On,
+                   "Timeout waiting for cpu fetch disable", 4000)
+          `uvm_info(`gfn, "cpu fetch disabled, indicating a reset", UVM_MEDIUM)
+          `DV_WAIT(cfg.pwrmgr_vif.pwr_rst_req.rstreqs[pwrmgr_reg_pkg::ResetEscIdx] == 1'b1 &&
+                   cfg.pwrmgr_vif.pwr_rst_req.reset_cause == pwrmgr_pkg::HwReq,
+                   "Timeout waiting for outgoing escalation reset", 40000)
+          `uvm_info(`gfn, "Outgoing escalation reset", UVM_MEDIUM)
+        end else begin
+          repeat (8000) begin
+            cfg.clk_rst_vif.wait_clks(1);
+            if (cfg.pwrmgr_vif.fetch_en != lc_ctrl_pkg::On) begin
+              `uvm_error(`gfn, "Unexpected cpu fetch disable, indicating a reset")
+            end
+          end
+        end
+      end
+    join
+  endtask
+
+  virtual task body();
+    wait_for_fast_fsm_active();
+    cfg.slow_clk_rst_vif.set_freq_mhz(1);
+    cfg.esc_clk_rst_vif.wait_clks(200);
+    check_stopped_esc_clk(120, 1'b0);
+    check_stopped_esc_clk(2000, 1'b1);
+    wait_for_fast_fsm_active();
+    // This fails to generate a reset, so the test fails. It should pass once
+    // lowrisc/opentitan#20516 is addressed.
+    check_stopped_esc_clk(136, 1'b1);
+  endtask : body
+
+endclass

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -16,6 +16,7 @@
 `include "pwrmgr_esc_clk_rst_malfunc_vseq.sv"
 `include "pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv"
 `include "pwrmgr_global_esc_vseq.sv"
+`include "pwrmgr_escalation_timeout_vseq.sv"
 `include "pwrmgr_glitch_vseq.sv"
 `include "pwrmgr_disable_rom_integrity_check_vseq.sv"
 `include "pwrmgr_reset_invalid_vseq.sv"

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -120,6 +120,10 @@
       run_opts: ["+test_timeout_ns=1000000000"]
     }
     {
+      name: pwrmgr_escalation_timeout
+      uvm_test_seq: pwrmgr_escalation_timeout_vseq
+    }
+    {
       name: pwrmgr_glitch
       uvm_test_seq: pwrmgr_glitch_vseq
       run_opts: ["+test_timeout_ns=1000000"]


### PR DESCRIPTION
Test the escalation clock timeout feature of pwrmgr. This test fails due to #20516.

Fixes #20158