### PR TITLE
[dif] Add `keymgr_dpe initialize` function.

### DIFF
--- a/sw/ip/keymgr_dpe/dif/dif_keymgr_dpe.h
+++ b/sw/ip/keymgr_dpe/dif/dif_keymgr_dpe.h
@@ -210,6 +210,21 @@ static const bitfield_field32_t kErrorBitfield = (bitfield_field32_t){
 typedef uint8_t dif_keymgr_dpe_status_codes_t;
 
 /**
+ * Initializes the keymgr_pde block by performing an advance operation.
+ *
+ * The hardware does not have an explicit initialize command. Initialization is
+ * simple the first advance call without software binding, max version or
+ * policy registers set. Use this call before calling
+ * `dif_keymgr_dpe_advance_state()`.
+ *
+ * @param keymgr_dpe A key manager handle.
+ * @param slot_dst_sel Target slot used to latch the UDS key.
+ * @return The result of the operation.
+ */
+dif_result_t dif_keymgr_dpe_initialize(const dif_keymgr_dpe_t *keymgr_dpe,
+                                       uint32_t slot_dst_sel);
+
+/**
  * Advances a keymgr_dpe slot with given parameters.
  *
  * @param keymgr_dpe A key manager handle.

--- a/sw/ip/keymgr_dpe/driver/BUILD
+++ b/sw/ip/keymgr_dpe/driver/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob([
+    "*.h",
+    "*.c",
+]))

--- a/sw/ip/keymgr_dpe/driver/keymgr_dpe.h
+++ b/sw/ip/keymgr_dpe/driver/keymgr_dpe.h
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_IP_KEYMGR_DPE_DRIVER_KEYMGR_DPE_H_
+#define OPENTITAN_SW_IP_KEYMGR_DPE_DRIVER_KEYMGR_DPE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/lib/sw/device/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * @file
+ * @brief This header contains declarations of device-specific driver
+ * information.
+ *
+ * This header contains "device-specific" driver declarations, i.e., information
+ * that all device implementations must provide, but which is specific to the
+ * particular choice of platform.
+ *
+ * Definitions for these symbols can be found in other files in the
+ * device-specific directory, which should be linked in depending on which
+ * platform an executable is intended for.
+ */
+
+/**
+ * Peripheral base address for core device on flash_ctrl in top chip.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+extern const uint32_t kKeymgrDpeBaseAddr[1];
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_IP_KEYMGR_DPE_DRIVER_KEYMGR_DPE_H_

--- a/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.c
+++ b/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.c
@@ -115,8 +115,8 @@ status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe) {
 
     // Advance to Initialized state.
     TRY(keymgr_dpe_testutils_check_state(keymgr_dpe, kDifKeymgrDpeStateReset));
-    TRY(keymgr_dpe_testutils_advance_state(
-        keymgr_dpe, &(dif_keymgr_dpe_advance_params_t){.slot_dst_sel = 1}));
+    TRY(dif_keymgr_dpe_initialize(keymgr_dpe, /*slot_dst_sel=*/1));
+    TRY(keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe));
     TRY(keymgr_dpe_testutils_check_state(keymgr_dpe,
                                          kDifKeymgrDpeStateAvailable));
     LOG_INFO("UDS is latched.");

--- a/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.c
+++ b/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.c
@@ -6,9 +6,6 @@
 
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
-#include "sw/ip/flash_ctrl/dif/dif_flash_ctrl.h"
-#include "sw/ip/flash_ctrl/driver/flash_ctrl.h"
-#include "sw/ip/flash_ctrl/test/utils/flash_ctrl_testutils.h"
 #include "sw/ip/keymgr_dpe/dif/dif_keymgr_dpe.h"
 #include "sw/ip/keymgr_dpe/driver/keymgr_dpe.h"
 #include "sw/ip/otp_ctrl/dif/dif_otp_ctrl.h"
@@ -21,58 +18,7 @@
 #include "sw/lib/sw/device/runtime/log.h"
 #include "sw/lib/sw/device/silicon_creator/base/chip.h"
 
