### PR TITLE
[hw,dma] Rename registers to be more compatible with other OT IP

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -315,7 +315,11 @@
     { name: "CFG_REGWEN"
       desc: '''
             Indicates whether the configuration registers are locked because the DMA controller is operating.
-            The CONTROL, STATUS, and CLEAR_STATE registers remain usable.
+            In the idle state, this register is set to kMultiBitBool4True.
+            When the DMA is performing an operation, i.e., the DMA is busy, this register is set to kMultiBitBool4False.
+            During the DMA operation, the CONTROL and STATUS registers remain usable.
+            The comportable registers (the interrupt and alert configuration) are NOT locked during the DMA operation and can still be updated.
+            When the DMA reaches an interrupt or alert condition, it will perform the action according to the current register configuration.
             '''
       swaccess: "ro"
       hwaccess: "hwo"
@@ -355,7 +359,7 @@
       ]
     }
     { name: "CHUNK_DATA_SIZE"
-      desc: "Total size of the data blob involved in DMA movement."
+      desc: "Number of bytes to be transferred in response to each interrupt/firmware request."
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -119,7 +119,7 @@
   ]
   regwidth: "32"
   registers: [
-    { name: "SRC_ADDRESS_LO"
+    { name: "SRC_ADDR_LO"
       desc: '''
             Lower 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
             Data is read from this location in a copy operation.
@@ -131,7 +131,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "src_address_lo"
+          name: "src_addr_lo"
           resval: 0x0
           desc: '''Lower 32 bits of the source address.
                 Must be aligned to the transfer width.
@@ -139,7 +139,7 @@
         }
       ]
     }
