### PR TITLE
[opentitantool] Support external JTAG dongles with HyperDebug

### DIFF
--- a/rules/opentitan/openocd.bzl
+++ b/rules/opentitan/openocd.bzl
@@ -19,10 +19,8 @@ OPENTITANTOOL_OPENOCD_TEST_CMD = """
 
 OPENTITANTOOL_OPENOCD_CMSIS_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
-    --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_cmsis_dap_adapter_cfg)"
 """
 
 OPENTITANTOOL_OPENOCD_CMSIS_SI_TEST_CMD = """
     --openocd="$(rootpath //third_party/openocd:openocd_bin)"
-    --openocd-adapter-config="$(rootpath //third_party/openocd:jtag_cmsis_dap_adapter_cfg)"
 """

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -64,15 +64,6 @@ DEFAULT_TEST_FAILURE_MSG = "({})|({})".format(
     ROM_BOOT_FAILURE_MSG,
 )
 
-OPENTITANTOOL_OPENOCD_TEST_CMDS = [
-    "--openocd=\"$(rootpath //third_party/openocd:openocd_bin)\"",
-    "--openocd-adapter-config=\"$(rootpath //third_party/openocd:jtag_olimex_cfg)\"",
-]
-OPENTITANTOOL_OPENOCD_DATA_DEPS = [
-    "//third_party/openocd:jtag_olimex_cfg",
-    "//third_party/openocd:openocd_bin",
-]
-
 # This constant holds a dictionary of slot-specific linker script dependencies
 # that determine how an `opentitan_flash_binary` is built.
 _FLASH_SLOTS = {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -18,8 +18,6 @@ load(
 )
 load(
     "//rules:opentitan_test.bzl",
-    "OPENTITANTOOL_OPENOCD_DATA_DEPS",
-    "OPENTITANTOOL_OPENOCD_TEST_CMDS",
     "ROM_BOOT_FAILURE_MSG",
     "cw310_params",
     "cw340_params",
@@ -3516,7 +3514,7 @@ test_suite(
     opentitan_test(
         name = "rv_dm_ndm_reset_req_{}".format(lc_state),
         srcs = ["rv_dm_ndm_reset_req.c"],
-        cw310 = cw310_jtag_params(
+        cw310 = hyper310_jtag_params(
             otp = _SIVAL_OTP_IMAGE[lc_state],
             tags = [
                 "lc_{}".format(lc_state),
@@ -3576,41 +3574,16 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     ),
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
-    deps = [
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
-
-# TODO(#19902): Migrate to `opentitan_test` once there is support for the
-# hyperdebug310 target. #19903 covers support for hyperdebug340, and #19901
-# covers support for cw340_params.
-opentitan_functest(
-    name = "openocd_hyperdebug_test",
-    srcs = ["example_test_from_flash.c"],
-    cw310 = cw310_params(
+    hyper310 = hyper310_jtag_params(
         bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
-        interface = "hyper310",
-        tags = ["flaky"],
-        test_cmds = [
-            "--bitstream=\"$(rootpath {bitstream})\"",
-            "--bootstrap=\"$(rootpath {flash})\"",
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     ),
-    cw340 = cw340_params(
-        bitstream = "//hw/bitstream/hyperdebug:rom_with_fake_keys_otp_test_unlocked0",
-        interface = "hyper340",
-        tags = ["flaky"],
-        test_cmds = [
-            "--bitstream=\"$(rootpath {bitstream})\"",
-            "--bootstrap=\"$(rootpath {flash})\"",
-        ] + OPENTITANTOOL_OPENOCD_TEST_CMDS,
-    ),
-    data = OPENTITANTOOL_OPENOCD_DATA_DEPS,
-    targets = ["cw310_rom_with_fake_keys"],
-    test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/host/opentitanlib/src/backend/chip_whisperer.rs
+++ b/sw/host/opentitanlib/src/backend/chip_whisperer.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use std::path::PathBuf;
 
 use crate::backend::BackendOpts;
 use crate::transport::chip_whisperer::board::Board;
@@ -16,11 +15,6 @@ pub struct ChipWhispererOpts {
     /// Comma-separated list of Chip Whisperer board UARTs for non-udev environments. List the console uart first.
     #[arg(long, alias = "cw310-uarts")]
     pub uarts: Option<String>,
-
-    /// Path to OpenOCD JTAG adapter config file to use (usually Olimex, but could be another
-    /// adapter).
-    #[arg(long)]
-    pub openocd_adapter_config: Option<PathBuf>,
 }
 
 pub fn create<B: Board + 'static>(args: &BackendOpts) -> Result<Box<dyn Transport>> {
@@ -36,6 +30,5 @@ pub fn create<B: Board + 'static>(args: &BackendOpts) -> Result<Box<dyn Transpor
         args.usb_pid,
         args.usb_serial.as_deref(),
         &uarts,
-        args.opts.openocd_adapter_config.clone(),
     )?))
 }

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -55,6 +55,13 @@ pub struct BackendOpts {
     /// Configuration files.
     #[arg(long, num_args = 1)]
     pub conf: Vec<PathBuf>,
+
+    /// Path to OpenOCD JTAG adapter config file to use (usually Olimex, but could be another
+    /// adapter).  If unspecified, will use native support of the backend transport.  (Currently
+    /// only the HyperDebug transport has such native JTAG support, and for any other transport,
+    /// this argument must be specified if using JTAG.)
+    #[arg(long)]
+    pub openocd_adapter_config: Option<PathBuf>,
 }
 
 #[derive(Error, Debug)]
@@ -128,6 +135,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
             process_config_file(&mut env, conf_file)?
         }
     }
+    env.set_openocd_adapter_config(&args.openocd_adapter_config);
     env.build(backend)
 }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -747,7 +747,7 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
     fn load_bitstream(fpga_program: &FpgaProgram) -> Result<()> {
         // First, try to establish a connection to the native Chip Whisperer interface
         // which we will use for bitstream loading.
-        let board = ChipWhisperer::<B>::new(None, None, None, &[], None)?;
+        let board = ChipWhisperer::<B>::new(None, None, None, &[])?;
 
         // Program the FPGA bitstream.
         log::info!("Programming the FPGA bitstream.");
@@ -757,7 +757,7 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
         Ok(())
     }
     fn clear_bitstream(_clear: &ClearBitstream) -> Result<()> {
-        let board = ChipWhisperer::<B>::new(None, None, None, &[], None)?;
+        let board = ChipWhisperer::<B>::new(None, None, None, &[])?;
         let usb = board.device.borrow();
         usb.spi1_enable(false)?;
         usb.clear_bitstream()?;

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -66,7 +66,7 @@ impl Capabilities {
         Self { capabilities: cap }
     }
 
-    fn add(&self, extra: Capability) -> Self {
+    pub fn add(&self, extra: Capability) -> Self {
         Self {
             capabilities: self.capabilities | extra,
         }


### PR DESCRIPTION
Move handling of the `--openocd_adapter_config=...` argument up from transport driver into `TransportWrapper`, allowing e.g. an Olimex JTAG dongle to be used with any one of the existing transports (including HyperDebug).