### PR TITLE
[fi] Add Ibex FI characterization tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -49,7 +49,10 @@ cc_library(
 cc_library(
     name = "ibex_fi",
     srcs = ["ibex_fi.c"],
-    hdrs = ["ibex_fi.h"],
+    hdrs = [
+        "ibex_fi.h",
+        "status.h",
+    ],
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
@@ -12,16 +12,20 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/status.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// NOP macros.
 #define NOP1 "addi x0, x0, 0\n"
 #define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
 #define NOP100 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10
 
+// Init x5 = 0 macro.
 #define INITX5 "addi x5, x0, 0"
 
+// Addi x5 = x5 + 1 macros.
 #define ADDI1 "addi x5, x5, 1\n"
 #define ADDI10 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1 ADDI1
 #define ADDI100 \
@@ -30,17 +34,172 @@
   ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 ADDI100 \
       ADDI100
 
+// Init x6 = 10000 macro.
+#define INITX6 "li x6, 10000"
+
+// Subi x6 = x6 - 1 macro.
+#define SUBI1 "addi x6, x6, -1\n"
+
+// Load word, addi, sw macro.
+#define LWADDISW1 "lw x5, (%0)\n addi x5, x5, 1\n sw x5, (%0)\n"
+#define LWADDISW10                                                      \
+  LWADDISW1 LWADDISW1 LWADDISW1 LWADDISW1 LWADDISW1 LWADDISW1 LWADDISW1 \
+      LWADDISW1 LWADDISW1 LWADDISW1
+#define LWADDISW100                                                            \
+  LWADDISW10 LWADDISW10 LWADDISW10 LWADDISW10 LWADDISW10 LWADDISW10 LWADDISW10 \
+      LWADDISW10 LWADDISW10 LWADDISW10
+#define LWADDISW1000                                                      \
+  LWADDISW100 LWADDISW100 LWADDISW100 LWADDISW100 LWADDISW100 LWADDISW100 \
+      LWADDISW100 LWADDISW100 LWADDISW100 LWADDISW100
+
+// Load word, subi, sw macro.
+#define LWSUBISW1 "lw x6, (%0)\n addi x6, x6, -1\n sw x6, (%0)\n"
+
 /**
- * Initializes the SCA trigger.
+ * ibex.char.mem_op_loop command handler.
  *
+ * This FI penetration tests executes the following instructions:
+ * - Add 100 NOPs to delay the trigger
+ * - 10000 iterations with a for loop:
+ *  - Load loop_counter1 value into x5: lw x5, (&loop_counter1)
+ *  - Increment loop counter1: addi x5, x5, 1
+ *  - Store loop counter1 back to loop_counter1: sw x5, (&loop_counter1)
+ *  - Load loop_counter2 value into x6: lw x6, (&loop_counter2)
+ *  - Decrement loop counter2: addi x6, x6, -1
+ *  - Store loop counter2 back to loop_counter2: sw x6, (&loop_counter2)
+ * - Return the values over UART.
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
  *
  * @param uj The received uJSON data.
  */
-status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
-  sca_select_trigger_type(kScaTriggerTypeSw);
-  // As we are using the software defined trigger, the first argument of
-  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
-  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4);
+status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
+  // Configure Ibex to allow reading ERR_STATUS register.
+  dif_rv_core_ibex_t rv_core_ibex;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // FI code target.
+  uint32_t loop_counter1 = 0;
+  uint32_t loop_counter2 = 10000;
+  sca_set_trigger_high();
+  asm volatile(NOP100);
+  for (int loop_cnt = 0; loop_cnt < 10000; loop_cnt++) {
+    asm volatile(LWADDISW1 : : "r"((uint32_t *)&loop_counter1));
+    asm volatile(LWSUBISW1 : : "r"((uint32_t *)&loop_counter2));
+  }
+  sca_set_trigger_low();
+
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+
+  // Send loop counters & ERR_STATUS to host.
+  ibex_fi_loop_counter_mirrored_t uj_output;
+  uj_output.loop_counter1 = loop_counter1;
+  uj_output.loop_counter2 = loop_counter2;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * ibex.char.unrolled_mem_op_loop command handler.
+ *
+ * This FI penetration tests executes the following instructions:
+ * - Add 100 NOPs to delay the trigger
+ * - 10000 iterations:
+ *  - Load loop_counter value into x5: lw x5, (&loop_counter)
+ *  - Increment loop counter: addi x5, x5, 1
+ *  - Store loop counter back to loop_counter: sw x5, (&loop_counter)
+ * - Return the value over UART.
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
+  // Configure Ibex to allow reading ERR_STATUS register.
+  dif_rv_core_ibex_t rv_core_ibex;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // FI code target.
+  uint32_t loop_counter = 0;
+  sca_set_trigger_high();
+  asm volatile(NOP100);
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
+  sca_set_trigger_low();
+
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+
+  // Send loop counter & ERR_STATUS to host.
+  ibex_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * ibex.char.reg_op_loop command handler.
+ *
+ * This FI penetration tests executes the following instructions:
+ * - Initialize register x5=0 & x6=10000
+ * - Add 100 NOPs to delay the trigger
+ * - Perform 10000 x5 = x5 + 1 additions and x6 = x6 - 1 subtractions
+ * - Return the values over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
+  // Configure Ibex to allow reading ERR_STATUS register.
+  dif_rv_core_ibex_t rv_core_ibex;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // FI code target.
+  uint32_t loop_counter1 = 0;
+  uint32_t loop_counter2 = 10000;
+  sca_set_trigger_high();
+  asm volatile(INITX5);
+  asm volatile(INITX6);
+  asm volatile(NOP100);
+  for (int loop_cnt = 0; loop_cnt < 10000; loop_cnt++) {
+    asm volatile(ADDI1);
+    asm volatile(SUBI1);
+  }
+  asm volatile("mv %0, x5" : "=r"(loop_counter1));
+  asm volatile("mv %0, x6" : "=r"(loop_counter2));
+  sca_set_trigger_low();
+
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+
+  // Send loop counters & ERR_STATUS to host.
+  ibex_fi_loop_counter_mirrored_t uj_output;
+  uj_output.loop_counter1 = loop_counter1;
+  uj_output.loop_counter2 = loop_counter2;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS(0);
 }
 
