### PR TITLE
[darjeeling,dma/dv] Rework coverplan and complete its implementation

### DIFF
--- a/hw/ip/dma/data/dma_testplan.hjson
+++ b/hw/ip/dma/data/dma_testplan.hjson
@@ -286,50 +286,73 @@
       {
         name: dma_config_cg
         desc: '''
-               - Cover Source and destination address space ID
-               - Cover source and destination address
-               - Cover DMA memory region base and size
-               - Cover DMA memory region threshold and limit
-               - Cover DMA memory region lock
-               - Cover total transfer width
-               - Cover transaction size
-               - Cover values of each field in DMA Control register
-                * OP code
-                * Hardware_handshake_mode
-                * Memory_buffer_auto_increment_enable
-                * Fifo_auto_increment_enable
-                * Data_direction
-                * Abort
-                * Interrupt Enable
-                * Go
-              - Cover values of each field in DMA Status register
-                * Busy
-                * Done
-                * Aborted
-                * Error
-                * Error code
-              - Cross OP code, source_Address_space_id, destination_space_id and DMA operating mode
-              - Cross transfer_size, source_address_space_id and DMA operating mode
-              - Cross transfer_size, destination_address_space_id and DMA operating mode
-              - Cross source_address, source_address_space_id and DMA operating mode
-              - Cross destination_address, destination_address_space_id and DMA operating mode
-              - Cross DMA memory base, DMA memory limit and DMA operating mode
-              - Cross DMA memory region lock, Write to DMA memory region base or limit and DMA operating mode
-              - Cross source_address_space_id, TL error on source interface and DMA operating mode
-              - Cross destination_address_space_id, TL error on destination interface and DMA operating mode
+               - Cover the following configuration registers when starting a transfer (i.e., when writing the `go` bit of the `CONTROL` register):
+                 * Source and destination address
+                 * Source and destination address space ID (ASID)
+                 * DMA-enabled memory range base and limit
+                 * Total data size
+                 * Chunk data size
+                 * Transfer width
+                 * Destination address limit
+                 * Destination address almost limit
+                 * Control register fields:
+                   + opcode
+                   + hardware handshake enable
+                   + memory buffer auto increment enable
+                   + FIFO auto increment enable
+                   + data direction
+                   + initial transfer
+                   + *exclude the `go` bit because it's used to sample this CG*
+                   + *exclude the `abort` bit because when aborting the internal state of the DMA is much more relevant than the values in the configuration registers*
+               - Cross coverage:
+                 * source address and source ASID
+                 * destination address and destination ASID
+                 * opcode, source and destination ASIDs, hardware handshake enable, and data direction
+                 * opcode, chunk data size, source and destination ASIDs, and data direction
+                 * opcode, total data size, transfer width, and data direction
+                 * opcode, hardware handshake enable, chunk data size, transfer width, and data direction
+                 * opcode, hardware handshake enable, memory buffer auto increment enable, FIFO auto increment enable, and data direction
+                 * opcode, hardware handshake enable, data direction, and initial transfer
+                 * source and destination address, DMA-enabled memory range base and limit, and data direction
+                 * source and destination address alignment, total data size alignment, and transfer width
+                 * memory buffer auto increment enable, data direction, and the results of (destination address + total data size) compared to {destination address limit, destination address almost limit}
+               '''
+      }
+      {
+        name: dma_tlul_error_cg
+        desc: '''
+              Cover TL-UL error responses differentiated between TL-UL ports and cross them with the following configuration values:
+              - source and destination ASID and data direction
               '''
       }
       {
-        name: dma_handshake_cg
+        name: dma_status_cg
         desc: '''
-              Cover the following crosses only in 'hardware handshake' mode
-              - Cross Destination address, memory buffer limit (if memory_buffer_auto_increment is set)
-              - Cross Destination address, memory buffer threshold (if memory_buffer_auto_increment is set)
-              - Cross fifo_address_auto_increment_enable and source_address_space_id
-              - Cross memory_buffer_auto_increment and destination_address_space_id
-              - Cross data_direction, source_address_space_id and destination_address_space_id
-              - Cross data_direction, source_address_space_id and fifo_address_auto_increment_enable
-              - Cross data_direction, destination_address_space_id and memory_buffer_auto_increment_enable
+              Cover all fields of the status register.
+              '''
+      }
+      {
+        name: dma_error_code_cg
+        desc: '''
+              Cover all fields of the error code register.
+              '''
+      }
+      {
+        name: dma_interrupt_cg
+        desc: '''
+              - Cover the following configuration registers when starting a transfer (i.e., when writing the `go` bit of the `CONTROL` register):
+                * handshake interrupt enable
+                * interrupt source clearing enablement
+                * interrupt source clearing bus selection
+                * interrupt source clearing destination address alignment
+                * interrupt source clearing write values; required bins:
+                  + all zeros
+                  + all ones
+                  + each of the one-hot values
+              - Cross coverage:
+                * handshake interrupt enable, interrupt source clearing enablement, and interrupt source clearing bus selection
+                * handshake interrupt enable, interrupt source clearing enablement, and interrupt source clearing destination addresses
+                * handshake interrupt enable, interrupt source clearing enablement, and interrupt source clearing write values
               '''
       }
     ]

