### PR TITLE
[dv,dma] Corrections and enhancements to DMA interrupt checking.

### DIFF
--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -76,6 +76,9 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
     // Initialize cip_base_env_cfg
     super.initialize(csr_base_addr);
 
+    // Interrupt count
+    num_interrupts = ral.intr_state.get_n_used_bits();
+
     // TL Agent Configuration objects - Non RAL
     `uvm_create_obj(tl_agent_cfg, tl_agent_dma_host_cfg)
     tl_agent_dma_host_cfg.max_outstanding_req = dma_pkg::NUM_MAX_OUTSTANDING_REQS;

--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -35,7 +35,7 @@ package dma_env_pkg;
   // Index of interrupt in intf_vif
   parameter uint DMA_DONE = 0;
   parameter uint DMA_ERROR = 1;
-  parameter uint DMA_MEMORY_BUFFER_LIMIT_INTR = 2;
+  parameter uint DMA_MEM_LIMIT = 2;
 
   // Completion status bits (DV-internal)
   typedef enum {

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -377,7 +377,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
     if (exp_buffer_limit_intr) begin
       `uvm_info(`gfn, $sformatf("Memory address:%0x crosses almost limit: 0x%0x limit: 0x%0x",
                                 item.a_addr, dma_config.mem_buffer_almost_limit,
-                                dma_config.mem_buffer_limit), UVM_LOW)  // UVM_HIGH)
+                                dma_config.mem_buffer_limit), UVM_HIGH)
 
       // Interrupt is expected only if enabled.
       exp_buffer_limit_intr = intr_enable_mem_limit;
@@ -541,7 +541,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
     fork
       // DMA memory buffer limit interrupt check
       forever begin
-        @(posedge cfg.intr_vif.pins[DMA_MEMORY_BUFFER_LIMIT_INTR]);
+        @(posedge cfg.intr_vif.pins[DMA_MEM_LIMIT]);
         if (!cfg.en_scb) continue;
         if (!cfg.under_reset) begin
           `DV_CHECK_EQ(exp_buffer_limit_intr, 1,
@@ -699,7 +699,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Got intr_enable = %0x", item.a_data), UVM_HIGH)
         intr_enable_done      = item.a_data[DMA_DONE];
         intr_enable_error     = item.a_data[DMA_ERROR];
-        intr_enable_mem_limit = item.a_data[DMA_MEMORY_BUFFER_LIMIT_INTR];
+        intr_enable_mem_limit = item.a_data[DMA_MEM_LIMIT];
       end
       "source_address_lo": begin
         dma_config.src_addr[31:0] = item.a_data;
@@ -927,7 +927,6 @@ class dma_scoreboard extends cip_base_scoreboard #(
                   $sformatf("Got handshake_intr_en = 0x%x", dma_config.handshake_intr_en), UVM_HIGH)
       end
       // TODO: we shall surely need to handle `status` register writes at some point
-      "intr_enable": /* Nothing to be done presently */;
       default: begin
         // This message may indicate a failure to update the configuration in the scoreboard
         // so that it matches the configuration programmed into the DUT
@@ -1107,7 +1106,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
 
     // The access is to a valid CSR, now process it.
     // writes -> update local variable and fifo at A-channel access
-    // reads  -> update predication at address phase and compare at D-channel access
+    // reads  -> update prediction at address phase and compare at D-channel access
     if (write && channel == AddrChannel) begin
       process_reg_write(item, csr);
     end  // addr_phase_write

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -147,8 +147,8 @@ class dma_generic_vseq extends dma_base_vseq;
 
         // Set the Interrupt Enables appropriately for this transfer; DONE and ERROR - which
         // terminate the test - must be enabled if this transfer is to be interrupt-driven.
-        // They may optionally be exercised when using polling. The MEMORY_BUFFER_LIMIT interrupt is
-        // always optional.
+        // They may optionally be exercised when using polling. The MEM_LIMIT interrupt is always
+        // optional.
         intr_enables = $urandom;
         if (intr_driven) begin
           intr_enables[DMA_DONE]  = 1'b1;

--- a/hw/ip/dma/dv/tb/tb.sv
+++ b/hw/ip/dma/dv/tb/tb.sv
@@ -49,9 +49,9 @@ module tb;
     .rst_ni (rst_n),
     .scanmode_i (prim_mubi_pkg::MuBi4False),
     .lsio_trigger_i (handshake_i),
-    .intr_dma_done_o (interrupts[0]),
-    .intr_dma_error_o (interrupts[1]),
-    .intr_dma_memory_buffer_limit_o (interrupts[2]),
+    .intr_dma_done_o (interrupts[DMA_DONE]),
+    .intr_dma_error_o (interrupts[DMA_ERROR]),
+    .intr_dma_memory_buffer_limit_o (interrupts[DMA_MEM_LIMIT]),
     .alert_rx_i (alert_rx),
     .alert_tx_o (alert_tx),
     // TL Interface


### PR DESCRIPTION
This PR was created to fix the failing 'dma_intr_test' vseqs but during investigation it was found to be necessary to make more extensive changes to the DMA interrupt prediction within the DV environment.

The first commit makes some small changes to assist with the 'intr_test' vseq bring up, but is unable to form reliable predictions of the interrupt signals whilst the sequence is performing CSR traffic because the interrupt signals change immediately in response to the INTR_TEST write cycle starting, but the scoreboard is not notified of the register write until the end of the cycle.

Commit 2 introduces for each interrupt signal a queue of the predicted events and a maximum latency before the event must be observed.

Coupled with checking of all interrupt signals on every clock cycle, but one cycle delayed to handle the situation described above, the DV environment is now able to detect not only the occurrence of unexpected interrupts, but also the absence of expected interrupts.

This allows `dma_intr_test` to completely successfully and has no apparent impact upon other DMA tests (all sequences still passing).

~~Note: It requires the small RTL change in PR #20598 for some stress sequences/seeds, since the DV detects the bus error on 'clear interrupt' write traffic too and uses this to inform the prediction of an 'ERROR' interrupt rather than 'DONE.'~~ Now merged.