### PR TITLE
[opentitantool] Add capability to read lc_ctrl regs

### DIFF
--- a/sw/host/opentitanlib/src/dif/lc_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/lc_ctrl.rs
@@ -109,7 +109,8 @@ impl DifLcCtrlToken {
     }
 }
 
-#[derive(IntoPrimitive, Clone, Debug)]
+#[derive(IntoPrimitive, Clone, Debug, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
 #[repr(u32)]
 pub enum LcCtrlReg {
     AlertTest = bindgen::dif::LC_CTRL_ALERT_TEST_REG_OFFSET,


### PR DESCRIPTION
Use the name in snake_case from the enum. For example, to read the first hardware revision reg, supply hw_revision0 as the argument.