--- a/hw/ip/dma/data/dma_testplan.hjson
+++ b/hw/ip/dma/data/dma_testplan.hjson
@@ -286,7 +286,6 @@
       {
         name: dma_memory_cg
         desc: '''
-               - Cover DMA operating mode
                - Cover Source and destination address space ID
                - Cover source and destination address
                - Cover DMA memory region base and size

--- a/hw/ip/dma/data/dma_testplan.hjson
+++ b/hw/ip/dma/data/dma_testplan.hjson
@@ -284,7 +284,7 @@
     ]
     covergroups: [
       {
-        name: dma_memory_cg
+        name: dma_config_cg
         desc: '''
                - Cover Source and destination address space ID
                - Cover source and destination address

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -16,17 +16,9 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   // Destination start address coverpoint
   cp_dst_addr: coverpoint dma_config.dst_addr;
   // Source address space ID
-  cp_src_asid: coverpoint dma_config.src_asid{
-    bins internal = {OtInternalAddr};
-    bins ctn = {SocControlAddr};
-    bins sys = {SocSystemAddr};
-  }
+  cp_src_asid: coverpoint dma_config.src_asid;
   // Destination address space ID
-  cp_dst_asid: coverpoint dma_config.dst_asid{
-    bins internal = {OtInternalAddr};
-    bins ctn = {SocControlAddr};
-    bins sys = {SocSystemAddr};
-  }
+  cp_dst_asid: coverpoint dma_config.dst_asid;
   // Total transfer size for operation
   cp_transfer_size: coverpoint dma_config.total_transfer_size {
     bins one_byte = {0};
@@ -36,19 +28,11 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
     bins range[4] = {[4:$]};
   }
   // Width of each transfer
-  cp_transfer_width: coverpoint dma_config.per_transfer_width{
-    bins one_byte = {0};
-    bins two_byte = {1};
-    bins fourbyte = {2};
-    bins reserved = {[0:$]} with (!(item inside {0,1,2}));
-  }
+  cp_transfer_width: coverpoint dma_config.per_transfer_width;
   // Cross of transfer width and total transfer size
   cp_transfer_width_x_transfer_size: cross cp_transfer_width, cp_transfer_size;
   // Opcode
-  cp_opcode: coverpoint dma_config.opcode{
-    bins copy = {0};
-    bins reserved = {[1:$]};
-  }
+  cp_opcode: coverpoint dma_config.opcode;
   // DMA enabled memory range base coverpoint
   cp_dma_mem_base: coverpoint dma_config.mem_range_base;
   // DMA enabled memory range limit coverpoint
@@ -58,33 +42,24 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   // Memory buffer almost limit coverpoint
   cp_dma_mem_buffer_almost_limit: coverpoint dma_config.mem_buffer_almost_limit;
   // handshake mode enable
-  cp_handshake_mode: coverpoint dma_config.handshake{
-    bins en = {1};
-    bins dis = {0};
-  }
+  cp_handshake_mode: coverpoint dma_config.handshake;
   // data direction
   cp_data_direction: coverpoint dma_config.direction{
     bins read_from_fifo = {DmaRcvData};
     bins write_to_fifo = {DmaSendData};
   }
-  cp_fifo_auto_inc: coverpoint dma_config.auto_inc_fifo{
-    bins fixed_addr = {0};
-    bins incr_addr = {1};
-  }
-  cp_mem_buffer_auto_inc: coverpoint dma_config.auto_inc_buffer{
-    bins fixed_addr = {0};
-    bins incr_addr = {1};
-  }
+  cp_fifo_auto_inc: coverpoint dma_config.auto_inc_fifo;
+  cp_mem_buffer_auto_inc: coverpoint dma_config.auto_inc_buffer;
   // Handshake mode FIFO enable coverpoint
   cp_handshake_fifo_mode: cross cp_data_direction, cp_fifo_auto_inc, cp_mem_buffer_auto_inc{
     bins read_src_inc_addr = binsof(cp_data_direction.read_from_fifo) &&
-                             binsof(cp_fifo_auto_inc.incr_addr);
+                             (binsof(cp_fifo_auto_inc) intersect {1});
     bins read_src_fixed_addr = binsof(cp_data_direction.read_from_fifo) &&
-                               binsof(cp_fifo_auto_inc.fixed_addr);
+                               (binsof(cp_fifo_auto_inc) intersect {0});
     bins write_src_inc_addr = binsof(cp_data_direction.write_to_fifo) &&
-                              binsof(cp_mem_buffer_auto_inc.incr_addr);
+                              (binsof(cp_mem_buffer_auto_inc) intersect {1});
     bins write_src_fixed_addr = binsof(cp_data_direction.write_to_fifo) &&
-                                binsof(cp_mem_buffer_auto_inc.fixed_addr);
+                                (binsof(cp_mem_buffer_auto_inc) intersect {0});
   }
   // DMA enabled memory region register lock
   cp_range_lock: coverpoint dma_config.mem_range_lock{
@@ -98,10 +73,7 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   // Abort via write to CONTROL
   cp_abort: coverpoint abort;
   // Cross OP code, source_address_space_id, destination_space_id and DMA operating mode
-  cp_op_code_x_asid_x_mode: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode{
-    // Ignore reserved values of OP code
-    ignore_bins reserved = binsof (cp_opcode.reserved);
-  }
+  cp_op_code_x_asid_x_mode: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode;
   cp_transfer_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
   cp_transfer_width_x_dst_asid_x_dma_op: cross cp_transfer_width, cp_dst_asid, cp_opcode;
   cp_src_addr_x_src_asid_x_dma_op: cross cp_src_addr, cp_src_asid, cp_opcode;
@@ -111,18 +83,10 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_range_lock_x_write_to_dma_mem_region_x_dma_op: cross cp_range_lock,
                                                           write_to_dma_mem_register, cp_opcode;
   // Coverpoint for TL error on source interface
-  cp_src_tl_err: coverpoint dma_config.src_asid iff (tl_src_err){
-    bins internal = {OtInternalAddr};
-    bins ctn = {SocControlAddr};
-    bins sys = {SocSystemAddr};
-  }
+  cp_src_tl_err: coverpoint dma_config.src_asid iff (tl_src_err);
 
   // Coverpoint for TL error on destination interface
-  cp_dst_tl_err: coverpoint dma_config.dst_asid iff (tl_dst_err){
-    bins internal = {OtInternalAddr};
-    bins ctn = {SocControlAddr};
-    bins sys = {SocSystemAddr};
-  }
+  cp_dst_tl_err: coverpoint dma_config.dst_asid iff (tl_dst_err);
 
   cp_src_asid_x_tl_src_err_x_dma_op: cross cp_src_asid, cp_src_tl_err, cp_opcode;
 

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -77,8 +77,8 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_handshake_intr: coverpoint dma_config.handshake_intr_en;
   // Abort via write to CONTROL
   cp_abort: coverpoint abort;
-  // Cross OP code, source_address_space_id, destination_space_id and DMA operating mode
-  cp_op_code_x_asid_x_mode: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode;
+  // Cross OP code, source_address_space_id, destination_space_id and handshake mode
+  cp_op_code_x_asid_x_handshake: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode;
   cp_transfer_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
   cp_transfer_width_x_dst_asid_x_dma_op: cross cp_transfer_width, cp_dst_asid, cp_opcode;
   cp_src_addr_x_src_asid_x_dma_op: cross cp_src_addr, cp_src_asid, cp_opcode;

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -42,10 +42,10 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_dma_mem_base: coverpoint dma_config.mem_range_base;
   // DMA enabled memory range limit coverpoint
   cp_dma_mem_range_limit: coverpoint dma_config.mem_range_limit;
-  // Memory buffer limit coverpoint
-  cp_dma_mem_buffer_limit: coverpoint dma_config.mem_buffer_limit;
-  // Memory buffer almost limit coverpoint
-  cp_dma_mem_buffer_almost_limit: coverpoint dma_config.mem_buffer_almost_limit;
+  // Destination address limit coverpoint
+  cp_dst_addr_limit: coverpoint dma_config.dst_addr_limit;
+  // Destination address almost limit coverpoint
+  cp_dst_addr_almost_limit: coverpoint dma_config.dst_addr_almost_limit;
   // handshake mode enable
   cp_handshake_mode: coverpoint dma_config.handshake;
   // data direction
@@ -98,14 +98,14 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_dst_asid_x_tl_dst_err_x_dma_op: cross cp_dst_asid, cp_dst_tl_err, cp_opcode;
 
   // Cross Destination address, memory buffer limit (if memory_buffer_auto_increment is set)
-  cp_dst_addr_x_mem_buffer_limit: cross cp_dst_addr,
-                                  cp_dma_mem_buffer_limit
-                                  iff (dma_config.auto_inc_buffer);
+  cp_dst_addr_x_dst_addr_limit: cross cp_dst_addr,
+                                      cp_dst_addr_limit
+                                      iff (dma_config.auto_inc_buffer);
 
   // Cross Destination address, memory buffer threshold (if memory_buffer_auto_increment is set)
-  cp_dst_addr_x_mem_buffer_threshold: cross cp_dst_addr,
-                                            cp_dma_mem_buffer_almost_limit
-                                            iff (dma_config.auto_inc_buffer);
+  cp_dst_addr_x_dst_addr_almost_limit: cross cp_dst_addr,
+                                             cp_dst_addr_almost_limit
+                                             iff (dma_config.auto_inc_buffer);
 
   cp_fifo_enable: cross cp_fifo_auto_inc, cp_mem_buffer_auto_inc, cp_data_direction;
 

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -20,7 +20,7 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   // Destination address space ID
   cp_dst_asid: coverpoint dma_config.dst_asid;
   // Total transfer size for operation
-  cp_transfer_size: coverpoint dma_config.total_transfer_size {
+  cp_total_data_size: coverpoint dma_config.total_data_size {
     bins one_byte = {1};
     bins two_byte = {2};
     bins three_byte = {3};
@@ -35,7 +35,7 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   // Width of each transfer
   cp_transfer_width: coverpoint dma_config.per_transfer_width;
   // Cross of transfer width and total transfer size
-  cp_transfer_width_x_transfer_size: cross cp_transfer_width, cp_transfer_size;
+  cp_transfer_width_x_transfer_size: cross cp_transfer_width, cp_total_data_size;
   // Opcode
   cp_opcode: coverpoint dma_config.opcode;
   // DMA enabled memory range base coverpoint
@@ -79,7 +79,7 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_abort: coverpoint abort;
   // Cross OP code, source_address_space_id, destination_space_id and handshake mode
   cp_op_code_x_asid_x_handshake: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode;
-  cp_transfer_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
+  cp_total_data_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
   cp_transfer_width_x_dst_asid_x_dma_op: cross cp_transfer_width, cp_dst_asid, cp_opcode;
   cp_src_addr_x_src_asid_x_dma_op: cross cp_src_addr, cp_src_asid, cp_opcode;
   cp_dst_addr_x_dst_asid_x_dma_op: cross cp_dst_addr, cp_dst_asid, cp_opcode;

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -21,11 +21,16 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_dst_asid: coverpoint dma_config.dst_asid;
   // Total transfer size for operation
   cp_transfer_size: coverpoint dma_config.total_transfer_size {
-    bins one_byte = {0};
-    bins two_byte = {1};
-    bins three_byte = {2};
-    bins four_byte = {3};
-    bins range[4] = {[4:$]};
+    bins one_byte = {1};
+    bins two_byte = {2};
+    bins three_byte = {3};
+    bins four_byte = {4};
+    bins between_5_and_15_byte = {[5:15]};
+    bins between_16_and_127_byte = {[16:127]};
+    bins between_128_and_1023_byte = {[128:1023]};
+    bins kibi_byte = {[1024:1024*1024-1]};
+    bins mebi_byte = {[1024*1024:1024*1024*1024-1]};
+    bins gibi_byte = {[1024*1024*1024:$]};
   }
   // Width of each transfer
   cp_transfer_width: coverpoint dma_config.per_transfer_width;

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -66,8 +66,8 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
     bins write_src_fixed_addr = binsof(cp_data_direction.write_to_fifo) &&
                                 (binsof(cp_mem_buffer_auto_inc) intersect {0});
   }
-  // DMA enabled memory region register lock
-  cp_range_lock: coverpoint dma_config.mem_range_lock{
+  // DMA enabled memory range REGWEN
+  cp_range_regwen: coverpoint dma_config.range_regwen{
     bins unlocked = {MuBi4True};
     bins locked = {MuBi4False};
 // TODO: this faults with vcs
@@ -85,8 +85,8 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_dst_addr_x_dst_asid_x_dma_op: cross cp_dst_addr, cp_dst_asid, cp_opcode;
   cp_dma_mem_base_x_dma_mem_limit_x_dma_op: cross cp_dma_mem_base, cp_dma_mem_range_limit,
                                                   cp_opcode;
-  cp_range_lock_x_write_to_dma_mem_region_x_dma_op: cross cp_range_lock,
-                                                          write_to_dma_mem_register, cp_opcode;
+  cp_range_regwen_x_write_to_dma_mem_region_x_dma_op: cross cp_range_regwen,
+                                                            write_to_dma_mem_register, cp_opcode;
   // Coverpoint for TL error on source interface
   cp_src_tl_err: coverpoint dma_config.src_asid iff (tl_src_err);
 

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -391,13 +391,13 @@ class dma_scoreboard extends cip_base_scoreboard #(
       end
     end
 
-    // Update the expected value of memory buffer limit interrupt for this address
+    // Update the expected value of destination address limit interrupt for this address
     if ((dma_config.handshake & dma_config.auto_inc_buffer) &&
-        (item.a_addr >= dma_config.mem_buffer_limit ||
-         item.a_addr >= dma_config.mem_buffer_almost_limit)) begin
+        (item.a_addr >= dma_config.dst_addr_limit ||
+         item.a_addr >= dma_config.dst_addr_almost_limit)) begin
       `uvm_info(`gfn, $sformatf("Memory address:%0x crosses almost limit: 0x%0x limit: 0x%0x",
-                                item.a_addr, dma_config.mem_buffer_almost_limit,
-                                dma_config.mem_buffer_limit), UVM_HIGH)
+                                item.a_addr, dma_config.dst_addr_almost_limit,
+                                dma_config.dst_addr_limit), UVM_HIGH)
 
       // Interrupt is expected only if enabled.
       predict_interrupts(MemLimitToIntrLatency, 1 << DMA_MEM_LIMIT, intr_enable);
@@ -889,19 +889,19 @@ class dma_scoreboard extends cip_base_scoreboard #(
                                   dma_config.per_transfer_width.name()), UVM_HIGH)
       end
       "destination_address_limit_lo": begin
