### PR TITLE
[sival,ret_sram] Fix sram_ctrl_sleep_sram_ret_contents_test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -50,7 +50,18 @@
       features: []
       stage: V2
       si_stage: SV3
-      tests: ["chip_sw_sleep_sram_ret_contents"]
+      tests: [
+        "chip_sw_sleep_sram_ret_contents_no_scramble",
+        "chip_sw_sleep_sram_ret_contents_scramble",
+      ]
+      bazel: [
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_sival",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_sival_rom_ext",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_rom_test",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_sival",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_sival_rom_ext",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_rom_test",
+      ]
     }
     {
       name: chip_sw_sram_execution

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1571,9 +1571,17 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_sleep_sram_ret_contents
+      name: chip_sw_sleep_sram_ret_contents_no_scramble
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
+                 "+bypass_alert_ready_to_end_check=1"]
+    }
+    {
+      name: chip_sw_sleep_sram_ret_contents_scramble
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_scb_tl_err_chk=0",
                  "+bypass_alert_ready_to_end_check=1"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
@@ -2495,13 +2499,11 @@ opentitan_test(
     ],
 )
 
-opentitan_test(
-    name = "sram_ctrl_sleep_sram_ret_contents_test",
-    srcs = ["sram_ctrl_sleep_sram_ret_contents_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
-    verilator = new_verilator_params(
-        timeout = "long",
-    ),
+cc_library(
+    name = "sram_ctrl_sleep_sram_ret_contents_impl",
+    srcs = ["sram_ctrl_sleep_sram_ret_contents_impl.c"],
+    hdrs = ["sram_ctrl_sleep_sram_ret_contents_impl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -2509,6 +2511,7 @@ opentitan_test(
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
@@ -2517,8 +2520,45 @@ opentitan_test(
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+opentitan_test(
+    name = "sram_ctrl_sleep_sram_ret_contents_no_scramble_test",
+    srcs = ["sram_ctrl_sleep_sram_ret_contents_no_scramble_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
+    ),
+    verilator = new_verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_impl",
+    ],
+)
+
+opentitan_test(
+    name = "sram_ctrl_sleep_sram_ret_contents_scramble_test",
+    srcs = ["sram_ctrl_sleep_sram_ret_contents_scramble_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
+    ),
+    verilator = new_verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_impl",
     ],
 )
 

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.h
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.h
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_SRAM_CTRL_SLEEP_SRAM_RET_CONTENTS_IMPL_H_
+#define OPENTITAN_SW_DEVICE_TESTS_SRAM_CTRL_SLEEP_SRAM_RET_CONTENTS_IMPL_H_
+
+#include <stdbool.h>
+
+/**
+ * This test checks whether the contents of retention sram are modified
+ * by either low power exit reset and hardware resets, depending on whether
+ * they are rescrambed or not.
+ *
+ * @param scramble When true, scramble the retention sram contents.
+ */
+bool execute_sram_ctrl_sleep_ret_sram_contents_test(bool scramble);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_SRAM_CTRL_SLEEP_SRAM_RET_CONTENTS_IMPL_H_

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_no_scramble_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_no_scramble_test.c
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sram_ctrl_sleep_sram_ret_contents_impl.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  return execute_sram_ctrl_sleep_ret_sram_contents_test(false);
+}

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_scramble_test.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_scramble_test.c
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sram_ctrl_sleep_sram_ret_contents_impl.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  return execute_sram_ctrl_sleep_ret_sram_contents_test(true);
+}


### PR DESCRIPTION
Break this test into two, one with additional ram scramble, the other without. This is so it is not necessary to track when scrambing happens in a single test.

Fixes #20582