### PR TITLE
[manuf] always generate all attestation certs during personalization

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -43,11 +43,8 @@ UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataIn, \
 // clang-format off
 #define STRUCT_MANUF_CERT_PERSO_DATA_IN(field, string) \
     field(rom_ext_measurement, uint32_t, 8) \
-    field(rom_ext_measurement_valid, bool) \
     field(owner_manifest_measurement, uint32_t, 8) \
-    field(owner_manifest_measurement_valid, bool) \
-    field(owner_measurement, uint32_t, 8) \
-    field(owner_measurement_valid, bool)
+    field(owner_measurement, uint32_t, 8)
 UJSON_SERDE_STRUCT(ManufCertPersoDataIn, \
                    manuf_cert_perso_data_in_t, \
                    STRUCT_MANUF_CERT_PERSO_DATA_IN);

--- a/sw/host/tests/manuf/provisioning/ft/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/ft/src/main.rs
@@ -47,21 +47,21 @@ pub struct ManufFtProvisioningDataInput {
     /// Measurement of the ROM_EXT image to be loaded onto the device.
     #[arg(
         long,
-        default_value = "0x11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"
+        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
     )]
     pub rom_ext_measurement: String,
 
     /// Measurement of the Ownership Manifest to be loaded onto the device.
     #[arg(
         long,
-        default_value = "0x11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"
+        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
     )]
     pub owner_manifest_measurement: String,
 
     /// Measurement of the Owner image to be loaded onto the device.
     #[arg(
         long,
-        default_value = "0x11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"
+        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
     )]
     pub owner_measurement: String,
 }
@@ -88,18 +88,6 @@ struct Opts {
     /// Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
-}
-
-/// Returns true if all elements of the array are zero.
-fn is_all_zero(array: &[u32]) -> bool {
-    if array.is_empty() {
-        return true;
-    }
-    let first = array[0];
-    if first == 0 {
-        return array.iter().all(|&item| item == first);
-    }
-    false
 }
 
 fn main() -> Result<()> {
@@ -131,11 +119,8 @@ fn main() -> Result<()> {
         hex_string_to_u32_arrayvec::<8>(opts.provisioning_data.owner_measurement.as_str())?;
     let attestation_tcb_measurements = ManufCertPersoDataIn {
         rom_ext_measurement: rom_ext_measurement.clone(),
-        rom_ext_measurement_valid: !is_all_zero(rom_ext_measurement.as_slice()),
         owner_manifest_measurement: owner_manifest_measurement.clone(),
-        owner_manifest_measurement_valid: !is_all_zero(owner_manifest_measurement.as_slice()),
         owner_measurement: owner_measurement.clone(),
-        owner_measurement_valid: !is_all_zero(owner_measurement.as_slice()),
     };
 
     test_unlock(


### PR DESCRIPTION
Before, we only generated attestation certs for a specific key ladder stage if the measurements were valid (not all 0s). Now, we always generate all certs, as the certs can be updated later during ROM_EXT execution if a boot stage has been updated. Only the UDS cert will forever remain unchanged for a given chip, as long as the HW has not been compromised.