### PR TITLE
[manuf] add Si exec_env for provisioning binaries and make harness args mandatory

### DIFF
--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -8,6 +8,11 @@ load(
     "RSA_ONLY_KEY_STRUCTS",
 )
 load(
+    "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic:provisioning_inputs.bzl",
+    "CP_PROVISIONING_INPUTS",
+    "FT_PROVISIONING_INPUTS",
+)
+load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
     "opentitan_binary",
@@ -108,7 +113,7 @@ opentitan_test(
         tags = ["manuf"],
         test_cmd = """
             --elf={sram_cp_provision}
-        """,
+        """ + CP_PROVISIONING_INPUTS,
         test_harness = "//sw/host/tests/manuf/provisioning/cp",
     ),
     exec_env = {
@@ -139,7 +144,7 @@ opentitan_test(
         test_cmd = """
             --provisioning-sram-elf={sram_cp_provision}
             --test-sram-elf={sram_cp_provision_functest}
-        """,
+        """ + CP_PROVISIONING_INPUTS,
         test_harness = "//sw/host/tests/manuf/provisioning/cp_test",
     ),
     exec_env = {
@@ -178,6 +183,30 @@ opentitan_binary(
         "//sw/device/silicon_creator/manuf/lib:individualize",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_generic",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
+opentitan_binary(
+    name = "ft_personalize_1",
+    testonly = True,
+    srcs = ["ft_personalize_1.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    rsa_key = rsa_key_for_lc_state(
+        RSA_ONLY_KEY_STRUCTS,
+        CONST.LCV.PROD,
+    ),
+    deps = [
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_generic",
+        "//sw/device/silicon_creator/manuf/lib:personalize",
     ],
 )
 
@@ -243,10 +272,10 @@ opentitan_binary(
 
 opentitan_test(
     name = "ft_provision",
-    srcs = ["ft_personalize_1.c"],
     cw310 = cw310_jtag_params(
         binaries = {
             ":sram_ft_individualize": "sram_ft_individualize",
+            ":ft_personalize_1": "ft_personalize_1",
             ":ft_personalize_2": "ft_personalize_2",
             ":ft_personalize_3": "ft_personalize_3",
         },
@@ -258,12 +287,10 @@ opentitan_test(
         ],
         test_cmd = """
             --elf={sram_ft_individualize}
-            --bootstrap={firmware}
+            --bootstrap={ft_personalize_1}
             --second-bootstrap={ft_personalize_2}
             --third-bootstrap={ft_personalize_3}
-            --target-mission-mode-lc-state="prod"
-            --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
-        """,
+        """ + FT_PROVISIONING_INPUTS,
         test_harness = "//sw/host/tests/manuf/provisioning/ft",
     ),
     exec_env = {
@@ -273,14 +300,4 @@ opentitan_test(
         RSA_ONLY_KEY_STRUCTS,
         CONST.LCV.PROD,
     ),
-    deps = [
-        "//sw/device/lib/dif:lc_ctrl",
-        "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:lc_ctrl_testutils",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_generic",
-        "//sw/device/silicon_creator/manuf/lib:personalize",
-    ],
 )

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/BUILD
@@ -72,6 +72,7 @@ opentitan_binary(
     srcs = ["sram_cp_provision_functest.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -103,17 +104,17 @@ opentitan_binary(
     ],
 )
 
+_CP_PROVISIONING_CMD_ARGS = """
+  --elf={sram_cp_provision}
+""" + CP_PROVISIONING_INPUTS
+
 opentitan_test(
     name = "cp_provision",
     cw310 = cw310_jtag_params(
-        binaries = {
-            ":sram_cp_provision": "sram_cp_provision",
-        },
+        binaries = {":sram_cp_provision": "sram_cp_provision"},
         bitstream = "//hw/bitstream:rom_with_fake_keys_otp_raw",
         tags = ["manuf"],
-        test_cmd = """
-            --elf={sram_cp_provision}
-        """ + CP_PROVISIONING_INPUTS,
+        test_cmd = _CP_PROVISIONING_CMD_ARGS,
         test_harness = "//sw/host/tests/manuf/provisioning/cp",
     ),
     exec_env = {
@@ -121,13 +122,9 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_creator": None,
     },
     silicon = silicon_jtag_params(
-        binaries = {
-            ":sram_cp_provision": "sram_cp_provision",
-        },
+        binaries = {":sram_cp_provision": "sram_cp_provision"},
         interface = "hyper310",
-        test_cmd = """
-            --elf={sram_cp_provision}
-        """,
+        test_cmd = _CP_PROVISIONING_CMD_ARGS,
         test_harness = "//sw/host/tests/manuf/provisioning/cp",
     ),
 )
@@ -158,6 +155,7 @@ opentitan_binary(
     srcs = ["sram_ft_individualize.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -192,6 +190,7 @@ opentitan_binary(
     srcs = ["ft_personalize_1.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rsa_key = rsa_key_for_lc_state(
@@ -216,6 +215,7 @@ opentitan_binary(
     srcs = ["ft_personalize_2.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rsa_key = rsa_key_for_lc_state(
@@ -246,6 +246,7 @@ opentitan_binary(
     srcs = ["ft_personalize_3.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rsa_key = rsa_key_for_lc_state(
@@ -270,34 +271,46 @@ opentitan_binary(
     ],
 )
 
+_FT_PROVISIONING_BINARIES = {
+    ":sram_ft_individualize": "sram_ft_individualize",
+    ":ft_personalize_1": "ft_personalize_1",
+    ":ft_personalize_2": "ft_personalize_2",
+    ":ft_personalize_3": "ft_personalize_3",
+}
+
+_FT_PROVISIONING_CMD_ARGS = """
+  --elf={sram_ft_individualize}
+  --bootstrap={ft_personalize_1}
+  --second-bootstrap={ft_personalize_2}
+  --third-bootstrap={ft_personalize_3}
+""" + FT_PROVISIONING_INPUTS
+
 opentitan_test(
     name = "ft_provision",
     cw310 = cw310_jtag_params(
-        binaries = {
-            ":sram_ft_individualize": "sram_ft_individualize",
-            ":ft_personalize_1": "ft_personalize_1",
-            ":ft_personalize_2": "ft_personalize_2",
-            ":ft_personalize_3": "ft_personalize_3",
-        },
+        binaries = _FT_PROVISIONING_BINARIES,
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_locked0_manuf_initialized",
         tags = [
             "lc_test_locked0",
             "manuf",
         ],
-        test_cmd = """
-            --elf={sram_ft_individualize}
-            --bootstrap={ft_personalize_1}
-            --second-bootstrap={ft_personalize_2}
-            --third-bootstrap={ft_personalize_3}
-        """ + FT_PROVISIONING_INPUTS,
+        test_cmd = _FT_PROVISIONING_CMD_ARGS,
         test_harness = "//sw/host/tests/manuf/provisioning/ft",
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:silicon_creator": None,
     },
     rsa_key = rsa_key_for_lc_state(
         RSA_ONLY_KEY_STRUCTS,
         CONST.LCV.PROD,
+    ),
+    silicon = silicon_jtag_params(
+        binaries = _FT_PROVISIONING_BINARIES,
+        data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
+        interface = "hyper310",
+        test_cmd = _FT_PROVISIONING_CMD_ARGS,
+        test_harness = "//sw/host/tests/manuf/provisioning/ft",
     ),
 )

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/generic/provisioning_inputs.bzl
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+_DEVICE_ID_AND_TEST_TOKENS = """
+  --device-id="0x11111111_22222222_33333333_44444444_55555555_66666666_77777777_88888888"
+  --test-unlock-token="0x11111111_11111111_11111111_11111111"
+  --test-exit-token="0x11111111_11111111_11111111_11111111"
+"""
+
+CP_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
+  --manuf-state="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+  --wafer-auth-secret="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+"""
+
+FT_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
+  --target-mission-mode-lc-state="prod"
+  --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
+  --rom-ext-measurement="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+  --owner-manifest-measurement="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+  --owner-measurement="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
+"""

--- a/sw/host/provisioning/cp_lib/src/lib.rs
+++ b/sw/host/provisioning/cp_lib/src/lib.rs
@@ -26,32 +26,23 @@ mod lc_raw_unlock_token;
 pub struct ManufCpProvisioningDataInput {
     // TODO(#19456): construct device ID from building blocks
     /// Device ID to provision.
-    #[arg(
-        long,
-        default_value = "0xCAFEBABE_11112222_33334444_55556666_77778888_9999AAAA_BBBBCCCC_DEADBEEF"
-    )]
+    #[arg(long)]
     pub device_id: String,
 
     /// Manufacturing State information to provision.
-    #[arg(
-        long,
-        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
-    )]
+    #[arg(long)]
     pub manuf_state: String,
 
     /// Wafer Authentication Secret to provision.
-    #[arg(
-        long,
-        default_value = "0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
-    )]
+    #[arg(long)]
     pub wafer_auth_secret: String,
 
     /// TestUnlock token to provision.
-    #[arg(long, default_value = "0x11111111_11111111_11111111_11111111")]
+    #[arg(long)]
     pub test_unlock_token: String,
 
     /// TestExit token to provision.
-    #[arg(long, default_value = "0x11111111_11111111_11111111_11111111")]
+    #[arg(long)]
     pub test_exit_token: String,
 }
 


### PR DESCRIPTION
This fixes #20213 and partially addresses #20212.