### PR TITLE
[ottf] Print an exception dump

### DIFF
--- a/sw/device/lib/testing/test_framework/freertos_port.c
+++ b/sw/device/lib/testing/test_framework/freertos_port.c
@@ -41,7 +41,7 @@ static const uint64_t kTimerDeadline =
     100;  // Counter must reach 100 for an IRQ to be triggered.
 
 // Override the timer ISR to support preemptive context switching.
-void ottf_timer_isr(void) {
+void ottf_timer_isr(uint32_t *exc_info) {
   LOG_INFO("Handling timer IQR ...");
   dif_rv_timer_irq_enable_snapshot_t irq_enable_snapshot;
   CHECK_DIF_OK(

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -194,7 +194,7 @@ static status_t manage_flow_control(const dif_uart_t *uart,
   return OK_STATUS((int32_t)flow_control_state);
 }
 
-bool ottf_console_flow_control_isr(void) {
+bool ottf_console_flow_control_isr(uint32_t *exc_info) {
   dif_uart_t *uart = (dif_uart_t *)ottf_console_get();
   flow_control_irqs += 1;
   bool rx;

--- a/sw/device/lib/testing/test_framework/ottf_isrs.S
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.S
@@ -121,6 +121,7 @@ handler_exception:
   jal save_current_sp_to_tcb
 
   // Jump to the exception handler.
+  mv a0, sp
   jal ottf_exception_handler
 
   // Return from ISR.
@@ -181,6 +182,7 @@ handler_irq_software:
   jal save_current_sp_to_tcb
 
   // Jump to the software ISR.
+  mv a0, sp
   jal ottf_software_isr
 
   // Return from ISR.
@@ -241,6 +243,7 @@ handler_irq_timer:
   jal save_current_sp_to_tcb
 
   // Jump to timer ISR.
+  mv a0, sp
   jal ottf_timer_isr
 
   // Return from ISR.
@@ -301,6 +304,7 @@ handler_irq_external:
   jal save_current_sp_to_tcb
 
   // Jump to external ISR.
+  mv a0, sp
   jal ottf_external_isr
 
   // Return from ISR.
@@ -361,6 +365,7 @@ handler_irq_internal:
   jal save_current_sp_to_tcb
 
   // Jump to the internal ISR.
+  mv a0, sp
   jal ottf_internal_isr
 
   // Return from ISR.

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -53,16 +54,55 @@ static const char *exception_reason[] = {
     "Reserved",
 };
 
-void ottf_generic_fault_print(const char *reason, uint32_t mcause) {
+static const char *exc_frame[] = {
+    "mepc", "  ra", "  t0", "  t1", "  t2", "  s0", "  s1", "  a0",
+    "  a1", "  a2", "  a3", "  a4", "  a5", "  a6", "  a7", "  s2",
+    "  s3", "  s4", "  s5", "  s6", "  s7", "  s8", "  s9", " s10",
+    " s11", "  t3", "  t4", "  t5", "  t6", "msts",
+};
+
+void ottf_generic_fault_print(uint32_t *exc_info, const char *reason,
+                              uint32_t mcause) {
+  enum { kExcWords = 30 };
   uint32_t mepc = ibex_mepc_read();
   uint32_t mtval = ibex_mtval_read();
+  if (exc_info) {
+    base_printf("===== Exception Frame @ %08x =====", exc_info);
+    for (size_t i = 0; i < kExcWords; ++i) {
+      if (i % 4 == 0) {
+        base_printf("\n");
+      }
+      const char *name = exc_frame[i];
+      if (name == NULL)
+        continue;
+      base_printf(" %4s=%08x", name, exc_info[i]);
+    }
+    uint32_t *sp = exc_info + kExcWords;
+    base_printf("\n");
+    uint32_t *ram_start = (uint32_t *)TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR;
+    uint32_t *ram_end =
+        (uint32_t *)(TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR +
+                     TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES);
+
+    extern const char _text_start[], _text_end[];
+    const uint32_t text_start = (uint32_t)_text_start;
+    const uint32_t text_end = (uint32_t)_text_end;
+    base_printf("===== Call Stack =====\n");
+    for (; sp >= ram_start && sp < ram_end; ++sp) {
+      uint32_t val = *sp;
+      if (val >= text_start && val < text_end) {
+        base_printf("    %08x\n", val);
+      }
+    }
+  }
   LOG_ERROR("FAULT: %s. MCAUSE=%08x MEPC=%08x MTVAL=%08x", reason, mcause, mepc,
             mtval);
 }
 
-static void generic_fault_handler(void) {
+static void generic_fault_handler(uint32_t *exc_info) {
   uint32_t mcause = ibex_mcause_read();
-  ottf_generic_fault_print(exception_reason[mcause & kIbexExcMax], mcause);
+  ottf_generic_fault_print(exc_info, exception_reason[mcause & kIbexExcMax],
+                           mcause);
   abort();
 }
 
@@ -76,84 +116,84 @@ OT_WEAK
 void *pxCurrentTCB = NULL;
 
 OT_WEAK
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   uint32_t mcause = ibex_mcause_read();
 
   switch ((ibex_exc_t)(mcause & kIbexExcMax)) {
     case kIbexExcInstrMisaligned:
-      ottf_instr_misaligned_fault_handler();
+      ottf_instr_misaligned_fault_handler(exc_info);
       break;
     case kIbexExcInstrAccessFault:
-      ottf_instr_access_fault_handler();
+      ottf_instr_access_fault_handler(exc_info);
       break;
     case kIbexExcIllegalInstrFault:
-      ottf_illegal_instr_fault_handler();
+      ottf_illegal_instr_fault_handler(exc_info);
       break;
     case kIbexExcBreakpoint:
-      ottf_breakpoint_handler();
+      ottf_breakpoint_handler(exc_info);
       break;
     case kIbexExcLoadAccessFault:
-      ottf_load_store_fault_handler();
+      ottf_load_store_fault_handler(exc_info);
       break;
     case kIbexExcStoreAccessFault:
-      ottf_load_store_fault_handler();
+      ottf_load_store_fault_handler(exc_info);
       break;
     case kIbexExcMachineECall:
-      ottf_machine_ecall_handler();
+      ottf_machine_ecall_handler(exc_info);
       break;
     case kIbexExcUserECall:
-      ottf_user_ecall_handler();
+      ottf_user_ecall_handler(exc_info);
       break;
     default:
-      generic_fault_handler();
+      generic_fault_handler(exc_info);
   }
 }
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_instr_misaligned_fault_handler(void);
+void ottf_instr_misaligned_fault_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_instr_access_fault_handler(void);
+void ottf_instr_access_fault_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_illegal_instr_fault_handler(void);
+void ottf_illegal_instr_fault_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_breakpoint_handler(void);
+void ottf_breakpoint_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_load_store_fault_handler(void);
+void ottf_load_store_fault_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_machine_ecall_handler(void);
+void ottf_machine_ecall_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_fault_handler")
-void ottf_user_ecall_handler(void);
+void ottf_user_ecall_handler(uint32_t *exc_info);
 
 OT_WEAK
-void ottf_software_isr(void) {
-  ottf_generic_fault_print("Software IRQ", ibex_mcause_read());
+void ottf_software_isr(uint32_t *exc_info) {
+  ottf_generic_fault_print(exc_info, "Software IRQ", ibex_mcause_read());
   abort();
 }
 
 OT_WEAK
-void ottf_timer_isr(void) {
-  ottf_generic_fault_print("Timer IRQ", ibex_mcause_read());
+void ottf_timer_isr(uint32_t *exc_info) {
+  ottf_generic_fault_print(exc_info, "Timer IRQ", ibex_mcause_read());
   abort();
 }
 
 OT_WEAK
-bool ottf_console_flow_control_isr(void) { return false; }
+bool ottf_console_flow_control_isr(uint32_t *exc_info) { return false; }
 
 OT_WEAK
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&ottf_plic, kPlicTarget, &plic_irq_id));
@@ -162,41 +202,41 @@ void ottf_external_isr(void) {
       top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
 
   if (peripheral == kTopEarlgreyPlicPeripheralUart0 &&
-      ottf_console_flow_control_isr()) {
+      ottf_console_flow_control_isr(exc_info)) {
     // Complete the IRQ at PLIC.
     CHECK_DIF_OK(
         dif_rv_plic_irq_complete(&ottf_plic, kPlicTarget, plic_irq_id));
     return;
   }
 
-  ottf_generic_fault_print("External IRQ", ibex_mcause_read());
+  ottf_generic_fault_print(exc_info, "External IRQ", ibex_mcause_read());
   abort();
 }
 
-static void generic_internal_irq_handler(void) {
-  ottf_generic_fault_print("Internal IRQ", ibex_mcause_read());
+static void generic_internal_irq_handler(uint32_t *exc_info) {
+  ottf_generic_fault_print(exc_info, "Internal IRQ", ibex_mcause_read());
   abort();
 }
 
 OT_WEAK
 OT_ALIAS("generic_internal_irq_handler")
-void ottf_external_nmi_handler(void);
+void ottf_external_nmi_handler(uint32_t *exc_info);
 
 OT_WEAK
 OT_ALIAS("generic_internal_irq_handler")
-void ottf_load_integrity_error_handler(void);
+void ottf_load_integrity_error_handler(uint32_t *exc_info);
 
 OT_WEAK
-void ottf_internal_isr(void) {
+void ottf_internal_isr(uint32_t *exc_info) {
   uint32_t mcause = ibex_mcause_read();
   switch ((ibex_internal_irq_t)(mcause)) {
     case kIbexInternalIrqLoadInteg:
-      ottf_load_integrity_error_handler();
+      ottf_load_integrity_error_handler(exc_info);
       break;
     case kIbexInternalIrqNmi:
-      ottf_external_nmi_handler();
+      ottf_external_nmi_handler(exc_info);
       break;
     default:
-      generic_internal_irq_handler();
+      generic_internal_irq_handler(exc_info);
   }
 }

--- a/sw/device/lib/testing/test_framework/ottf_isrs.h
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.h
@@ -23,7 +23,8 @@ extern dif_rv_plic_t ottf_plic;
  * @param reason A string describing the fault reason.
  * @param mcause The value of the mcause register for this fault.
  */
-void ottf_generic_fault_print(const char *reason, uint32_t mcause);
+void ottf_generic_fault_print(uint32_t *exc_info, const char *reason,
+                              uint32_t mcause);
 
 /**
  * OTTF exception handler.
@@ -33,7 +34,7 @@ void ottf_generic_fault_print(const char *reason, uint32_t mcause);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_exception_handler(void);
+void ottf_exception_handler(uint32_t *exc_info);
 
 /**
  * OTTF instruction misaligned fault handler.
@@ -44,7 +45,7 @@ void ottf_exception_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_instr_misaligned_fault_handler(void);
+void ottf_instr_misaligned_fault_handler(uint32_t *exc_info);
 
 /**
  * OTTF instruction access fault handler.
@@ -55,7 +56,7 @@ void ottf_instr_misaligned_fault_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_instr_access_fault_handler(void);
+void ottf_instr_access_fault_handler(uint32_t *exc_info);
 
 /**
  * OTTF illegal instruction fault handler.
@@ -66,7 +67,7 @@ void ottf_instr_access_fault_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_illegal_instr_fault_handler(void);
+void ottf_illegal_instr_fault_handler(uint32_t *exc_info);
 
 /**
  * OTTF breakpoint handler.
@@ -77,7 +78,7 @@ void ottf_illegal_instr_fault_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_breakpoint_handler(void);
+void ottf_breakpoint_handler(uint32_t *exc_info);
 
 /**
  * OTTF load/store fault handler.
@@ -88,7 +89,7 @@ void ottf_breakpoint_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_load_store_fault_handler(void);
+void ottf_load_store_fault_handler(uint32_t *exc_info);
 
 /**
  * OTTF machine-mode environment call handler.
@@ -99,7 +100,7 @@ void ottf_load_store_fault_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_machine_ecall_handler(void);
+void ottf_machine_ecall_handler(uint32_t *exc_info);
 
 /**
  * OTTF user-mode environment call handler.
@@ -110,7 +111,7 @@ void ottf_machine_ecall_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_user_ecall_handler(void);
+void ottf_user_ecall_handler(uint32_t *exc_info);
 
 /**
  * OTTF software IRQ handler.
@@ -118,7 +119,7 @@ void ottf_user_ecall_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_software_isr(void);
+void ottf_software_isr(uint32_t *exc_info);
 
 /**
  * OTTF timer IRQ handler.
@@ -126,7 +127,7 @@ void ottf_software_isr(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_timer_isr(void);
+void ottf_timer_isr(uint32_t *exc_info);
 
 /**
  * OTTF external IRQ handler.
@@ -134,7 +135,7 @@ void ottf_timer_isr(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_external_isr(void);
+void ottf_external_isr(uint32_t *exc_info);
 
 /**
  * OTTF external NMI internal IRQ handler.
@@ -142,7 +143,7 @@ void ottf_external_isr(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_external_nmi_handler(void);
+void ottf_external_nmi_handler(uint32_t *exc_info);
 
 /**
  * OTTF load integrity internal IRQ handler.
@@ -150,7 +151,7 @@ void ottf_external_nmi_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_load_integrity_error_handler(void);
+void ottf_load_integrity_error_handler(uint32_t *exc_info);
 
 /**
  * OTTF internal IRQ handler.
@@ -158,6 +159,6 @@ void ottf_load_integrity_error_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overridden at link-time by providing an additional non-weak definition.
  */
-void ottf_internal_isr(void);
+void ottf_internal_isr(uint32_t *exc_info);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ISRS_H_

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -47,7 +47,7 @@ rand_testutils_rng_t rand_testutils_rng_ctx;
 
 // The OTTF overrides the default machine ecall exception handler to implement
 // FreeRTOS context switching, required for supporting cooperative scheduling.
-void ottf_machine_ecall_handler(void) {
+void ottf_machine_ecall_handler(uint32_t *exc_info) {
   if (pxCurrentTCB != NULL) {
     // If the pointer to the current TCB is not NULL, we are operating in
     // concurrency mode. In this case, our default behavior is to assume a

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -190,7 +190,7 @@ static void sca_init_edn(void) {
  *
  * Disables the counter and clears pending interrupts.
  */
-void ottf_timer_isr(void) {
+void ottf_timer_isr(uint32_t *exc_info) {
   // Return values of below functions are ignored to improve capture
   // performance.
   OT_DISCARD(dif_rv_timer_counter_set_enabled(&timer, kRvTimerHart,

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -48,6 +48,7 @@ SECTIONS {
   } > ram_main
 
   .vectors : ALIGN (256){
+    _text_start = .;
     KEEP(*(.vectors))
     . = ALIGN(4);
   } > ram_main
@@ -57,6 +58,7 @@ SECTIONS {
     KEEP(*(.text))
     KEEP(*(.text.*))
     . = ALIGN(4);
+    _text_end = .;
   } > ram_main
 
   .rodata : ALIGN(4) {

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_static_critical_test.c
@@ -81,7 +81,7 @@ static volatile bool exception_observed = false;
 // in `ottf_exception_handler()`.
 extern const char kSecMmioNegTestReturn[];
 
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   CHECK(exception_expected == true);
   CHECK(exception_observed == false);
   exception_expected = false;

--- a/sw/device/tests/alert_handler_lpg_clkoff_test.c
+++ b/sw/device/tests/alert_handler_lpg_clkoff_test.c
@@ -402,7 +402,7 @@ void wait_enough_for_alert_ping(void) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral_serviced;
   dif_alert_handler_irq_t irq_serviced;
   isr_testutils_alert_handler_isr(plic_ctx, alert_handler_ctx,

--- a/sw/device/tests/alert_handler_lpg_reset_toggle.c
+++ b/sw/device/tests/alert_handler_lpg_reset_toggle.c
@@ -354,7 +354,7 @@ enum {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // We don't expect any interrupt to be fired.
   // If an interrupt is fired, the test will be ended.
   CHECK(false, "Unexpected external interrupt triggered.");

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -446,7 +446,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/alert_handler_ping_timeout_test.c
+++ b/sw/device/tests/alert_handler_ping_timeout_test.c
@@ -129,7 +129,7 @@ static void alert_handler_config(void) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral_serviced;
   dif_alert_handler_irq_t irq_serviced;
   isr_testutils_alert_handler_isr(plic_ctx, alert_handler_ctx,

--- a/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
+++ b/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
@@ -191,7 +191,7 @@ static void chip_sw_reset(void) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) { interrupt_serviced = true; }
+void ottf_external_isr(uint32_t *exc_info) { interrupt_serviced = true; }
 
 bool test_main(void) {
   init_peripherals();

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -162,7 +162,7 @@ static void execute_test(dif_aon_timer_t *aon_timer, uint64_t irq_time_us,
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Calc the elapsed time since the activation of the IRQ.
   irq_tick = tick_count_get();
 

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -70,7 +70,7 @@ static dif_alert_handler_t alert_handler;
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
 

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -323,7 +323,7 @@ static volatile dif_usbdev_irq_t usbdev_irq_serviced;
  * 4. Clears the IRQ at the peripheral.
  * 5. Completes the IRQ service at PLIC.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id));
 

--- a/sw/device/tests/chip_power_idle_load.c
+++ b/sw/device/tests/chip_power_idle_load.c
@@ -49,12 +49,12 @@ OTTF_DEFINE_TEST_CONFIG();
 
 // ISRs
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   LOG_INFO("got external IRQ");
   ext_irq_fired = true;
 }
 
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   nmi_fired = true;
 
   expected_isr_handler();

--- a/sw/device/tests/chip_power_sleep_load.c
+++ b/sw/device/tests/chip_power_sleep_load.c
@@ -64,12 +64,12 @@ OTTF_DEFINE_TEST_CONFIG();
 
 // ISRs
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   LOG_INFO("got external IRQ");
   ext_irq_fired = true;
 }
 
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   nmi_fired = true;
 
   expected_isr_handler();

--- a/sw/device/tests/clkmgr_sleep_frequency_test.c
+++ b/sw/device/tests/clkmgr_sleep_frequency_test.c
@@ -56,7 +56,7 @@ static volatile bool isr_entered;
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/entropy_src_csrng_test.c
+++ b/sw/device/tests/entropy_src_csrng_test.c
@@ -310,7 +310,7 @@ static void test_edn_cmd_done(const dif_edn_seed_material_t *seed_material) {
       entropy_testutils_error_check(&entropy_src, &csrng, &edn0, &edn1));
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Claim the IRQ at the PLIC.
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(

--- a/sw/device/tests/example_test_from_flash.c
+++ b/sw/device/tests/example_test_from_flash.c
@@ -50,13 +50,13 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
  * full OTTF, as it used to implement FreeRTOS context switching. See its
  * implementation in `sw/device/lib/testing/test_framework/ottf_main.c`.
  */
-// void ottf_exception_handler(void) {}
-// void ottf_instr_misaligned_fault_handler(void) {}
-// void ottf_instr_access_fault_handler(void) {}
-// void ottf_illegal_instr_fault_handler(void) {}
-// void ottf_breakpoint_handler(void) {}
-// void ottf_load_store_fault_handler(void) {}
-// void ottf_user_ecall_handler(void) {}
+// void ottf_exception_handler(uint32_t *exc_info) {}
+// void ottf_instr_misaligned_fault_handler(uint32_t *exc_info) {}
+// void ottf_instr_access_fault_handler(uint32_t *exc_info) {}
+// void ottf_illegal_instr_fault_handler(uint32_t *exc_info) {}
+// void ottf_breakpoint_handler(uint32_t *exc_info) {}
+// void ottf_load_store_fault_handler(uint32_t *exc_info) {}
+// void ottf_user_ecall_handler(uint32_t *exc_info) {}
 
 /**
  * Override any of the default OTTF ISRs (by uncommenting and implementing them)
@@ -66,9 +66,9 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
  * See `sw/device/lib/testing/test_framework/ottf_isrs.c` for implementation
  * details of the default OTTF ISRs.
  */
-// void ottf_software_isr(void) {}
-// void ottf_timer_isr(void) {}
-// void ottf_external_isr(void) {}
+// void ottf_software_isr(uint32_t *exc_info) {}
+// void ottf_timer_isr(uint32_t *exc_info) {}
+// void ottf_external_isr(uint32_t *exc_info) {}
 
 /**
  * Save data that will need to persist across resets by placing it in the

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -54,7 +54,7 @@ enum {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   isr_testutils_aon_timer_isr(plic_ctx, aon_timer_ctx, &peripheral_serviced,
                               &irq_serviced);
 }

--- a/sw/device/tests/flash_ctrl_info_access_lc.c
+++ b/sw/device/tests/flash_ctrl_info_access_lc.c
@@ -72,7 +72,7 @@ static volatile bool fired_irqs[kNumIRQs];
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral_serviced;
   dif_flash_ctrl_irq_t irq_serviced;
   isr_testutils_flash_ctrl_isr(plic_ctx, flash_ctx, &peripheral_serviced,

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -111,7 +111,7 @@ static volatile bool fired_irqs[FLASH_CTRL_NUM_IRQS];
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral_serviced;
   dif_flash_ctrl_irq_t irq_serviced;
   isr_testutils_flash_ctrl_isr(plic_ctx, flash_ctx, &peripheral_serviced,

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -40,7 +40,7 @@ static const dif_hmac_transaction_t kHmacTransactionConfig = {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   isr_testutils_hmac_isr(plic_ctx, hmac_ctx, &peripheral_serviced,
                          &irq_serviced);
 }

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -59,7 +59,7 @@ static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -106,7 +106,7 @@ static volatile dif_otbn_irq_t irq;
  * 4. Clears the IRQ at the peripheral.
  * 5. Completes the IRQ service at PLIC.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kTopEarlgreyPlicTargetIbex0,
                                      (dif_rv_plic_irq_id_t *)&irq_id));
 

--- a/sw/device/tests/otbn_irq_test.c
+++ b/sw/device/tests/otbn_irq_test.c
@@ -133,7 +133,7 @@ static void plic_init_with_irqs(void) {
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t irq_id;
   CHECK_DIF_OK(

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -81,7 +81,9 @@ static volatile bool has_irq_fired;
 /**
  * This overrides the default OTTF load integrity handler.
  */
-void ottf_load_integrity_error_handler(void) { has_irq_fired = true; }
+void ottf_load_integrity_error_handler(uint32_t *exc_info) {
+  has_irq_fired = true;
+}
 
 /**
  * Get `num` distinct random numbers in the range [0, `max`] from

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -45,7 +45,7 @@ static volatile dif_otbn_irq_t irq;
  * 4. Clears the IRQ at the peripheral.
  * 5. Completes the IRQ service at PLIC.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kTopEarlgreyPlicTargetIbex0,
                                      (dif_rv_plic_irq_id_t *)&irq_id));
 

--- a/sw/device/tests/plic_sw_irq_test.c
+++ b/sw/device/tests/plic_sw_irq_test.c
@@ -49,7 +49,7 @@ static void plic_configure_irqs(dif_rv_plic_t *plic) {
  * MSIP triggers this. Inside the routine, it reads all Interrupt Pending bits
  * and confirms only MSIP occurs.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t interrupt_id;
 
   ++external_intr_triggered;
@@ -66,7 +66,7 @@ void ottf_external_isr(void) {
  *
  * Only SW ISR should occur in this test.
  */
-void ottf_software_isr(void) {
+void ottf_software_isr(uint32_t *exc_info) {
   LOG_INFO("SOFTWARE ISR entered");
   ++software_intr_triggered;
 

--- a/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
@@ -94,7 +94,7 @@ static status_t external_isr(void) {
   return OK_STATUS();
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   status_t tmp = external_isr();
   if (status_ok(isr_result)) {
     isr_result = tmp;

--- a/sw/device/tests/pmod/i2c_host_irq_test.c
+++ b/sw/device/tests/pmod/i2c_host_irq_test.c
@@ -86,7 +86,7 @@ static status_t external_isr(void) {
   return OK_STATUS();
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   status_t tmp = external_isr();
   if (status_ok(isr_result)) {
     isr_result = tmp;

--- a/sw/device/tests/pmp_smoketest_napot.c
+++ b/sw/device/tests/pmp_smoketest_napot.c
@@ -32,7 +32,9 @@ static volatile char pmp_load_store_test_data[PMP_LOAD_RANGE_BUFFER_SIZE];
 /**
  * This overrides the default OTTF load/store fault exception handler.
  */
-void ottf_load_store_fault_handler(void) { pmp_load_exception = true; }
+void ottf_load_store_fault_handler(uint32_t *exc_info) {
+  pmp_load_exception = true;
+}
 
 static void pmp_configure_load_napot(void) {
   uintptr_t load_range_start =

--- a/sw/device/tests/pmp_smoketest_tor.c
+++ b/sw/device/tests/pmp_smoketest_tor.c
@@ -45,7 +45,9 @@ static volatile bool pmp_load_exception;
 __attribute__((aligned(PMP_LOAD_RANGE_SIZE)))  //
 static volatile char pmp_load_test_data[PMP_LOAD_RANGE_BUFFER_SIZE];
 
-void ottf_load_store_fault_handler(void) { pmp_load_exception = true; }
+void ottf_load_store_fault_handler(uint32_t *exc_info) {
+  pmp_load_exception = true;
+}
 
 static void pmp_configure_load_tor(void) {
   uintptr_t load_range_start =

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -274,7 +274,7 @@ static void log_entropy_src_alert_failures(void) {
 /**
  * External (OTTF) ISR override.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t irq_id;
   CHECK_DIF_OK(

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -38,7 +38,7 @@ bool is_pwrmgr_irq_pending(void) {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
 

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.c
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.c
@@ -285,7 +285,7 @@ void prepare_for_sysrst(pwrmgr_sleep_resets_lib_modes_t mode) {
   CHECK(false, "Failed to reset!");
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral;
   dif_rv_plic_irq_id_t irq_id;
   uint32_t irq = 0;

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.h
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.h
@@ -115,6 +115,6 @@ void prepare_for_sysrst(pwrmgr_sleep_resets_lib_modes_t mode);
  * Handles all peripheral interrupts expected for these tests. It expects
  * no barks from aon_timer, and phase 0 interrupts from the alert handler.
  */
-void ottf_external_isr(void);
+void ottf_external_isr(uint32_t *exc_info);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PWRMGR_SLEEP_RESETS_LIB_H_

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -250,7 +250,7 @@ static void set_extra_alert(volatile uint32_t *set) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral;
   dif_rv_plic_irq_id_t irq_id;
   uint32_t irq = 0;

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -74,7 +74,7 @@ volatile static bool double_fault;
 /**
  * Overrides the default OTTF exception handler.
  */
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   if (double_fault) {
     OT_ADDRESSABLE_LABEL(kDoubleFaultSecondAddr);
     mmio_region_write32(mmio_region_from_addr(kIllegalAddr2), 0, 0);

--- a/sw/device/tests/rv_core_ibex_address_translation_test.c
+++ b/sw/device/tests/rv_core_ibex_address_translation_test.c
@@ -79,7 +79,7 @@ static volatile bool access_fault = false;
  * stack by the OTTF exception handler entry subroutine, which means that the
  * return address can be loaded from there. See comments below for more details.
  */
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   // The frame address is the address of the stack location that holds the
   // `mepc`, since the OTTF exception handler entry code saves the `mepc` to
   // the top of the stack before transferring control flow to the exception

--- a/sw/device/tests/rv_core_ibex_epmp_test.c
+++ b/sw/device/tests/rv_core_ibex_epmp_test.c
@@ -75,7 +75,7 @@ static inline bool was_in_machine_mode(void) {
   return ((mstatus >> kMppOffset) & 0x3) == 0x3;
 }
 
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   uint32_t mtval = ibex_mtval_read();
   ibex_exc_t mcause = ibex_mcause_read();
   bool m_mode_exception = was_in_machine_mode();

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -232,7 +232,7 @@ static void alert_handler_nmi_test(void) {
  * It calls the `expected_isr_handler` function pointer that is previously set
  * by the test to handler the specific peripheral IRQ.
  */
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   nmi_fired = true;
 
   expected_isr_handler();
@@ -247,7 +247,7 @@ void ottf_external_nmi_handler(void) {
  * OTTF external IRQ handler
  * This functions overrides the OTTF weak definition.
  */
-void ottf_external_isr(void) { ext_irq_fired = true; }
+void ottf_external_isr(uint32_t *exc_info) { ext_irq_fired = true; }
 
 /**
  * Initialized all peripherals used in this test.

--- a/sw/device/tests/rv_dm_lc_disabled.c
+++ b/sw/device/tests/rv_dm_lc_disabled.c
@@ -21,7 +21,9 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static volatile bool access_exception_seen;
 
-void ottf_load_store_fault_handler(void) { access_exception_seen = true; }
+void ottf_load_store_fault_handler(uint32_t *exc_info) {
+  access_exception_seen = true;
+}
 
 status_t execute_test(bool debug_func) {
   mmio_region_t region =

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -67,7 +67,7 @@ static void handle_uart_isr(const dif_rv_plic_irq_id_t interrupt_id) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Claim the IRQ by reading the Ibex specific CC register.
   dif_rv_plic_irq_id_t interrupt_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic0, kPlicTarget, &interrupt_id));

--- a/sw/device/tests/rv_timer_smoketest.c
+++ b/sw/device/tests/rv_timer_smoketest.c
@@ -45,7 +45,7 @@ static void test_handler(void) {
 }
 
 // Override default OTTF timer ISR.
-void ottf_timer_isr(void) {
+void ottf_timer_isr(uint32_t *exc_info) {
   LOG_INFO("Entering handler_irq_timer()");
   test_handler();
   LOG_INFO("Exiting handler_irq_timer()");

--- a/sw/device/tests/sensor_ctrl_wakeup.c
+++ b/sw/device/tests/sensor_ctrl_wakeup.c
@@ -41,7 +41,7 @@ static bool get_wakeup_status(void) {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -58,7 +58,7 @@ static dif_rv_plic_t plic;
 static volatile bool interrupt_expected = false;
 static volatile bool interrupt_serviced = false;
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 

--- a/sw/device/tests/sim_dv/alert_handler_escalation.c
+++ b/sw/device/tests/sim_dv/alert_handler_escalation.c
@@ -81,7 +81,7 @@ static const dif_alert_handler_class_config_t kConfigProfiles[] = {{
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   // DO NOT REMOVE, DV sync message
   LOG_INFO("You are experiencing an NMI");
 

--- a/sw/device/tests/sim_dv/alert_handler_lpg_sleep_mode_alerts.c
+++ b/sw/device/tests/sim_dv/alert_handler_lpg_sleep_mode_alerts.c
@@ -422,7 +422,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -460,7 +460,7 @@ static void rv_core_ibex_fault_checker(bool enable, const char *ip_inst,
  * is correctly blocked.
  *
  */
-void ottf_load_store_fault_handler(void) {
+void ottf_load_store_fault_handler(uint32_t *exc_info) {
   LOG_INFO("At load access error handler");
 
   uint32_t mtval = ibex_mtval_read();
@@ -499,7 +499,7 @@ static void sram_ctrl_ret_fault_checker(bool enable, const char *ip_inst,
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
 
   // There may be multiple interrupts due to the alert firing, so this keeps an
@@ -563,7 +563,7 @@ void ottf_external_isr(void) {
  *
  * Handles NMI interrupts on Ibex for either escalation or watchdog.
  */
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   dif_rv_core_ibex_nmi_state_t nmi_state = (dif_rv_core_ibex_nmi_state_t){0};
   // Increment the nmi interrupt count.
   uint32_t nmi_count = 0;

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -493,7 +493,7 @@ void set_edn_auto_mode(void) {
   CHECK_DIF_OK(dif_edn_set_auto_mode(&edn1, edn1_params));
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -222,7 +222,7 @@ static void rv_core_ibex_fault_checker(bool enable) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
 
   LOG_INFO("At regular external ISR");
@@ -284,7 +284,7 @@ void ottf_external_isr(void) {
  *
  * Handles load integrity error exceptions on Ibex.
  */
-void ottf_load_integrity_error_handler(void) {
+void ottf_load_integrity_error_handler(uint32_t *exc_info) {
   LOG_INFO("At load integrity error handler");
 
   CHECK(kFaultTarget != kFaultTargetMainSramInstr,
@@ -313,7 +313,7 @@ void ottf_load_integrity_error_handler(void) {
  *
  * Handles instruction access faults on Ibex.
  */
-void ottf_instr_access_fault_handler(void) {
+void ottf_instr_access_fault_handler(uint32_t *exc_info) {
   LOG_INFO("At instr access fault handler");
 
   CHECK(kFaultTargetMainSramInstr == 2, "Expected fault target 2, got %d",
@@ -338,7 +338,7 @@ void ottf_instr_access_fault_handler(void) {
  *
  * Handles NMI interrupts on Ibex for either escalation or watchdog.
  */
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   dif_rv_core_ibex_nmi_state_t nmi_state = (dif_rv_core_ibex_nmi_state_t){0};
   LOG_INFO("At NMI handler");
 

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -164,7 +164,7 @@ static void gpio_input_test(const dif_gpio_t *gpio, uint32_t mask) {
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -114,7 +114,7 @@ const i2c_conf_t i2c_configuration[] = {
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -61,7 +61,7 @@ static uint32_t i2c_irq_fmt_threshold_id;
 static uint32_t i2c_base_addr;
 static top_earlgrey_plic_irq_id_t plic_irqs[9];
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 

--- a/sw/device/tests/sim_dv/lc_ctrl_program_error.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_program_error.c
@@ -141,7 +141,7 @@ static void lc_ctrl_fault_checker(bool enable, const char *ip_inst) {
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
 
   LOG_INFO("At regular external ISR");
@@ -204,7 +204,7 @@ void ottf_external_isr(void) {
  *
  * Handles NMI interrupts on Ibex for either escalation or watchdog.
  */
-void ottf_external_nmi_handler(void) {
+void ottf_external_nmi_handler(uint32_t *exc_info) {
   dif_rv_core_ibex_nmi_state_t nmi_state = (dif_rv_core_ibex_nmi_state_t){0};
   LOG_INFO("At NMI handler");
 

--- a/sw/device/tests/sim_dv/pattgen_ios_test.c
+++ b/sw/device/tests/sim_dv/pattgen_ios_test.c
@@ -70,7 +70,7 @@ static dif_pattgen_t pattgen;
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t irq_id;
 
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -81,7 +81,7 @@ static_assert(
  * line to the CPU, which results in a call to this OTTF ISR. This ISR
  * overrides the default OTTF implementation.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral;
   dif_rv_plic_irq_id_t irq_id;
   uint32_t irq = 0;

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -293,7 +293,7 @@ static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/rv_dm_access_after_wakeup.c
+++ b/sw/device/tests/sim_dv/rv_dm_access_after_wakeup.c
@@ -41,7 +41,7 @@ dif_rv_plic_t rv_plic;
  *
  * Simply claim the interrupt and does nothing else.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&rv_plic, kTopEarlgreyPlicTargetIbex0,
                                      &plic_irq_id));

--- a/sw/device/tests/sim_dv/sensor_ctrl_status.c
+++ b/sw/device/tests/sim_dv/sensor_ctrl_status.c
@@ -41,7 +41,7 @@ static sensor_ctrl_isr_ctx_t sensor_ctrl_isr_ctx = {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_sensor_ctrl_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_mio_dio_val_test.c
@@ -121,7 +121,7 @@ static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/sleep_pin_retention_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_retention_test.c
@@ -48,7 +48,7 @@ enum { kNumGpioPads = 8 };
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/sleep_pin_wake_test.c
+++ b/sw/device/tests/sim_dv/sleep_pin_wake_test.c
@@ -51,7 +51,7 @@ OT_SECTION(".non_volatile_scratch") uint32_t wakeup_detector_idx;
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_device_tpm_tx_rx_test.c
@@ -94,7 +94,7 @@ static void en_spi_device_irqs(dif_spi_device_t *spi_device) {
   }
 }
 
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -339,7 +339,7 @@ void spi_device_isr(void) {
  *
  * Runs in interrupt context.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&rv_plic, kPlicTarget, &plic_irq_id));

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -66,7 +66,7 @@ static volatile bool fired_irqs[SPI_DEVICE_NUM_IRQS];
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_main_test.c
@@ -107,7 +107,7 @@ static bool otp_ifetch_enabled(void) {
  * stack by the OTTF exception handler entry subroutine, which means that the
  * return address can be loaded from there. See comments below for more details.
  */
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   // The frame address is the address of the stack location that holds the
   // `mepc`, since the OTTF exception handler entry code saves the `mepc` to
   // the top of the stack before transferring control flow to the exception

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -301,7 +301,7 @@ static void execute_retention_sram_test(void) {
  * Override internal IRQ interrupt service routine to count
  * the number of integrity exceptions.
  */
-void ottf_internal_isr(void) {
+void ottf_internal_isr(uint32_t *exc_info) {
   LOG_INFO("%s - %d", __func__, reference_frame->ecc_error_counter);
   reference_frame->ecc_error_counter++;
 }

--- a/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_in_irq_test.c
@@ -156,7 +156,7 @@ void sysrst_ctrl_key_combo_detect(dif_sysrst_ctrl_key_combo_t key_combo,
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
 
   peripheral = (top_earlgrey_plic_peripheral_t)

--- a/sw/device/tests/spi_host_irq_test.c
+++ b/sw/device/tests/spi_host_irq_test.c
@@ -80,7 +80,7 @@ static status_t external_isr(void) {
   return OK_STATUS();
 }
 
-void ottf_external_isr(void) { test_result = external_isr(); }
+void ottf_external_isr(uint32_t *exc_info) { test_result = external_isr(); }
 
 static status_t check_irq_eq(uint32_t irq) {
   irq_global_ctrl(false);

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -42,7 +42,7 @@ static void sram_function_test(void) {
 // in `ottf_exception_handler()`.
 extern const char kSramRetNegTestReturn[];
 
-void ottf_exception_handler(void) {
+void ottf_exception_handler(uint32_t *exc_info) {
   // The frame address is the address of the stack location that holds the
   // `mepc`, since the OTTF exception handler entry code saves the `mepc` to
   // the top of the stack before transferring control flow to the exception

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
@@ -82,12 +82,12 @@ static void retention_sram_check(check_config_t config) {
  * Override internal interrupt handler to handle the ECC errors when reading the
  * scrambled memory.
  */
-void ottf_internal_isr(void) {}
+void ottf_internal_isr(uint32_t *exc_info) {}
 
 /**
  * Override external interrupt handler to handle the normal sleep IRQ.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_pwrmgr_irq_t irq_id;
   top_earlgrey_plic_peripheral_t peripheral;
 

--- a/sw/device/tests/uart_tx_rx_test.c
+++ b/sw/device/tests/uart_tx_rx_test.c
@@ -203,7 +203,7 @@ void update_uart_base_addr_and_irq_id(void) {
  *
  * This function overrides the default OTTF external ISR.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(

--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -87,7 +87,7 @@ static volatile dif_${n}_irq_t ${n}_irq_serviced;
  * 4. Clears the IRQ at the peripheral.
  * 5. Completes the IRQ service at PLIC.
  */
-void ottf_external_isr(void) {
+void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id));
 


### PR DESCRIPTION
1. When ottf gets an unexpected exception or interrupt, dump the machine state and stack.

Sample exception dump:
```
===== Exception Frame @ 1001fe88 =====
 mepc=20000a02   ra=200009b6   t0=00000038   t1=ffffffff
   t2=003c5a00   s0=0001c200   s1=005b8d80   a0=00008000
   a1=40000000   a2=00000000   a3=00000001   a4=00000000
   a5=00000000   a6=00000000   a7=00004ea4   s2=2000583a
   s3=0000cbb8   s4=00000000   s5=00000000   s6=00000000
   s7=00000000   s8=00000000   s9=00000000  s10=00000000
  s11=00000000   t3=00000000   t4=003c5a00   t5=00000000
   t6=ffffffff msts=00001800
===== Call Stack =====
    200024c4
    20000e52
    200024c4
    20000d9e
    20000548
    20000548
    200004c4
E00002 ottf_isrs.c:98] FAULT: Store Access Fault. MCAUSE=00000007 MEPC=200009fe MTVAL=00008000
```