### PR TITLE
[opentitantool] Fix omission in SPI/I2C alias handling

### DIFF
--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -115,7 +115,7 @@ _CP_PROVISIONING_CMD_ARGS = """
 
 opentitan_test(
     name = "cp_provision",
-    cw310 = cw310_jtag_params(
+    cw310 = hyper310_jtag_params(
         binaries = {":sram_cp_provision": "sram_cp_provision"},
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_unlocked0_manuf_empty",
         tags = ["manuf"],

--- a/sw/host/opentitanlib/src/app/i2c.rs
+++ b/sw/host/opentitanlib/src/app/i2c.rs
@@ -79,6 +79,7 @@ impl LogicalI2cWrapper {
                 .underlying_target
                 .set_max_speed(speed)?;
         }
+        self.physical_wrapper.last_used_by_uid.set(Some(self.uid));
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/app/spi.rs
+++ b/sw/host/opentitanlib/src/app/spi.rs
@@ -130,6 +130,7 @@ impl LogicalSpiWrapper {
                 .underlying_target
                 .set_pins(clock, hodi, hido, cs)?,
         }
+        self.physical_wrapper.last_used_by_uid.set(Some(self.uid));
         Ok(())
     }
 }


### PR DESCRIPTION
The JSON configuration format allows named aliases of SPI or I2C ports, such that e.g. "TPM" can be an alias for e.g. "SPI1".  The same hardware port can have multiple aliases.  A key point is that each alias can have its own default speed and other settings, and the `TransportWrapper` layer will make sure that before a port alias is used for communication, its settings are applied to the physical transport port.

It seems that a bug had gone un-noticed, because of which the settings were repeatedly applied if the same alias was used in a sequence of transactions.  This could seem to be merely the cause for some slowdown, but Alex discovered that when SPI chip select is to be kept asserted across a series of separate interactions, re-setting the speed and choice of chip select pin will interfere, by deasserting the chip select.

This CL adds code that was intentede from the start, to properly keep track of which alias has most recently been used to access any given physical port, and only apply speed and other settings if it was not the alias that currently is about to run a transaction.