-        dma_config.mem_buffer_limit[31:0] =
+        dma_config.dst_addr_limit[31:0] =
           `gmv(ral.destination_address_limit_lo.address_limit_lo);
       end
       "destination_address_limit_hi": begin
-        dma_config.mem_buffer_limit[63:32] =
+        dma_config.dst_addr_limit[63:32] =
           `gmv(ral.destination_address_limit_hi.address_limit_hi);
       end
       "destination_address_almost_limit_lo": begin
-        dma_config.mem_buffer_almost_limit[31:0] =
+        dma_config.dst_addr_almost_limit[31:0] =
           `gmv(ral.destination_address_almost_limit_lo.address_limit_lo);
       end
       "destination_address_almost_limit_hi": begin
-        dma_config.mem_buffer_almost_limit[63:32] =
+        dma_config.dst_addr_almost_limit[63:32] =
           `gmv(ral.destination_address_almost_limit_hi.address_limit_hi);
       end
       "clear_int_bus": begin

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -846,21 +846,21 @@ class dma_scoreboard extends cip_base_scoreboard #(
                                   dma_config.dst_asid.name()), UVM_HIGH)
       end
       "enabled_memory_range_base": begin
-        if (dma_config.mem_range_lock == MuBi4True) begin
+        if (dma_config.range_regwen == MuBi4True) begin
           dma_config.mem_range_base = item.a_data;
           `uvm_info(`gfn, $sformatf("Got enabled_memory_range_base = %0x",
                                     dma_config.mem_range_base), UVM_HIGH)
         end
       end
       "enabled_memory_range_limit": begin
