### PR TITLE
[darjeeling,dv] Fix `xbar_main` test failures

### DIFF
--- a/hw/ip/tlul/generic_dv/xbar_tests.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_tests.hjson
@@ -100,7 +100,7 @@
                  // Large delays can cause this test to time out for large crossbar configurations.
                  // Thus reduce the number of runs (called `num_trans` in `dv_base_vseq`) to prevent
                  // timeouts.
-                 "+max_num_trans=10",
+                 "+max_num_trans=9",
                 ]
     }
 
@@ -119,7 +119,7 @@
                  // Slow responses can cause this test to time out for large crossbar
                  // configurations. Thus reduce the number of runs (called `num_trans` in
                  // `dv_base_vseq`) to prevent timeouts.
-                 "+max_num_trans=10",
+                 "+max_num_trans=9",
                 ]
     }
 
@@ -146,7 +146,7 @@
                  // Slow responses can cause this test to time out for large crossbar
                  // configurations. Thus reduce the number of runs (called `num_trans` in
                  // `dv_base_vseq`) to prevent timeouts.
-                 "+max_num_trans=10",
+                 "+max_num_trans=5",
                 ]
     }
 

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -118,7 +118,6 @@ module tlul_socket_1n #(
       dev_select_outstanding <= '0;
     end else if (accept_t_req) begin
       if (!accept_t_rsp) begin
-        `ASSERT_I(NotOverflowed_A, num_req_outstanding <= MaxOutstanding)
         num_req_outstanding <= num_req_outstanding + 1'b1;
       end
       dev_select_outstanding <= dev_select_t;
@@ -126,6 +125,9 @@ module tlul_socket_1n #(
       num_req_outstanding <= num_req_outstanding - 1'b1;
     end
   end
+
+  `ASSERT(NotOverflowed_A,
+          accept_t_req && !accept_t_rsp -> num_req_outstanding <= MaxOutstanding)
 
   assign hold_all_requests =
       (num_req_outstanding != '0) &


### PR DESCRIPTION
This should fix most of the problems that currently cause multiple of [Darjeeling's `xbar_main` tests](https://reports.opentitan.org/integrated/hw/top_darjeeling/ip/xbar_main/dv/autogen/latest/report.html) to fail. Please see the commit messages for details.