### PR TITLE
[sival/otbn] Added test for `chip_sw_otbn_keymgr`.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -139,6 +139,7 @@
       stage: V2
       si_stage: SV2
       tests: []
+      bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test_fpga_cw310_sival"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "OTBN.KEYMGR",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1532,7 +1532,37 @@ opentitan_test(
 opentitan_test(
     name = "keymgr_sideload_otbn_test",
     srcs = ["keymgr_sideload_otbn_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    verilator = new_verilator_params(timeout = "long"),
+    deps = [
+        "//hw/ip/otbn/data:otbn_regs",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/crypto:x25519_sideload",
+    ],
+)
+
+opentitan_test(
+    name = "keymgr_sideload_otbn_simple_test",
+    srcs = ["keymgr_sideload_otbn_test.c"],
+    copts = ["-DTEST_SIMPLE_CASE_ONLY"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+    },
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/ip/otbn/data:otbn_regs",

--- a/sw/device/tests/keymgr_sideload_otbn_test.c
+++ b/sw/device/tests/keymgr_sideload_otbn_test.c
@@ -96,6 +96,10 @@ static void test_otbn_with_sideloaded_key(dif_keymgr_t *keymgr,
   uint32_t result[8];
   run_x25519_app(otbn, result, kErrBitsOk);
 
+#ifdef TEST_SIMPLE_CASE_ONLY
+  return;
+#endif
+
   // Clear the sideload key and check that OTBN errors with the correct error
   // code (`KEY_INVALID` bit 5 = 1).
   CHECK_DIF_OK(


### PR DESCRIPTION
Covers: https://github.com/lowRISC/opentitan/issues/20120