-        if (dma_config.mem_range_lock == MuBi4True) begin
+        if (dma_config.range_regwen == MuBi4True) begin
           dma_config.mem_range_limit = item.a_data;
           `uvm_info(`gfn, $sformatf("Got enabled_memory_range_limit = %0x",
                                     dma_config.mem_range_limit), UVM_HIGH)
         end
       end
       "range_valid": begin
-        if (dma_config.mem_range_lock == MuBi4True) begin
+        if (dma_config.range_regwen == MuBi4True) begin
           dma_config.mem_range_valid = `gmv(ral.range_valid.range_valid);
           `uvm_info(`gfn, $sformatf("Got mem_range_valid = %x",
                                     dma_config.mem_range_valid), UVM_HIGH)
@@ -868,9 +868,9 @@ class dma_scoreboard extends cip_base_scoreboard #(
       end
       "range_regwen": begin
         // Get mirrored field value and cast to associated enum in dma_config
-        dma_config.mem_range_lock = mubi4_t'(`gmv(ral.range_regwen.regwen));
+        dma_config.range_regwen = mubi4_t'(`gmv(ral.range_regwen.regwen));
         `uvm_info(`gfn, $sformatf("Got range register lock = %s",
-                                  dma_config.mem_range_lock.name()), UVM_HIGH)
+                                  dma_config.range_regwen.name()), UVM_HIGH)
       end
       "total_data_size": begin
         dma_config.total_data_size = item.a_data;

