### PR TITLE
[sca] Move trigger source select to own uJSON command

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -77,6 +77,21 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "trigger_sca",
+    srcs = ["trigger_sca.c"],
+    hdrs = ["trigger_sca.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/json:trigger_sca_commands",
+    ],
+)
+
 opentitan_binary(
     name = "firmware",
     testonly = True,
@@ -89,6 +104,7 @@ opentitan_binary(
         ":aes_sca",
         ":ibex_fi",
         ":prng_sca",
+        ":trigger_sca",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -716,24 +716,6 @@ status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj) {
 }
 
 /**
- * Select trigger type command handler.
- *
- * This function only supports 1-byte trigger values.
- *
- * The uJSON data contains:
- *  - Trigger: The trigger type.
- * @param uj The received uJSON data.
- */
-status_t handle_aes_sca_select_trigger_source(ujson_t *uj) {
-  cryptotest_aes_sca_trigger_t uj_trigger;
-  TRY(ujson_deserialize_cryptotest_aes_sca_trigger_t(uj, &uj_trigger));
-
-  sca_select_trigger_type((sca_trigger_type_t)uj_trigger.trigger);
-
-  return OK_STATUS(0);
-}
-
-/**
  * Initialize AES command handler.
  *
  * This command is designed to setup the AES.
@@ -760,9 +742,6 @@ status_t handle_aes_sca(ujson_t *uj) {
   switch (cmd) {
     case kAesScaSubcommandInit:
       return handle_aes_sca_init(uj);
-      break;
-    case kAesScaSubcommandSelectTriggerSource:
-      return handle_aes_sca_select_trigger_source(uj);
       break;
     case kAesScaSubcommandKeySet:
       return handle_aes_sca_key_set(uj);

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -16,12 +16,14 @@
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h"
 
 // Include handlers
 #include "aes.h"
 #include "aes_sca.h"
 #include "ibex_fi.h"
 #include "prng_sca.h"
+#include "trigger_sca.h"
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
@@ -41,6 +43,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandPrngSca:
         RESP_ERR(uj, handle_prng_sca(uj));
+        break;
+      case kCryptotestCommandTriggerSca:
+        RESP_ERR(uj, handle_trigger_sca(uj));
         break;
       default:
         LOG_ERROR("Unrecognized command: %d", cmd);

--- a/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.c
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/cryptotest/firmware/trigger_sca.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * Select trigger type command handler.
+ *
+ * This function only supports 1-byte trigger values.
+ *
+ * The uJSON data contains:
+ *  - Source: The trigger source type.
+ * @param uj The received uJSON data.
+ */
+status_t handle_trigger_sca_select_source(ujson_t *uj) {
+  cryptotest_trigger_sca_source_t uj_trigger;
+  TRY(ujson_deserialize_cryptotest_trigger_sca_source_t(uj, &uj_trigger));
+
+  sca_select_trigger_type((sca_trigger_type_t)uj_trigger.source);
+
+  return OK_STATUS(0);
+}
+
+status_t handle_trigger_sca(ujson_t *uj) {
+  trigger_sca_subcommand_t cmd;
+  TRY(ujson_deserialize_trigger_sca_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kTriggerScaSubcommandSelectTriggerSource:
+      return handle_trigger_sca_select_source(uj);
+      break;
+    default:
+      LOG_ERROR("Unrecognized TRIGGER SCA subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.h
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_TRIGGER_SCA_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_TRIGGER_SCA_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_trigger_sca_select_source(ujson_t *uj);
+status_t handle_trigger_sca(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_TRIGGER_SCA_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -38,3 +38,10 @@ cc_library(
     hdrs = ["prng_sca_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
+
+cc_library(
+    name = "trigger_sca_commands",
+    srcs = ["trigger_sca_commands.c"],
+    hdrs = ["trigger_sca_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)

--- a/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
@@ -12,7 +12,6 @@ extern "C" {
 #define AESSCA_CMD_MAX_MSG_BYTES 16
 #define AESSCA_CMD_MAX_KEY_BYTES 16
 #define AESSCA_CMD_MAX_LFSR_BYTES 4
-#define AESSCA_CMD_MAX_TRIGGER_BYTES 1
 #define AESSCA_CMD_MAX_DATA_BYTES 16
 
 // clang-format off
@@ -21,7 +20,6 @@ extern "C" {
 
 #define AESSCA_SUBCOMMAND(_, value) \
     value(_, Init) \
-    value(_, SelectTriggerSource) \
     value(_, KeySet) \
     value(_, SingleEncrypt) \
     value(_, BatchEncrypt) \
@@ -47,10 +45,6 @@ UJSON_SERDE_STRUCT(CryptotestAesScaData, cryptotest_aes_sca_data_t, AES_SCA_DATA
     field(text, uint8_t, AESSCA_CMD_MAX_DATA_BYTES) \
     field(text_length, size_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaText, cryptotest_aes_sca_text_t, AES_SCA_TEXT);
-
-#define AES_SCA_TRIGGER(field, string) \
-    field(trigger, uint8_t, AESSCA_CMD_MAX_TRIGGER_BYTES)
-UJSON_SERDE_STRUCT(CryptotestAesScaTrigger, cryptotest_aes_sca_trigger_t, AES_SCA_TRIGGER);
 
 #define AES_SCA_LFSR(field, string) \
     field(seed, uint8_t, AESSCA_CMD_MAX_LFSR_BYTES)

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -15,7 +15,8 @@ extern "C" {
     value(_, Aes) \
     value(_, AesSca) \
     value(_, IbexFi) \
-    value(_, PrngSca)
+    value(_, PrngSca) \
+    value(_, TriggerSca)
 UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
 
 // clang-format on

--- a/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "trigger_sca_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_TRIGGER_SCA_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_TRIGGER_SCA_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TRIGGERSCA_CMD_MAX_SOURCE_BYTES 1
+
+// clang-format off
+
+// TRIGGER SCA arguments
+
+#define TRIGGERSCA_SUBCOMMAND(_, value) \
+    value(_, SelectTriggerSource)
+UJSON_SERDE_ENUM(TriggerScaSubcommand, trigger_sca_subcommand_t, TRIGGERSCA_SUBCOMMAND);
+
+#define TRIGGER_SCA_SOURCE(field, string) \
+    field(source, uint8_t, TRIGGERSCA_CMD_MAX_SOURCE_BYTES)
+UJSON_SERDE_STRUCT(CryptotestTriggerScaSource, cryptotest_trigger_sca_source_t, TRIGGER_SCA_SOURCE);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_TRIGGER_SCA_COMMANDS_H_


### PR DESCRIPTION
Previously, the trigger source selection was implemented in the AES SCA command handler. However, as other SCA targets (KMAC, SHA3) might want to also change the trigger source, I've moved the handler to a separate command.