### PR TITLE
[doc] Fix CSR and WSR tables in OTBN README

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -277,7 +277,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
         Primarily intended to be used for key generation.
-
+        <br>
         The number is sourced from the EDN via a single-entry cache.
         Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
       </td>
@@ -290,7 +290,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
         A random number without guaranteed secrecy properties or specific statistical properties.
         Intended for use in masking and blinding schemes.
         Use RND for high-quality randomness.
-
+        <br>
         The number is sourced from an local PRNG.
         Reads never stall.
       </td>
@@ -354,7 +354,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
         Primarily intended to be used for key generation.
-
+        <br>
         The number is sourced from the EDN via a single-entry cache.
         Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
       </td>
@@ -367,7 +367,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
         A random number without guaranteed secrecy properties or specific statistical properties.
         Intended for use in masking and blinding schemes.
         Use RND for high-quality randomness.
-
+        <br>
         The number is sourced from an local PRNG.
         Reads never stall.
       </td>
@@ -386,7 +386,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td><a name="key-s0-l">KEY_S0_L</a></td>
       <td>
         Bits [255:0] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
-
+        <br>
         A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
@@ -397,7 +397,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         Bits [255:128] of this register are always zero.
         Bits [127:0] contain bits [383:256] of share 0 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
-
+        <br>
         A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
@@ -407,7 +407,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td><a name="key-s1-l">KEY_S1_L</a></td>
       <td>
         Bits [255:0] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
-
+        <br>
         A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>
@@ -418,7 +418,7 @@ All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is w
       <td>
         Bits [255:128] of this register are always zero.
         Bits [127:0] contain bits [383:256] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
-
+        <br>
         A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
       </td>
     </tr>

--- a/hw/ip/otbn/util/docs/md_isrs.py
+++ b/hw/ip/otbn/util/docs/md_isrs.py
@@ -51,9 +51,9 @@ def print_isr(indent: str, isr: Isr, add_anchors: bool) -> None:
         doc_lines += ['  </tbody>', '</table>']
 
     for line in doc_lines:
-        if line:
-            line = indent + ' ' * 4 + line
-        print(line)
+        if line == '':
+            line = '<br>'
+        print(indent + ' ' * 4 + line)
 
     print(f'{indent}  </td>')
     print(f'{indent}</tr>')


### PR DESCRIPTION
Blank lines inside HTML tags generate `<pre><code>...</code></pre>` blocks in Markdown. In  the source of the tables in https://opentitan.org/book/hw/ip/otbn/index.html, you can see that many table tags have been escaped
```
      <td>
        An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
        Primarily intended to be used for key generation.
<pre><code>    The number is sourced from the EDN via a single-entry cache.
    Reads when the cache is empty will cause OTBN to be stalled until a new random number is fetched from the EDN.
  &lt;/td&gt;
&lt;/tr&gt;
&lt;tr&gt;
  &lt;td&gt;0xFC1&lt;/td&gt;
  &lt;td&gt;RO&lt;/td&gt;
  &lt;td&gt;URND&lt;/td&gt;
  &lt;td&gt;
    A random number without guaranteed secrecy properties or specific statistical properties.
```