### PR TITLE
[ot_certs] Disable flaky test

### DIFF
--- a/sw/host/ot_certs/src/x509/tests.rs
+++ b/sw/host/ot_certs/src/x509/tests.rs
@@ -56,6 +56,7 @@ struct RandData {
 /// where every field is a variable, uses the offsets to fill those values
 /// and then parse the resulting certificate using OpenSSL+asn1 to see if the values
 /// match.
+#[ignore]
 #[test]
 fn offsets_are_correct() {
     // Generare a certificate where every field is a variable.


### PR DESCRIPTION
This test can break because it generates random values and in some case, the signature of the certificate uses less bytes than expected. Since this code will be replace by the new approach using the asn1 generator, just disable the test for now to avoid CI breakage.