### PR TITLE
[top_darjeeling/rv_dm] Convert next_dm parameter to a static signal

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -37,16 +37,6 @@
       desc:    "Number of hardware threads in the system."
       local:   "true"
     },
-    { name:    "NextDmAddr",
-      type:    "logic [31:0]",
-      default: "'0",
-      desc:    '''
-               32bit word address of the next debug module.
-               Set to 0x0 if this is the last debug module in the chain.,
-               '''
-      local:   "false",
-      expose:  "true"
-    },
   ]
   interrupt_list: [
   ],
@@ -58,6 +48,18 @@
     }
   ],
   inter_signal_list: [
+    {
+      package: "rv_dm_pkg"
+      struct:  "next_dm_addr"
+      type:    "uni"
+      name:    "next_dm_addr"
+      act:     "rcv"
+      default: "'0"
+      desc:    '''
+               32bit word address of the next debug module.
+               Set to 0x0 if this is the last debug module in the chain.
+               '''
+    }
     {
       struct:  "tl_h2d"
       package: "tlul_pkg"

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -51,6 +51,7 @@ module tb;
   rv_dm dut (
     .clk_i                (clk  ),
     .rst_ni               (rst_n),
+    .next_dm_addr_i       ('0),
 
     // the differing behavior of lc_hw_debug_en_i and pinmux_hw_debug_en_i
     // will be tested at the top-level. for the purposes of this TB we connect

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -15,12 +15,12 @@
 module rv_dm
   import rv_dm_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter logic [31:0]          NextDmAddr   = '0
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input  logic                clk_i,       // clock
   input  logic                rst_ni,      // asynchronous reset active low, connect PoR
                                            // here, not the system reset
+  input  logic [31:0]         next_dm_addr_i, // static word address of the next debug module.
   // SEC_CM: LC_HW_DEBUG_EN.INTERSIG.MUBI
   // HW Debug lifecycle enable signal (live version from the life cycle controller)
   input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
@@ -407,11 +407,11 @@ module rv_dm
     // However, we require that the DM can be placed at arbitrary offsets in the system, which
     // requires the generalized debug ROM implementation and two scratch registers. We hence set
     // this parameter to a non-zero value (inside dm_mem, this just feeds into a comparison with 0).
-    .DmBaseAddress  (1),
-    .NextDmAddr     (NextDmAddr)
+    .DmBaseAddress  (1)
   ) u_dm_top (
     .clk_i,
     .rst_ni,
+    .next_dm_addr_i,
     .testmode_i            (testmode              ),
     .ndmreset_o            (ndmreset_req          ),
     .dmactive_o,

--- a/hw/ip/rv_dm/rtl/rv_dm_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_pkg.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package rv_dm_pkg;
+
+  typedef logic [31:0] next_dm_addr_t;
+
+  parameter next_dm_addr_t NEXT_DM_ADDR_DEFAULT = '0;
+
+endpackage : rv_dm_pkg

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -20,6 +20,7 @@ filesets:
     files:
       - rtl/rv_dm_reg_pkg.sv
       - rtl/rv_dm_regs_reg_top.sv
+      - rtl/rv_dm_pkg.sv
       - rtl/rv_dm.sv
     file_type: systemVerilogSource
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4231,24 +4231,28 @@
         "0"
       ]
       param_decl: {}
-      memory: {}
-      param_list:
+      param_list: []
+      inter_signal_list:
       [
         {
-          name: NextDmAddr
+          name: next_dm_addr
           desc:
             '''
             32bit word address of the next debug module.
-            Set to 0x0 if this is the last debug module in the chain.,
+            Set to 0x0 if this is the last debug module in the chain.
             '''
-          type: logic [31:0]
+          struct: next_dm_addr
+          package: rv_dm_pkg
+          type: uni
+          act: rcv
+          width: 1
           default: "'0"
-          expose: "true"
-          name_top: RvDmNextDmAddr
+          inst_name: rv_dm
+          external: true
+          top_signame: rv_dm_next_dm_addr
+          conn_type: false
+          index: -1
         }
-      ]
-      inter_signal_list:
-      [
         {
           name: dmi_tl_h2d
           desc: TLUL-based DMI request input port
@@ -9572,6 +9576,7 @@
       lc_ctrl.dmi_tl_d2h: lc_ctrl_dmi_d2h
       rv_dm.dmi_tl_h2d: rv_dm_dmi_h2d
       rv_dm.dmi_tl_d2h: rv_dm_dmi_d2h
+      rv_dm.next_dm_addr: rv_dm_next_dm_addr
       pwrmgr_aon.strap: pwrmgr_strap_en
       rv_dm.pinmux_hw_debug_en: rv_pinmux_hw_debug_en
       peri.tl_ast: ast_tl
@@ -19618,6 +19623,25 @@
         index: -1
       }
       {
+        name: next_dm_addr
+        desc:
+          '''
+          32bit word address of the next debug module.
+          Set to 0x0 if this is the last debug module in the chain.
+          '''
+        struct: next_dm_addr
+        package: rv_dm_pkg
+        type: uni
+        act: rcv
+        width: 1
+        default: "'0"
+        inst_name: rv_dm
+        external: true
+        top_signame: rv_dm_next_dm_addr
+        conn_type: false
+        index: -1
+      }
+      {
         name: dmi_tl_h2d
         desc: TLUL-based DMI request input port
         struct: tl_h2d
@@ -23994,6 +24018,18 @@
         conn_type: false
         index: -1
         netname: rv_dm_dmi_d2h
+      }
+      {
+        package: rv_dm_pkg
+        struct: next_dm_addr
+        signame: rv_dm_next_dm_addr_i
+        width: 1
+        type: uni
+        default: "'0"
+        direction: in
+        conn_type: false
+        index: -1
+        netname: rv_dm_next_dm_addr
       }
       {
         package: ""

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1259,6 +1259,7 @@
         'lc_ctrl.dmi_tl_d2h'              : 'lc_ctrl_dmi_d2h',
         'rv_dm.dmi_tl_h2d'                : 'rv_dm_dmi_h2d',
         'rv_dm.dmi_tl_d2h'                : 'rv_dm_dmi_d2h',
+        'rv_dm.next_dm_addr'              : 'rv_dm_next_dm_addr',
         'pwrmgr_aon.strap'                : 'pwrmgr_strap_en',
         'rv_dm.pinmux_hw_debug_en'        : 'rv_pinmux_hw_debug_en',
         'peri.tl_ast'                     : 'ast_tl',

--- a/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
+++ b/hw/top_darjeeling/rtl/autogen/chip_darjeeling_asic.sv
@@ -1584,6 +1584,8 @@ module chip_darjeeling_asic #(
     // DMI into RV_DM
     .rv_dm_dmi_h2d_i              ( rv_dm_dmi_h2d              ),
     .rv_dm_dmi_d2h_o              ( rv_dm_dmi_d2h              ),
+    // Quasi-static word address for next_dm register value.
+    .rv_dm_next_dm_addr_i         ( '0                         ),
 
     // Pinmux strap
     .pwrmgr_strap_en_o            ( pwrmgr_strap_en            ),

--- a/hw/top_darjeeling/rtl/autogen/chip_darjeeling_cw310.sv
+++ b/hw/top_darjeeling/rtl/autogen/chip_darjeeling_cw310.sv
@@ -1431,6 +1431,8 @@ module chip_darjeeling_cw310 #(
     // DMI into RV_DM
     .rv_dm_dmi_h2d_i              ( rv_dm_dmi_h2d              ),
     .rv_dm_dmi_d2h_o              ( rv_dm_dmi_d2h              ),
+    // Quasi-static word address for next_dm register value.
+    .rv_dm_next_dm_addr_i         ( '0                         ),
 
     // Pinmux strap
     .pwrmgr_strap_en_o            ( pwrmgr_strap_en            ),

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -48,7 +48,6 @@ module top_darjeeling #(
   // parameters for sram_ctrl_ret_aon
   parameter bit SramCtrlRetAonInstrExec = 0,
   // parameters for rv_dm
-  parameter logic [31:0] RvDmNextDmAddr = '0,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,
@@ -209,6 +208,7 @@ module top_darjeeling #(
   output tlul_pkg::tl_d2h_t       lc_ctrl_dmi_d2h_o,
   input  tlul_pkg::tl_h2d_t       rv_dm_dmi_h2d_i,
   output tlul_pkg::tl_d2h_t       rv_dm_dmi_d2h_o,
+  input  rv_dm_pkg::next_dm_addr_t       rv_dm_next_dm_addr_i,
   output logic       pwrmgr_strap_en_o,
   input  lc_ctrl_pkg::lc_tx_t       rv_pinmux_hw_debug_en_i,
   output tlul_pkg::tl_h2d_t       ast_tl_req_o,
@@ -1656,14 +1656,14 @@ module top_darjeeling #(
       .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
   rv_dm #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[53:53]),
-    .NextDmAddr(RvDmNextDmAddr)
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[53:53])
   ) u_rv_dm (
       // [53]: fatal_fault
       .alert_tx_o  ( alert_tx[53:53] ),
       .alert_rx_i  ( alert_rx[53:53] ),
 
       // Inter-module signals
+      .next_dm_addr_i(rv_dm_next_dm_addr_i),
       .dmi_tl_h2d_i(rv_dm_dmi_h2d_i),
       .dmi_tl_d2h_o(rv_dm_dmi_d2h_o),
       .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),

--- a/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0005-dm_csrs-Implement-nextdm-register.patch
@@ -1,4 +1,4 @@
-From f6b2619166ce631d1208fe951249e4e7b341e2fb Mon Sep 17 00:00:00 2001
+From 308814a6b168a6a4df83a956af5dba0267943630 Mon Sep 17 00:00:00 2001
 From: Michael Schaffner <msf@opentitan.org>
 Date: Tue, 21 Nov 2023 19:40:16 -0800
 Subject: [PATCH 5/5] [dm_csrs] Implement nextdm register
@@ -6,19 +6,17 @@ Subject: [PATCH 5/5] [dm_csrs] Implement nextdm register
 Signed-off-by: Michael Schaffner <msf@opentitan.org>
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index b899b17..f3aa721 100644
+index b899b17..9686883 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
-@@ -18,7 +18,8 @@
- module dm_csrs #(
-   parameter int unsigned        NrHarts          = 1,
-   parameter int unsigned        BusWidth         = 32,
--  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
-+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
-+  parameter logic [31:0]        NextDmAddr       = '0
+@@ -22,6 +22,7 @@ module dm_csrs #(
  ) (
    input  logic                              clk_i,           // Clock
    input  logic                              rst_ni,          // Asynchronous reset active low
++  input  logic [31:0]                       next_dm_addr_i,  // Static next_dm word address.
+   input  logic                              testmode_i,
+   input  logic                              dmi_rst_ni,      // sync. DTM reset,
+                                                              // active-low
 @@ -307,8 +308,8 @@ module dm_csrs #(
          dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
          dm::AbstractCS:   resp_queue_inp.data = abstractcs;
@@ -26,7 +24,7 @@ index b899b17..f3aa721 100644
 -        // command is read-only
 -        dm::Command:    resp_queue_inp.data = '0;
 +        dm::Command:      resp_queue_inp.data = '0;
-+        dm::NextDM:       resp_queue_inp.data = NextDmAddr;
++        dm::NextDM:       resp_queue_inp.data = next_dm_addr_i;
          [(dm::ProgBuf0):ProgBufEnd]: begin
            resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
            if (!cmdbusy_i) begin
@@ -39,30 +37,47 @@ index b899b17..f3aa721 100644
            // this field can only be written legally when there is no command executing
            if (!cmdbusy_i) begin
 diff --git a/src/dm_top.sv b/src/dm_top.sv
-index 6188b28..a5bde9f 100644
+index 6188b28..89dc590 100644
 --- a/src/dm_top.sv
 +++ b/src/dm_top.sv
-@@ -25,7 +25,12 @@ module dm_top #(
-   // that don't use hart numbers in a contiguous fashion.
-   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
-   // toggle new behavior to drive master_be_o during a read
--  parameter bit                 ReadByteEnable   = 1
-+  parameter bit                 ReadByteEnable   = 1,
+@@ -30,6 +30,12 @@ module dm_top #(
+   input  logic                  clk_i,       // clock
+   // asynchronous reset active low, connect PoR here, not the system reset
+   input  logic                  rst_ni,
 +  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
 +  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
 +  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
-+  // register is a word address and not a byte address.
-+  parameter logic [31:0]        NextDmAddr       = '0
- ) (
-   input  logic                  clk_i,       // clock
-   // asynchronous reset active low, connect PoR here, not the system reset
-@@ -111,7 +116,8 @@ module dm_top #(
-   dm_csrs #(
-     .NrHarts(NrHarts),
-     .BusWidth(BusWidth),
--    .SelectableHarts(SelectableHarts)
-+    .SelectableHarts(SelectableHarts),
-+    .NextDmAddr(NextDmAddr)
++  // register is a word address and not a byte address. This value is passed in as a static signal
++  // so that it becomes possible to assign this value with chiplet tie-offs or straps, if needed.
++  input  logic [31:0]           next_dm_addr_i,
+   input  logic                  testmode_i,
+   output logic                  ndmreset_o,  // non-debug module reset
+   output logic                  dmactive_o,  // debug module is active
+@@ -115,6 +121,7 @@ module dm_top #(
    ) i_dm_csrs (
      .clk_i,
      .rst_ni,
++    .next_dm_addr_i,
+     .testmode_i,
+     .dmi_rst_ni,
+     .dmi_req_valid_i,
+diff --git a/tb/tb_test_env.sv b/tb/tb_test_env.sv
+index 4b300ca..9ac8f28 100644
+--- a/tb/tb_test_env.sv
++++ b/tb/tb_test_env.sv
+@@ -245,6 +245,7 @@ module tb_test_env #(
+ 
+        .clk_i             ( clk_i             ),
+        .rst_ni            ( rst_ni            ),
++       .next_dm_addr_i    ( '0                ),
+        .testmode_i        ( 1'b0              ),
+        .ndmreset_o        ( ndmreset          ),
+        .dmactive_o        (                   ), // active debug session TODO
+@@ -258,6 +259,7 @@ module tb_test_env #(
+        .slave_be_i        ( dm_be             ),
+        .slave_wdata_i     ( dm_wdata          ),
+        .slave_rdata_o     ( dm_rdata          ),
++       .slave_err_o       (                   ),
+ 
+        .master_req_o      ( sb_req            ),
+        .master_add_o      ( sb_addr           ),

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -18,11 +18,11 @@
 module dm_csrs #(
   parameter int unsigned        NrHarts          = 1,
   parameter int unsigned        BusWidth         = 32,
-  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
-  parameter logic [31:0]        NextDmAddr       = '0
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
 ) (
   input  logic                              clk_i,           // Clock
   input  logic                              rst_ni,          // Asynchronous reset active low
+  input  logic [31:0]                       next_dm_addr_i,  // Static next_dm word address.
   input  logic                              testmode_i,
   input  logic                              dmi_rst_ni,      // sync. DTM reset,
                                                              // active-low
@@ -309,7 +309,7 @@ module dm_csrs #(
         dm::AbstractCS:   resp_queue_inp.data = abstractcs;
         dm::AbstractAuto: resp_queue_inp.data = abstractauto_q;
         dm::Command:      resp_queue_inp.data = '0;
-        dm::NextDM:       resp_queue_inp.data = NextDmAddr;
+        dm::NextDM:       resp_queue_inp.data = next_dm_addr_i;
         [(dm::ProgBuf0):ProgBufEnd]: begin
           resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
           if (!cmdbusy_i) begin

--- a/hw/vendor/pulp_riscv_dbg/src/dm_top.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_top.sv
@@ -25,16 +25,17 @@ module dm_top #(
   // that don't use hart numbers in a contiguous fashion.
   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
   // toggle new behavior to drive master_be_o during a read
-  parameter bit                 ReadByteEnable   = 1,
-  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
-  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
-  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
-  // register is a word address and not a byte address.
-  parameter logic [31:0]        NextDmAddr       = '0
+  parameter bit                 ReadByteEnable   = 1
 ) (
   input  logic                  clk_i,       // clock
   // asynchronous reset active low, connect PoR here, not the system reset
   input  logic                  rst_ni,
+  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
+  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
+  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
+  // register is a word address and not a byte address. This value is passed in as a static signal
+  // so that it becomes possible to assign this value with chiplet tie-offs or straps, if needed.
+  input  logic [31:0]           next_dm_addr_i,
   input  logic                  testmode_i,
   output logic                  ndmreset_o,  // non-debug module reset
   output logic                  dmactive_o,  // debug module is active
@@ -116,11 +117,11 @@ module dm_top #(
   dm_csrs #(
     .NrHarts(NrHarts),
     .BusWidth(BusWidth),
-    .SelectableHarts(SelectableHarts),
-    .NextDmAddr(NextDmAddr)
+    .SelectableHarts(SelectableHarts)
   ) i_dm_csrs (
     .clk_i,
     .rst_ni,
+    .next_dm_addr_i,
     .testmode_i,
     .dmi_rst_ni,
     .dmi_req_valid_i,

--- a/hw/vendor/pulp_riscv_dbg/tb/tb_test_env.sv
+++ b/hw/vendor/pulp_riscv_dbg/tb/tb_test_env.sv
@@ -245,6 +245,7 @@ module tb_test_env #(
 
        .clk_i             ( clk_i             ),
        .rst_ni            ( rst_ni            ),
+       .next_dm_addr_i    ( '0                ),
        .testmode_i        ( 1'b0              ),
        .ndmreset_o        ( ndmreset          ),
        .dmactive_o        (                   ), // active debug session TODO
@@ -258,6 +259,7 @@ module tb_test_env #(
        .slave_be_i        ( dm_be             ),
        .slave_wdata_i     ( dm_wdata          ),
        .slave_rdata_o     ( dm_rdata          ),
+       .slave_err_o       (                   ),
 
        .master_req_o      ( sb_req            ),
        .master_add_o      ( sb_addr           ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1386,6 +1386,8 @@ module chip_${top["name"]}_${target["name"]} #(
     // DMI into RV_DM
     .rv_dm_dmi_h2d_i              ( rv_dm_dmi_h2d              ),
     .rv_dm_dmi_d2h_o              ( rv_dm_dmi_d2h              ),
+    // Quasi-static word address for next_dm register value.
+    .rv_dm_next_dm_addr_i         ( '0                         ),
 
     // Pinmux strap
     .pwrmgr_strap_en_o            ( pwrmgr_strap_en            ),
@@ -1633,6 +1635,8 @@ module chip_${top["name"]}_${target["name"]} #(
     // DMI into RV_DM
     .rv_dm_dmi_h2d_i              ( rv_dm_dmi_h2d              ),
     .rv_dm_dmi_d2h_o              ( rv_dm_dmi_d2h              ),
+    // Quasi-static word address for next_dm register value.
+    .rv_dm_next_dm_addr_i         ( '0                         ),
 
     // Pinmux strap
     .pwrmgr_strap_en_o            ( pwrmgr_strap_en            ),


### PR DESCRIPTION
Converting the `next_dm` value to a static signal so that it can be assigned using straps/tie-offs in a chiplet setting.