### PR TITLE
[rom_ext] Initialize the boot log in the ROM_EXT

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -69,3 +69,20 @@ rom_error_t boot_log_check(const boot_log_t *boot_log) {
 
   return kErrorBootLogInvalid;
 }
+
+void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
+                            const chip_info_t *info) {
+  rom_error_t error = boot_log_check(boot_log);
+  if (launder32(error) == kErrorOk) {
+    HARDENED_CHECK_EQ(error, kErrorOk);
+    return;
+  }
+  boot_log->identifier = kBootLogIdentifier;
+  boot_log->chip_version.scm_revision_low = info->scm_revision.scm_revision_low;
+  boot_log->chip_version.scm_revision_high =
+      info->scm_revision.scm_revision_high;
+  boot_log->bl0_slot = kBootLogUninitialized;
+  boot_log->rom_ext_slot = rom_ext_slot;
+  boot_log_digest_update(boot_log);
+  return;
+}

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -82,6 +82,16 @@ void boot_log_digest_update(boot_log_t *boot_log);
 OT_WARN_UNUSED_RESULT
 rom_error_t boot_log_check(const boot_log_t *boot_log);
 
+/**
+ * Check the boot_log and initialize it if not yet initialized.
+ *
+ * @param boot_log A buffer that holds the boot_log.
+ * @param rom_ext_slot The current ROM_EXT slot.
+ * @param info A pointer to the chip_info_t structure in ROM.
+ */
+void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
+                            const chip_info_t *info);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The ROM_EXT assumes that the ROM will initialize the boot_log in retention RAM, however, the ROM in the earlgrey_es was cut before the introduction of the boot_log data structure.

1. Detect an uninitialized boot_log in the ROM_EXT and initialize it.