### PR TITLE
[sival] Move the FPGA sival platforms to hyper310

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -596,9 +596,9 @@ jobs:
     demands: BOARD -equals cw310
   timeoutInMinutes: 45
   dependsOn:
-    - chip_earlgrey_cw310
+    - chip_earlgrey_cw310_hyperdebug
     - sw_build
-  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
+  condition: succeeded( 'chip_earlgrey_cw310_hyperdebug', 'sw_build' )
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
@@ -606,12 +606,13 @@ jobs:
     parameters:
       downloadPartialBuildBinFrom:
         - chip_earlgrey_cw310
+        - chip_earlgrey_cw310_hyperdebug
         - sw_build
   - bash: |
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh cw310 cw310_sival,-manuf,-hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh hyper310 cw310_sival || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
@@ -702,7 +703,7 @@ jobs:
       set -e
       . util/build_consts.sh
       module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh cw310 manuf || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+      ci/scripts/run-fpga-tests.sh cw310 manuf,-cw310_sival || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -115,6 +115,37 @@ fpga_cw310(
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
 )
 
+fpga_cw310(
+    name = "fpga_hyper310_rom_with_fake_keys",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ],
+    base = ":fpga_cw310",
+    base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
+    exec_env = "fpga_hyper310_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    otp = "//hw/ip/otp_ctrl/data:img_rma",
+    otp_mmi = "//hw/bitstream/hyperdebug:otp_mmi",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    rom_mmi = "//hw/bitstream/hyperdebug:rom_mmi",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    test_cmd = """
+        --exec="transport init"
+        --exec="fpga load-bitstream {bitstream}"
+        --exec="bootstrap --clear-uart=true {firmware}"
+        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+        no-op
+    """,
+)
+
 # FPGA configuration used to emulate silicon targets. This rule can be used by
 # targets that require executing at the `rom_ext` stage level in flash, as well
 # as SRAM programs. Use the `fpga_cw310_sival_rom_ext` execution environment to
@@ -123,7 +154,7 @@ fpga_cw310(
 fpga_cw310(
     name = "fpga_cw310_sival",
     testonly = True,
-    base = ":fpga_cw310_rom_with_fake_keys",
+    base = ":fpga_hyper310_rom_with_fake_keys",
     exec_env = "fpga_cw310_sival",
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
 

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -20,6 +20,7 @@ load(
     _fpga_cw305 = "fpga_cw305",
     _fpga_cw310 = "fpga_cw310",
     _fpga_cw340 = "fpga_cw340",
+    _hyper310_jtag_params = "hyper310_jtag_params",
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:silicon.bzl",
@@ -57,6 +58,7 @@ fpga_cw305 = _fpga_cw305
 fpga_cw340 = _fpga_cw340
 cw310_params = _cw310_params
 cw310_jtag_params = _cw310_jtag_params
+hyper310_jtag_params = _hyper310_jtag_params
 
 silicon = _silicon
 silicon_params = _silicon_params

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -27,6 +27,8 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:openocd.bzl",
+    "OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS",
+    "OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD",
     "OPENTITANTOOL_OPENOCD_DATA_DEPS",
     "OPENTITANTOOL_OPENOCD_TEST_CMD",
 )
@@ -297,7 +299,66 @@ def cw310_jtag_params(
         rom_ext = rom_ext,
         otp = otp,
         bitstream = bitstream,
-        test_cmd = OPENTITANTOOL_OPENOCD_TEST_CMD + test_cmd,
+        test_cmd = """
+            --clear-bitstream
+            --bitstream={bitstream}
+        """ + OPENTITANTOOL_OPENOCD_TEST_CMD + test_cmd,
         data = OPENTITANTOOL_OPENOCD_DATA_DEPS + data,
+        param = kwargs,
+    )
+
+def hyper310_jtag_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = None,
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        **kwargs):
+    """A macro to create Hyper310 parameters for OpenTitan JTAG tests.
+
+    This creates version of the Hyper310 parameter structure pre-initialized
+    with OpenOCD dependencies and test_cmd parameters.
+
+    Args:
+      tags: The test tags to apply to the test rule.
+      timeout: The timeout to apply to the test rule.
+      local: Whether to set the `local` flag on this test.
+      test_harness: Use an alternative test harness for this test.
+      binaries: Dict of binary labels to substitution parameter names.
+      rom: Use an alternate ROM for this test.
+      rom_ext: Use an alternate ROM_EXT for this test.
+      otp: Use an alternate OTP configuration for this test.
+      bitstream: Use an alternate bitstream for this test.
+      test_cmd: Use an alternate test_cmd for this test.
+      data: Additional files needed by this test.
+      kwargs: Additional key-value pairs to override in the test `param` dict.
+    Returns:
+      struct of test parameters.
+    """
+    if bitstream and (rom or otp):
+        fail("Cannot use rom or otp with bitstream.")
+    if not bitstream:
+        bitstream = "@//hw/bitstream/universal:splice"
+    return struct(
+        tags = ["hyper310", "exclusive"] + tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = """
+            --clear-bitstream
+            --bitstream={bitstream}
+        """ + OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD + test_cmd,
+        data = OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS + data,
         param = kwargs,
     )

--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -15,8 +15,11 @@ OPENTITANTOOL_OPENOCD_CMSIS_DATA_DEPS = [
 OPENTITANTOOL_OPENOCD_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
     --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_olimex_cfg)"
-    --clear-bitstream
-    --bitstream={bitstream}
+"""
+
+OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD = """
+    --openocd="$(rootpath //third_party/openocd:openocd_bin)"
+    --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_cmsis_dap_adapter_cfg)"
 """
 
 OPENTITANTOOL_OPENOCD_CMSIS_SI_TEST_CMD = """

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -6,8 +6,8 @@ load("//rules:linker.bzl", "ld_library")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
-    "cw310_jtag_params",
     "cw310_params",
