### PR TITLE
[manuf] add test harness to load and run any SRAM program

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -283,7 +283,7 @@ jobs:
         --build_tests_only=false \
         --test_output=errors \
         --define DISABLE_VERILATOR_BUILD=true \
-        --test_tag_filters=-broken,-cw310,-verilator,-dv \
+        --test_tag_filters=-broken,-cw310,-verilator,-dv,-silicon \
         --target_pattern_file="${TARGET_PATTERN_FILE}"
     displayName: Build & test SW
   - template: ci/publish-bazel-test-results.yml

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -122,3 +122,22 @@ status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
                                 /*delay=*/0));
   return OK_STATUS();
 }
+
+status_t manuf_flash_info_field_write(dif_flash_ctrl_state_t *flash_state,
+                                      flash_info_field_t field,
+                                      uint32_t *data_in, size_t num_words,
+                                      bool erase_page_before_write) {
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  uint32_t byte_address =
+      (field.page * device_info.bytes_per_page) + field.byte_offset;
+  if (erase_page_before_write) {
+    TRY(flash_ctrl_testutils_erase_and_write_page(
+        flash_state, byte_address, field.partition, data_in,
+        kDifFlashCtrlPartitionTypeInfo, num_words));
+  } else {
+    TRY(flash_ctrl_testutils_write(flash_state, byte_address, field.partition,
+                                   data_in, kDifFlashCtrlPartitionTypeInfo,
+                                   num_words));
+  }
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -68,7 +68,26 @@ extern const flash_info_field_t kFlashInfoFieldCdi1Certificate;
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
-                                     flash_info_field_t field, uint32_t *buf,
-                                     size_t len);
+                                     flash_info_field_t field,
+                                     uint32_t *data_out, size_t num_words);
+
+/**
+ * Write info flash page field.
+ *
+ * Assumes the page containing the field has already been configured for
+ * write/erase access.
+ *
+ * @param flash_state Flash controller instance.
+ * @param field Flash info field information.
+ * @param data_in Input buffer.
+ * @param num_words Number of words to read from flash and write to `data_out`.
+ * @param erase_page_before_write Whether to erase the page before writing it.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_flash_info_field_write(dif_flash_ctrl_state_t *flash_state,
+                                      flash_info_field_t field,
+                                      uint32_t *data_in, size_t num_words,
+                                      bool erase_page_before_write);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_FLASH_INFO_FIELDS_H_

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -217,6 +217,35 @@ cc_library(
     ],
 )
 
+opentitan_test(
+    name = "manuf_load_ast_calibration_into_flash",
+    srcs = ["sram_load_ast_calibration_into_flash.c"],
+    exec_env = {
+        "//hw/top_earlgrey:silicon_creator": None,
+    },
+    kind = "ram",
+    linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    silicon = silicon_jtag_params(
+        interface = "hyper310",
+        test_cmd = "--elf={firmware}",
+        test_harness = "//sw/host/tests/manuf/manuf_sram_program_load",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
 # We are using a bitstream with ROM execution disabled so the contents of flash
 # does not matter but opentitan_functest() is unhappy if we don't provide one.
 # Additionally, ROM execution is disabled in the OTP image we use so we do not

--- a/sw/device/silicon_creator/manuf/tests/sram_load_ast_calibration_into_flash.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_load_ast_calibration_into_flash.c
@@ -1,0 +1,120 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pinmux_t pinmux;
+static dif_flash_ctrl_state_t flash_state;
+static dif_uart_t uart;
+
+// ---------------------------------------------------------------------------
+// Enter Calibration Values for Specific Chip Here:
+// ---------------------------------------------------------------------------
+enum {
+  kNumCalibrationWords = 8,
+};
+const uint32_t kAstCfgData[kNumCalibrationWords] = {
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+};
+uint32_t kAstCfgAddrs[kNumCalibrationWords] = {
+    0x0, 0x4, 0x8, 0xc, 0x10, 0x14, 0x18, 0x1c,
+};
+// ---------------------------------------------------------------------------
+
+static status_t peripheral_handles_init(void) {
+  TRY(dif_flash_ctrl_init_state(
+      &flash_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  TRY(dif_pinmux_init(mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR),
+                      &pinmux));
+  TRY(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                    &uart));
+  return OK_STATUS();
+}
+
+static status_t init_uart(void) {
+  TRY_CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  TRY_CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+            "kClockFreqPeripheralHz must fit in uint32_t");
+  TRY(dif_uart_configure(&uart,
+                         (dif_uart_config_t){
+                             .baudrate = (uint32_t)kUartBaudrate,
+                             .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                             .parity_enable = kDifToggleDisabled,
+                             .parity = kDifUartParityEven,
+                             .tx_enable = kDifToggleEnabled,
+                             .rx_enable = kDifToggleEnabled,
+                         }));
+  base_uart_stdout(&uart);
+  return OK_STATUS();
+}
+
+static void manually_init_ast(void) {
+  for (size_t i = 0; i < kNumCalibrationWords; ++i) {
+    abs_mmio_write32(TOP_EARLGREY_AST_BASE_ADDR + kAstCfgAddrs[i],
+                     kAstCfgData[i]);
+  }
+}
+
+static status_t write_ast_values_to_flash(void) {
+  // Prepase AST calibration data buffer.
+  uint32_t ast_cfgs[(kNumCalibrationWords * 2) + 1];
+  ast_cfgs[0] = kNumCalibrationWords;
+  for (size_t i = 0; i < kNumCalibrationWords; ++i) {
+    ast_cfgs[i * 2 + 1] = kAstCfgAddrs[i] + TOP_EARLGREY_AST_BASE_ADDR;
+    ast_cfgs[i * 2 + 2] = kAstCfgData[i];
+  }
+
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
+      &flash_state, kFlashInfoFieldAstCalibrationData.page,
+      kFlashInfoFieldAstCalibrationData.bank,
+      kFlashInfoFieldAstCalibrationData.partition,
+      (dif_flash_ctrl_region_properties_t){
+          .ecc_en = kMultiBitBool4True,
+          .high_endurance_en = kMultiBitBool4False,
+          .erase_en = kMultiBitBool4True,
+          .prog_en = kMultiBitBool4True,
+          .rd_en = kMultiBitBool4True,
+          .scramble_en = kMultiBitBool4False},
+      /*offset=*/NULL));
+  TRY(manuf_flash_info_field_write(&flash_state,
+                                   kFlashInfoFieldAstCalibrationData, ast_cfgs,
+                                   (kNumCalibrationWords * 2) + 1,
+                                   /*erase_page_before_write=*/true));
+
+  return OK_STATUS();
+}
+
+void sram_main(void) {
+  // Initialize AST, DIF handles, pinmux, and UART.
+  manually_init_ast();
+  peripheral_handles_init();
+  pinmux_testutils_init(&pinmux);
+  CHECK_STATUS_OK(init_uart());
+  LOG_INFO("AST manually configured.");
+
+  // Write AST calibration values to flash info page 0.
+  CHECK_STATUS_OK(write_ast_values_to_flash());
+  LOG_INFO("AST calibration values written to flash info page 0.");
+
+  test_status_set(kTestStatusPassed);
+}

