### PR TITLE
[silicon_creator/keymgr] add function to set Owner max key version

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -117,6 +117,14 @@ void keymgr_owner_int_max_ver_set(uint32_t max_key_ver) {
   sec_mmio_write32(kBase + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
 }
 
+void keymgr_owner_max_ver_set(uint32_t max_key_ver) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioOwnerMaxVerSet, 2);
+  // Write and lock (rw0c) the max key version.
+  sec_mmio_write32_shadowed(
+      kBase + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, max_key_ver);
+  sec_mmio_write32(kBase + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+}
+
 void keymgr_advance_state(void) {
   uint32_t reg =
       bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -94,6 +94,7 @@ enum {
   kKeymgrSecMmioSwBindingSet = 17,
   kKeymgrSecMmioCreatorMaxVerSet = 2,
   kKeymgrSecMmioOwnerIntMaxVerSet = 2,
+  kKeymgrSecMmioOwnerMaxVerSet = 2,
 };
 
 /**
@@ -133,10 +134,18 @@ void keymgr_creator_max_ver_set(uint32_t max_key_ver);
 /**
  * Sets the Silicon Owner Intermediate max key version.
  *
- * @param max_key_ver Maximum key version associated with the Silicon Onwer
+ * @param max_key_ver Maximum key version associated with the Silicon Owner
  * Intermediate key manager stage.
  */
 void keymgr_owner_int_max_ver_set(uint32_t max_key_ver);
+
+/**
+ * Sets the Silicon Owner max key version.
+ *
+ * @param max_key_ver Maximum key version associated with the Silicon Owner
+ * key manager stage.
+ */
+void keymgr_owner_max_ver_set(uint32_t max_key_ver);
 
 /**
  * Sets the entropy reseed interval of the key manager.

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -147,6 +147,13 @@ TEST_F(KeymgrTest, SetOwnerIntMaxVerKey) {
   keymgr_owner_int_max_ver_set(cfg_.max_key_ver);
 }
 
+TEST_F(KeymgrTest, SetOwnerMaxVerKey) {
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+  keymgr_owner_max_ver_set(cfg_.max_key_ver);
+}
+
 TEST_F(KeymgrTest, AdvanceState) {
   EXPECT_ABS_WRITE32_SHADOWED(
       base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,


### PR DESCRIPTION
This adds a function to the silicon_creator keymgr driver to set the owner max key version. Additionally this updates the on-host unit tests and on-device functest to test this additional function.

Lastly, this updates the on-device functest to crank the keymgr through all possible key states, as will be done for both ES and PROD chips with the updated attestation flow.