### PR TITLE
[hw,mbx,rtl] Use the transition to the Read/Abort to generate the IRQ

### DIFF
--- a/hw/ip/mbx/rtl/mbx_fsm.sv
+++ b/hw/ip/mbx/rtl/mbx_fsm.sv
@@ -62,9 +62,9 @@ module mbx_fsm #(
   assign mbx_read_o      = (ctrl_state_q == MbxRead);
   assign mbx_sys_abort_o = (ctrl_state_q == MbxSysAbortHost);
   // The transition to the abort state marks the abort interrupt generation
-  assign mbx_irq_abort_o = (ctrl_state_d == MbxSysAbortHost);
+  assign mbx_irq_abort_o = (ctrl_state_q != MbxSysAbortHost) && (ctrl_state_d == MbxSysAbortHost);
   // The transition to the read state marks the ready interrupt generation
-  assign mbx_irq_ready_o  = (ctrl_state_d == MbxRead);
+  assign mbx_irq_ready_o = (ctrl_state_q != MbxRead) && (ctrl_state_d == MbxRead);
 
   logic ombx_set_ready, ombx_clear_ready;
   // Outbound mailbox is Ready, but only if not simultaneous with the exceptional conditions that


### PR DESCRIPTION
Instead of only using the next state signal of the FSM, we also take into account the current state, to compute the transition edge into the Read and Abort state, that generates the event for the IRQ primitive.

Closes https://github.com/lowRISC/opentitan-integrated/issues/714