### PR TITLE
[dvsim] cast self.seed to 'int'

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -474,7 +474,7 @@ class RunTest(Deploy):
         self.build_seed = sim_cfg.build_seed
         self.seed = RunTest.get_seed()
         # Systemverilog accepts seeds with a maximum size of 32 bits.
-        self.svseed = self.seed & 0xFFFFFFFF
+        self.svseed = int(self.seed) & 0xFFFFFFFF
         self.simulated_time = JobTime()
         super().__init__(sim_cfg)
 


### PR DESCRIPTION
#20616 causes 

    self.svseed = self.seed & 0xFFFFFFFF
TypeError: unsupported operand type(s) for &: 'str' and 'int'

Add explicit cast int to self.seed