@@ -61,11 +220,9 @@ status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Configure Ibex to allow reading ERR_STATUS register.
   dif_rv_core_ibex_t rv_core_ibex;
-  if (dif_rv_core_ibex_init(
-          mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-          &rv_core_ibex) != kDifOk) {
-    return ABORTED();
-  }
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -87,15 +244,27 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
-  if (dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes) != kDifOk) {
-    return ABORTED();
-  }
+  UJSON_CHECK_DIF_OK(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
 
   // Send loop counter & ERR_STATUS to host.
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * Initializes the SCA trigger.
+ *
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4);
   return OK_STATUS(0);
 }
 
@@ -114,6 +283,12 @@ status_t handle_ibex_fi(ujson_t *uj) {
       return handle_ibex_fi_init_trigger(uj);
     case kIbexFiSubcommandCharUnrolledRegOpLoop:
       return handle_ibex_fi_char_unrolled_reg_op_loop(uj);
+    case kIbexFiSubcommandCharRegOpLoop:
+      return handle_ibex_fi_char_reg_op_loop(uj);
+    case kIbexFiSubcommandCharUnrolledMemOpLoop:
+      return handle_ibex_fi_char_unrolled_mem_op_loop(uj);
+    case kIbexFiSubcommandCharMemOpLoop:
+      return handle_ibex_fi_char_mem_op_loop(uj);
     default:
       LOG_ERROR("Unrecognized IBEX FI subcommand: %d", cmd);
       return INVALID_ARGUMENT();

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
@@ -8,6 +8,9 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj);
+status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj);
+status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_init_trigger(ujson_t *uj);
 status_t handle_ibex_fi(ujson_t *uj);

--- a/sw/device/tests/crypto/cryptotest/firmware/status.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/status.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_STATUS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_STATUS_H_
+
+#define UJSON_CHECK_DIF_OK(dif_call) \
+  do {                               \
+    if (dif_call != kDifOk) {        \
+      return ABORTED();              \
+    }                                \
+  } while (false)
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_STATUS_H_

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
@@ -13,13 +13,22 @@ extern "C" {
 
 #define IBEXFI_SUBCOMMAND(_, value) \
     value(_, InitTrigger) \
-    value(_, CharUnrolledRegOpLoop)
+    value(_, CharUnrolledRegOpLoop) \
+    value(_, CharRegOpLoop) \
+    value(_, CharUnrolledMemOpLoop) \
+    value(_, CharMemOpLoop)
 UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
+
+#define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
+    field(loop_counter1, uint32_t) \
+    field(loop_counter2, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 // clang-format on
 


### PR DESCRIPTION
Adds new FI tests to characterize Ibex:
- ibex.char.mem_op_loop
- ibex.char.reg_op_loop
- ibex.char.unrolled_mem_op_loop

Host code is available at [#259](https://github.com/lowRISC/ot-sca/pull/259).