--- a/sw/host/tests/manuf/manuf_sram_program_load/BUILD
+++ b/sw/host/tests/manuf/manuf_sram_program_load/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "manuf_sram_program_load",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)

--- a/sw/host/tests/manuf/manuf_sram_program_load/src/main.rs
+++ b/sw/host/tests/manuf/manuf_sram_program_load/src/main.rs
@@ -1,0 +1,104 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use clap::Parser;
+use regex::Regex;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::jtag::JtagTap;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::load_sram_program::{
+    ExecutionMode, ExecutionResult, SramProgramParams,
+};
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    #[command(flatten)]
+    sram_program: SramProgramParams,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+fn sram_load_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Connect to the RISC-V TAP
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+    jtag.reset(false)?;
+
+    // Make sure to remove any messages from the ROM.
+    let uart = transport.uart("console")?;
+    uart.clear_rx_buffer()?;
+
+    // Load SRAM program and run it.
+    match opts
+        .sram_program
+        .load_and_execute(&mut *jtag, ExecutionMode::Jump)?
+    {
+        ExecutionResult::Executing => log::info!("program successfully started"),
+        res => bail!("program execution failed: {:?}", res),
+    }
+
+    // Disconnect JTAG.
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
+    jtag.disconnect()?;
+
+    // Wait for test status pass over the UART.
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS.*\n")?),
+        exit_failure: Some(Regex::new(r"(FAIL|FAULT).*\n")?),
+        newline: true,
+        ..Default::default()
+    };
+    let mut stdout = std::io::stdout();
+    let result = console.interact(&*uart, None, Some(&mut stdout))?;
+    match result {
+        ExitStatus::None | ExitStatus::CtrlC => Ok(()),
+        ExitStatus::Timeout => {
+            if console.exit_success.is_some() {
+                Err(anyhow!("Console timeout exceeded"))
+            } else {
+                Ok(())
+            }
+        }
+        ExitStatus::ExitSuccess => {
+            log::info!(
+                "ExitSuccess({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Ok(())
+        }
+        ExitStatus::ExitFailure => {
+            log::info!(
+                "ExitFailure({:?})",
+                console.captures(result).unwrap().get(0).unwrap().as_str()
+            );
+            Err(anyhow!("Matched exit_failure expression"))
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    sram_load_program(&opts, &transport)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Useful for running SRAM programs during bringup and manufacturing.

Additionally, add a test SRAM program to initialize the AST configuration flash info field.