### PR TITLE
[manuf] add placeholders for writing attestation certs to flash and console

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -27,7 +27,7 @@ UJSON_SERDE_STRUCT(EccP256PublicKey, \
 // clang-format on
 
 /**
- * Data imported during device personalization.
+ * Data imported during device RMA token personalization.
  */
 // clang-format off
 #define STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_IN(field, string) \
@@ -38,7 +38,7 @@ UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataIn, \
 // clang-format on
 
 /**
- * Data imported during device certificate personalization.
+ * Data imported during device (attestation) certificate personalization.
  */
 // clang-format off
 #define STRUCT_MANUF_CERT_PERSO_DATA_IN(field, string) \
@@ -79,7 +79,7 @@ UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
 // clang-format on
 
 /**
- * Data exported during device personalization.
+ * Data exported during device RMA token personalization.
  */
 // clang-format off
 #define STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_OUT(field, string) \
@@ -87,6 +87,22 @@ UJSON_SERDE_STRUCT(WrappedRmaUnlockToken, \
 UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataOut, \
                    manuf_rma_token_perso_data_out_t, \
                    STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_OUT);
+// clang-format on
+
+/**
+ * Data exported during device (attestation) certificate personalization.
+ *
+ * TODO(#19455): replace the certificate fields with actual X.509 certificates
+ * instead of just the public keys.
+ */
+// clang-format off
+#define STRUCT_MANUF_CERT_PERSO_DATA_OUT(field, string) \
+    field(uds_certificate, ecc_p256_public_key_t) \
+    field(cdi_0_certificate, ecc_p256_public_key_t) \
+    field(cdi_1_certificate, ecc_p256_public_key_t)
+UJSON_SERDE_STRUCT(ManufCertPersoDataOut, \
+                   manuf_cert_perso_data_out_t, \
+                   STRUCT_MANUF_CERT_PERSO_DATA_OUT);
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -83,16 +83,16 @@ typedef enum flash_ctrl_partition {
   /**
    * Bank 1 information partition type 0 pages.
    */ \
-  X(kFlashCtrlInfoPageBootData0,          1, 0) \
-  X(kFlashCtrlInfoPageBootData1,          1, 1) \
-  X(kFlashCtrlInfoPageOwnerSlot0,         1, 2) \
-  X(kFlashCtrlInfoPageOwnerSlot1,         1, 3) \
-  X(kFlashCtrlInfoPageBank1Type0Page4,    1, 4) \
-  X(kFlashCtrlInfoPageBank1Type0Page5,    1, 5) \
-  X(kFlashCtrlInfoPageCreatorCertificate, 1, 6) \
-  X(kFlashCtrlInfoPageBootServices,       1, 7) \
-  X(kFlashCtrlInfoPageOwnerCerificate0,   1, 8) \
-  X(kFlashCtrlInfoPageOwnerCerificate1,   1, 9) \
+  X(kFlashCtrlInfoPageBootData0,       1, 0) \
+  X(kFlashCtrlInfoPageBootData1,       1, 1) \
+  X(kFlashCtrlInfoPageOwnerSlot0,      1, 2) \
+  X(kFlashCtrlInfoPageOwnerSlot1,      1, 3) \
+  X(kFlashCtrlInfoPageBank1Type0Page4, 1, 4) \
+  X(kFlashCtrlInfoPageBank1Type0Page5, 1, 5) \
+  X(kFlashCtrlInfoPageUdsCertificate,  1, 6) \
+  X(kFlashCtrlInfoPageBootServices,    1, 7) \
+  X(kFlashCtrlInfoPageCdi0Certificate, 1, 8) \
+  X(kFlashCtrlInfoPageCdi1Certificate, 1, 9) \
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -89,6 +89,27 @@ const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed = {
     .byte_offset = (2 * kAttestationSeedBytes),
 };
 
+const flash_info_field_t kFlashInfoFieldUdsCertificate = {
+    .partition = 0,
+    .bank = 1,
+    .page = 6,
+    .byte_offset = 0,
+};
+
+const flash_info_field_t kFlashInfoFieldCdi0Certificate = {
+    .partition = 0,
+    .bank = 1,
+    .page = 8,
+    .byte_offset = 0,
+};
+
+const flash_info_field_t kFlashInfoFieldCdi1Certificate = {
+    .partition = 0,
+    .bank = 1,
+    .page = 9,
+    .byte_offset = 0,
+};
+
 status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
                                      flash_info_field_t field,
                                      uint32_t *data_out, size_t num_words) {

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -50,6 +50,9 @@ extern const flash_info_field_t kFlashInfoFieldWaferAuthSecret;
 extern const flash_info_field_t kFlashInfoFieldUdsAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldCdi0AttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed;
+extern const flash_info_field_t kFlashInfoFieldUdsCertificate;
+extern const flash_info_field_t kFlashInfoFieldCdi0Certificate;
+extern const flash_info_field_t kFlashInfoFieldCdi1Certificate;
 
 /**
  * Reads info flash page field.

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -266,7 +266,9 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:otbn_boot_services",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
+        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/otbn/crypto:boot",
     ],
 )


### PR DESCRIPTION
This adds placeholders to the FT personalization flow for the attestation certificates. These placeholders simply write the attestation public keys to the flash info pages where their corresponding certificates will eventually be stored. Additionally, the public keys are written out over the console to be picked up by the host side (and eventually stored in a device registry). Once #20456 is merged, and certificate templates are generated / checked into the repository, then we will overwrite the public keys with the actual certificates that hold such public keys.