### PR TITLE
[opentitanlib] make `uart_read` one character at a time

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -40,6 +40,7 @@ load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",
     "SLOTS",
+    "msg_template_bfv_all_except",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -51,6 +52,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "identifier": "0",
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.BAD_IDENTIFIER),
     },
     {
         "name": "too_small",
@@ -59,6 +61,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "length": hex(CONST.ROM_EXT_SIZE_MIN - 1),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.BAD_LENGTH),
     },
     {
         "name": "too_large",
@@ -67,6 +70,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "length": hex(CONST.ROM_EXT_SIZE_MAX + 1),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.BAD_LENGTH),
     },
     {
         "name": "empty_code",
@@ -77,6 +81,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_CODE_REGION),
     },
     {
         "name": "code_in_manifest",
@@ -87,6 +92,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_CODE_REGION),
     },
     {
         "name": "code_outside_image",
@@ -97,6 +103,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_CODE_REGION),
     },
     {
         "name": "code_start_unaligned",
@@ -107,6 +114,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_CODE_REGION),
     },
     {
         "name": "code_end_unaligned",
@@ -117,6 +125,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 8),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_CODE_REGION)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_CODE_REGION),
     },
     {
         "name": "entry_before_code_start",
@@ -127,6 +136,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 4),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_ENTRY_POINT),
     },
     {
         "name": "entry_at_code_end",
@@ -137,6 +147,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 12),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_ENTRY_POINT),
     },
     {
         "name": "entry_unaligned",
@@ -147,6 +158,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "entry_point": hex(CONST.MANIFEST_SIZE + 10),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_ENTRY_POINT),
     },
     {
         "name": "rollback",
@@ -158,6 +170,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "security_version": "0",
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.ROLLBACK),
         "sec_ver": 1,
     },
 ]
@@ -219,6 +232,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
         cw310 = cw310_params(
             assemble = "{firmware}@{offset}",
+            exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
             offset = SLOTS[slot],
             otp = ":otp_img_boot_policy_bad_manifest_{}_sec_ver_{}".format(

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_rollback/BUILD
@@ -4,6 +4,7 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
     "cw310_params",
     "opentitan_test",
 )
@@ -29,6 +30,7 @@ load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",
     "SLOTS",
+    "msg_template_bfv_all_except",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -38,21 +40,26 @@ BOOT_POLICY_ROLLBACK_CASES = [
         "a": 0,
         "b": 0,
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        # By default the failure message include BFV but this will conflict with what we're looking for.
+        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.ROLLBACK),
     },
     {
         "a": 0,
         "b": 1,
         "exit_success": "slot=0x20080000, security_version=1",
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     {
         "a": 2,
         "b": 0,
         "exit_success": "slot=0x20000000, security_version=2",
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     {
         "a": 1,
         "b": 1,
         "exit_success": "slot=0x20000000, security_version=1",
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
 ]
 
@@ -91,6 +98,7 @@ otp_json(
                 "//sw/device/silicon_creator/rom/e2e/boot_policy_newer:empty_test_slot_a_sec_ver_{}".format(t["a"]): "fw_a",
                 "//sw/device/silicon_creator/rom/e2e/boot_policy_newer:empty_test_slot_b_sec_ver_{}".format(t["b"]): "fw_b",
             },
+            exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
             otp = ":otp_img_boot_policy_rollback_{}".format(lc_state),
             slot_a = SLOTS["a"],

--- a/sw/device/silicon_creator/rom/e2e/defs.bzl
+++ b/sw/device/silicon_creator/rom/e2e/defs.bzl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:const.bzl", "CONST")
+load("//rules:const.bzl", "CONST", "hex_digits")
 load("//rules:opentitan.bzl", "SILICON_CREATOR_KEYS")
 
 MSG_TEMPLATE_BFV = "{}{}\r\n(?s:.*){}{}\r\n".format(
@@ -11,6 +11,17 @@ MSG_TEMPLATE_BFV = "{}{}\r\n(?s:.*){}{}\r\n".format(
     CONST.SHUTDOWN.PREFIX.BFV,
     "{0}",
 )
+
+def msg_template_bfv_all_except(bfv_const):
+    hex_str = hex_digits(bfv_const)
+    regex = "|".join([
+        "{}[^{}]".format(
+            hex_str[0:idx],
+            hex_str[idx],
+        )
+        for idx in range(1, 8)
+    ])
+    return "((FAIL|FAULT).*\n)|{}({})\r\n".format(CONST.SHUTDOWN.PREFIX.BFV, regex)
 
 MSG_TEMPLATE_BFV_LCV = "{}{}\r\n{}{}\r\n(?s:.*){}{}\r\n{}{}\r\n".format(
     CONST.SHUTDOWN.PREFIX.BFV,

--- a/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
+++ b/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
@@ -31,6 +31,7 @@ fn test_ndm_reset_req(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // Enable console and wait for the message.
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
     log::info!("Waiting for \"wait for ndm reset\" message");
     let _ = UartConsole::wait_for(&*uart, "wait for ndm reset", opts.timeout)?;


### PR DESCRIPTION
This is a hack to provide temporary solution to address some of our flaky tests, where `UartConsole::wait_for` over-consumes data.

The hack is currently only applied to serial console. In the long term we should use async instead of all our custom event loop with mio.

Fix #20580
