### PR TITLE
[manuf] add data deps to provisioning harnesses

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -10,6 +10,10 @@ load(
     "hyper310_jtag_params",
     "opentitan_test",
 )
+load(
+    "//sw/device/silicon_creator/manuf:provisioning_inputs.bzl",
+    "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -167,14 +171,17 @@ cc_library(
 )
 
 # As more SKUs are created with different OTP software configuration partitions,
-# libraries can be added accordingly.
-cc_library(
-    name = "individualize_sw_cfg_earlgrey_a0_sku_sival_bringup",
-    deps = [
-        ":individualize_sw_cfg",
-        "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_sw_cfg",
-    ],
-)
+# libraries can be added to INDIVIDUALIZE_OTP_SW_CFGS accordingly.
+[
+    cc_library(
+        name = "individualize_sw_cfg_earlgrey_a0_sku_{}".format(otp_sw_cfg),
+        deps = [
+            ":individualize_sw_cfg",
+            "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/{}:otp_sw_cfg".format(otp_sw_cfg),
+        ],
+    )
+    for otp_sw_cfg in EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS
+]
 
 opentitan_test(
     name = "individualize_sw_cfg_functest",

--- a/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
@@ -25,3 +25,8 @@ FT_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
   --owner-manifest-measurement="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
   --owner-measurement="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
 """
+
+FT_PERSONALIZE_SIGNING_KEYS = select({
+    "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_dev_0"},
+})

--- a/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
@@ -2,6 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS = [
+    "sival_bringup",
+    "sival",
+]
+
 _DEVICE_ID_AND_TEST_TOKENS = """
   --device-id="0x11111111_22222222_33333333_44444444_55555555_66666666_77777777_88888888"
   --test-unlock-token="0x11111111_11111111_11111111_11111111"

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -17,8 +17,9 @@ load(
     "silicon_jtag_params",
 )
 load(
-    "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:provisioning_inputs.bzl",
+    "//sw/device/silicon_creator/manuf:provisioning_inputs.bzl",
     "CP_PROVISIONING_INPUTS",
+    "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
     "FT_PROVISIONING_INPUTS",
 )
 
@@ -150,38 +151,50 @@ opentitan_test(
     },
 )
 
-opentitan_binary(
-    name = "sram_ft_individualize",
+[
+    opentitan_binary(
+        name = "sram_ft_individualize_{}".format(otp_sw_cfgs),
+        testonly = True,
+        srcs = ["sram_ft_individualize.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+        kind = "ram",
+        linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+        deps = [
+            ":flash_info_permissions",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/arch:device",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:otp_ctrl",
+            "//sw/device/lib/dif:pinmux",
+            "//sw/device/lib/runtime:hart",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
+            "//sw/device/lib/testing:otp_ctrl_testutils",
+            "//sw/device/lib/testing:pinmux_testutils",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_console",
+            "//sw/device/lib/testing/test_framework:ottf_test_config",
+            "//sw/device/lib/testing/test_framework:status",
+            "//sw/device/lib/testing/test_framework:ujson_ottf",
+            "//sw/device/silicon_creator/manuf/lib:individualize",
+            "//sw/device/silicon_creator/manuf/lib:sram_start",
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_{}".format(otp_sw_cfgs),
+        ],
+    )
+    for otp_sw_cfgs in EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS
+]
+
+filegroup(
+    name = "sram_ft_individualize_all",
     testonly = True,
-    srcs = ["sram_ft_individualize.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-    },
-    kind = "ram",
-    linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
-    deps = [
-        ":flash_info_permissions",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/dif:lc_ctrl",
-        "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/dif:pinmux",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:lc_ctrl_testutils",
-        "//sw/device/lib/testing:otp_ctrl_testutils",
-        "//sw/device/lib/testing:pinmux_testutils",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_console",
-        "//sw/device/lib/testing/test_framework:ottf_test_config",
-        "//sw/device/lib/testing/test_framework:status",
-        "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/silicon_creator/manuf/lib:individualize",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_sival_bringup",
-        "//sw/device/silicon_creator/manuf/lib:sram_start",
+    srcs = [
+        ":sram_ft_individualize_sival",
+        ":sram_ft_individualize_sival_bringup",
     ],
 )
 
@@ -275,7 +288,7 @@ opentitan_binary(
 )
 
 _FT_PROVISIONING_BINARIES = {
-    ":sram_ft_individualize": "sram_ft_individualize",
+    ":sram_ft_individualize_sival_bringup": "sram_ft_individualize",
     ":ft_personalize_1": "ft_personalize_1",
     ":ft_personalize_2": "ft_personalize_2",
     ":ft_personalize_3": "ft_personalize_3",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -20,6 +20,7 @@ load(
     "//sw/device/silicon_creator/manuf:provisioning_inputs.bzl",
     "CP_PROVISIONING_INPUTS",
     "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
+    "FT_PERSONALIZE_SIGNING_KEYS",
     "FT_PROVISIONING_INPUTS",
 )
 
@@ -207,10 +208,7 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rsa_key = rsa_key_for_lc_state(
-        RSA_ONLY_KEY_STRUCTS,
-        CONST.LCV.PROD,
-    ),
+    rsa_key = FT_PERSONALIZE_SIGNING_KEYS,
     deps = [
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
@@ -232,10 +230,7 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rsa_key = rsa_key_for_lc_state(
-        RSA_ONLY_KEY_STRUCTS,
-        CONST.LCV.PROD,
-    ),
+    rsa_key = FT_PERSONALIZE_SIGNING_KEYS,
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -263,10 +258,7 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rsa_key = rsa_key_for_lc_state(
-        RSA_ONLY_KEY_STRUCTS,
-        CONST.LCV.PROD,
-    ),
+    rsa_key = FT_PERSONALIZE_SIGNING_KEYS,
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/crypto/drivers:entropy",

--- a/sw/host/tests/manuf/provisioning/cp/BUILD
+++ b/sw/host/tests/manuf/provisioning/cp/BUILD
@@ -8,7 +8,9 @@ package(default_visibility = ["//visibility:public"])
 
 rust_binary(
     name = "cp",
+    testonly = True,
     srcs = ["src/main.rs"],
+    data = ["//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_cp_provision"],
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/cp_lib",

--- a/sw/host/tests/manuf/provisioning/ft/BUILD
+++ b/sw/host/tests/manuf/provisioning/ft/BUILD
@@ -8,7 +8,14 @@ package(default_visibility = ["//visibility:public"])
 
 rust_binary(
     name = "ft",
+    testonly = True,
     srcs = ["src/main.rs"],
+    data = [
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_1",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_2",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_3",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_ft_individualize_all",
+    ],
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ft_lib",

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.7.tar.gz",
-            strip_prefix = "crt-0.4.7",
-            sha256 = "92ab725c9b0b6b09e25b9cc70158d47d53275899ec53edfa95e69ebf114cbaa2",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.8.tar.gz",
+            strip_prefix = "crt-0.4.8",
+            sha256 = "60175c75ac280b9da52f8fdc7b1f3cac9f39d3718c80fe393d5f90577f6780df",
         )


### PR DESCRIPTION
This PR contains several commits that:
1. adds several FT individualization SRAM binaries per OTP SKU,
2. makes the provisioning test harnesses directly `bazel run`-able,
3. make the FT perso binaries signable with the DEV key on nitrokeys (using the integrated bazel signing flow).