--- a/hw/ip/dma/dv/env/dma_seq_item.sv
+++ b/hw/ip/dma/dv/env/dma_seq_item.sv
@@ -45,7 +45,7 @@ class dma_seq_item extends uvm_sequence_item;
   rand bit [31:0] mem_range_limit;
   rand bit [31:0] total_data_size;
   rand bit [31:0] chunk_data_size;
-  rand mubi4_t mem_range_lock;
+  rand mubi4_t range_regwen;
   rand opcode_e opcode;
   rand dma_transfer_width_e per_transfer_width;
   rand asid_encoding_e src_asid;
@@ -90,7 +90,7 @@ class dma_seq_item extends uvm_sequence_item;
     `uvm_field_int(mem_range_valid, UVM_DEFAULT)
     `uvm_field_int(mem_range_base, UVM_DEFAULT)
     `uvm_field_int(mem_range_limit, UVM_DEFAULT)
-    `uvm_field_enum(mubi4_t, mem_range_lock, UVM_DEFAULT)
+    `uvm_field_enum(mubi4_t, range_regwen, UVM_DEFAULT)
     `uvm_field_int(total_data_size, UVM_DEFAULT)
     `uvm_field_int(chunk_data_size, UVM_DEFAULT)
     `uvm_field_enum(dma_transfer_width_e, per_transfer_width, UVM_DEFAULT)
@@ -304,14 +304,14 @@ class dma_seq_item extends uvm_sequence_item;
     }
   }
 
-  constraint mem_range_lock_c {
+  constraint range_regwen_c {
     // For valid DMA configurations, the memory range registers _may_ be locked but this is not
     // obligatory. Having the separate 'RANGE_VALID' bit affords the opportunity for FW at
     // different stages within the boot process to employ different address ranges.
     if (!valid_dma_config) {
       // We need to keep this True to prevent subsequent randomization failures; the REGWEN can
       // only be restored to True (permitting changes) by an IP block reset.
-      mem_range_lock == MuBi4True;
+      range_regwen == MuBi4True;
     }
   }
 
@@ -337,8 +337,8 @@ class dma_seq_item extends uvm_sequence_item;
   function void lock_memory_range();
     mem_range_base.rand_mode(0);
     mem_range_limit.rand_mode(0);
-    mem_range_lock.rand_mode(0);
-    mem_range_lock_c.constraint_mode(0);
+    range_regwen.rand_mode(0);
+    range_regwen_c.constraint_mode(0);
     `uvm_info(`gfn, $sformatf("Disable randomisation of mem_range_base and mem_range_limit"),
               UVM_HIGH)
   endfunction
@@ -639,7 +639,7 @@ class dma_seq_item extends uvm_sequence_item;
     handshake = 0;
     // reset non random variables
     valid_dma_config = 0;
-    mem_range_lock = MuBi4True;
+    range_regwen = MuBi4True;
   endfunction
 
   // Disable randomization of all variables
@@ -657,7 +657,7 @@ class dma_seq_item extends uvm_sequence_item;
     auto_inc_buffer.rand_mode(0);
     auto_inc_fifo.rand_mode(0);
     handshake.rand_mode(0);
