### PR TITLE
[dma] Src and dst alignment may differ

### DIFF
--- a/hw/ip/dma/dv/env/dma_seq_item.sv
+++ b/hw/ip/dma/dv/env/dma_seq_item.sv
@@ -164,9 +164,10 @@ class dma_seq_item extends uvm_sequence_item;
           mem_range_limit - src_addr >= total_transfer_size;
         }
       }
-      // For valid configurations, Address must be aligned to transfer width
+      // For valid configurations, the source address must be aligned to the transfer width.
       per_transfer_width == DmaXfer4BperTxn -> src_addr[1:0] == 2'd0;
       per_transfer_width == DmaXfer2BperTxn -> src_addr[0] == 1'b0;
+      // Only the SoC System bus has a full 64-bit address space.
       src_asid != SocSystemAddr -> src_addr[63:32] == '0;
     }
   }
@@ -200,9 +201,10 @@ class dma_seq_item extends uvm_sequence_item;
           (src_addr > dst_addr + total_transfer_size + 'h10);
         }
       }
-      // For valid configurations, Address must be aligned to transfer width but must further have
-      // the same alignment as the source.
-      dst_addr[1:0] == src_addr[1:0];
+      // For valid configurations, the destination address must be aligned to the transfer width.
+      per_transfer_width == DmaXfer4BperTxn -> dst_addr[1:0] == 2'd0;
+      per_transfer_width == DmaXfer2BperTxn -> dst_addr[0] == 1'b0;
+      // Only the SoC System bus has a full 64-bit address space.
       dst_asid != SocSystemAddr -> dst_addr[63:32] == '0;
     }
   }
@@ -529,14 +531,6 @@ class dma_seq_item extends uvm_sequence_item;
                   UVM_MEDIUM)
         valid_config = 0;
       end
-    end
-
-    // Source and destination address must have same alignment for valid DMA configuration
-    if (src_addr[1:0] != dst_addr[1:0]) begin
-      `uvm_info(`gfn,
-                $sformatf(" - Invalid addr alignment src_addr[1:0](0x%0x) != dst_addr[1:0](0x%0x)",
-                src_addr[1:0], dst_addr[1:0]), UVM_MEDIUM)
-      valid_config = 0;
     end
 
     // Check that the upper 32 bits of the destination and source address are zero for

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -853,15 +853,9 @@ module dma
             next_error[DmaDestAddrErr] = 1'b1;
           end
 
-          // Source and destination must have the same alignment
-          if (reg2hw.source_address_lo.q[1:0] != reg2hw.destination_address_lo.q[1:0]) begin
-            next_error[DmaSourceAddrErr] = 1'b1;
-            next_error[DmaDestAddrErr] = 1'b1;
-          end
           // If data from the SOC system bus or the control bus is transferred
           // to the OT internal memory, we must check if the destination address range falls into
           // the DMA enabled memory region.
-
           if ((src_asid inside {SocControlAddr, SocSystemAddr}) && (dst_asid == OtInternalAddr) &&
               // Out-of-bound check
               ((reg2hw.destination_address_lo.q > control_q.enabled_memory_range_limit) ||


### PR DESCRIPTION
The source and destination addresses of a transfer may have different alignment within the bus word because read steering was necessary to achieve function for 1B/txn and 2B/txn transfers to a FIFO without automatic address incrementing. This change was implemented in [PR #680](https://github.com/lowRISC/opentitan-integrated/pull/680).

The current PR removes the needless check within the DMA and the corresponding constraints within the DV to permit 1-byte and 2-byte transfers to be employed with arbitrary source and destination alignments. Whilst the intended behavior in this case was never explicitly specified, it may be useful to have this functionality available as a contingency, since it is already present and exercised in DV, with the constraints no longer present/required.


Summary: This is free functionality already present, allowing an arbitrary byte- or hword-aligned copy to be performed memory-to-memory, albeit with limited throughput. (Throughput has never been a priority of the present implementation.)

@Razer6, @andreaskurth - comments?