### PR TITLE
[otbn,dv] Fix a couple of timing issues

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -727,13 +727,12 @@ class otbn_base_vseq extends cip_base_vseq #(
             end
           join_any
 
-          // When we get here, we know that either the OTBN sequence finished or we timed out
-          // and it's still going. We can see whether OTBN is still going by looking at the status
-          // from the model (which is also in sync with the RTL). Because we wait on the negedge
-          // when updating cycle_counter above, we know we've got the "new version" of the status at
-          // this point.
-          if (cfg.model_agent_cfg.vif.status inside {otbn_pkg::StatusBusyExecute,
-                                                   otbn_pkg::StatusBusySecWipeInt}) begin
+          // When we get here, we know that either the OTBN sequence finished or we timed out and
+          // it's still going. We can see whether OTBN is still in the middle of a run by looking at
+          // the status from the model (which is also in sync with the RTL). Because we wait on the
+          // negedge when updating cycle_counter above, we know we've got the "new version" of the
+          // status at this point.
+          if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute) begin
             timed_out = 1'b1;
           end else begin
             timed_out = 1'b0;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -20,7 +20,7 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
         rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_en_a :
                                        cfg.trace_vif.rf_base_rd_en_b;
       end while(!rd_en);,
-      cfg.clk_rst_vif.wait_clks(2000);)
+      cfg.clk_rst_vif.wait_clks(20000);)
     if (!rd_en) begin
       `uvm_fatal(`gfn,
                  $sformatf("Timeout while waiting for register file %s to be used",

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -20,9 +20,12 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
         rd_en = insert_intg_err_to_a ? cfg.trace_vif.rf_base_rd_en_a :
                                        cfg.trace_vif.rf_base_rd_en_b;
       end while(!rd_en);,
-      cfg.clk_rst_vif.wait_clks(2000);,
-      "Not getting selected rd_en from OTBN for 2000 cycles!"
-    )
+      cfg.clk_rst_vif.wait_clks(2000);)
+    if (!rd_en) begin
+      `uvm_fatal(`gfn,
+                 $sformatf("Timeout while waiting for register file %s to be used",
+                           insert_intg_err_to_a ? "A" : "B"))
+    end
   endtask
 
   function bit [otbn_pkg::BaseIntgWidth-1:0] corrupt_data(


### PR DESCRIPTION
There are careful notes in the commit messages. These changes fix some tests that look much healthier on master. (Oh no!) I think the fundamental problem is that the `integrated_dev` branch has different relationships between the EDN clock and the master clock.

Not a problem, but it exposes some incorrect guesses that we made when we did OTBN DV in the first place :-) These commits should tighten things up (and will work equally well on `master`, I hope).