### PR TITLE
[dvsim] Change systemverilog seed to 32 bits

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -113,7 +113,7 @@
 
   run_opts:   ["-licqueue",
                "-ucli -do {run_script}",
-               "+ntb_random_seed={seed}",
+               "+ntb_random_seed={svseed}",
                // Disable the display of the SystemVerilog assert and cover statement summary
                // at the end of simulation. This summary is list of assertions that started but
                // did not finish because the simulation terminated, or assertions that did not
@@ -134,7 +134,7 @@
 
   // Individual test specific coverage data - this will be deleted if the test fails
   // so that coverage from failiing tests is not included in the final report.
-  cov_db_test_dir_name: "{run_dir_name}.{seed}"
+  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
   cov_db_test_dir: "{cov_db_dir}/snps/coverage/db/testdata/{cov_db_test_dir_name}"
 
   // Merging coverage.

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -69,9 +69,7 @@
                // "--x-initial unique",
                ]
 
-  run_opts: [// Set random seed.
-             // "+verilator+seed+{seed}",
-             ]
+  run_opts: []
 
   // Supported wave dumping formats (in order of preference).
   supported_wave_formats: ["fst"]

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -68,7 +68,7 @@
                "-64bit -xmlibdirname {build_db_dir}",
                // Use the same snapshot name set during the build step.
                "-r {tb}",
-               "+SVSEED={seed}",
+               "+SVSEED={svseed}",
                "{uvm_testname_plusarg}",
                "{uvm_testseq_plusarg}",
                // Ignore "IEEE 1800-2009 SystemVerilog simulation semantics" warning
@@ -129,7 +129,7 @@
 
   // Individual test specific coverage data - this will be deleted if the test fails
   // so that coverage from failiing tests is not included in the final report.
-  cov_db_test_dir_name: "{run_dir_name}.{seed}"
+  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
   cov_db_test_dir:      "{cov_db_dir}/{cov_db_test_dir_name}"
 
   // Merging coverage.

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -473,6 +473,8 @@ class RunTest(Deploy):
         self.index = index
         self.build_seed = sim_cfg.build_seed
         self.seed = RunTest.get_seed()
+        # Systemverilog accepts seeds with a maximum size of 32 bits.
+        self.svseed = self.seed & 0xFFFFFFFF
         self.simulated_time = JobTime()
         super().__init__(sim_cfg)
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -42,7 +42,7 @@ class SimCfg(FlowCfg):
 
     # TODO: Find a way to set these in sim cfg instead
     ignored_wildcards = [
-        "build_mode", "index", "test", "seed", "uvm_test", "uvm_test_seq",
+        "build_mode", "index", "test", "seed", "svseed", "uvm_test", "uvm_test_seq",
         "cov_db_dirs", "sw_images", "sw_build_device", "sw_build_cmd",
         "sw_build_opts"
     ]


### PR DESCRIPTION
This commit changes the systemverilog seed to 32 bits. It used to be 256 bits. However, systemverilog seeds can only be 32 bits long. This caused the simulations to resort to using a default seed, which in turn caused all the test runs to have the same random values.

This PR resolves #20565