### PR TITLE
[dma] Fix for signaling of memory buffer (almost) limit interrupt

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -1163,7 +1163,8 @@ module dma
   assign send_memory_buffer_limit_interrupt = send_almost_limit_interrupt || send_limit_interrupt;
 
   // Data was moved if we get a write valid response
-  assign data_move_state_valid = (write_rsp_valid && (ctrl_state_q == DmaSendWrite));
+  assign data_move_state_valid = (write_rsp_valid && (ctrl_state_q == DmaSendWrite ||
+                                                      ctrl_state_q == DmaWaitWriteResponse));
 
   assign data_move_state = (ctrl_state_q == DmaSendWrite)         ||
                            (ctrl_state_q == DmaWaitWriteResponse) ||


### PR DESCRIPTION
Memory limit interrupts must be signaled on receipt of the write response, which may occur in two FSM states.
This PR corrects the RTL to include the second state so that interrupts are not omitted. (Found in DV)