-    { name: "SRC_ADDRESS_HI"
+    { name: "SRC_ADDR_HI"
       desc: '''Upper 32 bits of the source address.
             Must be aligned to the transfer width.
             Source and destination address must have the same alignment.
@@ -149,7 +149,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "src_address_hi"
+          name: "src_addr_hi"
           resval: 0x0
           desc: '''
                 Upper 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
@@ -159,7 +159,7 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_LO"
+    { name: "DST_ADDR_LO"
       desc: '''
             Lower 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
             Data is written to this location in a copy operation.
@@ -172,7 +172,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "dst_address_lo"
+          name: "dst_addr_lo"
           resval: 0x0
           desc: '''Lower 32 bits of the destination address.
                 Must be aligned to the transfer width.
@@ -181,7 +181,7 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_HI"
+    { name: "DST_ADDR_HI"
       desc: '''Upper 32 bits of the destination address.
             Must be aligned to the transfer width.
             Source and destination address must have the same alignment.
@@ -191,7 +191,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "dst_address_hi"
+          name: "dst_addr_hi"
           resval: 0x0
           desc: '''
                 Upper 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
@@ -201,7 +201,7 @@
         }
       ]
     }
-    { name: "ADDRESS_SPACE_ID"
+    { name: "ADDR_SPACE_ID"
       desc: "Address space that source and destination pointers refer to."
       swaccess: "rw"
       hwaccess: "hro"
@@ -412,14 +412,14 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_LIMIT_LO"
+    { name: "DST_ADDR_LIMIT_LO"
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "address_limit_lo"
+          name: "addr_limit_lo"
           resval: 0x0
           desc: '''
                 Limit address configuration.
@@ -432,14 +432,14 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_LIMIT_HI"
+    { name: "DST_ADDR_LIMIT_HI"
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "address_limit_hi"
+          name: "addr_limit_hi"
           resval: 0x0
           desc: '''
                 Limit address configuration.
@@ -452,14 +452,14 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_ALMOST_LIMIT_LO"
+    { name: "DST_ADDR_ALMOST_LIMIT_LO"
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "address_limit_lo"
+          name: "addr_limit_lo"
           resval: 0x0
           desc: '''
                 Threshold for detecting that the buffer limit is approaching so as to prevent destination buffer overflow.
@@ -472,14 +472,14 @@
         }
       ]
     }
-    { name: "DST_ADDRESS_ALMOST_LIMIT_HI"
+    { name: "DST_ADDR_ALMOST_LIMIT_HI"
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "address_limit_hi"
+          name: "addr_limit_hi"
           resval: 0x0
           desc: '''
                 Threshold for detecting that the buffer limit is approaching so as to prevent destination buffer overflow.
@@ -666,12 +666,12 @@
       hwaccess: "hwo"
       fields: [
         { bits: "0"
-          name: "src_address_error"
+          name: "src_addr_error"
           resval: 0x0
           desc: "Source address is invalid."
         }
         { bits: "1"
-          name: "dst_address_error"
+          name: "dst_addr_error"
           resval: 0x0
           desc: "Destination address is invalid."
         }

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -729,7 +729,7 @@
         ]
       }
     }
-    { name: "HANDSHAKE_INTERRUPT_ENABLE"
+    { name: "HANDSHAKE_INTR_ENABLE"
       desc: "Enable bits for incoming handshake interrupt wires."
       swaccess: "rw"
       hwaccess: "hro"
@@ -742,11 +742,11 @@
         }
       ]
     }
-    { name: "CLEAR_INT_SRC"
+    { name: "CLEAR_INTR_SRC"
       desc: '''
             Valid bits for which interrupt sources need clearing.
-            When HANDSHAKE_INTERRUPT_ENABLE is non-zero and corresponding lsio_trigger becomes set,
-            DMA issues writes with address from INT_SOURCE_ADDR and write value from INT_SOURCE_WR_VAL corresponding to each
+            When HANDSHAKE_INTR_ENABLE is non-zero and corresponding lsio_trigger becomes set,
+            DMA issues writes with address from INTR_SOURCE_ADDR and write value from INTR_SOURCE_WR_VAL corresponding to each
             bit set in this register.
             '''
       swaccess: "rw"
@@ -760,7 +760,7 @@
         }
       ]
     }
-    { name: "CLEAR_INT_BUS"
+    { name: "CLEAR_INTR_BUS"
       desc: '''Bus selection bit where the clearing command should be performed."
             0: CTN/System fabric
             1: OT-internal crossbar
@@ -777,7 +777,7 @@
       ]
     }
     { multireg: {
-        name: "INT_SOURCE_ADDR"
+        name: "INTR_SOURCE_ADDR"
         desc: "Destination address for interrupt source clearing write."
         count: "NumIntClearSources"
         cname: "ADDR"
@@ -795,7 +795,7 @@
     }
     { skipto: "0x12C" }
     { multireg: {
-        name: "INT_SOURCE_WR_VAL"
+        name: "INTR_SOURCE_WR_VAL"
         desc: "Write value for interrupt clearing write."
         count: "NumIntClearSources"
         cname: "WRVAL"

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -119,7 +119,7 @@
   ]
   regwidth: "32"
   registers: [
-    { name: "SOURCE_ADDRESS_LO"
+    { name: "SRC_ADDRESS_LO"
       desc: '''
             Lower 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
             Data is read from this location in a copy operation.
@@ -131,7 +131,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "source_address_lo"
+          name: "src_address_lo"
           resval: 0x0
           desc: '''Lower 32 bits of the source address.
                 Must be aligned to the transfer width.
@@ -139,7 +139,7 @@
         }
       ]
     }
-    { name: "SOURCE_ADDRESS_HI"
+    { name: "SRC_ADDRESS_HI"
       desc: '''Upper 32 bits of the source address.
             Must be aligned to the transfer width.
             Source and destination address must have the same alignment.
@@ -149,7 +149,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "source_address_hi"
+          name: "src_address_hi"
           resval: 0x0
           desc: '''
                 Upper 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
@@ -208,7 +208,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "3:0"
-          name: "source_asid"
+          name: "src_asid"
           resval: 0x7
           desc: "Target address space that the source address pointer refers to."
           enum: [
@@ -746,7 +746,7 @@
       desc: '''
             Valid bits for which interrupt sources need clearing.
             When HANDSHAKE_INTR_ENABLE is non-zero and corresponding lsio_trigger becomes set,
-            DMA issues writes with address from INTR_SOURCE_ADDR and write value from INTR_SOURCE_WR_VAL corresponding to each
+            DMA issues writes with address from INTR_SRC_ADDR and write value from INTR_SRC_WR_VAL corresponding to each
             bit set in this register.
             '''
       swaccess: "rw"
@@ -777,7 +777,7 @@
       ]
     }
     { multireg: {
-        name: "INTR_SOURCE_ADDR"
+        name: "INTR_SRC_ADDR"
         desc: "Destination address for interrupt source clearing write."
         count: "NumIntClearSources"
         cname: "ADDR"
@@ -795,7 +795,7 @@
     }
     { skipto: "0x12C" }
     { multireg: {
-        name: "INTR_SOURCE_WR_VAL"
+        name: "INTR_SRC_WR_VAL"
         desc: "Write value for interrupt clearing write."
         count: "NumIntClearSources"
         cname: "WRVAL"

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -159,7 +159,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_LO"
+    { name: "DST_ADDRESS_LO"
       desc: '''
             Lower 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
             Data is written to this location in a copy operation.
@@ -172,7 +172,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "destination_address_lo"
+          name: "dst_address_lo"
           resval: 0x0
           desc: '''Lower 32 bits of the destination address.
                 Must be aligned to the transfer width.
@@ -181,7 +181,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_HI"
+    { name: "DST_ADDRESS_HI"
       desc: '''Upper 32 bits of the destination address.
             Must be aligned to the transfer width.
             Source and destination address must have the same alignment.
@@ -191,7 +191,7 @@
       regwen: "CFG_REGWEN"
       fields: [
         { bits: "31:0"
-          name: "destination_address_hi"
+          name: "dst_address_hi"
           resval: 0x0
           desc: '''
                 Upper 32 bits of the physical or virtual address of memory location within SoC memory address map or physical address within OT non-secure memory space.
@@ -227,7 +227,7 @@
           ]
         }
         { bits: "7:4"
-          name: "destination_asid"
+          name: "dst_asid"
           resval: 0x7
           desc: "Target address space that the destination address pointer refers to."
           enum: [
@@ -412,7 +412,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_LIMIT_LO"
+    { name: "DST_ADDRESS_LIMIT_LO"
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
@@ -432,7 +432,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_LIMIT_HI"
+    { name: "DST_ADDRESS_LIMIT_HI"
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
@@ -452,7 +452,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_ALMOST_LIMIT_LO"
+    { name: "DST_ADDRESS_ALMOST_LIMIT_LO"
       desc: "Lower 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"
@@ -472,7 +472,7 @@
         }
       ]
     }
-    { name: "DESTINATION_ADDRESS_ALMOST_LIMIT_HI"
+    { name: "DST_ADDRESS_ALMOST_LIMIT_HI"
       desc: "Upper 32 bits of DMA memory buffer limit address."
       swaccess: "rw"
       hwaccess: "hro"

--- a/hw/ip/dma/data/dma_testplan.hjson
+++ b/hw/ip/dma/data/dma_testplan.hjson
@@ -145,7 +145,7 @@
                     such that all valid source and destination combinations are covered at least once
                   * Randomize total transfer width and transaction size
                   * Randomize DMAC.data_direction
-                  * Randomize DMAC.FIFO_address_auto_increment_enable and DMAC.memory_address_auto_increment_enable
+                  * Randomize DMAC.FIFO_addr_auto_increment_enable and DMAC.memory_addr_auto_increment_enable
                   * Program DMAC register with OP code and enable 'hardware handshake' mode
                 - Start DMA operation by setting DMAC.GO bit
               - Start DMA operation by setting DMAC.GO bit
@@ -196,7 +196,7 @@
 
               Stimulus:
               - Configure DMA for 'hardware handshake' mode
-              - Set memory_buffer_address_auto_increment
+              - Set memory_buffer_addr_auto_increment
               - Set memory_buffer_threshold and memory_buffer_limit such that
                 * Threshold is less than the limit and
                 * Threshold and limit are within the DMA memory region
@@ -261,7 +261,7 @@
         tests: ["dma_illegal_transfer"]
       }
       {
-        name: dma_illegal_address_range
+        name: dma_illegal_addr_range
         desc: '''
               Test to check DMA hardware enforced security check for illegal source or destination address
 
@@ -279,7 +279,7 @@
               - Check if DMA generates an alert
               '''
         stage: V2S
-        tests: ["dma_illegal_address_range"]
+        tests: ["dma_illegal_addr_range"]
       }
     ]
     covergroups: [

--- a/hw/ip/dma/doc/theory_of_operation.md
+++ b/hw/ip/dma/doc/theory_of_operation.md
@@ -117,11 +117,11 @@ hardware handshake DMA operation.
 
 **Receiving data from LSIO**
 
--   [*Source address*](../data/dma.hjson#src_address_lo): address of the low speed IO
+-   [*Source address*](../data/dma.hjson#src_addr_lo): address of the low speed IO
     receive FIFO read out register.
--   [*Destination address*](../data/dma.hjson#dst_address_lo): address to the memory
+-   [*Destination address*](../data/dma.hjson#dst_addr_lo): address to the memory
     buffer where received data is placed.
--   [*Address space ID*](../data/dma.hjson#address_space_id) (ASID): (OT Internal, CTN or System)
+-   [*Address space ID*](../data/dma.hjson#addr_space_id) (ASID): (OT Internal, CTN or System)
 
     -   Source ASID: Specify the address space in which the LSIO FIFO is
         visible.
@@ -134,7 +134,7 @@ hardware handshake DMA operation.
     interrupt times the FIFO read data width).
 -   [*Transfer Width*](../data/dma.hjson#transfer_width): Width of each transaction
     (equivalent to FIFO read data width).
--   [*Limit register*](../data/dma.hjson#dst_address_limit_lo): Marks the end of the buffer used
+-   [*Limit register*](../data/dma.hjson#dst_addr_limit_lo): Marks the end of the buffer used
     to write 'total size' worth of data payloads if memory buffer
     auto-increment feature is used. DMAC shall set an overflow
     indication if the buffer limit is reached.
@@ -156,7 +156,7 @@ hardware handshake DMA operation.
         loaded into consecutive buffer segments in memory, where each
         segment is equivalent to 'total size' worth of data. To
         prepare for the next data buffer segment, [*Destination
-        address*](../data/dma.hjson#dst_address_lo) register is incremented by '[*Total
+        address*](../data/dma.hjson#dst_addr_lo) register is incremented by '[*Total
         Size*](../data/dma.hjson#total-data-size)' once an equivalent amount of data is
         emptied from the FIFO & written to the buffer segment. If auto
         increment feature is not set, then the memory buffer gets
@@ -181,11 +181,11 @@ hardware handshake DMA operation.
 
 **Sending data to LSIO**
 
--   [*Source address*](../data/dma.hjson#src_address_lo): Pointer to the head of the
+-   [*Source address*](../data/dma.hjson#src_addr_lo): Pointer to the head of the
     memory buffer.
--   [*Destination address*](../data/dma.hjson#dst_address_lo): pointer to the FIFO
+-   [*Destination address*](../data/dma.hjson#dst_addr_lo): pointer to the FIFO
     register.
--   [*Address space ID*](../data/dma.hjson#address_space_id) (ASID): (OT Internal, CTN or System)
+-   [*Address space ID*](../data/dma.hjson#addr_space_id) (ASID): (OT Internal, CTN or System)
 
     -   Source ASID: Specify the address space in which the source
         buffer resides.
@@ -197,7 +197,7 @@ hardware handshake DMA operation.
     into the FIFO.
 -   [*Transfer Width*](../data/dma.hjson#transfer_width): Write Data width of the LSIO FIFO
     register. Each write transaction is equal to this size.
--   [*Limit register*](../data/dma.hjson#dst_address_limit_lo): Marks the end of the memory
+-   [*Limit register*](../data/dma.hjson#dst_addr_limit_lo): Marks the end of the memory
     buffer used to read 'total size' worth of data segments if
     auto-increment feature is used. DMAC shall set an overflow
     indication if the buffer limit is reached.
@@ -219,7 +219,7 @@ hardware handshake DMA operation.
     -   Data buffer Auto-increment Enable: If set to 1, data shall be
         read from consecutive buffer spaces, each equivalent to 'total
         size' worth of data. To prepare for the next data buffer
-        segment [*Source address*](../data/dma.hjson#src_address_lo) register is
+        segment [*Source address*](../data/dma.hjson#src_addr_lo) register is
         incremented by '[*Total Size*](../data/dma.hjson#total-data-size)' once the
         equivalent amount of data is written to the FIFO. If auto
         increment feature is not set, then the same memory buffer

--- a/hw/ip/dma/doc/theory_of_operation.md
+++ b/hw/ip/dma/doc/theory_of_operation.md
@@ -117,7 +117,7 @@ hardware handshake DMA operation.
 
 **Receiving data from LSIO**
 
--   [*Source address*](../data/dma.hjson#source_address_lo): address of the low speed IO
+-   [*Source address*](../data/dma.hjson#src_address_lo): address of the low speed IO
     receive FIFO read out register.
 -   [*Destination address*](../data/dma.hjson#destination_address_lo): address to the memory
     buffer where received data is placed.
@@ -181,7 +181,7 @@ hardware handshake DMA operation.
 
 **Sending data to LSIO**
 
--   [*Source address*](../data/dma.hjson#source_address_lo): Pointer to the head of the
+-   [*Source address*](../data/dma.hjson#src_address_lo): Pointer to the head of the
     memory buffer.
 -   [*Destination address*](../data/dma.hjson#destination_address_lo): pointer to the FIFO
     register.
@@ -219,7 +219,7 @@ hardware handshake DMA operation.
     -   Data buffer Auto-increment Enable: If set to 1, data shall be
         read from consecutive buffer spaces, each equivalent to 'total
         size' worth of data. To prepare for the next data buffer
-        segment [*Source address*](../data/dma.hjson#source_address_lo) register is
+        segment [*Source address*](../data/dma.hjson#src_address_lo) register is
         incremented by '[*Total Size*](../data/dma.hjson#total-data-size)' once the
         equivalent amount of data is written to the FIFO. If auto
         increment feature is not set, then the same memory buffer

--- a/hw/ip/dma/doc/theory_of_operation.md
+++ b/hw/ip/dma/doc/theory_of_operation.md
@@ -119,7 +119,7 @@ hardware handshake DMA operation.
 
 -   [*Source address*](../data/dma.hjson#src_address_lo): address of the low speed IO
     receive FIFO read out register.
--   [*Destination address*](../data/dma.hjson#destination_address_lo): address to the memory
+-   [*Destination address*](../data/dma.hjson#dst_address_lo): address to the memory
     buffer where received data is placed.
 -   [*Address space ID*](../data/dma.hjson#address_space_id) (ASID): (OT Internal, CTN or System)
 
@@ -134,7 +134,7 @@ hardware handshake DMA operation.
     interrupt times the FIFO read data width).
 -   [*Transfer Width*](../data/dma.hjson#transfer_width): Width of each transaction
     (equivalent to FIFO read data width).
--   [*Limit register*](../data/dma.hjson#destination_address_limit_lo): Marks the end of the buffer used
+-   [*Limit register*](../data/dma.hjson#dst_address_limit_lo): Marks the end of the buffer used
     to write 'total size' worth of data payloads if memory buffer
     auto-increment feature is used. DMAC shall set an overflow
     indication if the buffer limit is reached.
@@ -156,7 +156,7 @@ hardware handshake DMA operation.
         loaded into consecutive buffer segments in memory, where each
         segment is equivalent to 'total size' worth of data. To
         prepare for the next data buffer segment, [*Destination
-        address*](../data/dma.hjson#destination_address_lo) register is incremented by '[*Total
+        address*](../data/dma.hjson#dst_address_lo) register is incremented by '[*Total
         Size*](../data/dma.hjson#total-data-size)' once an equivalent amount of data is
         emptied from the FIFO & written to the buffer segment. If auto
         increment feature is not set, then the memory buffer gets
@@ -183,7 +183,7 @@ hardware handshake DMA operation.
 
 -   [*Source address*](../data/dma.hjson#src_address_lo): Pointer to the head of the
     memory buffer.
--   [*Destination address*](../data/dma.hjson#destination_address_lo): pointer to the FIFO
+-   [*Destination address*](../data/dma.hjson#dst_address_lo): pointer to the FIFO
     register.
 -   [*Address space ID*](../data/dma.hjson#address_space_id) (ASID): (OT Internal, CTN or System)
 
@@ -197,7 +197,7 @@ hardware handshake DMA operation.
     into the FIFO.
 -   [*Transfer Width*](../data/dma.hjson#transfer_width): Write Data width of the LSIO FIFO
     register. Each write transaction is equal to this size.
--   [*Limit register*](../data/dma.hjson#destination_address_limit_lo): Marks the end of the memory
+-   [*Limit register*](../data/dma.hjson#dst_address_limit_lo): Marks the end of the memory
     buffer used to read 'total size' worth of data segments if
     auto-increment feature is used. DMAC shall set an overflow
     indication if the buffer limit is reached.

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -240,10 +240,10 @@ endgroup
 
 covergroup dma_interrupt_cg with function sample(
   bit [dma_reg_pkg::NumIntClearSources-1:0] handshake_interrupt_enable,
-  bit [dma_reg_pkg::NumIntClearSources-1:0] clear_int_src,
-  bit [dma_reg_pkg::NumIntClearSources-1:0] clear_int_bus,
-  bit [dma_reg_pkg::NumIntClearSources-1:0][2:0] int_source_addr_offset,
-  bit [dma_reg_pkg::NumIntClearSources-1:0][31:0] int_source_wr_val
+  bit [dma_reg_pkg::NumIntClearSources-1:0] clear_intr_src,
+  bit [dma_reg_pkg::NumIntClearSources-1:0] clear_intr_bus,
+  bit [dma_reg_pkg::NumIntClearSources-1:0][2:0] intr_source_addr_offset,
+  bit [dma_reg_pkg::NumIntClearSources-1:0][31:0] intr_source_wr_val
 );
   option.per_instance = 1;
   option.name = "dma_interrupt_cg";
@@ -252,15 +252,15 @@ covergroup dma_interrupt_cg with function sample(
     `DMA_ENV_COV_INTERRUPT_BINS
   }
 
-  cp_clear_int_src: coverpoint clear_int_src {
+  cp_clear_intr_src: coverpoint clear_intr_src {
     `DMA_ENV_COV_INTERRUPT_BINS
   }
 
-  cp_clear_int_bus: coverpoint clear_int_bus {
+  cp_clear_intr_bus: coverpoint clear_intr_bus {
     `DMA_ENV_COV_INTERRUPT_BINS
   }
 
-  cp_int_source_addr_offset: coverpoint int_source_addr_offset {
+  cp_int_source_addr_offset: coverpoint intr_source_addr_offset {
     bins all_zero = {0};
     bins first_1_others_0 = {3'b001};
     bins first_2_others_0 = {3'b010};
@@ -285,7 +285,7 @@ covergroup dma_interrupt_cg with function sample(
     // Is there a way to programatically generate more enumerations like the above?
   }
 
-  cp_int_source_wr_val: coverpoint int_source_wr_val {
+  cp_int_source_wr_val: coverpoint intr_source_wr_val {
     bins all_zero = {0};
     bins first_all_ones_others_zero = {32'hffff_ffff};
     bins second_all_ones_others_zero = {64'hffff_ffff_0000_0000};

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -124,30 +124,6 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_mem_buffer_auto_inc: coverpoint dma_config.auto_inc_buffer;
 
   cp_handshake_intr: coverpoint dma_config.handshake_intr_en;
-<<<<<<< HEAD
-=======
-  // Abort via write to CONTROL
-  cp_abort: coverpoint abort;
-  // Cross OP code, src_address_space_id, dst_address_space_id and DMA operating mode
-  cp_op_code_x_asid_x_mode: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode{
-    // Ignore reserved values of OP code
-    ignore_bins reserved = binsof (cp_opcode.reserved);
-  }
-  cp_transfer_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
-  cp_transfer_width_x_dst_asid_x_dma_op: cross cp_transfer_width, cp_dst_asid, cp_opcode;
-  cp_src_addr_x_src_asid_x_dma_op: cross cp_src_addr, cp_src_asid, cp_opcode;
-  cp_dst_addr_x_dst_asid_x_dma_op: cross cp_dst_addr, cp_dst_asid, cp_opcode;
-  cp_dma_mem_base_x_dma_mem_limit_x_dma_op: cross cp_dma_mem_base, cp_dma_mem_range_limit,
-                                                  cp_opcode;
-  cp_range_lock_x_write_to_dma_mem_region_x_dma_op: cross cp_range_lock,
-                                                          write_to_dma_mem_register, cp_opcode;
-  // Coverpoint for TL error on source interface
-  cp_src_tl_err: coverpoint dma_config.src_asid iff (tl_src_err){
-    bins internal = {OtInternalAddr};
-    bins ctn = {SocControlAddr};
-    bins sys = {SocSystemAddr};
-  }
->>>>>>> 8dc715b9f8 ([hw,dma] Use dst to denote the destination)
 
   cp_initial_transfer: coverpoint initial_transfer;
 

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -124,6 +124,30 @@ covergroup dma_config_cg with function sample(dma_seq_item dma_config,
   cp_mem_buffer_auto_inc: coverpoint dma_config.auto_inc_buffer;
 
   cp_handshake_intr: coverpoint dma_config.handshake_intr_en;
+<<<<<<< HEAD
+=======
+  // Abort via write to CONTROL
+  cp_abort: coverpoint abort;
+  // Cross OP code, src_address_space_id, dst_address_space_id and DMA operating mode
+  cp_op_code_x_asid_x_mode: cross cp_opcode, cp_src_asid, cp_dst_asid, cp_handshake_mode{
+    // Ignore reserved values of OP code
+    ignore_bins reserved = binsof (cp_opcode.reserved);
+  }
+  cp_transfer_size_x_src_asid_x_dma_op: cross cp_transfer_width, cp_src_asid, cp_opcode;
+  cp_transfer_width_x_dst_asid_x_dma_op: cross cp_transfer_width, cp_dst_asid, cp_opcode;
+  cp_src_addr_x_src_asid_x_dma_op: cross cp_src_addr, cp_src_asid, cp_opcode;
+  cp_dst_addr_x_dst_asid_x_dma_op: cross cp_dst_addr, cp_dst_asid, cp_opcode;
+  cp_dma_mem_base_x_dma_mem_limit_x_dma_op: cross cp_dma_mem_base, cp_dma_mem_range_limit,
+                                                  cp_opcode;
+  cp_range_lock_x_write_to_dma_mem_region_x_dma_op: cross cp_range_lock,
+                                                          write_to_dma_mem_register, cp_opcode;
+  // Coverpoint for TL error on source interface
+  cp_src_tl_err: coverpoint dma_config.src_asid iff (tl_src_err){
+    bins internal = {OtInternalAddr};
+    bins ctn = {SocControlAddr};
+    bins sys = {SocSystemAddr};
+  }
+>>>>>>> 8dc715b9f8 ([hw,dma] Use dst to denote the destination)
 
   cp_initial_transfer: coverpoint initial_transfer;
 

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -63,9 +63,9 @@ class dma_scoreboard extends cip_base_scoreboard #(
   bit fifo_intr_cleared;
   // Variable to indicate number of writes expected to clear FIFO interrupts
   uint num_fifo_reg_write;
-  // Variable to store clear_int_src register intended for use in monitor_lsio_trigger task
+  // Variable to store clear_intr_src register intended for use in monitor_lsio_trigger task
   // since ref argument can not be used in fork-join_none
-  bit[31:0] clear_int_src;
+  bit[31:0] clear_intr_src;
   bit [TL_DW-1:0] exp_digest[16];
 
   // Allow up to this number of clock cycles from CSR modification until interrupt signal change.
@@ -109,15 +109,15 @@ class dma_scoreboard extends cip_base_scoreboard #(
 
   // Look up the given address in the list of 'Clear Interrupt' addresses, returning a positive
   // index iff found.
-  function int int_addr_lookup(bit [31:0] addr);
-    for (uint idx = 0; idx < dma_config.int_src_addr.size(); idx++) begin
-      if (dma_config.int_src_addr[idx] == addr) begin
+  function int intr_addr_lookup(bit [31:0] addr);
+    for (uint idx = 0; idx < dma_config.intr_src_addr.size(); idx++) begin
+      if (dma_config.intr_src_addr[idx] == addr) begin
         // Address matches; this address should just receive write traffic.
         return int'(idx);
       end
     end
     return -1;
-  endfunction : int_addr_lookup
+  endfunction : intr_addr_lookup
 
   // Check if the address matches our expectations and is valid for the current configuration.
   // This method is common for both source and destination address.
@@ -238,7 +238,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
                                     dma_config.per_transfer_width);
     tl_a_op_e a_opcode = tl_a_op_e'(item.a_opcode);
     bit [31:0] memory_range;
-    int int_source;
+    int intr_source;
 
     `uvm_info(`gfn, $sformatf("Got addr txn \n:%s", item.sprint()), UVM_DEBUG)
     // Common checks
@@ -272,8 +272,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
                $sformatf("Unexpected opcode : %d on %s", a_opcode.name(), if_name))
 
       // Is this address a 'Clear Interrupt' operation?
-      int_source = int_addr_lookup(item.a_addr);
-      `DV_CHECK_EQ(int_source, -1, "Unexpected Read access to Clear Interrupt address")
+      intr_source = intr_addr_lookup(item.a_addr);
+      `DV_CHECK_EQ(intr_source, -1, "Unexpected Read access to Clear Interrupt address")
 
       // Validate the read address for this source access.
       check_addr(item.a_addr, exp_src_addr, restricted, dma_config.get_read_fifo_en(),
@@ -300,13 +300,13 @@ class dma_scoreboard extends cip_base_scoreboard #(
                                                       dma_config.src_asid != OtInternalAddr);
 
       // Is this address a 'Clear Interrupt' operation?
-      int_source = int_addr_lookup(item.a_addr);
+      intr_source = intr_addr_lookup(item.a_addr);
       // Push addr item to destination queue
       dst_queue.push_back(item);
       `uvm_info(`gfn, $sformatf("Addr channel checks done for destination item"), UVM_HIGH)
 
       // Write to 'Clear Interrupt' address?
-      if (int_source < 0) begin
+      if (intr_source < 0) begin
         // Regular write traffic
         uint exp_a_mask_count_ones;
         uint num_bytes_this_txn;
@@ -345,8 +345,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
                                if_name, dma_config.dst_asid.name()))
 
         // Track write-side progress through this transfer
-        `uvm_info(`gfn, $sformatf("num_bytes_this_txn %x int_source %x",
-                                  num_bytes_this_txn, int_source), UVM_HIGH);
+        `uvm_info(`gfn, $sformatf("num_bytes_this_txn %x intr_source %x",
+                                  num_bytes_this_txn, intr_source), UVM_HIGH);
 
         // On-the-fly checking of writing data
         check_write_data(if_name, item);
@@ -374,15 +374,15 @@ class dma_scoreboard extends cip_base_scoreboard #(
         // Write to 'Clear Interrupt' address, so check the value written and the bus to which the
         // write has been sent.
         string exp_name;
-        exp_name = dma_config.clear_int_bus[int_source] ? "host" : "ctn";
+        exp_name = dma_config.clear_intr_bus[intr_source] ? "host" : "ctn";
 
         `uvm_info(`gfn, $sformatf("Clear Interrupt write of 0x%0x to address 0x%0x",
                                   item.a_data, item.a_addr), UVM_HIGH)
         `DV_CHECK_EQ(if_name, exp_name,
                      $sformatf("%s received %s-targeted clear interrupt write", if_name, exp_name))
-        `DV_CHECK_EQ(dma_config.int_src_wr_val[int_source], item.a_data,
+        `DV_CHECK_EQ(dma_config.intr_src_wr_val[intr_source], item.a_data,
                      $sformatf("Unexpected value 0x%0x written to clear interrupt %d", item.a_data,
-                               int_source))
+                               intr_source))
         `DV_CHECK_EQ(item.a_mask, 4'hF, "Unexpected write enables to clear interrupt write")
 
         // We're expecting only full word writes.
@@ -498,17 +498,17 @@ class dma_scoreboard extends cip_base_scoreboard #(
                       uvm_tlm_analysis_fifo#(tl_channels_e) dir_fifo,
                       uvm_tlm_analysis_fifo#(tl_seq_item) a_chan_fifo,
                       uvm_tlm_analysis_fifo#(tl_seq_item) d_chan_fifo);
-    bit exp_int_clearing;
+    bit exp_intr_clearing;
     tl_channels_e dir;
     tl_seq_item   item;
     fork
       forever begin
         dir_fifo.get(dir);
         // Clear Interrupt writes are emitted even for invalid configurations.
-        exp_int_clearing = dma_config.handshake & |dma_config.clear_int_src &
-                          |dma_config.handshake_intr_en;
+        exp_intr_clearing = dma_config.handshake & |dma_config.clear_intr_src &
+                           |dma_config.handshake_intr_en;
         // Check if transaction is expected for a valid configuration
-        `DV_CHECK_FATAL(dma_config.is_valid_config || exp_int_clearing,
+        `DV_CHECK_FATAL(dma_config.is_valid_config || exp_intr_clearing,
                            $sformatf("transaction observed on %s for invalid configuration",
                                      if_name))
         // Check if there is any active operation, but be aware that the Abort functionality
@@ -528,7 +528,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
             process_tl_addr_txn(if_name, item);
             // Update num_fifo_reg_write
             if (num_fifo_reg_write > 0) begin
-              `uvm_info(`gfn, $sformatf("Processed FIFO clear_int_src addr: %0x0x", item.a_addr),
+              `uvm_info(`gfn, $sformatf("Processed FIFO clear_intr_src addr: %0x0x", item.a_addr),
                         UVM_DEBUG)
               num_fifo_reg_write--;
             end else begin
@@ -680,11 +680,11 @@ class dma_scoreboard extends cip_base_scoreboard #(
           // Wait for at least one LSIoO trigger to be active and it is eanbled
           @(posedge cfg.dma_vif.handshake_i);
           handshake_en = `gmv(ral.control.hardware_handshake_enable);
-          handshake_intr_en = `gmv(ral.handshake_interrupt_enable);
+          handshake_intr_en = `gmv(ral.handshake_intr_enable);
           // Update number of register writes expected in case at least one
           // of the enabled handshake interrupt is asserted
           if (handshake_en && (cfg.dma_vif.handshake_i & handshake_intr_en)) begin
-            num_fifo_reg_write = $countones(clear_int_src);
+            num_fifo_reg_write = $countones(clear_intr_src);
             `uvm_info(`gfn,
                       $sformatf("Handshake mode: num_fifo_reg_write:%0d", num_fifo_reg_write),
                       UVM_HIGH)
@@ -781,7 +781,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
-  // Return the index that a register name refers to e.g. "int_source_addr_1" yields 1
+  // Return the index that a register name refers to e.g. "intr_source_addr_1" yields 1
   function uint get_index_from_reg_name(string reg_name);
     int str_len = reg_name.len();
     // Note: this extracts the final two characters which are either '_y' or 'xy',
@@ -909,12 +909,12 @@ class dma_scoreboard extends cip_base_scoreboard #(
         dma_config.dst_addr_almost_limit[63:32] =
           `gmv(ral.destination_address_almost_limit_hi.address_limit_hi);
       end
-      "clear_int_bus": begin
-        dma_config.clear_int_bus = `gmv(ral.clear_int_bus.bus);
+      "clear_intr_bus": begin
+        dma_config.clear_intr_bus = `gmv(ral.clear_intr_bus.bus);
       end
-      "clear_int_src": begin
-        dma_config.clear_int_src = `gmv(ral.clear_int_src.source);
-        clear_int_src = dma_config.clear_int_src;
+      "clear_intr_src": begin
+        dma_config.clear_intr_src = `gmv(ral.clear_intr_src.source);
+        clear_intr_src = dma_config.clear_intr_src;
       end
       "sha2_digest_0",
       "sha2_digest_1",
@@ -935,37 +935,37 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_error(`gfn, $sformatf("this reg does not have write access: %0s",
                                        csr.get_full_name()))
       end
-      "int_source_addr_0",
-      "int_source_addr_1",
-      "int_source_addr_2",
-      "int_source_addr_3",
-      "int_source_addr_4",
-      "int_source_addr_5",
-      "int_source_addr_6",
-      "int_source_addr_7",
-      "int_source_addr_8",
-      "int_source_addr_9",
-      "int_source_addr_10": begin
+      "intr_source_addr_0",
+      "intr_source_addr_1",
+      "intr_source_addr_2",
+      "intr_source_addr_3",
+      "intr_source_addr_4",
+      "intr_source_addr_5",
+      "intr_source_addr_6",
+      "intr_source_addr_7",
+      "intr_source_addr_8",
+      "intr_source_addr_9",
+      "intr_source_addr_10": begin
         int index;
         `uvm_info(`gfn, $sformatf("Update %s", csr.get_name()), UVM_DEBUG)
         index = get_index_from_reg_name(csr.get_name());
-        dma_config.int_src_addr[index] = item.a_data;
+        dma_config.intr_src_addr[index] = item.a_data;
       end
-      "int_source_wr_val_0",
-      "int_source_wr_val_1",
-      "int_source_wr_val_2",
-      "int_source_wr_val_3",
-      "int_source_wr_val_4",
-      "int_source_wr_val_5",
-      "int_source_wr_val_6",
-      "int_source_wr_val_7",
-      "int_source_wr_val_8",
-      "int_source_wr_val_9",
-      "int_source_wr_val_10": begin
+      "intr_source_wr_val_0",
+      "intr_source_wr_val_1",
+      "intr_source_wr_val_2",
+      "intr_source_wr_val_3",
+      "intr_source_wr_val_4",
+      "intr_source_wr_val_5",
+      "intr_source_wr_val_6",
+      "intr_source_wr_val_7",
+      "intr_source_wr_val_8",
+      "intr_source_wr_val_9",
+      "intr_source_wr_val_10": begin
         int index;
         `uvm_info(`gfn, $sformatf("Update %s", csr.get_name()), UVM_DEBUG)
         index = get_index_from_reg_name(csr.get_name());
-        dma_config.int_src_wr_val[index] = item.a_data;
+        dma_config.intr_src_wr_val[index] = item.a_data;
       end
       "control": begin
         bit go, initial_transfer, start_transfer;
@@ -1035,25 +1035,25 @@ class dma_scoreboard extends cip_base_scoreboard #(
           exp_bytes_transferred += dma_config.chunk_size(exp_bytes_transferred);
         end
         if (cfg.en_cov && go) begin
-          logic [dma_reg_pkg::NumIntClearSources-1:0][2:0] int_source_addr_offset;
-          logic [dma_reg_pkg::NumIntClearSources-1:0][31:0] int_source_wr_val;
+          logic [dma_reg_pkg::NumIntClearSources-1:0][2:0] intr_source_addr_offset;
+          logic [dma_reg_pkg::NumIntClearSources-1:0][31:0] intr_source_wr_val;
           for (int unsigned i = 0; i < dma_reg_pkg::NumIntClearSources; i++) begin
-            int_source_addr_offset[i] = dma_config.int_src_addr[i] % 8;
-            int_source_wr_val[i] = dma_config.int_src_wr_val[i];
+            intr_source_addr_offset[i] = dma_config.intr_src_addr[i] % 8;
+            intr_source_wr_val[i] = dma_config.intr_src_wr_val[i];
           end
           cov.config_cg.sample(.dma_config(dma_config),
                                .initial_transfer(initial_transfer));
           cov.interrupt_cg.sample(
             .handshake_interrupt_enable(dma_config.handshake_intr_en),
-            .clear_int_src(dma_config.clear_int_src),
-            .clear_int_bus(dma_config.clear_int_bus),
-            .int_source_addr_offset(int_source_addr_offset),
-            .int_source_wr_val(int_source_wr_val)
+            .clear_intr_src(dma_config.clear_intr_src),
+            .clear_intr_bus(dma_config.clear_intr_bus),
+            .intr_source_addr_offset(intr_source_addr_offset),
+            .intr_source_wr_val(intr_source_wr_val)
           );
         end
       end
-      "handshake_interrupt_enable": begin
-        dma_config.handshake_intr_en = `gmv(ral.handshake_interrupt_enable.mask);
+      "handshake_intr_enable": begin
+        dma_config.handshake_intr_en = `gmv(ral.handshake_intr_enable.mask);
         `uvm_info(`gfn,
                   $sformatf("Got handshake_intr_en = 0x%x", dma_config.handshake_intr_en), UVM_HIGH)
       end

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -820,33 +820,33 @@ class dma_scoreboard extends cip_base_scoreboard #(
         // Test bits are fire-and-forget; they are not retained anywhere.
         predict_interrupts(CSRtoIntrLatency, item.a_data, `gmv(ral.intr_enable));
       end
-      "src_address_lo": begin
+      "src_addr_lo": begin
         dma_config.src_addr[31:0] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got src_address_lo = %0x",
+        `uvm_info(`gfn, $sformatf("Got src_addr_lo = %0x",
                                   dma_config.src_addr[31:0]), UVM_HIGH)
       end
-      "src_address_hi": begin
+      "src_addr_hi": begin
         dma_config.src_addr[63:32] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got src_address_hi = %0x",
+        `uvm_info(`gfn, $sformatf("Got src_addr_hi = %0x",
                                   dma_config.src_addr[63:32]), UVM_HIGH)
       end
-      "dst_address_lo": begin
+      "dst_addr_lo": begin
         dma_config.dst_addr[31:0] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got dst_address_lo = %0x",
+        `uvm_info(`gfn, $sformatf("Got dst_addr_lo = %0x",
                                   dma_config.dst_addr[31:0]), UVM_HIGH)
       end
-      "dst_address_hi": begin
+      "dst_addr_hi": begin
         dma_config.dst_addr[63:32] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got dst_address_hi = %0x",
+        `uvm_info(`gfn, $sformatf("Got dst_addr_hi = %0x",
                                   dma_config.dst_addr[63:32]), UVM_HIGH)
       end
-      "address_space_id": begin
+      "addr_space_id": begin
         // Get mirrored field value and cast to associated enum in dma_config
-        dma_config.src_asid = asid_encoding_e'(`gmv(ral.address_space_id.src_asid));
+        dma_config.src_asid = asid_encoding_e'(`gmv(ral.addr_space_id.src_asid));
         `uvm_info(`gfn, $sformatf("Got source address space id : %s",
                                   dma_config.src_asid.name()), UVM_HIGH)
         // Get mirrored field value and cast to associated enum in dma_config
-        dma_config.dst_asid = asid_encoding_e'(`gmv(ral.address_space_id.dst_asid));
+        dma_config.dst_asid = asid_encoding_e'(`gmv(ral.addr_space_id.dst_asid));
         `uvm_info(`gfn, $sformatf("Got destination address space id : %s",
                                   dma_config.dst_asid.name()), UVM_HIGH)
       end
@@ -893,21 +893,17 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Got transfer_width = %s",
                                   dma_config.per_transfer_width.name()), UVM_HIGH)
       end
-      "dst_address_limit_lo": begin
-        dma_config.dst_addr_limit[31:0] =
-          `gmv(ral.dst_address_limit_lo.address_limit_lo);
+      "dst_addr_limit_lo": begin
+        dma_config.dst_addr_limit[31:0] = `gmv(ral.dst_addr_limit_lo.addr_limit_lo);
       end
-      "dst_address_limit_hi": begin
-        dma_config.dst_addr_limit[63:32] =
-          `gmv(ral.dst_address_limit_hi.address_limit_hi);
+      "dst_addr_limit_hi": begin
+        dma_config.dst_addr_limit[63:32] = `gmv(ral.dst_addr_limit_hi.addr_limit_hi);
       end
-      "dst_address_almost_limit_lo": begin
-        dma_config.dst_addr_almost_limit[31:0] =
-          `gmv(ral.dst_address_almost_limit_lo.address_limit_lo);
+      "dst_addr_almost_limit_lo": begin
+        dma_config.dst_addr_almost_limit[31:0] = `gmv(ral.dst_addr_almost_limit_lo.addr_limit_lo);
       end
-      "dst_address_almost_limit_hi": begin
-        dma_config.dst_addr_almost_limit[63:32] =
-          `gmv(ral.dst_address_almost_limit_hi.address_limit_hi);
+      "dst_addr_almost_limit_hi": begin
+        dma_config.dst_addr_almost_limit[63:32] = `gmv(ral.dst_addr_almost_limit_hi.addr_limit_hi);
       end
       "clear_intr_bus": begin
         dma_config.clear_intr_bus = `gmv(ral.clear_intr_bus.bus);
@@ -1169,8 +1165,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
       "error_code": begin
         bit [DmaErrLast-1:0] error_code;
         do_read_check = 1'b0;
-        error_code[DmaSrcAddrErr]    = get_field_val(ral.error_code.src_address_error, item.d_data);
-        error_code[DmaDstAddrErr]    = get_field_val(ral.error_code.dst_address_error, item.d_data);
+        error_code[DmaSrcAddrErr]    = get_field_val(ral.error_code.src_addr_error, item.d_data);
+        error_code[DmaDstAddrErr]    = get_field_val(ral.error_code.dst_addr_error, item.d_data);
         error_code[DmaOpcodeErr]     = get_field_val(ral.error_code.opcode_error, item.d_data);
         error_code[DmaSizeErr]       = get_field_val(ral.error_code.size_error, item.d_data);
         error_code[DmaBusErr]        = get_field_val(ral.error_code.bus_error, item.d_data);

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -781,7 +781,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
-  // Return the index that a register name refers to e.g. "intr_source_addr_1" yields 1
+  // Return the index that a register name refers to e.g. "intr_src_addr_1" yields 1
   function uint get_index_from_reg_name(string reg_name);
     int str_len = reg_name.len();
     // Note: this extracts the final two characters which are either '_y' or 'xy',
@@ -820,14 +820,14 @@ class dma_scoreboard extends cip_base_scoreboard #(
         // Test bits are fire-and-forget; they are not retained anywhere.
         predict_interrupts(CSRtoIntrLatency, item.a_data, `gmv(ral.intr_enable));
       end
-      "source_address_lo": begin
+      "src_address_lo": begin
         dma_config.src_addr[31:0] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got source_address_lo = %0x",
+        `uvm_info(`gfn, $sformatf("Got src_address_lo = %0x",
                                   dma_config.src_addr[31:0]), UVM_HIGH)
       end
-      "source_address_hi": begin
+      "src_address_hi": begin
         dma_config.src_addr[63:32] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got source_address_hi = %0x",
+        `uvm_info(`gfn, $sformatf("Got src_address_hi = %0x",
                                   dma_config.src_addr[63:32]), UVM_HIGH)
       end
       "destination_address_lo": begin
@@ -842,7 +842,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       end
       "address_space_id": begin
         // Get mirrored field value and cast to associated enum in dma_config
-        dma_config.src_asid = asid_encoding_e'(`gmv(ral.address_space_id.source_asid));
+        dma_config.src_asid = asid_encoding_e'(`gmv(ral.address_space_id.src_asid));
         `uvm_info(`gfn, $sformatf("Got source address space id : %s",
                                   dma_config.src_asid.name()), UVM_HIGH)
         // Get mirrored field value and cast to associated enum in dma_config
@@ -935,33 +935,33 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_error(`gfn, $sformatf("this reg does not have write access: %0s",
                                        csr.get_full_name()))
       end
-      "intr_source_addr_0",
-      "intr_source_addr_1",
-      "intr_source_addr_2",
-      "intr_source_addr_3",
-      "intr_source_addr_4",
-      "intr_source_addr_5",
-      "intr_source_addr_6",
-      "intr_source_addr_7",
-      "intr_source_addr_8",
-      "intr_source_addr_9",
-      "intr_source_addr_10": begin
+      "intr_src_addr_0",
+      "intr_src_addr_1",
+      "intr_src_addr_2",
+      "intr_src_addr_3",
+      "intr_src_addr_4",
+      "intr_src_addr_5",
+      "intr_src_addr_6",
+      "intr_src_addr_7",
+      "intr_src_addr_8",
+      "intr_src_addr_9",
+      "intr_src_addr_10": begin
         int index;
         `uvm_info(`gfn, $sformatf("Update %s", csr.get_name()), UVM_DEBUG)
         index = get_index_from_reg_name(csr.get_name());
         dma_config.intr_src_addr[index] = item.a_data;
       end
-      "intr_source_wr_val_0",
-      "intr_source_wr_val_1",
-      "intr_source_wr_val_2",
-      "intr_source_wr_val_3",
-      "intr_source_wr_val_4",
-      "intr_source_wr_val_5",
-      "intr_source_wr_val_6",
-      "intr_source_wr_val_7",
-      "intr_source_wr_val_8",
-      "intr_source_wr_val_9",
-      "intr_source_wr_val_10": begin
+      "intr_src_wr_val_0",
+      "intr_src_wr_val_1",
+      "intr_src_wr_val_2",
+      "intr_src_wr_val_3",
+      "intr_src_wr_val_4",
+      "intr_src_wr_val_5",
+      "intr_src_wr_val_6",
+      "intr_src_wr_val_7",
+      "intr_src_wr_val_8",
+      "intr_src_wr_val_9",
+      "intr_src_wr_val_10": begin
         int index;
         `uvm_info(`gfn, $sformatf("Update %s", csr.get_name()), UVM_DEBUG)
         index = get_index_from_reg_name(csr.get_name());
@@ -1169,7 +1169,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       "error_code": begin
         bit [DmaErrLast-1:0] error_code;
         do_read_check = 1'b0;
-        error_code[DmaSourceAddrErr] = get_field_val(ral.error_code.src_address_error, item.d_data);
+        error_code[DmaSrcAddrErr]    = get_field_val(ral.error_code.src_address_error, item.d_data);
         error_code[DmaDestAddrErr]   = get_field_val(ral.error_code.dst_address_error, item.d_data);
         error_code[DmaOpcodeErr]     = get_field_val(ral.error_code.opcode_error, item.d_data);
         error_code[DmaSizeErr]       = get_field_val(ral.error_code.size_error, item.d_data);

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -830,14 +830,14 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Got src_address_hi = %0x",
                                   dma_config.src_addr[63:32]), UVM_HIGH)
       end
-      "destination_address_lo": begin
+      "dst_address_lo": begin
         dma_config.dst_addr[31:0] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got destination_address_lo = %0x",
+        `uvm_info(`gfn, $sformatf("Got dst_address_lo = %0x",
                                   dma_config.dst_addr[31:0]), UVM_HIGH)
       end
-      "destination_address_hi": begin
+      "dst_address_hi": begin
         dma_config.dst_addr[63:32] = item.a_data;
-        `uvm_info(`gfn, $sformatf("Got destination_address_hi = %0x",
+        `uvm_info(`gfn, $sformatf("Got dst_address_hi = %0x",
                                   dma_config.dst_addr[63:32]), UVM_HIGH)
       end
       "address_space_id": begin
@@ -846,7 +846,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Got source address space id : %s",
                                   dma_config.src_asid.name()), UVM_HIGH)
         // Get mirrored field value and cast to associated enum in dma_config
-        dma_config.dst_asid = asid_encoding_e'(`gmv(ral.address_space_id.destination_asid));
+        dma_config.dst_asid = asid_encoding_e'(`gmv(ral.address_space_id.dst_asid));
         `uvm_info(`gfn, $sformatf("Got destination address space id : %s",
                                   dma_config.dst_asid.name()), UVM_HIGH)
       end
@@ -893,21 +893,21 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Got transfer_width = %s",
                                   dma_config.per_transfer_width.name()), UVM_HIGH)
       end
-      "destination_address_limit_lo": begin
+      "dst_address_limit_lo": begin
         dma_config.dst_addr_limit[31:0] =
-          `gmv(ral.destination_address_limit_lo.address_limit_lo);
+          `gmv(ral.dst_address_limit_lo.address_limit_lo);
       end
-      "destination_address_limit_hi": begin
+      "dst_address_limit_hi": begin
         dma_config.dst_addr_limit[63:32] =
-          `gmv(ral.destination_address_limit_hi.address_limit_hi);
+          `gmv(ral.dst_address_limit_hi.address_limit_hi);
       end
-      "destination_address_almost_limit_lo": begin
+      "dst_address_almost_limit_lo": begin
         dma_config.dst_addr_almost_limit[31:0] =
-          `gmv(ral.destination_address_almost_limit_lo.address_limit_lo);
+          `gmv(ral.dst_address_almost_limit_lo.address_limit_lo);
       end
-      "destination_address_almost_limit_hi": begin
+      "dst_address_almost_limit_hi": begin
         dma_config.dst_addr_almost_limit[63:32] =
-          `gmv(ral.destination_address_almost_limit_hi.address_limit_hi);
+          `gmv(ral.dst_address_almost_limit_hi.address_limit_hi);
       end
       "clear_intr_bus": begin
         dma_config.clear_intr_bus = `gmv(ral.clear_intr_bus.bus);
@@ -1170,7 +1170,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
         bit [DmaErrLast-1:0] error_code;
         do_read_check = 1'b0;
         error_code[DmaSrcAddrErr]    = get_field_val(ral.error_code.src_address_error, item.d_data);
-        error_code[DmaDestAddrErr]   = get_field_val(ral.error_code.dst_address_error, item.d_data);
+        error_code[DmaDstAddrErr]    = get_field_val(ral.error_code.dst_address_error, item.d_data);
         error_code[DmaOpcodeErr]     = get_field_val(ral.error_code.opcode_error, item.d_data);
         error_code[DmaSizeErr]       = get_field_val(ral.error_code.size_error, item.d_data);
         error_code[DmaBusErr]        = get_field_val(ral.error_code.bus_error, item.d_data);

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -264,18 +264,18 @@ class dma_base_vseq extends cip_base_vseq #(
   endfunction
 
   // Task: Write to Source Address CSR
-  task set_src_address(bit [63:0] src_address);
-    `uvm_info(`gfn, $sformatf("DMA: Source Address = 0x%016h", src_address), UVM_HIGH)
-    csr_wr(ral.src_address_lo, src_address[31:0]);
-    csr_wr(ral.src_address_hi, src_address[63:32]);
-  endtask : set_src_address
+  task set_src_addr(bit [63:0] src_addr);
+    `uvm_info(`gfn, $sformatf("DMA: Source Address = 0x%016h", src_addr), UVM_HIGH)
+    csr_wr(ral.src_addr_lo, src_addr[31:0]);
+    csr_wr(ral.src_addr_hi, src_addr[63:32]);
+  endtask : set_src_addr
 
   // Task: Write to Destination Address CSR
-  task set_dst_address(bit [63:0] dst_address);
-    csr_wr(ral.dst_addr_lo, dst_address[31:0]);
-    csr_wr(ral.dst_addr_hi, dst_address[63:32]);
-    `uvm_info(`gfn, $sformatf("DMA: Destination Address = 0x%016h", dst_address), UVM_HIGH)
-  endtask : set_dst_address
+  task set_dst_addr(bit [63:0] dst_addr);
+    csr_wr(ral.dst_addr_lo, dst_addr[31:0]);
+    csr_wr(ral.dst_addr_hi, dst_addr[63:32]);
+    `uvm_info(`gfn, $sformatf("DMA: Destination Address = 0x%016h", dst_addr), UVM_HIGH)
+  endtask : set_dst_addr
 
   task set_dst_addr_range(bit[63:0] almost_limit,
                                      bit[63:0] limit);
@@ -302,13 +302,13 @@ class dma_base_vseq extends cip_base_vseq #(
   endtask : set_dma_enabled_memory_range
 
   // Task: Write to Source and Destination Address Space ID (ASID)
-  task set_address_space_id(asid_encoding_e src_asid, asid_encoding_e dst_asid);
-    ral.address_space_id.src_asid.set(int'(src_asid));
-    ral.address_space_id.dst_asid.set(int'(dst_asid));
-    csr_update(.csr(ral.address_space_id));
+  task set_addr_space_id(asid_encoding_e src_asid, asid_encoding_e dst_asid);
+    ral.addr_space_id.src_asid.set(int'(src_asid));
+    ral.addr_space_id.dst_asid.set(int'(dst_asid));
+    csr_update(.csr(ral.addr_space_id));
     `uvm_info(`gfn, $sformatf("DMA: Source ASID = %d", src_asid), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("DMA: Destination ASID = %d", dst_asid), UVM_HIGH)
-  endtask : set_address_space_id
+  endtask : set_addr_space_id
 
   // Task: Set number of bytes to transfer
   task set_total_size(bit [31:0] total_data_size);
@@ -348,10 +348,10 @@ class dma_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "DMA: Start Common Configuration", UVM_HIGH)
     // Not yet requested an Abort during this transaction.
     abort_pending = 1'b0;
-    set_src_address(dma_config.src_addr);
-    set_dst_address(dma_config.dst_addr);
-    set_dst_address_range(dma_config.dst_addr_almost_limit,  dma_config.dst_addr_limit);
-    set_address_space_id(dma_config.src_asid, dma_config.dst_asid);
+    set_src_addr(dma_config.src_addr);
+    set_dst_addr(dma_config.dst_addr);
+    set_dst_addr_range(dma_config.dst_addr_almost_limit, dma_config.dst_addr_limit);
+    set_addr_space_id(dma_config.src_asid, dma_config.dst_asid);
     set_total_size(dma_config.total_data_size);
     set_chunk_data_size(dma_config.chunk_data_size);
     set_transfer_width(dma_config.per_transfer_width);

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -271,21 +271,21 @@ class dma_base_vseq extends cip_base_vseq #(
   endtask : set_src_address
 
   // Task: Write to Destination Address CSR
-  task set_destination_address(bit [63:0] destination_address);
-    csr_wr(ral.destination_address_lo, destination_address[31:0]);
-    csr_wr(ral.destination_address_hi, destination_address[63:32]);
-    `uvm_info(`gfn, $sformatf("DMA: Destination Address = 0x%016h", destination_address), UVM_HIGH)
-  endtask : set_destination_address
+  task set_dst_address(bit [63:0] dst_address);
+    csr_wr(ral.dst_addr_lo, dst_address[31:0]);
+    csr_wr(ral.dst_addr_hi, dst_address[63:32]);
+    `uvm_info(`gfn, $sformatf("DMA: Destination Address = 0x%016h", dst_address), UVM_HIGH)
+  endtask : set_dst_address
 
-  task set_destination_address_range(bit[63:0] almost_limit,
+  task set_dst_addr_range(bit[63:0] almost_limit,
                                      bit[63:0] limit);
-    csr_wr(ral.destination_address_limit_lo, limit[31:0]);
-    csr_wr(ral.destination_address_limit_hi, limit[63:32]);
+    csr_wr(ral.dst_addr_limit_lo, limit[31:0]);
+    csr_wr(ral.dst_addr_limit_hi, limit[63:32]);
     `uvm_info(`gfn, $sformatf("DMA: Destination Limit = 0x%016h", limit), UVM_HIGH)
-    csr_wr(ral.destination_address_almost_limit_lo, almost_limit[31:0]);
-    csr_wr(ral.destination_address_almost_limit_hi, almost_limit[63:32]);
+    csr_wr(ral.dst_addr_almost_limit_lo, almost_limit[31:0]);
+    csr_wr(ral.dst_addr_almost_limit_hi, almost_limit[63:32]);
     `uvm_info(`gfn, $sformatf("DMA: Destination Almost Limit = 0x%016h", almost_limit), UVM_HIGH)
-  endtask : set_destination_address_range
+  endtask : set_dst_addr_range
 
   // Task: Set DMA Enabled Memory base and limit
   task set_dma_enabled_memory_range(bit [32:0] base, bit [31:0] limit, bit valid, mubi4_t lock);
@@ -304,7 +304,7 @@ class dma_base_vseq extends cip_base_vseq #(
   // Task: Write to Source and Destination Address Space ID (ASID)
   task set_address_space_id(asid_encoding_e src_asid, asid_encoding_e dst_asid);
     ral.address_space_id.src_asid.set(int'(src_asid));
-    ral.address_space_id.destination_asid.set(int'(dst_asid));
+    ral.address_space_id.dst_asid.set(int'(dst_asid));
     csr_update(.csr(ral.address_space_id));
     `uvm_info(`gfn, $sformatf("DMA: Source ASID = %d", src_asid), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("DMA: Destination ASID = %d", dst_asid), UVM_HIGH)
@@ -349,9 +349,8 @@ class dma_base_vseq extends cip_base_vseq #(
     // Not yet requested an Abort during this transaction.
     abort_pending = 1'b0;
     set_src_address(dma_config.src_addr);
-    set_destination_address(dma_config.dst_addr);
-    set_destination_address_range(dma_config.dst_addr_almost_limit,
-                                  dma_config.dst_addr_limit);
+    set_dst_address(dma_config.dst_addr);
+    set_dst_address_range(dma_config.dst_addr_almost_limit,  dma_config.dst_addr_limit);
     set_address_space_id(dma_config.src_asid, dma_config.dst_asid);
     set_total_size(dma_config.total_data_size);
     set_chunk_data_size(dma_config.chunk_data_size);

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -264,11 +264,11 @@ class dma_base_vseq extends cip_base_vseq #(
   endfunction
 
   // Task: Write to Source Address CSR
-  task set_source_address(bit [63:0] source_address);
-    `uvm_info(`gfn, $sformatf("DMA: Source Address = 0x%016h", source_address), UVM_HIGH)
-    csr_wr(ral.source_address_lo, source_address[31:0]);
-    csr_wr(ral.source_address_hi, source_address[63:32]);
-  endtask : set_source_address
+  task set_src_address(bit [63:0] src_address);
+    `uvm_info(`gfn, $sformatf("DMA: Source Address = 0x%016h", src_address), UVM_HIGH)
+    csr_wr(ral.src_address_lo, src_address[31:0]);
+    csr_wr(ral.src_address_hi, src_address[63:32]);
+  endtask : set_src_address
 
   // Task: Write to Destination Address CSR
   task set_destination_address(bit [63:0] destination_address);
@@ -303,7 +303,7 @@ class dma_base_vseq extends cip_base_vseq #(
 
   // Task: Write to Source and Destination Address Space ID (ASID)
   task set_address_space_id(asid_encoding_e src_asid, asid_encoding_e dst_asid);
-    ral.address_space_id.source_asid.set(int'(src_asid));
+    ral.address_space_id.src_asid.set(int'(src_asid));
     ral.address_space_id.destination_asid.set(int'(dst_asid));
     csr_update(.csr(ral.address_space_id));
     `uvm_info(`gfn, $sformatf("DMA: Source ASID = %d", src_asid), UVM_HIGH)
@@ -335,8 +335,8 @@ class dma_base_vseq extends cip_base_vseq #(
     csr_wr(ral.clear_intr_src, dma_config.clear_intr_src);
     csr_wr(ral.clear_intr_bus, dma_config.clear_intr_bus);
     foreach (dma_config.intr_src_addr[i]) begin
-      csr_wr(ral.intr_source_addr[i], dma_config.intr_src_addr[i]);
-      csr_wr(ral.intr_source_wr_val[i], dma_config.intr_src_wr_val[i]);
+      csr_wr(ral.intr_src_addr[i], dma_config.intr_src_addr[i]);
+      csr_wr(ral.intr_src_wr_val[i], dma_config.intr_src_wr_val[i]);
     end
     ral.handshake_intr_enable.set(dma_config.handshake_intr_en);
     csr_update(ral.handshake_intr_enable);
@@ -348,7 +348,7 @@ class dma_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "DMA: Start Common Configuration", UVM_HIGH)
     // Not yet requested an Abort during this transaction.
     abort_pending = 1'b0;
-    set_source_address(dma_config.src_addr);
+    set_src_address(dma_config.src_addr);
     set_destination_address(dma_config.dst_addr);
     set_destination_address_range(dma_config.dst_addr_almost_limit,
                                   dma_config.dst_addr_limit);

--- a/hw/ip/dma/rtl/dma_pkg.sv
+++ b/hw/ip/dma/rtl/dma_pkg.sv
@@ -9,7 +9,7 @@ package dma_pkg;
 
   // Possible error bits the DMA can raise
   typedef enum logic [3:0] {
-    DmaSourceAddrErr,
+    DmaSrcAddrErr,
     DmaDestAddrErr,
     DmaOpcodeErr,
     DmaSizeErr,

--- a/hw/ip/dma/rtl/dma_pkg.sv
+++ b/hw/ip/dma/rtl/dma_pkg.sv
@@ -10,7 +10,7 @@ package dma_pkg;
   // Possible error bits the DMA can raise
   typedef enum logic [3:0] {
     DmaSrcAddrErr,
-    DmaDestAddrErr,
+    DmaDstAddrErr,
     DmaOpcodeErr,
     DmaSizeErr,
     DmaBusErr,

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -71,11 +71,11 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_lo_reg_t;
+  } dma_reg2hw_dst_address_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_hi_reg_t;
+  } dma_reg2hw_dst_address_hi_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -83,7 +83,7 @@ package dma_reg_pkg;
     } src_asid;
     struct packed {
       logic [3:0]  q;
-    } destination_asid;
+    } dst_asid;
   } dma_reg2hw_address_space_id_reg_t;
 
   typedef struct packed {
@@ -118,19 +118,19 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_limit_lo_reg_t;
+  } dma_reg2hw_dst_address_limit_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_limit_hi_reg_t;
+  } dma_reg2hw_dst_address_limit_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_almost_limit_lo_reg_t;
+  } dma_reg2hw_dst_address_almost_limit_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_destination_address_almost_limit_hi_reg_t;
+  } dma_reg2hw_dst_address_almost_limit_hi_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -225,12 +225,12 @@ package dma_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_destination_address_lo_reg_t;
+  } dma_hw2reg_dst_address_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_destination_address_hi_reg_t;
+  } dma_hw2reg_dst_address_hi_reg_t;
 
   typedef struct packed {
     logic [3:0]  d;
@@ -322,8 +322,8 @@ package dma_reg_pkg;
     dma_reg2hw_alert_test_reg_t alert_test; // [1157:1156]
     dma_reg2hw_src_address_lo_reg_t src_address_lo; // [1155:1124]
     dma_reg2hw_src_address_hi_reg_t src_address_hi; // [1123:1092]
-    dma_reg2hw_destination_address_lo_reg_t destination_address_lo; // [1091:1060]
-    dma_reg2hw_destination_address_hi_reg_t destination_address_hi; // [1059:1028]
+    dma_reg2hw_dst_address_lo_reg_t dst_address_lo; // [1091:1060]
+    dma_reg2hw_dst_address_hi_reg_t dst_address_hi; // [1059:1028]
     dma_reg2hw_address_space_id_reg_t address_space_id; // [1027:1020]
     dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [1019:987]
     dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [986:954]
@@ -332,12 +332,10 @@ package dma_reg_pkg;
     dma_reg2hw_total_data_size_reg_t total_data_size; // [948:917]
     dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [916:885]
     dma_reg2hw_transfer_width_reg_t transfer_width; // [884:883]
-    dma_reg2hw_destination_address_limit_lo_reg_t destination_address_limit_lo; // [882:851]
-    dma_reg2hw_destination_address_limit_hi_reg_t destination_address_limit_hi; // [850:819]
-    dma_reg2hw_destination_address_almost_limit_lo_reg_t
-        destination_address_almost_limit_lo; // [818:787]
-    dma_reg2hw_destination_address_almost_limit_hi_reg_t
-        destination_address_almost_limit_hi; // [786:755]
+    dma_reg2hw_dst_address_limit_lo_reg_t dst_address_limit_lo; // [882:851]
+    dma_reg2hw_dst_address_limit_hi_reg_t dst_address_limit_hi; // [850:819]
+    dma_reg2hw_dst_address_almost_limit_lo_reg_t dst_address_almost_limit_lo; // [818:787]
+    dma_reg2hw_dst_address_almost_limit_hi_reg_t dst_address_almost_limit_hi; // [786:755]
     dma_reg2hw_control_reg_t control; // [754:743]
     dma_reg2hw_status_reg_t status; // [742:737]
     dma_reg2hw_handshake_intr_enable_reg_t handshake_intr_enable; // [736:726]
@@ -352,8 +350,8 @@ package dma_reg_pkg;
     dma_hw2reg_intr_state_reg_t intr_state; // [701:696]
     dma_hw2reg_src_address_lo_reg_t src_address_lo; // [695:663]
     dma_hw2reg_src_address_hi_reg_t src_address_hi; // [662:630]
-    dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [629:597]
-    dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [596:564]
+    dma_hw2reg_dst_address_lo_reg_t dst_address_lo; // [629:597]
+    dma_hw2reg_dst_address_hi_reg_t dst_address_hi; // [596:564]
     dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [563:560]
     dma_hw2reg_control_reg_t control; // [559:554]
     dma_hw2reg_status_reg_t status; // [553:544]
@@ -368,8 +366,8 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_ALERT_TEST_OFFSET = 9'h c;
   parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_LO_OFFSET = 9'h 10;
   parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_HI_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LO_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_HI_OFFSET = 9'h 1c;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LO_OFFSET = 9'h 18;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_HI_OFFSET = 9'h 1c;
   parameter logic [BlockAw-1:0] DMA_ADDRESS_SPACE_ID_OFFSET = 9'h 20;
   parameter logic [BlockAw-1:0] DMA_ENABLED_MEMORY_RANGE_BASE_OFFSET = 9'h 24;
   parameter logic [BlockAw-1:0] DMA_ENABLED_MEMORY_RANGE_LIMIT_OFFSET = 9'h 28;
@@ -379,10 +377,10 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_TOTAL_DATA_SIZE_OFFSET = 9'h 38;
   parameter logic [BlockAw-1:0] DMA_CHUNK_DATA_SIZE_OFFSET = 9'h 3c;
   parameter logic [BlockAw-1:0] DMA_TRANSFER_WIDTH_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_LO_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LIMIT_HI_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LIMIT_LO_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LIMIT_HI_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_ALMOST_LIMIT_LO_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_ALMOST_LIMIT_HI_OFFSET = 9'h 50;
   parameter logic [BlockAw-1:0] DMA_CONTROL_OFFSET = 9'h 54;
   parameter logic [BlockAw-1:0] DMA_STATUS_OFFSET = 9'h 58;
   parameter logic [BlockAw-1:0] DMA_ERROR_CODE_OFFSET = 9'h 5c;
@@ -446,8 +444,8 @@ package dma_reg_pkg;
     DMA_ALERT_TEST,
     DMA_SRC_ADDRESS_LO,
     DMA_SRC_ADDRESS_HI,
-    DMA_DESTINATION_ADDRESS_LO,
-    DMA_DESTINATION_ADDRESS_HI,
+    DMA_DST_ADDRESS_LO,
+    DMA_DST_ADDRESS_HI,
     DMA_ADDRESS_SPACE_ID,
     DMA_ENABLED_MEMORY_RANGE_BASE,
     DMA_ENABLED_MEMORY_RANGE_LIMIT,
@@ -457,10 +455,10 @@ package dma_reg_pkg;
     DMA_TOTAL_DATA_SIZE,
     DMA_CHUNK_DATA_SIZE,
     DMA_TRANSFER_WIDTH,
-    DMA_DESTINATION_ADDRESS_LIMIT_LO,
-    DMA_DESTINATION_ADDRESS_LIMIT_HI,
-    DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO,
-    DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI,
+    DMA_DST_ADDRESS_LIMIT_LO,
+    DMA_DST_ADDRESS_LIMIT_HI,
+    DMA_DST_ADDRESS_ALMOST_LIMIT_LO,
+    DMA_DST_ADDRESS_ALMOST_LIMIT_HI,
     DMA_CONTROL,
     DMA_STATUS,
     DMA_ERROR_CODE,
@@ -515,8 +513,8 @@ package dma_reg_pkg;
     4'b 0001, // index[ 3] DMA_ALERT_TEST
     4'b 1111, // index[ 4] DMA_SRC_ADDRESS_LO
     4'b 1111, // index[ 5] DMA_SRC_ADDRESS_HI
-    4'b 1111, // index[ 6] DMA_DESTINATION_ADDRESS_LO
-    4'b 1111, // index[ 7] DMA_DESTINATION_ADDRESS_HI
+    4'b 1111, // index[ 6] DMA_DST_ADDRESS_LO
+    4'b 1111, // index[ 7] DMA_DST_ADDRESS_HI
     4'b 0001, // index[ 8] DMA_ADDRESS_SPACE_ID
     4'b 1111, // index[ 9] DMA_ENABLED_MEMORY_RANGE_BASE
     4'b 1111, // index[10] DMA_ENABLED_MEMORY_RANGE_LIMIT
@@ -526,10 +524,10 @@ package dma_reg_pkg;
     4'b 1111, // index[14] DMA_TOTAL_DATA_SIZE
     4'b 1111, // index[15] DMA_CHUNK_DATA_SIZE
     4'b 0001, // index[16] DMA_TRANSFER_WIDTH
-    4'b 1111, // index[17] DMA_DESTINATION_ADDRESS_LIMIT_LO
-    4'b 1111, // index[18] DMA_DESTINATION_ADDRESS_LIMIT_HI
-    4'b 1111, // index[19] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO
-    4'b 1111, // index[20] DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI
+    4'b 1111, // index[17] DMA_DST_ADDRESS_LIMIT_LO
+    4'b 1111, // index[18] DMA_DST_ADDRESS_LIMIT_HI
+    4'b 1111, // index[19] DMA_DST_ADDRESS_ALMOST_LIMIT_LO
+    4'b 1111, // index[20] DMA_DST_ADDRESS_ALMOST_LIMIT_HI
     4'b 1111, // index[21] DMA_CONTROL
     4'b 0001, // index[22] DMA_STATUS
     4'b 0001, // index[23] DMA_ERROR_CODE

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -63,19 +63,19 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_src_address_lo_reg_t;
+  } dma_reg2hw_src_addr_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_src_address_hi_reg_t;
+  } dma_reg2hw_src_addr_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_lo_reg_t;
+  } dma_reg2hw_dst_addr_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_hi_reg_t;
+  } dma_reg2hw_dst_addr_hi_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -84,7 +84,7 @@ package dma_reg_pkg;
     struct packed {
       logic [3:0]  q;
     } dst_asid;
-  } dma_reg2hw_address_space_id_reg_t;
+  } dma_reg2hw_addr_space_id_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -118,19 +118,19 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_limit_lo_reg_t;
+  } dma_reg2hw_dst_addr_limit_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_limit_hi_reg_t;
+  } dma_reg2hw_dst_addr_limit_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_almost_limit_lo_reg_t;
+  } dma_reg2hw_dst_addr_almost_limit_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_dst_address_almost_limit_hi_reg_t;
+  } dma_reg2hw_dst_addr_almost_limit_hi_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -215,22 +215,22 @@ package dma_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_src_address_lo_reg_t;
+  } dma_hw2reg_src_addr_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_src_address_hi_reg_t;
+  } dma_hw2reg_src_addr_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_dst_address_lo_reg_t;
+  } dma_hw2reg_dst_addr_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_dst_address_hi_reg_t;
+  } dma_hw2reg_dst_addr_hi_reg_t;
 
   typedef struct packed {
     logic [3:0]  d;
@@ -278,11 +278,11 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } src_address_error;
+    } src_addr_error;
     struct packed {
       logic        d;
       logic        de;
-    } dst_address_error;
+    } dst_addr_error;
     struct packed {
       logic        d;
       logic        de;
@@ -320,11 +320,11 @@ package dma_reg_pkg;
     dma_reg2hw_intr_enable_reg_t intr_enable; // [1166:1164]
     dma_reg2hw_intr_test_reg_t intr_test; // [1163:1158]
     dma_reg2hw_alert_test_reg_t alert_test; // [1157:1156]
-    dma_reg2hw_src_address_lo_reg_t src_address_lo; // [1155:1124]
-    dma_reg2hw_src_address_hi_reg_t src_address_hi; // [1123:1092]
-    dma_reg2hw_dst_address_lo_reg_t dst_address_lo; // [1091:1060]
-    dma_reg2hw_dst_address_hi_reg_t dst_address_hi; // [1059:1028]
-    dma_reg2hw_address_space_id_reg_t address_space_id; // [1027:1020]
+    dma_reg2hw_src_addr_lo_reg_t src_addr_lo; // [1155:1124]
+    dma_reg2hw_src_addr_hi_reg_t src_addr_hi; // [1123:1092]
+    dma_reg2hw_dst_addr_lo_reg_t dst_addr_lo; // [1091:1060]
+    dma_reg2hw_dst_addr_hi_reg_t dst_addr_hi; // [1059:1028]
+    dma_reg2hw_addr_space_id_reg_t addr_space_id; // [1027:1020]
     dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [1019:987]
     dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [986:954]
     dma_reg2hw_range_valid_reg_t range_valid; // [953:953]
@@ -332,10 +332,10 @@ package dma_reg_pkg;
     dma_reg2hw_total_data_size_reg_t total_data_size; // [948:917]
     dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [916:885]
     dma_reg2hw_transfer_width_reg_t transfer_width; // [884:883]
-    dma_reg2hw_dst_address_limit_lo_reg_t dst_address_limit_lo; // [882:851]
-    dma_reg2hw_dst_address_limit_hi_reg_t dst_address_limit_hi; // [850:819]
-    dma_reg2hw_dst_address_almost_limit_lo_reg_t dst_address_almost_limit_lo; // [818:787]
-    dma_reg2hw_dst_address_almost_limit_hi_reg_t dst_address_almost_limit_hi; // [786:755]
+    dma_reg2hw_dst_addr_limit_lo_reg_t dst_addr_limit_lo; // [882:851]
+    dma_reg2hw_dst_addr_limit_hi_reg_t dst_addr_limit_hi; // [850:819]
+    dma_reg2hw_dst_addr_almost_limit_lo_reg_t dst_addr_almost_limit_lo; // [818:787]
+    dma_reg2hw_dst_addr_almost_limit_hi_reg_t dst_addr_almost_limit_hi; // [786:755]
     dma_reg2hw_control_reg_t control; // [754:743]
     dma_reg2hw_status_reg_t status; // [742:737]
     dma_reg2hw_handshake_intr_enable_reg_t handshake_intr_enable; // [736:726]
@@ -348,10 +348,10 @@ package dma_reg_pkg;
   // HW -> register type
   typedef struct packed {
     dma_hw2reg_intr_state_reg_t intr_state; // [701:696]
-    dma_hw2reg_src_address_lo_reg_t src_address_lo; // [695:663]
-    dma_hw2reg_src_address_hi_reg_t src_address_hi; // [662:630]
-    dma_hw2reg_dst_address_lo_reg_t dst_address_lo; // [629:597]
-    dma_hw2reg_dst_address_hi_reg_t dst_address_hi; // [596:564]
+    dma_hw2reg_src_addr_lo_reg_t src_addr_lo; // [695:663]
+    dma_hw2reg_src_addr_hi_reg_t src_addr_hi; // [662:630]
+    dma_hw2reg_dst_addr_lo_reg_t dst_addr_lo; // [629:597]
+    dma_hw2reg_dst_addr_hi_reg_t dst_addr_hi; // [596:564]
     dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [563:560]
     dma_hw2reg_control_reg_t control; // [559:554]
     dma_hw2reg_status_reg_t status; // [553:544]
@@ -364,11 +364,11 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_INTR_ENABLE_OFFSET = 9'h 4;
   parameter logic [BlockAw-1:0] DMA_INTR_TEST_OFFSET = 9'h 8;
   parameter logic [BlockAw-1:0] DMA_ALERT_TEST_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_LO_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_HI_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LO_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_HI_OFFSET = 9'h 1c;
-  parameter logic [BlockAw-1:0] DMA_ADDRESS_SPACE_ID_OFFSET = 9'h 20;
+  parameter logic [BlockAw-1:0] DMA_SRC_ADDR_LO_OFFSET = 9'h 10;
+  parameter logic [BlockAw-1:0] DMA_SRC_ADDR_HI_OFFSET = 9'h 14;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_LO_OFFSET = 9'h 18;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_HI_OFFSET = 9'h 1c;
+  parameter logic [BlockAw-1:0] DMA_ADDR_SPACE_ID_OFFSET = 9'h 20;
   parameter logic [BlockAw-1:0] DMA_ENABLED_MEMORY_RANGE_BASE_OFFSET = 9'h 24;
   parameter logic [BlockAw-1:0] DMA_ENABLED_MEMORY_RANGE_LIMIT_OFFSET = 9'h 28;
   parameter logic [BlockAw-1:0] DMA_RANGE_VALID_OFFSET = 9'h 2c;
@@ -377,10 +377,10 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_TOTAL_DATA_SIZE_OFFSET = 9'h 38;
   parameter logic [BlockAw-1:0] DMA_CHUNK_DATA_SIZE_OFFSET = 9'h 3c;
   parameter logic [BlockAw-1:0] DMA_TRANSFER_WIDTH_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LIMIT_LO_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_LIMIT_HI_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_ALMOST_LIMIT_LO_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] DMA_DST_ADDRESS_ALMOST_LIMIT_HI_OFFSET = 9'h 50;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_LIMIT_LO_OFFSET = 9'h 44;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_LIMIT_HI_OFFSET = 9'h 48;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_ALMOST_LIMIT_LO_OFFSET = 9'h 4c;
+  parameter logic [BlockAw-1:0] DMA_DST_ADDR_ALMOST_LIMIT_HI_OFFSET = 9'h 50;
   parameter logic [BlockAw-1:0] DMA_CONTROL_OFFSET = 9'h 54;
   parameter logic [BlockAw-1:0] DMA_STATUS_OFFSET = 9'h 58;
   parameter logic [BlockAw-1:0] DMA_ERROR_CODE_OFFSET = 9'h 5c;
@@ -442,11 +442,11 @@ package dma_reg_pkg;
     DMA_INTR_ENABLE,
     DMA_INTR_TEST,
     DMA_ALERT_TEST,
-    DMA_SRC_ADDRESS_LO,
-    DMA_SRC_ADDRESS_HI,
-    DMA_DST_ADDRESS_LO,
-    DMA_DST_ADDRESS_HI,
-    DMA_ADDRESS_SPACE_ID,
+    DMA_SRC_ADDR_LO,
+    DMA_SRC_ADDR_HI,
+    DMA_DST_ADDR_LO,
+    DMA_DST_ADDR_HI,
+    DMA_ADDR_SPACE_ID,
     DMA_ENABLED_MEMORY_RANGE_BASE,
     DMA_ENABLED_MEMORY_RANGE_LIMIT,
     DMA_RANGE_VALID,
@@ -455,10 +455,10 @@ package dma_reg_pkg;
     DMA_TOTAL_DATA_SIZE,
     DMA_CHUNK_DATA_SIZE,
     DMA_TRANSFER_WIDTH,
-    DMA_DST_ADDRESS_LIMIT_LO,
-    DMA_DST_ADDRESS_LIMIT_HI,
-    DMA_DST_ADDRESS_ALMOST_LIMIT_LO,
-    DMA_DST_ADDRESS_ALMOST_LIMIT_HI,
+    DMA_DST_ADDR_LIMIT_LO,
+    DMA_DST_ADDR_LIMIT_HI,
+    DMA_DST_ADDR_ALMOST_LIMIT_LO,
+    DMA_DST_ADDR_ALMOST_LIMIT_HI,
     DMA_CONTROL,
     DMA_STATUS,
     DMA_ERROR_CODE,
@@ -511,11 +511,11 @@ package dma_reg_pkg;
     4'b 0001, // index[ 1] DMA_INTR_ENABLE
     4'b 0001, // index[ 2] DMA_INTR_TEST
     4'b 0001, // index[ 3] DMA_ALERT_TEST
-    4'b 1111, // index[ 4] DMA_SRC_ADDRESS_LO
-    4'b 1111, // index[ 5] DMA_SRC_ADDRESS_HI
-    4'b 1111, // index[ 6] DMA_DST_ADDRESS_LO
-    4'b 1111, // index[ 7] DMA_DST_ADDRESS_HI
-    4'b 0001, // index[ 8] DMA_ADDRESS_SPACE_ID
+    4'b 1111, // index[ 4] DMA_SRC_ADDR_LO
+    4'b 1111, // index[ 5] DMA_SRC_ADDR_HI
+    4'b 1111, // index[ 6] DMA_DST_ADDR_LO
+    4'b 1111, // index[ 7] DMA_DST_ADDR_HI
+    4'b 0001, // index[ 8] DMA_ADDR_SPACE_ID
     4'b 1111, // index[ 9] DMA_ENABLED_MEMORY_RANGE_BASE
     4'b 1111, // index[10] DMA_ENABLED_MEMORY_RANGE_LIMIT
     4'b 0001, // index[11] DMA_RANGE_VALID
@@ -524,10 +524,10 @@ package dma_reg_pkg;
     4'b 1111, // index[14] DMA_TOTAL_DATA_SIZE
     4'b 1111, // index[15] DMA_CHUNK_DATA_SIZE
     4'b 0001, // index[16] DMA_TRANSFER_WIDTH
-    4'b 1111, // index[17] DMA_DST_ADDRESS_LIMIT_LO
-    4'b 1111, // index[18] DMA_DST_ADDRESS_LIMIT_HI
-    4'b 1111, // index[19] DMA_DST_ADDRESS_ALMOST_LIMIT_LO
-    4'b 1111, // index[20] DMA_DST_ADDRESS_ALMOST_LIMIT_HI
+    4'b 1111, // index[17] DMA_DST_ADDR_LIMIT_LO
+    4'b 1111, // index[18] DMA_DST_ADDR_LIMIT_HI
+    4'b 1111, // index[19] DMA_DST_ADDR_ALMOST_LIMIT_LO
+    4'b 1111, // index[20] DMA_DST_ADDR_ALMOST_LIMIT_HI
     4'b 1111, // index[21] DMA_CONTROL
     4'b 0001, // index[22] DMA_STATUS
     4'b 0001, // index[23] DMA_ERROR_CODE

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -63,11 +63,11 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_source_address_lo_reg_t;
+  } dma_reg2hw_src_address_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_source_address_hi_reg_t;
+  } dma_reg2hw_src_address_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -80,7 +80,7 @@ package dma_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [3:0]  q;
-    } source_asid;
+    } src_asid;
     struct packed {
       logic [3:0]  q;
     } destination_asid;
@@ -191,11 +191,11 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_intr_source_addr_mreg_t;
+  } dma_reg2hw_intr_src_addr_mreg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_intr_source_wr_val_mreg_t;
+  } dma_reg2hw_intr_src_wr_val_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -215,12 +215,12 @@ package dma_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_source_address_lo_reg_t;
+  } dma_hw2reg_src_address_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } dma_hw2reg_source_address_hi_reg_t;
+  } dma_hw2reg_src_address_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -320,8 +320,8 @@ package dma_reg_pkg;
     dma_reg2hw_intr_enable_reg_t intr_enable; // [1166:1164]
     dma_reg2hw_intr_test_reg_t intr_test; // [1163:1158]
     dma_reg2hw_alert_test_reg_t alert_test; // [1157:1156]
-    dma_reg2hw_source_address_lo_reg_t source_address_lo; // [1155:1124]
-    dma_reg2hw_source_address_hi_reg_t source_address_hi; // [1123:1092]
+    dma_reg2hw_src_address_lo_reg_t src_address_lo; // [1155:1124]
+    dma_reg2hw_src_address_hi_reg_t src_address_hi; // [1123:1092]
     dma_reg2hw_destination_address_lo_reg_t destination_address_lo; // [1091:1060]
     dma_reg2hw_destination_address_hi_reg_t destination_address_hi; // [1059:1028]
     dma_reg2hw_address_space_id_reg_t address_space_id; // [1027:1020]
@@ -343,15 +343,15 @@ package dma_reg_pkg;
     dma_reg2hw_handshake_intr_enable_reg_t handshake_intr_enable; // [736:726]
     dma_reg2hw_clear_intr_src_reg_t clear_intr_src; // [725:715]
     dma_reg2hw_clear_intr_bus_reg_t clear_intr_bus; // [714:704]
-    dma_reg2hw_intr_source_addr_mreg_t [10:0] intr_source_addr; // [703:352]
-    dma_reg2hw_intr_source_wr_val_mreg_t [10:0] intr_source_wr_val; // [351:0]
+    dma_reg2hw_intr_src_addr_mreg_t [10:0] intr_src_addr; // [703:352]
+    dma_reg2hw_intr_src_wr_val_mreg_t [10:0] intr_src_wr_val; // [351:0]
   } dma_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
     dma_hw2reg_intr_state_reg_t intr_state; // [701:696]
-    dma_hw2reg_source_address_lo_reg_t source_address_lo; // [695:663]
-    dma_hw2reg_source_address_hi_reg_t source_address_hi; // [662:630]
+    dma_hw2reg_src_address_lo_reg_t src_address_lo; // [695:663]
+    dma_hw2reg_src_address_hi_reg_t src_address_hi; // [662:630]
     dma_hw2reg_destination_address_lo_reg_t destination_address_lo; // [629:597]
     dma_hw2reg_destination_address_hi_reg_t destination_address_hi; // [596:564]
     dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [563:560]
@@ -366,8 +366,8 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_INTR_ENABLE_OFFSET = 9'h 4;
   parameter logic [BlockAw-1:0] DMA_INTR_TEST_OFFSET = 9'h 8;
   parameter logic [BlockAw-1:0] DMA_ALERT_TEST_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] DMA_SOURCE_ADDRESS_LO_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] DMA_SOURCE_ADDRESS_HI_OFFSET = 9'h 14;
+  parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_LO_OFFSET = 9'h 10;
+  parameter logic [BlockAw-1:0] DMA_SRC_ADDRESS_HI_OFFSET = 9'h 14;
   parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_LO_OFFSET = 9'h 18;
   parameter logic [BlockAw-1:0] DMA_DESTINATION_ADDRESS_HI_OFFSET = 9'h 1c;
   parameter logic [BlockAw-1:0] DMA_ADDRESS_SPACE_ID_OFFSET = 9'h 20;
@@ -405,28 +405,28 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_HANDSHAKE_INTR_ENABLE_OFFSET = 9'h a0;
   parameter logic [BlockAw-1:0] DMA_CLEAR_INTR_SRC_OFFSET = 9'h a4;
   parameter logic [BlockAw-1:0] DMA_CLEAR_INTR_BUS_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_0_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_1_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_2_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_3_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_4_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_5_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_6_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_7_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_8_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_9_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_10_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_0_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_1_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_2_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_3_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_4_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_5_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_6_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_7_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_8_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_9_OFFSET = 9'h 150;
-  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_10_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_0_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_1_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_2_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_3_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_4_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_5_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_6_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_7_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_8_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_9_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_ADDR_10_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_0_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_1_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_2_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_3_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_4_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_5_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_6_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_7_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_8_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_9_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_10_OFFSET = 9'h 154;
 
   // Reset values for hwext registers and their fields
   parameter logic [2:0] DMA_INTR_TEST_RESVAL = 3'h 0;
@@ -444,8 +444,8 @@ package dma_reg_pkg;
     DMA_INTR_ENABLE,
     DMA_INTR_TEST,
     DMA_ALERT_TEST,
-    DMA_SOURCE_ADDRESS_LO,
-    DMA_SOURCE_ADDRESS_HI,
+    DMA_SRC_ADDRESS_LO,
+    DMA_SRC_ADDRESS_HI,
     DMA_DESTINATION_ADDRESS_LO,
     DMA_DESTINATION_ADDRESS_HI,
     DMA_ADDRESS_SPACE_ID,
@@ -483,28 +483,28 @@ package dma_reg_pkg;
     DMA_HANDSHAKE_INTR_ENABLE,
     DMA_CLEAR_INTR_SRC,
     DMA_CLEAR_INTR_BUS,
-    DMA_INTR_SOURCE_ADDR_0,
-    DMA_INTR_SOURCE_ADDR_1,
-    DMA_INTR_SOURCE_ADDR_2,
-    DMA_INTR_SOURCE_ADDR_3,
-    DMA_INTR_SOURCE_ADDR_4,
-    DMA_INTR_SOURCE_ADDR_5,
-    DMA_INTR_SOURCE_ADDR_6,
-    DMA_INTR_SOURCE_ADDR_7,
-    DMA_INTR_SOURCE_ADDR_8,
-    DMA_INTR_SOURCE_ADDR_9,
-    DMA_INTR_SOURCE_ADDR_10,
-    DMA_INTR_SOURCE_WR_VAL_0,
-    DMA_INTR_SOURCE_WR_VAL_1,
-    DMA_INTR_SOURCE_WR_VAL_2,
-    DMA_INTR_SOURCE_WR_VAL_3,
-    DMA_INTR_SOURCE_WR_VAL_4,
-    DMA_INTR_SOURCE_WR_VAL_5,
-    DMA_INTR_SOURCE_WR_VAL_6,
-    DMA_INTR_SOURCE_WR_VAL_7,
-    DMA_INTR_SOURCE_WR_VAL_8,
-    DMA_INTR_SOURCE_WR_VAL_9,
-    DMA_INTR_SOURCE_WR_VAL_10
+    DMA_INTR_SRC_ADDR_0,
+    DMA_INTR_SRC_ADDR_1,
+    DMA_INTR_SRC_ADDR_2,
+    DMA_INTR_SRC_ADDR_3,
+    DMA_INTR_SRC_ADDR_4,
+    DMA_INTR_SRC_ADDR_5,
+    DMA_INTR_SRC_ADDR_6,
+    DMA_INTR_SRC_ADDR_7,
+    DMA_INTR_SRC_ADDR_8,
+    DMA_INTR_SRC_ADDR_9,
+    DMA_INTR_SRC_ADDR_10,
+    DMA_INTR_SRC_WR_VAL_0,
+    DMA_INTR_SRC_WR_VAL_1,
+    DMA_INTR_SRC_WR_VAL_2,
+    DMA_INTR_SRC_WR_VAL_3,
+    DMA_INTR_SRC_WR_VAL_4,
+    DMA_INTR_SRC_WR_VAL_5,
+    DMA_INTR_SRC_WR_VAL_6,
+    DMA_INTR_SRC_WR_VAL_7,
+    DMA_INTR_SRC_WR_VAL_8,
+    DMA_INTR_SRC_WR_VAL_9,
+    DMA_INTR_SRC_WR_VAL_10
   } dma_id_e;
 
   // Register width information to check illegal writes
@@ -513,8 +513,8 @@ package dma_reg_pkg;
     4'b 0001, // index[ 1] DMA_INTR_ENABLE
     4'b 0001, // index[ 2] DMA_INTR_TEST
     4'b 0001, // index[ 3] DMA_ALERT_TEST
-    4'b 1111, // index[ 4] DMA_SOURCE_ADDRESS_LO
-    4'b 1111, // index[ 5] DMA_SOURCE_ADDRESS_HI
+    4'b 1111, // index[ 4] DMA_SRC_ADDRESS_LO
+    4'b 1111, // index[ 5] DMA_SRC_ADDRESS_HI
     4'b 1111, // index[ 6] DMA_DESTINATION_ADDRESS_LO
     4'b 1111, // index[ 7] DMA_DESTINATION_ADDRESS_HI
     4'b 0001, // index[ 8] DMA_ADDRESS_SPACE_ID
@@ -552,28 +552,28 @@ package dma_reg_pkg;
     4'b 0011, // index[40] DMA_HANDSHAKE_INTR_ENABLE
     4'b 0011, // index[41] DMA_CLEAR_INTR_SRC
     4'b 0011, // index[42] DMA_CLEAR_INTR_BUS
-    4'b 1111, // index[43] DMA_INTR_SOURCE_ADDR_0
-    4'b 1111, // index[44] DMA_INTR_SOURCE_ADDR_1
-    4'b 1111, // index[45] DMA_INTR_SOURCE_ADDR_2
-    4'b 1111, // index[46] DMA_INTR_SOURCE_ADDR_3
-    4'b 1111, // index[47] DMA_INTR_SOURCE_ADDR_4
-    4'b 1111, // index[48] DMA_INTR_SOURCE_ADDR_5
-    4'b 1111, // index[49] DMA_INTR_SOURCE_ADDR_6
-    4'b 1111, // index[50] DMA_INTR_SOURCE_ADDR_7
-    4'b 1111, // index[51] DMA_INTR_SOURCE_ADDR_8
-    4'b 1111, // index[52] DMA_INTR_SOURCE_ADDR_9
-    4'b 1111, // index[53] DMA_INTR_SOURCE_ADDR_10
-    4'b 1111, // index[54] DMA_INTR_SOURCE_WR_VAL_0
-    4'b 1111, // index[55] DMA_INTR_SOURCE_WR_VAL_1
-    4'b 1111, // index[56] DMA_INTR_SOURCE_WR_VAL_2
-    4'b 1111, // index[57] DMA_INTR_SOURCE_WR_VAL_3
-    4'b 1111, // index[58] DMA_INTR_SOURCE_WR_VAL_4
-    4'b 1111, // index[59] DMA_INTR_SOURCE_WR_VAL_5
-    4'b 1111, // index[60] DMA_INTR_SOURCE_WR_VAL_6
-    4'b 1111, // index[61] DMA_INTR_SOURCE_WR_VAL_7
-    4'b 1111, // index[62] DMA_INTR_SOURCE_WR_VAL_8
-    4'b 1111, // index[63] DMA_INTR_SOURCE_WR_VAL_9
-    4'b 1111  // index[64] DMA_INTR_SOURCE_WR_VAL_10
+    4'b 1111, // index[43] DMA_INTR_SRC_ADDR_0
+    4'b 1111, // index[44] DMA_INTR_SRC_ADDR_1
+    4'b 1111, // index[45] DMA_INTR_SRC_ADDR_2
+    4'b 1111, // index[46] DMA_INTR_SRC_ADDR_3
+    4'b 1111, // index[47] DMA_INTR_SRC_ADDR_4
+    4'b 1111, // index[48] DMA_INTR_SRC_ADDR_5
+    4'b 1111, // index[49] DMA_INTR_SRC_ADDR_6
+    4'b 1111, // index[50] DMA_INTR_SRC_ADDR_7
+    4'b 1111, // index[51] DMA_INTR_SRC_ADDR_8
+    4'b 1111, // index[52] DMA_INTR_SRC_ADDR_9
+    4'b 1111, // index[53] DMA_INTR_SRC_ADDR_10
+    4'b 1111, // index[54] DMA_INTR_SRC_WR_VAL_0
+    4'b 1111, // index[55] DMA_INTR_SRC_WR_VAL_1
+    4'b 1111, // index[56] DMA_INTR_SRC_WR_VAL_2
+    4'b 1111, // index[57] DMA_INTR_SRC_WR_VAL_3
+    4'b 1111, // index[58] DMA_INTR_SRC_WR_VAL_4
+    4'b 1111, // index[59] DMA_INTR_SRC_WR_VAL_5
+    4'b 1111, // index[60] DMA_INTR_SRC_WR_VAL_6
+    4'b 1111, // index[61] DMA_INTR_SRC_WR_VAL_7
+    4'b 1111, // index[62] DMA_INTR_SRC_WR_VAL_8
+    4'b 1111, // index[63] DMA_INTR_SRC_WR_VAL_9
+    4'b 1111  // index[64] DMA_INTR_SRC_WR_VAL_10
   };
 
 endpackage

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -179,23 +179,23 @@ package dma_reg_pkg;
 
   typedef struct packed {
     logic [10:0] q;
-  } dma_reg2hw_handshake_interrupt_enable_reg_t;
+  } dma_reg2hw_handshake_intr_enable_reg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } dma_reg2hw_clear_int_src_reg_t;
+  } dma_reg2hw_clear_intr_src_reg_t;
 
   typedef struct packed {
     logic [10:0] q;
-  } dma_reg2hw_clear_int_bus_reg_t;
+  } dma_reg2hw_clear_intr_bus_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_int_source_addr_mreg_t;
+  } dma_reg2hw_intr_source_addr_mreg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } dma_reg2hw_int_source_wr_val_mreg_t;
+  } dma_reg2hw_intr_source_wr_val_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -340,11 +340,11 @@ package dma_reg_pkg;
         destination_address_almost_limit_hi; // [786:755]
     dma_reg2hw_control_reg_t control; // [754:743]
     dma_reg2hw_status_reg_t status; // [742:737]
-    dma_reg2hw_handshake_interrupt_enable_reg_t handshake_interrupt_enable; // [736:726]
-    dma_reg2hw_clear_int_src_reg_t clear_int_src; // [725:715]
-    dma_reg2hw_clear_int_bus_reg_t clear_int_bus; // [714:704]
-    dma_reg2hw_int_source_addr_mreg_t [10:0] int_source_addr; // [703:352]
-    dma_reg2hw_int_source_wr_val_mreg_t [10:0] int_source_wr_val; // [351:0]
+    dma_reg2hw_handshake_intr_enable_reg_t handshake_intr_enable; // [736:726]
+    dma_reg2hw_clear_intr_src_reg_t clear_intr_src; // [725:715]
+    dma_reg2hw_clear_intr_bus_reg_t clear_intr_bus; // [714:704]
+    dma_reg2hw_intr_source_addr_mreg_t [10:0] intr_source_addr; // [703:352]
+    dma_reg2hw_intr_source_wr_val_mreg_t [10:0] intr_source_wr_val; // [351:0]
   } dma_reg2hw_t;
 
   // HW -> register type
@@ -402,31 +402,31 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_13_OFFSET = 9'h 94;
   parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_14_OFFSET = 9'h 98;
   parameter logic [BlockAw-1:0] DMA_SHA2_DIGEST_15_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] DMA_HANDSHAKE_INTERRUPT_ENABLE_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_SRC_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] DMA_CLEAR_INT_BUS_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_0_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_1_OFFSET = 9'h b0;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_2_OFFSET = 9'h b4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_3_OFFSET = 9'h b8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_4_OFFSET = 9'h bc;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_5_OFFSET = 9'h c0;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_6_OFFSET = 9'h c4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_7_OFFSET = 9'h c8;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_8_OFFSET = 9'h cc;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_9_OFFSET = 9'h d0;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_ADDR_10_OFFSET = 9'h d4;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_0_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_1_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_2_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_3_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_4_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_5_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_6_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_7_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_8_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_9_OFFSET = 9'h 150;
-  parameter logic [BlockAw-1:0] DMA_INT_SOURCE_WR_VAL_10_OFFSET = 9'h 154;
+  parameter logic [BlockAw-1:0] DMA_HANDSHAKE_INTR_ENABLE_OFFSET = 9'h a0;
+  parameter logic [BlockAw-1:0] DMA_CLEAR_INTR_SRC_OFFSET = 9'h a4;
+  parameter logic [BlockAw-1:0] DMA_CLEAR_INTR_BUS_OFFSET = 9'h a8;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_0_OFFSET = 9'h ac;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_1_OFFSET = 9'h b0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_2_OFFSET = 9'h b4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_3_OFFSET = 9'h b8;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_4_OFFSET = 9'h bc;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_5_OFFSET = 9'h c0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_6_OFFSET = 9'h c4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_7_OFFSET = 9'h c8;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_8_OFFSET = 9'h cc;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_9_OFFSET = 9'h d0;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_ADDR_10_OFFSET = 9'h d4;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_0_OFFSET = 9'h 12c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_1_OFFSET = 9'h 130;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_2_OFFSET = 9'h 134;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_3_OFFSET = 9'h 138;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_4_OFFSET = 9'h 13c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_5_OFFSET = 9'h 140;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_6_OFFSET = 9'h 144;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_7_OFFSET = 9'h 148;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_8_OFFSET = 9'h 14c;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_9_OFFSET = 9'h 150;
+  parameter logic [BlockAw-1:0] DMA_INTR_SOURCE_WR_VAL_10_OFFSET = 9'h 154;
 
   // Reset values for hwext registers and their fields
   parameter logic [2:0] DMA_INTR_TEST_RESVAL = 3'h 0;
@@ -480,31 +480,31 @@ package dma_reg_pkg;
     DMA_SHA2_DIGEST_13,
     DMA_SHA2_DIGEST_14,
     DMA_SHA2_DIGEST_15,
-    DMA_HANDSHAKE_INTERRUPT_ENABLE,
-    DMA_CLEAR_INT_SRC,
-    DMA_CLEAR_INT_BUS,
-    DMA_INT_SOURCE_ADDR_0,
-    DMA_INT_SOURCE_ADDR_1,
-    DMA_INT_SOURCE_ADDR_2,
-    DMA_INT_SOURCE_ADDR_3,
-    DMA_INT_SOURCE_ADDR_4,
-    DMA_INT_SOURCE_ADDR_5,
-    DMA_INT_SOURCE_ADDR_6,
-    DMA_INT_SOURCE_ADDR_7,
-    DMA_INT_SOURCE_ADDR_8,
-    DMA_INT_SOURCE_ADDR_9,
-    DMA_INT_SOURCE_ADDR_10,
-    DMA_INT_SOURCE_WR_VAL_0,
-    DMA_INT_SOURCE_WR_VAL_1,
-    DMA_INT_SOURCE_WR_VAL_2,
-    DMA_INT_SOURCE_WR_VAL_3,
-    DMA_INT_SOURCE_WR_VAL_4,
-    DMA_INT_SOURCE_WR_VAL_5,
-    DMA_INT_SOURCE_WR_VAL_6,
-    DMA_INT_SOURCE_WR_VAL_7,
-    DMA_INT_SOURCE_WR_VAL_8,
-    DMA_INT_SOURCE_WR_VAL_9,
-    DMA_INT_SOURCE_WR_VAL_10
+    DMA_HANDSHAKE_INTR_ENABLE,
+    DMA_CLEAR_INTR_SRC,
+    DMA_CLEAR_INTR_BUS,
+    DMA_INTR_SOURCE_ADDR_0,
+    DMA_INTR_SOURCE_ADDR_1,
+    DMA_INTR_SOURCE_ADDR_2,
+    DMA_INTR_SOURCE_ADDR_3,
+    DMA_INTR_SOURCE_ADDR_4,
+    DMA_INTR_SOURCE_ADDR_5,
+    DMA_INTR_SOURCE_ADDR_6,
+    DMA_INTR_SOURCE_ADDR_7,
+    DMA_INTR_SOURCE_ADDR_8,
+    DMA_INTR_SOURCE_ADDR_9,
+    DMA_INTR_SOURCE_ADDR_10,
+    DMA_INTR_SOURCE_WR_VAL_0,
+    DMA_INTR_SOURCE_WR_VAL_1,
+    DMA_INTR_SOURCE_WR_VAL_2,
+    DMA_INTR_SOURCE_WR_VAL_3,
+    DMA_INTR_SOURCE_WR_VAL_4,
+    DMA_INTR_SOURCE_WR_VAL_5,
+    DMA_INTR_SOURCE_WR_VAL_6,
+    DMA_INTR_SOURCE_WR_VAL_7,
+    DMA_INTR_SOURCE_WR_VAL_8,
+    DMA_INTR_SOURCE_WR_VAL_9,
+    DMA_INTR_SOURCE_WR_VAL_10
   } dma_id_e;
 
   // Register width information to check illegal writes
@@ -549,31 +549,31 @@ package dma_reg_pkg;
     4'b 1111, // index[37] DMA_SHA2_DIGEST_13
     4'b 1111, // index[38] DMA_SHA2_DIGEST_14
     4'b 1111, // index[39] DMA_SHA2_DIGEST_15
-    4'b 0011, // index[40] DMA_HANDSHAKE_INTERRUPT_ENABLE
-    4'b 0011, // index[41] DMA_CLEAR_INT_SRC
-    4'b 0011, // index[42] DMA_CLEAR_INT_BUS
-    4'b 1111, // index[43] DMA_INT_SOURCE_ADDR_0
-    4'b 1111, // index[44] DMA_INT_SOURCE_ADDR_1
-    4'b 1111, // index[45] DMA_INT_SOURCE_ADDR_2
-    4'b 1111, // index[46] DMA_INT_SOURCE_ADDR_3
-    4'b 1111, // index[47] DMA_INT_SOURCE_ADDR_4
-    4'b 1111, // index[48] DMA_INT_SOURCE_ADDR_5
-    4'b 1111, // index[49] DMA_INT_SOURCE_ADDR_6
-    4'b 1111, // index[50] DMA_INT_SOURCE_ADDR_7
-    4'b 1111, // index[51] DMA_INT_SOURCE_ADDR_8
-    4'b 1111, // index[52] DMA_INT_SOURCE_ADDR_9
-    4'b 1111, // index[53] DMA_INT_SOURCE_ADDR_10
-    4'b 1111, // index[54] DMA_INT_SOURCE_WR_VAL_0
-    4'b 1111, // index[55] DMA_INT_SOURCE_WR_VAL_1
-    4'b 1111, // index[56] DMA_INT_SOURCE_WR_VAL_2
-    4'b 1111, // index[57] DMA_INT_SOURCE_WR_VAL_3
-    4'b 1111, // index[58] DMA_INT_SOURCE_WR_VAL_4
-    4'b 1111, // index[59] DMA_INT_SOURCE_WR_VAL_5
-    4'b 1111, // index[60] DMA_INT_SOURCE_WR_VAL_6
-    4'b 1111, // index[61] DMA_INT_SOURCE_WR_VAL_7
-    4'b 1111, // index[62] DMA_INT_SOURCE_WR_VAL_8
-    4'b 1111, // index[63] DMA_INT_SOURCE_WR_VAL_9
-    4'b 1111  // index[64] DMA_INT_SOURCE_WR_VAL_10
+    4'b 0011, // index[40] DMA_HANDSHAKE_INTR_ENABLE
+    4'b 0011, // index[41] DMA_CLEAR_INTR_SRC
+    4'b 0011, // index[42] DMA_CLEAR_INTR_BUS
+    4'b 1111, // index[43] DMA_INTR_SOURCE_ADDR_0
+    4'b 1111, // index[44] DMA_INTR_SOURCE_ADDR_1
+    4'b 1111, // index[45] DMA_INTR_SOURCE_ADDR_2
+    4'b 1111, // index[46] DMA_INTR_SOURCE_ADDR_3
+    4'b 1111, // index[47] DMA_INTR_SOURCE_ADDR_4
+    4'b 1111, // index[48] DMA_INTR_SOURCE_ADDR_5
+    4'b 1111, // index[49] DMA_INTR_SOURCE_ADDR_6
+    4'b 1111, // index[50] DMA_INTR_SOURCE_ADDR_7
+    4'b 1111, // index[51] DMA_INTR_SOURCE_ADDR_8
+    4'b 1111, // index[52] DMA_INTR_SOURCE_ADDR_9
+    4'b 1111, // index[53] DMA_INTR_SOURCE_ADDR_10
+    4'b 1111, // index[54] DMA_INTR_SOURCE_WR_VAL_0
+    4'b 1111, // index[55] DMA_INTR_SOURCE_WR_VAL_1
+    4'b 1111, // index[56] DMA_INTR_SOURCE_WR_VAL_2
+    4'b 1111, // index[57] DMA_INTR_SOURCE_WR_VAL_3
+    4'b 1111, // index[58] DMA_INTR_SOURCE_WR_VAL_4
+    4'b 1111, // index[59] DMA_INTR_SOURCE_WR_VAL_5
+    4'b 1111, // index[60] DMA_INTR_SOURCE_WR_VAL_6
+    4'b 1111, // index[61] DMA_INTR_SOURCE_WR_VAL_7
+    4'b 1111, // index[62] DMA_INTR_SOURCE_WR_VAL_8
+    4'b 1111, // index[63] DMA_INTR_SOURCE_WR_VAL_9
+    4'b 1111  // index[64] DMA_INTR_SOURCE_WR_VAL_10
   };
 
 endpackage

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -245,81 +245,81 @@ module dma_reg_top (
   logic [31:0] sha2_digest_13_qs;
   logic [31:0] sha2_digest_14_qs;
   logic [31:0] sha2_digest_15_qs;
-  logic handshake_interrupt_enable_we;
-  logic [10:0] handshake_interrupt_enable_qs;
-  logic [10:0] handshake_interrupt_enable_wd;
-  logic clear_int_src_we;
-  logic [10:0] clear_int_src_qs;
-  logic [10:0] clear_int_src_wd;
-  logic clear_int_bus_we;
-  logic [10:0] clear_int_bus_qs;
-  logic [10:0] clear_int_bus_wd;
-  logic int_source_addr_0_we;
-  logic [31:0] int_source_addr_0_qs;
-  logic [31:0] int_source_addr_0_wd;
-  logic int_source_addr_1_we;
-  logic [31:0] int_source_addr_1_qs;
-  logic [31:0] int_source_addr_1_wd;
-  logic int_source_addr_2_we;
-  logic [31:0] int_source_addr_2_qs;
-  logic [31:0] int_source_addr_2_wd;
-  logic int_source_addr_3_we;
-  logic [31:0] int_source_addr_3_qs;
-  logic [31:0] int_source_addr_3_wd;
-  logic int_source_addr_4_we;
-  logic [31:0] int_source_addr_4_qs;
-  logic [31:0] int_source_addr_4_wd;
-  logic int_source_addr_5_we;
-  logic [31:0] int_source_addr_5_qs;
-  logic [31:0] int_source_addr_5_wd;
-  logic int_source_addr_6_we;
-  logic [31:0] int_source_addr_6_qs;
-  logic [31:0] int_source_addr_6_wd;
-  logic int_source_addr_7_we;
-  logic [31:0] int_source_addr_7_qs;
-  logic [31:0] int_source_addr_7_wd;
-  logic int_source_addr_8_we;
-  logic [31:0] int_source_addr_8_qs;
-  logic [31:0] int_source_addr_8_wd;
-  logic int_source_addr_9_we;
-  logic [31:0] int_source_addr_9_qs;
-  logic [31:0] int_source_addr_9_wd;
-  logic int_source_addr_10_we;
-  logic [31:0] int_source_addr_10_qs;
-  logic [31:0] int_source_addr_10_wd;
-  logic int_source_wr_val_0_we;
-  logic [31:0] int_source_wr_val_0_qs;
-  logic [31:0] int_source_wr_val_0_wd;
-  logic int_source_wr_val_1_we;
-  logic [31:0] int_source_wr_val_1_qs;
-  logic [31:0] int_source_wr_val_1_wd;
-  logic int_source_wr_val_2_we;
-  logic [31:0] int_source_wr_val_2_qs;
-  logic [31:0] int_source_wr_val_2_wd;
-  logic int_source_wr_val_3_we;
-  logic [31:0] int_source_wr_val_3_qs;
-  logic [31:0] int_source_wr_val_3_wd;
-  logic int_source_wr_val_4_we;
-  logic [31:0] int_source_wr_val_4_qs;
-  logic [31:0] int_source_wr_val_4_wd;
-  logic int_source_wr_val_5_we;
-  logic [31:0] int_source_wr_val_5_qs;
-  logic [31:0] int_source_wr_val_5_wd;
-  logic int_source_wr_val_6_we;
-  logic [31:0] int_source_wr_val_6_qs;
-  logic [31:0] int_source_wr_val_6_wd;
-  logic int_source_wr_val_7_we;
-  logic [31:0] int_source_wr_val_7_qs;
-  logic [31:0] int_source_wr_val_7_wd;
-  logic int_source_wr_val_8_we;
-  logic [31:0] int_source_wr_val_8_qs;
-  logic [31:0] int_source_wr_val_8_wd;
-  logic int_source_wr_val_9_we;
-  logic [31:0] int_source_wr_val_9_qs;
-  logic [31:0] int_source_wr_val_9_wd;
-  logic int_source_wr_val_10_we;
-  logic [31:0] int_source_wr_val_10_qs;
-  logic [31:0] int_source_wr_val_10_wd;
+  logic handshake_intr_enable_we;
+  logic [10:0] handshake_intr_enable_qs;
+  logic [10:0] handshake_intr_enable_wd;
+  logic clear_intr_src_we;
+  logic [10:0] clear_intr_src_qs;
+  logic [10:0] clear_intr_src_wd;
+  logic clear_intr_bus_we;
+  logic [10:0] clear_intr_bus_qs;
+  logic [10:0] clear_intr_bus_wd;
+  logic intr_source_addr_0_we;
+  logic [31:0] intr_source_addr_0_qs;
+  logic [31:0] intr_source_addr_0_wd;
+  logic intr_source_addr_1_we;
+  logic [31:0] intr_source_addr_1_qs;
+  logic [31:0] intr_source_addr_1_wd;
+  logic intr_source_addr_2_we;
+  logic [31:0] intr_source_addr_2_qs;
+  logic [31:0] intr_source_addr_2_wd;
+  logic intr_source_addr_3_we;
+  logic [31:0] intr_source_addr_3_qs;
+  logic [31:0] intr_source_addr_3_wd;
+  logic intr_source_addr_4_we;
+  logic [31:0] intr_source_addr_4_qs;
+  logic [31:0] intr_source_addr_4_wd;
+  logic intr_source_addr_5_we;
+  logic [31:0] intr_source_addr_5_qs;
+  logic [31:0] intr_source_addr_5_wd;
+  logic intr_source_addr_6_we;
+  logic [31:0] intr_source_addr_6_qs;
+  logic [31:0] intr_source_addr_6_wd;
+  logic intr_source_addr_7_we;
+  logic [31:0] intr_source_addr_7_qs;
+  logic [31:0] intr_source_addr_7_wd;
+  logic intr_source_addr_8_we;
+  logic [31:0] intr_source_addr_8_qs;
+  logic [31:0] intr_source_addr_8_wd;
+  logic intr_source_addr_9_we;
+  logic [31:0] intr_source_addr_9_qs;
+  logic [31:0] intr_source_addr_9_wd;
+  logic intr_source_addr_10_we;
+  logic [31:0] intr_source_addr_10_qs;
+  logic [31:0] intr_source_addr_10_wd;
+  logic intr_source_wr_val_0_we;
+  logic [31:0] intr_source_wr_val_0_qs;
+  logic [31:0] intr_source_wr_val_0_wd;
+  logic intr_source_wr_val_1_we;
+  logic [31:0] intr_source_wr_val_1_qs;
+  logic [31:0] intr_source_wr_val_1_wd;
+  logic intr_source_wr_val_2_we;
+  logic [31:0] intr_source_wr_val_2_qs;
+  logic [31:0] intr_source_wr_val_2_wd;
+  logic intr_source_wr_val_3_we;
+  logic [31:0] intr_source_wr_val_3_qs;
+  logic [31:0] intr_source_wr_val_3_wd;
+  logic intr_source_wr_val_4_we;
+  logic [31:0] intr_source_wr_val_4_qs;
+  logic [31:0] intr_source_wr_val_4_wd;
+  logic intr_source_wr_val_5_we;
+  logic [31:0] intr_source_wr_val_5_qs;
+  logic [31:0] intr_source_wr_val_5_wd;
+  logic intr_source_wr_val_6_we;
+  logic [31:0] intr_source_wr_val_6_qs;
+  logic [31:0] intr_source_wr_val_6_wd;
+  logic intr_source_wr_val_7_we;
+  logic [31:0] intr_source_wr_val_7_qs;
+  logic [31:0] intr_source_wr_val_7_wd;
+  logic intr_source_wr_val_8_we;
+  logic [31:0] intr_source_wr_val_8_qs;
+  logic [31:0] intr_source_wr_val_8_wd;
+  logic intr_source_wr_val_9_we;
+  logic [31:0] intr_source_wr_val_9_qs;
+  logic [31:0] intr_source_wr_val_9_wd;
+  logic intr_source_wr_val_10_we;
+  logic [31:0] intr_source_wr_val_10_qs;
+  logic [31:0] intr_source_wr_val_10_wd;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -2214,24 +2214,24 @@ module dma_reg_top (
   );
 
 
-  // R[handshake_interrupt_enable]: V(False)
+  // R[handshake_intr_enable]: V(False)
   // Create REGWEN-gated WE signal
-  logic handshake_interrupt_enable_gated_we;
-  assign handshake_interrupt_enable_gated_we =
-    handshake_interrupt_enable_we &
+  logic handshake_intr_enable_gated_we;
+  assign handshake_intr_enable_gated_we =
+    handshake_intr_enable_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h7ff),
     .Mubi    (1'b0)
-  ) u_handshake_interrupt_enable (
+  ) u_handshake_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (handshake_interrupt_enable_gated_we),
-    .wd     (handshake_interrupt_enable_wd),
+    .we     (handshake_intr_enable_gated_we),
+    .wd     (handshake_intr_enable_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2239,32 +2239,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.handshake_interrupt_enable.q),
+    .q      (reg2hw.handshake_intr_enable.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (handshake_interrupt_enable_qs)
+    .qs     (handshake_intr_enable_qs)
   );
 
 
-  // R[clear_int_src]: V(False)
+  // R[clear_intr_src]: V(False)
   // Create REGWEN-gated WE signal
-  logic clear_int_src_gated_we;
-  assign clear_int_src_gated_we =
-    clear_int_src_we &
+  logic clear_intr_src_gated_we;
+  assign clear_intr_src_gated_we =
+    clear_intr_src_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0)
-  ) u_clear_int_src (
+  ) u_clear_intr_src (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clear_int_src_gated_we),
-    .wd     (clear_int_src_wd),
+    .we     (clear_intr_src_gated_we),
+    .wd     (clear_intr_src_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2272,32 +2272,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clear_int_src.q),
+    .q      (reg2hw.clear_intr_src.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (clear_int_src_qs)
+    .qs     (clear_intr_src_qs)
   );
 
 
-  // R[clear_int_bus]: V(False)
+  // R[clear_intr_bus]: V(False)
   // Create REGWEN-gated WE signal
-  logic clear_int_bus_gated_we;
-  assign clear_int_bus_gated_we =
-    clear_int_bus_we &
+  logic clear_intr_bus_gated_we;
+  assign clear_intr_bus_gated_we =
+    clear_intr_bus_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0)
-  ) u_clear_int_bus (
+  ) u_clear_intr_bus (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clear_int_bus_gated_we),
-    .wd     (clear_int_bus_wd),
+    .we     (clear_intr_bus_gated_we),
+    .wd     (clear_intr_bus_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2305,33 +2305,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clear_int_bus.q),
+    .q      (reg2hw.clear_intr_bus.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (clear_int_bus_qs)
+    .qs     (clear_intr_bus_qs)
   );
 
 
-  // Subregister 0 of Multireg int_source_addr
-  // R[int_source_addr_0]: V(False)
+  // Subregister 0 of Multireg intr_source_addr
+  // R[intr_source_addr_0]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_0_gated_we;
-  assign int_source_addr_0_gated_we =
-    int_source_addr_0_we &
+  logic intr_source_addr_0_gated_we;
+  assign intr_source_addr_0_gated_we =
+    intr_source_addr_0_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_0 (
+  ) u_intr_source_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_0_gated_we),
-    .wd     (int_source_addr_0_wd),
+    .we     (intr_source_addr_0_gated_we),
+    .wd     (intr_source_addr_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2339,33 +2339,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[0].q),
+    .q      (reg2hw.intr_source_addr[0].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_0_qs)
+    .qs     (intr_source_addr_0_qs)
   );
 
 
-  // Subregister 1 of Multireg int_source_addr
-  // R[int_source_addr_1]: V(False)
+  // Subregister 1 of Multireg intr_source_addr
+  // R[intr_source_addr_1]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_1_gated_we;
-  assign int_source_addr_1_gated_we =
-    int_source_addr_1_we &
+  logic intr_source_addr_1_gated_we;
+  assign intr_source_addr_1_gated_we =
+    intr_source_addr_1_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_1 (
+  ) u_intr_source_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_1_gated_we),
-    .wd     (int_source_addr_1_wd),
+    .we     (intr_source_addr_1_gated_we),
+    .wd     (intr_source_addr_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2373,33 +2373,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[1].q),
+    .q      (reg2hw.intr_source_addr[1].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_1_qs)
+    .qs     (intr_source_addr_1_qs)
   );
 
 
-  // Subregister 2 of Multireg int_source_addr
-  // R[int_source_addr_2]: V(False)
+  // Subregister 2 of Multireg intr_source_addr
+  // R[intr_source_addr_2]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_2_gated_we;
-  assign int_source_addr_2_gated_we =
-    int_source_addr_2_we &
+  logic intr_source_addr_2_gated_we;
+  assign intr_source_addr_2_gated_we =
+    intr_source_addr_2_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_2 (
+  ) u_intr_source_addr_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_2_gated_we),
-    .wd     (int_source_addr_2_wd),
+    .we     (intr_source_addr_2_gated_we),
+    .wd     (intr_source_addr_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2407,33 +2407,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[2].q),
+    .q      (reg2hw.intr_source_addr[2].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_2_qs)
+    .qs     (intr_source_addr_2_qs)
   );
 
 
-  // Subregister 3 of Multireg int_source_addr
-  // R[int_source_addr_3]: V(False)
+  // Subregister 3 of Multireg intr_source_addr
+  // R[intr_source_addr_3]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_3_gated_we;
-  assign int_source_addr_3_gated_we =
-    int_source_addr_3_we &
+  logic intr_source_addr_3_gated_we;
+  assign intr_source_addr_3_gated_we =
+    intr_source_addr_3_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_3 (
+  ) u_intr_source_addr_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_3_gated_we),
-    .wd     (int_source_addr_3_wd),
+    .we     (intr_source_addr_3_gated_we),
+    .wd     (intr_source_addr_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2441,33 +2441,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[3].q),
+    .q      (reg2hw.intr_source_addr[3].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_3_qs)
+    .qs     (intr_source_addr_3_qs)
   );
 
 
-  // Subregister 4 of Multireg int_source_addr
-  // R[int_source_addr_4]: V(False)
+  // Subregister 4 of Multireg intr_source_addr
+  // R[intr_source_addr_4]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_4_gated_we;
-  assign int_source_addr_4_gated_we =
-    int_source_addr_4_we &
+  logic intr_source_addr_4_gated_we;
+  assign intr_source_addr_4_gated_we =
+    intr_source_addr_4_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_4 (
+  ) u_intr_source_addr_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_4_gated_we),
-    .wd     (int_source_addr_4_wd),
+    .we     (intr_source_addr_4_gated_we),
+    .wd     (intr_source_addr_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2475,33 +2475,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[4].q),
+    .q      (reg2hw.intr_source_addr[4].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_4_qs)
+    .qs     (intr_source_addr_4_qs)
   );
 
 
-  // Subregister 5 of Multireg int_source_addr
-  // R[int_source_addr_5]: V(False)
+  // Subregister 5 of Multireg intr_source_addr
+  // R[intr_source_addr_5]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_5_gated_we;
-  assign int_source_addr_5_gated_we =
-    int_source_addr_5_we &
+  logic intr_source_addr_5_gated_we;
+  assign intr_source_addr_5_gated_we =
+    intr_source_addr_5_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_5 (
+  ) u_intr_source_addr_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_5_gated_we),
-    .wd     (int_source_addr_5_wd),
+    .we     (intr_source_addr_5_gated_we),
+    .wd     (intr_source_addr_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2509,33 +2509,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[5].q),
+    .q      (reg2hw.intr_source_addr[5].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_5_qs)
+    .qs     (intr_source_addr_5_qs)
   );
 
 
-  // Subregister 6 of Multireg int_source_addr
-  // R[int_source_addr_6]: V(False)
+  // Subregister 6 of Multireg intr_source_addr
+  // R[intr_source_addr_6]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_6_gated_we;
-  assign int_source_addr_6_gated_we =
-    int_source_addr_6_we &
+  logic intr_source_addr_6_gated_we;
+  assign intr_source_addr_6_gated_we =
+    intr_source_addr_6_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_6 (
+  ) u_intr_source_addr_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_6_gated_we),
-    .wd     (int_source_addr_6_wd),
+    .we     (intr_source_addr_6_gated_we),
+    .wd     (intr_source_addr_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2543,33 +2543,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[6].q),
+    .q      (reg2hw.intr_source_addr[6].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_6_qs)
+    .qs     (intr_source_addr_6_qs)
   );
 
 
-  // Subregister 7 of Multireg int_source_addr
-  // R[int_source_addr_7]: V(False)
+  // Subregister 7 of Multireg intr_source_addr
+  // R[intr_source_addr_7]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_7_gated_we;
-  assign int_source_addr_7_gated_we =
-    int_source_addr_7_we &
+  logic intr_source_addr_7_gated_we;
+  assign intr_source_addr_7_gated_we =
+    intr_source_addr_7_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_7 (
+  ) u_intr_source_addr_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_7_gated_we),
-    .wd     (int_source_addr_7_wd),
+    .we     (intr_source_addr_7_gated_we),
+    .wd     (intr_source_addr_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2577,33 +2577,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[7].q),
+    .q      (reg2hw.intr_source_addr[7].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_7_qs)
+    .qs     (intr_source_addr_7_qs)
   );
 
 
-  // Subregister 8 of Multireg int_source_addr
-  // R[int_source_addr_8]: V(False)
+  // Subregister 8 of Multireg intr_source_addr
+  // R[intr_source_addr_8]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_8_gated_we;
-  assign int_source_addr_8_gated_we =
-    int_source_addr_8_we &
+  logic intr_source_addr_8_gated_we;
+  assign intr_source_addr_8_gated_we =
+    intr_source_addr_8_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_8 (
+  ) u_intr_source_addr_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_8_gated_we),
-    .wd     (int_source_addr_8_wd),
+    .we     (intr_source_addr_8_gated_we),
+    .wd     (intr_source_addr_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2611,33 +2611,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[8].q),
+    .q      (reg2hw.intr_source_addr[8].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_8_qs)
+    .qs     (intr_source_addr_8_qs)
   );
 
 
-  // Subregister 9 of Multireg int_source_addr
-  // R[int_source_addr_9]: V(False)
+  // Subregister 9 of Multireg intr_source_addr
+  // R[intr_source_addr_9]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_9_gated_we;
-  assign int_source_addr_9_gated_we =
-    int_source_addr_9_we &
+  logic intr_source_addr_9_gated_we;
+  assign intr_source_addr_9_gated_we =
+    intr_source_addr_9_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_9 (
+  ) u_intr_source_addr_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_9_gated_we),
-    .wd     (int_source_addr_9_wd),
+    .we     (intr_source_addr_9_gated_we),
+    .wd     (intr_source_addr_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2645,33 +2645,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[9].q),
+    .q      (reg2hw.intr_source_addr[9].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_9_qs)
+    .qs     (intr_source_addr_9_qs)
   );
 
 
-  // Subregister 10 of Multireg int_source_addr
-  // R[int_source_addr_10]: V(False)
+  // Subregister 10 of Multireg intr_source_addr
+  // R[intr_source_addr_10]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_addr_10_gated_we;
-  assign int_source_addr_10_gated_we =
-    int_source_addr_10_we &
+  logic intr_source_addr_10_gated_we;
+  assign intr_source_addr_10_gated_we =
+    intr_source_addr_10_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_addr_10 (
+  ) u_intr_source_addr_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_addr_10_gated_we),
-    .wd     (int_source_addr_10_wd),
+    .we     (intr_source_addr_10_gated_we),
+    .wd     (intr_source_addr_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2679,33 +2679,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_addr[10].q),
+    .q      (reg2hw.intr_source_addr[10].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_addr_10_qs)
+    .qs     (intr_source_addr_10_qs)
   );
 
 
-  // Subregister 0 of Multireg int_source_wr_val
-  // R[int_source_wr_val_0]: V(False)
+  // Subregister 0 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_0]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_0_gated_we;
-  assign int_source_wr_val_0_gated_we =
-    int_source_wr_val_0_we &
+  logic intr_source_wr_val_0_gated_we;
+  assign intr_source_wr_val_0_gated_we =
+    intr_source_wr_val_0_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_0 (
+  ) u_intr_source_wr_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_0_gated_we),
-    .wd     (int_source_wr_val_0_wd),
+    .we     (intr_source_wr_val_0_gated_we),
+    .wd     (intr_source_wr_val_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2713,33 +2713,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[0].q),
+    .q      (reg2hw.intr_source_wr_val[0].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_0_qs)
+    .qs     (intr_source_wr_val_0_qs)
   );
 
 
-  // Subregister 1 of Multireg int_source_wr_val
-  // R[int_source_wr_val_1]: V(False)
+  // Subregister 1 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_1]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_1_gated_we;
-  assign int_source_wr_val_1_gated_we =
-    int_source_wr_val_1_we &
+  logic intr_source_wr_val_1_gated_we;
+  assign intr_source_wr_val_1_gated_we =
+    intr_source_wr_val_1_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_1 (
+  ) u_intr_source_wr_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_1_gated_we),
-    .wd     (int_source_wr_val_1_wd),
+    .we     (intr_source_wr_val_1_gated_we),
+    .wd     (intr_source_wr_val_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2747,33 +2747,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[1].q),
+    .q      (reg2hw.intr_source_wr_val[1].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_1_qs)
+    .qs     (intr_source_wr_val_1_qs)
   );
 
 
-  // Subregister 2 of Multireg int_source_wr_val
-  // R[int_source_wr_val_2]: V(False)
+  // Subregister 2 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_2]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_2_gated_we;
-  assign int_source_wr_val_2_gated_we =
-    int_source_wr_val_2_we &
+  logic intr_source_wr_val_2_gated_we;
+  assign intr_source_wr_val_2_gated_we =
+    intr_source_wr_val_2_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_2 (
+  ) u_intr_source_wr_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_2_gated_we),
-    .wd     (int_source_wr_val_2_wd),
+    .we     (intr_source_wr_val_2_gated_we),
+    .wd     (intr_source_wr_val_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2781,33 +2781,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[2].q),
+    .q      (reg2hw.intr_source_wr_val[2].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_2_qs)
+    .qs     (intr_source_wr_val_2_qs)
   );
 
 
-  // Subregister 3 of Multireg int_source_wr_val
-  // R[int_source_wr_val_3]: V(False)
+  // Subregister 3 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_3]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_3_gated_we;
-  assign int_source_wr_val_3_gated_we =
-    int_source_wr_val_3_we &
+  logic intr_source_wr_val_3_gated_we;
+  assign intr_source_wr_val_3_gated_we =
+    intr_source_wr_val_3_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_3 (
+  ) u_intr_source_wr_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_3_gated_we),
-    .wd     (int_source_wr_val_3_wd),
+    .we     (intr_source_wr_val_3_gated_we),
+    .wd     (intr_source_wr_val_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2815,33 +2815,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[3].q),
+    .q      (reg2hw.intr_source_wr_val[3].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_3_qs)
+    .qs     (intr_source_wr_val_3_qs)
   );
 
 
-  // Subregister 4 of Multireg int_source_wr_val
-  // R[int_source_wr_val_4]: V(False)
+  // Subregister 4 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_4]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_4_gated_we;
-  assign int_source_wr_val_4_gated_we =
-    int_source_wr_val_4_we &
+  logic intr_source_wr_val_4_gated_we;
+  assign intr_source_wr_val_4_gated_we =
+    intr_source_wr_val_4_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_4 (
+  ) u_intr_source_wr_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_4_gated_we),
-    .wd     (int_source_wr_val_4_wd),
+    .we     (intr_source_wr_val_4_gated_we),
+    .wd     (intr_source_wr_val_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2849,33 +2849,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[4].q),
+    .q      (reg2hw.intr_source_wr_val[4].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_4_qs)
+    .qs     (intr_source_wr_val_4_qs)
   );
 
 
-  // Subregister 5 of Multireg int_source_wr_val
-  // R[int_source_wr_val_5]: V(False)
+  // Subregister 5 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_5]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_5_gated_we;
-  assign int_source_wr_val_5_gated_we =
-    int_source_wr_val_5_we &
+  logic intr_source_wr_val_5_gated_we;
+  assign intr_source_wr_val_5_gated_we =
+    intr_source_wr_val_5_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_5 (
+  ) u_intr_source_wr_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_5_gated_we),
-    .wd     (int_source_wr_val_5_wd),
+    .we     (intr_source_wr_val_5_gated_we),
+    .wd     (intr_source_wr_val_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2883,33 +2883,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[5].q),
+    .q      (reg2hw.intr_source_wr_val[5].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_5_qs)
+    .qs     (intr_source_wr_val_5_qs)
   );
 
 
-  // Subregister 6 of Multireg int_source_wr_val
-  // R[int_source_wr_val_6]: V(False)
+  // Subregister 6 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_6]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_6_gated_we;
-  assign int_source_wr_val_6_gated_we =
-    int_source_wr_val_6_we &
+  logic intr_source_wr_val_6_gated_we;
+  assign intr_source_wr_val_6_gated_we =
+    intr_source_wr_val_6_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_6 (
+  ) u_intr_source_wr_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_6_gated_we),
-    .wd     (int_source_wr_val_6_wd),
+    .we     (intr_source_wr_val_6_gated_we),
+    .wd     (intr_source_wr_val_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2917,33 +2917,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[6].q),
+    .q      (reg2hw.intr_source_wr_val[6].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_6_qs)
+    .qs     (intr_source_wr_val_6_qs)
   );
 
 
-  // Subregister 7 of Multireg int_source_wr_val
-  // R[int_source_wr_val_7]: V(False)
+  // Subregister 7 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_7]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_7_gated_we;
-  assign int_source_wr_val_7_gated_we =
-    int_source_wr_val_7_we &
+  logic intr_source_wr_val_7_gated_we;
+  assign intr_source_wr_val_7_gated_we =
+    intr_source_wr_val_7_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_7 (
+  ) u_intr_source_wr_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_7_gated_we),
-    .wd     (int_source_wr_val_7_wd),
+    .we     (intr_source_wr_val_7_gated_we),
+    .wd     (intr_source_wr_val_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2951,33 +2951,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[7].q),
+    .q      (reg2hw.intr_source_wr_val[7].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_7_qs)
+    .qs     (intr_source_wr_val_7_qs)
   );
 
 
-  // Subregister 8 of Multireg int_source_wr_val
-  // R[int_source_wr_val_8]: V(False)
+  // Subregister 8 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_8]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_8_gated_we;
-  assign int_source_wr_val_8_gated_we =
-    int_source_wr_val_8_we &
+  logic intr_source_wr_val_8_gated_we;
+  assign intr_source_wr_val_8_gated_we =
+    intr_source_wr_val_8_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_8 (
+  ) u_intr_source_wr_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_8_gated_we),
-    .wd     (int_source_wr_val_8_wd),
+    .we     (intr_source_wr_val_8_gated_we),
+    .wd     (intr_source_wr_val_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2985,33 +2985,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[8].q),
+    .q      (reg2hw.intr_source_wr_val[8].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_8_qs)
+    .qs     (intr_source_wr_val_8_qs)
   );
 
 
-  // Subregister 9 of Multireg int_source_wr_val
-  // R[int_source_wr_val_9]: V(False)
+  // Subregister 9 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_9]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_9_gated_we;
-  assign int_source_wr_val_9_gated_we =
-    int_source_wr_val_9_we &
+  logic intr_source_wr_val_9_gated_we;
+  assign intr_source_wr_val_9_gated_we =
+    intr_source_wr_val_9_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_9 (
+  ) u_intr_source_wr_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_9_gated_we),
-    .wd     (int_source_wr_val_9_wd),
+    .we     (intr_source_wr_val_9_gated_we),
+    .wd     (intr_source_wr_val_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3019,33 +3019,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[9].q),
+    .q      (reg2hw.intr_source_wr_val[9].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_9_qs)
+    .qs     (intr_source_wr_val_9_qs)
   );
 
 
-  // Subregister 10 of Multireg int_source_wr_val
-  // R[int_source_wr_val_10]: V(False)
+  // Subregister 10 of Multireg intr_source_wr_val
+  // R[intr_source_wr_val_10]: V(False)
   // Create REGWEN-gated WE signal
-  logic int_source_wr_val_10_gated_we;
-  assign int_source_wr_val_10_gated_we =
-    int_source_wr_val_10_we &
+  logic intr_source_wr_val_10_gated_we;
+  assign intr_source_wr_val_10_gated_we =
+    intr_source_wr_val_10_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_int_source_wr_val_10 (
+  ) u_intr_source_wr_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (int_source_wr_val_10_gated_we),
-    .wd     (int_source_wr_val_10_wd),
+    .we     (intr_source_wr_val_10_gated_we),
+    .wd     (intr_source_wr_val_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3053,11 +3053,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.int_source_wr_val[10].q),
+    .q      (reg2hw.intr_source_wr_val[10].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (int_source_wr_val_10_qs)
+    .qs     (intr_source_wr_val_10_qs)
   );
 
 
@@ -3105,31 +3105,31 @@ module dma_reg_top (
     addr_hit[37] = (reg_addr == DMA_SHA2_DIGEST_13_OFFSET);
     addr_hit[38] = (reg_addr == DMA_SHA2_DIGEST_14_OFFSET);
     addr_hit[39] = (reg_addr == DMA_SHA2_DIGEST_15_OFFSET);
-    addr_hit[40] = (reg_addr == DMA_HANDSHAKE_INTERRUPT_ENABLE_OFFSET);
-    addr_hit[41] = (reg_addr == DMA_CLEAR_INT_SRC_OFFSET);
-    addr_hit[42] = (reg_addr == DMA_CLEAR_INT_BUS_OFFSET);
-    addr_hit[43] = (reg_addr == DMA_INT_SOURCE_ADDR_0_OFFSET);
-    addr_hit[44] = (reg_addr == DMA_INT_SOURCE_ADDR_1_OFFSET);
-    addr_hit[45] = (reg_addr == DMA_INT_SOURCE_ADDR_2_OFFSET);
-    addr_hit[46] = (reg_addr == DMA_INT_SOURCE_ADDR_3_OFFSET);
-    addr_hit[47] = (reg_addr == DMA_INT_SOURCE_ADDR_4_OFFSET);
-    addr_hit[48] = (reg_addr == DMA_INT_SOURCE_ADDR_5_OFFSET);
-    addr_hit[49] = (reg_addr == DMA_INT_SOURCE_ADDR_6_OFFSET);
-    addr_hit[50] = (reg_addr == DMA_INT_SOURCE_ADDR_7_OFFSET);
-    addr_hit[51] = (reg_addr == DMA_INT_SOURCE_ADDR_8_OFFSET);
-    addr_hit[52] = (reg_addr == DMA_INT_SOURCE_ADDR_9_OFFSET);
-    addr_hit[53] = (reg_addr == DMA_INT_SOURCE_ADDR_10_OFFSET);
-    addr_hit[54] = (reg_addr == DMA_INT_SOURCE_WR_VAL_0_OFFSET);
-    addr_hit[55] = (reg_addr == DMA_INT_SOURCE_WR_VAL_1_OFFSET);
-    addr_hit[56] = (reg_addr == DMA_INT_SOURCE_WR_VAL_2_OFFSET);
-    addr_hit[57] = (reg_addr == DMA_INT_SOURCE_WR_VAL_3_OFFSET);
-    addr_hit[58] = (reg_addr == DMA_INT_SOURCE_WR_VAL_4_OFFSET);
-    addr_hit[59] = (reg_addr == DMA_INT_SOURCE_WR_VAL_5_OFFSET);
-    addr_hit[60] = (reg_addr == DMA_INT_SOURCE_WR_VAL_6_OFFSET);
-    addr_hit[61] = (reg_addr == DMA_INT_SOURCE_WR_VAL_7_OFFSET);
-    addr_hit[62] = (reg_addr == DMA_INT_SOURCE_WR_VAL_8_OFFSET);
-    addr_hit[63] = (reg_addr == DMA_INT_SOURCE_WR_VAL_9_OFFSET);
-    addr_hit[64] = (reg_addr == DMA_INT_SOURCE_WR_VAL_10_OFFSET);
+    addr_hit[40] = (reg_addr == DMA_HANDSHAKE_INTR_ENABLE_OFFSET);
+    addr_hit[41] = (reg_addr == DMA_CLEAR_INTR_SRC_OFFSET);
+    addr_hit[42] = (reg_addr == DMA_CLEAR_INTR_BUS_OFFSET);
+    addr_hit[43] = (reg_addr == DMA_INTR_SOURCE_ADDR_0_OFFSET);
+    addr_hit[44] = (reg_addr == DMA_INTR_SOURCE_ADDR_1_OFFSET);
+    addr_hit[45] = (reg_addr == DMA_INTR_SOURCE_ADDR_2_OFFSET);
+    addr_hit[46] = (reg_addr == DMA_INTR_SOURCE_ADDR_3_OFFSET);
+    addr_hit[47] = (reg_addr == DMA_INTR_SOURCE_ADDR_4_OFFSET);
+    addr_hit[48] = (reg_addr == DMA_INTR_SOURCE_ADDR_5_OFFSET);
+    addr_hit[49] = (reg_addr == DMA_INTR_SOURCE_ADDR_6_OFFSET);
+    addr_hit[50] = (reg_addr == DMA_INTR_SOURCE_ADDR_7_OFFSET);
+    addr_hit[51] = (reg_addr == DMA_INTR_SOURCE_ADDR_8_OFFSET);
+    addr_hit[52] = (reg_addr == DMA_INTR_SOURCE_ADDR_9_OFFSET);
+    addr_hit[53] = (reg_addr == DMA_INTR_SOURCE_ADDR_10_OFFSET);
+    addr_hit[54] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_0_OFFSET);
+    addr_hit[55] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_1_OFFSET);
+    addr_hit[56] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_2_OFFSET);
+    addr_hit[57] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_3_OFFSET);
+    addr_hit[58] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_4_OFFSET);
+    addr_hit[59] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_5_OFFSET);
+    addr_hit[60] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_6_OFFSET);
+    addr_hit[61] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_7_OFFSET);
+    addr_hit[62] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_8_OFFSET);
+    addr_hit[63] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_9_OFFSET);
+    addr_hit[64] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_10_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3304,81 +3304,81 @@ module dma_reg_top (
   assign status_aborted_wd = reg_wdata[2];
 
   assign status_error_wd = reg_wdata[3];
-  assign handshake_interrupt_enable_we = addr_hit[40] & reg_we & !reg_error;
+  assign handshake_intr_enable_we = addr_hit[40] & reg_we & !reg_error;
 
-  assign handshake_interrupt_enable_wd = reg_wdata[10:0];
-  assign clear_int_src_we = addr_hit[41] & reg_we & !reg_error;
+  assign handshake_intr_enable_wd = reg_wdata[10:0];
+  assign clear_intr_src_we = addr_hit[41] & reg_we & !reg_error;
 
-  assign clear_int_src_wd = reg_wdata[10:0];
-  assign clear_int_bus_we = addr_hit[42] & reg_we & !reg_error;
+  assign clear_intr_src_wd = reg_wdata[10:0];
+  assign clear_intr_bus_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign clear_int_bus_wd = reg_wdata[10:0];
-  assign int_source_addr_0_we = addr_hit[43] & reg_we & !reg_error;
+  assign clear_intr_bus_wd = reg_wdata[10:0];
+  assign intr_source_addr_0_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign int_source_addr_0_wd = reg_wdata[31:0];
-  assign int_source_addr_1_we = addr_hit[44] & reg_we & !reg_error;
+  assign intr_source_addr_0_wd = reg_wdata[31:0];
+  assign intr_source_addr_1_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign int_source_addr_1_wd = reg_wdata[31:0];
-  assign int_source_addr_2_we = addr_hit[45] & reg_we & !reg_error;
+  assign intr_source_addr_1_wd = reg_wdata[31:0];
+  assign intr_source_addr_2_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign int_source_addr_2_wd = reg_wdata[31:0];
-  assign int_source_addr_3_we = addr_hit[46] & reg_we & !reg_error;
+  assign intr_source_addr_2_wd = reg_wdata[31:0];
+  assign intr_source_addr_3_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign int_source_addr_3_wd = reg_wdata[31:0];
-  assign int_source_addr_4_we = addr_hit[47] & reg_we & !reg_error;
+  assign intr_source_addr_3_wd = reg_wdata[31:0];
+  assign intr_source_addr_4_we = addr_hit[47] & reg_we & !reg_error;
 
-  assign int_source_addr_4_wd = reg_wdata[31:0];
-  assign int_source_addr_5_we = addr_hit[48] & reg_we & !reg_error;
+  assign intr_source_addr_4_wd = reg_wdata[31:0];
+  assign intr_source_addr_5_we = addr_hit[48] & reg_we & !reg_error;
 
-  assign int_source_addr_5_wd = reg_wdata[31:0];
-  assign int_source_addr_6_we = addr_hit[49] & reg_we & !reg_error;
+  assign intr_source_addr_5_wd = reg_wdata[31:0];
+  assign intr_source_addr_6_we = addr_hit[49] & reg_we & !reg_error;
 
-  assign int_source_addr_6_wd = reg_wdata[31:0];
-  assign int_source_addr_7_we = addr_hit[50] & reg_we & !reg_error;
+  assign intr_source_addr_6_wd = reg_wdata[31:0];
+  assign intr_source_addr_7_we = addr_hit[50] & reg_we & !reg_error;
 
-  assign int_source_addr_7_wd = reg_wdata[31:0];
-  assign int_source_addr_8_we = addr_hit[51] & reg_we & !reg_error;
+  assign intr_source_addr_7_wd = reg_wdata[31:0];
+  assign intr_source_addr_8_we = addr_hit[51] & reg_we & !reg_error;
 
-  assign int_source_addr_8_wd = reg_wdata[31:0];
-  assign int_source_addr_9_we = addr_hit[52] & reg_we & !reg_error;
+  assign intr_source_addr_8_wd = reg_wdata[31:0];
+  assign intr_source_addr_9_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign int_source_addr_9_wd = reg_wdata[31:0];
-  assign int_source_addr_10_we = addr_hit[53] & reg_we & !reg_error;
+  assign intr_source_addr_9_wd = reg_wdata[31:0];
+  assign intr_source_addr_10_we = addr_hit[53] & reg_we & !reg_error;
 
-  assign int_source_addr_10_wd = reg_wdata[31:0];
-  assign int_source_wr_val_0_we = addr_hit[54] & reg_we & !reg_error;
+  assign intr_source_addr_10_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_0_we = addr_hit[54] & reg_we & !reg_error;
 
-  assign int_source_wr_val_0_wd = reg_wdata[31:0];
-  assign int_source_wr_val_1_we = addr_hit[55] & reg_we & !reg_error;
+  assign intr_source_wr_val_0_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_1_we = addr_hit[55] & reg_we & !reg_error;
 
-  assign int_source_wr_val_1_wd = reg_wdata[31:0];
-  assign int_source_wr_val_2_we = addr_hit[56] & reg_we & !reg_error;
+  assign intr_source_wr_val_1_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_2_we = addr_hit[56] & reg_we & !reg_error;
 
-  assign int_source_wr_val_2_wd = reg_wdata[31:0];
-  assign int_source_wr_val_3_we = addr_hit[57] & reg_we & !reg_error;
+  assign intr_source_wr_val_2_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_3_we = addr_hit[57] & reg_we & !reg_error;
 
-  assign int_source_wr_val_3_wd = reg_wdata[31:0];
-  assign int_source_wr_val_4_we = addr_hit[58] & reg_we & !reg_error;
+  assign intr_source_wr_val_3_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_4_we = addr_hit[58] & reg_we & !reg_error;
 
-  assign int_source_wr_val_4_wd = reg_wdata[31:0];
-  assign int_source_wr_val_5_we = addr_hit[59] & reg_we & !reg_error;
+  assign intr_source_wr_val_4_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_5_we = addr_hit[59] & reg_we & !reg_error;
 
-  assign int_source_wr_val_5_wd = reg_wdata[31:0];
-  assign int_source_wr_val_6_we = addr_hit[60] & reg_we & !reg_error;
+  assign intr_source_wr_val_5_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_6_we = addr_hit[60] & reg_we & !reg_error;
 
-  assign int_source_wr_val_6_wd = reg_wdata[31:0];
-  assign int_source_wr_val_7_we = addr_hit[61] & reg_we & !reg_error;
+  assign intr_source_wr_val_6_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_7_we = addr_hit[61] & reg_we & !reg_error;
 
-  assign int_source_wr_val_7_wd = reg_wdata[31:0];
-  assign int_source_wr_val_8_we = addr_hit[62] & reg_we & !reg_error;
+  assign intr_source_wr_val_7_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_8_we = addr_hit[62] & reg_we & !reg_error;
 
-  assign int_source_wr_val_8_wd = reg_wdata[31:0];
-  assign int_source_wr_val_9_we = addr_hit[63] & reg_we & !reg_error;
+  assign intr_source_wr_val_8_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_9_we = addr_hit[63] & reg_we & !reg_error;
 
-  assign int_source_wr_val_9_wd = reg_wdata[31:0];
-  assign int_source_wr_val_10_we = addr_hit[64] & reg_we & !reg_error;
+  assign intr_source_wr_val_9_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_10_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign int_source_wr_val_10_wd = reg_wdata[31:0];
+  assign intr_source_wr_val_10_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -3423,31 +3423,31 @@ module dma_reg_top (
     reg_we_check[37] = 1'b0;
     reg_we_check[38] = 1'b0;
     reg_we_check[39] = 1'b0;
-    reg_we_check[40] = handshake_interrupt_enable_gated_we;
-    reg_we_check[41] = clear_int_src_gated_we;
-    reg_we_check[42] = clear_int_bus_gated_we;
-    reg_we_check[43] = int_source_addr_0_gated_we;
-    reg_we_check[44] = int_source_addr_1_gated_we;
-    reg_we_check[45] = int_source_addr_2_gated_we;
-    reg_we_check[46] = int_source_addr_3_gated_we;
-    reg_we_check[47] = int_source_addr_4_gated_we;
-    reg_we_check[48] = int_source_addr_5_gated_we;
-    reg_we_check[49] = int_source_addr_6_gated_we;
-    reg_we_check[50] = int_source_addr_7_gated_we;
-    reg_we_check[51] = int_source_addr_8_gated_we;
-    reg_we_check[52] = int_source_addr_9_gated_we;
-    reg_we_check[53] = int_source_addr_10_gated_we;
-    reg_we_check[54] = int_source_wr_val_0_gated_we;
-    reg_we_check[55] = int_source_wr_val_1_gated_we;
-    reg_we_check[56] = int_source_wr_val_2_gated_we;
-    reg_we_check[57] = int_source_wr_val_3_gated_we;
-    reg_we_check[58] = int_source_wr_val_4_gated_we;
-    reg_we_check[59] = int_source_wr_val_5_gated_we;
-    reg_we_check[60] = int_source_wr_val_6_gated_we;
-    reg_we_check[61] = int_source_wr_val_7_gated_we;
-    reg_we_check[62] = int_source_wr_val_8_gated_we;
-    reg_we_check[63] = int_source_wr_val_9_gated_we;
-    reg_we_check[64] = int_source_wr_val_10_gated_we;
+    reg_we_check[40] = handshake_intr_enable_gated_we;
+    reg_we_check[41] = clear_intr_src_gated_we;
+    reg_we_check[42] = clear_intr_bus_gated_we;
+    reg_we_check[43] = intr_source_addr_0_gated_we;
+    reg_we_check[44] = intr_source_addr_1_gated_we;
+    reg_we_check[45] = intr_source_addr_2_gated_we;
+    reg_we_check[46] = intr_source_addr_3_gated_we;
+    reg_we_check[47] = intr_source_addr_4_gated_we;
+    reg_we_check[48] = intr_source_addr_5_gated_we;
+    reg_we_check[49] = intr_source_addr_6_gated_we;
+    reg_we_check[50] = intr_source_addr_7_gated_we;
+    reg_we_check[51] = intr_source_addr_8_gated_we;
+    reg_we_check[52] = intr_source_addr_9_gated_we;
+    reg_we_check[53] = intr_source_addr_10_gated_we;
+    reg_we_check[54] = intr_source_wr_val_0_gated_we;
+    reg_we_check[55] = intr_source_wr_val_1_gated_we;
+    reg_we_check[56] = intr_source_wr_val_2_gated_we;
+    reg_we_check[57] = intr_source_wr_val_3_gated_we;
+    reg_we_check[58] = intr_source_wr_val_4_gated_we;
+    reg_we_check[59] = intr_source_wr_val_5_gated_we;
+    reg_we_check[60] = intr_source_wr_val_6_gated_we;
+    reg_we_check[61] = intr_source_wr_val_7_gated_we;
+    reg_we_check[62] = intr_source_wr_val_8_gated_we;
+    reg_we_check[63] = intr_source_wr_val_9_gated_we;
+    reg_we_check[64] = intr_source_wr_val_10_gated_we;
   end
 
   // Read data return
@@ -3640,103 +3640,103 @@ module dma_reg_top (
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[10:0] = handshake_interrupt_enable_qs;
+        reg_rdata_next[10:0] = handshake_intr_enable_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[10:0] = clear_int_src_qs;
+        reg_rdata_next[10:0] = clear_intr_src_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[10:0] = clear_int_bus_qs;
+        reg_rdata_next[10:0] = clear_intr_bus_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[31:0] = int_source_addr_0_qs;
+        reg_rdata_next[31:0] = intr_source_addr_0_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[31:0] = int_source_addr_1_qs;
+        reg_rdata_next[31:0] = intr_source_addr_1_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[31:0] = int_source_addr_2_qs;
+        reg_rdata_next[31:0] = intr_source_addr_2_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[31:0] = int_source_addr_3_qs;
+        reg_rdata_next[31:0] = intr_source_addr_3_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[31:0] = int_source_addr_4_qs;
+        reg_rdata_next[31:0] = intr_source_addr_4_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[31:0] = int_source_addr_5_qs;
+        reg_rdata_next[31:0] = intr_source_addr_5_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[31:0] = int_source_addr_6_qs;
+        reg_rdata_next[31:0] = intr_source_addr_6_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[31:0] = int_source_addr_7_qs;
+        reg_rdata_next[31:0] = intr_source_addr_7_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[31:0] = int_source_addr_8_qs;
+        reg_rdata_next[31:0] = intr_source_addr_8_qs;
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[31:0] = int_source_addr_9_qs;
+        reg_rdata_next[31:0] = intr_source_addr_9_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[31:0] = int_source_addr_10_qs;
+        reg_rdata_next[31:0] = intr_source_addr_10_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_0_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_0_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_1_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_1_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_2_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_2_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_3_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_3_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_4_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_4_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_5_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_5_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_6_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_6_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_7_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_7_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_8_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_8_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_9_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_9_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[31:0] = int_source_wr_val_10_qs;
+        reg_rdata_next[31:0] = intr_source_wr_val_10_qs;
       end
 
       default: begin

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -150,17 +150,17 @@ module dma_reg_top (
   logic src_address_hi_we;
   logic [31:0] src_address_hi_qs;
   logic [31:0] src_address_hi_wd;
-  logic destination_address_lo_we;
-  logic [31:0] destination_address_lo_qs;
-  logic [31:0] destination_address_lo_wd;
-  logic destination_address_hi_we;
-  logic [31:0] destination_address_hi_qs;
-  logic [31:0] destination_address_hi_wd;
+  logic dst_address_lo_we;
+  logic [31:0] dst_address_lo_qs;
+  logic [31:0] dst_address_lo_wd;
+  logic dst_address_hi_we;
+  logic [31:0] dst_address_hi_qs;
+  logic [31:0] dst_address_hi_wd;
   logic address_space_id_we;
   logic [3:0] address_space_id_src_asid_qs;
   logic [3:0] address_space_id_src_asid_wd;
-  logic [3:0] address_space_id_destination_asid_qs;
-  logic [3:0] address_space_id_destination_asid_wd;
+  logic [3:0] address_space_id_dst_asid_qs;
+  logic [3:0] address_space_id_dst_asid_wd;
   logic enabled_memory_range_base_we;
   logic [31:0] enabled_memory_range_base_qs;
   logic [31:0] enabled_memory_range_base_wd;
@@ -184,18 +184,18 @@ module dma_reg_top (
   logic transfer_width_we;
   logic [1:0] transfer_width_qs;
   logic [1:0] transfer_width_wd;
-  logic destination_address_limit_lo_we;
-  logic [31:0] destination_address_limit_lo_qs;
-  logic [31:0] destination_address_limit_lo_wd;
-  logic destination_address_limit_hi_we;
-  logic [31:0] destination_address_limit_hi_qs;
-  logic [31:0] destination_address_limit_hi_wd;
-  logic destination_address_almost_limit_lo_we;
-  logic [31:0] destination_address_almost_limit_lo_qs;
-  logic [31:0] destination_address_almost_limit_lo_wd;
-  logic destination_address_almost_limit_hi_we;
-  logic [31:0] destination_address_almost_limit_hi_qs;
-  logic [31:0] destination_address_almost_limit_hi_wd;
+  logic dst_address_limit_lo_we;
+  logic [31:0] dst_address_limit_lo_qs;
+  logic [31:0] dst_address_limit_lo_wd;
+  logic dst_address_limit_hi_we;
+  logic [31:0] dst_address_limit_hi_qs;
+  logic [31:0] dst_address_limit_hi_wd;
+  logic dst_address_almost_limit_lo_we;
+  logic [31:0] dst_address_almost_limit_lo_qs;
+  logic [31:0] dst_address_almost_limit_lo_wd;
+  logic dst_address_almost_limit_hi_we;
+  logic [31:0] dst_address_almost_limit_hi_qs;
+  logic [31:0] dst_address_almost_limit_hi_wd;
   logic control_we;
   logic [3:0] control_opcode_qs;
   logic [3:0] control_opcode_wd;
@@ -627,69 +627,69 @@ module dma_reg_top (
   );
 
 
-  // R[destination_address_lo]: V(False)
+  // R[dst_address_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_lo_gated_we;
-  assign destination_address_lo_gated_we =
-    destination_address_lo_we &
+  logic dst_address_lo_gated_we;
+  assign dst_address_lo_gated_we =
+    dst_address_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_lo (
+  ) u_dst_address_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_lo_gated_we),
-    .wd     (destination_address_lo_wd),
+    .we     (dst_address_lo_gated_we),
+    .wd     (dst_address_lo_wd),
 
     // from internal hardware
-    .de     (hw2reg.destination_address_lo.de),
-    .d      (hw2reg.destination_address_lo.d),
+    .de     (hw2reg.dst_address_lo.de),
+    .d      (hw2reg.dst_address_lo.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_lo.q),
+    .q      (reg2hw.dst_address_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_lo_qs)
+    .qs     (dst_address_lo_qs)
   );
 
 
-  // R[destination_address_hi]: V(False)
+  // R[dst_address_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_hi_gated_we;
-  assign destination_address_hi_gated_we =
-    destination_address_hi_we &
+  logic dst_address_hi_gated_we;
+  assign dst_address_hi_gated_we =
+    dst_address_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_hi (
+  ) u_dst_address_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_hi_gated_we),
-    .wd     (destination_address_hi_wd),
+    .we     (dst_address_hi_gated_we),
+    .wd     (dst_address_hi_wd),
 
     // from internal hardware
-    .de     (hw2reg.destination_address_hi.de),
-    .d      (hw2reg.destination_address_hi.d),
+    .de     (hw2reg.dst_address_hi.de),
+    .d      (hw2reg.dst_address_hi.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_hi.q),
+    .q      (reg2hw.dst_address_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_hi_qs)
+    .qs     (dst_address_hi_qs)
   );
 
 
@@ -726,19 +726,19 @@ module dma_reg_top (
     .qs     (address_space_id_src_asid_qs)
   );
 
-  //   F[destination_asid]: 7:4
+  //   F[dst_asid]: 7:4
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0)
-  ) u_address_space_id_destination_asid (
+  ) u_address_space_id_dst_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (address_space_id_gated_we),
-    .wd     (address_space_id_destination_asid_wd),
+    .wd     (address_space_id_dst_asid_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -746,11 +746,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.address_space_id.destination_asid.q),
+    .q      (reg2hw.address_space_id.dst_asid.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (address_space_id_destination_asid_qs)
+    .qs     (address_space_id_dst_asid_qs)
   );
 
 
@@ -1020,24 +1020,24 @@ module dma_reg_top (
   );
 
 
-  // R[destination_address_limit_lo]: V(False)
+  // R[dst_address_limit_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_limit_lo_gated_we;
-  assign destination_address_limit_lo_gated_we =
-    destination_address_limit_lo_we &
+  logic dst_address_limit_lo_gated_we;
+  assign dst_address_limit_lo_gated_we =
+    dst_address_limit_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_limit_lo (
+  ) u_dst_address_limit_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_limit_lo_gated_we),
-    .wd     (destination_address_limit_lo_wd),
+    .we     (dst_address_limit_lo_gated_we),
+    .wd     (dst_address_limit_lo_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1045,32 +1045,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_limit_lo.q),
+    .q      (reg2hw.dst_address_limit_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_limit_lo_qs)
+    .qs     (dst_address_limit_lo_qs)
   );
 
 
-  // R[destination_address_limit_hi]: V(False)
+  // R[dst_address_limit_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_limit_hi_gated_we;
-  assign destination_address_limit_hi_gated_we =
-    destination_address_limit_hi_we &
+  logic dst_address_limit_hi_gated_we;
+  assign dst_address_limit_hi_gated_we =
+    dst_address_limit_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_limit_hi (
+  ) u_dst_address_limit_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_limit_hi_gated_we),
-    .wd     (destination_address_limit_hi_wd),
+    .we     (dst_address_limit_hi_gated_we),
+    .wd     (dst_address_limit_hi_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1078,32 +1078,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_limit_hi.q),
+    .q      (reg2hw.dst_address_limit_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_limit_hi_qs)
+    .qs     (dst_address_limit_hi_qs)
   );
 
 
-  // R[destination_address_almost_limit_lo]: V(False)
+  // R[dst_address_almost_limit_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_almost_limit_lo_gated_we;
-  assign destination_address_almost_limit_lo_gated_we =
-    destination_address_almost_limit_lo_we &
+  logic dst_address_almost_limit_lo_gated_we;
+  assign dst_address_almost_limit_lo_gated_we =
+    dst_address_almost_limit_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_almost_limit_lo (
+  ) u_dst_address_almost_limit_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_almost_limit_lo_gated_we),
-    .wd     (destination_address_almost_limit_lo_wd),
+    .we     (dst_address_almost_limit_lo_gated_we),
+    .wd     (dst_address_almost_limit_lo_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1111,32 +1111,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_almost_limit_lo.q),
+    .q      (reg2hw.dst_address_almost_limit_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_almost_limit_lo_qs)
+    .qs     (dst_address_almost_limit_lo_qs)
   );
 
 
-  // R[destination_address_almost_limit_hi]: V(False)
+  // R[dst_address_almost_limit_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic destination_address_almost_limit_hi_gated_we;
-  assign destination_address_almost_limit_hi_gated_we =
-    destination_address_almost_limit_hi_we &
+  logic dst_address_almost_limit_hi_gated_we;
+  assign dst_address_almost_limit_hi_gated_we =
+    dst_address_almost_limit_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_destination_address_almost_limit_hi (
+  ) u_dst_address_almost_limit_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (destination_address_almost_limit_hi_gated_we),
-    .wd     (destination_address_almost_limit_hi_wd),
+    .we     (dst_address_almost_limit_hi_gated_we),
+    .wd     (dst_address_almost_limit_hi_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1144,11 +1144,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.destination_address_almost_limit_hi.q),
+    .q      (reg2hw.dst_address_almost_limit_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (destination_address_almost_limit_hi_qs)
+    .qs     (dst_address_almost_limit_hi_qs)
   );
 
 
@@ -3071,8 +3071,8 @@ module dma_reg_top (
     addr_hit[ 3] = (reg_addr == DMA_ALERT_TEST_OFFSET);
     addr_hit[ 4] = (reg_addr == DMA_SRC_ADDRESS_LO_OFFSET);
     addr_hit[ 5] = (reg_addr == DMA_SRC_ADDRESS_HI_OFFSET);
-    addr_hit[ 6] = (reg_addr == DMA_DESTINATION_ADDRESS_LO_OFFSET);
-    addr_hit[ 7] = (reg_addr == DMA_DESTINATION_ADDRESS_HI_OFFSET);
+    addr_hit[ 6] = (reg_addr == DMA_DST_ADDRESS_LO_OFFSET);
+    addr_hit[ 7] = (reg_addr == DMA_DST_ADDRESS_HI_OFFSET);
     addr_hit[ 8] = (reg_addr == DMA_ADDRESS_SPACE_ID_OFFSET);
     addr_hit[ 9] = (reg_addr == DMA_ENABLED_MEMORY_RANGE_BASE_OFFSET);
     addr_hit[10] = (reg_addr == DMA_ENABLED_MEMORY_RANGE_LIMIT_OFFSET);
@@ -3082,10 +3082,10 @@ module dma_reg_top (
     addr_hit[14] = (reg_addr == DMA_TOTAL_DATA_SIZE_OFFSET);
     addr_hit[15] = (reg_addr == DMA_CHUNK_DATA_SIZE_OFFSET);
     addr_hit[16] = (reg_addr == DMA_TRANSFER_WIDTH_OFFSET);
-    addr_hit[17] = (reg_addr == DMA_DESTINATION_ADDRESS_LIMIT_LO_OFFSET);
-    addr_hit[18] = (reg_addr == DMA_DESTINATION_ADDRESS_LIMIT_HI_OFFSET);
-    addr_hit[19] = (reg_addr == DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_OFFSET);
-    addr_hit[20] = (reg_addr == DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_OFFSET);
+    addr_hit[17] = (reg_addr == DMA_DST_ADDRESS_LIMIT_LO_OFFSET);
+    addr_hit[18] = (reg_addr == DMA_DST_ADDRESS_LIMIT_HI_OFFSET);
+    addr_hit[19] = (reg_addr == DMA_DST_ADDRESS_ALMOST_LIMIT_LO_OFFSET);
+    addr_hit[20] = (reg_addr == DMA_DST_ADDRESS_ALMOST_LIMIT_HI_OFFSET);
     addr_hit[21] = (reg_addr == DMA_CONTROL_OFFSET);
     addr_hit[22] = (reg_addr == DMA_STATUS_OFFSET);
     addr_hit[23] = (reg_addr == DMA_ERROR_CODE_OFFSET);
@@ -3235,17 +3235,17 @@ module dma_reg_top (
   assign src_address_hi_we = addr_hit[5] & reg_we & !reg_error;
 
   assign src_address_hi_wd = reg_wdata[31:0];
-  assign destination_address_lo_we = addr_hit[6] & reg_we & !reg_error;
+  assign dst_address_lo_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign destination_address_lo_wd = reg_wdata[31:0];
-  assign destination_address_hi_we = addr_hit[7] & reg_we & !reg_error;
+  assign dst_address_lo_wd = reg_wdata[31:0];
+  assign dst_address_hi_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign destination_address_hi_wd = reg_wdata[31:0];
+  assign dst_address_hi_wd = reg_wdata[31:0];
   assign address_space_id_we = addr_hit[8] & reg_we & !reg_error;
 
   assign address_space_id_src_asid_wd = reg_wdata[3:0];
 
-  assign address_space_id_destination_asid_wd = reg_wdata[7:4];
+  assign address_space_id_dst_asid_wd = reg_wdata[7:4];
   assign enabled_memory_range_base_we = addr_hit[9] & reg_we & !reg_error;
 
   assign enabled_memory_range_base_wd = reg_wdata[31:0];
@@ -3268,18 +3268,18 @@ module dma_reg_top (
   assign transfer_width_we = addr_hit[16] & reg_we & !reg_error;
 
   assign transfer_width_wd = reg_wdata[1:0];
-  assign destination_address_limit_lo_we = addr_hit[17] & reg_we & !reg_error;
+  assign dst_address_limit_lo_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign destination_address_limit_lo_wd = reg_wdata[31:0];
-  assign destination_address_limit_hi_we = addr_hit[18] & reg_we & !reg_error;
+  assign dst_address_limit_lo_wd = reg_wdata[31:0];
+  assign dst_address_limit_hi_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign destination_address_limit_hi_wd = reg_wdata[31:0];
-  assign destination_address_almost_limit_lo_we = addr_hit[19] & reg_we & !reg_error;
+  assign dst_address_limit_hi_wd = reg_wdata[31:0];
+  assign dst_address_almost_limit_lo_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign destination_address_almost_limit_lo_wd = reg_wdata[31:0];
-  assign destination_address_almost_limit_hi_we = addr_hit[20] & reg_we & !reg_error;
+  assign dst_address_almost_limit_lo_wd = reg_wdata[31:0];
+  assign dst_address_almost_limit_hi_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign destination_address_almost_limit_hi_wd = reg_wdata[31:0];
+  assign dst_address_almost_limit_hi_wd = reg_wdata[31:0];
   assign control_we = addr_hit[21] & reg_we & !reg_error;
 
   assign control_opcode_wd = reg_wdata[3:0];
@@ -3389,8 +3389,8 @@ module dma_reg_top (
     reg_we_check[3] = alert_test_we;
     reg_we_check[4] = src_address_lo_gated_we;
     reg_we_check[5] = src_address_hi_gated_we;
-    reg_we_check[6] = destination_address_lo_gated_we;
-    reg_we_check[7] = destination_address_hi_gated_we;
+    reg_we_check[6] = dst_address_lo_gated_we;
+    reg_we_check[7] = dst_address_hi_gated_we;
     reg_we_check[8] = address_space_id_gated_we;
     reg_we_check[9] = enabled_memory_range_base_gated_we;
     reg_we_check[10] = enabled_memory_range_limit_gated_we;
@@ -3400,10 +3400,10 @@ module dma_reg_top (
     reg_we_check[14] = total_data_size_gated_we;
     reg_we_check[15] = chunk_data_size_gated_we;
     reg_we_check[16] = transfer_width_gated_we;
-    reg_we_check[17] = destination_address_limit_lo_gated_we;
-    reg_we_check[18] = destination_address_limit_hi_gated_we;
-    reg_we_check[19] = destination_address_almost_limit_lo_gated_we;
-    reg_we_check[20] = destination_address_almost_limit_hi_gated_we;
+    reg_we_check[17] = dst_address_limit_lo_gated_we;
+    reg_we_check[18] = dst_address_limit_hi_gated_we;
+    reg_we_check[19] = dst_address_almost_limit_lo_gated_we;
+    reg_we_check[20] = dst_address_almost_limit_hi_gated_we;
     reg_we_check[21] = control_we;
     reg_we_check[22] = status_we;
     reg_we_check[23] = 1'b0;
@@ -3485,16 +3485,16 @@ module dma_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[31:0] = destination_address_lo_qs;
+        reg_rdata_next[31:0] = dst_address_lo_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[31:0] = destination_address_hi_qs;
+        reg_rdata_next[31:0] = dst_address_hi_qs;
       end
 
       addr_hit[8]: begin
         reg_rdata_next[3:0] = address_space_id_src_asid_qs;
-        reg_rdata_next[7:4] = address_space_id_destination_asid_qs;
+        reg_rdata_next[7:4] = address_space_id_dst_asid_qs;
       end
 
       addr_hit[9]: begin
@@ -3530,19 +3530,19 @@ module dma_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = destination_address_limit_lo_qs;
+        reg_rdata_next[31:0] = dst_address_limit_lo_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = destination_address_limit_hi_qs;
+        reg_rdata_next[31:0] = dst_address_limit_hi_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = destination_address_almost_limit_lo_qs;
+        reg_rdata_next[31:0] = dst_address_almost_limit_lo_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[31:0] = destination_address_almost_limit_hi_qs;
+        reg_rdata_next[31:0] = dst_address_almost_limit_hi_qs;
       end
 
       addr_hit[21]: begin

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -144,23 +144,23 @@ module dma_reg_top (
   logic intr_test_dma_memory_buffer_limit_wd;
   logic alert_test_we;
   logic alert_test_wd;
-  logic src_address_lo_we;
-  logic [31:0] src_address_lo_qs;
-  logic [31:0] src_address_lo_wd;
-  logic src_address_hi_we;
-  logic [31:0] src_address_hi_qs;
-  logic [31:0] src_address_hi_wd;
-  logic dst_address_lo_we;
-  logic [31:0] dst_address_lo_qs;
-  logic [31:0] dst_address_lo_wd;
-  logic dst_address_hi_we;
-  logic [31:0] dst_address_hi_qs;
-  logic [31:0] dst_address_hi_wd;
-  logic address_space_id_we;
-  logic [3:0] address_space_id_src_asid_qs;
-  logic [3:0] address_space_id_src_asid_wd;
-  logic [3:0] address_space_id_dst_asid_qs;
-  logic [3:0] address_space_id_dst_asid_wd;
+  logic src_addr_lo_we;
+  logic [31:0] src_addr_lo_qs;
+  logic [31:0] src_addr_lo_wd;
+  logic src_addr_hi_we;
+  logic [31:0] src_addr_hi_qs;
+  logic [31:0] src_addr_hi_wd;
+  logic dst_addr_lo_we;
+  logic [31:0] dst_addr_lo_qs;
+  logic [31:0] dst_addr_lo_wd;
+  logic dst_addr_hi_we;
+  logic [31:0] dst_addr_hi_qs;
+  logic [31:0] dst_addr_hi_wd;
+  logic addr_space_id_we;
+  logic [3:0] addr_space_id_src_asid_qs;
+  logic [3:0] addr_space_id_src_asid_wd;
+  logic [3:0] addr_space_id_dst_asid_qs;
+  logic [3:0] addr_space_id_dst_asid_wd;
   logic enabled_memory_range_base_we;
   logic [31:0] enabled_memory_range_base_qs;
   logic [31:0] enabled_memory_range_base_wd;
@@ -184,18 +184,18 @@ module dma_reg_top (
   logic transfer_width_we;
   logic [1:0] transfer_width_qs;
   logic [1:0] transfer_width_wd;
-  logic dst_address_limit_lo_we;
-  logic [31:0] dst_address_limit_lo_qs;
-  logic [31:0] dst_address_limit_lo_wd;
-  logic dst_address_limit_hi_we;
-  logic [31:0] dst_address_limit_hi_qs;
-  logic [31:0] dst_address_limit_hi_wd;
-  logic dst_address_almost_limit_lo_we;
-  logic [31:0] dst_address_almost_limit_lo_qs;
-  logic [31:0] dst_address_almost_limit_lo_wd;
-  logic dst_address_almost_limit_hi_we;
-  logic [31:0] dst_address_almost_limit_hi_qs;
-  logic [31:0] dst_address_almost_limit_hi_wd;
+  logic dst_addr_limit_lo_we;
+  logic [31:0] dst_addr_limit_lo_qs;
+  logic [31:0] dst_addr_limit_lo_wd;
+  logic dst_addr_limit_hi_we;
+  logic [31:0] dst_addr_limit_hi_qs;
+  logic [31:0] dst_addr_limit_hi_wd;
+  logic dst_addr_almost_limit_lo_we;
+  logic [31:0] dst_addr_almost_limit_lo_qs;
+  logic [31:0] dst_addr_almost_limit_lo_wd;
+  logic dst_addr_almost_limit_hi_we;
+  logic [31:0] dst_addr_almost_limit_hi_qs;
+  logic [31:0] dst_addr_almost_limit_hi_wd;
   logic control_we;
   logic [3:0] control_opcode_qs;
   logic [3:0] control_opcode_wd;
@@ -221,8 +221,8 @@ module dma_reg_top (
   logic status_error_qs;
   logic status_error_wd;
   logic status_sha2_digest_valid_qs;
-  logic error_code_src_address_error_qs;
-  logic error_code_dst_address_error_qs;
+  logic error_code_src_addr_error_qs;
+  logic error_code_dst_addr_error_qs;
   logic error_code_opcode_error_qs;
   logic error_code_size_error_qs;
   logic error_code_bus_error_qs;
@@ -561,143 +561,143 @@ module dma_reg_top (
   assign reg2hw.alert_test.qe = alert_test_qe;
 
 
-  // R[src_address_lo]: V(False)
+  // R[src_addr_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic src_address_lo_gated_we;
-  assign src_address_lo_gated_we =
-    src_address_lo_we &
+  logic src_addr_lo_gated_we;
+  assign src_addr_lo_gated_we =
+    src_addr_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_src_address_lo (
+  ) u_src_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (src_address_lo_gated_we),
-    .wd     (src_address_lo_wd),
+    .we     (src_addr_lo_gated_we),
+    .wd     (src_addr_lo_wd),
 
     // from internal hardware
-    .de     (hw2reg.src_address_lo.de),
-    .d      (hw2reg.src_address_lo.d),
+    .de     (hw2reg.src_addr_lo.de),
+    .d      (hw2reg.src_addr_lo.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.src_address_lo.q),
+    .q      (reg2hw.src_addr_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (src_address_lo_qs)
+    .qs     (src_addr_lo_qs)
   );
 
 
-  // R[src_address_hi]: V(False)
+  // R[src_addr_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic src_address_hi_gated_we;
-  assign src_address_hi_gated_we =
-    src_address_hi_we &
+  logic src_addr_hi_gated_we;
+  assign src_addr_hi_gated_we =
+    src_addr_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_src_address_hi (
+  ) u_src_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (src_address_hi_gated_we),
-    .wd     (src_address_hi_wd),
+    .we     (src_addr_hi_gated_we),
+    .wd     (src_addr_hi_wd),
 
     // from internal hardware
-    .de     (hw2reg.src_address_hi.de),
-    .d      (hw2reg.src_address_hi.d),
+    .de     (hw2reg.src_addr_hi.de),
+    .d      (hw2reg.src_addr_hi.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.src_address_hi.q),
+    .q      (reg2hw.src_addr_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (src_address_hi_qs)
+    .qs     (src_addr_hi_qs)
   );
 
 
-  // R[dst_address_lo]: V(False)
+  // R[dst_addr_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_lo_gated_we;
-  assign dst_address_lo_gated_we =
-    dst_address_lo_we &
+  logic dst_addr_lo_gated_we;
+  assign dst_addr_lo_gated_we =
+    dst_addr_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_lo (
+  ) u_dst_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_lo_gated_we),
-    .wd     (dst_address_lo_wd),
+    .we     (dst_addr_lo_gated_we),
+    .wd     (dst_addr_lo_wd),
 
     // from internal hardware
-    .de     (hw2reg.dst_address_lo.de),
-    .d      (hw2reg.dst_address_lo.d),
+    .de     (hw2reg.dst_addr_lo.de),
+    .d      (hw2reg.dst_addr_lo.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_lo.q),
+    .q      (reg2hw.dst_addr_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_lo_qs)
+    .qs     (dst_addr_lo_qs)
   );
 
 
-  // R[dst_address_hi]: V(False)
+  // R[dst_addr_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_hi_gated_we;
-  assign dst_address_hi_gated_we =
-    dst_address_hi_we &
+  logic dst_addr_hi_gated_we;
+  assign dst_addr_hi_gated_we =
+    dst_addr_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_hi (
+  ) u_dst_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_hi_gated_we),
-    .wd     (dst_address_hi_wd),
+    .we     (dst_addr_hi_gated_we),
+    .wd     (dst_addr_hi_wd),
 
     // from internal hardware
-    .de     (hw2reg.dst_address_hi.de),
-    .d      (hw2reg.dst_address_hi.d),
+    .de     (hw2reg.dst_addr_hi.de),
+    .d      (hw2reg.dst_addr_hi.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_hi.q),
+    .q      (reg2hw.dst_addr_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_hi_qs)
+    .qs     (dst_addr_hi_qs)
   );
 
 
-  // R[address_space_id]: V(False)
+  // R[addr_space_id]: V(False)
   // Create REGWEN-gated WE signal
-  logic address_space_id_gated_we;
-  assign address_space_id_gated_we =
-    address_space_id_we &
+  logic addr_space_id_gated_we;
+  assign addr_space_id_gated_we =
+    addr_space_id_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   //   F[src_asid]: 3:0
   prim_subreg #(
@@ -705,13 +705,13 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0)
-  ) u_address_space_id_src_asid (
+  ) u_addr_space_id_src_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (address_space_id_gated_we),
-    .wd     (address_space_id_src_asid_wd),
+    .we     (addr_space_id_gated_we),
+    .wd     (addr_space_id_src_asid_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -719,11 +719,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.address_space_id.src_asid.q),
+    .q      (reg2hw.addr_space_id.src_asid.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (address_space_id_src_asid_qs)
+    .qs     (addr_space_id_src_asid_qs)
   );
 
   //   F[dst_asid]: 7:4
@@ -732,13 +732,13 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0)
-  ) u_address_space_id_dst_asid (
+  ) u_addr_space_id_dst_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (address_space_id_gated_we),
-    .wd     (address_space_id_dst_asid_wd),
+    .we     (addr_space_id_gated_we),
+    .wd     (addr_space_id_dst_asid_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -746,11 +746,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.address_space_id.dst_asid.q),
+    .q      (reg2hw.addr_space_id.dst_asid.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (address_space_id_dst_asid_qs)
+    .qs     (addr_space_id_dst_asid_qs)
   );
 
 
@@ -1020,24 +1020,24 @@ module dma_reg_top (
   );
 
 
-  // R[dst_address_limit_lo]: V(False)
+  // R[dst_addr_limit_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_limit_lo_gated_we;
-  assign dst_address_limit_lo_gated_we =
-    dst_address_limit_lo_we &
+  logic dst_addr_limit_lo_gated_we;
+  assign dst_addr_limit_lo_gated_we =
+    dst_addr_limit_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_limit_lo (
+  ) u_dst_addr_limit_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_limit_lo_gated_we),
-    .wd     (dst_address_limit_lo_wd),
+    .we     (dst_addr_limit_lo_gated_we),
+    .wd     (dst_addr_limit_lo_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1045,32 +1045,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_limit_lo.q),
+    .q      (reg2hw.dst_addr_limit_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_limit_lo_qs)
+    .qs     (dst_addr_limit_lo_qs)
   );
 
 
-  // R[dst_address_limit_hi]: V(False)
+  // R[dst_addr_limit_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_limit_hi_gated_we;
-  assign dst_address_limit_hi_gated_we =
-    dst_address_limit_hi_we &
+  logic dst_addr_limit_hi_gated_we;
+  assign dst_addr_limit_hi_gated_we =
+    dst_addr_limit_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_limit_hi (
+  ) u_dst_addr_limit_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_limit_hi_gated_we),
-    .wd     (dst_address_limit_hi_wd),
+    .we     (dst_addr_limit_hi_gated_we),
+    .wd     (dst_addr_limit_hi_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1078,32 +1078,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_limit_hi.q),
+    .q      (reg2hw.dst_addr_limit_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_limit_hi_qs)
+    .qs     (dst_addr_limit_hi_qs)
   );
 
 
-  // R[dst_address_almost_limit_lo]: V(False)
+  // R[dst_addr_almost_limit_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_almost_limit_lo_gated_we;
-  assign dst_address_almost_limit_lo_gated_we =
-    dst_address_almost_limit_lo_we &
+  logic dst_addr_almost_limit_lo_gated_we;
+  assign dst_addr_almost_limit_lo_gated_we =
+    dst_addr_almost_limit_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_almost_limit_lo (
+  ) u_dst_addr_almost_limit_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_almost_limit_lo_gated_we),
-    .wd     (dst_address_almost_limit_lo_wd),
+    .we     (dst_addr_almost_limit_lo_gated_we),
+    .wd     (dst_addr_almost_limit_lo_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1111,32 +1111,32 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_almost_limit_lo.q),
+    .q      (reg2hw.dst_addr_almost_limit_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_almost_limit_lo_qs)
+    .qs     (dst_addr_almost_limit_lo_qs)
   );
 
 
-  // R[dst_address_almost_limit_hi]: V(False)
+  // R[dst_addr_almost_limit_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic dst_address_almost_limit_hi_gated_we;
-  assign dst_address_almost_limit_hi_gated_we =
-    dst_address_almost_limit_hi_we &
+  logic dst_addr_almost_limit_hi_gated_we;
+  assign dst_addr_almost_limit_hi_gated_we =
+    dst_addr_almost_limit_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_dst_address_almost_limit_hi (
+  ) u_dst_addr_almost_limit_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dst_address_almost_limit_hi_gated_we),
-    .wd     (dst_address_almost_limit_hi_wd),
+    .we     (dst_addr_almost_limit_hi_gated_we),
+    .wd     (dst_addr_almost_limit_hi_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1144,11 +1144,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.dst_address_almost_limit_hi.q),
+    .q      (reg2hw.dst_addr_almost_limit_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (dst_address_almost_limit_hi_qs)
+    .qs     (dst_addr_almost_limit_hi_qs)
   );
 
 
@@ -1533,13 +1533,13 @@ module dma_reg_top (
 
 
   // R[error_code]: V(False)
-  //   F[src_address_error]: 0:0
+  //   F[src_addr_error]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_error_code_src_address_error (
+  ) u_error_code_src_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -1548,8 +1548,8 @@ module dma_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.error_code.src_address_error.de),
-    .d      (hw2reg.error_code.src_address_error.d),
+    .de     (hw2reg.error_code.src_addr_error.de),
+    .d      (hw2reg.error_code.src_addr_error.d),
 
     // to internal hardware
     .qe     (),
@@ -1557,16 +1557,16 @@ module dma_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (error_code_src_address_error_qs)
+    .qs     (error_code_src_addr_error_qs)
   );
 
-  //   F[dst_address_error]: 1:1
+  //   F[dst_addr_error]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_error_code_dst_address_error (
+  ) u_error_code_dst_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -1575,8 +1575,8 @@ module dma_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.error_code.dst_address_error.de),
-    .d      (hw2reg.error_code.dst_address_error.d),
+    .de     (hw2reg.error_code.dst_addr_error.de),
+    .d      (hw2reg.error_code.dst_addr_error.d),
 
     // to internal hardware
     .qe     (),
@@ -1584,7 +1584,7 @@ module dma_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (error_code_dst_address_error_qs)
+    .qs     (error_code_dst_addr_error_qs)
   );
 
   //   F[opcode_error]: 2:2
@@ -3069,11 +3069,11 @@ module dma_reg_top (
     addr_hit[ 1] = (reg_addr == DMA_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == DMA_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == DMA_ALERT_TEST_OFFSET);
-    addr_hit[ 4] = (reg_addr == DMA_SRC_ADDRESS_LO_OFFSET);
-    addr_hit[ 5] = (reg_addr == DMA_SRC_ADDRESS_HI_OFFSET);
-    addr_hit[ 6] = (reg_addr == DMA_DST_ADDRESS_LO_OFFSET);
-    addr_hit[ 7] = (reg_addr == DMA_DST_ADDRESS_HI_OFFSET);
-    addr_hit[ 8] = (reg_addr == DMA_ADDRESS_SPACE_ID_OFFSET);
+    addr_hit[ 4] = (reg_addr == DMA_SRC_ADDR_LO_OFFSET);
+    addr_hit[ 5] = (reg_addr == DMA_SRC_ADDR_HI_OFFSET);
+    addr_hit[ 6] = (reg_addr == DMA_DST_ADDR_LO_OFFSET);
+    addr_hit[ 7] = (reg_addr == DMA_DST_ADDR_HI_OFFSET);
+    addr_hit[ 8] = (reg_addr == DMA_ADDR_SPACE_ID_OFFSET);
     addr_hit[ 9] = (reg_addr == DMA_ENABLED_MEMORY_RANGE_BASE_OFFSET);
     addr_hit[10] = (reg_addr == DMA_ENABLED_MEMORY_RANGE_LIMIT_OFFSET);
     addr_hit[11] = (reg_addr == DMA_RANGE_VALID_OFFSET);
@@ -3082,10 +3082,10 @@ module dma_reg_top (
     addr_hit[14] = (reg_addr == DMA_TOTAL_DATA_SIZE_OFFSET);
     addr_hit[15] = (reg_addr == DMA_CHUNK_DATA_SIZE_OFFSET);
     addr_hit[16] = (reg_addr == DMA_TRANSFER_WIDTH_OFFSET);
-    addr_hit[17] = (reg_addr == DMA_DST_ADDRESS_LIMIT_LO_OFFSET);
-    addr_hit[18] = (reg_addr == DMA_DST_ADDRESS_LIMIT_HI_OFFSET);
-    addr_hit[19] = (reg_addr == DMA_DST_ADDRESS_ALMOST_LIMIT_LO_OFFSET);
-    addr_hit[20] = (reg_addr == DMA_DST_ADDRESS_ALMOST_LIMIT_HI_OFFSET);
+    addr_hit[17] = (reg_addr == DMA_DST_ADDR_LIMIT_LO_OFFSET);
+    addr_hit[18] = (reg_addr == DMA_DST_ADDR_LIMIT_HI_OFFSET);
+    addr_hit[19] = (reg_addr == DMA_DST_ADDR_ALMOST_LIMIT_LO_OFFSET);
+    addr_hit[20] = (reg_addr == DMA_DST_ADDR_ALMOST_LIMIT_HI_OFFSET);
     addr_hit[21] = (reg_addr == DMA_CONTROL_OFFSET);
     addr_hit[22] = (reg_addr == DMA_STATUS_OFFSET);
     addr_hit[23] = (reg_addr == DMA_ERROR_CODE_OFFSET);
@@ -3229,23 +3229,23 @@ module dma_reg_top (
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
-  assign src_address_lo_we = addr_hit[4] & reg_we & !reg_error;
+  assign src_addr_lo_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign src_address_lo_wd = reg_wdata[31:0];
-  assign src_address_hi_we = addr_hit[5] & reg_we & !reg_error;
+  assign src_addr_lo_wd = reg_wdata[31:0];
+  assign src_addr_hi_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign src_address_hi_wd = reg_wdata[31:0];
-  assign dst_address_lo_we = addr_hit[6] & reg_we & !reg_error;
+  assign src_addr_hi_wd = reg_wdata[31:0];
+  assign dst_addr_lo_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign dst_address_lo_wd = reg_wdata[31:0];
-  assign dst_address_hi_we = addr_hit[7] & reg_we & !reg_error;
+  assign dst_addr_lo_wd = reg_wdata[31:0];
+  assign dst_addr_hi_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign dst_address_hi_wd = reg_wdata[31:0];
-  assign address_space_id_we = addr_hit[8] & reg_we & !reg_error;
+  assign dst_addr_hi_wd = reg_wdata[31:0];
+  assign addr_space_id_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign address_space_id_src_asid_wd = reg_wdata[3:0];
+  assign addr_space_id_src_asid_wd = reg_wdata[3:0];
 
-  assign address_space_id_dst_asid_wd = reg_wdata[7:4];
+  assign addr_space_id_dst_asid_wd = reg_wdata[7:4];
   assign enabled_memory_range_base_we = addr_hit[9] & reg_we & !reg_error;
 
   assign enabled_memory_range_base_wd = reg_wdata[31:0];
@@ -3268,18 +3268,18 @@ module dma_reg_top (
   assign transfer_width_we = addr_hit[16] & reg_we & !reg_error;
 
   assign transfer_width_wd = reg_wdata[1:0];
-  assign dst_address_limit_lo_we = addr_hit[17] & reg_we & !reg_error;
+  assign dst_addr_limit_lo_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign dst_address_limit_lo_wd = reg_wdata[31:0];
-  assign dst_address_limit_hi_we = addr_hit[18] & reg_we & !reg_error;
+  assign dst_addr_limit_lo_wd = reg_wdata[31:0];
+  assign dst_addr_limit_hi_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign dst_address_limit_hi_wd = reg_wdata[31:0];
-  assign dst_address_almost_limit_lo_we = addr_hit[19] & reg_we & !reg_error;
+  assign dst_addr_limit_hi_wd = reg_wdata[31:0];
+  assign dst_addr_almost_limit_lo_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign dst_address_almost_limit_lo_wd = reg_wdata[31:0];
-  assign dst_address_almost_limit_hi_we = addr_hit[20] & reg_we & !reg_error;
+  assign dst_addr_almost_limit_lo_wd = reg_wdata[31:0];
+  assign dst_addr_almost_limit_hi_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign dst_address_almost_limit_hi_wd = reg_wdata[31:0];
+  assign dst_addr_almost_limit_hi_wd = reg_wdata[31:0];
   assign control_we = addr_hit[21] & reg_we & !reg_error;
 
   assign control_opcode_wd = reg_wdata[3:0];
@@ -3387,11 +3387,11 @@ module dma_reg_top (
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;
     reg_we_check[3] = alert_test_we;
-    reg_we_check[4] = src_address_lo_gated_we;
-    reg_we_check[5] = src_address_hi_gated_we;
-    reg_we_check[6] = dst_address_lo_gated_we;
-    reg_we_check[7] = dst_address_hi_gated_we;
-    reg_we_check[8] = address_space_id_gated_we;
+    reg_we_check[4] = src_addr_lo_gated_we;
+    reg_we_check[5] = src_addr_hi_gated_we;
+    reg_we_check[6] = dst_addr_lo_gated_we;
+    reg_we_check[7] = dst_addr_hi_gated_we;
+    reg_we_check[8] = addr_space_id_gated_we;
     reg_we_check[9] = enabled_memory_range_base_gated_we;
     reg_we_check[10] = enabled_memory_range_limit_gated_we;
     reg_we_check[11] = range_valid_gated_we;
@@ -3400,10 +3400,10 @@ module dma_reg_top (
     reg_we_check[14] = total_data_size_gated_we;
     reg_we_check[15] = chunk_data_size_gated_we;
     reg_we_check[16] = transfer_width_gated_we;
-    reg_we_check[17] = dst_address_limit_lo_gated_we;
-    reg_we_check[18] = dst_address_limit_hi_gated_we;
-    reg_we_check[19] = dst_address_almost_limit_lo_gated_we;
-    reg_we_check[20] = dst_address_almost_limit_hi_gated_we;
+    reg_we_check[17] = dst_addr_limit_lo_gated_we;
+    reg_we_check[18] = dst_addr_limit_hi_gated_we;
+    reg_we_check[19] = dst_addr_almost_limit_lo_gated_we;
+    reg_we_check[20] = dst_addr_almost_limit_hi_gated_we;
     reg_we_check[21] = control_we;
     reg_we_check[22] = status_we;
     reg_we_check[23] = 1'b0;
@@ -3477,24 +3477,24 @@ module dma_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[31:0] = src_address_lo_qs;
+        reg_rdata_next[31:0] = src_addr_lo_qs;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[31:0] = src_address_hi_qs;
+        reg_rdata_next[31:0] = src_addr_hi_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[31:0] = dst_address_lo_qs;
+        reg_rdata_next[31:0] = dst_addr_lo_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[31:0] = dst_address_hi_qs;
+        reg_rdata_next[31:0] = dst_addr_hi_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[3:0] = address_space_id_src_asid_qs;
-        reg_rdata_next[7:4] = address_space_id_dst_asid_qs;
+        reg_rdata_next[3:0] = addr_space_id_src_asid_qs;
+        reg_rdata_next[7:4] = addr_space_id_dst_asid_qs;
       end
 
       addr_hit[9]: begin
@@ -3530,19 +3530,19 @@ module dma_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = dst_address_limit_lo_qs;
+        reg_rdata_next[31:0] = dst_addr_limit_lo_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = dst_address_limit_hi_qs;
+        reg_rdata_next[31:0] = dst_addr_limit_hi_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = dst_address_almost_limit_lo_qs;
+        reg_rdata_next[31:0] = dst_addr_almost_limit_lo_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[31:0] = dst_address_almost_limit_hi_qs;
+        reg_rdata_next[31:0] = dst_addr_almost_limit_hi_qs;
       end
 
       addr_hit[21]: begin
@@ -3565,8 +3565,8 @@ module dma_reg_top (
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[0] = error_code_src_address_error_qs;
-        reg_rdata_next[1] = error_code_dst_address_error_qs;
+        reg_rdata_next[0] = error_code_src_addr_error_qs;
+        reg_rdata_next[1] = error_code_dst_addr_error_qs;
         reg_rdata_next[2] = error_code_opcode_error_qs;
         reg_rdata_next[3] = error_code_size_error_qs;
         reg_rdata_next[4] = error_code_bus_error_qs;

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -144,12 +144,12 @@ module dma_reg_top (
   logic intr_test_dma_memory_buffer_limit_wd;
   logic alert_test_we;
   logic alert_test_wd;
-  logic source_address_lo_we;
-  logic [31:0] source_address_lo_qs;
-  logic [31:0] source_address_lo_wd;
-  logic source_address_hi_we;
-  logic [31:0] source_address_hi_qs;
-  logic [31:0] source_address_hi_wd;
+  logic src_address_lo_we;
+  logic [31:0] src_address_lo_qs;
+  logic [31:0] src_address_lo_wd;
+  logic src_address_hi_we;
+  logic [31:0] src_address_hi_qs;
+  logic [31:0] src_address_hi_wd;
   logic destination_address_lo_we;
   logic [31:0] destination_address_lo_qs;
   logic [31:0] destination_address_lo_wd;
@@ -157,8 +157,8 @@ module dma_reg_top (
   logic [31:0] destination_address_hi_qs;
   logic [31:0] destination_address_hi_wd;
   logic address_space_id_we;
-  logic [3:0] address_space_id_source_asid_qs;
-  logic [3:0] address_space_id_source_asid_wd;
+  logic [3:0] address_space_id_src_asid_qs;
+  logic [3:0] address_space_id_src_asid_wd;
   logic [3:0] address_space_id_destination_asid_qs;
   logic [3:0] address_space_id_destination_asid_wd;
   logic enabled_memory_range_base_we;
@@ -254,72 +254,72 @@ module dma_reg_top (
   logic clear_intr_bus_we;
   logic [10:0] clear_intr_bus_qs;
   logic [10:0] clear_intr_bus_wd;
-  logic intr_source_addr_0_we;
-  logic [31:0] intr_source_addr_0_qs;
-  logic [31:0] intr_source_addr_0_wd;
-  logic intr_source_addr_1_we;
-  logic [31:0] intr_source_addr_1_qs;
-  logic [31:0] intr_source_addr_1_wd;
-  logic intr_source_addr_2_we;
-  logic [31:0] intr_source_addr_2_qs;
-  logic [31:0] intr_source_addr_2_wd;
-  logic intr_source_addr_3_we;
-  logic [31:0] intr_source_addr_3_qs;
-  logic [31:0] intr_source_addr_3_wd;
-  logic intr_source_addr_4_we;
-  logic [31:0] intr_source_addr_4_qs;
-  logic [31:0] intr_source_addr_4_wd;
-  logic intr_source_addr_5_we;
-  logic [31:0] intr_source_addr_5_qs;
-  logic [31:0] intr_source_addr_5_wd;
-  logic intr_source_addr_6_we;
-  logic [31:0] intr_source_addr_6_qs;
-  logic [31:0] intr_source_addr_6_wd;
-  logic intr_source_addr_7_we;
-  logic [31:0] intr_source_addr_7_qs;
-  logic [31:0] intr_source_addr_7_wd;
-  logic intr_source_addr_8_we;
-  logic [31:0] intr_source_addr_8_qs;
-  logic [31:0] intr_source_addr_8_wd;
-  logic intr_source_addr_9_we;
-  logic [31:0] intr_source_addr_9_qs;
-  logic [31:0] intr_source_addr_9_wd;
-  logic intr_source_addr_10_we;
-  logic [31:0] intr_source_addr_10_qs;
-  logic [31:0] intr_source_addr_10_wd;
-  logic intr_source_wr_val_0_we;
-  logic [31:0] intr_source_wr_val_0_qs;
-  logic [31:0] intr_source_wr_val_0_wd;
-  logic intr_source_wr_val_1_we;
-  logic [31:0] intr_source_wr_val_1_qs;
-  logic [31:0] intr_source_wr_val_1_wd;
-  logic intr_source_wr_val_2_we;
-  logic [31:0] intr_source_wr_val_2_qs;
-  logic [31:0] intr_source_wr_val_2_wd;
-  logic intr_source_wr_val_3_we;
-  logic [31:0] intr_source_wr_val_3_qs;
-  logic [31:0] intr_source_wr_val_3_wd;
-  logic intr_source_wr_val_4_we;
-  logic [31:0] intr_source_wr_val_4_qs;
-  logic [31:0] intr_source_wr_val_4_wd;
-  logic intr_source_wr_val_5_we;
-  logic [31:0] intr_source_wr_val_5_qs;
-  logic [31:0] intr_source_wr_val_5_wd;
-  logic intr_source_wr_val_6_we;
-  logic [31:0] intr_source_wr_val_6_qs;
-  logic [31:0] intr_source_wr_val_6_wd;
-  logic intr_source_wr_val_7_we;
-  logic [31:0] intr_source_wr_val_7_qs;
-  logic [31:0] intr_source_wr_val_7_wd;
-  logic intr_source_wr_val_8_we;
-  logic [31:0] intr_source_wr_val_8_qs;
-  logic [31:0] intr_source_wr_val_8_wd;
-  logic intr_source_wr_val_9_we;
-  logic [31:0] intr_source_wr_val_9_qs;
-  logic [31:0] intr_source_wr_val_9_wd;
-  logic intr_source_wr_val_10_we;
-  logic [31:0] intr_source_wr_val_10_qs;
-  logic [31:0] intr_source_wr_val_10_wd;
+  logic intr_src_addr_0_we;
+  logic [31:0] intr_src_addr_0_qs;
+  logic [31:0] intr_src_addr_0_wd;
+  logic intr_src_addr_1_we;
+  logic [31:0] intr_src_addr_1_qs;
+  logic [31:0] intr_src_addr_1_wd;
+  logic intr_src_addr_2_we;
+  logic [31:0] intr_src_addr_2_qs;
+  logic [31:0] intr_src_addr_2_wd;
+  logic intr_src_addr_3_we;
+  logic [31:0] intr_src_addr_3_qs;
+  logic [31:0] intr_src_addr_3_wd;
+  logic intr_src_addr_4_we;
+  logic [31:0] intr_src_addr_4_qs;
+  logic [31:0] intr_src_addr_4_wd;
+  logic intr_src_addr_5_we;
+  logic [31:0] intr_src_addr_5_qs;
+  logic [31:0] intr_src_addr_5_wd;
+  logic intr_src_addr_6_we;
+  logic [31:0] intr_src_addr_6_qs;
+  logic [31:0] intr_src_addr_6_wd;
+  logic intr_src_addr_7_we;
+  logic [31:0] intr_src_addr_7_qs;
+  logic [31:0] intr_src_addr_7_wd;
+  logic intr_src_addr_8_we;
+  logic [31:0] intr_src_addr_8_qs;
+  logic [31:0] intr_src_addr_8_wd;
+  logic intr_src_addr_9_we;
+  logic [31:0] intr_src_addr_9_qs;
+  logic [31:0] intr_src_addr_9_wd;
+  logic intr_src_addr_10_we;
+  logic [31:0] intr_src_addr_10_qs;
+  logic [31:0] intr_src_addr_10_wd;
+  logic intr_src_wr_val_0_we;
+  logic [31:0] intr_src_wr_val_0_qs;
+  logic [31:0] intr_src_wr_val_0_wd;
+  logic intr_src_wr_val_1_we;
+  logic [31:0] intr_src_wr_val_1_qs;
+  logic [31:0] intr_src_wr_val_1_wd;
+  logic intr_src_wr_val_2_we;
+  logic [31:0] intr_src_wr_val_2_qs;
+  logic [31:0] intr_src_wr_val_2_wd;
+  logic intr_src_wr_val_3_we;
+  logic [31:0] intr_src_wr_val_3_qs;
+  logic [31:0] intr_src_wr_val_3_wd;
+  logic intr_src_wr_val_4_we;
+  logic [31:0] intr_src_wr_val_4_qs;
+  logic [31:0] intr_src_wr_val_4_wd;
+  logic intr_src_wr_val_5_we;
+  logic [31:0] intr_src_wr_val_5_qs;
+  logic [31:0] intr_src_wr_val_5_wd;
+  logic intr_src_wr_val_6_we;
+  logic [31:0] intr_src_wr_val_6_qs;
+  logic [31:0] intr_src_wr_val_6_wd;
+  logic intr_src_wr_val_7_we;
+  logic [31:0] intr_src_wr_val_7_qs;
+  logic [31:0] intr_src_wr_val_7_wd;
+  logic intr_src_wr_val_8_we;
+  logic [31:0] intr_src_wr_val_8_qs;
+  logic [31:0] intr_src_wr_val_8_wd;
+  logic intr_src_wr_val_9_we;
+  logic [31:0] intr_src_wr_val_9_qs;
+  logic [31:0] intr_src_wr_val_9_wd;
+  logic intr_src_wr_val_10_we;
+  logic [31:0] intr_src_wr_val_10_qs;
+  logic [31:0] intr_src_wr_val_10_wd;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -561,69 +561,69 @@ module dma_reg_top (
   assign reg2hw.alert_test.qe = alert_test_qe;
 
 
-  // R[source_address_lo]: V(False)
+  // R[src_address_lo]: V(False)
   // Create REGWEN-gated WE signal
-  logic source_address_lo_gated_we;
-  assign source_address_lo_gated_we =
-    source_address_lo_we &
+  logic src_address_lo_gated_we;
+  assign src_address_lo_gated_we =
+    src_address_lo_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_source_address_lo (
+  ) u_src_address_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (source_address_lo_gated_we),
-    .wd     (source_address_lo_wd),
+    .we     (src_address_lo_gated_we),
+    .wd     (src_address_lo_wd),
 
     // from internal hardware
-    .de     (hw2reg.source_address_lo.de),
-    .d      (hw2reg.source_address_lo.d),
+    .de     (hw2reg.src_address_lo.de),
+    .d      (hw2reg.src_address_lo.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.source_address_lo.q),
+    .q      (reg2hw.src_address_lo.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (source_address_lo_qs)
+    .qs     (src_address_lo_qs)
   );
 
 
-  // R[source_address_hi]: V(False)
+  // R[src_address_hi]: V(False)
   // Create REGWEN-gated WE signal
-  logic source_address_hi_gated_we;
-  assign source_address_hi_gated_we =
-    source_address_hi_we &
+  logic src_address_hi_gated_we;
+  assign src_address_hi_gated_we =
+    src_address_hi_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_source_address_hi (
+  ) u_src_address_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (source_address_hi_gated_we),
-    .wd     (source_address_hi_wd),
+    .we     (src_address_hi_gated_we),
+    .wd     (src_address_hi_wd),
 
     // from internal hardware
-    .de     (hw2reg.source_address_hi.de),
-    .d      (hw2reg.source_address_hi.d),
+    .de     (hw2reg.src_address_hi.de),
+    .d      (hw2reg.src_address_hi.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.source_address_hi.q),
+    .q      (reg2hw.src_address_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (source_address_hi_qs)
+    .qs     (src_address_hi_qs)
   );
 
 
@@ -699,19 +699,19 @@ module dma_reg_top (
   assign address_space_id_gated_we =
     address_space_id_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
-  //   F[source_asid]: 3:0
+  //   F[src_asid]: 3:0
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0)
-  ) u_address_space_id_source_asid (
+  ) u_address_space_id_src_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (address_space_id_gated_we),
-    .wd     (address_space_id_source_asid_wd),
+    .wd     (address_space_id_src_asid_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -719,11 +719,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.address_space_id.source_asid.q),
+    .q      (reg2hw.address_space_id.src_asid.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (address_space_id_source_asid_qs)
+    .qs     (address_space_id_src_asid_qs)
   );
 
   //   F[destination_asid]: 7:4
@@ -2313,25 +2313,25 @@ module dma_reg_top (
   );
 
 
-  // Subregister 0 of Multireg intr_source_addr
-  // R[intr_source_addr_0]: V(False)
+  // Subregister 0 of Multireg intr_src_addr
+  // R[intr_src_addr_0]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_0_gated_we;
-  assign intr_source_addr_0_gated_we =
-    intr_source_addr_0_we &
+  logic intr_src_addr_0_gated_we;
+  assign intr_src_addr_0_gated_we =
+    intr_src_addr_0_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_0 (
+  ) u_intr_src_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_0_gated_we),
-    .wd     (intr_source_addr_0_wd),
+    .we     (intr_src_addr_0_gated_we),
+    .wd     (intr_src_addr_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2339,33 +2339,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[0].q),
+    .q      (reg2hw.intr_src_addr[0].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_0_qs)
+    .qs     (intr_src_addr_0_qs)
   );
 
 
-  // Subregister 1 of Multireg intr_source_addr
-  // R[intr_source_addr_1]: V(False)
+  // Subregister 1 of Multireg intr_src_addr
+  // R[intr_src_addr_1]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_1_gated_we;
-  assign intr_source_addr_1_gated_we =
-    intr_source_addr_1_we &
+  logic intr_src_addr_1_gated_we;
+  assign intr_src_addr_1_gated_we =
+    intr_src_addr_1_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_1 (
+  ) u_intr_src_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_1_gated_we),
-    .wd     (intr_source_addr_1_wd),
+    .we     (intr_src_addr_1_gated_we),
+    .wd     (intr_src_addr_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2373,33 +2373,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[1].q),
+    .q      (reg2hw.intr_src_addr[1].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_1_qs)
+    .qs     (intr_src_addr_1_qs)
   );
 
 
-  // Subregister 2 of Multireg intr_source_addr
-  // R[intr_source_addr_2]: V(False)
+  // Subregister 2 of Multireg intr_src_addr
+  // R[intr_src_addr_2]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_2_gated_we;
-  assign intr_source_addr_2_gated_we =
-    intr_source_addr_2_we &
+  logic intr_src_addr_2_gated_we;
+  assign intr_src_addr_2_gated_we =
+    intr_src_addr_2_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_2 (
+  ) u_intr_src_addr_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_2_gated_we),
-    .wd     (intr_source_addr_2_wd),
+    .we     (intr_src_addr_2_gated_we),
+    .wd     (intr_src_addr_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2407,33 +2407,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[2].q),
+    .q      (reg2hw.intr_src_addr[2].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_2_qs)
+    .qs     (intr_src_addr_2_qs)
   );
 
 
-  // Subregister 3 of Multireg intr_source_addr
-  // R[intr_source_addr_3]: V(False)
+  // Subregister 3 of Multireg intr_src_addr
+  // R[intr_src_addr_3]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_3_gated_we;
-  assign intr_source_addr_3_gated_we =
-    intr_source_addr_3_we &
+  logic intr_src_addr_3_gated_we;
+  assign intr_src_addr_3_gated_we =
+    intr_src_addr_3_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_3 (
+  ) u_intr_src_addr_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_3_gated_we),
-    .wd     (intr_source_addr_3_wd),
+    .we     (intr_src_addr_3_gated_we),
+    .wd     (intr_src_addr_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2441,33 +2441,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[3].q),
+    .q      (reg2hw.intr_src_addr[3].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_3_qs)
+    .qs     (intr_src_addr_3_qs)
   );
 
 
-  // Subregister 4 of Multireg intr_source_addr
-  // R[intr_source_addr_4]: V(False)
+  // Subregister 4 of Multireg intr_src_addr
+  // R[intr_src_addr_4]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_4_gated_we;
-  assign intr_source_addr_4_gated_we =
-    intr_source_addr_4_we &
+  logic intr_src_addr_4_gated_we;
+  assign intr_src_addr_4_gated_we =
+    intr_src_addr_4_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_4 (
+  ) u_intr_src_addr_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_4_gated_we),
-    .wd     (intr_source_addr_4_wd),
+    .we     (intr_src_addr_4_gated_we),
+    .wd     (intr_src_addr_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2475,33 +2475,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[4].q),
+    .q      (reg2hw.intr_src_addr[4].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_4_qs)
+    .qs     (intr_src_addr_4_qs)
   );
 
 
-  // Subregister 5 of Multireg intr_source_addr
-  // R[intr_source_addr_5]: V(False)
+  // Subregister 5 of Multireg intr_src_addr
+  // R[intr_src_addr_5]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_5_gated_we;
-  assign intr_source_addr_5_gated_we =
-    intr_source_addr_5_we &
+  logic intr_src_addr_5_gated_we;
+  assign intr_src_addr_5_gated_we =
+    intr_src_addr_5_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_5 (
+  ) u_intr_src_addr_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_5_gated_we),
-    .wd     (intr_source_addr_5_wd),
+    .we     (intr_src_addr_5_gated_we),
+    .wd     (intr_src_addr_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2509,33 +2509,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[5].q),
+    .q      (reg2hw.intr_src_addr[5].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_5_qs)
+    .qs     (intr_src_addr_5_qs)
   );
 
 
-  // Subregister 6 of Multireg intr_source_addr
-  // R[intr_source_addr_6]: V(False)
+  // Subregister 6 of Multireg intr_src_addr
+  // R[intr_src_addr_6]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_6_gated_we;
-  assign intr_source_addr_6_gated_we =
-    intr_source_addr_6_we &
+  logic intr_src_addr_6_gated_we;
+  assign intr_src_addr_6_gated_we =
+    intr_src_addr_6_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_6 (
+  ) u_intr_src_addr_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_6_gated_we),
-    .wd     (intr_source_addr_6_wd),
+    .we     (intr_src_addr_6_gated_we),
+    .wd     (intr_src_addr_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2543,33 +2543,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[6].q),
+    .q      (reg2hw.intr_src_addr[6].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_6_qs)
+    .qs     (intr_src_addr_6_qs)
   );
 
 
-  // Subregister 7 of Multireg intr_source_addr
-  // R[intr_source_addr_7]: V(False)
+  // Subregister 7 of Multireg intr_src_addr
+  // R[intr_src_addr_7]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_7_gated_we;
-  assign intr_source_addr_7_gated_we =
-    intr_source_addr_7_we &
+  logic intr_src_addr_7_gated_we;
+  assign intr_src_addr_7_gated_we =
+    intr_src_addr_7_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_7 (
+  ) u_intr_src_addr_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_7_gated_we),
-    .wd     (intr_source_addr_7_wd),
+    .we     (intr_src_addr_7_gated_we),
+    .wd     (intr_src_addr_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2577,33 +2577,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[7].q),
+    .q      (reg2hw.intr_src_addr[7].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_7_qs)
+    .qs     (intr_src_addr_7_qs)
   );
 
 
-  // Subregister 8 of Multireg intr_source_addr
-  // R[intr_source_addr_8]: V(False)
+  // Subregister 8 of Multireg intr_src_addr
+  // R[intr_src_addr_8]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_8_gated_we;
-  assign intr_source_addr_8_gated_we =
-    intr_source_addr_8_we &
+  logic intr_src_addr_8_gated_we;
+  assign intr_src_addr_8_gated_we =
+    intr_src_addr_8_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_8 (
+  ) u_intr_src_addr_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_8_gated_we),
-    .wd     (intr_source_addr_8_wd),
+    .we     (intr_src_addr_8_gated_we),
+    .wd     (intr_src_addr_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2611,33 +2611,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[8].q),
+    .q      (reg2hw.intr_src_addr[8].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_8_qs)
+    .qs     (intr_src_addr_8_qs)
   );
 
 
-  // Subregister 9 of Multireg intr_source_addr
-  // R[intr_source_addr_9]: V(False)
+  // Subregister 9 of Multireg intr_src_addr
+  // R[intr_src_addr_9]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_9_gated_we;
-  assign intr_source_addr_9_gated_we =
-    intr_source_addr_9_we &
+  logic intr_src_addr_9_gated_we;
+  assign intr_src_addr_9_gated_we =
+    intr_src_addr_9_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_9 (
+  ) u_intr_src_addr_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_9_gated_we),
-    .wd     (intr_source_addr_9_wd),
+    .we     (intr_src_addr_9_gated_we),
+    .wd     (intr_src_addr_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2645,33 +2645,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[9].q),
+    .q      (reg2hw.intr_src_addr[9].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_9_qs)
+    .qs     (intr_src_addr_9_qs)
   );
 
 
-  // Subregister 10 of Multireg intr_source_addr
-  // R[intr_source_addr_10]: V(False)
+  // Subregister 10 of Multireg intr_src_addr
+  // R[intr_src_addr_10]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_addr_10_gated_we;
-  assign intr_source_addr_10_gated_we =
-    intr_source_addr_10_we &
+  logic intr_src_addr_10_gated_we;
+  assign intr_src_addr_10_gated_we =
+    intr_src_addr_10_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_addr_10 (
+  ) u_intr_src_addr_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_addr_10_gated_we),
-    .wd     (intr_source_addr_10_wd),
+    .we     (intr_src_addr_10_gated_we),
+    .wd     (intr_src_addr_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2679,33 +2679,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_addr[10].q),
+    .q      (reg2hw.intr_src_addr[10].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_addr_10_qs)
+    .qs     (intr_src_addr_10_qs)
   );
 
 
-  // Subregister 0 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_0]: V(False)
+  // Subregister 0 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_0]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_0_gated_we;
-  assign intr_source_wr_val_0_gated_we =
-    intr_source_wr_val_0_we &
+  logic intr_src_wr_val_0_gated_we;
+  assign intr_src_wr_val_0_gated_we =
+    intr_src_wr_val_0_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_0 (
+  ) u_intr_src_wr_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_0_gated_we),
-    .wd     (intr_source_wr_val_0_wd),
+    .we     (intr_src_wr_val_0_gated_we),
+    .wd     (intr_src_wr_val_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2713,33 +2713,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[0].q),
+    .q      (reg2hw.intr_src_wr_val[0].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_0_qs)
+    .qs     (intr_src_wr_val_0_qs)
   );
 
 
-  // Subregister 1 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_1]: V(False)
+  // Subregister 1 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_1]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_1_gated_we;
-  assign intr_source_wr_val_1_gated_we =
-    intr_source_wr_val_1_we &
+  logic intr_src_wr_val_1_gated_we;
+  assign intr_src_wr_val_1_gated_we =
+    intr_src_wr_val_1_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_1 (
+  ) u_intr_src_wr_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_1_gated_we),
-    .wd     (intr_source_wr_val_1_wd),
+    .we     (intr_src_wr_val_1_gated_we),
+    .wd     (intr_src_wr_val_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2747,33 +2747,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[1].q),
+    .q      (reg2hw.intr_src_wr_val[1].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_1_qs)
+    .qs     (intr_src_wr_val_1_qs)
   );
 
 
-  // Subregister 2 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_2]: V(False)
+  // Subregister 2 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_2]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_2_gated_we;
-  assign intr_source_wr_val_2_gated_we =
-    intr_source_wr_val_2_we &
+  logic intr_src_wr_val_2_gated_we;
+  assign intr_src_wr_val_2_gated_we =
+    intr_src_wr_val_2_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_2 (
+  ) u_intr_src_wr_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_2_gated_we),
-    .wd     (intr_source_wr_val_2_wd),
+    .we     (intr_src_wr_val_2_gated_we),
+    .wd     (intr_src_wr_val_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2781,33 +2781,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[2].q),
+    .q      (reg2hw.intr_src_wr_val[2].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_2_qs)
+    .qs     (intr_src_wr_val_2_qs)
   );
 
 
-  // Subregister 3 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_3]: V(False)
+  // Subregister 3 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_3]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_3_gated_we;
-  assign intr_source_wr_val_3_gated_we =
-    intr_source_wr_val_3_we &
+  logic intr_src_wr_val_3_gated_we;
+  assign intr_src_wr_val_3_gated_we =
+    intr_src_wr_val_3_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_3 (
+  ) u_intr_src_wr_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_3_gated_we),
-    .wd     (intr_source_wr_val_3_wd),
+    .we     (intr_src_wr_val_3_gated_we),
+    .wd     (intr_src_wr_val_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2815,33 +2815,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[3].q),
+    .q      (reg2hw.intr_src_wr_val[3].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_3_qs)
+    .qs     (intr_src_wr_val_3_qs)
   );
 
 
-  // Subregister 4 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_4]: V(False)
+  // Subregister 4 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_4]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_4_gated_we;
-  assign intr_source_wr_val_4_gated_we =
-    intr_source_wr_val_4_we &
+  logic intr_src_wr_val_4_gated_we;
+  assign intr_src_wr_val_4_gated_we =
+    intr_src_wr_val_4_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_4 (
+  ) u_intr_src_wr_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_4_gated_we),
-    .wd     (intr_source_wr_val_4_wd),
+    .we     (intr_src_wr_val_4_gated_we),
+    .wd     (intr_src_wr_val_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2849,33 +2849,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[4].q),
+    .q      (reg2hw.intr_src_wr_val[4].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_4_qs)
+    .qs     (intr_src_wr_val_4_qs)
   );
 
 
-  // Subregister 5 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_5]: V(False)
+  // Subregister 5 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_5]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_5_gated_we;
-  assign intr_source_wr_val_5_gated_we =
-    intr_source_wr_val_5_we &
+  logic intr_src_wr_val_5_gated_we;
+  assign intr_src_wr_val_5_gated_we =
+    intr_src_wr_val_5_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_5 (
+  ) u_intr_src_wr_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_5_gated_we),
-    .wd     (intr_source_wr_val_5_wd),
+    .we     (intr_src_wr_val_5_gated_we),
+    .wd     (intr_src_wr_val_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2883,33 +2883,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[5].q),
+    .q      (reg2hw.intr_src_wr_val[5].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_5_qs)
+    .qs     (intr_src_wr_val_5_qs)
   );
 
 
-  // Subregister 6 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_6]: V(False)
+  // Subregister 6 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_6]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_6_gated_we;
-  assign intr_source_wr_val_6_gated_we =
-    intr_source_wr_val_6_we &
+  logic intr_src_wr_val_6_gated_we;
+  assign intr_src_wr_val_6_gated_we =
+    intr_src_wr_val_6_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_6 (
+  ) u_intr_src_wr_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_6_gated_we),
-    .wd     (intr_source_wr_val_6_wd),
+    .we     (intr_src_wr_val_6_gated_we),
+    .wd     (intr_src_wr_val_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2917,33 +2917,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[6].q),
+    .q      (reg2hw.intr_src_wr_val[6].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_6_qs)
+    .qs     (intr_src_wr_val_6_qs)
   );
 
 
-  // Subregister 7 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_7]: V(False)
+  // Subregister 7 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_7]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_7_gated_we;
-  assign intr_source_wr_val_7_gated_we =
-    intr_source_wr_val_7_we &
+  logic intr_src_wr_val_7_gated_we;
+  assign intr_src_wr_val_7_gated_we =
+    intr_src_wr_val_7_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_7 (
+  ) u_intr_src_wr_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_7_gated_we),
-    .wd     (intr_source_wr_val_7_wd),
+    .we     (intr_src_wr_val_7_gated_we),
+    .wd     (intr_src_wr_val_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2951,33 +2951,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[7].q),
+    .q      (reg2hw.intr_src_wr_val[7].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_7_qs)
+    .qs     (intr_src_wr_val_7_qs)
   );
 
 
-  // Subregister 8 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_8]: V(False)
+  // Subregister 8 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_8]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_8_gated_we;
-  assign intr_source_wr_val_8_gated_we =
-    intr_source_wr_val_8_we &
+  logic intr_src_wr_val_8_gated_we;
+  assign intr_src_wr_val_8_gated_we =
+    intr_src_wr_val_8_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_8 (
+  ) u_intr_src_wr_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_8_gated_we),
-    .wd     (intr_source_wr_val_8_wd),
+    .we     (intr_src_wr_val_8_gated_we),
+    .wd     (intr_src_wr_val_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2985,33 +2985,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[8].q),
+    .q      (reg2hw.intr_src_wr_val[8].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_8_qs)
+    .qs     (intr_src_wr_val_8_qs)
   );
 
 
-  // Subregister 9 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_9]: V(False)
+  // Subregister 9 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_9]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_9_gated_we;
-  assign intr_source_wr_val_9_gated_we =
-    intr_source_wr_val_9_we &
+  logic intr_src_wr_val_9_gated_we;
+  assign intr_src_wr_val_9_gated_we =
+    intr_src_wr_val_9_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_9 (
+  ) u_intr_src_wr_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_9_gated_we),
-    .wd     (intr_source_wr_val_9_wd),
+    .we     (intr_src_wr_val_9_gated_we),
+    .wd     (intr_src_wr_val_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3019,33 +3019,33 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[9].q),
+    .q      (reg2hw.intr_src_wr_val[9].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_9_qs)
+    .qs     (intr_src_wr_val_9_qs)
   );
 
 
-  // Subregister 10 of Multireg intr_source_wr_val
-  // R[intr_source_wr_val_10]: V(False)
+  // Subregister 10 of Multireg intr_src_wr_val
+  // R[intr_src_wr_val_10]: V(False)
   // Create REGWEN-gated WE signal
-  logic intr_source_wr_val_10_gated_we;
-  assign intr_source_wr_val_10_gated_we =
-    intr_source_wr_val_10_we &
+  logic intr_src_wr_val_10_gated_we;
+  assign intr_src_wr_val_10_gated_we =
+    intr_src_wr_val_10_we &
           prim_mubi_pkg::mubi4_test_true_strict(prim_mubi_pkg::mubi4_t'(cfg_regwen_qs));
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_intr_source_wr_val_10 (
+  ) u_intr_src_wr_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_source_wr_val_10_gated_we),
-    .wd     (intr_source_wr_val_10_wd),
+    .we     (intr_src_wr_val_10_gated_we),
+    .wd     (intr_src_wr_val_10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3053,11 +3053,11 @@ module dma_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_source_wr_val[10].q),
+    .q      (reg2hw.intr_src_wr_val[10].q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (intr_source_wr_val_10_qs)
+    .qs     (intr_src_wr_val_10_qs)
   );
 
 
@@ -3069,8 +3069,8 @@ module dma_reg_top (
     addr_hit[ 1] = (reg_addr == DMA_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == DMA_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == DMA_ALERT_TEST_OFFSET);
-    addr_hit[ 4] = (reg_addr == DMA_SOURCE_ADDRESS_LO_OFFSET);
-    addr_hit[ 5] = (reg_addr == DMA_SOURCE_ADDRESS_HI_OFFSET);
+    addr_hit[ 4] = (reg_addr == DMA_SRC_ADDRESS_LO_OFFSET);
+    addr_hit[ 5] = (reg_addr == DMA_SRC_ADDRESS_HI_OFFSET);
     addr_hit[ 6] = (reg_addr == DMA_DESTINATION_ADDRESS_LO_OFFSET);
     addr_hit[ 7] = (reg_addr == DMA_DESTINATION_ADDRESS_HI_OFFSET);
     addr_hit[ 8] = (reg_addr == DMA_ADDRESS_SPACE_ID_OFFSET);
@@ -3108,28 +3108,28 @@ module dma_reg_top (
     addr_hit[40] = (reg_addr == DMA_HANDSHAKE_INTR_ENABLE_OFFSET);
     addr_hit[41] = (reg_addr == DMA_CLEAR_INTR_SRC_OFFSET);
     addr_hit[42] = (reg_addr == DMA_CLEAR_INTR_BUS_OFFSET);
-    addr_hit[43] = (reg_addr == DMA_INTR_SOURCE_ADDR_0_OFFSET);
-    addr_hit[44] = (reg_addr == DMA_INTR_SOURCE_ADDR_1_OFFSET);
-    addr_hit[45] = (reg_addr == DMA_INTR_SOURCE_ADDR_2_OFFSET);
-    addr_hit[46] = (reg_addr == DMA_INTR_SOURCE_ADDR_3_OFFSET);
-    addr_hit[47] = (reg_addr == DMA_INTR_SOURCE_ADDR_4_OFFSET);
-    addr_hit[48] = (reg_addr == DMA_INTR_SOURCE_ADDR_5_OFFSET);
-    addr_hit[49] = (reg_addr == DMA_INTR_SOURCE_ADDR_6_OFFSET);
-    addr_hit[50] = (reg_addr == DMA_INTR_SOURCE_ADDR_7_OFFSET);
-    addr_hit[51] = (reg_addr == DMA_INTR_SOURCE_ADDR_8_OFFSET);
-    addr_hit[52] = (reg_addr == DMA_INTR_SOURCE_ADDR_9_OFFSET);
-    addr_hit[53] = (reg_addr == DMA_INTR_SOURCE_ADDR_10_OFFSET);
-    addr_hit[54] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_0_OFFSET);
-    addr_hit[55] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_1_OFFSET);
-    addr_hit[56] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_2_OFFSET);
-    addr_hit[57] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_3_OFFSET);
-    addr_hit[58] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_4_OFFSET);
-    addr_hit[59] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_5_OFFSET);
-    addr_hit[60] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_6_OFFSET);
-    addr_hit[61] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_7_OFFSET);
-    addr_hit[62] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_8_OFFSET);
-    addr_hit[63] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_9_OFFSET);
-    addr_hit[64] = (reg_addr == DMA_INTR_SOURCE_WR_VAL_10_OFFSET);
+    addr_hit[43] = (reg_addr == DMA_INTR_SRC_ADDR_0_OFFSET);
+    addr_hit[44] = (reg_addr == DMA_INTR_SRC_ADDR_1_OFFSET);
+    addr_hit[45] = (reg_addr == DMA_INTR_SRC_ADDR_2_OFFSET);
+    addr_hit[46] = (reg_addr == DMA_INTR_SRC_ADDR_3_OFFSET);
+    addr_hit[47] = (reg_addr == DMA_INTR_SRC_ADDR_4_OFFSET);
+    addr_hit[48] = (reg_addr == DMA_INTR_SRC_ADDR_5_OFFSET);
+    addr_hit[49] = (reg_addr == DMA_INTR_SRC_ADDR_6_OFFSET);
+    addr_hit[50] = (reg_addr == DMA_INTR_SRC_ADDR_7_OFFSET);
+    addr_hit[51] = (reg_addr == DMA_INTR_SRC_ADDR_8_OFFSET);
+    addr_hit[52] = (reg_addr == DMA_INTR_SRC_ADDR_9_OFFSET);
+    addr_hit[53] = (reg_addr == DMA_INTR_SRC_ADDR_10_OFFSET);
+    addr_hit[54] = (reg_addr == DMA_INTR_SRC_WR_VAL_0_OFFSET);
+    addr_hit[55] = (reg_addr == DMA_INTR_SRC_WR_VAL_1_OFFSET);
+    addr_hit[56] = (reg_addr == DMA_INTR_SRC_WR_VAL_2_OFFSET);
+    addr_hit[57] = (reg_addr == DMA_INTR_SRC_WR_VAL_3_OFFSET);
+    addr_hit[58] = (reg_addr == DMA_INTR_SRC_WR_VAL_4_OFFSET);
+    addr_hit[59] = (reg_addr == DMA_INTR_SRC_WR_VAL_5_OFFSET);
+    addr_hit[60] = (reg_addr == DMA_INTR_SRC_WR_VAL_6_OFFSET);
+    addr_hit[61] = (reg_addr == DMA_INTR_SRC_WR_VAL_7_OFFSET);
+    addr_hit[62] = (reg_addr == DMA_INTR_SRC_WR_VAL_8_OFFSET);
+    addr_hit[63] = (reg_addr == DMA_INTR_SRC_WR_VAL_9_OFFSET);
+    addr_hit[64] = (reg_addr == DMA_INTR_SRC_WR_VAL_10_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3229,12 +3229,12 @@ module dma_reg_top (
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
-  assign source_address_lo_we = addr_hit[4] & reg_we & !reg_error;
+  assign src_address_lo_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign source_address_lo_wd = reg_wdata[31:0];
-  assign source_address_hi_we = addr_hit[5] & reg_we & !reg_error;
+  assign src_address_lo_wd = reg_wdata[31:0];
+  assign src_address_hi_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign source_address_hi_wd = reg_wdata[31:0];
+  assign src_address_hi_wd = reg_wdata[31:0];
   assign destination_address_lo_we = addr_hit[6] & reg_we & !reg_error;
 
   assign destination_address_lo_wd = reg_wdata[31:0];
@@ -3243,7 +3243,7 @@ module dma_reg_top (
   assign destination_address_hi_wd = reg_wdata[31:0];
   assign address_space_id_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign address_space_id_source_asid_wd = reg_wdata[3:0];
+  assign address_space_id_src_asid_wd = reg_wdata[3:0];
 
   assign address_space_id_destination_asid_wd = reg_wdata[7:4];
   assign enabled_memory_range_base_we = addr_hit[9] & reg_we & !reg_error;
@@ -3313,72 +3313,72 @@ module dma_reg_top (
   assign clear_intr_bus_we = addr_hit[42] & reg_we & !reg_error;
 
   assign clear_intr_bus_wd = reg_wdata[10:0];
-  assign intr_source_addr_0_we = addr_hit[43] & reg_we & !reg_error;
+  assign intr_src_addr_0_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign intr_source_addr_0_wd = reg_wdata[31:0];
-  assign intr_source_addr_1_we = addr_hit[44] & reg_we & !reg_error;
+  assign intr_src_addr_0_wd = reg_wdata[31:0];
+  assign intr_src_addr_1_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign intr_source_addr_1_wd = reg_wdata[31:0];
-  assign intr_source_addr_2_we = addr_hit[45] & reg_we & !reg_error;
+  assign intr_src_addr_1_wd = reg_wdata[31:0];
+  assign intr_src_addr_2_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign intr_source_addr_2_wd = reg_wdata[31:0];
-  assign intr_source_addr_3_we = addr_hit[46] & reg_we & !reg_error;
+  assign intr_src_addr_2_wd = reg_wdata[31:0];
+  assign intr_src_addr_3_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign intr_source_addr_3_wd = reg_wdata[31:0];
-  assign intr_source_addr_4_we = addr_hit[47] & reg_we & !reg_error;
+  assign intr_src_addr_3_wd = reg_wdata[31:0];
+  assign intr_src_addr_4_we = addr_hit[47] & reg_we & !reg_error;
 
-  assign intr_source_addr_4_wd = reg_wdata[31:0];
-  assign intr_source_addr_5_we = addr_hit[48] & reg_we & !reg_error;
+  assign intr_src_addr_4_wd = reg_wdata[31:0];
+  assign intr_src_addr_5_we = addr_hit[48] & reg_we & !reg_error;
 
-  assign intr_source_addr_5_wd = reg_wdata[31:0];
-  assign intr_source_addr_6_we = addr_hit[49] & reg_we & !reg_error;
+  assign intr_src_addr_5_wd = reg_wdata[31:0];
+  assign intr_src_addr_6_we = addr_hit[49] & reg_we & !reg_error;
 
-  assign intr_source_addr_6_wd = reg_wdata[31:0];
-  assign intr_source_addr_7_we = addr_hit[50] & reg_we & !reg_error;
+  assign intr_src_addr_6_wd = reg_wdata[31:0];
+  assign intr_src_addr_7_we = addr_hit[50] & reg_we & !reg_error;
 
-  assign intr_source_addr_7_wd = reg_wdata[31:0];
-  assign intr_source_addr_8_we = addr_hit[51] & reg_we & !reg_error;
+  assign intr_src_addr_7_wd = reg_wdata[31:0];
+  assign intr_src_addr_8_we = addr_hit[51] & reg_we & !reg_error;
 
-  assign intr_source_addr_8_wd = reg_wdata[31:0];
-  assign intr_source_addr_9_we = addr_hit[52] & reg_we & !reg_error;
+  assign intr_src_addr_8_wd = reg_wdata[31:0];
+  assign intr_src_addr_9_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign intr_source_addr_9_wd = reg_wdata[31:0];
-  assign intr_source_addr_10_we = addr_hit[53] & reg_we & !reg_error;
+  assign intr_src_addr_9_wd = reg_wdata[31:0];
+  assign intr_src_addr_10_we = addr_hit[53] & reg_we & !reg_error;
 
-  assign intr_source_addr_10_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_0_we = addr_hit[54] & reg_we & !reg_error;
+  assign intr_src_addr_10_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_0_we = addr_hit[54] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_0_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_1_we = addr_hit[55] & reg_we & !reg_error;
+  assign intr_src_wr_val_0_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_1_we = addr_hit[55] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_1_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_2_we = addr_hit[56] & reg_we & !reg_error;
+  assign intr_src_wr_val_1_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_2_we = addr_hit[56] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_2_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_3_we = addr_hit[57] & reg_we & !reg_error;
+  assign intr_src_wr_val_2_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_3_we = addr_hit[57] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_3_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_4_we = addr_hit[58] & reg_we & !reg_error;
+  assign intr_src_wr_val_3_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_4_we = addr_hit[58] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_4_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_5_we = addr_hit[59] & reg_we & !reg_error;
+  assign intr_src_wr_val_4_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_5_we = addr_hit[59] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_5_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_6_we = addr_hit[60] & reg_we & !reg_error;
+  assign intr_src_wr_val_5_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_6_we = addr_hit[60] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_6_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_7_we = addr_hit[61] & reg_we & !reg_error;
+  assign intr_src_wr_val_6_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_7_we = addr_hit[61] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_7_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_8_we = addr_hit[62] & reg_we & !reg_error;
+  assign intr_src_wr_val_7_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_8_we = addr_hit[62] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_8_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_9_we = addr_hit[63] & reg_we & !reg_error;
+  assign intr_src_wr_val_8_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_9_we = addr_hit[63] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_9_wd = reg_wdata[31:0];
-  assign intr_source_wr_val_10_we = addr_hit[64] & reg_we & !reg_error;
+  assign intr_src_wr_val_9_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_10_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign intr_source_wr_val_10_wd = reg_wdata[31:0];
+  assign intr_src_wr_val_10_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -3387,8 +3387,8 @@ module dma_reg_top (
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;
     reg_we_check[3] = alert_test_we;
-    reg_we_check[4] = source_address_lo_gated_we;
-    reg_we_check[5] = source_address_hi_gated_we;
+    reg_we_check[4] = src_address_lo_gated_we;
+    reg_we_check[5] = src_address_hi_gated_we;
     reg_we_check[6] = destination_address_lo_gated_we;
     reg_we_check[7] = destination_address_hi_gated_we;
     reg_we_check[8] = address_space_id_gated_we;
@@ -3426,28 +3426,28 @@ module dma_reg_top (
     reg_we_check[40] = handshake_intr_enable_gated_we;
     reg_we_check[41] = clear_intr_src_gated_we;
     reg_we_check[42] = clear_intr_bus_gated_we;
-    reg_we_check[43] = intr_source_addr_0_gated_we;
-    reg_we_check[44] = intr_source_addr_1_gated_we;
-    reg_we_check[45] = intr_source_addr_2_gated_we;
-    reg_we_check[46] = intr_source_addr_3_gated_we;
-    reg_we_check[47] = intr_source_addr_4_gated_we;
-    reg_we_check[48] = intr_source_addr_5_gated_we;
-    reg_we_check[49] = intr_source_addr_6_gated_we;
-    reg_we_check[50] = intr_source_addr_7_gated_we;
-    reg_we_check[51] = intr_source_addr_8_gated_we;
-    reg_we_check[52] = intr_source_addr_9_gated_we;
-    reg_we_check[53] = intr_source_addr_10_gated_we;
-    reg_we_check[54] = intr_source_wr_val_0_gated_we;
-    reg_we_check[55] = intr_source_wr_val_1_gated_we;
-    reg_we_check[56] = intr_source_wr_val_2_gated_we;
-    reg_we_check[57] = intr_source_wr_val_3_gated_we;
-    reg_we_check[58] = intr_source_wr_val_4_gated_we;
-    reg_we_check[59] = intr_source_wr_val_5_gated_we;
-    reg_we_check[60] = intr_source_wr_val_6_gated_we;
-    reg_we_check[61] = intr_source_wr_val_7_gated_we;
-    reg_we_check[62] = intr_source_wr_val_8_gated_we;
-    reg_we_check[63] = intr_source_wr_val_9_gated_we;
-    reg_we_check[64] = intr_source_wr_val_10_gated_we;
+    reg_we_check[43] = intr_src_addr_0_gated_we;
+    reg_we_check[44] = intr_src_addr_1_gated_we;
+    reg_we_check[45] = intr_src_addr_2_gated_we;
+    reg_we_check[46] = intr_src_addr_3_gated_we;
+    reg_we_check[47] = intr_src_addr_4_gated_we;
+    reg_we_check[48] = intr_src_addr_5_gated_we;
+    reg_we_check[49] = intr_src_addr_6_gated_we;
+    reg_we_check[50] = intr_src_addr_7_gated_we;
+    reg_we_check[51] = intr_src_addr_8_gated_we;
+    reg_we_check[52] = intr_src_addr_9_gated_we;
+    reg_we_check[53] = intr_src_addr_10_gated_we;
+    reg_we_check[54] = intr_src_wr_val_0_gated_we;
+    reg_we_check[55] = intr_src_wr_val_1_gated_we;
+    reg_we_check[56] = intr_src_wr_val_2_gated_we;
+    reg_we_check[57] = intr_src_wr_val_3_gated_we;
+    reg_we_check[58] = intr_src_wr_val_4_gated_we;
+    reg_we_check[59] = intr_src_wr_val_5_gated_we;
+    reg_we_check[60] = intr_src_wr_val_6_gated_we;
+    reg_we_check[61] = intr_src_wr_val_7_gated_we;
+    reg_we_check[62] = intr_src_wr_val_8_gated_we;
+    reg_we_check[63] = intr_src_wr_val_9_gated_we;
+    reg_we_check[64] = intr_src_wr_val_10_gated_we;
   end
 
   // Read data return
@@ -3477,11 +3477,11 @@ module dma_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[31:0] = source_address_lo_qs;
+        reg_rdata_next[31:0] = src_address_lo_qs;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[31:0] = source_address_hi_qs;
+        reg_rdata_next[31:0] = src_address_hi_qs;
       end
 
       addr_hit[6]: begin
@@ -3493,7 +3493,7 @@ module dma_reg_top (
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[3:0] = address_space_id_source_asid_qs;
+        reg_rdata_next[3:0] = address_space_id_src_asid_qs;
         reg_rdata_next[7:4] = address_space_id_destination_asid_qs;
       end
 
@@ -3652,91 +3652,91 @@ module dma_reg_top (
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[31:0] = intr_source_addr_0_qs;
+        reg_rdata_next[31:0] = intr_src_addr_0_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[31:0] = intr_source_addr_1_qs;
+        reg_rdata_next[31:0] = intr_src_addr_1_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[31:0] = intr_source_addr_2_qs;
+        reg_rdata_next[31:0] = intr_src_addr_2_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[31:0] = intr_source_addr_3_qs;
+        reg_rdata_next[31:0] = intr_src_addr_3_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[31:0] = intr_source_addr_4_qs;
+        reg_rdata_next[31:0] = intr_src_addr_4_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[31:0] = intr_source_addr_5_qs;
+        reg_rdata_next[31:0] = intr_src_addr_5_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[31:0] = intr_source_addr_6_qs;
+        reg_rdata_next[31:0] = intr_src_addr_6_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[31:0] = intr_source_addr_7_qs;
+        reg_rdata_next[31:0] = intr_src_addr_7_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[31:0] = intr_source_addr_8_qs;
+        reg_rdata_next[31:0] = intr_src_addr_8_qs;
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[31:0] = intr_source_addr_9_qs;
+        reg_rdata_next[31:0] = intr_src_addr_9_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[31:0] = intr_source_addr_10_qs;
+        reg_rdata_next[31:0] = intr_src_addr_10_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_0_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_0_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_1_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_1_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_2_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_2_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_3_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_3_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_4_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_4_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_5_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_5_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_6_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_6_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_7_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_7_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_8_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_8_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_9_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_9_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[31:0] = intr_source_wr_val_10_qs;
+        reg_rdata_next[31:0] = intr_src_wr_val_10_qs;
       end
 
       default: begin

--- a/sw/ip/dma/dif/dif_dma.c
+++ b/sw/ip/dma/dif/dif_dma.c
@@ -11,13 +11,12 @@
 #include "sw/lib/sw/device/base/mmio.h"
 
 static_assert(kDifDmaOpentitanInternalBus ==
-                  DMA_ADDRESS_SPACE_ID_DESTINATION_ASID_VALUE_OT_ADDR,
+                  DMA_ADDR_SPACE_ID_DST_ASID_VALUE_OT_ADDR,
               "Address Space ID mismatches with value defined in HW");
 static_assert(kDifDmaSoCControlRegisterBus ==
-                  DMA_ADDRESS_SPACE_ID_DESTINATION_ASID_VALUE_SOC_ADDR,
+                  DMA_ADDR_SPACE_ID_DST_ASID_VALUE_SOC_ADDR,
               "Address Space ID mismatches with value defined in HW");
-static_assert(kDifDmaSoCSystemBus ==
-                  DMA_ADDRESS_SPACE_ID_DESTINATION_ASID_VALUE_SYS_ADDR_,
+static_assert(kDifDmaSoCSystemBus == DMA_ADDR_SPACE_ID_DST_ASID_VALUE_SYS_ADDR_,
               "Address Space ID mismatches with value defined in HW");
 
 dif_result_t dif_dma_configure(const dif_dma_t *dma,
@@ -26,23 +25,23 @@ dif_result_t dif_dma_configure(const dif_dma_t *dma,
     return kDifBadArg;
   }
 
-  mmio_region_write32(dma->base_addr, DMA_SOURCE_ADDRESS_LO_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_SRC_ADDR_LO_REG_OFFSET,
                       transaction.source.address & UINT32_MAX);
-  mmio_region_write32(dma->base_addr, DMA_SOURCE_ADDRESS_HI_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_SRC_ADDR_HI_REG_OFFSET,
                       transaction.source.address >> (sizeof(uint32_t) * 8));
 
-  mmio_region_write32(dma->base_addr, DMA_DESTINATION_ADDRESS_LO_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_DST_ADDR_LO_REG_OFFSET,
                       transaction.destination.address & UINT32_MAX);
   mmio_region_write32(
-      dma->base_addr, DMA_DESTINATION_ADDRESS_HI_REG_OFFSET,
+      dma->base_addr, DMA_DST_ADDR_HI_REG_OFFSET,
       transaction.destination.address >> (sizeof(uint32_t) * 8));
 
   uint32_t reg = 0;
-  reg = bitfield_field32_write(reg, DMA_ADDRESS_SPACE_ID_SOURCE_ASID_FIELD,
+  reg = bitfield_field32_write(reg, DMA_ADDR_SPACE_ID_SRC_ASID_FIELD,
                                transaction.source.asid);
-  reg = bitfield_field32_write(reg, DMA_ADDRESS_SPACE_ID_DESTINATION_ASID_FIELD,
+  reg = bitfield_field32_write(reg, DMA_ADDR_SPACE_ID_DST_ASID_FIELD,
                                transaction.destination.asid);
-  mmio_region_write32(dma->base_addr, DMA_ADDRESS_SPACE_ID_REG_OFFSET, reg);
+  mmio_region_write32(dma->base_addr, DMA_ADDR_SPACE_ID_REG_OFFSET, reg);
 
   mmio_region_write32(dma->base_addr, DMA_CHUNK_DATA_SIZE_REG_OFFSET,
                       transaction.chunk_size);
@@ -183,18 +182,14 @@ dif_result_t dif_dma_irq_thresholds_set(const dif_dma_t *dma,
     return kDifBadArg;
   }
 
-  mmio_region_write32(dma->base_addr,
-                      DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_DST_ADDR_ALMOST_LIMIT_LO_REG_OFFSET,
                       almost_limit & UINT32_MAX);
-  mmio_region_write32(dma->base_addr,
-                      DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_DST_ADDR_ALMOST_LIMIT_HI_REG_OFFSET,
                       almost_limit >> (sizeof(uint32_t) * 8));
 
-  mmio_region_write32(dma->base_addr,
-                      DMA_DESTINATION_ADDRESS_LIMIT_LO_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_DST_ADDR_LIMIT_LO_REG_OFFSET,
                       limit & UINT32_MAX);
-  mmio_region_write32(dma->base_addr,
-                      DMA_DESTINATION_ADDRESS_LIMIT_HI_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_DST_ADDR_LIMIT_HI_REG_OFFSET,
                       limit >> (sizeof(uint32_t) * 8));
 
   return kDifOk;
@@ -207,16 +202,14 @@ dif_result_t dif_dma_irq_thresholds_get(const dif_dma_t *dma,
     return kDifBadArg;
   }
 
-  uint64_t val_lo = mmio_region_read32(
-      dma->base_addr, DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_REG_OFFSET);
-  uint64_t val_hi = mmio_region_read32(
-      dma->base_addr, DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_REG_OFFSET);
+  uint64_t val_lo = mmio_region_read32(dma->base_addr,
+                                       DMA_DST_ADDR_ALMOST_LIMIT_LO_REG_OFFSET);
+  uint64_t val_hi = mmio_region_read32(dma->base_addr,
+                                       DMA_DST_ADDR_ALMOST_LIMIT_HI_REG_OFFSET);
   *almost_limit = val_lo | (val_hi << (sizeof(uint32_t) * 8));
 
-  val_lo = mmio_region_read32(dma->base_addr,
-                              DMA_DESTINATION_ADDRESS_LIMIT_LO_REG_OFFSET);
-  val_hi = mmio_region_read32(dma->base_addr,
-                              DMA_DESTINATION_ADDRESS_LIMIT_HI_REG_OFFSET);
+  val_lo = mmio_region_read32(dma->base_addr, DMA_DST_ADDR_LIMIT_LO_REG_OFFSET);
+  val_hi = mmio_region_read32(dma->base_addr, DMA_DST_ADDR_LIMIT_HI_REG_OFFSET);
   *limit = val_lo | (val_hi << (sizeof(uint32_t) * 8));
 
   return kDifOk;
@@ -309,7 +302,7 @@ dif_result_t dif_dma_handshake_irq_enable(const dif_dma_t *dma,
   if (dma == NULL) {
     return kDifBadArg;
   }
-  mmio_region_write32(dma->base_addr, DMA_HANDSHAKE_INTERRUPT_ENABLE_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_HANDSHAKE_INTR_ENABLE_REG_OFFSET,
                       enable_state);
   return kDifOk;
 }
@@ -319,7 +312,7 @@ dif_result_t dif_dma_handshake_clear_irq(const dif_dma_t *dma,
   if (dma == NULL) {
     return kDifBadArg;
   }
-  mmio_region_write32(dma->base_addr, DMA_CLEAR_INT_SRC_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_CLEAR_INTR_SRC_REG_OFFSET,
                       clear_state);
 
   return kDifOk;
@@ -330,31 +323,31 @@ dif_result_t dif_dma_handshake_clear_irq_bus(const dif_dma_t *dma,
   if (dma == NULL) {
     return kDifBadArg;
   }
-  mmio_region_write32(dma->base_addr, DMA_CLEAR_INT_BUS_REG_OFFSET,
+  mmio_region_write32(dma->base_addr, DMA_CLEAR_INTR_BUS_REG_OFFSET,
                       clear_irq_bus);
 
   return kDifOk;
 }
 
-dif_result_t dif_dma_int_src_addr(const dif_dma_t *dma, dif_dma_int_idx_t idx,
-                                  uint32_t int_src_addr) {
+dif_result_t dif_dma_intr_src_addr(const dif_dma_t *dma, dif_dma_intr_idx_t idx,
+                                   uint32_t intr_src_addr) {
   if (dma == NULL) {
     return kDifBadArg;
   }
   mmio_region_write32(dma->base_addr,
-                      DMA_INT_SOURCE_ADDR_0_REG_OFFSET + (ptrdiff_t)idx,
-                      int_src_addr);
+                      DMA_INTR_SRC_ADDR_0_REG_OFFSET + (ptrdiff_t)idx,
+                      intr_src_addr);
   return kDifOk;
 }
 
-dif_result_t dif_dma_int_write_value(const dif_dma_t *dma,
-                                     dif_dma_int_idx_t idx,
-                                     uint32_t int_src_value) {
+dif_result_t dif_dma_intr_write_value(const dif_dma_t *dma,
+                                      dif_dma_intr_idx_t idx,
+                                      uint32_t intr_src_value) {
   if (dma == NULL) {
     return kDifBadArg;
   }
   mmio_region_write32(dma->base_addr,
-                      DMA_INT_SOURCE_WR_VAL_0_REG_OFFSET + (ptrdiff_t)idx,
-                      int_src_value);
+                      DMA_INTR_SRC_WR_VAL_0_REG_OFFSET + (ptrdiff_t)idx,
+                      intr_src_value);
   return kDifOk;
 }

--- a/sw/ip/dma/dif/dif_dma.h
+++ b/sw/ip/dma/dif/dif_dma.h
@@ -397,44 +397,44 @@ dif_result_t dif_dma_handshake_clear_irq_bus(const dif_dma_t *dma,
  * Address index for every interrupt. Used to configure the write address and
  * write value for the interrupt clearing mechanism.
  */
-typedef enum dif_dma_int_idx {
-  kDifDmaIntClearIdx0 = 0x0,
-  kDifDmaIntClearIdx1 = 0x4,
-  kDifDmaIntClearIdx2 = 0x8,
-  kDifDmaIntClearIdx3 = 0xC,
-  kDifDmaIntClearIdx4 = 0x10,
-  kDifDmaIntClearIdx5 = 0x14,
-  kDifDmaIntClearIdx6 = 0x18,
-  kDifDmaIntClearIdx7 = 0x1C,
-  kDifDmaIntClearIdx8 = 0x20,
-  kDifDmaIntClearIdx9 = 0x24,
-  kDifDmaIntClearIdx10 = 0x28,
-} dif_dma_int_idx_t;
+typedef enum dif_dma_intr_idx {
+  kDifDmaIntrClearIdx0 = 0x0,
+  kDifDmaIntrClearIdx1 = 0x4,
+  kDifDmaIntrClearIdx2 = 0x8,
+  kDifDmaIntrClearIdx3 = 0xC,
+  kDifDmaIntrClearIdx4 = 0x10,
+  kDifDmaIntrClearIdx5 = 0x14,
+  kDifDmaIntrClearIdx6 = 0x18,
+  kDifDmaIntrClearIdx7 = 0x1C,
+  kDifDmaIntrClearIdx8 = 0x20,
+  kDifDmaIntrClearIdx9 = 0x24,
+  kDifDmaIntrClearIdx10 = 0x28,
+} dif_dma_intr_idx_t;
 
 /**
  * Set the write address for the interrupt clearing mechanism.
  *
  * @param dma A DMA Controller handle.
  * @param idx Index of the selected interrupt.
- * @param int_src_addr Address to write the interrupt clearing value to.
+ * @param intr_src_addr Address to write the interrupt clearing value to.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_dma_int_src_addr(const dif_dma_t *dma, dif_dma_int_idx_t idx,
-                                  uint32_t int_src_addr);
+dif_result_t dif_dma_intr_src_addr(const dif_dma_t *dma, dif_dma_intr_idx_t idx,
+                                   uint32_t intr_src_addr);
 
 /**
  * Set the write value for the interrupt clearing mechanism.
  *
  * @param dma A DMA Controller handle.
  * @param idx Index of the selected interrupt.
- * @param int_src_value Value to write the interrupt clearing value to.
+ * @param intr_src_value Value to write the interrupt clearing value to.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_dma_int_write_value(const dif_dma_t *dma,
-                                     dif_dma_int_idx_t idx,
-                                     uint32_t int_src_value);
+dif_result_t dif_dma_intr_write_value(const dif_dma_t *dma,
+                                      dif_dma_intr_idx_t idx,
+                                      uint32_t intr_src_value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/ip/dma/dif/dif_dma_unittest.cc
+++ b/sw/ip/dma/dif/dif_dma_unittest.cc
@@ -37,22 +37,20 @@ class ConfigureTest
 TEST_P(ConfigureTest, Success) {
   dif_dma_transaction_t transaction = GetParam();
   EXPECT_WRITE32(
-      DMA_SOURCE_ADDRESS_LO_REG_OFFSET,
+      DMA_SRC_ADDR_LO_REG_OFFSET,
       transaction.source.address & std::numeric_limits<uint32_t>::max());
-  EXPECT_WRITE32(DMA_SOURCE_ADDRESS_HI_REG_OFFSET,
-                 transaction.source.address >> 32);
+  EXPECT_WRITE32(DMA_SRC_ADDR_HI_REG_OFFSET, transaction.source.address >> 32);
   EXPECT_WRITE32(
-      DMA_DESTINATION_ADDRESS_LO_REG_OFFSET,
+      DMA_DST_ADDR_LO_REG_OFFSET,
       transaction.destination.address & std::numeric_limits<uint32_t>::max());
-  EXPECT_WRITE32(DMA_DESTINATION_ADDRESS_HI_REG_OFFSET,
+  EXPECT_WRITE32(DMA_DST_ADDR_HI_REG_OFFSET,
                  transaction.destination.address >> 32);
 
   EXPECT_WRITE32(
-      DMA_ADDRESS_SPACE_ID_REG_OFFSET,
+      DMA_ADDR_SPACE_ID_REG_OFFSET,
       {
-          {DMA_ADDRESS_SPACE_ID_SOURCE_ASID_OFFSET, transaction.source.asid},
-          {DMA_ADDRESS_SPACE_ID_DESTINATION_ASID_OFFSET,
-           transaction.destination.asid},
+          {DMA_ADDR_SPACE_ID_SRC_ASID_OFFSET, transaction.source.asid},
+          {DMA_ADDR_SPACE_ID_DST_ASID_OFFSET, transaction.destination.asid},
       });
 
   EXPECT_WRITE32(DMA_CHUNK_DATA_SIZE_REG_OFFSET, transaction.chunk_size);
@@ -303,22 +301,20 @@ TEST_F(MemoryRangeLockTest, GetBadArg) {
 class IrqThresholdsTest : public DmaTestInitialized {};
 
 TEST_F(IrqThresholdsTest, SetSuccess) {
-  EXPECT_WRITE32(DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_REG_OFFSET,
-                 0x9000F000);
-  EXPECT_WRITE32(DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_REG_OFFSET,
-                 0x80001000);
-  EXPECT_WRITE32(DMA_DESTINATION_ADDRESS_LIMIT_LO_REG_OFFSET, 0xE0005000);
-  EXPECT_WRITE32(DMA_DESTINATION_ADDRESS_LIMIT_HI_REG_OFFSET, 0xF0001000);
+  EXPECT_WRITE32(DMA_DST_ADDR_ALMOST_LIMIT_LO_REG_OFFSET, 0x9000F000);
+  EXPECT_WRITE32(DMA_DST_ADDR_ALMOST_LIMIT_HI_REG_OFFSET, 0x80001000);
+  EXPECT_WRITE32(DMA_DST_ADDR_LIMIT_LO_REG_OFFSET, 0xE0005000);
+  EXPECT_WRITE32(DMA_DST_ADDR_LIMIT_HI_REG_OFFSET, 0xF0001000);
 
   EXPECT_DIF_OK(dif_dma_irq_thresholds_set(&dma_, 0x800010009000F000,
                                            0xF0001000E0005000));
 }
 
 TEST_F(IrqThresholdsTest, GetSuccess) {
-  EXPECT_READ32(DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_LO_REG_OFFSET, 0x9000F000);
-  EXPECT_READ32(DMA_DESTINATION_ADDRESS_ALMOST_LIMIT_HI_REG_OFFSET, 0x80001000);
-  EXPECT_READ32(DMA_DESTINATION_ADDRESS_LIMIT_LO_REG_OFFSET, 0xE0005000);
-  EXPECT_READ32(DMA_DESTINATION_ADDRESS_LIMIT_HI_REG_OFFSET, 0xF0001000);
+  EXPECT_READ32(DMA_DST_ADDR_ALMOST_LIMIT_LO_REG_OFFSET, 0x9000F000);
+  EXPECT_READ32(DMA_DST_ADDR_ALMOST_LIMIT_HI_REG_OFFSET, 0x80001000);
+  EXPECT_READ32(DMA_DST_ADDR_LIMIT_LO_REG_OFFSET, 0xE0005000);
+  EXPECT_READ32(DMA_DST_ADDR_LIMIT_HI_REG_OFFSET, 0xF0001000);
 
   uint64_t almost = 0;
   uint64_t limit = 0;
@@ -434,8 +430,8 @@ TEST_P(ErrorTest, GetSuccess) {
 INSTANTIATE_TEST_SUITE_P(
     ErrorTest, ErrorTest,
     testing::ValuesIn(std::vector<error_code_reg_t>{{
-        {1 << DMA_ERROR_CODE_SRC_ADDRESS_ERROR_BIT, kDifDmaErrorSourceAddress},
-        {1 << DMA_ERROR_CODE_DST_ADDRESS_ERROR_BIT,
+        {1 << DMA_ERROR_CODE_SRC_ADDR_ERROR_BIT, kDifDmaErrorSourceAddress},
+        {1 << DMA_ERROR_CODE_DST_ADDR_ERROR_BIT,
          kDifDmaErrorDestinationAddress},
         {1 << DMA_ERROR_CODE_OPCODE_ERROR_BIT, kDifDmaErrorOpcode},
         {1 << DMA_ERROR_CODE_SIZE_ERROR_BIT, kDifDmaErrorSize},
@@ -534,7 +530,7 @@ TEST_F(GetDigestTest, BadArg) {
 class HandshakeEnableIrqTest : public DmaTestInitialized {};
 
 TEST_F(HandshakeEnableIrqTest, Success) {
-  EXPECT_WRITE32(DMA_HANDSHAKE_INTERRUPT_ENABLE_REG_OFFSET, 0x3);
+  EXPECT_WRITE32(DMA_HANDSHAKE_INTR_ENABLE_REG_OFFSET, 0x3);
 
   EXPECT_DIF_OK(dif_dma_handshake_irq_enable(&dma_, 0x3));
 }
@@ -547,7 +543,7 @@ TEST_F(HandshakeEnableIrqTest, BadArg) {
 class HandshakeClearIrqTest : public DmaTestInitialized {};
 
 TEST_F(HandshakeClearIrqTest, Success) {
-  EXPECT_WRITE32(DMA_CLEAR_INT_SRC_REG_OFFSET, 0x3);
+  EXPECT_WRITE32(DMA_CLEAR_INTR_SRC_REG_OFFSET, 0x3);
 
   EXPECT_DIF_OK(dif_dma_handshake_clear_irq(&dma_, 0x3));
 }
@@ -560,7 +556,7 @@ TEST_F(HandshakeClearIrqTest, BadArg) {
 class HandshakeClearBusTest : public DmaTestInitialized {};
 
 TEST_F(HandshakeClearBusTest, Success) {
-  EXPECT_WRITE32(DMA_CLEAR_INT_BUS_REG_OFFSET, 0x2);
+  EXPECT_WRITE32(DMA_CLEAR_INTR_BUS_REG_OFFSET, 0x2);
 
   EXPECT_DIF_OK(dif_dma_handshake_clear_irq_bus(&dma_, 0x2));
 }
@@ -571,7 +567,7 @@ TEST_F(HandshakeClearBusTest, BadArg) {
 
 typedef struct dma_clear_irq_reg {
   uint32_t reg;
-  dif_dma_int_idx_t idx;
+  dif_dma_intr_idx_t idx;
 } dma_clear_irq_reg_t;
 
 class HandshakeClearAddressTest
@@ -583,28 +579,28 @@ TEST_P(HandshakeClearAddressTest, GetSuccess) {
 
   EXPECT_WRITE32(clear_irq_reg.reg, 0x123456);
 
-  EXPECT_DIF_OK(dif_dma_int_src_addr(&dma_, clear_irq_reg.idx, 0x123456));
+  EXPECT_DIF_OK(dif_dma_intr_src_addr(&dma_, clear_irq_reg.idx, 0x123456));
 }
 
 INSTANTIATE_TEST_SUITE_P(
     HandshakeClearAddressTest, HandshakeClearAddressTest,
     testing::ValuesIn(std::vector<dma_clear_irq_reg_t>{{
-        {DMA_INT_SOURCE_ADDR_0_REG_OFFSET, kDifDmaIntClearIdx0},
-        {DMA_INT_SOURCE_ADDR_1_REG_OFFSET, kDifDmaIntClearIdx1},
-        {DMA_INT_SOURCE_ADDR_2_REG_OFFSET, kDifDmaIntClearIdx2},
-        {DMA_INT_SOURCE_ADDR_3_REG_OFFSET, kDifDmaIntClearIdx3},
-        {DMA_INT_SOURCE_ADDR_4_REG_OFFSET, kDifDmaIntClearIdx4},
-        {DMA_INT_SOURCE_ADDR_5_REG_OFFSET, kDifDmaIntClearIdx5},
-        {DMA_INT_SOURCE_ADDR_6_REG_OFFSET, kDifDmaIntClearIdx6},
-        {DMA_INT_SOURCE_ADDR_7_REG_OFFSET, kDifDmaIntClearIdx7},
-        {DMA_INT_SOURCE_ADDR_8_REG_OFFSET, kDifDmaIntClearIdx8},
-        {DMA_INT_SOURCE_ADDR_9_REG_OFFSET, kDifDmaIntClearIdx9},
-        {DMA_INT_SOURCE_ADDR_10_REG_OFFSET, kDifDmaIntClearIdx10},
+        {DMA_INTR_SRC_ADDR_0_REG_OFFSET, kDifDmaIntrClearIdx0},
+        {DMA_INTR_SRC_ADDR_1_REG_OFFSET, kDifDmaIntrClearIdx1},
+        {DMA_INTR_SRC_ADDR_2_REG_OFFSET, kDifDmaIntrClearIdx2},
+        {DMA_INTR_SRC_ADDR_3_REG_OFFSET, kDifDmaIntrClearIdx3},
+        {DMA_INTR_SRC_ADDR_4_REG_OFFSET, kDifDmaIntrClearIdx4},
+        {DMA_INTR_SRC_ADDR_5_REG_OFFSET, kDifDmaIntrClearIdx5},
+        {DMA_INTR_SRC_ADDR_6_REG_OFFSET, kDifDmaIntrClearIdx6},
+        {DMA_INTR_SRC_ADDR_7_REG_OFFSET, kDifDmaIntrClearIdx7},
+        {DMA_INTR_SRC_ADDR_8_REG_OFFSET, kDifDmaIntrClearIdx8},
+        {DMA_INTR_SRC_ADDR_9_REG_OFFSET, kDifDmaIntrClearIdx9},
+        {DMA_INTR_SRC_ADDR_10_REG_OFFSET, kDifDmaIntrClearIdx10},
     }}));
 
 TEST_F(HandshakeClearAddressTest, BadArg) {
   EXPECT_DIF_BADARG(
-      dif_dma_int_src_addr(nullptr, kDifDmaIntClearIdx0, 0x12345));
+      dif_dma_intr_src_addr(nullptr, kDifDmaIntrClearIdx0, 0x12345));
 }
 
 class HandshakeClearValueTest
@@ -616,28 +612,28 @@ TEST_P(HandshakeClearValueTest, GetSuccess) {
 
   EXPECT_WRITE32(clear_irq_reg.reg, 0x123456);
 
-  EXPECT_DIF_OK(dif_dma_int_write_value(&dma_, clear_irq_reg.idx, 0x123456));
+  EXPECT_DIF_OK(dif_dma_intr_write_value(&dma_, clear_irq_reg.idx, 0x123456));
 }
 
 INSTANTIATE_TEST_SUITE_P(
     HandshakeClearValueTest, HandshakeClearValueTest,
     testing::ValuesIn(std::vector<dma_clear_irq_reg_t>{{
-        {DMA_INT_SOURCE_WR_VAL_0_REG_OFFSET, kDifDmaIntClearIdx0},
-        {DMA_INT_SOURCE_WR_VAL_1_REG_OFFSET, kDifDmaIntClearIdx1},
-        {DMA_INT_SOURCE_WR_VAL_2_REG_OFFSET, kDifDmaIntClearIdx2},
-        {DMA_INT_SOURCE_WR_VAL_3_REG_OFFSET, kDifDmaIntClearIdx3},
-        {DMA_INT_SOURCE_WR_VAL_4_REG_OFFSET, kDifDmaIntClearIdx4},
-        {DMA_INT_SOURCE_WR_VAL_5_REG_OFFSET, kDifDmaIntClearIdx5},
-        {DMA_INT_SOURCE_WR_VAL_6_REG_OFFSET, kDifDmaIntClearIdx6},
-        {DMA_INT_SOURCE_WR_VAL_7_REG_OFFSET, kDifDmaIntClearIdx7},
-        {DMA_INT_SOURCE_WR_VAL_8_REG_OFFSET, kDifDmaIntClearIdx8},
-        {DMA_INT_SOURCE_WR_VAL_9_REG_OFFSET, kDifDmaIntClearIdx9},
-        {DMA_INT_SOURCE_WR_VAL_10_REG_OFFSET, kDifDmaIntClearIdx10},
+        {DMA_INTR_SRC_WR_VAL_0_REG_OFFSET, kDifDmaIntrClearIdx0},
+        {DMA_INTR_SRC_WR_VAL_1_REG_OFFSET, kDifDmaIntrClearIdx1},
+        {DMA_INTR_SRC_WR_VAL_2_REG_OFFSET, kDifDmaIntrClearIdx2},
+        {DMA_INTR_SRC_WR_VAL_3_REG_OFFSET, kDifDmaIntrClearIdx3},
+        {DMA_INTR_SRC_WR_VAL_4_REG_OFFSET, kDifDmaIntrClearIdx4},
+        {DMA_INTR_SRC_WR_VAL_5_REG_OFFSET, kDifDmaIntrClearIdx5},
+        {DMA_INTR_SRC_WR_VAL_6_REG_OFFSET, kDifDmaIntrClearIdx6},
+        {DMA_INTR_SRC_WR_VAL_7_REG_OFFSET, kDifDmaIntrClearIdx7},
+        {DMA_INTR_SRC_WR_VAL_8_REG_OFFSET, kDifDmaIntrClearIdx8},
+        {DMA_INTR_SRC_WR_VAL_9_REG_OFFSET, kDifDmaIntrClearIdx9},
+        {DMA_INTR_SRC_WR_VAL_10_REG_OFFSET, kDifDmaIntrClearIdx10},
     }}));
 
 TEST_F(HandshakeClearValueTest, BadArg) {
   EXPECT_DIF_BADARG(
-      dif_dma_int_write_value(nullptr, kDifDmaIntClearIdx0, 0x4567));
+      dif_dma_intr_write_value(nullptr, kDifDmaIntrClearIdx0, 0x4567));
 }
 
 }  // namespace dif_dma_test


### PR DESCRIPTION
This PR aims to rename registers to be more common with other OT IP.

In particular, we now use the following terms:
* INTR for the LSIO triggers/interrupts
* ADDR for address
* SRC for source
* DST for destination
