### PR TITLE
[primgen] Fix parameters in a primgen template

### DIFF
--- a/hw/ip/prim/util/primgen/abstract_prim.sv.tpl
+++ b/hw/ip/prim/util/primgen/abstract_prim.sv.tpl
@@ -24,7 +24,7 @@ ${module_header_params}
   ${module_header_ports}
 );
 % if num_techlibs > 1:
-  parameter prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
+  localparam prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
 % endif
 
 ${instances}


### PR DESCRIPTION
It turns out that the existing code would give something of this form:

    module prim_foo #(param1, param2) (arg1, arg2);
      parameter prim_pkg::impl_e Impl = `PRIM_DEFAULT_IMPL;
    endmodule

Unfortunately, SystemVerilog doesn't actually allow you to declare two lists of parameters like this. The presence of the #(param1, param2) list means that the Impl line gets turned into a localparam.

Annoyingly, JasperGold prints out a warning (presumably to tell the user that something surprising is happening!)

This patch changes the generated code so that everything goes in a formal parameter list. The result should actually be slightly more useful (because the person instantiating the object can pick the implementation), and tools will no longer spit out a warning.