### PR TITLE
[signing] Allow using alternate keys for signing

### DIFF
--- a/signing/README.md
+++ b/signing/README.md
@@ -25,10 +25,26 @@ might look like the following:
 }
 ```
 
+## Signing with a token
+
 Once a profile configuration is in place, you can build binaries signed by
-the keyset by telling bazel that you want to use a NitroKey:
+the keyset by telling bazel that you want to use a token.
+
+In the example below, we instruct bazel to use a NitroKey as the token
+and to sign with the key specified by the `rsa_key` attribute of the target
+(or the target's `exec_env`).
 ```
 $ bazel build --//signing:token=//signing/tokens:nitrokey //label-of-target
+```
+
+To sign with an alternate key, you can override the key label via the
+keyset in question.  For `silicon_creator` code, the keyset is
+`//sw/device/silicon_creator/rom/keys/real/rsa:keyset`.
+```
+$ bazel build \
+    --//signing:token=//signing/tokens:nitrokey \
+    --//sw/device/silicon_creator/rom/keys/real/rsa:keyset=earlgrey_a0_dev_0 \
+    //label-of-target
 ```
 
 ## Configuration for silicon\_owner SiVAL signing

--- a/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
@@ -86,6 +86,7 @@ filegroup(
 
 keyset(
     name = "keyset",
+    build_setting_default = "",
     keys = {
         "earlgrey_a0_test_0.der": "earlgrey_a0_test_0",
         "earlgrey_a0_test_1.der": "earlgrey_a0_test_1",

--- a/sw/device/silicon_creator/rom_ext/keys/real/BUILD
+++ b/sw/device/silicon_creator/rom_ext/keys/real/BUILD
@@ -47,6 +47,7 @@ cc_test(
 
 keyset(
     name = "keyset",
+    build_setting_default = "",
     keys = {
         "earlgrey_z0_sival_1.der": "earlgrey_z0_sival_1",
     },


### PR DESCRIPTION
The `rsa_key` attributes specify a keyset and the label of a key.  It is sometimes desireable to sign with an alternate key.

1. Turn the `keyset` rule into a build setting, allowing the key to be overridden on the bazel command-line.