### PR TITLE
[Sival, rv_timer] Test counter wrap 

### DIFF
--- a/hw/ip/rv_timer/README.md
+++ b/hw/ip/rv_timer/README.md
@@ -34,7 +34,7 @@ assumes the clock is neither turned off nor changed during runtime.
 
 ## Compatibility
 
-The timer IP provides memory-mapped registers `mtime` and `mtimecmp` which can
+The timer IP provides memory-mapped registers equivalent to `mtime` and `mtimecmp` which can
 be used as the machine-mode timer registers defined in the RISC-V privileged
 spec. Additional features such as prescaler, step, and a configurable number of
 timers and harts have been added.

--- a/hw/ip/rv_timer/doc/programmers_guide.md
+++ b/hw/ip/rv_timer/doc/programmers_guide.md
@@ -41,9 +41,10 @@ the RISC-V privileged specification.
 ```asm
 # New comparand is in a1:a0.
 li t0, -1
-sw t0, mtimecmp   # No smaller than old value.
-sw a1, mtimecmp+4 # No smaller than new value.
-sw a0, mtimecmp   # New value.
+li t1, TOP_EARLGREY_RV_TIMER_BASE_ADDR
+sw t0, RV_TIMER_COMPARE_LOWER0_0_REG_OFFSET(t1)   # No smaller than old value.
+sw a1, RV_TIMER_COMPARE_UPPER0_0_REG_OFFSET(t1)   # No smaller than new value.
+sw a0, RV_TIMER_COMPARE_LOWER0_0_REG_OFFSET(t1)   # New value.
 ```
 
 ## Timer behaviour close to 2^64

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -41,15 +41,14 @@
       bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_sival_rom_ext"]
     }
     {
-      name: riscv_isa_csrs
-      desc: '''Verify that the timer counter and compare registers can be read and written via
-            the registers `mtime` and `mtimecmp` and that `mtime` will wrap to zero when the limit
-            is reached.
+      name: counter_wrap
+      desc: '''Verify that the timer counter will wrap to zero when the limit is reached.
 
             - Enable interrupts.
-            - Set the compare register to zero by writing to `mtimecmp` CSR.
-            - Set the counter to `UINT64_MAX - 500 milliseconds` by writing to `mtime` CSR.
+            - Set the counter to `UINT64_MAX - 5 milliseconds`.
+            - Set the compare register to UINT64_MAX.
             - Enable the timer.
+            - Start a busy loop of 5 milliseconds based on the `mcycleh` CSR.
             - Verify that the counter has wrapped around by reading `mtime`.
             - Verify that the interrupt has fired.
             '''

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -57,7 +57,8 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER", "RV_TIMER.RISCV_CSRS_INTEGRATION"]
-      tests: []
+      tests: ["chip_sw_rv_timer_systick_test"]
+      bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_sival_rom_ext"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -19,7 +19,7 @@
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER"]
       tests: ["chip_sw_rv_timer_irq"]
-      bazel: ["//sw/device/tests:rv_timer_smoketest_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rv_timer_smoketest_fpga_cw310_sival_rom_ext"]
     }
     {
       name: tick_configuration
@@ -38,7 +38,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE"]
       tests: ["chip_sw_rv_timer_systick_test"]
-      bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_sival_rom_ext"]
     }
     {
       name: riscv_isa_csrs


### PR DESCRIPTION
The original test description does not make sense because the Ibex does not implement the timer CSRs as described [here](https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html?highlight=MTIME#machine-architecture-id-marchid) and therefore the rv_timer memory mapped registers are used instead.
This PR:
 - Updates the documentations to make it clear.
 - Update the test description to only check the counter wrap.
 - Update the existing systick_test exec_env.
 - Increment the systick_test to also check the counter wrap.

Fix https://github.com/lowRISC/opentitan/issues/19978
Fix https://github.com/lowRISC/opentitan/issues/19979