### PR TITLE
[prim_sha2,rtl] Add prim_sha2 RTL 

### DIFF
--- a/hw/ip/prim/lint/prim_sha2.vbl
+++ b/hw/ip/prim/lint/prim_sha2.vbl
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_sha2 pre_dv Verilator testbenches
+
+# waive long line violations in test vectors feeding
+waive --rule=line-length --location="prim_sha_multimode32_tb.sv"
+waive --rule=line-length --location="prim_sha_tb.sv"

--- a/hw/ip/prim/lint/prim_sha2.vlt
+++ b/hw/ip/prim/lint/prim_sha2.vlt
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for sha-2
+
+`verilator_config
+
+// The wipe_secret and wipe_v inputs to hmac_core and sha2_pad are not
+// currently used, but we're keeping them attached for future use.
+lint_off -rule UNUSED -file "*/rtl/prim_sha2_pad.sv" -match "Signal is not used: 'wipe_secret'"
+lint_off -rule UNUSED -file "*/rtl/prim_sha2_pad.sv" -match "Signal is not used: 'wipe_v'"

--- a/hw/ip/prim/lint/prim_sha2.waiver
+++ b/hw/ip/prim/lint/prim_sha2.waiver
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for SHA-2: prim_sha2, prim_sha2_pad, prim_sha2_32, prim_sha2_pkg
+
+waive -rules {CONST_FF RESET_ONLY PARTIAL_CONST_ASSIGN} -location {prim_sha2.sv} -regexp {processed_length\[8:0\]} \
+      -comment "lower 512bits of message are aligned. So ignoring txcount for lower 9 bits"
+waive -rules {CONST_FF RESET_ONLY PARTIAL_CONST_ASSIGN} -location {prim_sha2_pad.sv} -regexp {tx_count\[4:0\]} \
+      -comment "lower 32bits of message are aligned. So ignoring txcount for lower 5 bits"
+waive -rules {NOT_READ HIER_NET_NOT_READ CONST_OUTPUT} -location {prim_sha2_pad.sv prim_sha2.sv} \
+      -regexp {padded_length\[8:0\]} \
+      -comment "lower 512bits of padded message are 0 (always aligned message)"
+
+waive -rules {EXPLICIT_BITLEN} -location {prim_sha2.sv} -regexp {.*(0|1)} \
+      -comment "Added or subtracted by 1"
+
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_sha2_pad.sv} -regexp {wipe_(secret|v)} \
+      -comment "Not used but remained for future use"
+
+waive -rules {NOT_READ} -location {*_reg_top.sv} -regexp {(address|param|user)} \
+      -comment "Register module waiver"
+
+# ARITH_CONTEXT
+waive -rules {ARITH_CONTEXT} -location {prim_sha2.sv}     -regexp {Bitlength of arithmetic operation '.processed_length.63:9. \+ 1'b1.'} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {prim_sha2_pad.sv} -regexp {Bitlength of arithmetic operation 'tx_count.63:5. \+ 2'd1'} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {prim_sha2_pad.sv} -regexp {Bitlength of arithmetic operation 'message_length.63:9. \+ (1'b1|2'b10)'} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {prim_sha2_pkg.sv} -regexp {Bitlength of arithmetic operation 'h_i\[3\]\[31:0\] \+ temp1' is self-determined in this context} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {prim_sha2_pkg.sv} -regexp {Bitlength of arithmetic operation '\(temp1 \+ temp2\)' is self-determined in this context} \
+      -comment "Bitwidth overflow is intended"
+
+# INPUT_NOT_READ
+waive -rules {INPUT_NOT_READ} -location {prim_sha2_pkg.sv} -regexp {Input port 'h_i\[0:7\]\[63:32\]' is not read from in function 'compress_multi_256'}
+      -comment "Upper bits are only used in SHA2-384/512"
+
+
+
+# INTEGER
+waive -rules {INTEGER}        -location {prim_sha2_pkg.sv} -regexp {'amt' of type int used as a}
+waive -rules {TWO_STATE_TYPE} -location {prim_sha2_pkg.sv} -regexp {'amt' is of two state type 'int'} \
+      -comment "shift function behaves as static, it is called with constant in the design"
+waive -rules {INTEGER}        -location {prim_sha2_pkg.sv} -regexp {'amt' of type integer used as a non-constant value}
+      -comment "rotate function behaves as static function - it is called with a constant value in the design"
+
+waive -rules {INTEGER}        -location {tlul_socket_1n.sv} -regexp {'idx' of type int used} \
+      -comment "It compares with the signal and used as constant"

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -30,6 +30,7 @@ filesets:
       - lowrisc:prim:xnor2
       - lowrisc:prim:and2
       - lowrisc:prim:reg_we_check
+      - lowrisc:prim:sha2
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_sram_arbiter.sv

--- a/hw/ip/prim/prim_sha2.core
+++ b/hw/ip/prim/prim_sha2.core
@@ -1,0 +1,46 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:sha2"
+description: "SHA-2 (configurable multi-mode and 256) engine"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:sha2_pkg
+    files:
+      - rtl/prim_sha2_pad.sv
+      - rtl/prim_sha2.sv
+      - rtl/prim_sha2_32.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sha2.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sha2.waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sha2.vbl
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/prim_sha2_pkg.core
+++ b/hw/ip/prim/prim_sha2_pkg.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:sha2_pkg"
+description: "HMAC and SHA-2 package"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_sha2_pkg.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sha2.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -3,178 +3,301 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // SHA-256/384/512 configurable mode engine (64-bit word datapath)
-//
 
-module prim_sha2 import prim_sha2_pkg::*; (
+module prim_sha2 import prim_sha2_pkg::*;
+#(
+  parameter bit MultimodeEn = 0, // assert to enable multi-mode digest feature
+
+  localparam int unsigned RndWidth256 = $clog2(NumRound256),
+  localparam int unsigned RndWidth512 = $clog2(NumRound512),
+  localparam sha_word64_t ZeroWord      = '0
+ ) (
   input clk_i,
   input rst_ni,
 
-  input              wipe_secret,
-  input sha_word64_t wipe_v,
+  input               wipe_secret_i,
+  input sha_word64_t  wipe_v_i,
+  // control signals and message words input to the message FIFO
+  input               fifo_rvalid_i, // indicates that the message FIFO (prim_sync_fifo) has words
+                                     // ready to write into the SHA-2 padding buffer
+  input  sha_fifo64_t fifo_rdata_i,
+  output logic        fifo_rready_o, // indicates the internal padding buffer is ready to receive
+                                     // words from the message FIFO
+  // control signals
+  input               sha_en_i,   // if disabled, it clears internal content
+  input               hash_start_i,
+  input digest_mode_e digest_mode_i,
+  input               hash_process_i,
+  output logic        hash_done_o,
 
-  // Control signals and message words input to the message FIFO
-  input               fifo_rvalid, // indicates that the message FIFO (prim_sync_fifo) has words
-                                   // ready to write into the SHA-2 padding buffer
-  input  sha_fifo64_t fifo_rdata,
-  output logic        fifo_rready, // indicates that the internal padding buffer is ready to receive
-                                  // words from the message FIFO
-
-  // Control signals
-  input               sha_en,   // if disabled, it clears internal content
-  input               hash_start,
-  input digest_mode_e digest_mode,
-  input               hash_process,
-  output logic        hash_done,
-
-  input  [127:0]            message_length, // bits but byte based
-  output sha_word64_t [7:0] digest,
-
-  output logic idle
+  input  [127:0]            message_length_i, // bits but byte based
+  output sha_word64_t [7:0] digest_o, // tie off unused port slice when MultimodeEn = 0
+  output logic idle_o
 );
-
-  localparam int unsigned RoundWidth256 = $clog2(NumRound256);
-  localparam int unsigned RoundWidth512 = $clog2(NumRound512);
-
-  localparam sha_word64_t ZeroWord = '0;
 
   logic        msg_feed_complete;
   logic        shaf_rready;
-  sha_word64_t shaf_rdata;
   logic        shaf_rvalid;
 
-  logic [RoundWidth512-1:0] round;
-
-  logic         [3:0] w_index;
-  sha_word64_t [15:0] w;
-
-  digest_mode_e digest_mode_flag;
-
-
-  // w, hash, digest update logic control signals
+  // control signals - shared for both modes
   logic update_w_from_fifo, calculate_next_w;
-  logic init_hash, run_hash, complete_one_chunk;
+  logic init_hash, run_hash, one_chunk_done;
   logic update_digest, clear_digest;
+  logic hash_done_next; // to meet the phase with digest value
 
-  logic hash_done_next; // to meet the phase with digest value.
+  // datapath signals - shared for both modes
+  logic [RndWidth512-1:0] round_d, round_q;
+  logic [3:0]             w_index_d, w_index_q;
+  digest_mode_e           digest_mode_flag_d, digest_mode_flag_q;
+  sha_word64_t            shaf_rdata;
 
-  sha_word64_t [7:0] hash;    // a,b,c,d,e,f,g,h
+  // tie off unused input ports and signals slices
+  if (!MultimodeEn) begin : gen_tie_unused
+    logic unused_signals;
+    assign unused_signals = ^{wipe_v_i[63:32], digest_mode_i, shaf_rdata[63:32],
+                              digest_mode_flag_d, digest_mode_flag_q};
+  end
 
-  // Fill up w
-  always_ff @(posedge clk_i or negedge rst_ni) begin : fill_w
-    if (!rst_ni) begin
-      w <= '0;
-    end else if (wipe_secret) begin
-      w <= w ^ {16{wipe_v}};
-    end else if (!sha_en || hash_start) begin
-      w <= '0;
-    end else if (!run_hash && update_w_from_fifo) begin
-      // this logic runs at the first stage of SHA: hash not running yet,
-      // still filling in first 16 words
-      w <= {shaf_rdata, w[15:1]};
-    end else if (calculate_next_w) begin // message scheduling/derivation for last 48/64 rounds
-      if (digest_mode_flag == SHA2_256) begin
-        // this computes the next w[16] and shifts out w[0] into compression (see compress() below)
-        w <= {{32'b0, calc_w_256(w[0][31:0], w[1][31:0], w[9][31:0], w[14][31:0])}, w[15:1]};
-      end else if ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) begin
-        w <= {calc_w_512(w[0], w[1], w[9], w[14]), w[15:1]};
+  assign digest_mode_flag_d = hash_start_i  ? digest_mode_i   :    // latch in configured mode
+                              hash_done_o   ? None            :    // clear
+                                              digest_mode_flag_q;  // keep
+
+  if (MultimodeEn) begin : gen_multimode
+    // datapath signal definitions for multi-mode
+    sha_word64_t [7:0]  hash_d, hash_q; // a,b,c,d,e,f,g,h
+    sha_word64_t [15:0] w_d, w_q;
+    sha_word64_t [7:0]  digest_d, digest_q;
+
+    // compute w
+    always_comb begin : compute_w_multimode
+      w_d = w_q;
+      if (wipe_secret_i) begin
+        w_d = w_q ^ {16{wipe_v_i[63:0]}};
+      end else if (!sha_en_i || hash_start_i) begin
+        w_d = '0;
+      end else if (!run_hash && update_w_from_fifo) begin
+        // this logic runs at the first stage of SHA: hash not running yet,
+        // still filling in first 16 words
+        w_d = {shaf_rdata, w_q[15:1]};
+      end else if (calculate_next_w) begin // message scheduling/derivation for last 48/64 rounds
+        if (digest_mode_flag_q == SHA2_256) begin
+          // this computes the next w[16] and shifts out w[0] into compression below
+          w_d = {{32'b0, calc_w_256(w_q[0][31:0], w_q[1][31:0], w_q[9][31:0],
+                w_q[14][31:0])}, w_q[15:1]};
+        end else if ((digest_mode_flag_q == SHA2_384) || (digest_mode_flag_q == SHA2_512)) begin
+          w_d = {calc_w_512(w_q[0], w_q[1], w_q[9], w_q[14]), w_q[15:1]};
+        end
+      end else if (run_hash) begin
+        // just shift-out the words as they get consumed. There's no incoming data.
+        w_d = {ZeroWord, w_q[15:1]};
       end
-    end else if (run_hash) begin
-      // Just shift-out the words as they get consumed. There's no incoming data.
-      w <= {ZeroWord, w[15:1]};
-    end
-  end : fill_w
+    end : compute_w_multimode
 
-  // Update engine
-  always_ff @(posedge clk_i or negedge rst_ni) begin : compress_round
-    if (!rst_ni) begin
-      hash <= '{default:'0};
-    end else if (wipe_secret) begin
-      for (int i = 0 ; i < 8 ; i++) begin
-        hash[i] <= hash[i] ^ wipe_v;
-      end
-    end else if (init_hash) begin
-      hash <= digest;
-    end else if (run_hash) begin
-      if (digest_mode_flag == SHA2_256) begin
-        hash <= compress_256( w[0][31:0], CubicRootPrime256[round[RoundWidth256-1:0]], hash);
-      end else if ((digest_mode_flag == SHA2_512) || (digest_mode_flag == SHA2_384)) begin
-        hash <= compress_512( w[0], CubicRootPrime512[round], hash);
-      end
-    end
-  end : compress_round
+    // update w
+    always_ff @(posedge clk_i or negedge rst_ni) begin : update_w_multimode
+      if (!rst_ni)            w_q <= '0;
+      else if (MultimodeEn)   w_q <= w_d;
+    end : update_w_multimode
 
-  // Digest
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      digest <= '{default: '0};
-    end else if (wipe_secret) begin
-      for (int i = 0 ; i < 8 ; i++) begin
-        digest[i] <= digest[i] ^ wipe_v;
-      end
-    end else if (hash_start) begin
-      for (int i = 0 ; i < 8 ; i++) begin
-        if (digest_mode == SHA2_256) begin
-          digest[i] <= {32'b0, InitHash_256[i]};
-        end else if (digest_mode == SHA2_384) begin
-          digest[i] <= InitHash_384[i];
-        end else if (digest_mode == SHA2_512) begin
-          digest[i] <= InitHash_512[i];
+    // compute hash
+    always_comb begin : compression_multimode
+      hash_d = hash_q;
+      if (wipe_secret_i) begin
+        for (int i = 0; i < 8; i++) begin
+          hash_d[i] = hash_q[i] ^ wipe_v_i;
+        end
+      end else if (init_hash) begin
+        hash_d = digest_q;
+      end else if (run_hash) begin
+        if (digest_mode_flag_q == SHA2_256) begin
+          hash_d = compress_multi_256(w_q[0][31:0],
+                   CubicRootPrime256[round_q[RndWidth256-1:0]], hash_q);
+        end else if ((digest_mode_flag_q == SHA2_512) || (digest_mode_flag_q == SHA2_384)) begin
+          hash_d = compress_512(w_q[0], CubicRootPrime512[round_q], hash_q);
         end
       end
-    end else if (!sha_en || clear_digest) begin
-      digest <= '0;
-    end else if (update_digest) begin
-      for (int i = 0 ; i < 8 ; i++) begin
-        digest[i] <= digest[i] + hash[i];
+    end : compression_multimode
+
+    // update hash
+    always_ff @(posedge clk_i or negedge rst_ni) begin : update_hash_multimode
+      if (!rst_ni)  hash_q <= '0;
+      else          hash_q <= hash_d;
+    end : update_hash_multimode
+
+    // compute digest
+    always_comb begin : compute_digest_multimode
+      digest_d = digest_q;
+      if (wipe_secret_i) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+          digest_d[i] = digest_q[i] ^ wipe_v_i;
+        end
+      end else if (hash_start_i) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+          if (digest_mode_i == SHA2_256) begin
+            digest_d[i] = {32'b0, InitHash_256[i]};
+          end else if (digest_mode_i == SHA2_384) begin
+            digest_d[i] = InitHash_384[i];
+          end else if (digest_mode_i == SHA2_512) begin
+            digest_d[i] = InitHash_512[i];
+          end
+        end
+      end else if (!sha_en_i || clear_digest) begin
+        digest_d = '0;
+      end else if (update_digest) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+          digest_d[i] = digest_q[i] + hash_q[i];
+        end
+        if (hash_done_o == 1'b1 && digest_mode_flag_q == SHA2_384) begin
+          // final digest truncation for SHA-2 384
+          digest_d[6] = '0;
+          digest_d[7] = '0;
+        end else if (hash_done_o == 1'b1 && digest_mode_flag_q == SHA2_256) begin
+          // make sure to clear out most significant 32-bits of each digest word (zero-padding)
+          for (int i = 0 ; i < 8 ; i++) begin
+            digest_d[i][63:32] = 32'b0;
+          end
+        end
       end
-      if (hash_done == 1'b1 && digest_mode_flag == SHA2_384) begin
-        // final digest truncation for SHA-2 384
-        digest[6] <= '0;
-        digest[7] <= '0;
-      end else if (hash_done == 1'b1 && digest_mode_flag == SHA2_256) begin
-        // make sure to clear out most significant 32-bits of each digest word (zero-padding)
-        digest[0][63:32] <= '0;
-        digest[1][63:32] <= '0;
-        digest[2][63:32] <= '0;
-        digest[3][63:32] <= '0;
-        digest[4][63:32] <= '0;
-        digest[5][63:32] <= '0;
-        digest[6][63:32] <= '0;
-        digest[7][63:32] <= '0;
+    end : compute_digest_multimode
+
+    // update digest
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni)  digest_q <= '0;
+      else          digest_q <= digest_d;
+    end
+
+    // assign digest to output
+    assign digest_o = digest_q;
+
+  end else begin : gen_256 // MultimodeEn = 0
+    // datapath signal definitions for SHA-2 256 only
+    sha_word32_t        shaf_rdata256;
+    sha_word32_t [7:0]  hash256_d, hash256_q; // a,b,c,d,e,f,g,h
+    sha_word32_t [15:0] w256_d, w256_q;
+    sha_word32_t [7:0]  digest256_d, digest256_q;
+
+    assign shaf_rdata256 = shaf_rdata[31:0];
+
+    always_comb begin : compute_w_256
+      // ~MultimodeEn
+      w256_d = w256_q;
+      if (wipe_secret_i) begin
+        w256_d = w256_q ^ {16{wipe_v_i[31:0]}};
+      end else if (!sha_en_i || hash_start_i) begin
+        w256_d = '0;
+      end else if (!run_hash && update_w_from_fifo) begin
+        // this logic runs at the first stage of SHA: hash not running yet,
+        // still filling in first 16 words
+        w256_d = {shaf_rdata256, w256_q[15:1]};
+      end else if (calculate_next_w) begin // message scheduling/derivation for last 48/64 rounds
+        w256_d = {calc_w_256(w256_q[0][31:0], w256_q[1][31:0], w256_q[9][31:0],
+                 w256_q[14][31:0]), w256_q[15:1]};
+      end else if (run_hash) begin
+        // just shift-out the words as they get consumed. There's no incoming data.
+        w256_d = {ZeroWord[31:0], w256_q[15:1]};
       end
+    end : compute_w_256
+
+    // update w_256
+    always_ff @(posedge clk_i or negedge rst_ni) begin : update_w_256
+      if (!rst_ni)            w256_q <= '0;
+      else if (!MultimodeEn)  w256_q <= w256_d;
+    end : update_w_256
+
+    // compute hash_256
+    always_comb begin : compression_256
+      hash256_d = hash256_q;
+      if (wipe_secret_i) begin
+        for (int i = 0; i < 8; i++) begin
+          hash256_d[i] = hash256_q[i] ^ wipe_v_i[31:0];
+        end
+      end else if (init_hash) begin
+        hash256_d = digest256_q;
+      end else if (run_hash) begin
+        hash256_d = compress_256(w256_q[0], CubicRootPrime256[round_q[RndWidth256-1:0]], hash256_q);
+      end
+    end : compression_256
+
+    // update hash_256
+    always_ff @(posedge clk_i or negedge rst_ni) begin : update_hash256
+      if (!rst_ni) hash256_q <= '0;
+      else         hash256_q <= hash256_d;
+    end : update_hash256
+
+    // compute digest_256
+    always_comb begin : compute_digest_256
+      digest256_d = digest256_q;
+      if (wipe_secret_i) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+          digest256_d[i] = digest256_q[i] ^ wipe_v_i[31:0];
+        end
+      end else if (hash_start_i) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+            digest256_d[i] = InitHash_256[i];
+        end
+      end else if (!sha_en_i || clear_digest) begin
+        digest256_d = '0;
+      end else if (update_digest) begin
+        for (int i = 0 ; i < 8 ; i++) begin
+          digest256_d[i] = digest256_q[i] + hash256_q[i];
+        end
+      end
+    end : compute_digest_256
+
+    // update digest_256
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni)  digest256_q <= '0;
+      else          digest256_q <= digest256_d;
+    end
+
+    // assign digest to output
+    for (genvar i = 0; i < 8; i++) begin  : gen_assign_digest_256
+      assign digest_o[i][31:0]  = digest256_q[i];
+      assign digest_o[i][63:32] = 32'b0;
     end
   end
 
-  // round counter
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      round <= '0;
-    end else if (!sha_en || hash_start) begin
-      round <= '0;
+  // compute round counter (shared)
+  always_comb begin : round_counter
+    round_d = round_q;
+    if (!sha_en_i || hash_start_i) begin
+      round_d = '0;
     end else if (run_hash) begin
-      if (((round[RoundWidth256-1:0] == RoundWidth256'(unsigned'(NumRound256-1))) &&
-         digest_mode_flag == SHA2_256) || ((round == RoundWidth512'(unsigned'(NumRound512-1))) &&
-         ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)))) begin
-        round <= '0;
+      if (((round_q[RndWidth256-1:0] == RndWidth256'(unsigned'(NumRound256-1))) &&
+         (digest_mode_flag_q == SHA2_256 || !MultimodeEn)) ||
+         ((round_q == RndWidth512'(unsigned'(NumRound512-1))) &&
+         ((digest_mode_flag_q == SHA2_384) || (digest_mode_flag_q == SHA2_512)))) begin
+        round_d = '0;
       end else begin
-        round <= round + 1;
+        round_d = round_q + 1;
       end
     end
+    // assign most significant bit round_d (and consequently round_q) to constant 0
+    if (!MultimodeEn) round_d[RndWidth512-1] = 'b0;
   end
 
-  // w_index
+  // update round counter (shared)
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if      (!rst_ni)               w_index <= '0;
-    else if (!sha_en || hash_start) w_index <= '0;
-    else if (update_w_from_fifo)    w_index <= w_index + 1;
+    if (!rst_ni) round_q <= '0;
+    else         round_q <= round_d;
+  end
+
+  // compute w_index (shared)
+  assign w_index_d = (~sha_en_i || hash_start_i)  ? '0            :  // clear
+                     update_w_from_fifo           ? w_index_q + 1 :  // increment
+                                                    w_index_q;       // keep
+  // update w_index (shared)
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) w_index_q <= '0;
+    else         w_index_q <= w_index_d;
   end
 
   // ready for a word from the padding buffer in sha2_pad
   assign shaf_rready = update_w_from_fifo;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) hash_done <= 1'b0;
-    else         hash_done <= hash_done_next;
+    if (!rst_ni) hash_done_o <= 1'b0;
+    else         hash_done_o <= hash_done_next;
   end
 
   typedef enum logic [1:0] {
@@ -187,31 +310,26 @@ module prim_sha2 import prim_sha2_pkg::*; (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if      (!rst_ni)    fifo_st_q <= FifoIdle;
-    else if (!sha_en)    fifo_st_q <= FifoIdle;
-    else if (hash_start) fifo_st_q <= FifoLoadFromFifo;
     else                 fifo_st_q <= fifo_st_d;
   end
 
   always_comb begin
-    fifo_st_d = FifoIdle;
+    fifo_st_d          = FifoIdle;
     update_w_from_fifo = 1'b0;
-    hash_done_next = 1'b0;
+    hash_done_next     = 1'b0;
 
     unique case (fifo_st_q)
       FifoIdle: begin
-        if (hash_start) fifo_st_d = FifoLoadFromFifo;
-        else fifo_st_d = FifoIdle;
+        if (hash_start_i) fifo_st_d = FifoLoadFromFifo;
+        else              fifo_st_d = FifoIdle;
       end
 
       FifoLoadFromFifo: begin
-        if (!sha_en) begin
-          fifo_st_d          = FifoIdle;
-          update_w_from_fifo = 1'b0;
-        end else if (!shaf_rvalid) begin
+        if (!shaf_rvalid) begin
           // Wait until it is filled
           fifo_st_d          = FifoLoadFromFifo;
           update_w_from_fifo = 1'b0;
-        end else if (w_index == 4'd 15) begin
+        end else if (w_index_q == 4'd 15) begin
           fifo_st_d = FifoWait;
           // To increment w_index and it rolls over to 0
           update_w_from_fifo = 1'b1;
@@ -222,15 +340,14 @@ module prim_sha2 import prim_sha2_pkg::*; (
       end
 
       FifoWait: begin
-        // Wait until next fetch begins (begin at round == 48)
-        if (msg_feed_complete && complete_one_chunk) begin
-          fifo_st_d = FifoIdle;
+        if (msg_feed_complete && one_chunk_done) begin
+          fifo_st_d      = FifoIdle;
           // hashing the full message is done
           hash_done_next = 1'b1;
-        end else if (complete_one_chunk) begin
-          fifo_st_d = FifoLoadFromFifo;
+        end else if (one_chunk_done) begin
+          fifo_st_d      = FifoLoadFromFifo;
         end else begin
-          fifo_st_d = FifoWait;
+          fifo_st_d      = FifoWait;
         end
       end
 
@@ -238,16 +355,21 @@ module prim_sha2 import prim_sha2_pkg::*; (
         fifo_st_d = FifoIdle;
       end
     endcase
+
+    if (!sha_en_i)  begin
+      fifo_st_d          = FifoIdle;
+      update_w_from_fifo = 1'b0;
+    end else if (hash_start_i) begin
+      fifo_st_d          = FifoLoadFromFifo;
+    end
   end
 
-  // Latch SHA-2 configured mode at hash_start
-   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)         digest_mode_flag <= None;
-    else if (hash_start) digest_mode_flag <= digest_mode;
-    else if (hash_done)  digest_mode_flag <= None;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) digest_mode_flag_q <= None;
+    else         digest_mode_flag_q <= digest_mode_flag_d;
   end
 
-  // SHA control
+  // SHA control (shared)
   typedef enum logic [1:0] {
     ShaIdle,
     ShaCompress,
@@ -257,36 +379,36 @@ module prim_sha2 import prim_sha2_pkg::*; (
   sha_st_t sha_st_q, sha_st_d;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                    sha_st_q <= ShaIdle;
-    else if (!sha_en || hash_start) sha_st_q <= ShaIdle;
-    else                            sha_st_q <= sha_st_d;
+    if (!rst_ni) sha_st_q <= ShaIdle;
+    else         sha_st_q <= sha_st_d;
   end
 
-  assign clear_digest = hash_start;
+  assign clear_digest = hash_start_i;
 
   always_comb begin
     update_digest    = 1'b0;
     calculate_next_w = 1'b0;
     init_hash        = 1'b0;
     run_hash         = 1'b0;
+    sha_st_d         = sha_st_q;
 
     unique case (sha_st_q)
       ShaIdle: begin
         if (fifo_st_q == FifoWait) begin
           init_hash = 1'b1;
-          sha_st_d = ShaCompress;
+          sha_st_d  = ShaCompress;
         end else begin
-          sha_st_d = ShaIdle;
+          sha_st_d  = ShaIdle;
         end
       end
 
       ShaCompress: begin
         run_hash = 1'b1;
-        if ((digest_mode_flag == SHA2_256 && round < 48) ||
-           (((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) && round < 64)) begin
+        if (((digest_mode_flag_q == SHA2_256 || ~MultimodeEn) && round_q < 48) ||
+           (((digest_mode_flag_q == SHA2_384) ||
+           (digest_mode_flag_q == SHA2_512)) && round_q < 64)) begin
           calculate_next_w = 1'b1;
-        end
-        if (complete_one_chunk) begin
+        end else if (one_chunk_done) begin
           sha_st_d = ShaUpdateDigest;
         end else begin
           sha_st_d = ShaCompress;
@@ -307,34 +429,35 @@ module prim_sha2 import prim_sha2_pkg::*; (
         sha_st_d = ShaIdle;
       end
     endcase
+
+    if (!sha_en_i || hash_start_i) sha_st_d  = ShaIdle;
   end
 
-  assign complete_one_chunk = ((digest_mode_flag == SHA2_256) && (round == 7'd63)) ? 1'b1 :
-                              (((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512))
-                              && (round == 7'd79)) ? 1'b1 : 1'b0;
+  assign one_chunk_done = ((digest_mode_flag_q == SHA2_256 || ~MultimodeEn)
+                          && (round_q == 7'd63)) ? 1'b1 :
+                          (((digest_mode_flag_q == SHA2_384) || (digest_mode_flag_q == SHA2_512))
+                          && (round_q == 7'd79)) ? 1'b1 : 1'b0;
 
-  sha2_multimode_pad u_pad (
+  prim_sha2_pad #(
+      .MultimodeEn(MultimodeEn)
+    ) u_pad (
     .clk_i,
     .rst_ni,
-
-    .fifo_rvalid,
-    .fifo_rdata,
-    .fifo_rready,
-
-    .shaf_rvalid, // set when the 512-bit chunk is ready in the padding buffer and can load into w
-    .shaf_rdata,
-    .shaf_rready, // indicates that w is ready for more words from padding buffer
-
-    .sha_en,
-    .hash_start,
-    .digest_mode,
-    .hash_process,
-    .hash_done,
-
-    .message_length,
-    .msg_feed_complete
+    .fifo_rvalid_i,
+    .fifo_rdata_i,
+    .fifo_rready_o,
+    .shaf_rvalid_o (shaf_rvalid), // is set when the 512-bit chunk is ready in the padding buffer
+    .shaf_rdata_o  (shaf_rdata),
+    .shaf_rready_i (shaf_rready), // indicates that w is ready for more words from padding buffer
+    .sha_en_i,
+    .hash_start_i,
+    .digest_mode_i,
+    .hash_process_i,
+    .hash_done_o,
+    .message_length_i,
+    .msg_feed_complete_o (msg_feed_complete)
   );
 
   // Idle
-  assign idle = (fifo_st_q == FifoIdle) && (sha_st_q == ShaIdle) && !hash_start;
-endmodule : sha2_multimode
+  assign idle_o = (fifo_st_q == FifoIdle) && (sha_st_q == ShaIdle) && !hash_start_i;
+endmodule : prim_sha2

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -1,0 +1,340 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SHA-256/384/512 configurable mode engine (64-bit word datapath)
+//
+
+module prim_sha2 import prim_sha2_pkg::*; (
+  input clk_i,
+  input rst_ni,
+
+  input              wipe_secret,
+  input sha_word64_t wipe_v,
+
+  // Control signals and message words input to the message FIFO
+  input               fifo_rvalid, // indicates that the message FIFO (prim_sync_fifo) has words
+                                   // ready to write into the SHA-2 padding buffer
+  input  sha_fifo64_t fifo_rdata,
+  output logic        fifo_rready, // indicates that the internal padding buffer is ready to receive
+                                  // words from the message FIFO
+
+  // Control signals
+  input               sha_en,   // if disabled, it clears internal content
+  input               hash_start,
+  input digest_mode_e digest_mode,
+  input               hash_process,
+  output logic        hash_done,
+
+  input  [127:0]            message_length, // bits but byte based
+  output sha_word64_t [7:0] digest,
+
+  output logic idle
+);
+
+  localparam int unsigned RoundWidth256 = $clog2(NumRound256);
+  localparam int unsigned RoundWidth512 = $clog2(NumRound512);
+
+  localparam sha_word64_t ZeroWord = '0;
+
+  logic        msg_feed_complete;
+  logic        shaf_rready;
+  sha_word64_t shaf_rdata;
+  logic        shaf_rvalid;
+
+  logic [RoundWidth512-1:0] round;
+
+  logic         [3:0] w_index;
+  sha_word64_t [15:0] w;
+
+  digest_mode_e digest_mode_flag;
+
+
+  // w, hash, digest update logic control signals
+  logic update_w_from_fifo, calculate_next_w;
+  logic init_hash, run_hash, complete_one_chunk;
+  logic update_digest, clear_digest;
+
+  logic hash_done_next; // to meet the phase with digest value.
+
+  sha_word64_t [7:0] hash;    // a,b,c,d,e,f,g,h
+
+  // Fill up w
+  always_ff @(posedge clk_i or negedge rst_ni) begin : fill_w
+    if (!rst_ni) begin
+      w <= '0;
+    end else if (wipe_secret) begin
+      w <= w ^ {16{wipe_v}};
+    end else if (!sha_en || hash_start) begin
+      w <= '0;
+    end else if (!run_hash && update_w_from_fifo) begin
+      // this logic runs at the first stage of SHA: hash not running yet,
+      // still filling in first 16 words
+      w <= {shaf_rdata, w[15:1]};
+    end else if (calculate_next_w) begin // message scheduling/derivation for last 48/64 rounds
+      if (digest_mode_flag == SHA2_256) begin
+        // this computes the next w[16] and shifts out w[0] into compression (see compress() below)
+        w <= {{32'b0, calc_w_256(w[0][31:0], w[1][31:0], w[9][31:0], w[14][31:0])}, w[15:1]};
+      end else if ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) begin
+        w <= {calc_w_512(w[0], w[1], w[9], w[14]), w[15:1]};
+      end
+    end else if (run_hash) begin
+      // Just shift-out the words as they get consumed. There's no incoming data.
+      w <= {ZeroWord, w[15:1]};
+    end
+  end : fill_w
+
+  // Update engine
+  always_ff @(posedge clk_i or negedge rst_ni) begin : compress_round
+    if (!rst_ni) begin
+      hash <= '{default:'0};
+    end else if (wipe_secret) begin
+      for (int i = 0 ; i < 8 ; i++) begin
+        hash[i] <= hash[i] ^ wipe_v;
+      end
+    end else if (init_hash) begin
+      hash <= digest;
+    end else if (run_hash) begin
+      if (digest_mode_flag == SHA2_256) begin
+        hash <= compress_256( w[0][31:0], CubicRootPrime256[round[RoundWidth256-1:0]], hash);
+      end else if ((digest_mode_flag == SHA2_512) || (digest_mode_flag == SHA2_384)) begin
+        hash <= compress_512( w[0], CubicRootPrime512[round], hash);
+      end
+    end
+  end : compress_round
+
+  // Digest
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      digest <= '{default: '0};
+    end else if (wipe_secret) begin
+      for (int i = 0 ; i < 8 ; i++) begin
+        digest[i] <= digest[i] ^ wipe_v;
+      end
+    end else if (hash_start) begin
+      for (int i = 0 ; i < 8 ; i++) begin
+        if (digest_mode == SHA2_256) begin
+          digest[i] <= {32'b0, InitHash_256[i]};
+        end else if (digest_mode == SHA2_384) begin
+          digest[i] <= InitHash_384[i];
+        end else if (digest_mode == SHA2_512) begin
+          digest[i] <= InitHash_512[i];
+        end
+      end
+    end else if (!sha_en || clear_digest) begin
+      digest <= '0;
+    end else if (update_digest) begin
+      for (int i = 0 ; i < 8 ; i++) begin
+        digest[i] <= digest[i] + hash[i];
+      end
+      if (hash_done == 1'b1 && digest_mode_flag == SHA2_384) begin
+        // final digest truncation for SHA-2 384
+        digest[6] <= '0;
+        digest[7] <= '0;
+      end else if (hash_done == 1'b1 && digest_mode_flag == SHA2_256) begin
+        // make sure to clear out most significant 32-bits of each digest word (zero-padding)
+        digest[0][63:32] <= '0;
+        digest[1][63:32] <= '0;
+        digest[2][63:32] <= '0;
+        digest[3][63:32] <= '0;
+        digest[4][63:32] <= '0;
+        digest[5][63:32] <= '0;
+        digest[6][63:32] <= '0;
+        digest[7][63:32] <= '0;
+      end
+    end
+  end
+
+  // round counter
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      round <= '0;
+    end else if (!sha_en || hash_start) begin
+      round <= '0;
+    end else if (run_hash) begin
+      if (((round[RoundWidth256-1:0] == RoundWidth256'(unsigned'(NumRound256-1))) &&
+         digest_mode_flag == SHA2_256) || ((round == RoundWidth512'(unsigned'(NumRound512-1))) &&
+         ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)))) begin
+        round <= '0;
+      end else begin
+        round <= round + 1;
+      end
+    end
+  end
+
+  // w_index
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if      (!rst_ni)               w_index <= '0;
+    else if (!sha_en || hash_start) w_index <= '0;
+    else if (update_w_from_fifo)    w_index <= w_index + 1;
+  end
+
+  // ready for a word from the padding buffer in sha2_pad
+  assign shaf_rready = update_w_from_fifo;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) hash_done <= 1'b0;
+    else         hash_done <= hash_done_next;
+  end
+
+  typedef enum logic [1:0] {
+    FifoIdle,
+    FifoLoadFromFifo,
+    FifoWait
+  } fifoctl_state_e;
+
+  fifoctl_state_e fifo_st_q, fifo_st_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if      (!rst_ni)    fifo_st_q <= FifoIdle;
+    else if (!sha_en)    fifo_st_q <= FifoIdle;
+    else if (hash_start) fifo_st_q <= FifoLoadFromFifo;
+    else                 fifo_st_q <= fifo_st_d;
+  end
+
+  always_comb begin
+    fifo_st_d = FifoIdle;
+    update_w_from_fifo = 1'b0;
+    hash_done_next = 1'b0;
+
+    unique case (fifo_st_q)
+      FifoIdle: begin
+        if (hash_start) fifo_st_d = FifoLoadFromFifo;
+        else fifo_st_d = FifoIdle;
+      end
+
+      FifoLoadFromFifo: begin
+        if (!sha_en) begin
+          fifo_st_d          = FifoIdle;
+          update_w_from_fifo = 1'b0;
+        end else if (!shaf_rvalid) begin
+          // Wait until it is filled
+          fifo_st_d          = FifoLoadFromFifo;
+          update_w_from_fifo = 1'b0;
+        end else if (w_index == 4'd 15) begin
+          fifo_st_d = FifoWait;
+          // To increment w_index and it rolls over to 0
+          update_w_from_fifo = 1'b1;
+        end else begin
+          fifo_st_d          = FifoLoadFromFifo;
+          update_w_from_fifo = 1'b1;
+        end
+      end
+
+      FifoWait: begin
+        // Wait until next fetch begins (begin at round == 48)
+        if (msg_feed_complete && complete_one_chunk) begin
+          fifo_st_d = FifoIdle;
+          // hashing the full message is done
+          hash_done_next = 1'b1;
+        end else if (complete_one_chunk) begin
+          fifo_st_d = FifoLoadFromFifo;
+        end else begin
+          fifo_st_d = FifoWait;
+        end
+      end
+
+      default: begin
+        fifo_st_d = FifoIdle;
+      end
+    endcase
+  end
+
+  // Latch SHA-2 configured mode at hash_start
+   always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)         digest_mode_flag <= None;
+    else if (hash_start) digest_mode_flag <= digest_mode;
+    else if (hash_done)  digest_mode_flag <= None;
+  end
+
+  // SHA control
+  typedef enum logic [1:0] {
+    ShaIdle,
+    ShaCompress,
+    ShaUpdateDigest
+  } sha_st_t;
+
+  sha_st_t sha_st_q, sha_st_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                    sha_st_q <= ShaIdle;
+    else if (!sha_en || hash_start) sha_st_q <= ShaIdle;
+    else                            sha_st_q <= sha_st_d;
+  end
+
+  assign clear_digest = hash_start;
+
+  always_comb begin
+    update_digest    = 1'b0;
+    calculate_next_w = 1'b0;
+    init_hash        = 1'b0;
+    run_hash         = 1'b0;
+
+    unique case (sha_st_q)
+      ShaIdle: begin
+        if (fifo_st_q == FifoWait) begin
+          init_hash = 1'b1;
+          sha_st_d = ShaCompress;
+        end else begin
+          sha_st_d = ShaIdle;
+        end
+      end
+
+      ShaCompress: begin
+        run_hash = 1'b1;
+        if ((digest_mode_flag == SHA2_256 && round < 48) ||
+           (((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) && round < 64)) begin
+          calculate_next_w = 1'b1;
+        end
+        if (complete_one_chunk) begin
+          sha_st_d = ShaUpdateDigest;
+        end else begin
+          sha_st_d = ShaCompress;
+        end
+      end
+
+      ShaUpdateDigest: begin
+        update_digest = 1'b1;
+        if (fifo_st_q == FifoWait) begin
+          init_hash = 1'b1;
+          sha_st_d  = ShaCompress;
+        end else begin
+          sha_st_d = ShaIdle;
+        end
+      end
+
+      default: begin
+        sha_st_d = ShaIdle;
+      end
+    endcase
+  end
+
+  assign complete_one_chunk = ((digest_mode_flag == SHA2_256) && (round == 7'd63)) ? 1'b1 :
+                              (((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512))
+                              && (round == 7'd79)) ? 1'b1 : 1'b0;
+
+  sha2_multimode_pad u_pad (
+    .clk_i,
+    .rst_ni,
+
+    .fifo_rvalid,
+    .fifo_rdata,
+    .fifo_rready,
+
+    .shaf_rvalid, // set when the 512-bit chunk is ready in the padding buffer and can load into w
+    .shaf_rdata,
+    .shaf_rready, // indicates that w is ready for more words from padding buffer
+
+    .sha_en,
+    .hash_start,
+    .digest_mode,
+    .hash_process,
+    .hash_done,
+
+    .message_length,
+    .msg_feed_complete
+  );
+
+  // Idle
+  assign idle = (fifo_st_q == FifoIdle) && (sha_st_q == ShaIdle) && !hash_start;
+endmodule : sha2_multimode

--- a/hw/ip/prim/rtl/prim_sha2_32.sv
+++ b/hw/ip/prim/rtl/prim_sha2_32.sv
@@ -2,204 +2,259 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// 32-bit input wrapper for the SHA-2 multi-mode engine
-//
+// 32-bit input wrapper for the SHA-2 engine
 
-module prim_sha2_32 import prim_sha2_pkg::*; (
+module prim_sha2_32 import prim_sha2_pkg::*;
+#(
+  parameter bit MultimodeEn = 0 // assert to enable multi-mode feature
+ ) (
   input clk_i,
   input rst_ni,
 
-  input              wipe_secret,
-  input sha_word32_t wipe_v,
-
+  input              wipe_secret_i,
+  input sha_word32_t wipe_v_i,
   // Control signals and message words input to the message FIFO
-  input               fifo_rvalid,      // indicates that there are data words/word parts
-                                        // fifo_rdata ready to write into the SHA-2 padding buffer
-  input  sha_fifo32_t fifo_rdata,
-  output logic        word_buffer_ready, // indicates that the wrapper word accumulation buffer is
-                                         // ready to receive words to feed into the SHA-2 engine
-
+  input               fifo_rvalid_i,      // indicates that there are data words/word parts
+                                          // ready to write into the SHA-2 padding buffer
+  input  sha_fifo32_t fifo_rdata_i,
+  output logic        fifo_rready_o,      // indicates that the wrapper word accumulation buffer is
+                                        // ready to receive words to feed into the SHA-2 engine
   // Control signals
-  input                sha_en,   // if disabled, it clears internal content
-  input                hash_start,
-  input digest_mode_e  digest_mode,
-  input                hash_process,
-  output logic         hash_done,
-
-  input [127:0]             message_length,   // keep message length 128 bits (bits but byte based)
-  output sha_word64_t [7:0] digest,
-  output logic              idle
+  input                     sha_en_i, // if disabled, it clears internal content
+  input                     hash_start_i,
+  input digest_mode_e       digest_mode_i,
+  input                     hash_process_i,
+  output logic              hash_done_o,
+  input [127:0]             message_length_i, // use extended message length 128 bits
+  output sha_word64_t [7:0] digest_o,         // use extended digest length
+  output logic              idle_o
 );
-
-  sha_fifo64_t  word_buffer_d, word_buffer_q;
+  // signal definitions shared for both 256-bit and multi-mode
   sha_fifo64_t  full_word;
-  logic [1:0]   word_part_count;
-  logic         word_part_inc, word_part_reset;
-  logic         sha_process, process_flag;
-  logic         word_valid, sha_ready;
-  digest_mode_e digest_mode_flag;
+  logic sha_ready;
 
-  always_comb begin : accumulate_word
-    word_part_inc                 = 1'b0;
-    word_part_reset               = 1'b0;
-    full_word.mask                = 8'hFF; // to keep the padding buffer ready to receive
-    full_word.data                = 64'h0;
-    sha_process                   = 1'b0;
-    word_valid                    = 1'b0;
-    word_buffer_ready             = 1'b0;
-    word_buffer_d                 = word_buffer_q;
+  // tie off unused ports/port slices
+  if (!MultimodeEn) begin : gen_tie_unused
+    logic unused_signals;
+    assign unused_signals = ^{message_length_i[127:64],digest_mode_i};
+  end
 
-    if (sha_en && fifo_rvalid) begin // valid incoming word part and SHA engine is enabled
-      if (word_part_count == 2'b00) begin
-        if (digest_mode_flag != SHA2_256) begin
-          // accumulate most significant 32 bits of word and mask bits
-          word_buffer_d.data[63:32] = fifo_rdata.data;
-          word_buffer_d.mask[7:4]   = fifo_rdata.mask;
-          word_part_inc             =  1'b1;
-          word_buffer_ready         = 1'b1;
-          if (hash_process || process_flag) begin // ready to push out word (partial)
-            word_valid      = 1'b1;
-            // add least significant padding
-            full_word.data  =  {fifo_rdata.data, 32'b0};
-            full_word.mask  =  {fifo_rdata.mask, 4'h0};
-            sha_process     = 1'b1;
+  // logic and prim_sha2 instantiation for MultimodeEn = 1
+  if (MultimodeEn) begin : gen_multimode_logic
+    // signal definitions for multi-mode
+    sha_fifo64_t  word_buffer_d, word_buffer_q;
+    logic [1:0]   word_part_count_d, word_part_count_q;
+    logic         sha_process, process_flag_d, process_flag_q;
+    logic         word_valid;
+    logic         word_part_inc, word_part_reset;
+    digest_mode_e digest_mode_flag_d, digest_mode_flag_q;
+
+    always_comb begin : multimode_combinational
+      word_part_inc                 = 1'b0;
+      word_part_reset               = 1'b0;
+      full_word.mask                = 8'hFF; // to keep the padding buffer ready to receive
+      full_word.data                = 64'h0;
+      sha_process                   = 1'b0;
+      word_valid                    = 1'b0;
+      fifo_rready_o                 = 1'b0;
+
+      // assign word_buffer
+      if (!sha_en_i || hash_start_i) word_buffer_d = 0;
+      else                           word_buffer_d = word_buffer_q;
+
+      if (sha_en_i && fifo_rvalid_i) begin // valid incoming word part and SHA engine is enabled
+        if (word_part_count_q == 2'b00) begin
+          if (digest_mode_flag_q != SHA2_256) begin
+            // accumulate most significant 32 bits of word and mask bits
+            word_buffer_d.data[63:32] = fifo_rdata_i.data;
+            word_buffer_d.mask[7:4]   = fifo_rdata_i.mask;
+            word_part_inc             = 1'b1;
+            fifo_rready_o             = 1'b1;
+            if (hash_process_i || process_flag_q) begin // ready to push out word (partial)
+              word_valid      = 1'b1;
+              // add least significant padding
+              full_word.data  =  {fifo_rdata_i.data, 32'b0};
+              full_word.mask  =  {fifo_rdata_i.mask, 4'h0};
+              sha_process     = 1'b1;
+              if (sha_ready == 1'b1) begin
+                // if word has been absorbed into hash engine
+                fifo_rready_o = 1'b1; // word pushed out to SHA engine, word buffer ready
+                word_part_inc = 1'b0;
+              end else begin
+                fifo_rready_o = 1'b0;
+              end
+            end
+          end else begin   // SHA2_256 so pad and push out the word
+            word_valid = 1'b1;
+            // store the word with most significant padding
+            word_buffer_d.data = {32'b0, fifo_rdata_i.data};
+            word_buffer_d.mask = {4'hF, fifo_rdata_i.mask}; // pad with all-1 byte mask
+
+            // pad with all-zero data and all-one byte masking and push word out already for 256
+            full_word.data =  {32'b0, fifo_rdata_i.data};
+            full_word.mask = {4'hF, fifo_rdata_i.mask};
+            if (hash_process_i || process_flag_q) begin
+                sha_process = 1'b1;
+            end
             if (sha_ready == 1'b1) begin
               // if word has been absorbed into hash engine
-              word_buffer_ready = 1'b1; // word has been pushed out to SHA engine, word buffer ready
-              word_part_inc     = 1'b0;
+              fifo_rready_o = 1'b1; // word pushed out to SHA engine so word buffer ready
             end else begin
-              word_buffer_ready = 1'b0;
+              fifo_rready_o = 1'b0;
             end
           end
-        end else begin   // SHA2_256 so pad and push out the word
-          word_valid = 1'b1;
-          // store the word with most significant padding
-          word_buffer_d.data = {32'b0, fifo_rdata.data};
-          word_buffer_d.mask = {4'hF, fifo_rdata.mask}; // pad with all-1 byte mask
-          // pad with all-zero data and all-one byte masking and push word out already for 256
-          full_word.data =  {32'b0, fifo_rdata.data};
-          full_word.mask = {4'hF, fifo_rdata.mask};
-          if (hash_process || process_flag) begin
+        end else if (word_part_count_q == 2'b01) begin
+          fifo_rready_o = 1'b1; // buffer still has room for another word
+          // accumulate least significant 32 bits and mask
+          word_buffer_d.data [31:0] = fifo_rdata_i.data;
+          word_buffer_d.mask [3:0]  = fifo_rdata_i.mask;
+
+          // now ready to pass full word through
+          word_valid              = 1'b1;
+          full_word.data [63:32]  = word_buffer_q.data[63:32];
+          full_word.mask [7:4]    = word_buffer_q.mask[7:4];
+          full_word.data [31:0]   = fifo_rdata_i.data;
+          full_word.mask  [3:0]   = fifo_rdata_i.mask;
+
+          if (hash_process_i || process_flag_q) begin
               sha_process = 1'b1;
           end
           if (sha_ready == 1'b1) begin
-            // if word has been absorbed into hash engine
-            word_buffer_ready = 1'b1; // word has been pushed out to SHA engine so word buffer ready
+            // word has been consumed
+            fifo_rready_o       = 1'b1; // word pushed out to SHA engine so word buffer ready
+            word_part_reset   = 1'b1;
+            word_part_inc     = 1'b0;
           end else begin
-            word_buffer_ready = 1'b0;
+            fifo_rready_o       = 1'b1;
+            word_part_inc     = 1'b1;
+          end
+        end else if (word_part_count_q == 2'b10) begin // word buffer is full and not loaded out yet
+          // fifo_rready_o is now deasserted: accumulated word is waiting to be pushed out
+          fifo_rready_o     = 1'b0;
+          word_valid        = 1'b1; // word buffer is ready to shift word out to SHA engine
+          full_word         = word_buffer_q;
+          if (hash_process_i || process_flag_q) begin
+              sha_process   = 1'b1;
+          end
+          if (sha_ready == 1'b1) begin // waiting on sha_ready to turn 1
+            // do not assert fifo_rready_o yet
+            word_part_reset = 1'b1;
           end
         end
-      end else if (word_part_count == 2'b01) begin
-        word_buffer_ready = 1'b1; // buffer still has room for another word
-        // accumulate least significant 32 bits and mask
-        word_buffer_d.data [31:0] = fifo_rdata.data;
-        word_buffer_d.mask [3:0]  = fifo_rdata.mask;
-        // now ready to pass full word through
-        word_valid = 1'b1;
-        full_word.data [63:32]  = word_buffer_q.data[63:32];
-        full_word.mask [7:4]    = word_buffer_q.mask[7:4];
-        full_word.data [31:0]   = fifo_rdata.data;
-        full_word.mask  [3:0]   = fifo_rdata.mask;
-        if (hash_process || process_flag) begin
-            sha_process = 1'b1;
-        end
-        if (sha_ready == 1'b1) begin
-          // word has been consumed
-          word_buffer_ready = 1'b1; // word has been pushed out to SHA engine so word buffer ready
-          word_part_reset   = 1'b1;
-          word_part_inc     = 1'b0;
-        end else begin
-          word_buffer_ready = 1'b1;
-          word_part_inc     = 1'b1;
-        end
-      end else if (word_part_count == 2'b10) begin // word buffer is full and has not loaded out yet
-        // word_buffer_ready is now deasserted: accumulated word is waiting to be pushed out
-        word_buffer_ready = 1'b0;
-        word_valid        = 1'b1; // word buffer is ready to shift word out to SHA engine
-        full_word         = word_buffer_q;
-        if (hash_process || process_flag) begin
-            sha_process = 1'b1;
-        end
-        if (sha_ready == 1'b1) begin // waiting on sha_ready to turn 1
-          // do not assert word_buffer_ready yet
-          word_part_reset = 1'b1;
+      end else if (sha_en_i) begin // hash engine still enabled but no new valid input
+        // provide the last latched input so long as hash is enabled
+        full_word = word_buffer_q;
+        if (word_part_count_q == 2'b00 && (hash_process_i || process_flag_q)) begin
+          sha_process = 1'b1; // wait on hash_process_i
+        end else if (word_part_count_q == 2'b01 && (hash_process_i || process_flag_q)) begin
+          // 384/512: msg ended: apply 32-bit word packing and push last word
+          full_word.data [31:0] = 32'b0;
+          full_word.mask [3:0]  = 4'h0;
+          word_valid            = 1'b1;
+          sha_process           = 1'b1;
+          if (sha_ready == 1'b1) begin // word has been consumed
+            word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
+          end
+        end else if (word_part_count_q == 2'b01) begin // word feeding stalled but msg not ended
+          word_valid = 1'b0;
+        end else if (word_part_count_q == 2'b10 && (hash_process_i || process_flag_q)) begin
+          // 384/512: msg ended but last word still waiting to be fed in
+          word_valid  = 1'b1;
+          sha_process = 1'b1;
+          if (sha_ready == 1'b1) begin // word has been consumed
+            word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
+          end
+        end else if (word_part_count_q == 2'b10) begin // word feeding stalled
+          word_valid = 1'b0;
         end
       end
-    end else if (sha_en) begin // hash engine still enabled but no new valid input
-      // provide the last latched input so long as hash is enabled
-      full_word = word_buffer_q;
-      if (word_part_count == 2'b00 && (hash_process || process_flag)) begin
-        sha_process = 1'b1; // wait on hash_process
-      end else if (word_part_count == 2'b01 && (hash_process || process_flag)) begin
-        // 384/512: msg ended: apply 32-bit word packing and push last word
-        full_word.data [31:0] = 32'b0;
-        full_word.mask [3:0]  = 4'h0;
-        word_valid            = 1'b1;
-        sha_process           = 1'b1;
-        if (sha_ready == 1'b1) begin // word has been consumed
-          word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
-        end
-      end else if (word_part_count == 2'b01) begin // word feeding stalled but msg not ended
-        word_valid = 1'b0;
-      end else if (word_part_count == 2'b10 && (hash_process || process_flag)) begin
-        // 384/512: msg ended but last word still waiting to be fed in
-        word_valid  = 1'b1;
-        sha_process = 1'b1;
-        if (sha_ready == 1'b1) begin // word has been consumed
-          word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
-        end
-      end else if (word_part_count == 2'b10) begin // word feeding stalled
-        word_valid = 1'b0;
+
+      // assign word_part_count_d
+      if ((word_part_reset || hash_start_i || !sha_en_i)) begin
+        word_part_count_d = '0;
+      end else if (word_part_inc) begin
+        word_part_count_d = word_part_count_q + 1'b1;
+      end else begin
+        word_part_count_d = word_part_count_q;
       end
+
+      // assign digest_mode_flag_d
+      if (hash_start_i)     digest_mode_flag_d = digest_mode_i;      // latch in configured mode
+      else if (hash_done_o) digest_mode_flag_d = None;               // clear
+      else                  digest_mode_flag_d = digest_mode_flag_q; // keep
+
+      // assign process_flag
+      if (!sha_en_i || hash_start_i) process_flag_d = 1'b0;
+      else if (hash_process_i)       process_flag_d = 1'b1;
+      else                           process_flag_d = process_flag_q;
+    end : multimode_combinational
+
+    prim_sha2 #(
+      .MultimodeEn(1)
+    ) u_prim_sha2_multimode (
+      .clk_i (clk_i),
+      .rst_ni (rst_ni),
+      .wipe_secret_i      (wipe_secret_i),
+      .wipe_v_i           ({wipe_v_i, wipe_v_i}),
+      .fifo_rvalid_i      (word_valid),
+      .fifo_rdata_i       (full_word),
+      .fifo_rready_o      (sha_ready),
+      .sha_en_i           (sha_en_i),
+      .hash_start_i       (hash_start_i),
+      .digest_mode_i      (digest_mode_i),
+      .hash_process_i     (sha_process),
+      .hash_done_o        (hash_done_o),
+      .message_length_i   (message_length_i),
+      .digest_o           (digest_o),
+      .idle_o             (idle_o)
+    );
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni)  word_part_count_q <= '0;
+      else          word_part_count_q <= word_part_count_d;
     end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni)  word_buffer_q <= 0;
+      else          word_buffer_q <= word_buffer_d;
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+     if (!rst_ni)          process_flag_q <= '0;
+      else  process_flag_q <= process_flag_d;
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) digest_mode_flag_q <= None;
+      else         digest_mode_flag_q <= digest_mode_flag_d;
+    end
+  // logic and prim_sha2 instantiation for MultimodeEn = 0
+  end else begin : gen_sha256_logic  // MultimodeEn = 0
+    always_comb begin : sha256_combinational
+      full_word.data   = {32'b0, fifo_rdata_i.data};
+      full_word.mask   = {4'hF,  fifo_rdata_i.mask};
+      fifo_rready_o    = sha_ready;
+    end : sha256_combinational
+
+    prim_sha2 #(
+      .MultimodeEn(0)
+    ) u_prim_sha2_256 (
+      .clk_i (clk_i),
+      .rst_ni (rst_ni),
+      .wipe_secret_i      (wipe_secret_i),
+      .wipe_v_i           ({wipe_v_i, wipe_v_i}),
+      .fifo_rvalid_i      (fifo_rvalid_i), // feed input directly
+      .fifo_rdata_i       (full_word),
+      .fifo_rready_o      (sha_ready),
+      .sha_en_i           (sha_en_i),
+      .hash_start_i       (hash_start_i),
+      .digest_mode_i      (None),           // unused input port tied to ground
+      .hash_process_i     (hash_process_i), // feed input port directly to SHA-2 engine
+      .hash_done_o        (hash_done_o),
+      .message_length_i   ({{64'b0}, message_length_i[63:0]}),
+      .digest_o           (digest_o),
+      .idle_o             (idle_o)
+    );
   end
 
-  // Instantiate 64-bit SHA-2 multi-mode engine
-  sha2_multimode u_sha2_multimode64 (
-    .clk_i (clk_i),
-    .rst_ni (rst_ni),
-
-    .wipe_secret      (wipe_secret),
-    .wipe_v           ({wipe_v, wipe_v}),
-
-    .fifo_rvalid      (word_valid),
-    .fifo_rdata       (full_word),
-    .fifo_rready      (sha_ready),
-
-    .sha_en           (sha_en),
-    .hash_start       (hash_start),
-    .digest_mode      (digest_mode),
-    .hash_process     (sha_process),
-    .hash_done        (hash_done),
-
-    .message_length   (message_length),
-    .digest           (digest),
-
-    .idle             (idle)
-  );
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                                       word_part_count <= '0;
-    else if (word_part_reset || hash_start || !sha_en) word_part_count <= '0;
-    else if (word_part_inc)                            word_part_count <= word_part_count + 1'b1;
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                    word_buffer_q <= 0;
-    else if (!sha_en || hash_start) word_buffer_q <= 0;
-    else                            word_buffer_q <= word_buffer_d;
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                    process_flag <= '0;
-    else if (!sha_en || hash_start) process_flag <= '0;
-    else if (hash_process)          process_flag <= '1;
-  end
-
-  // Latch SHA-2 configured mode
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                digest_mode_flag <= None;
-    else if (hash_start)        digest_mode_flag <= digest_mode;
-    else if (hash_done == 1'b1) digest_mode_flag <= None;
-  end
-endmodule : sha2_multimode32
+endmodule : prim_sha2_32

--- a/hw/ip/prim/rtl/prim_sha2_32.sv
+++ b/hw/ip/prim/rtl/prim_sha2_32.sv
@@ -1,0 +1,205 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// 32-bit input wrapper for the SHA-2 multi-mode engine
+//
+
+module prim_sha2_32 import prim_sha2_pkg::*; (
+  input clk_i,
+  input rst_ni,
+
+  input              wipe_secret,
+  input sha_word32_t wipe_v,
+
+  // Control signals and message words input to the message FIFO
+  input               fifo_rvalid,      // indicates that there are data words/word parts
+                                        // fifo_rdata ready to write into the SHA-2 padding buffer
+  input  sha_fifo32_t fifo_rdata,
+  output logic        word_buffer_ready, // indicates that the wrapper word accumulation buffer is
+                                         // ready to receive words to feed into the SHA-2 engine
+
+  // Control signals
+  input                sha_en,   // if disabled, it clears internal content
+  input                hash_start,
+  input digest_mode_e  digest_mode,
+  input                hash_process,
+  output logic         hash_done,
+
+  input [127:0]             message_length,   // keep message length 128 bits (bits but byte based)
+  output sha_word64_t [7:0] digest,
+  output logic              idle
+);
+
+  sha_fifo64_t  word_buffer_d, word_buffer_q;
+  sha_fifo64_t  full_word;
+  logic [1:0]   word_part_count;
+  logic         word_part_inc, word_part_reset;
+  logic         sha_process, process_flag;
+  logic         word_valid, sha_ready;
+  digest_mode_e digest_mode_flag;
+
+  always_comb begin : accumulate_word
+    word_part_inc                 = 1'b0;
+    word_part_reset               = 1'b0;
+    full_word.mask                = 8'hFF; // to keep the padding buffer ready to receive
+    full_word.data                = 64'h0;
+    sha_process                   = 1'b0;
+    word_valid                    = 1'b0;
+    word_buffer_ready             = 1'b0;
+    word_buffer_d                 = word_buffer_q;
+
+    if (sha_en && fifo_rvalid) begin // valid incoming word part and SHA engine is enabled
+      if (word_part_count == 2'b00) begin
+        if (digest_mode_flag != SHA2_256) begin
+          // accumulate most significant 32 bits of word and mask bits
+          word_buffer_d.data[63:32] = fifo_rdata.data;
+          word_buffer_d.mask[7:4]   = fifo_rdata.mask;
+          word_part_inc             =  1'b1;
+          word_buffer_ready         = 1'b1;
+          if (hash_process || process_flag) begin // ready to push out word (partial)
+            word_valid      = 1'b1;
+            // add least significant padding
+            full_word.data  =  {fifo_rdata.data, 32'b0};
+            full_word.mask  =  {fifo_rdata.mask, 4'h0};
+            sha_process     = 1'b1;
+            if (sha_ready == 1'b1) begin
+              // if word has been absorbed into hash engine
+              word_buffer_ready = 1'b1; // word has been pushed out to SHA engine, word buffer ready
+              word_part_inc     = 1'b0;
+            end else begin
+              word_buffer_ready = 1'b0;
+            end
+          end
+        end else begin   // SHA2_256 so pad and push out the word
+          word_valid = 1'b1;
+          // store the word with most significant padding
+          word_buffer_d.data = {32'b0, fifo_rdata.data};
+          word_buffer_d.mask = {4'hF, fifo_rdata.mask}; // pad with all-1 byte mask
+          // pad with all-zero data and all-one byte masking and push word out already for 256
+          full_word.data =  {32'b0, fifo_rdata.data};
+          full_word.mask = {4'hF, fifo_rdata.mask};
+          if (hash_process || process_flag) begin
+              sha_process = 1'b1;
+          end
+          if (sha_ready == 1'b1) begin
+            // if word has been absorbed into hash engine
+            word_buffer_ready = 1'b1; // word has been pushed out to SHA engine so word buffer ready
+          end else begin
+            word_buffer_ready = 1'b0;
+          end
+        end
+      end else if (word_part_count == 2'b01) begin
+        word_buffer_ready = 1'b1; // buffer still has room for another word
+        // accumulate least significant 32 bits and mask
+        word_buffer_d.data [31:0] = fifo_rdata.data;
+        word_buffer_d.mask [3:0]  = fifo_rdata.mask;
+        // now ready to pass full word through
+        word_valid = 1'b1;
+        full_word.data [63:32]  = word_buffer_q.data[63:32];
+        full_word.mask [7:4]    = word_buffer_q.mask[7:4];
+        full_word.data [31:0]   = fifo_rdata.data;
+        full_word.mask  [3:0]   = fifo_rdata.mask;
+        if (hash_process || process_flag) begin
+            sha_process = 1'b1;
+        end
+        if (sha_ready == 1'b1) begin
+          // word has been consumed
+          word_buffer_ready = 1'b1; // word has been pushed out to SHA engine so word buffer ready
+          word_part_reset   = 1'b1;
+          word_part_inc     = 1'b0;
+        end else begin
+          word_buffer_ready = 1'b1;
+          word_part_inc     = 1'b1;
+        end
+      end else if (word_part_count == 2'b10) begin // word buffer is full and has not loaded out yet
+        // word_buffer_ready is now deasserted: accumulated word is waiting to be pushed out
+        word_buffer_ready = 1'b0;
+        word_valid        = 1'b1; // word buffer is ready to shift word out to SHA engine
+        full_word         = word_buffer_q;
+        if (hash_process || process_flag) begin
+            sha_process = 1'b1;
+        end
+        if (sha_ready == 1'b1) begin // waiting on sha_ready to turn 1
+          // do not assert word_buffer_ready yet
+          word_part_reset = 1'b1;
+        end
+      end
+    end else if (sha_en) begin // hash engine still enabled but no new valid input
+      // provide the last latched input so long as hash is enabled
+      full_word = word_buffer_q;
+      if (word_part_count == 2'b00 && (hash_process || process_flag)) begin
+        sha_process = 1'b1; // wait on hash_process
+      end else if (word_part_count == 2'b01 && (hash_process || process_flag)) begin
+        // 384/512: msg ended: apply 32-bit word packing and push last word
+        full_word.data [31:0] = 32'b0;
+        full_word.mask [3:0]  = 4'h0;
+        word_valid            = 1'b1;
+        sha_process           = 1'b1;
+        if (sha_ready == 1'b1) begin // word has been consumed
+          word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
+        end
+      end else if (word_part_count == 2'b01) begin // word feeding stalled but msg not ended
+        word_valid = 1'b0;
+      end else if (word_part_count == 2'b10 && (hash_process || process_flag)) begin
+        // 384/512: msg ended but last word still waiting to be fed in
+        word_valid  = 1'b1;
+        sha_process = 1'b1;
+        if (sha_ready == 1'b1) begin // word has been consumed
+          word_part_reset = 1'b1; // which will also reset word_valid in the next cycle
+        end
+      end else if (word_part_count == 2'b10) begin // word feeding stalled
+        word_valid = 1'b0;
+      end
+    end
+  end
+
+  // Instantiate 64-bit SHA-2 multi-mode engine
+  sha2_multimode u_sha2_multimode64 (
+    .clk_i (clk_i),
+    .rst_ni (rst_ni),
+
+    .wipe_secret      (wipe_secret),
+    .wipe_v           ({wipe_v, wipe_v}),
+
+    .fifo_rvalid      (word_valid),
+    .fifo_rdata       (full_word),
+    .fifo_rready      (sha_ready),
+
+    .sha_en           (sha_en),
+    .hash_start       (hash_start),
+    .digest_mode      (digest_mode),
+    .hash_process     (sha_process),
+    .hash_done        (hash_done),
+
+    .message_length   (message_length),
+    .digest           (digest),
+
+    .idle             (idle)
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                                       word_part_count <= '0;
+    else if (word_part_reset || hash_start || !sha_en) word_part_count <= '0;
+    else if (word_part_inc)                            word_part_count <= word_part_count + 1'b1;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                    word_buffer_q <= 0;
+    else if (!sha_en || hash_start) word_buffer_q <= 0;
+    else                            word_buffer_q <= word_buffer_d;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                    process_flag <= '0;
+    else if (!sha_en || hash_start) process_flag <= '0;
+    else if (hash_process)          process_flag <= '1;
+  end
+
+  // Latch SHA-2 configured mode
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                digest_mode_flag <= None;
+    else if (hash_start)        digest_mode_flag <= digest_mode;
+    else if (hash_done == 1'b1) digest_mode_flag <= None;
+  end
+endmodule : sha2_multimode32

--- a/hw/ip/prim/rtl/prim_sha2_pad.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pad.sv
@@ -2,56 +2,67 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Multi-mode SHA-2 engine padding logic
-//
+// SHA-256/Multi-Mode SHA-2 Padding logic
 
 `include "prim_assert.sv"
 