-    mem_range_lock.rand_mode(0);
+    range_regwen.rand_mode(0);
   endfunction
 
   // Return if Read FIFO mode enabled (no auto increment of source address)

--- a/hw/ip/dma/dv/env/dma_seq_item.sv
+++ b/hw/ip/dma/dv/env/dma_seq_item.sv
@@ -38,8 +38,8 @@ class dma_seq_item extends uvm_sequence_item;
   rand bit handshake;
   rand bit [63:0] src_addr;
   rand bit [63:0] dst_addr;
-  rand bit [63:0] mem_buffer_almost_limit;
-  rand bit [63:0] mem_buffer_limit;
+  rand bit [63:0] dst_addr_almost_limit;
+  rand bit [63:0] dst_addr_limit;
   rand bit        mem_range_valid;
   rand bit [31:0] mem_range_base;
   rand bit [31:0] mem_range_limit;
@@ -98,8 +98,8 @@ class dma_seq_item extends uvm_sequence_item;
     `uvm_field_int(auto_inc_fifo, UVM_DEFAULT)
     `uvm_field_int(handshake, UVM_DEFAULT)
     `uvm_field_int(is_valid_config, UVM_DEFAULT)
-    `uvm_field_int(mem_buffer_almost_limit, UVM_DEFAULT)
-    `uvm_field_int(mem_buffer_limit, UVM_DEFAULT)
+    `uvm_field_int(dst_addr_almost_limit, UVM_DEFAULT)
+    `uvm_field_int(dst_addr_limit, UVM_DEFAULT)
     `uvm_field_int(handshake_intr_en, UVM_DEFAULT)
     `uvm_field_int(clear_int_src, UVM_DEFAULT)
     `uvm_field_int(clear_int_bus, UVM_DEFAULT)
@@ -278,28 +278,28 @@ class dma_seq_item extends uvm_sequence_item;
     }
   }
 
-  constraint mem_buffer_limit_c {
+  constraint dst_addr_limit_c {
     // Set solver order to make sure mem buffer limit is randomized correctly in case
     // valid_dma_config is set
-    solve mem_buffer_almost_limit before mem_buffer_limit;
+    solve dst_addr_almost_limit before dst_addr_limit;
     // For valid dma config, mem buffer limit must be greater than destination address
     // in order to detect passing the limit
     if (valid_dma_config) {
        if (handshake && direction == DmaRcvData) {
-          mem_buffer_limit > mem_buffer_almost_limit;
+          dst_addr_limit > dst_addr_almost_limit;
        }
     }
   }
 
-  constraint mem_buffer_almost_limit_c {
+  constraint dst_addr_almost_limit_c {
     // Set solver order to make sure mem buffer almost limit is randomized correctly
     // in case valid_dma_config is set
-    solve dst_addr before mem_buffer_almost_limit;
+    solve dst_addr before dst_addr_almost_limit;
     // For valid dma config, mem buffer almost limit must not be
     // less than destination address
     if (valid_dma_config) {
        if (handshake && direction == DmaRcvData) {
-          mem_buffer_almost_limit > dst_addr;
+          dst_addr_almost_limit > dst_addr;
        }
     }
   }
@@ -388,8 +388,8 @@ class dma_seq_item extends uvm_sequence_item;
         $sformatf("\n\tmem_range_valid         : %0d",    mem_range_valid),
         $sformatf("\n\tmem_range_base          : 0x%08x", mem_range_base),
         $sformatf("\n\tmem_range_limit         : 0x%08x", mem_range_limit),
-        $sformatf("\n\tmem_buffer_almost_limit : 0x%16x", mem_buffer_almost_limit),
-        $sformatf("\n\tmem_buffer_limit        : 0x%16x", mem_buffer_limit),
+        $sformatf("\n\tdst_addr_almost_limit   : 0x%16x", dst_addr_almost_limit),
+        $sformatf("\n\tdst_addr_limit          : 0x%16x", dst_addr_limit),
         $sformatf("\n\tclear_int_src           : 0x%8x",  clear_int_src),
         $sformatf("\n\tclear_int_bus           : 0x%8x",  clear_int_bus),
         $sformatf("\n\thandshake_intr_en       : 0x%08x", handshake_intr_en),

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -350,8 +350,8 @@ class dma_base_vseq extends cip_base_vseq #(
     abort_pending = 1'b0;
     set_source_address(dma_config.src_addr);
     set_destination_address(dma_config.dst_addr);
-    set_destination_address_range(dma_config.mem_buffer_almost_limit,
-                                  dma_config.mem_buffer_limit);
+    set_destination_address_range(dma_config.dst_addr_almost_limit,
+                                  dma_config.dst_addr_limit);
     set_address_space_id(dma_config.src_asid, dma_config.dst_asid);
     set_total_size(dma_config.total_data_size);
     set_chunk_data_size(dma_config.chunk_data_size);

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -362,7 +362,7 @@ class dma_base_vseq extends cip_base_vseq #(
     set_dma_enabled_memory_range(dma_config.mem_range_base,
                                  dma_config.mem_range_limit,
                                  dma_config.mem_range_valid,
-                                 dma_config.mem_range_lock);
+                                 dma_config.range_regwen);
   endtask : run_common_config
 
   // Task: Enable/Disable Interrupt(s)

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -87,10 +87,10 @@ class dma_base_vseq extends cip_base_vseq #(
   endfunction
 
   // Set up randomized source data for the transfer
-  function void randomize_src_data(bit [31:0] total_transfer_size);
+  function void randomize_src_data(bit [31:0] total_data_size);
     bit [31:0] offset;
-    cfg.src_data = new[total_transfer_size];
-    for (offset = 32'b0; offset < total_transfer_size; offset++) begin
+    cfg.src_data = new[total_data_size];
+    for (offset = 32'b0; offset < total_data_size; offset++) begin
       cfg.src_data[offset] = $urandom_range(0, 255);
       `uvm_info(`gfn, $sformatf("%0x: %0x", offset, cfg.src_data[offset]), UVM_DEBUG)
     end
@@ -156,7 +156,7 @@ class dma_base_vseq extends cip_base_vseq #(
 
   function void supply_data(ref dma_seq_item dma_config, bit [31:0] offset, bit [31:0] size);
     `uvm_info(`gfn, $sformatf("Supplying bytes [0x%0x,0x%0x) of 0x%0x-byte transfer",
-                    offset, offset + size, dma_config.total_transfer_size), UVM_MEDIUM)
+                    offset, offset + size, dma_config.total_data_size), UVM_MEDIUM)
 
     // Configure Source model
     if (dma_config.get_read_fifo_en()) begin
