### PR TITLE
[sival] Update silicon_owner exec_env manifest.

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -294,7 +294,7 @@ silicon(
     exec_env = "silicon_owner_sival_rom_ext",
     lib = "//sw/device/lib/arch:silicon",
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    manifest = "//sw/device/silicon_owner:manifest_standard",
     param = {
         "interface": "hyper310",
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -23,6 +23,8 @@ load(
     "FT_PERSONALIZE_SIGNING_KEYS",
     "FT_PROVISIONING_INPUTS",
 )
+load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -321,4 +323,39 @@ opentitan_test(
         test_cmd = _FT_PROVISIONING_CMD_ARGS,
         test_harness = "//sw/host/tests/manuf/provisioning/ft",
     ),
+)
+
+offline_presigning_artifacts(
+    name = "presigning",
+    testonly = True,
+    srcs = [
+        ":ft_personalize_1",
+        ":ft_personalize_2",
+        ":ft_personalize_3",
+    ],
+    manifest = "//sw/device/silicon_creator/rom_ext/sival:manifest_sival",
+    rsa_key = {
+        "//sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_prod_0": "ealrgrey_a0_prod_0",
+    },
+    tags = ["manual"],
+)
+
+pkg_tar(
+    name = "digests",
+    testonly = True,
+    srcs = [":presigning"],
+    mode = "0644",
+    tags = ["manual"],
+)
+
+offline_signature_attach(
+    name = "signed",
+    testonly = True,
+    srcs = [
+        ":presigning",
+    ],
+    rsa_signatures = [
+        "//sw/device/silicon_creator/rom_ext/sival/signatures:rsa_signatures",
+    ],
+    tags = ["manual"],
 )

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/signatures/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/signatures/BUILD
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "rsa_signatures",
+    srcs = glob(["*.rsa_sig"]),
+)
+
+filegroup(
+    name = "spx_signatures",
+    srcs = glob(["*.spx_sig"]),
+)

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -4,8 +4,8 @@
 
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
-load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
-load("//rules:signing.bzl", "offline_fake_rsa_sign", "offline_presigning_artifacts", "offline_signature_attach")
+load("//rules/opentitan:defs.bzl", "opentitan_binary")
+load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
1. Update the silicon_owner_sival_rom_ext environment to use a BL0 manifest configuration.
2. Add offline signing scaffolding for sival manuf firmware.