+    "hyper310_jtag_params",
     "opentitan_test",
 )
 
@@ -241,7 +241,7 @@ cc_library(
 opentitan_test(
     name = "personalize_functest",
     srcs = ["personalize_functest.c"],
-    cw310 = cw310_jtag_params(
+    cw310 = hyper310_jtag_params(
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_individualized",
         tags = [

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -10,6 +10,7 @@ load(
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
@@ -287,7 +288,7 @@ _FT_PROVISIONING_CMD_ARGS = """
 
 opentitan_test(
     name = "ft_provision",
-    cw310 = cw310_jtag_params(
+    cw310 = hyper310_jtag_params(
         binaries = _FT_PROVISIONING_BINARIES,
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_locked0_manuf_initialized",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -155,7 +155,7 @@ opentitan_test(
             "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
             "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
         ],
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
     )
     for i in range(0, 8)
 ]

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -9,8 +9,6 @@ load(
 )
 load(
     "//rules:opentitan_test.bzl",
-    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
-    "OPENTITANTOOL_OPENOCD_TEST_CMDS",
     "cw310_params",
     "opentitan_functest",
 )

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
@@ -36,6 +36,7 @@ package(default_visibility = ["//visibility:public"])
     opentitan_test(
         name = "e2e_bootstrap_entry_{}".format(lc_state),
         cw310 = cw310_params(
+            timeout = "moderate",
             binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
             otp = ":otp_img_e2e_bootstrap_entry_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -34,6 +34,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
     "cw310_jtag_params",
+    "hyper310_jtag_params",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_for_lc_state",
@@ -1332,7 +1333,7 @@ opentitan_test(
 opentitan_test(
     name = "flash_ctrl_rma_test",
     srcs = ["flash_ctrl_rma_test.c"],
-    cw310 = cw310_jtag_params(
+    cw310 = hyper310_jtag_params(
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_personalized",
         tags = [
             "broken",
@@ -3068,7 +3069,7 @@ _RV_DM_JTAG_LC_STATES = get_lc_items(
     opentitan_test(
         name = "rv_dm_jtag_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
-        cw310 = cw310_jtag_params(
+        cw310 = hyper310_jtag_params(
             otp = _SIVAL_OTP_IMAGE[lc_state],
             tags = [
                 "lc_{}".format(lc_state),
@@ -3099,7 +3100,7 @@ test_suite(
     opentitan_test(
         name = "rv_dm_jtag_tap_sel_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
-        cw310 = cw310_jtag_params(
+        cw310 = hyper310_jtag_params(
             otp = _SIVAL_OTP_IMAGE[lc_state],
             tags = [
                 "lc_{}".format(lc_state),
@@ -3187,7 +3188,7 @@ test_suite(
     opentitan_test(
         name = "rv_dm_lc_disabled_jtag_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
-        cw310 = cw310_jtag_params(
+        cw310 = hyper310_jtag_params(
             otp = _SIVAL_OTP_IMAGE[lc_state],
             tags = [
                 "lc_{}".format(lc_state),
@@ -3485,11 +3486,20 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":rv_core_ibex_epmp_test": "sram_program",
+        },
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
+        tags = ["manual"],
+        test_cmd = "--elf={sram_program}",
+        test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+    ),
     silicon = silicon_jtag_params(
         test_cmd = "--elf={firmware}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -20,7 +20,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -50,7 +50,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -81,7 +81,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [
@@ -112,7 +112,7 @@ opentitan_test(
         ],  # Requires the PMOD::BoB.
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
     deps = [


### PR DESCRIPTION
Test the sival tests against the hyper310 interface, which reflects the interface used with actual silicon.

Move the SPI flash qualification tests off the fpga_cw310_sival execution environment, since hyper310 does not support that interface. The Pmod board's i2c interfaces should still be supported, so leave those in the fpga_cw310_sival group. Place the SPI tests on a substitute execution environment (fpga_cw310_rom_with_fake_keys).