### PR TITLE
[sram] Initialize the AST from the flash info page

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -37,6 +37,7 @@ cc_library(
     srcs = ["sram_start.S"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":ast_program",
         ":sram_start_headers",
         "//hw/ip/csrng/data:csrng_regs",
         "//hw/ip/edn/data:edn_regs",
@@ -276,5 +277,45 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/silicon_creator/lib:attestation",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+cc_library(
+    name = "ast_program",
+    srcs = ["ast_program.c"],
+    deps = [
+        ":flash_info_fields",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+    ],
+)
+
+opentitan_test(
+    name = "ast_program_functest",
+    srcs = [
+        "ast_program.c",
+        "ast_program_functest.c",
+    ],
+    defines = [
+        "AST_PROGRAM_UNITTEST=1",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+    deps = [
+        ":flash_info_fields",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:crc32",
     ],
 )

--- a/sw/device/silicon_creator/manuf/lib/ast_program.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program.c
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#ifndef AST_PROGRAM_UNITTEST
+// In normal operation, AST writes should go directly to the AST
+// peripheral.  The DIF variables should be only visible to this
+// source unit.
+#define ast_write(addr, data) abs_mmio_write32(addr, data)
+static dif_flash_ctrl_state_t flash_state;
+static dif_uart_t uart0;
+#else
+// If we're running a unit test, we want to supply an AST writing function
+// and make the DIFs externally visible so the test program can verify
+// the written values and examine/modify the flash.
+extern void ast_write(uint32_t addr, uint32_t data);
+dif_flash_ctrl_state_t flash_state;
+dif_uart_t uart0;
+#endif
+
+static status_t setup_uart(bool enable) {
+  if (enable) {
+    TRY(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart0));
+    TRY(dif_uart_configure(&uart0,
+                           (dif_uart_config_t){
+                               .baudrate = (uint32_t)kUartBaudrate,
+                               .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                               .parity_enable = kDifToggleDisabled,
+                               .parity = kDifUartParityEven,
+                               .tx_enable = kDifToggleEnabled,
+                               .rx_enable = kDifToggleEnabled,
+                           }));
+    base_uart_stdout(&uart0);
+  } else {
+    base_uart_stdout(NULL);
+  }
+  return OK_STATUS();
+}
+
+status_t ast_program_init(bool verbose) {
+  setup_uart(verbose);
+  LOG_INFO("Starting AST config");
+  // Initialize the flash_ctrl DIF.
+  TRY(dif_flash_ctrl_init_state(
+      &flash_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  // Set up parameters for accessing the AST calibration data in flash info page
+  // 0.
+  dif_flash_ctrl_info_region_t info_region = {
+      .bank = kFlashInfoFieldAstCalibrationData.bank,
+      .page = kFlashInfoFieldAstCalibrationData.page,
+      .partition_id = kFlashInfoFieldAstCalibrationData.partition};
+
+  dif_flash_ctrl_region_properties_t kFlashInfoPage0Permissions = {
+      .ecc_en = kMultiBitBool4True,
+      .high_endurance_en = kMultiBitBool4False,
+      .erase_en = kMultiBitBool4True,
+      .prog_en = kMultiBitBool4True,
+      .rd_en = kMultiBitBool4True,
+      .scramble_en = kMultiBitBool4False};
+
+  TRY(dif_flash_ctrl_set_info_region_properties(&flash_state, info_region,
+                                                kFlashInfoPage0Permissions));
+  TRY(dif_flash_ctrl_set_info_region_enablement(&flash_state, info_region,
+                                                kDifToggleEnabled));
+  return OK_STATUS();
+}
+
+status_t ast_program_config(bool verbose) {
+  TRY(ast_program_init(verbose));
+  LOG_INFO("Reading AST data");
+  // Prepare the read transaction.
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  uint32_t byte_address =
+      (kFlashInfoFieldAstCalibrationData.page * device_info.bytes_per_page) +
+      kFlashInfoFieldAstCalibrationData.byte_offset;
+  dif_flash_ctrl_transaction_t transaction = {
+      .byte_address = byte_address,
+      .op = kDifFlashCtrlOpRead,
+      .partition_type = kDifFlashCtrlPartitionTypeInfo,
+      .partition_id = kFlashInfoFieldAstCalibrationData.partition,
+      .word_count = kFlashInfoFieldMaxAstCalibrationDataSizeIn32BitWords};
+  // Read the data.
+  TRY(dif_flash_ctrl_start(&flash_state, transaction));
+  uint32_t ast_data[kFlashInfoFieldMaxAstCalibrationDataSizeIn32BitWords];
+  TRY(dif_flash_ctrl_read_fifo_pop(&flash_state, transaction.word_count,
+                                   ast_data));
+  dif_flash_ctrl_output_t output;
+  TRY(dif_flash_ctrl_end(&flash_state, &output));
+
+  // Program AST
+  // The form of the AST data is: <count> [<address> <data> ...]
+  if (ast_data[0] < kFlashInfoFieldMaxAstCalibrationDataSizeIn32BitWords / 2) {
+    LOG_INFO("Programming %u AST words", ast_data[0]);
+    for (size_t i = 0; i < ast_data[0]; ++i) {
+      uint32_t addr = ast_data[1 + i * 2];
+      uint32_t data = ast_data[2 + i * 2];
+      ast_write(addr, data);
+    }
+  } else {
+    LOG_ERROR("AST data error: length %u >= %u", ast_data[0],
+              kFlashInfoFieldMaxAstCalibrationDataSizeIn32BitWords / 2);
+    return UNKNOWN();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/crc32.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+OTTF_DEFINE_TEST_CONFIG(.console.test_may_clobber = true);
+
+// These symbols come from the `ast_program` module.
+extern status_t ast_program_config(bool verbose);
+extern status_t ast_program_init(bool verbose);
+extern dif_flash_ctrl_state_t flash_state;
+
+// Light-weight mocking: we export `ast_write` to the `ast_program` module so we
+// can get a call for every word that would be written to AST.
+uint32_t ast_crc;
+uint32_t ast_nr_writes;
+void ast_write(uint32_t addr, uint32_t data) {
+  crc32_add32(&ast_crc, addr);
+  crc32_add32(&ast_crc, data);
+  ast_nr_writes += 1;
+}
+
+/**
+ * Reset the CRC and count between tests.
+ */
+static void test_state_reset(void) {
+  ast_nr_writes = 0;
+  crc32_init(&ast_crc);
+}
+
+/**
+ * Erase the INFO page containing the AST calibration data.
+ */
+static status_t erase_page(void) {
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  uint32_t byte_address =
+      (kFlashInfoFieldAstCalibrationData.page * device_info.bytes_per_page);
+
+  return flash_ctrl_testutils_erase_page(
+      &flash_state, byte_address, kFlashInfoFieldAstCalibrationData.partition,
+      kDifFlashCtrlPartitionTypeInfo);
+}
+
+/**
+ * Program a blob into the AST calibration info page.
+ *
+ * @param data: The AST blob.  The format is <count> [<addr> <data> ...].
+ */
+static status_t program_page(const uint32_t *data) {
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  uint32_t byte_address =
+      (kFlashInfoFieldAstCalibrationData.page * device_info.bytes_per_page) +
+      kFlashInfoFieldAstCalibrationData.byte_offset;
+
+  // The AST blob is 1 count word plus 2 additional words for every <count>.
+  uint32_t size = (1 + data[0] * 2) * sizeof(uint32_t);
+  return flash_ctrl_testutils_write(&flash_state, byte_address,
+                                    kFlashInfoFieldAstCalibrationData.partition,
+                                    data, kDifFlashCtrlPartitionTypeInfo, size);
+}
+
+/**
+ * A fake AST configuration blob for testing.
+ */
+static const uint32_t sample_blob[] = {
+    // The number of configuration pairs:
+    4,
+    // The config address/data pairs:
+    0x40480000,
+    0x1234,
+    0x40480004,
+    0x5678,
+    0x40480008,
+    0xabcd,
+    0x4048000c,
+    0xef00,
+};
+
+static status_t execute_test(void) {
+  LOG_INFO("Initialize");
+  TRY(ast_program_init(true));
+
+  LOG_INFO("Erase the INFO page. Verify no AST programming; expect error.");
+  test_state_reset();
+  TRY(erase_page());
+  TRY_CHECK(status_err(ast_program_config(true)));
+  TRY_CHECK(ast_nr_writes == 0);
+
+  LOG_INFO(
+      "Program a sample blob into the INFO page.  Verify AST programming.");
+  test_state_reset();
+  TRY(program_page(sample_blob));
+  TRY(ast_program_config(true));
+  uint32_t crc = crc32(&sample_blob[1], sizeof(sample_blob) - sizeof(uint32_t));
+  TRY_CHECK(ast_nr_writes == 4);
+  TRY_CHECK(crc32_finish(&ast_crc) == crc);
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  // Run once just to get the flash controller initialzed.
+  status_t sts = execute_test();
+  LOG_INFO("result = %r", sts);
+  return status_ok(sts);
+}

--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -173,6 +173,9 @@ sram_start:
          (MULTIBIT_ASM_BOOL4_FALSE << EDN_CTRL_CMD_FIFO_RST_OFFSET)
   sw t0, EDN_CTRL_REG_OFFSET(a0)
 
+  // Configure the AST
+  li a0, 1
+  call ast_program_config
   // Jump into the C program entry point.
   call sram_main
 


### PR DESCRIPTION
1. Check if there is AST calibration data in info page 0, and if so, write it to the AST registers.