### PR TITLE
[manuf] cleanup CP and FT provisioning stages

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -6,7 +6,6 @@ load("//rules:autogen.bzl", "autogen_hjson_header")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
-    "STD_OTP_OVERLAYS_WITHOUT_SECRET_PARTITIONS",
     "otp_alert_classification",
     "otp_alert_digest",
     "otp_bytestring",

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup/BUILD
@@ -334,7 +334,6 @@ cc_library(
 otp_image(
     name = "otp_img_test_unlocked0_manuf_empty",
     src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
-    visibility = ["//visibility:private"],
 )
 
 # `MANUF_INITIALIZED` configuration. This configuration will be generally used

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -117,13 +117,13 @@ opentitan_test(
     name = "cp_provision",
     cw310 = cw310_jtag_params(
         binaries = {":sram_cp_provision": "sram_cp_provision"},
-        bitstream = "//hw/bitstream:rom_with_fake_keys_otp_raw",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_unlocked0_manuf_empty",
         tags = ["manuf"],
         test_cmd = _CP_PROVISIONING_CMD_ARGS,
         test_harness = "//sw/host/tests/manuf/provisioning/cp",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:silicon_creator": None,
     },
     silicon = silicon_jtag_params(

--- a/sw/host/tests/manuf/provisioning/cp/src/main.rs
+++ b/sw/host/tests/manuf/provisioning/cp/src/main.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::Parser;
 
-use cp_lib::{reset_and_lock, run_sram_cp_provision, unlock_raw, ManufCpProvisioningDataInput};
+use cp_lib::{reset_and_lock, run_sram_cp_provision, ManufCpProvisioningDataInput};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::load_sram_program::SramProgramParams;
 use ujson_lib::provisioning_data::ManufCpProvisioningData;
@@ -48,11 +48,6 @@ fn main() -> Result<()> {
         )?,
     };
 
-    unlock_raw(
-        &transport,
-        &opts.init.jtag_params,
-        opts.init.bootstrap.options.reset_delay,
-    )?;
     run_sram_cp_provision(
         &transport,
         &opts.init.jtag_params,


### PR DESCRIPTION
This contains several cleanup to the provisioning firmware to:
1. optimize stack utilization during FT personalization stage 3, and
2. remove the raw unlock operation from the CP stage