### PR TITLE
[opentitantool] Introduce binary protocol for HyperDebug gpio monitoring

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -432,7 +432,7 @@ impl Inner {
         // Send Ctrl-C, followed by the command, then newline.  This will discard any previous
         // partial input, before executing our command.
         port.write(format!("\x03{}\n", cmd).as_bytes())
-            .context("communication error")?;
+            .context("writing to HyperDebug console")?;
 
         // Now process response from HyperDebug.  First we expect to see the echo of the command
         // we just "typed". Then zero, one or more lines of useful output, which we want to pass
@@ -458,7 +458,7 @@ impl Inner {
                                 line_end -= 1;
                             }
                             let line = std::str::from_utf8(&buf[line_start..line_end])
-                                .context("communication error")?;
+                                .context("utf8 decoding from HyperDebug console")?;
                             if seen_echo {
                                 callback(line);
                             } else if line.len() >= 2 && line[line.len() - 2..] == *"^C" {
@@ -488,7 +488,7 @@ impl Inner {
                         return Ok(());
                     }
                 }
-                Err(error) => return Err(error).context("communication error"),
+                Err(error) => return Err(error).context("reading from HyperDebug console"),
             }
         }
     }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -246,7 +246,6 @@ impl HyperdebugSpiTarget {
                 "Unrecognized reponse to GET_USB_SPI_CONFIG".to_string()
             )
         );
-        log::info!("HyperDebug feature bitmap: 0x{:04x}", resp.feature_bitmap);
 
         Ok(Self {
             inner: Rc::clone(inner),

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240112_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "71942c4aabbc93fe3ec49c631009a30028f07658b36c803b40ffb348b915abef",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240125_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "cabcd31873ba14f15b5d0a0b9ddbf510c7c6416c2f5d151aea01a0e91297c2a8",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
HyperDebug supports logic analyzer functionality, in which it will record events on a given set of gpio pins. 
 `opentitantool` can then later be used to retrieve a transcript of every level change with microsecond timestamp.

This has been used by the GSC team to verify the reaction time of firmware under test.  Such testing involve typically a few handfuls of events, which can easily be transmitted via the textual protocol. However, we now plan on using the functionality for cases with 30000 events to be retrieved, which would take many tens of seconds to inefficently transmit via the console (which runs slow enough that the physical UART can keep up).

To improve performance, this CL introduces another Google-specific extension to the binary CMSIS-DAP protocol, for GPIO operations, and adds code to replicate the `gpio monitoring read` functionality.  (Starting and stopping the monitoring can still only be done through the textual protocol, those do not carry a large amount of data.  Though there may be a 80-character limit on a single command, which could impact the ability to monitor 5 or more signals at once, so in the future we may want to allow starting monitoring also through the binary protocol.)

Corresponding HyperDebug functionality implemented here:
https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/5128914 