### PR TITLE
[rom_ext] add attestation keygen flow

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -516,6 +516,7 @@ cc_library(
     deps = [
         ":attestation",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -304,6 +304,29 @@ void flash_ctrl_status_get(flash_ctrl_status_t *status) {
       bitfield_bit32_read(fc_status, FLASH_CTRL_STATUS_INIT_WIP_BIT);
 }
 
+void flash_ctrl_error_code_get(flash_ctrl_error_code_t *error_code) {
+  // Read flash error code.
+  uint32_t code = abs_mmio_read32(kBase + FLASH_CTRL_ERR_CODE_REG_OFFSET);
+
+  // Extract flash controller error code bits.
+  error_code->macro_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_MACRO_ERR_BIT);
+  error_code->update_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT);
+  error_code->prog_type_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT);
+  error_code->prog_win_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT);
+  error_code->prog_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_PROG_ERR_BIT);
+  error_code->rd_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_RD_ERR_BIT);
+  error_code->mp_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_MP_ERR_BIT);
+  error_code->op_err =
+      bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_OP_ERR_BIT);
+}
+
 rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
                                  void *data) {
   transaction_start((transaction_params_t){

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -226,10 +226,61 @@ typedef struct flash_ctrl_status {
  * This function checks the various status bits as described in
  * `flash_ctrl_status_t`.
  *
- * @param flash_ctrl flash controller device to check the status bits for.
- * @param[out] status_out The current status of the flash controller.
+ * @param[out] status The current status of the flash controller.
  */
 void flash_ctrl_status_get(flash_ctrl_status_t *status);
+
+/**
+ * Error code bits.
+ */
+typedef struct flash_ctrl_error_code {
+  /**
+   * Flash macro error occured.
+   */
+  bool macro_err;
+  /**
+   * Shadow register update error.
+   */
+  bool update_err;
+  /**
+   * Flash program type is unavailable.
+   */
+  bool prog_type_err;
+  /**
+   * Flash program window resolution error. Start and end of programming region
+   * are in different windows.
+   */
+  bool prog_win_err;
+  /**
+   * Flash programming error, could be an integrity error. Read the
+   * STD_FAULT_STATUS register.
+   */
+  bool prog_err;
+  /**
+   * Flash read error, could be an integrity error. Read the STD_FAULT_STATUS
+   * register.
+   */
+  bool rd_err;
+  /**
+   * Flash access permission error. Read the ERR_ADDR register for the faulting
+   * address.
+   */
+  bool mp_err;
+  /**
+   * Software has supplied an undefined flash operation.
+   */
+  bool op_err;
+} flash_ctrl_error_code_t;
+
+/**
+ * Query the error code register on the flash controller.
+ *
+ * This function checks the various error code bits as described in
+ * `flash_ctrl_error_code_t`.
+ *
+ * @param[out] error_code The current error code of the flash controller.
+ */
+void flash_ctrl_error_code_get(flash_ctrl_error_code_t *error_code);
 
 /**
  * Reads data from the data partition.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -217,6 +217,60 @@ TEST_F(StatusCheckTest, AllSetStatus) {
   EXPECT_EQ(status.rd_full, true);
 }
 
+class ErrorCodeCheckTest : public FlashCtrlTest {};
+
+TEST_F(ErrorCodeCheckTest, DefaultErrorCodes) {
+  EXPECT_ABS_READ32(base_ + FLASH_CTRL_ERR_CODE_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_ERR_CODE_MACRO_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_PROG_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_RD_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_MP_ERR_BIT, false},
+                        {FLASH_CTRL_ERR_CODE_OP_ERR_BIT, false},
+                    });
+
+  flash_ctrl_error_code_t error_code;
+  flash_ctrl_error_code_get(&error_code);
+
+  EXPECT_EQ(error_code.macro_err, false);
+  EXPECT_EQ(error_code.update_err, false);
+  EXPECT_EQ(error_code.prog_type_err, false);
+  EXPECT_EQ(error_code.prog_win_err, false);
+  EXPECT_EQ(error_code.prog_err, false);
+  EXPECT_EQ(error_code.rd_err, false);
+  EXPECT_EQ(error_code.mp_err, false);
+  EXPECT_EQ(error_code.op_err, false);
+}
+
+TEST_F(ErrorCodeCheckTest, AllSetErrorCodes) {
+  EXPECT_ABS_READ32(base_ + FLASH_CTRL_ERR_CODE_REG_OFFSET,
+                    {
+                        {FLASH_CTRL_ERR_CODE_MACRO_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_UPDATE_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_PROG_TYPE_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_PROG_WIN_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_PROG_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_RD_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_MP_ERR_BIT, true},
+                        {FLASH_CTRL_ERR_CODE_OP_ERR_BIT, true},
+                    });
+
+  flash_ctrl_error_code_t error_code;
+  flash_ctrl_error_code_get(&error_code);
+
+  EXPECT_EQ(error_code.macro_err, true);
+  EXPECT_EQ(error_code.update_err, true);
+  EXPECT_EQ(error_code.prog_type_err, true);
+  EXPECT_EQ(error_code.prog_win_err, true);
+  EXPECT_EQ(error_code.prog_err, true);
+  EXPECT_EQ(error_code.rd_err, true);
+  EXPECT_EQ(error_code.mp_err, true);
+  EXPECT_EQ(error_code.op_err, true);
+}
+
 class TransferTest : public FlashCtrlTest {
  protected:
   const std::vector<uint32_t> words_ = {0x12345678, 0x90ABCDEF, 0x0F1E2D3C,

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -117,6 +117,14 @@ void keymgr_owner_int_max_ver_set(uint32_t max_key_ver) {
   sec_mmio_write32(kBase + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
 }
 
+void keymgr_owner_max_ver_set(uint32_t max_key_ver) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioOwnerMaxVerSet, 2);
+  // Write and lock (rw0c) the max key version.
+  sec_mmio_write32_shadowed(
+      kBase + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, max_key_ver);
+  sec_mmio_write32(kBase + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+}
+
 void keymgr_advance_state(void) {
   uint32_t reg =
       bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -94,6 +94,7 @@ enum {
   kKeymgrSecMmioSwBindingSet = 17,
   kKeymgrSecMmioCreatorMaxVerSet = 2,
   kKeymgrSecMmioOwnerIntMaxVerSet = 2,
+  kKeymgrSecMmioOwnerMaxVerSet = 2,
 };
 
 /**
@@ -133,10 +134,18 @@ void keymgr_creator_max_ver_set(uint32_t max_key_ver);
 /**
  * Sets the Silicon Owner Intermediate max key version.
  *
- * @param max_key_ver Maximum key version associated with the Silicon Onwer
+ * @param max_key_ver Maximum key version associated with the Silicon Owner
  * Intermediate key manager stage.
  */
 void keymgr_owner_int_max_ver_set(uint32_t max_key_ver);
+
+/**
+ * Sets the Silicon Owner max key version.
+ *
+ * @param max_key_ver Maximum key version associated with the Silicon Owner
+ * key manager stage.
+ */
+void keymgr_owner_max_ver_set(uint32_t max_key_ver);
 
 /**
  * Sets the entropy reseed interval of the key manager.

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -147,6 +147,13 @@ TEST_F(KeymgrTest, SetOwnerIntMaxVerKey) {
   keymgr_owner_int_max_ver_set(cfg_.max_key_ver);
 }
 
+TEST_F(KeymgrTest, SetOwnerMaxVerKey) {
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+  keymgr_owner_max_ver_set(cfg_.max_key_ver);
+}
+
 TEST_F(KeymgrTest, AdvanceState) {
   EXPECT_ABS_WRITE32_SHADOWED(
       base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -6,8 +6,8 @@
 
 #include <stdint.h>
 
-/*
- * Declarations for the manifest fields populdated by the linker script.
+/**
+ * Declarations for the manifest fields populated by the linker script.
  */
 extern char _manifest_code_start[];
 extern char _manifest_code_end[];

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -206,11 +206,14 @@ cc_library(
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/runtime:hart",
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib:otbn_boot_services",
         "//sw/device/silicon_creator/lib:shutdown",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
@@ -228,6 +231,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/lib/sigverify",
         "//sw/device/silicon_creator/rom_ext/keys/fake",
+        "//sw/otbn/crypto:boot",
     ],
 )
 


### PR DESCRIPTION
This adds the attestation keygen flow to the ROM_EXT to partially address #19588. This does not yet add the certificate updating portion yet. That will be done in a follow up. 

**Note: this depends on https://github.com/lowRISC/opentitan/pull/20525.**
