### PR TITLE
[aes, kmac, otbn] Fixes for pre_syn Yosys synthesis flows

### DIFF
--- a/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
@@ -81,7 +81,7 @@ if { $lr_synth_flatten } {
   yosys "flatten"
 }
 
-yosys "clean"
+yosys "clean -purge"
 yosys "write_verilog $lr_synth_netlist_out"
 
 if { $lr_synth_timing_run } {
@@ -96,4 +96,3 @@ yosys "check"
 yosys "log ======== Yosys Stat Report ========"
 yosys "tee -o $lr_synth_out_dir/reports/area.rpt stat -liberty $lr_synth_cell_library_path"
 yosys "log ====== End Yosys Stat Report ======"
-

--- a/hw/ip/kmac/pre_syn/syn_yosys.sh
+++ b/hw/ip/kmac/pre_syn/syn_yosys.sh
@@ -168,7 +168,9 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
     sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT.*StateWidth.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT_StateWidth(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT_StateWidthPad(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT_sha3_pkg.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 
 #-------------------------------------------------------------------------

--- a/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
@@ -64,7 +64,7 @@ if { $lr_synth_flatten } {
   yosys "flatten"
 }
 
-yosys "clean"
+yosys "clean -purge"
 yosys "write_verilog $lr_synth_netlist_out"
 
 if { $lr_synth_timing_run } {
@@ -79,4 +79,3 @@ yosys "check"
 yosys "log ======== Yosys Stat Report ========"
 yosys "tee -o $lr_synth_out_dir/reports/area.rpt stat -liberty $lr_synth_cell_library_path"
 yosys "log ====== End Yosys Stat Report ======"
-

--- a/hw/ip/otbn/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/otbn/pre_syn/tcl/yosys_run_synth.tcl
@@ -64,7 +64,7 @@ if { $lr_synth_flatten } {
   yosys "flatten"
 }
 
-yosys "clean"
+yosys "clean -purge"
 yosys "write_verilog $lr_synth_netlist_out"
 
 if { $lr_synth_timing_run } {


### PR DESCRIPTION
This PR contains a couple of relevant fixes to re-enable the Yosys synthesis flow for KMAC and to make the produced netlist more suitable for analysis SCA countermeasures using the [PROLEAD](https://github.com/ChairImpSec/PROLEAD) tool.

This is contributes to the overall penetration testing effort.