### PR TITLE
[opentitanlib] set DFT straps before POR

### DIFF
--- a/sw/host/opentitanlib/src/app/config/opentitan.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan.json
@@ -38,6 +38,20 @@
       "level": false,
       "pull_mode": "None",
       "alias_of": "IOC5"
+    },
+    {
+      "name": "DFT_STRAP0",
+      "mode": "Alternate",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "IOC3"
+    },
+    {
+      "name": "DFT_STRAP1",
+      "mode": "Alternate",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "IOC4"
     }
   ],
   "strappings": [
@@ -117,6 +131,21 @@
           "name": "TAP_STRAP1",
           "mode": "PushPull",
           "level": true
+        }
+      ]
+    },
+    {
+      "name": "PINMUX_DFT_MODE_OFF",
+      "pins": [
+        {
+          "name": "DFT_STRAP0",
+          "mode": "PushPull",
+          "level": false
+        },
+        {
+          "name": "DFT_STRAP1",
+          "mode": "PushPull",
+          "level": false
         }
       ]
     },

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -923,8 +923,11 @@ impl TransportWrapper {
     }
 
     pub fn reset_target(&self, reset_delay: Duration, clear_uart_rx: bool) -> Result<()> {
-        let reset_strapping = self.pin_strapping("RESET")?;
+        log::info!("Setting the DFT straps (to disabled)");
+        let dft_strapping = self.pin_strapping("PINMUX_DFT_MODE_OFF")?;
+        dft_strapping.apply()?;
         log::info!("Asserting the reset signal");
+        let reset_strapping = self.pin_strapping("RESET")?;
         reset_strapping.apply()?;
         std::thread::sleep(reset_delay);
         if clear_uart_rx {
@@ -934,6 +937,12 @@ impl TransportWrapper {
         log::info!("Deasserting the reset signal");
         reset_strapping.remove()?;
         std::thread::sleep(reset_delay);
+        log::info!("Deasserting the DFT straps");
+        dft_strapping.remove()?;
+        let dft_strap_0 = self.gpio_pin("DFT_STRAP0")?;
+        let dft_strap_1 = self.gpio_pin("DFT_STRAP1")?;
+        dft_strap_0.set_mode(PinMode::Alternate)?;
+        dft_strap_1.set_mode(PinMode::Alternate)?;
         Ok(())
     }
 }

--- a/sw/host/tests/manuf/manuf_sram_program_load/src/main.rs
+++ b/sw/host/tests/manuf/manuf_sram_program_load/src/main.rs
@@ -32,6 +32,7 @@ struct Opts {
 fn sram_load_program(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // Connect to the RISC-V TAP
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
     let mut jtag = opts
         .init
         .jtag_params


### PR DESCRIPTION
This configures the DFT straps to disable DFT mode on PORs. This is to solve a JTAG reliability issue with test unlocked parts.