### PR TITLE
[dv,dma] Retain 'abort' bit when modifying the CONTROL register

### DIFF
--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -260,12 +260,16 @@ class dma_generic_vseq extends dma_base_vseq;
           end
         join
 
+        // Notification that the transaction is ending, indicating the completion status
+        //
+        // Note: perform this before collecting other results, and the SHA digest in particular,
+        //       because doing so can take many hundreds of clock cycles and parallel processes
+        //       could otherwise time out after - for example - generating an abort stimulus.
+        ending_txn(j, num_txns, dma_config, status);
+
         if (dma_config.opcode inside {OpcSha256, OpcSha384, OpcSha512}) begin
           read_sha2_digest(dma_config.opcode, digest);
         end
-
-        // Notification that the transaction is ending, indicating the completion status
-        ending_txn(j, num_txns, dma_config, status);
 
         `uvm_info(`gfn, $sformatf("Transaction completed with status 0x%0x", int'(status)),
                   UVM_MEDIUM)

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -145,10 +145,6 @@ class dma_generic_vseq extends dma_base_vseq;
         run_common_config(dma_config);
         start_device(dma_config);
 
-        // Notification that transaction is just starting; after the configuration has been decided
-        // and programmed into the DMA controller, but before the transfer has commenced.
-        starting_txn(j, num_txns, dma_config);
-
         // Set the Interrupt Enables appropriately for this transfer; DONE and ERROR - which
         // terminate the test - must be enabled if this transfer is to be interrupt-driven.
         // They may optionally be exercised when using polling. The MEMORY_BUFFER_LIMIT interrupt is
@@ -160,6 +156,10 @@ class dma_generic_vseq extends dma_base_vseq;
         end
         enable_interrupts( intr_enables, 1'b1);
         enable_interrupts(~intr_enables, 1'b0);
+
+        // Notification that transaction is just starting; after the configuration has been decided
+        // and programmed into the DMA controller, but before the transfer has commenced.
+        starting_txn(j, num_txns, dma_config);
 
         // Start the Initial chunk of the transfer.
         start_chunk(dma_config, 1'b1);


### PR DESCRIPTION
This PR addresses a couple of recent changes to the DV and RTL that introduces a chance  of `dma_abort` sequences from failing.

The Abort request placed by the parallel thread could be cancelled by the main thread initiating the transfer slightly after the abort was requested. This time window was opened by the introduction of code in the main thread to modify the interrupt enables between notification of 'transaction starting' and actually starting the transaction. Additionally, the DMA controller now clears the abort status when starting, so the test would complete normally and thus led to the abort-generating thread reporting a timeout.

The pending abort is now retained in the DV test bench, since the RAL layer does not remember that Abort had been set (SW access is Write Only, and the CONTROL.abort bit always reads as zero).