-module prim_sha2_pad import prim_sha2_pkg::*; (
+module prim_sha2_pad import prim_sha2_pkg::*;
+#(
+  parameter bit MultimodeEn = 1
+ ) (
   input clk_i,
   input rst_ni,
 
   // to actual FIFO
-  input                 fifo_rvalid,
-  input  sha_fifo64_t   fifo_rdata,
-  output logic          fifo_rready,
-
+  input                 fifo_rvalid_i,
+  input  sha_fifo64_t   fifo_rdata_i,
+  output logic          fifo_rready_o,
   // from SHA2 compression engine
-  output logic          shaf_rvalid,
-  output sha_word64_t   shaf_rdata,
-  input                 shaf_rready,
-
-  input                 sha_en,
-  input                 hash_start,
-  input digest_mode_e   digest_mode,
-  input                 hash_process,
-  input                 hash_done,
-
-  input        [127:0]  message_length, // # of bytes in bits (8 bits granularity)
-  output logic          msg_feed_complete // indicates all message is feeded
+  output logic          shaf_rvalid_o,
+  output sha_word64_t   shaf_rdata_o,
+  input                 shaf_rready_i,
+  input                 sha_en_i,
+  input                 hash_start_i,
+  input digest_mode_e   digest_mode_i,
+  input                 hash_process_i,
+  input                 hash_done_o,
+  input        [127:0]  message_length_i,   // # of bytes in bits (8 bits granularity)
+  output logic          msg_feed_complete_o // indicates all message is feeded
 );
 
