### PR TITLE
[dv,top_level] Add test for sensor_ctrl deep sleep wake up

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -63,6 +63,8 @@
         "PWRMGR.LOW_POWER.PINMUX_AON_USB_WKUP_REQ_WAKEUP_REQUEST",
         "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_ENABLE",
         "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_REQUEST",
+        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
+        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
         "PWRMGR.LOW_POWER.WAKE_INFO"
       ]
       tests: ["chip_sw_pwrmgr_random_sleep_all_wake_ups"]
@@ -199,6 +201,24 @@
         "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_test_rom",
         "//sw/device/tests:pwrmgr_deep_sleep_all_reset_reqs_test_fpga_cw310_test_rom",
       ]
+    }
+    {
+      name: chip_sw_sensor_ctrl_deep_sleep_wake_up
+      desc: '''Verify that the chip will wake up from deep sleep by sensor_ctrl.
+
+            This forces the sensor_ctrl alert input from AST to trigger wake up.
+            It does this while the chip is in deep sleep, so clocks are off.
+            SiVal: This test can only run in sim_dv.
+            '''
+      stage: V3
+      si_stage: None
+      features: [
+        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
+        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
+        "PWRMGR.LOW_POWER.WAKE_INFO"
+      ]
+      tests: ["chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_reset_reqs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1834,6 +1834,13 @@
       run_opts: ["+sw_test_timeout_ns=18_000_000", "+do_random=1"]
     }
     {
+      name: chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up
+      uvm_test_seq: "chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq"
+      sw_images: ["//sw/device/tests:pwrmgr_sensor_ctrl_deep_sleep_wake_up:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000", "+do_random=1"]
+    }
+    {
       name: chip_rv_dm_ndm_reset_req
       uvm_test_seq: "chip_rv_dm_ndm_reset_vseq"
       sw_images: ["//sw/device/tests:rv_dm_ndm_reset_req_rma:1:new_rules"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -114,6 +114,7 @@ filesets:
       - seq_lib/chip_sw_sensor_ctrl_status_intr_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_repeat_reset_wkup_vseq.sv: {is_include_file: true}
       - seq_lib/chip_rv_dm_ndm_reset_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -706,6 +706,14 @@ interface chip_if;
     release `AST_HIER.adc_d_o;
   endtask
 
+  task static trigger_sensor_ctrl_wkup();
+    `uvm_info(MsgId, "forcing sensor_ctrl ast_alert_i to 1", UVM_MEDIUM)
+    force `SENSOR_CTRL_HIER.ast_alert_i.alerts[0].p = 1'b1;
+    #100us;
+    `uvm_info(MsgId, "releasing sensor_ctrl ast_alert_i", UVM_MEDIUM)
+    release `SENSOR_CTRL_HIER.ast_alert_i.alerts[0].p;
+  endtask
+
   // alert_esc_if alert_if[NUM_ALERTS](.clk  (`ALERT_HANDLER_HIER.clk_i),
   //                                   .rst_n(`ALERT_HANDLER_HIER.rst_ni));
   // for (genvar i = 0; i < NUM_ALERTS; i++) begin : gen_alert_rx_conn

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq)
+  `uvm_object_new
+
+
+  virtual task body();
+    uint timeout_long  = 10_000_000;
+    uint timeout_short = 1_000_000;
+
+    super.body();
+
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Issue WFI to enter sensor_ctrl sleep");,
+                   "Timed out waiting for enter sensor_ctrl sleep", timeout_long)
+    #400us;
+    cfg.chip_vif.trigger_sensor_ctrl_wkup();
+    `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Woke up by sensor_ctrl");,
+                   "Timed out waiting for wake up sensor_ctrl sleep", timeout_long)
+
+  endtask
+
+endclass : chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -65,6 +65,7 @@
 `include "chip_sw_sensor_ctrl_status_intr_vseq.sv"
 `include "chip_sw_rv_dm_access_after_wakeup_vseq.sv"
 `include "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv"
+`include "chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq.sv"
 `include "chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv"
 `include "chip_tap_straps_vseq.sv"
 `include "chip_sw_repeat_reset_wkup_vseq.sv"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2297,6 +2297,25 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "pwrmgr_sensor_ctrl_deep_sleep_wake_up",
+    srcs = ["pwrmgr_sensor_ctrl_deep_sleep_wake_up.c"],
+    exec_env = {"//hw/top_earlgrey:sim_dv": None},
+    deps = [
+        "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests/sim_dv:pwrmgr_sleep_all_wake_ups_impl",
+    ],
+)
+
+opentitan_test(
     name = "pwrmgr_smoketest",
     srcs = ["pwrmgr_smoketest.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/pwrmgr_sensor_ctrl_deep_sleep_wake_up.c
+++ b/sw/device/tests/pwrmgr_sensor_ctrl_deep_sleep_wake_up.c
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pwrmgr_regs.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+/*
+  PWRMGR SENSOR_CTRL SLEEP WAKE UP TEST
+
+  This test runs power manager wake up from deep sleep mode to be woken
+  up by sensor_ctrl via AST inputs.
+ */
+
+OTTF_DEFINE_TEST_CONFIG();
+
+/**
+ * Clean up pwrmgr wakeup reason register for the next round.
+ */
+static void delay_n_clear(uint32_t delay_in_us) {
+  busy_spin_micros(delay_in_us);
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr));
+}
+
+bool test_main(void) {
+  dif_pwrmgr_domain_config_t cfg;
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  init_units();
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+
+  // Enable pwrmgr interrupt.
+  CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+  dif_pwrmgr_wakeup_reason_t wakeup_reason;
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
+
+  if (wakeup_reason.request_sources == 0) {
+    // This is a POR. Prepare to start the test.
+    CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr));
+  } else if (wakeup_reason.types != kDifPwrmgrWakeupTypeRequest) {
+    LOG_ERROR("Unexpected wakeup_reason.types 0x%x", wakeup_reason.types);
+    return false;
+  } else {
+    // This is a reset from deep_sleep wakeup. Run checks.
+    check_wakeup_reason(5);
+    LOG_INFO("Woke up by sensor_ctrl");
+    clear_wakeup(PWRMGR_PARAM_SENSOR_CTRL_AON_WKUP_REQ_IDX);
+    return true;
+  }
+
+  delay_n_clear(4);
+  CHECK_DIF_OK(dif_pwrmgr_get_domain_config(&pwrmgr, &cfg));
+  cfg &= (kDifPwrmgrDomainOptionIoClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInActivePower);
+  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
+      &pwrmgr, kDifPwrmgrWakeupRequestSourceSix, cfg));
+  LOG_INFO("Issue WFI to enter sensor_ctrl sleep");
+  wait_for_interrupt();
+
+  // This is not reachable.
+  return false;
+}


### PR DESCRIPTION
This is a sim_dv test that forces sensor_ctrl alert inputs while the chip is in deep sleep. It will fail unless the sensor_ctrl synchronizes incoming alerts with the aon clock. Can be used to verify the fix for #20614.