### PR TITLE
[ot_certs] Add test generation for templates

### DIFF
--- a/sw/device/silicon_creator/lib/cert/uds_example_data.json
+++ b/sw/device/silicon_creator/lib/cert/uds_example_data.json
@@ -1,0 +1,9 @@
+{
+    "creator_pub_key_ec_x": "0x006d13d8dca1d8211298d41abd8f7ac38c07333c78e652b44c5b425fce61184a",
+    "creator_pub_key_ec_y": "0x0a0636f5073209440adb17dd8b102bc1154dc95394abfaeecd89852e1d622be1",
+    "creator_pub_key_id": "04897afec876db9674abc7d9fa3fd69fb6a5cd3f",
+    "auth_key_key_id": [138, 57, 54, 65, 64, 74, 25, 4, 6, 13, 153, 255, 0, 1, 5, 7, 2, 1, 5, 98],
+    "otp_creator_sw_cfg_hash": [54, 60, 19, 14, 168, 195, 35, 36, 37,98, 65, 53, 45, 24, 59, 10, 18, 12, 255, 3],
+    "otp_owner_sw_cfg_hash": "465644d935385783658357583758c593583b6537",
+    "otp_hw_cfg_hash": "009e9809f85978327592857a093f539078626589"
+}

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -17,6 +17,7 @@ rust_library(
         "src/template/hjson.rs",
         "src/template/mod.rs",
         "src/template/subst.rs",
+        "src/template/testgen.rs",
         "src/x509.rs",
         "src/x509/extension.rs",
     ],

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -16,6 +16,7 @@ rust_library(
         "src/lib.rs",
         "src/template/hjson.rs",
         "src/template/mod.rs",
+        "src/template/subst.rs",
         "src/x509.rs",
         "src/x509/extension.rs",
     ],