@@ -208,7 +208,7 @@ class dma_base_vseq extends cip_base_vseq #(
   // Returns the byte offset of the next chunk to be transferred, if any.
   function bit [31:0] configure_mem_model(ref dma_seq_item dma_config, input bit [31:0] offset);
     // Decide how many bytes of data to supply in this chunk
-    bit [31:0] chunk_size = dma_config.total_transfer_size - offset;
+    bit [31:0] chunk_size = dma_config.total_data_size - offset;
     if (chunk_size > dma_config.chunk_data_size) begin
       chunk_size = dma_config.chunk_data_size;
     end
@@ -241,7 +241,7 @@ class dma_base_vseq extends cip_base_vseq #(
       // into a single large FIFO and the scoreboard will check it all at the end of the transfer.
       bit [31:0] max_size = chunk_size;
       if (dma_config.handshake && dma_config.direction == DmaSendData) begin
-        max_size = dma_config.total_transfer_size;
+        max_size = dma_config.total_data_size;
       end
 
       // Enable write FIFO mode in models
@@ -353,10 +353,10 @@ class dma_base_vseq extends cip_base_vseq #(
     set_destination_address_range(dma_config.mem_buffer_almost_limit,
                                   dma_config.mem_buffer_limit);
     set_address_space_id(dma_config.src_asid, dma_config.dst_asid);
-    set_total_size(dma_config.total_transfer_size);
+    set_total_size(dma_config.total_data_size);
     set_chunk_data_size(dma_config.chunk_data_size);
     set_transfer_width(dma_config.per_transfer_width);
-    randomize_src_data(dma_config.total_transfer_size);
+    randomize_src_data(dma_config.total_data_size);
     void'(configure_mem_model(dma_config, 32'd0));
     set_handshake_int_regs(dma_config);
     set_dma_enabled_memory_range(dma_config.mem_range_base,

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_smoke_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_smoke_vseq.sv
@@ -41,7 +41,7 @@ class dma_generic_smoke_vseq extends dma_generic_vseq;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(
       dma_config,
       src_addr[1:0] == dst_addr[1:0]; // Use same alignment for source and destination address
-      total_transfer_size % 4 == 0; // Limit to multiples of 4B
+      total_data_size % 4 == 0; // Limit to multiples of 4B
       per_transfer_width == DmaXfer4BperTxn; // Limit to only 4B transfers
       opcode == OpcCopy;) // Avoid any involved operations such as SHA2 hashing
     `uvm_info(`gfn, $sformatf("DMA: Randomized a new transaction:%s",

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -182,9 +182,9 @@ class dma_generic_vseq extends dma_base_vseq;
               bit [31:0] num_written = get_bytes_written(dma_config);
               `uvm_info(`gfn,
                         $sformatf("STATUS.done bit set after 0x%0x bytes of 0x%0x-byte transfer",
-                        num_written, dma_config.total_transfer_size), UVM_MEDIUM)
+                        num_written, dma_config.total_data_size), UVM_MEDIUM)
               // Has the entire transfer been completed yet?
-              if (num_written >= dma_config.total_transfer_size) begin
+              if (num_written >= dma_config.total_data_size) begin
                 stop = 1'b1;
               end else if (!dma_config.handshake) begin
                 // Model the FirmWare running on the OT side, responding to the Done interrupt and
@@ -199,7 +199,7 @@ class dma_generic_vseq extends dma_base_vseq;
               end else begin
                 `uvm_fatal(`gfn,
                       $sformatf("STATUS.done bit set prematurely (0x%x byte(s) of 0x%x transferred",
-                      num_written, dma_config.total_transfer_size))
+                      num_written, dma_config.total_data_size))
               end
             end
           end