-enum {
-  /** Flash Secret partition ID. */
-  kFlashInfoPartitionId = 0,
-
-  /** Secret partition flash bank ID. */
-  kFlashInfoBankId = 0,
-
-  /** Creator Secret flash info page ID. */
-  kFlashInfoPageIdCreatorSecret = 1,
-
-  /** Owner Secret flash info page ID. */
-  kFlashInfoPageIdOwnerSecret = 2,
-};
-
-static status_t write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
-                                const keymgr_dpe_testutils_secret_t *data,
-                                bool scramble) {
-  uint32_t address = 0;
-  if (scramble) {
-    TRY(flash_ctrl_testutils_info_region_scrambled_setup(
-        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
-  } else {
-    TRY(flash_ctrl_testutils_info_region_setup(
-        flash, page_id, kFlashInfoBankId, kFlashInfoPartitionId, &address));
-  }
-
-  TRY(flash_ctrl_testutils_erase_and_write_page(
-      flash, address, kFlashInfoPartitionId, data->value,
-      kDifFlashCtrlPartitionTypeInfo, ARRAYSIZE(data->value)));
-
-  keymgr_dpe_testutils_secret_t readback_data;
-  TRY(flash_ctrl_testutils_read(
-      flash, address, kFlashInfoPartitionId, readback_data.value,
-      kDifFlashCtrlPartitionTypeInfo, ARRAYSIZE(readback_data.value), 0));
-  TRY_CHECK(memcmp(data->value, readback_data.value, sizeof(data->value)) == 0);
-  return OK_STATUS();
-}
-
-status_t keymgr_dpe_testutils_flash_init(
-    dif_flash_ctrl_state_t *flash,
-    const keymgr_dpe_testutils_secret_t *creator_secret,
-    const keymgr_dpe_testutils_secret_t *owner_secret) {
-  // Initialize flash secrets.
-  write_info_page(flash, kFlashInfoPageIdCreatorSecret, creator_secret,
-                  /*scramble=*/true);
-  write_info_page(flash, kFlashInfoPageIdOwnerSecret, owner_secret,
-                  /*scramble=*/true);
-  return OK_STATUS();
-}
-
 status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe) {
-  dif_flash_ctrl_state_t flash;
   dif_rstmgr_t rstmgr;
   dif_rstmgr_reset_info_bitfield_t info;
 
@@ -81,15 +27,7 @@ status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe) {
 
   // POR reset.
   if (info == kDifRstmgrResetInfoPor) {
-    LOG_INFO("Powered up for the first time, program flash");
-
-    TRY(dif_flash_ctrl_init_state(
-        &flash, mmio_region_from_addr(kFlashCtrlCoreBaseAddr[0])));
-
-    TRY(keymgr_dpe_testutils_flash_init(&flash, &kCreatorSecret,
-                                        &kOwnerSecret));
-
-    // Lock otp secret partition.
+    LOG_INFO("Powered up for the first time, lock SECRET2 partition");
     dif_otp_ctrl_t otp;
     TRY(dif_otp_ctrl_init(mmio_region_from_addr(kOtpCtrlCoreBaseAddr[0]),
                           &otp));

--- a/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.h
+++ b/sw/ip/keymgr_dpe/test/utils/keymgr_dpe_testutils.h
@@ -5,65 +5,11 @@
 #ifndef OPENTITAN_SW_IP_KEYMGR_DPE_TEST_UTILS_KEYMGR_DPE_TESTUTILS_H_
 #define OPENTITAN_SW_IP_KEYMGR_DPE_TEST_UTILS_KEYMGR_DPE_TESTUTILS_H_
 
-#include "sw/ip/flash_ctrl/dif/dif_flash_ctrl.h"
 #include "sw/ip/keymgr_dpe/dif/dif_keymgr_dpe.h"
 #include "sw/lib/sw/device/base/status.h"
 
 /**
- * Struct to hold the creator or owner secrets for the key manager. In the spec,
- * these are also known as `creator_div_secret` and `owner_div_secret`
- * respectively. Both these values are stored in the flash memory, therefore
- * these structs are useful to set and write these two secrets with
- * `keymgr_dpe_testutils_flash_init` function provided below.
- */
-typedef struct keymgr_dpe_testutils_secret {
-  uint32_t value[8];
-} keymgr_dpe_testutils_secret_t;
-
-/**
- * Key manager Creator Secret (a.k.a. `creator_div_secret`) stored in info flash
- * page.
- */
-static const keymgr_dpe_testutils_secret_t kCreatorSecret = {
-    .value = {0x4e919d54, 0x322288d8, 0x4bd127c7, 0x9f89bc56, 0xb4fb0fdf,
-              0x1ca1567b, 0x13a0e876, 0xa6521d8f}};
-
-/**
- * Key manager Owner Secret (a.k.a. `owner_div_secret`) stored in info flash
- * page.
- */
-static const keymgr_dpe_testutils_secret_t kOwnerSecret = {.value = {
-                                                               0xa6521d8f,
-                                                               0x13a0e876,
-                                                               0x1ca1567b,
-                                                               0xb4fb0fdf,
-                                                               0x9f89bc56,
-                                                               0x4bd127c7,
-                                                               0x322288d8,
-                                                               0x4e919d54,
-                                                           }};
-
-/**
- * Programs flash with secrets so that a keymgr_dpe slot can be advanced from
- * UDS stage to the next stage (a.k.a. CreatorRootKey in the old keymgr
- * terminology).
- *
- * This is normally a subfunction of `keymgr_dpe_testutils_startup`, but some
- * tests use the function separately as well.
- *
- * @param flash[out] An unitialized flash_ctrl handle.
- * @param creator_secret The creator secret to be programmed to flash.
- * @param owner_secret The owner secret to be programmed to flash.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-status_t keymgr_dpe_testutils_flash_init(
-    dif_flash_ctrl_state_t *flash,
-    const keymgr_dpe_testutils_secret_t *creator_secret,
-    const keymgr_dpe_testutils_secret_t *owner_secret);
-
-/**
- * Programs flash, restarts and initializes keymgr_dpe with UDS (a.k.a. the OTP
+ * Locks OTP, restarts and initializes keymgr_dpe with UDS (a.k.a. the OTP
  * root key).
  *
  * This procedure essentially gets the keymgr_dpe into the stage where it

--- a/sw/top_darjeeling/sw/device/arch/BUILD
+++ b/sw/top_darjeeling/sw/device/arch/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//sw/top_darjeeling/sw/drivers:entropy_src",
         "//sw/top_darjeeling/sw/drivers:flash_ctrl",
         "//sw/top_darjeeling/sw/drivers:keymgr",
+        "//sw/top_darjeeling/sw/drivers:keymgr_dpe",
         "//sw/top_darjeeling/sw/drivers:kmac",
         "//sw/top_darjeeling/sw/drivers:lc_ctrl",
         "//sw/top_darjeeling/sw/drivers:otp_ctrl",

--- a/sw/top_darjeeling/sw/device/arch/drivers.c
+++ b/sw/top_darjeeling/sw/device/arch/drivers.c
@@ -6,6 +6,7 @@
 #include "sw/ip/edn/driver/edn.h"
 #include "sw/ip/flash_ctrl/driver/flash_ctrl.h"
 #include "sw/ip/keymgr/driver/keymgr.h"
+#include "sw/ip/keymgr_dpe/driver/keymgr_dpe.h"
 #include "sw/ip/kmac/driver/kmac.h"
 #include "sw/ip/lc_ctrl/driver/lc_ctrl.h"
 #include "sw/ip/otp_ctrl/driver/otp_ctrl.h"
@@ -34,6 +35,8 @@ const uint32_t kFlashCtrlMemBaseAddr[] = {
     TOP_DARJEELING_FLASH_CTRL_MEM_BASE_ADDR};
 
 const uint32_t kKeymgrBaseAddr[] = {TOP_DARJEELING_KEYMGR_BASE_ADDR};
+
+const uint32_t kKeymgrDpeBaseAddr[] = {TOP_DARJEELING_KEYMGR_DPE_BASE_ADDR};
 
 const uint32_t kKmacBaseAddr[] = {TOP_DARJEELING_KMAC_BASE_ADDR};
 

--- a/sw/top_darjeeling/sw/drivers/BUILD
+++ b/sw/top_darjeeling/sw/drivers/BUILD
@@ -150,6 +150,15 @@ cc_library(
 )
 
 cc_library(
+    name = "keymgr_dpe",
+    hdrs = ["//sw/ip/keymgr_dpe/driver:keymgr_dpe.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/lib/sw/device/base:mmio",
+    ],
+)
+
+cc_library(
     name = "kmac",
     hdrs = ["//sw/ip/kmac/driver:kmac.h"],
     target_compatible_with = [OPENTITAN_CPU],

--- a/sw/top_darjeeling/sw/test/utils/BUILD
+++ b/sw/top_darjeeling/sw/test/utils/BUILD
@@ -213,6 +213,31 @@ cc_library(
 )
 
 cc_library(
+    name = "keymgr_dpe_testutils",
+    srcs = ["//sw/ip/keymgr_dpe/test/utils:keymgr_dpe_testutils.c"],
+    hdrs = ["//sw/ip/keymgr_dpe/test/utils:keymgr_dpe_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":kmac_testutils",
+        ":otp_ctrl_testutils",
+        ":rstmgr_testutils",
+        "//hw/ip/keymgr_dpe/data:keymgr_dpe_regs",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/lib/sw/device/base:mmio",
+        "//sw/lib/sw/device/runtime:ibex",
+        "//sw/lib/sw/device/silicon_creator/base:chip",
+        "//sw/top_darjeeling/sw/dif:keymgr_dpe",
+        "//sw/top_darjeeling/sw/dif:otp_ctrl",
+        "//sw/top_darjeeling/sw/dif:rstmgr",
+        "//sw/top_darjeeling/sw/drivers:keymgr_dpe",
+        "//sw/top_darjeeling/sw/drivers:kmac",
+        "//sw/top_darjeeling/sw/drivers:otp_ctrl",
+        "//sw/top_darjeeling/sw/drivers:rstmgr",
+    ],
+)
+
+cc_library(
     name = "kmac_testutils",
     srcs = ["//sw/ip/kmac/test/utils:kmac_testutils.c"],
     hdrs = ["//sw/ip/kmac/test/utils:kmac_testutils.h"],


### PR DESCRIPTION
The first keymgr_dpe advance call is used to initialize the key manager and latch the UDS key in one of the destination slots. Software binding, max version and policy registers are not used by hardware during this operation.

This change also updates the `keymgr_dpe_testutils.c` to use the new initialization function.