### PR TITLE
[ot_certs] Add a parsing command

### DIFF
--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -35,6 +35,11 @@ rust_library(
         "@crate_index//:serde",
         "@crate_index//:serde_with",
         "@crate_index//:strum",
+        # We need those because they are not re-exported by openssl
+        # This can be fixed when https://github.com/sfackler/rust-openssl/pull/2021
+        # is merged.
+        "@crate_index//:openssl-sys",
+        "@crate_index//:foreign-types",
     ],
 )
 
@@ -46,11 +51,6 @@ rust_test(
     ],
     deps = [
         "@crate_index//:base64ct",
-        # We need those because they are not re-exported by openssl
-        # This can be fixed when https://github.com/sfackler/rust-openssl/pull/2021
-        # is merged.
-        "@crate_index//:openssl-sys",
-        "@crate_index//:foreign-types",
     ],
 )
 

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "env_logger",
  "erased-serde",
  "foreign-types",
+ "heck",
  "hex",
  "humantime",
  "humantime-serde",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -31,6 +31,7 @@ erased-serde = "0.3.12"
 # Note: this is needed because openssl does not re-rexports this, we cannot use a
 # too recent version because it break things.
 foreign-types = "0.3.2"
+heck = "0.4.1"
 hex = "0.4.3"
 humantime = "2.1.0"
 humantime-serde = "1.1"

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -158,6 +158,12 @@ alias(
 )
 
 alias(
+    name = "heck",
+    actual = "@crate_index__heck-0.4.1//:heck",
+    tags = ["manual"],
+)
+
+alias(
     name = "hex",
     actual = "@crate_index__hex-0.4.3//:hex",
     tags = ["manual"],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -316,6 +316,7 @@ _NORMAL_DEPENDENCIES = {
             "env_logger": "@crate_index__env_logger-0.10.0//:env_logger",
             "erased-serde": "@crate_index__erased-serde-0.3.31//:erased_serde",
             "foreign-types": "@crate_index__foreign-types-0.3.2//:foreign_types",
+            "heck": "@crate_index__heck-0.4.1//:heck",
             "hex": "@crate_index__hex-0.4.3//:hex",
             "humantime": "@crate_index__humantime-2.1.0//:humantime",
             "humantime-serde": "@crate_index__humantime-serde-1.1.1//:humantime_serde",


### PR DESCRIPTION
This add the `certificate parse` command to parse an X509 certificate. It will fully decode the DICE TCB as well.
The result is printed by opentitantool so the output format can be any supported (hjson, json5, etc).