### PR TITLE
[util,formal] Make sure to fail in Make if a command dies

### DIFF
--- a/hw/formal/tools/dvsim/formal.mk
+++ b/hw/formal/tools/dvsim/formal.mk
@@ -25,7 +25,9 @@ endif
 
 do_build: pre_build
 	@echo "[make]: do_build"
-	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts} 2>&1 | tee ${build_log}
+	cd ${sv_flist_gen_dir} && \
+	  set -o pipefail && \
+	  ${build_cmd} ${build_opts} 2>&1 | tee ${build_log}
 
 post_build: do_build
 	@echo "[make]: post_build"


### PR DESCRIPTION
Piping the command into tee doesn't quite work. For example:

    blargl 2>&1 | tee /dev/null
    echo $?

will print out 0 because tee passed, even though blargl doesn't exist.

Use the pipefail option to avoid this happening.