-  logic [127:0] tx_count;    // fin received data count.
+  logic [127:0] tx_count_d, tx_count;    // fin received data count.
   logic         inc_txcount;
   logic         fifo_partial;
   logic         txcnt_eq_1a0;
-  logic         hash_process_flag; // set by hash_process, clear by hash_done
-  digest_mode_e digest_mode_flag;
+  logic         hash_process_flag_d, hash_process_flag;
+  digest_mode_e digest_mode_flag_d,  digest_mode_flag;
 
-  assign fifo_partial = ~&fifo_rdata.mask;
-
-  // tx_count[8:0] == 'h1c0 --> should send LenHi
-  assign txcnt_eq_1a0 = (digest_mode_flag == SHA2_256) ? (tx_count[8:0] == 9'h1a0) :
-                        ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
-                        (tx_count[9:0] == 10'h340) : '0;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                                 hash_process_flag <= 1'b0;
-    else if (!sha_en || hash_start || hash_done) hash_process_flag <= 1'b0;
-    else if (hash_process)                       hash_process_flag <= 1'b1;
+  // tie off unused inport ports and signals
+  if (!MultimodeEn) begin : gen_tie_unused
+    logic unused_signals;
+    assign unused_signals = ^{message_length_i[127:64], digest_mode_i};
   end
 
-  // Data path: fout_wdata
+  assign fifo_partial = MultimodeEn ? ~&fifo_rdata_i.mask :
+                                      ~&fifo_rdata_i.mask[3:0];
+
+  // tx_count[8:0] == 'h1c0 --> should send LenHi
+  assign txcnt_eq_1a0 = (digest_mode_flag == SHA2_256   || ~MultimodeEn)               ?
+                                                                        (tx_count[8:0] == 9'h1a0)  :
+                        ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                                                                        (tx_count[9:0] == 10'h340) :
+                                                                        '0;
+
+  assign hash_process_flag_d = (~sha_en_i || hash_start_i || hash_done_o) ? 1'b0 :
+                               hash_process_i                             ? 1'b1 :
+                                                                          hash_process_flag;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)  hash_process_flag <= 1'b0;
+    else          hash_process_flag <= hash_process_flag_d;
+  end
+
+  // data path: fout_wdata
   typedef enum logic [2:0] {
     FifoIn,         // fin_wdata, fin_wstrb
     Pad80,          // {8'h80, 8'h00} , strb (calc based on len[4:3])
@@ -64,7 +75,7 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
   always_comb begin
     unique case (sel_data)
       FifoIn: begin
-        shaf_rdata = fifo_rdata.data;
+        shaf_rdata_o = fifo_rdata_i.data;
       end
 
       Pad80: begin
@@ -73,63 +84,67 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
         // msglen[4:3] == 01 |-> {msg,  'h80, 'h00, 'h00}
         // msglen[4:3] == 10 |-> {msg[15:0],  'h80, 'h00}
         // msglen[4:3] == 11 |-> {msg[23:0],        'h80}
-        if (digest_mode_flag == SHA2_256) begin
-          unique case (message_length[4:3])
-            2'b 00:  shaf_rdata = 64'h 0000_0000_8000_0000;
-            2'b 01:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31:24], 24'h 8000_00};
-            2'b 10:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31:16], 16'h 8000};
-            2'b 11:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31: 8],  8'h 80};
-            default: shaf_rdata = 64'h0;
+        if ((digest_mode_flag == SHA2_256) || ~MultimodeEn) begin
+          unique case (message_length_i[4:3])
+            2'b 00:  shaf_rdata_o = 64'h 0000_0000_8000_0000;
+            2'b 01:  shaf_rdata_o = {32'h 0000_0000, fifo_rdata_i.data[31:24], 24'h 8000_00};
+            2'b 10:  shaf_rdata_o = {32'h 0000_0000, fifo_rdata_i.data[31:16], 16'h 8000};
+            2'b 11:  shaf_rdata_o = {32'h 0000_0000, fifo_rdata_i.data[31: 8],  8'h 80};
+            default: shaf_rdata_o = 64'h0;
           endcase
         end else if ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) begin