@@ -209,7 +209,7 @@ class dma_generic_vseq extends dma_base_vseq;
             // 'bytes read' and 'bytes written' counters to supply input and check output at the
             // appropriate times.
             while (dma_config.handshake && !stop &&
-                   num_bytes_supplied < dma_config.total_transfer_size) begin
+                   num_bytes_supplied < dma_config.total_data_size) begin
               if (num_bytes_supplied <= get_bytes_read(dma_config)) begin
                 // All supplied input data has been read; provide the next complete chunk of data
                 // in zero simulation time.
@@ -222,7 +222,7 @@ class dma_generic_vseq extends dma_base_vseq;
           end
           // Waggle the interrupt lines up and down at random times to keep the data moving
           begin
-            uint bytes_to_move = dma_config.total_transfer_size;
+            uint bytes_to_move = dma_config.total_data_size;
             while (dma_config.handshake && !stop) begin
               uint num_bytes_per_txn;
               uint bytes_moved;

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -39,7 +39,7 @@ class dma_generic_vseq extends dma_base_vseq;
       randomize_item(dma_config);
     end
     // Has the DMA-enabled memory configuration now been locked?
-    if (dma_config.mem_range_lock != MuBi4True) begin
+    if (dma_config.range_regwen != MuBi4True) begin
       // Suppress further attempts at randomization because otherwise the TB will form incorrect
       // predictions.
       set_memory_range_randomization(dma_config, 0);

--- a/hw/ip/dma/dv/env/seq_lib/dma_handshake_smoke_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_handshake_smoke_vseq.sv
@@ -26,7 +26,7 @@ class dma_handshake_smoke_vseq extends dma_handshake_vseq;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(
       dma_config,
       src_addr[1:0] == dst_addr[1:0]; // Use same alignment for source and destination address
-      total_transfer_size % 4 == 0; // Limit to multiples of 4B
+      total_data_size % 4 == 0; // Limit to multiples of 4B
       per_transfer_width == DmaXfer4BperTxn; // Limit to only 4B transfers
       handshake == 1'b1; // Enable hardware handshake mode
       handshake_intr_en != 0; // At least one handshake interrupt signal must be enabled

--- a/hw/ip/dma/dv/env/seq_lib/dma_memory_smoke_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_memory_smoke_vseq.sv
@@ -42,7 +42,7 @@ class dma_memory_smoke_vseq extends dma_memory_vseq;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(
       dma_config,
       src_addr[1:0] == dst_addr[1:0]; // Use same alignment for source and destination address
-      total_transfer_size % 4 == 0; // Limit to multiples of 4B
+      total_data_size % 4 == 0; // Limit to multiples of 4B
       per_transfer_width == DmaXfer4BperTxn; // Limit to only 4B transfers
       handshake == 1'b0; // Disable hardware handshake mode
       opcode == OpcCopy;) // Avoid any involved operations such as SHA2 hashing


### PR DESCRIPTION
This PR reworks the DMA's block-level functional coverage plan and completes its implementation with covergroups, thereby resolving https://github.com/lowRISC/opentitan-integrated/issues/137.

I suggest reviewing this PR commit-by-commit.
- The first 9 commits change the previous coverplan and its implementation to make fixes that I think are fairly uncontroversial.
- The 10th (second-to-last) commit reworks the coverplan to bring it up-to-date with the current specification and to cover more of the implementation.
- The 11th (last) commit changes the covergroups to match the reworked coverplan.

## Results

The pass rate of tests does not change (i.e., the `dma_abort` test has ca. 80% pass rate, the `dma_intr_test` has ca. 0% pass rate, and the other tests have 100% pass rate).

Coverage results are as follows (measured with Xcelium 22.09-s001):
- `dma_config_cg` has a total coverage of 29.3% (average per testpoint: 67.3%). Main gaps are:
  - source and destination addresses: lower than 64 KiB *--> suggest creating medium-prio issue to extend existing test to cover this*
  - source and destination ASID: SoC System Addresses *--> this is known; need to check if we already track this with an issue*
  - total data size: MiB and GiB ranges *--> suggest creating low-prio issue to extend existing test to run a MiB-sized transfer (ca. once per full regression, as it takes relatively long); suggest accepting not testing GiB-sized transfers*
  - memory range base and limit: lower than 64 KiB *--> suggest creating a high-prio issue to extend existing test to cover this*
  - destination address limit: lower than 4 GiB *--> suggest creating a high-prio issue to extend existing test to cover this*
- `dma_tlul_error_cg` has a total coverage of 31.6% (average per testpoint: 48.2%). Main gaps are:
  - errors coming from SoC System IF *--> this is known; see above*
  - any configurations transferring data from/to SoC System Addresses *--> this is known; see above*
- `dma_status_cg` has a total coverage of 100%
- `dma_error_code_cg` has a total coverage of 0.4% (average per testpoint: 0.4%). Main gaps are:
  - No errors recorded (i.e., error code is always 0). *--> need to check if sampling is correct; if it is, suggest creating a high-prio issue to cover this*
- `dma_interrupt_cg` has a total coverage of 60.1% (average per testpoint: 86.8%). Main gaps are:
  - no handshake interrupt enabled (i.e., all tests have at least one handshake interrupt enabled)
  - only MSB interrupt enabled (although this may well be covered by simply running more iterations of the existing test config)
  - interrupt source address offset: offsets other than 0 and 4 *--> do we even need to support this?*
  - interrupt source write value: none of the current bins is covered *--> are the bins really meaningful?*