### PR TITLE
[dma] Report bus errors from 'clear int' writes

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -79,7 +79,7 @@ module dma
 
   logic [INT_CLEAR_SOURCES_WIDTH-1:0] clear_index_d, clear_index_q;
   logic                               clear_index_en, int_clear_tlul_rsp_valid;
-  logic                               int_clear_tlul_gnt;
+  logic                               int_clear_tlul_gnt, int_clear_tlul_rsp_error;
 
   logic [DmaErrLast-1:0] next_error;
 
@@ -610,6 +610,8 @@ module dma
                                                                       dma_ctn_tlul_gnt;
     int_clear_tlul_rsp_valid = reg2hw.clear_int_bus.q[clear_index_q]? dma_host_tlul_rsp_valid :
                                                                       dma_ctn_tlul_rsp_valid;
+    int_clear_tlul_rsp_error = reg2hw.clear_int_bus.q[clear_index_q]? dma_host_tlul_rsp_err :
+                                                                      dma_ctn_tlul_rsp_err;
     dma_state_error = 1'b0;
 
     sha2_hash_start      = 1'b0;
@@ -689,9 +691,11 @@ module dma
             // Need to wait for this to not overrun TLUL adapter
             // The response might come immediately
             if (int_clear_tlul_rsp_valid) begin
-              // Proceed if we handled all
-              if (32'(clear_index_q) >= (NumIntClearSources - 1)) begin
-                ctrl_state_d = DmaAddrSetup;
+              if (int_clear_tlul_rsp_error) begin
+                next_error[DmaBusErr] = 1'b1;
+                ctrl_state_d = DmaError;
+              end else if (32'(clear_index_q) >= (NumIntClearSources - 1)) begin
+                ctrl_state_d = DmaAddrSetup;  // Proceed now we've handled all
               end
             end
           end else begin
@@ -709,7 +713,10 @@ module dma
           // Writes also get a resp valid, but no data.
           // Need to wait for this to not overrun TLUL adapter
           if (int_clear_tlul_rsp_valid) begin
-            if (32'(clear_index_q) < (NumIntClearSources - 1)) begin
+            if (int_clear_tlul_rsp_error) begin
+              next_error[DmaBusErr] = 1'b1;
+              ctrl_state_d = DmaError;
+            end else if (32'(clear_index_q) < (NumIntClearSources - 1)) begin
               clear_index_en = 1'b1;
               clear_index_d  = clear_index_q + INT_CLEAR_SOURCES_WIDTH'(1'b1);
               ctrl_state_d   = DmaClearIntrSrc;


### PR DESCRIPTION
Ensure that failed 'clear interrupt' writes are reported as bus errors, as per regular source/destination accesses.
Diagnostically important from a firmware development perspective, mostly, although it could be important in
production software for recovering from any faults.

@Razer6 - there may be some merit to considering whether all bus errors should be reported identically/indistinguishably to software, or perhaps the 'clear interrupt' writes are fundamentally different from regular source/destination accesses?

(Detected in DV when revising the prediction of DUT interrupts; DV detects and responds to generated bus errors in stress tests.)