-          unique case (message_length[5:3])
-            3'b 000: shaf_rdata = 64'h 8000_0000_0000_0000;
-            3'b 001: shaf_rdata = {fifo_rdata.data[63:56], 56'h 8000_0000_0000_00};
-            3'b 010: shaf_rdata = {fifo_rdata.data[63:48], 48'h 8000_0000_0000};
-            3'b 011: shaf_rdata = {fifo_rdata.data[63:40], 40'h 8000_0000_00};
-            3'b 100: shaf_rdata = {fifo_rdata.data[63:32], 32'h 8000_0000};
-            3'b 101: shaf_rdata = {fifo_rdata.data[63:24], 24'h 8000_00};
-            3'b 110: shaf_rdata = {fifo_rdata.data[63:16], 16'h 8000};
-            3'b 111: shaf_rdata = {fifo_rdata.data[63:8],  8'h 80};
-            default: shaf_rdata = 64'h0;
+          unique case (message_length_i[5:3])
+            3'b 000: shaf_rdata_o = 64'h 8000_0000_0000_0000;
+            3'b 001: shaf_rdata_o = {fifo_rdata_i.data[63:56], 56'h 8000_0000_0000_00};
+            3'b 010: shaf_rdata_o = {fifo_rdata_i.data[63:48], 48'h 8000_0000_0000};
+            3'b 011: shaf_rdata_o = {fifo_rdata_i.data[63:40], 40'h 8000_0000_00};
+            3'b 100: shaf_rdata_o = {fifo_rdata_i.data[63:32], 32'h 8000_0000};
+            3'b 101: shaf_rdata_o = {fifo_rdata_i.data[63:24], 24'h 8000_00};
+            3'b 110: shaf_rdata_o = {fifo_rdata_i.data[63:16], 16'h 8000};
+            3'b 111: shaf_rdata_o = {fifo_rdata_i.data[63:8],  8'h 80};
+            default: shaf_rdata_o = 64'h0;
           endcase
         end else
