### PR TITLE
[manuf] ensure flash_ctrl is initialized before reading AST values

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/sram_load_ast_calibration_into_flash.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_load_ast_calibration_into_flash.c
@@ -64,6 +64,7 @@ static void manually_init_ast(uint32_t *data) {
 }
 
 static status_t write_ast_values_to_flash(uint32_t *data) {
+  TRY(flash_ctrl_testutils_wait_for_init(&flash_state));
   TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_state, kFlashInfoFieldAstCalibrationData.page,
       kFlashInfoFieldAstCalibrationData.bank,


### PR DESCRIPTION
AST calibration values are programmed into, and read out of flash INFO page 0 during provisioning flows. Not waiting for the flash_ctrl to initialize before performing operations can cause reliability issues.