@@ -34,6 +35,7 @@ rust_library(
         "@crate_index//:openssl",
         "@crate_index//:rand",
         "@crate_index//:serde",
+        "@crate_index//:serde_json",
         "@crate_index//:serde_with",
         "@crate_index//:strum",
         # We need those because they are not re-exported by openssl

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -39,6 +39,7 @@ use std::{collections::HashMap, marker::PhantomData};
 
 mod hjson;
 pub mod subst;
+pub mod testgen;
 
 /// Full template file, including variable declarations and certificate spec.
 #[serde_as]

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -38,6 +38,7 @@ use serde_with::{serde_as, As, DeserializeAs, Same, SerializeAs};
 use std::{collections::HashMap, marker::PhantomData};
 
 mod hjson;
+pub mod subst;
 
 /// Full template file, including variable declarations and certificate spec.
 #[serde_as]

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -1,0 +1,384 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines substitution data that can be used to replace the
+//! variables in a template by actual values.
+
+use anyhow::{bail, ensure, Context, Result};
+use hex::{FromHex, ToHex};
+use num_bigint_dig::BigUint;
+use num_traits::{FromPrimitive, Num};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::template::{
+    Certificate, Conversion, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, Flags,
+    Signature, SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SubstValue {
+    ByteArray(Vec<u8>),
+    Int32(i32),
+    String(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubstData {
+    #[serde(flatten)]
+    pub values: HashMap<String, SubstValue>,
+}
+
+impl Default for SubstData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubstData {
+    pub fn new() -> SubstData {
+        SubstData {
+            values: HashMap::new(),
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self)?)
+    }
+
+    pub fn from_json(content: &str) -> Result<SubstData> {
+        Ok(serde_json::from_str(content)?)
+    }
+}
+
+pub trait Subst: Sized {
+    fn subst(&self, data: &SubstData) -> Result<Self>;
+}
+
+impl SubstValue {
+    // Parse the content of the data according to a specified
+    // type. This parsing needs to be consistent with the one
+    // in the template and template::hjson. See also Template::subst.
+    pub fn parse(&self, var_type: &VariableType) -> Result<SubstValue> {
+        match *var_type {
+            VariableType::ByteArray { size } => self.parse_as_byte_array(size),
+            VariableType::Integer { size } => self.parse_as_integer(size),
+            VariableType::String { size } => self.parse_as_string(size),
+        }
+    }
+
+    fn parse_as_byte_array(&self, size: usize) -> Result<SubstValue> {
+        match self {
+            SubstValue::ByteArray(bytes) => {
+                ensure!(
+                    bytes.len() == size,
+                    "expected a byte array of size {size} but got {} bytes",
+                    bytes.len()
+                );
+                Ok(self.clone())
+            }
+            SubstValue::String(s) => {
+                // To be consistent with the template, interpret this
+                // as a hexstring.
+                let bytes = Vec::<u8>::from_hex(s)
+                    .with_context(|| format!("cannot parse {s} as an hexstring"))?;
+                ensure!(
+                    bytes.len() == size,
+                    "expected a byte array of size {size} but got {} bytes",
+                    bytes.len()
+                );
+                Ok(SubstValue::ByteArray(bytes))
+            }
+            _ => bail!("cannot parse value {self:?} as a byte-array"),
+        }
+    }
+
+    fn parse_as_integer(&self, size: usize) -> Result<SubstValue> {
+        match self {
+            SubstValue::ByteArray(bytes) => {
+                // Integer are represented as byte arrays.
+                ensure!(
+                    bytes.len() <= size,
+                    "expected an integer that fits on {size} bytes but it uses {} bytes",
+                    bytes.len()
+                );
+                Ok(self.clone())
+            }
+            SubstValue::String(s) => {
+                // To be consistent with the template, interpret this as
+                // an integer and convert it to a big-endian byte array.
+                // See template::hjson::BigUintVisitor.
+
+                // Unless the string starts with '0x', expect a decimal string.
+                let (radix, s) = s
+                    .strip_prefix("0x")
+                    .map_or_else(|| (10, s.as_str()), |s| (16, s));
+                let val = BigUint::from_str_radix(s, radix)
+                    .with_context(|| format!("cannot parse {s} as an integer"))?;
+                let bytes = val.to_bytes_be();
+                ensure!(
+                    bytes.len() <= size,
+                    "expected an integer that fits on {size} bytes but it uses {} bytes",
+                    bytes.len()
+                );
+                Ok(SubstValue::ByteArray(bytes))
+            }
+            SubstValue::Int32(_) => {
+                // TODO: make this check smarter (ie 0xff could fit on byte but is considered to use 4)
+                ensure!(
+                    4 <= size,
+                    "expected an integer that fits on {size} bytes but it uses 4 bytes"
+                );
+                Ok(self.clone())
+            }
+        }
+    }
+
+    fn parse_as_string(&self, size: usize) -> Result<SubstValue> {
+        match self {
+            SubstValue::String(s) => {
+                ensure!(
+                    s.len() <= size,
+                    "expected a string of at most {size} bytes but it uses {} bytes",
+                    s.len()
+                );
+                Ok(self.clone())
+            }
+            _ => bail!("cannot parse value {self:?} as a string"),
+        }
+    }
+}
+
+impl Subst for Template {
+    // Substitute data into the template. Variables that are not
+    // specified in the data are left untouched. The substitution
+    // will take into account the type specified in the template
+    // variables. Consider an example where the substitution data
+    // specifies:
+    //   "x": String("3256")
+    // If the template specifies:
+    //   x: { type: "integer" }
+    // Then "3256" will be parsed as integer 3256. On the other hand,
+    // if the template specifies:
+    //   x: { type: "byte-array" }
+    // Then "3256" will be parsed as an hexstring and represent [0x32, 0x56].
+    // This behaviour is consistent with how the data is interpreted
+    // in the template hson.
+    // This function will return if a substitution does not make sense (wrong type
+    // or impossible conversion).
+    fn subst(&self, data: &SubstData) -> Result<Template> {
+        // The first step is to match all variables in the substitution
+        // data with variables in the template to parse them if necessary.
+        let mut variables = self.variables.clone();
+        let mut new_data = SubstData::new();
+        for (var_name, val) in data.values.iter() {
+            let Some(var_type) = variables.remove(var_name) else {
+                // Variable does not appear in the template: ignore it.
+                continue;
+            };
+            new_data.values.insert(var_name.clone(), val.parse(&var_type).with_context(
+                || format!("cannot parse content of substitution variable {var_name} according to the type {var_type:?} specified in the template ")
+            )?);
+        }
+        Ok(Template {
+            name: self.name.clone(),
+            variables,
+            certificate: self.certificate.subst(&new_data)?,
+        })
+    }
+}
+
+// This is a private trait to factor the implementation of
+// Subst for Value<T>.
+trait ConvertValue<T> {
+    fn convert(&self, convert: &Option<Conversion>) -> Result<Value<T>>;
+}
+
+impl ConvertValue<Vec<u8>> for SubstValue {
+    fn convert(&self, convert: &Option<Conversion>) -> Result<Value<Vec<u8>>> {
+        // The only supported conversion to byte array is from a byte array.
+        let SubstValue::ByteArray(bytes) = &self else {
+            bail!("cannot substitute a byte-array field with value {:?}", self);
+        };
+        ensure!(convert.is_none(), "substitution of a byte-array field with a byte-array value cannot specify a conversion");
+        Ok(Value::Literal(bytes.clone()))
+    }
+}
+
+impl ConvertValue<BigUint> for SubstValue {
+    fn convert(&self, convert: &Option<Conversion>) -> Result<Value<BigUint>> {
+        match self {
+            SubstValue::Int32(x) => {
+                // No conversion supported.
+                ensure!(convert.is_none(), "substitution of an integer field with an int32 value cannot specify a conversion");
+                Ok(Value::Literal(
+                    BigUint::from_i32(*x).expect("cannot create a BigUint from an int32"),
+                ))
+            }
+            SubstValue::ByteArray(bytes) => {
+                // No conversion means big-endian.
+                match convert {
+                    None | Some(Conversion::BigEndian) => {
+                        Ok(Value::Literal(BigUint::from_bytes_be(bytes)))
+                    }
+                    _ => bail!("substitution of an integer field with a byte-array cannot specify conversion {:?}", convert)
+                }
+            }
+            _ => bail!("cannot substitute an integer field with value {:?}", self),
+        }
+    }
+}
+
+impl ConvertValue<String> for SubstValue {
+    fn convert(&self, convert: &Option<Conversion>) -> Result<Value<String>> {
+        match self {
+            SubstValue::String(x) => {
+                // No conversion supposed.
+                ensure!(convert.is_none(), "substitution of a string field with a string value cannot specify a conversion");
+                Ok(Value::Literal(x.clone()))
+            },
+            SubstValue::ByteArray(bytes) => {
+                match convert {
+                    Some(Conversion::LowercaseHex) => {
+                        Ok(Value::Literal(bytes.encode_hex::<String>()))
+                    }
+                    _ => bail!("substitution of a string field with a byte-array cannot specify conversion {:?}", convert)
+                }
+            }
+            _ => bail!("cannot substitute an string field with value {:?}", self),
+        }
+    }
+}
+
+impl<T> Subst for Value<T>
+where
+    Value<T>: Clone,
+    SubstValue: ConvertValue<T>,
+{
+    fn subst(&self, data: &SubstData) -> Result<Value<T>> {
+        match self {
+            Value::Literal(_) => Ok(self.clone()),
+            Value::Variable(Variable { name, convert }) => match data.values.get(name) {
+                None => Ok(self.clone()),
+                Some(val) => val.convert(convert),
+            },
+        }
+    }
+}
+
+impl Subst for Certificate {
+    fn subst(&self, data: &SubstData) -> Result<Certificate> {
+        Ok(Certificate {
+            serial_number: self.serial_number.subst(data)?,
+            issuer: self.issuer.subst(data)?,
+            subject: self.subject.subst(data)?,
+            subject_public_key_info: self.subject_public_key_info.subst(data)?,
+            authority_key_identifier: self.authority_key_identifier.subst(data)?,
+            subject_key_identifier: self.subject_key_identifier.subst(data)?,
+            model: self.model.subst(data)?,
+            vendor: self.vendor.subst(data)?,
+            version: self.version.subst(data)?,
+            svn: self.svn.subst(data)?,
+            layer: self.layer.subst(data)?,
+            fw_ids: self.fw_ids.subst(data)?,
+            flags: self.flags.subst(data)?,
+            signature: self.signature.subst(data)?,
+        })
+    }
+}
+
+impl Subst for FirmwareId {
+    fn subst(&self, data: &SubstData) -> Result<FirmwareId> {
+        Ok(FirmwareId {
+            hash_algorithm: self.hash_algorithm,
+            digest: self.digest.subst(data)?,
+        })
+    }
+}
+
+impl Subst for Flags {
+    fn subst(&self, _data: &SubstData) -> Result<Flags> {
+        Ok(*self)
+    }
+}
+
+impl Subst for SubjectPublicKeyInfo {
+    fn subst(&self, data: &SubstData) -> Result<SubjectPublicKeyInfo> {
+        match self {
+            SubjectPublicKeyInfo::EcPublicKey(ec) => {
+                Ok(SubjectPublicKeyInfo::EcPublicKey(ec.subst(data)?))
+            }
+        }
+    }
+}
+
+impl Subst for EcPublicKeyInfo {
+    fn subst(&self, data: &SubstData) -> Result<EcPublicKeyInfo> {
+        Ok(EcPublicKeyInfo {
+            curve: self.curve.clone(),
+            public_key: self.public_key.subst(data)?,
+        })
+    }
+}
+
+impl Subst for EcPublicKey {
+    fn subst(&self, data: &SubstData) -> Result<EcPublicKey> {
+        Ok(EcPublicKey {
+            x: self.x.subst(data)?,
+            y: self.y.subst(data)?,
+        })
+    }
+}
+
+impl Subst for Signature {
+    fn subst(&self, data: &SubstData) -> Result<Signature> {
+        match self {
+            Signature::EcdsaWithSha256 { value } => Ok(Signature::EcdsaWithSha256 {
+                value: value.subst(data)?,
+            }),
+        }
+    }
+}
+
+impl Subst for EcdsaSignature {
+    fn subst(&self, data: &SubstData) -> Result<EcdsaSignature> {
+        Ok(EcdsaSignature {
+            r: self.r.subst(data)?,
+            s: self.s.subst(data)?,
+        })
+    }
+}
+
+impl<T> Subst for Option<T>
+where
+    T: Subst,
+{
+    fn subst(&self, data: &SubstData) -> Result<Option<T>> {
+        self.as_ref().map(|x| x.subst(data)).transpose()
+    }
+}
+
+impl<T> Subst for Vec<T>
+where
+    T: Subst,
+{
+    fn subst(&self, data: &SubstData) -> Result<Vec<T>> {
+        self.iter()
+            .map(|x| x.subst(data))
+            .collect::<Result<Vec<_>>>()
+    }
+}
+
+impl<K, V> Subst for HashMap<K, V>
+where
+    K: Clone + Eq + std::hash::Hash,
+    V: Subst,
+{
+    fn subst(&self, data: &SubstData) -> Result<HashMap<K, V>> {
+        self.iter()
+            .map(|(k, v)| Ok((k.clone(), v.subst(data)?)))
+            .collect::<Result<HashMap<K, V>>>()
+    }
+}

--- a/sw/host/ot_certs/src/template/testgen.rs
+++ b/sw/host/ot_certs/src/template/testgen.rs
@@ -1,0 +1,97 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides functionality to generate substitute data for template
+//! to test corner cases of the certificate generator.
+
+use anyhow::{ensure, Result};
+use rand::distributions::DistString;
+
+use openssl::bn::{BigNum, BigNumContext};
+use openssl::ec::{EcGroup, EcKey};
+use openssl::nid::Nid;
+use openssl::pkey::Private;
+
+use crate::template::subst::{SubstData, SubstValue};
+use crate::template::{EcCurve, EcPublicKeyInfo, SubjectPublicKeyInfo, Template, Value, Variable};
+
+// Convert a template curve name to an openssl one.
+fn ecgroup_from_curve(curve: &EcCurve) -> EcGroup {
+    match curve {
+        EcCurve::Prime256v1 => EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap(),
+    }
+}
+
+impl Template {
+    /// Generate a random set of data to substitute in the template to fill all the values.
+    /// This generator will make sure to generate valid values for the public key if possible.
+    pub fn random_test(&self) -> Result<SubstData> {
+        let mut data = SubstData::new();
+        for (var, var_type) in &self.variables {
+            let val = match *var_type {
+                super::VariableType::ByteArray { size } => {
+                    let bytes = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
+                    SubstValue::ByteArray(bytes)
+                }
+                super::VariableType::String { size } => {
+                    let s = rand::distributions::Alphanumeric
+                        .sample_string(&mut rand::thread_rng(), size);
+                    SubstValue::String(s)
+                }
+                super::VariableType::Integer { size } => {
+                    if size == 4 {
+                        SubstValue::Int32(rand::random::<i32>())
+                    } else {
+                        let bytes = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
+                        SubstValue::ByteArray(bytes)
+                    }
+                }
+            };
+            data.values.insert(var.to_string(), val);
+        }
+        // We want to make sure that we generate a valid public key, otherwise
+        // tools like openssl might fail to parse the certificate.
+        for (key, val) in self.random_public_key()?.values {
+            data.values.insert(key, val);
+        }
+        Ok(data)
+    }
+
+    fn random_public_key(&self) -> Result<SubstData> {
+        match &self.certificate.subject_public_key_info {
+            SubjectPublicKeyInfo::EcPublicKey(ec) => Self::random_ec_public_key(ec),
+        }
+    }
+
+    fn random_ec_public_key(ec_pubkey: &EcPublicKeyInfo) -> Result<SubstData> {
+        // Generate a public key using openssl.
+        let group = ecgroup_from_curve(&ec_pubkey.curve);
+        let privkey = EcKey::<Private>::generate(&group)?;
+        let mut ctx = BigNumContext::new()?;
+        let mut x = BigNum::new()?;
+        let mut y = BigNum::new()?;
+        privkey
+            .public_key()
+            .affine_coordinates(&group, &mut x, &mut y, &mut ctx)?;
+        let mut data = SubstData::new();
+        // If any of the coordinates is a variable, create a substitution for it.
+        if let Value::Variable(Variable { name, convert }) = &ec_pubkey.public_key.x {
+            ensure!(
+                convert.is_none(),
+                "cannot generate a random public key if 'x' a variable with conversion"
+            );
+            data.values
+                .insert(name.clone(), SubstValue::ByteArray(x.to_vec()));
+        }
+        if let Value::Variable(Variable { name, convert }) = &ec_pubkey.public_key.y {
+            ensure!(
+                convert.is_none(),
+                "cannot generate a random public key if 'y' a variable with conversion"
+            );
+            data.values
+                .insert(name.clone(), SubstValue::ByteArray(y.to_vec()));
+        }
+        Ok(data)
+    }
+}


### PR DESCRIPTION
The first few commits are that of #20606

This creates a new command to generate random test data and output it to json files. This will used for unittest asn1 of der and codegen. It can be used to generate random certificates.
Test with:
```bash
CERT="uds" # try also with "generic"
./bazelisk.sh run //sw/host/opentitantool -- --format=json certificate testgen $PWD/sw/device/silicon_creator/lib/cert/$CERT.hjson > $PWD/tmp.json
# alternatively:
./bazelisk.sh run //sw/host/opentitantool -- certificate testgen $PWD/sw/device/silicon_creator/lib/cert/$CERT.hjson --output $PWD/tmp.json
# then substitute and see the result
./bazelisk.sh run //sw/host/opentitantool -- certificate subst $PWD/sw/device/silicon_creator/lib/cert/$CERT.hjson $PWD/tmp.json
```