### PR TITLE
[opentitantool] fix token parsing for LC transition command

### DIFF
--- a/sw/host/opentitanlib/src/dif/lc_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/lc_ctrl.rs
@@ -279,6 +279,18 @@ impl From<[u32; 4]> for DifLcCtrlToken {
     }
 }
 
+impl From<Vec<u32>> for DifLcCtrlToken {
+    fn from(vector: Vec<u32>) -> Self {
+        let bytes: [u8; 16] = vector
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect::<Vec<u8>>()
+            .try_into()
+            .unwrap();
+        DifLcCtrlToken::from(bytes)
+    }
+}
+
 impl DifLcCtrlToken {
     /// Converts a 128-bit transition token into four native u32 words. These
     /// values are suitable to write to [LcCtrlReg::TransitionToken0] and

--- a/sw/host/opentitantool/src/command/lc.rs
+++ b/sw/host/opentitantool/src/command/lc.rs
@@ -58,11 +58,13 @@ fn parse_token_str(token: &str) -> Result<DifLcCtrlToken> {
     } else {
         hex_str_no_sep.as_str()
     };
-    let mut token_bytes_vec = decode(sanitized_hex_str)?;
-    token_bytes_vec.reverse();
+    let token_bytes_vec = decode(sanitized_hex_str)?
+        .chunks(4)
+        .map(|bytes| u32::from_be_bytes(bytes.try_into().unwrap()))
+        .collect::<Vec<u32>>();
     let length = token_bytes_vec.len();
     ensure!(
-        length == 16,
+        length == 4,
         "Expected a token of length 16-bytes but it was {length}-bytes."
     );
     Ok(DifLcCtrlToken::from(token_bytes_vec))


### PR DESCRIPTION
The token was being parsed in the wrong order. Resulting in failed transitions.