### PR TITLE
[opentitanlib] Add strappings for hyper310 SPI TPM

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
@@ -217,7 +217,7 @@
       "name": "TPM",
       "bits_per_sec": 250000,
       "chip_select": "IOA7",
-      "alias_of": "QSPI"
+      "alias_of": "SPI1"
     }
   ],
   "i2c": [

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw310.json
@@ -1,6 +1,79 @@
 {
   "includes": ["/__builtin__/hyperdebug_chipwhisperer.json"],
   "interface": "hyper310",
+  "pins": [
+    {
+      "name": "SPI_DEV_SCK",
+      "mode": "Alternate",
+      "alias_of": "CN10_24"
+    },
+    {
+      "name": "SPI_DEV_D0",
+      "mode": "Alternate",
+      "alias_of": "CN10_23"
+    },
+    {
+      "name": "SPI_DEV_D1",
+      "mode": "Alternate",
+      "alias_of": "CN10_10"
+    },
+    {
+      "name": "SPI_TPM_SCK",
+      "mode": "Input",
+      "alias_of": "CN7_15"
+    },
+    {
+      "name": "SPI_TPM_MOSI",
+      "mode": "Input",
+      "alias_of": "CN7_14"
+    },
+    {
+      "name": "SPI_TPM_MISO",
+      "mode": "Input",
+      "alias_of": "CN7_12"
+    },
+    {
+      "name": "SPI_TPM_CSB",
+      "mode": "Alternate",
+      "pull_mode": "PullUp",
+      "alias_of": "IOA7"
+    }
+  ],
+  "strappings": [
+    {
+      "name": "SPI_TPM",
+      "pins": [
+        {
+          "name": "SPI_DEV_SCK",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D0",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D1",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_TPM_SCK",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_MOSI",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_MISO",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_CSB",
+          "mode": "PushPull"
+        }
+      ]
+    }
+  ],
   "spi": [
     {
       "name": "BOOTSTRAP",


### PR DESCRIPTION
The "QSPI" SPI interface is mapped to the STM32's OCTOSPI peripheral in the hyperdebug firmware, but it is incapable of performing the TPM protocol. Use SPI1 instead, and add strappings to set pins to high impedance for the unused interface, since they will both be driving the same traces.