### PR TITLE
[tlul/rtl] Change `ASSERT_I` to `ASSERT` to fix erroneous assertion failure

### DIFF
--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -118,7 +118,6 @@ module tlul_socket_1n #(
       dev_select_outstanding <= '0;
     end else if (accept_t_req) begin
       if (!accept_t_rsp) begin
-        `ASSERT_I(NotOverflowed_A, num_req_outstanding <= MaxOutstanding)
         num_req_outstanding <= num_req_outstanding + 1'b1;
       end
       dev_select_outstanding <= dev_select_t;
@@ -126,6 +125,9 @@ module tlul_socket_1n #(
       num_req_outstanding <= num_req_outstanding - 1'b1;
     end
   end
+
+  `ASSERT(NotOverflowed_A,
+          accept_t_req && !accept_t_rsp -> num_req_outstanding <= MaxOutstanding)
 
   assign hold_all_requests =
       (num_req_outstanding != '0) &


### PR DESCRIPTION
`ASSERT_I` is not disabled during reset or when reset is unknown, so it fails erroneously.  This caused a large number of tests (32 according to the current report) in Darjeelings `xbar_main` regressions to fail.

This commit fixes that problem by changing the assertion to `ASSERT`, which is disabled when reset is not deasserted (thus it's also disabled when reset is unknown).

This is a cherry-picked commit from https://github.com/lowRISC/opentitan/pull/20571, as requested in [this comment](https://github.com/lowRISC/opentitan/pull/20571#issuecomment-1843994716).