-            shaf_rdata = '0;
+            shaf_rdata_o = '0;
       end
 
       Pad00: begin
-        shaf_rdata = '0;
+        shaf_rdata_o = '0;
       end
 
       LenHi: begin
-        shaf_rdata = (digest_mode_flag == SHA2_256) ? {32'b0, message_length[63:32]}:
+        shaf_rdata_o = ((digest_mode_flag == SHA2_256) || ~MultimodeEn) ?
+                                                     {32'b0, message_length_i[63:32]}:
                      ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
-                     message_length[127:64] : '0;
+                                                     message_length_i[127:64] : '0;
       end
 
       LenLo: begin
-        shaf_rdata = (digest_mode_flag == SHA2_256) ? {32'b0, message_length[31:0]}:
+        shaf_rdata_o = ((digest_mode_flag == SHA2_256) || ~MultimodeEn) ?
+                                                     {32'b0, message_length_i[31:0]}:
                      ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
-                     message_length[63:0]: '0;
+                                                     message_length_i[63:0]: '0;
       end
 
       default: begin
-        shaf_rdata = '0;
+        shaf_rdata_o = '0;
       end
     endcase
+
+    if (!MultimodeEn) shaf_rdata_o [63:32] = 32'b0; // assign most sig 32 bits to constant 0
   end
 
   // Padded length
-  // $ceil(message_length + 8 + 64, 512) -> message_length [8:0] + 440 and ignore carry
-  //assign length_added = (message_length[8:0] + 9'h1b8) ;
+  // $ceil(message_length_i + 8 + 64, 512) -> message_length_i [8:0] + 440 and ignore carry
+  //assign length_added = (message_length_i[8:0] + 9'h1b8) ;
 
   // fifo control
-  // add 8'h 80 , N 8'h00, 64'h message_length
+  // add 8'h 80 , N 8'h00, 64'h message_length_i
 
   // Steps
-  // 1. `hash_start` from CPU (or DMA?)
-  // 2. calculate `padded_length` from `message_length`
-  // 3. Check if tx_count == message_length, then go to 5
+  // 1. `hash_start_i` from CPU (or DMA?)
+  // 2. calculate `padded_length` from `message_length_i`
+  // 3. Check if tx_count == message_length_i, then go to 5
   // 4. Receiving FIFO input (hand over to fifo output)
   // 5. Padding bit 1 (8'h80) followed by 8'h00 if needed
   // 6. Padding with length (high -> low)
@@ -137,7 +152,7 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
   // State Machine
   typedef enum logic [2:0] {
     StIdle,        // fin_full to prevent unwanted FIFO write
-    StFifoReceive, // Check tx_count == message_length
+    StFifoReceive, // Check tx_count == message_length_i
     StPad80,       // 8'h 80 + 8'h 00 X N
     StPad00,
     StLenHi,
@@ -148,24 +163,22 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) st_q <= StIdle;
-    else if (!sha_en) st_q <= StIdle;
-    else if (hash_start) st_q <= StFifoReceive;
-    else st_q <= st_d;
+    else         st_q <= st_d;
   end
 
   // Next state
   always_comb begin
-    shaf_rvalid = 1'b0;
-    inc_txcount = 1'b0;
-    sel_data    = FifoIn;
-    fifo_rready = 1'b0;
-    st_d        = StIdle;
+    shaf_rvalid_o = 1'b0;
+    inc_txcount   = 1'b0;
+    sel_data      = FifoIn;
+    fifo_rready_o = 1'b0;
+    st_d          = StIdle;
 
     unique case (st_q)
       StIdle: begin
-        sel_data    = FifoIn;
-        shaf_rvalid = 1'b0;
-        if (sha_en && hash_start) begin
+        sel_data      = FifoIn;
+        shaf_rvalid_o = 1'b0;
+        if (sha_en_i && hash_start_i) begin
           inc_txcount = 1'b0;
           st_d        = StFifoReceive;
         end else begin
@@ -175,96 +188,98 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
 
       StFifoReceive: begin
         sel_data = FifoIn;
-        if (fifo_partial && fifo_rvalid) begin
+        if (fifo_partial && fifo_rvalid_i) begin
           // End of the message (last bit is not word-aligned) , assume hash_process_flag is set
-          shaf_rvalid = 1'b0; // Update entry at StPad80
-          inc_txcount = 1'b0;
-          fifo_rready = 1'b0;
+          shaf_rvalid_o = 1'b0; // Update entry at StPad80
+          inc_txcount   = 1'b0;
+          fifo_rready_o = 1'b0;
           st_d = StPad80;
         end else if (!hash_process_flag) begin
-          fifo_rready = shaf_rready;
-          shaf_rvalid = fifo_rvalid;
-          inc_txcount = shaf_rready;
+          fifo_rready_o = shaf_rready_i;
+          shaf_rvalid_o = fifo_rvalid_i;
+          inc_txcount   = shaf_rready_i;
           st_d = StFifoReceive;
-        end else if (tx_count == message_length) begin
+        end else if (((tx_count        == message_length_i) & MultimodeEn) ||
+                     ((tx_count [63:0] == message_length_i [63:0]) & !MultimodeEn)) begin
           // already received all msg and was waiting process flag
-          shaf_rvalid  = 1'b0;
-          inc_txcount  = 1'b0;
-          fifo_rready  = 1'b0;
+          shaf_rvalid_o = 1'b0;
+          inc_txcount   = 1'b0;
+          fifo_rready_o = 1'b0;
           st_d = StPad80;
         end else begin
-          shaf_rvalid = fifo_rvalid;
-          fifo_rready = shaf_rready; // 0 always
-          inc_txcount = shaf_rready; // 0 always
+          shaf_rvalid_o = fifo_rvalid_i;
+          fifo_rready_o = shaf_rready_i; // 0 always
+          inc_txcount   = shaf_rready_i; // 0 always
           st_d = StFifoReceive;
         end
       end
 
       StPad80: begin
-        sel_data    = Pad80;
-        shaf_rvalid = 1'b1;
-        fifo_rready = (digest_mode_flag == SHA2_256) ? shaf_rready && |message_length[4:3]:
-                      ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
-                      shaf_rready && |message_length[5:3] : '0; // Only when partial
+        sel_data      = Pad80;
+        shaf_rvalid_o = 1'b1;
+        fifo_rready_o = (digest_mode_flag == SHA2_256 || ~MultimodeEn) ?
+                        shaf_rready_i && |message_length_i[4:3] :
+                        ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                        shaf_rready_i && |message_length_i[5:3] : '0; // Only when partial
 
         // exactly 192 bits left, do not need to pad00's
-        if (shaf_rready && txcnt_eq_1a0) begin
-          st_d = StLenHi;
+        if (shaf_rready_i && txcnt_eq_1a0) begin
+          st_d        = StLenHi;
           inc_txcount = 1'b1;
         // it does not matter if value is < or > than 416 bits.  If it's the former, 00 pad until
         // length field.  If >, then the next chunk will contain the length field with appropriate
         // 0 padding.
-        end else if (shaf_rready && !txcnt_eq_1a0) begin
-          st_d = StPad00;
+        end else if (shaf_rready_i && !txcnt_eq_1a0) begin
+          st_d        = StPad00;
           inc_txcount = 1'b1;
         end else begin
-          st_d = StPad80;
+          st_d        = StPad80;
           inc_txcount = 1'b0;
         end
 
         // # Below part is temporal code to speed up the SHA by 16 clocks per chunk
         // # (80 clk --> 64 clk)
         // # leaving this as a reference but needs to verify it.
-        //if (shaf_rready && !txcnt_eq_1a0) begin
+        //if (shaf_rready_i && !txcnt_eq_1a0) begin
         //  st_d = StPad00;
         //
         //  inc_txcount = 1'b1;
-        //  shaf_rvalid = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
+        //  shaf_rvalid_o = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
         //  fifo_rready = (msg_word_aligned) ? 1'b0 : 1'b1;
-        //end else if (!shaf_rready && !txcnt_eq_1a0) begin
+        //end else if (!shaf_rready_i && !txcnt_eq_1a0) begin
         //  st_d = StPad80;
         //
         //  inc_txcount = 1'b0;
-        //  shaf_rvalid = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
+        //  shaf_rvalid_o = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
         //
-        //end else if (shaf_rready && txcnt_eq_1a0) begin
+        //end else if (shaf_rready_i && txcnt_eq_1a0) begin
         //  st_d = StLenHi;
         //  inc_txcount = 1'b1;
         //end else begin
-        //  // !shaf_rready && txcnt_eq_1a0 , just wait until fifo_rready asserted
+        //  // !shaf_rready_i && txcnt_eq_1a0 , just wait until fifo_rready asserted
         //  st_d = StPad80;
         //  inc_txcount = 1'b0;
         //end
       end
 
       StPad00: begin
-        sel_data = Pad00;
-        shaf_rvalid = 1'b1;
+        sel_data      = Pad00;
+        shaf_rvalid_o = 1'b1;
 
-        if (shaf_rready) begin
+        if (shaf_rready_i) begin
           inc_txcount = 1'b1;
           if (txcnt_eq_1a0) st_d = StLenHi;
-          else st_d = StPad00;
+          else              st_d = StPad00;
         end else begin
           st_d = StPad00;
         end
       end
 
       StLenHi: begin
-        sel_data    = LenHi;
-        shaf_rvalid = 1'b1;
+        sel_data      = LenHi;
+        shaf_rvalid_o = 1'b1;
 
-        if (shaf_rready) begin
+        if (shaf_rready_i) begin
           st_d = StLenLo;
           inc_txcount = 1'b1;
         end else begin
@@ -274,10 +289,10 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
       end
 
       StLenLo: begin
-        sel_data      = LenLo;
-        shaf_rvalid   = 1'b1;
+        sel_data        = LenLo;
+        shaf_rvalid_o   = 1'b1;
 
-        if (shaf_rready) begin
+        if (shaf_rready_i) begin
           st_d        = StIdle;
           inc_txcount = 1'b1;
         end else begin
@@ -290,31 +305,42 @@ module prim_sha2_pad import prim_sha2_pkg::*; (
         st_d = StIdle;
       end
     endcase
+
+    if (!sha_en_i)         st_d = StIdle;
+    else if (hash_start_i) st_d = StFifoReceive;
   end
 
   // tx_count
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      tx_count <= '0;
-    end else if (hash_start) begin
-      tx_count <= '0;
+  always_comb begin
+    tx_count_d = tx_count;
+
+    if (hash_start_i) begin
+      tx_count_d = '0;
     end else if (inc_txcount) begin
-      if (digest_mode_flag == SHA2_256) begin
-        tx_count[127:5] <= tx_count[127:5] + 1'b1;
+      if ((digest_mode_flag == SHA2_256) || !MultimodeEn) begin
+        tx_count_d[127:5] = tx_count[127:5] + 1'b1;
       end else if ((digest_mode_flag == SHA2_384) ||(digest_mode_flag == SHA2_512)) begin
-        tx_count[127:6] <= tx_count[127:6] + 1'b1;
+        tx_count_d[127:6] = tx_count[127:6] + 1'b1;
       end
     end
   end
 
-  // Latch SHA-2 configured mode
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                digest_mode_flag <= None;
-    else if (hash_start)        digest_mode_flag <= digest_mode;
-    else if (hash_done == 1'b1) digest_mode_flag <= None;
+    if (!rst_ni) tx_count <= '0;
+    else         tx_count <= tx_count_d;
+  end
+
+  assign digest_mode_flag_d = ~MultimodeEn ? None           :    // assign to constant
+                              hash_start_i ? digest_mode_i  :    // latch in configured mode
+                              hash_done_o  ? None           :    // clear
+                                             digest_mode_flag; // keep
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)  digest_mode_flag <= None;
+    else          digest_mode_flag <= digest_mode_flag_d;
   end
 
   // State machine is in Idle only when it meets tx_count == message length
-  assign msg_feed_complete = hash_process_flag && (st_q == StIdle);
+  assign msg_feed_complete_o = hash_process_flag && (st_q == StIdle);
 
 endmodule

--- a/hw/ip/prim/rtl/prim_sha2_pad.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pad.sv
@@ -1,0 +1,320 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multi-mode SHA-2 engine padding logic
+//
+
+`include "prim_assert.sv"
+
+module prim_sha2_pad import prim_sha2_pkg::*; (
+  input clk_i,
+  input rst_ni,
+
+  // to actual FIFO
+  input                 fifo_rvalid,
+  input  sha_fifo64_t   fifo_rdata,
+  output logic          fifo_rready,
+
+  // from SHA2 compression engine
+  output logic          shaf_rvalid,
+  output sha_word64_t   shaf_rdata,
+  input                 shaf_rready,
+
+  input                 sha_en,
+  input                 hash_start,
+  input digest_mode_e   digest_mode,
+  input                 hash_process,
+  input                 hash_done,
+
+  input        [127:0]  message_length, // # of bytes in bits (8 bits granularity)
+  output logic          msg_feed_complete // indicates all message is feeded
+);
+
+  logic [127:0] tx_count;    // fin received data count.
+  logic         inc_txcount;
+  logic         fifo_partial;
+  logic         txcnt_eq_1a0;
+  logic         hash_process_flag; // set by hash_process, clear by hash_done
+  digest_mode_e digest_mode_flag;
+
+  assign fifo_partial = ~&fifo_rdata.mask;
+
+  // tx_count[8:0] == 'h1c0 --> should send LenHi
+  assign txcnt_eq_1a0 = (digest_mode_flag == SHA2_256) ? (tx_count[8:0] == 9'h1a0) :
+                        ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                        (tx_count[9:0] == 10'h340) : '0;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                                 hash_process_flag <= 1'b0;
+    else if (!sha_en || hash_start || hash_done) hash_process_flag <= 1'b0;
+    else if (hash_process)                       hash_process_flag <= 1'b1;
+  end
+
+  // Data path: fout_wdata
+  typedef enum logic [2:0] {
+    FifoIn,         // fin_wdata, fin_wstrb
+    Pad80,          // {8'h80, 8'h00} , strb (calc based on len[4:3])
+    Pad00,          // 32'h0, full strb
+    LenHi,          // len[63:32], full strb
+    LenLo           // len[31:0], full strb
+  } sel_data_e;
+  sel_data_e sel_data;
+
+  always_comb begin
+    unique case (sel_data)
+      FifoIn: begin
+        shaf_rdata = fifo_rdata.data;
+      end
+
+      Pad80: begin
+        // {a[7:0], b[7:0], c[7:0], d[7:0]}
+        // msglen[4:3] == 00 |-> {'h80, 'h00, 'h00, 'h00}
+        // msglen[4:3] == 01 |-> {msg,  'h80, 'h00, 'h00}
+        // msglen[4:3] == 10 |-> {msg[15:0],  'h80, 'h00}
+        // msglen[4:3] == 11 |-> {msg[23:0],        'h80}
+        if (digest_mode_flag == SHA2_256) begin
+          unique case (message_length[4:3])
+            2'b 00:  shaf_rdata = 64'h 0000_0000_8000_0000;
+            2'b 01:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31:24], 24'h 8000_00};
+            2'b 10:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31:16], 16'h 8000};
+            2'b 11:  shaf_rdata = {32'h 0000_0000, fifo_rdata.data[31: 8],  8'h 80};
+            default: shaf_rdata = 64'h0;
+          endcase
+        end else if ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) begin
+          unique case (message_length[5:3])
+            3'b 000: shaf_rdata = 64'h 8000_0000_0000_0000;
+            3'b 001: shaf_rdata = {fifo_rdata.data[63:56], 56'h 8000_0000_0000_00};
+            3'b 010: shaf_rdata = {fifo_rdata.data[63:48], 48'h 8000_0000_0000};
+            3'b 011: shaf_rdata = {fifo_rdata.data[63:40], 40'h 8000_0000_00};
+            3'b 100: shaf_rdata = {fifo_rdata.data[63:32], 32'h 8000_0000};
+            3'b 101: shaf_rdata = {fifo_rdata.data[63:24], 24'h 8000_00};
+            3'b 110: shaf_rdata = {fifo_rdata.data[63:16], 16'h 8000};
+            3'b 111: shaf_rdata = {fifo_rdata.data[63:8],  8'h 80};
+            default: shaf_rdata = 64'h0;
+          endcase
+        end else
+            shaf_rdata = '0;
+      end
+
+      Pad00: begin
+        shaf_rdata = '0;
+      end
+
+      LenHi: begin
+        shaf_rdata = (digest_mode_flag == SHA2_256) ? {32'b0, message_length[63:32]}:
+                     ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                     message_length[127:64] : '0;
+      end
+
+      LenLo: begin
+        shaf_rdata = (digest_mode_flag == SHA2_256) ? {32'b0, message_length[31:0]}:
+                     ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                     message_length[63:0]: '0;
+      end
+
+      default: begin
+        shaf_rdata = '0;
+      end
+    endcase
+  end
+
+  // Padded length
+  // $ceil(message_length + 8 + 64, 512) -> message_length [8:0] + 440 and ignore carry
+  //assign length_added = (message_length[8:0] + 9'h1b8) ;
+
+  // fifo control
+  // add 8'h 80 , N 8'h00, 64'h message_length
+
+  // Steps
+  // 1. `hash_start` from CPU (or DMA?)
+  // 2. calculate `padded_length` from `message_length`
+  // 3. Check if tx_count == message_length, then go to 5
+  // 4. Receiving FIFO input (hand over to fifo output)
+  // 5. Padding bit 1 (8'h80) followed by 8'h00 if needed
+  // 6. Padding with length (high -> low)
+
+  // State Machine
+  typedef enum logic [2:0] {
+    StIdle,        // fin_full to prevent unwanted FIFO write
+    StFifoReceive, // Check tx_count == message_length
+    StPad80,       // 8'h 80 + 8'h 00 X N
+    StPad00,
+    StLenHi,
+    StLenLo
+  } pad_st_e;
+
+  pad_st_e st_q, st_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) st_q <= StIdle;
+    else if (!sha_en) st_q <= StIdle;
+    else if (hash_start) st_q <= StFifoReceive;
+    else st_q <= st_d;
+  end
+
+  // Next state
+  always_comb begin
+    shaf_rvalid = 1'b0;
+    inc_txcount = 1'b0;
+    sel_data    = FifoIn;
+    fifo_rready = 1'b0;
+    st_d        = StIdle;
+
+    unique case (st_q)
+      StIdle: begin
+        sel_data    = FifoIn;
+        shaf_rvalid = 1'b0;
+        if (sha_en && hash_start) begin
+          inc_txcount = 1'b0;
+          st_d        = StFifoReceive;
+        end else begin
+          st_d        = StIdle;
+        end
+      end
+
+      StFifoReceive: begin
+        sel_data = FifoIn;
+        if (fifo_partial && fifo_rvalid) begin
+          // End of the message (last bit is not word-aligned) , assume hash_process_flag is set
+          shaf_rvalid = 1'b0; // Update entry at StPad80
+          inc_txcount = 1'b0;
+          fifo_rready = 1'b0;
+          st_d = StPad80;
+        end else if (!hash_process_flag) begin
+          fifo_rready = shaf_rready;
+          shaf_rvalid = fifo_rvalid;
+          inc_txcount = shaf_rready;
+          st_d = StFifoReceive;
+        end else if (tx_count == message_length) begin
+          // already received all msg and was waiting process flag
+          shaf_rvalid  = 1'b0;
+          inc_txcount  = 1'b0;
+          fifo_rready  = 1'b0;
+          st_d = StPad80;
+        end else begin
+          shaf_rvalid = fifo_rvalid;
+          fifo_rready = shaf_rready; // 0 always
+          inc_txcount = shaf_rready; // 0 always
+          st_d = StFifoReceive;
+        end
+      end
+
+      StPad80: begin
+        sel_data    = Pad80;
+        shaf_rvalid = 1'b1;
+        fifo_rready = (digest_mode_flag == SHA2_256) ? shaf_rready && |message_length[4:3]:
+                      ((digest_mode_flag == SHA2_384) || (digest_mode_flag == SHA2_512)) ?
+                      shaf_rready && |message_length[5:3] : '0; // Only when partial
+
+        // exactly 192 bits left, do not need to pad00's
+        if (shaf_rready && txcnt_eq_1a0) begin
+          st_d = StLenHi;
+          inc_txcount = 1'b1;
+        // it does not matter if value is < or > than 416 bits.  If it's the former, 00 pad until
+        // length field.  If >, then the next chunk will contain the length field with appropriate
+        // 0 padding.
+        end else if (shaf_rready && !txcnt_eq_1a0) begin
+          st_d = StPad00;
+          inc_txcount = 1'b1;
+        end else begin
+          st_d = StPad80;
+          inc_txcount = 1'b0;
+        end
+
+        // # Below part is temporal code to speed up the SHA by 16 clocks per chunk
+        // # (80 clk --> 64 clk)
+        // # leaving this as a reference but needs to verify it.
+        //if (shaf_rready && !txcnt_eq_1a0) begin
+        //  st_d = StPad00;
+        //
+        //  inc_txcount = 1'b1;
+        //  shaf_rvalid = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
+        //  fifo_rready = (msg_word_aligned) ? 1'b0 : 1'b1;
+        //end else if (!shaf_rready && !txcnt_eq_1a0) begin
+        //  st_d = StPad80;
+        //
+        //  inc_txcount = 1'b0;
+        //  shaf_rvalid = (msg_word_aligned) ? 1'b1 : fifo_rvalid;
+        //
+        //end else if (shaf_rready && txcnt_eq_1a0) begin
+        //  st_d = StLenHi;
+        //  inc_txcount = 1'b1;
+        //end else begin
+        //  // !shaf_rready && txcnt_eq_1a0 , just wait until fifo_rready asserted
+        //  st_d = StPad80;
+        //  inc_txcount = 1'b0;
+        //end
+      end
+
+      StPad00: begin
+        sel_data = Pad00;
+        shaf_rvalid = 1'b1;
+
+        if (shaf_rready) begin
+          inc_txcount = 1'b1;
+          if (txcnt_eq_1a0) st_d = StLenHi;
+          else st_d = StPad00;
+        end else begin
+          st_d = StPad00;
+        end
+      end
+
+      StLenHi: begin
+        sel_data    = LenHi;
+        shaf_rvalid = 1'b1;
+
+        if (shaf_rready) begin
+          st_d = StLenLo;
+          inc_txcount = 1'b1;
+        end else begin
+          st_d = StLenHi;
+          inc_txcount = 1'b0;
+        end
+      end
+
+      StLenLo: begin
+        sel_data      = LenLo;
+        shaf_rvalid   = 1'b1;
+
+        if (shaf_rready) begin
+          st_d        = StIdle;
+          inc_txcount = 1'b1;
+        end else begin
+          st_d        = StLenLo;
+          inc_txcount = 1'b0;
+        end
+      end
+
+      default: begin
+        st_d = StIdle;
+      end
+    endcase
+  end
+
+  // tx_count
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tx_count <= '0;
+    end else if (hash_start) begin
+      tx_count <= '0;
+    end else if (inc_txcount) begin
+      if (digest_mode_flag == SHA2_256) begin
+        tx_count[127:5] <= tx_count[127:5] + 1'b1;
+      end else if ((digest_mode_flag == SHA2_384) ||(digest_mode_flag == SHA2_512)) begin
+        tx_count[127:6] <= tx_count[127:6] + 1'b1;
+      end
+    end
+  end
+
+  // Latch SHA-2 configured mode
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)                digest_mode_flag <= None;
+    else if (hash_start)        digest_mode_flag <= digest_mode;
+    else if (hash_done == 1'b1) digest_mode_flag <= None;
+  end
+
+  // State machine is in Idle only when it meets tx_count == message length
+  assign msg_feed_complete = hash_process_flag && (st_q == StIdle);
+
+endmodule

--- a/hw/ip/prim/rtl/prim_sha2_pkg.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pkg.sv
@@ -1,0 +1,214 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prim_sha2_pkg;
+
+  localparam int MsgFifoDepth = 16;
+
+  localparam int NumRound256 = 64;   // SHA-224, SHA-256
+  localparam int NumRound512 = 80;   // SHA-512, SHA-384
+
+  typedef logic [31:0] sha_word32_t;
+  typedef logic [63:0] sha_word64_t;
+
+  localparam int WordByte32 = $bits(sha_word32_t)/8;
+  localparam int WordByte64 = $bits(sha_word64_t)/8;
+
+  typedef struct packed {
+    sha_word32_t           data;
+    logic [WordByte32-1:0] mask; // 4 mask bits: to mask off bytes if this is not word-aligned
+                                 // set to all-1 for word-aligned input
+  } sha_fifo32_t;
+
+  typedef struct packed {
+    sha_word64_t           data;
+    logic [WordByte64-1:0] mask; // 8 mask bits: to mask off bytes if this is not word-aligned
+                                 // set to all-1 for word-aligned input
+  } sha_fifo64_t;
+
+  typedef enum logic [1:0] {
+    None,
+    SHA2_256,
+    SHA2_384,
+    SHA2_512
+  } digest_mode_e;
+
+  localparam sha_word32_t InitHash_256 [8]= '{
+    32'h 6a09_e667, 32'h bb67_ae85, 32'h 3c6e_f372, 32'h a54f_f53a,
+    32'h 510e_527f, 32'h 9b05_688c, 32'h 1f83_d9ab, 32'h 5be0_cd19
+  };
+
+  localparam sha_word64_t InitHash_384 [8]= '{
+    64'h cbbb_9d5d_c105_9ed8, 64'h 629a_292a_367c_d507, 64'h 9159_015a_3070_dd17,
+    64'h 152f_ecd8_f70e_5939, 64'h 6733_2667_ffc0_0b31, 64'h 8eb4_4a87_6858_1511,
+    64'h db0c_2e0d_64f9_8fa7, 64'h 47b5_481d_befa_4fa4
+  };
+
+  localparam sha_word64_t InitHash_512 [8]= '{
+    64'h 6a09_e667_f3bc_c908, 64'h bb67_ae85_84ca_a73b, 64'h 3c6e_f372_fe94_f82b,
+    64'h a54f_f53a_5f1d_36f1, 64'h 510e_527f_ade6_82d1, 64'h 9b05_688c_2b3e_6c1f,
+    64'h 1f83_d9ab_fb41_bd6b, 64'h 5be0_cd19_137e_2179
+  };
+
+  // SHA-256 constants
+  localparam sha_word32_t CubicRootPrime256 [64] = '{
+    32'h 428a_2f98, 32'h 7137_4491, 32'h b5c0_fbcf, 32'h e9b5_dba5,
+    32'h 3956_c25b, 32'h 59f1_11f1, 32'h 923f_82a4, 32'h ab1c_5ed5,
+    32'h d807_aa98, 32'h 1283_5b01, 32'h 2431_85be, 32'h 550c_7dc3,
+    32'h 72be_5d74, 32'h 80de_b1fe, 32'h 9bdc_06a7, 32'h c19b_f174,
+    32'h e49b_69c1, 32'h efbe_4786, 32'h 0fc1_9dc6, 32'h 240c_a1cc,
+    32'h 2de9_2c6f, 32'h 4a74_84aa, 32'h 5cb0_a9dc, 32'h 76f9_88da,
+    32'h 983e_5152, 32'h a831_c66d, 32'h b003_27c8, 32'h bf59_7fc7,
+    32'h c6e0_0bf3, 32'h d5a7_9147, 32'h 06ca_6351, 32'h 1429_2967,
+    32'h 27b7_0a85, 32'h 2e1b_2138, 32'h 4d2c_6dfc, 32'h 5338_0d13,
+    32'h 650a_7354, 32'h 766a_0abb, 32'h 81c2_c92e, 32'h 9272_2c85,
+    32'h a2bf_e8a1, 32'h a81a_664b, 32'h c24b_8b70, 32'h c76c_51a3,
+    32'h d192_e819, 32'h d699_0624, 32'h f40e_3585, 32'h 106a_a070,
+    32'h 19a4_c116, 32'h 1e37_6c08, 32'h 2748_774c, 32'h 34b0_bcb5,
+    32'h 391c_0cb3, 32'h 4ed8_aa4a, 32'h 5b9c_ca4f, 32'h 682e_6ff3,
+    32'h 748f_82ee, 32'h 78a5_636f, 32'h 84c8_7814, 32'h 8cc7_0208,
+    32'h 90be_fffa, 32'h a450_6ceb, 32'h bef9_a3f7, 32'h c671_78f2
+  };
+
+  // SHA-512/SHA-384 constants
+  localparam sha_word64_t CubicRootPrime512 [80] = '{
+    64'h 428a_2f98_d728_ae22, 64'h 7137_4491_23ef_65cd, 64'h b5c0_fbcf_ec4d_3b2f,
+    64'h e9b5_dba5_8189_dbbc, 64'h 3956_c25b_f348_b538, 64'h 59f1_11f1_b605_d019,
+    64'h 923f_82a4_af19_4f9b, 64'h ab1c_5ed5_da6d_8118, 64'h d807_aa98_a303_0242,
+    64'h 1283_5b01_4570_6fbe, 64'h 2431_85be_4ee4_b28c, 64'h 550c_7dc3_d5ff_b4e2,
+    64'h 72be_5d74_f27b_896f, 64'h 80de_b1fe_3b16_96b1, 64'h 9bdc_06a7_25c7_1235,
+    64'h c19b_f174_cf69_2694, 64'h e49b_69c1_9ef1_4ad2, 64'h efbe_4786_384f_25e3,
+    64'h 0fc1_9dc6_8b8c_d5b5, 64'h 240c_a1cc_77ac_9c65, 64'h 2de9_2c6f_592b_0275,
+    64'h 4a74_84aa_6ea6_e483, 64'h 5cb0_a9dc_bd41_fbd4, 64'h 76f9_88da_8311_53b5,
+    64'h 983e_5152_ee66_dfab, 64'h a831_c66d_2db4_3210, 64'h b003_27c8_98fb_213f,
+    64'h bf59_7fc7_beef_0ee4, 64'h c6e0_0bf3_3da8_8fc2, 64'h d5a7_9147_930a_a725,
+    64'h 06ca_6351_e003_826f, 64'h 1429_2967_0a0e_6e70, 64'h 27b7_0a85_46d2_2ffc,
+    64'h 2e1b_2138_5c26_c926, 64'h 4d2c_6dfc_5ac4_2aed, 64'h 5338_0d13_9d95_b3df,
+    64'h 650a_7354_8baf_63de, 64'h 766a_0abb_3c77_b2a8, 64'h 81c2_c92e_47ed_aee6,
+    64'h 9272_2c85_1482_353b, 64'h a2bf_e8a1_4cf1_0364, 64'h a81a_664b_bc42_3001,
+    64'h c24b_8b70_d0f8_9791, 64'h c76c_51a3_0654_be30, 64'h d192_e819_d6ef_5218,
+    64'h d699_0624_5565_a910, 64'h f40e_3585_5771_202a, 64'h 106a_a070_32bb_d1b8,
+    64'h 19a4_c116_b8d2_d0c8, 64'h 1e37_6c08_5141_ab53, 64'h 2748_774c_df8e_eb99,
+    64'h 34b0_bcb5_e19b_48a8, 64'h 391c_0cb3_c5c9_5a63, 64'h 4ed8_aa4a_e341_8acb,
+    64'h 5b9c_ca4f_7763_e373, 64'h 682e_6ff3_d6b2_b8a3, 64'h 748f_82ee_5def_b2fc,
+    64'h 78a5_636f_4317_2f60, 64'h 84c8_7814_a1f0_ab72, 64'h 8cc7_0208_1a64_39ec,
+    64'h 90be_fffa_2363_1e28, 64'h a450_6ceb_de82_bde9, 64'h bef9_a3f7_b2c6_7915,
+    64'h c671_78f2_e372_532b, 64'h ca27_3ece_ea26_619c, 64'h d186_b8c7_21c0_c207,
+    64'h eada_7dd6_cde0_eb1e, 64'h f57d_4f7f_ee6e_d178, 64'h 06f0_67aa_7217_6fba,
+    64'h 0a63_7dc5_a2c8_98a6, 64'h 113f_9804_bef9_0dae, 64'h 1b71_0b35_131c_471b,
+    64'h 28db_77f5_2304_7d84, 64'h 32ca_ab7b_40c7_2493, 64'h 3c9e_be0a_15c9_bebc,
+    64'h 431d_67c4_9c10_0d4c, 64'h 4cc5_d4be_cb3e_42b6, 64'h 597f_299c_fc65_7e2a,
+    64'h 5fcb_6fab_3ad6_faec, 64'h 6c44_198c_4a47_5817
+  };
+
+  function automatic sha_word32_t conv_endian32( input sha_word32_t v, input logic swap);
+    sha_word32_t conv_data = {<<8{v}};
+    conv_endian32 = (swap) ? conv_data : v ;
+  endfunction : conv_endian32
+
+  function automatic sha_word64_t conv_endian64( input sha_word64_t v, input logic swap);
+    sha_word64_t conv_data = {<<8{v}};
+    conv_endian64 = (swap) ? conv_data : v ;
+  endfunction : conv_endian64
+
+  function automatic sha_word32_t rotr32( input sha_word32_t v , input integer amt );
+    rotr32 = (v >> amt) | (v << (32-amt));
+  endfunction : rotr32
+
+  function automatic sha_word64_t rotr64( input sha_word64_t v , input integer amt );
+    rotr64 = (v >> amt) | (v << (64-amt));
+  endfunction : rotr64
+
+  function automatic sha_word32_t shiftr32( input sha_word32_t v, input integer amt );
+    shiftr32 = (v >> amt);
+  endfunction : shiftr32
+
+  function automatic sha_word64_t shiftr64( input sha_word64_t v, input integer amt );
+    shiftr64 = (v >> amt);
+  endfunction : shiftr64
+
+  // compression function for SHA-256
+  function automatic sha_word64_t [7:0] compress_256( input sha_word32_t w, input sha_word32_t k,
+                                                input sha_word64_t [7:0] h_i);
+    // as input: takes 64-bit word hash vector, 32-bit slice of w[0] and 32-bit constant
+    automatic sha_word32_t sigma_0, sigma_1, ch, maj, temp1, temp2;
+
+    sigma_1 = rotr32(h_i[4][31:0], 6) ^ rotr32(h_i[4][31:0], 11) ^ rotr32(h_i[4][31:0], 25);
+    ch = (h_i[4][31:0] & h_i[5][31:0]) ^ (~h_i[4][31:0] & h_i[6][31:0]);
+    temp1 = (h_i[7][31:0] + sigma_1 + ch + k + w);
+    sigma_0 = rotr32(h_i[0][31:0], 2) ^ rotr32(h_i[0][31:0], 13) ^ rotr32(h_i[0][31:0], 22);
+    maj = (h_i[0][31:0] & h_i[1][31:0]) ^ (h_i[0][31:0] & h_i[2][31:0]) ^
+          (h_i[1][31:0] & h_i[2][31:0]);
+    temp2 = (sigma_0 + maj);
+
+    // 32-bit zero padding to complete 64-bit words of hash vector for output
+    compress_256[7] = {32'b0, h_i[6][31:0]};          // h = g
+    compress_256[6] = {32'b0, h_i[5][31:0]};          // g = f
+    compress_256[5] = {32'b0, h_i[4][31:0]};          // f = e
+    compress_256[4] = {32'b0, h_i[3][31:0] + temp1};  // e = (d + temp1)
+    compress_256[3] = {32'b0, h_i[2][31:0]};          // d = c
+    compress_256[2] = {32'b0, h_i[1][31:0]};          // c = b
+    compress_256[1] = {32'b0, h_i[0][31:0]};          // b = a
+    compress_256[0] = {32'b0, (temp1 + temp2)};       // a = (temp1 + temp2)
+  endfunction : compress_256
+
+  // compression function for SHA-512/384
+  function automatic sha_word64_t [7:0] compress_512( input sha_word64_t w, input sha_word64_t k,
+                                                input sha_word64_t [7:0] h_i);
+    automatic sha_word64_t sigma_0, sigma_1, ch, maj, temp1, temp2;
+
+    sigma_1 = rotr64(h_i[4], 14) ^ rotr64(h_i[4], 18) ^ rotr64(h_i[4], 41);
+    ch = (h_i[4] & h_i[5]) ^ (~h_i[4] & h_i[6]);
+    temp1 = (h_i[7] + sigma_1 + ch + k + w);
+    sigma_0 = rotr64(h_i[0], 28) ^ rotr64(h_i[0], 34) ^ rotr64(h_i[0], 39);
+    maj = (h_i[0] & h_i[1]) ^ (h_i[0] & h_i[2]) ^ (h_i[1] & h_i[2]);
+    temp2 = (sigma_0 + maj);
+
+    compress_512[7] = h_i[6];          // h = g
+    compress_512[6] = h_i[5];          // g = f
+    compress_512[5] = h_i[4];          // f = e
+    compress_512[4] = h_i[3] + temp1;  // e = (d + temp1)
+    compress_512[3] = h_i[2];          // d = c
+    compress_512[2] = h_i[1];          // c = b
+    compress_512[1] = h_i[0];          // b = a
+    compress_512[0] = (temp1 + temp2); // a = (temp1 + temp2)
+  endfunction : compress_512
+
+  function automatic sha_word32_t calc_w_256(input sha_word32_t w_0,
+                                       input sha_word32_t w_1,
+                                       input sha_word32_t w_9,
+                                       input sha_word32_t w_14);
+    automatic sha_word32_t sum0, sum1;
+    sum0 = rotr32(w_1,   7) ^ rotr32(w_1,  18) ^ shiftr32(w_1,   3);
+    sum1 = rotr32(w_14, 17) ^ rotr32(w_14, 19) ^ shiftr32(w_14, 10);
+    calc_w_256 = w_0 + sum0 + w_9 + sum1;
+  endfunction : calc_w_256
+
+  function automatic sha_word64_t calc_w_512(input sha_word64_t w_0,
+                                       input sha_word64_t w_1,
+                                       input sha_word64_t w_9,
+                                       input sha_word64_t w_14);
+    automatic sha_word64_t sum0, sum1;
+    sum0 = rotr64(w_1,   1) ^ rotr64(w_1,  8) ^ shiftr64(w_1,   7);
+    sum1 = rotr64(w_14, 19) ^ rotr64(w_14, 61) ^ shiftr64(w_14, 6);
+    calc_w_512 = w_0 + sum0 + w_9 + sum1;
+  endfunction : calc_w_512
+
+  typedef enum logic [31:0] {
+    NoError                    = 32'h 0000_0000,
+    // SwPushMsgWhenShaDisabled is not used in this version. The error code is
+    // guarded by the HW. HW drops the message write request if `sha_en` is
+    // off. eunchan@ left the error code to not corrupt the code sequence.
+    // Need to rename to DeprecatedSwPush...
+    //
+    // Issue #3022
+    SwPushMsgWhenShaDisabled   = 32'h 0000_0001,
+    SwHashStartWhenShaDisabled = 32'h 0000_0002,
+    SwUpdateSecretKeyInProcess = 32'h 0000_0003,
+    SwHashStartWhenActive      = 32'h 0000_0004,
+    SwPushMsgWhenDisallowed    = 32'h 0000_0005
+  } err_code_e;
+
+endpackage : hmac_multimode_pkg


### PR DESCRIPTION
This PR is a reduced PR spun off from the PR #20472 (see discussion in PR) which commits only the RTL for the SHA-2 multi-mode primitive that can be compile-time configured as 256-bit or multi-mode. This also includes fixes for RTL code styling in the HMAC IP that were not complying with the Verilog style guidelines, and RTL fixes and linting waiver updates to pass AscentLint linting. 

After discussions in the Silicon WG meeting Dec 12 2023, it was agreed that we would get the SHA-2 prim changes and testbenches first merged, and follow up with the instantiation in HMAC and DMA in a later PR to not impact RTL freeze and coverage metrics (even if DV regression pass rates are unaffected). We will also discuss if it is required/useful to extend HMAC to support the extended digest modes for Earlgrey PROD and Darjeeling later.

The first commit is the multi-mode RTL implementation as baseline, and second is the actual prim_sha2 RTL and linting waivers. 