### PR TITLE
Remove uses of `incompatible_use_toolchain_transition`.

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -23,7 +23,9 @@ load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 # Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
 # to get to them.
 OPENTITAN_CPU = _OPENTITAN_CPU
+
 OPENTITAN_PLATFORM = _OPENTITAN_PLATFORM
+
 opentitan_transition = _opentitan_transition
 
 _targets_compatible_with = {
@@ -93,25 +95,25 @@ def create_key_struct(rsa_key, spx_key):
 SILICON_CREATOR_KEYS = struct(
     FAKE = struct(
         RSA = struct(
-            TEST = [
-                create_test_key("fake_rsa_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0"),
-            ],
             DEV = [
                 create_dev_key("fake_rsa_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/rsa:dev_private_key_0"),
             ],
             PROD = [
                 create_prod_key("fake_rsa_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0"),
             ],
+            TEST = [
+                create_test_key("fake_rsa_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0"),
+            ],
         ),
         SPX = struct(
-            TEST = [
-                create_test_key("fake_spx_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx"),
-            ],
             DEV = [
                 create_dev_key("fake_spx_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx"),
             ],
             PROD = [
                 create_prod_key("fake_spx_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx"),
+            ],
+            TEST = [
+                create_test_key("fake_spx_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx"),
             ],
         ),
     ),
@@ -119,27 +121,35 @@ SILICON_CREATOR_KEYS = struct(
     REAL = None,
     UNAUTHORIZED = struct(
         RSA = [
-            create_key_("rsa_unauthorized_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/rsa:unauthorized_private_key_0", []),
+            create_key_(
+                "rsa_unauthorized_0",
+                "@//sw/device/silicon_creator/rom/keys/unauthorized/rsa:unauthorized_private_key_0",
+                [],
+            ),
         ],
         SPX = [
-            create_key_("spx_unauthorized_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:unauthorized_0_spx", []),
+            create_key_(
+                "spx_unauthorized_0",
+                "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:unauthorized_0_spx",
+                [],
+            ),
         ],
     ),
 )
 
 SILICON_OWNER_KEYS = struct(
     FAKE = struct(
+        # We can't expose real private keys publicly.
+        REAL = None,
         RSA = struct(
-            TEST = [
-                create_test_key("fake_rsa_rom_ext_test_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0"),
-            ],
             DEV = [
                 create_dev_key("fake_rsa_rom_ext_dev_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_dev_private_key_0"),
             ],
             PROD = None,
+            TEST = [
+                create_test_key("fake_rsa_rom_ext_test_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0"),
+            ],
         ),
-        # We can't expose real private keys publicly.
-        REAL = None,
         UNAUTHORIZED = None,
     ),
 )
@@ -181,22 +191,52 @@ def filter_key_structs_for_lc_state(key_structs, hw_lc_state):
     return [k for k in key_structs if (not k.rsa or key_allowed_in_lc_state(k.rsa, hw_lc_state)) and (not k.spx or key_allowed_in_lc_state(k.spx, hw_lc_state))]
 
 RSA_ONLY_KEY_STRUCTS = [
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.TEST[0], None),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.DEV[0], None),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.PROD[0], None),
-    create_key_struct(SILICON_CREATOR_KEYS.UNAUTHORIZED.RSA[0], None),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.TEST[0],
+        None,
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.DEV[0],
+        None,
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.PROD[0],
+        None,
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.UNAUTHORIZED.RSA[0],
+        None,
+    ),
 ]
 
 RSA_SPX_KEY_STRUCTS = [
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.TEST[0], SILICON_CREATOR_KEYS.FAKE.SPX.TEST[0]),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.DEV[0], SILICON_CREATOR_KEYS.FAKE.SPX.DEV[0]),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.RSA.PROD[0], SILICON_CREATOR_KEYS.FAKE.SPX.PROD[0]),
-    create_key_struct(SILICON_CREATOR_KEYS.UNAUTHORIZED.RSA[0], SILICON_CREATOR_KEYS.UNAUTHORIZED.SPX[0]),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.TEST[0],
+        SILICON_CREATOR_KEYS.FAKE.SPX.TEST[0],
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.DEV[0],
+        SILICON_CREATOR_KEYS.FAKE.SPX.DEV[0],
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.FAKE.RSA.PROD[0],
+        SILICON_CREATOR_KEYS.FAKE.SPX.PROD[0],
+    ),
+    create_key_struct(
+        SILICON_CREATOR_KEYS.UNAUTHORIZED.RSA[0],
+        SILICON_CREATOR_KEYS.UNAUTHORIZED.SPX[0],
+    ),
 ]
 
 RSA_ONLY_ROM_EXT_KEY_STRUCTS = [
-    create_key_struct(SILICON_OWNER_KEYS.FAKE.RSA.TEST[0], None),
-    create_key_struct(SILICON_OWNER_KEYS.FAKE.RSA.DEV[0], None),
+    create_key_struct(
+        SILICON_OWNER_KEYS.FAKE.RSA.TEST[0],
+        None,
+    ),
+    create_key_struct(
+        SILICON_OWNER_KEYS.FAKE.RSA.DEV[0],
+        None,
+    ),
 ]
 
 def _obj_transform_impl(ctx):
@@ -224,7 +264,6 @@ def _obj_transform_impl(ctx):
     return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
 
 obj_transform = rv_rule(
-    implementation = _obj_transform_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "suffix": attr.string(default = "bin"),
@@ -232,6 +271,7 @@ obj_transform = rv_rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],
+    implementation = _obj_transform_impl,
 )
 
 # A provider for device-specific archive files that hold binaries of SRAM programs.
@@ -367,7 +407,6 @@ def _bin_to_archive_impl(ctx):
     return ArchiveInfo(archive_infos = cc_info_dict)
 
 bin_to_archive = rv_rule(
-    implementation = _bin_to_archive_impl,
     attrs = {
         "binaries": attr.label_list(allow_files = True),
         "devices": attr.string_list(),
@@ -377,6 +416,7 @@ bin_to_archive = rv_rule(
     },
     fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
+    implementation = _bin_to_archive_impl,
 )
 
 def _elf_to_disassembly_impl(ctx):
@@ -405,14 +445,13 @@ def _elf_to_disassembly_impl(ctx):
         return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
 
 elf_to_disassembly = rv_rule(
-    implementation = _elf_to_disassembly_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "platform": attr.string(default = OPENTITAN_PLATFORM),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+    implementation = _elf_to_disassembly_impl,
 )
 
 def _elf_to_scrambled_rom_impl(ctx):
@@ -447,7 +486,6 @@ def _elf_to_scrambled_rom_impl(ctx):
     )]
 
 elf_to_scrambled_rom_vmem = rv_rule(
-    implementation = _elf_to_scrambled_rom_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "data": attr.label_list(allow_files = True),
@@ -461,6 +499,7 @@ elf_to_scrambled_rom_vmem = rv_rule(
             allow_single_file = True,
         ),
     },
+    implementation = _elf_to_scrambled_rom_impl,
 )
 
 def _bin_to_vmem_impl(ctx):
@@ -509,16 +548,19 @@ def _bin_to_vmem_impl(ctx):
     )]
 
 bin_to_vmem = rv_rule(
-    implementation = _bin_to_vmem_impl,
     attrs = {
         "bin": attr.label(allow_single_file = True),
         "word_size": attr.int(
             default = 64,
             doc = "Word size of VMEM file.",
             mandatory = True,
-            values = [32, 64],
+            values = [
+                32,
+                64,
+            ],
         ),
     },
+    implementation = _bin_to_vmem_impl,
 )
 
 def _scramble_flash_vmem_impl(ctx):
@@ -575,7 +617,6 @@ def _scramble_flash_vmem_impl(ctx):
     )]
 
 scramble_flash_vmem = rv_rule(
-    implementation = _scramble_flash_vmem_impl,
     attrs = {
         "otp": attr.label(allow_single_file = True),
         "otp_mmap": attr.label(
@@ -598,6 +639,7 @@ scramble_flash_vmem = rv_rule(
             cfg = "exec",
         ),
     },
+    implementation = _scramble_flash_vmem_impl,
 )
 
 def _gen_sim_dv_logs_db_impl(ctx):
@@ -635,8 +677,6 @@ def _gen_sim_dv_logs_db_impl(ctx):
     )]
 
 gen_sim_dv_logs_db = rule(
-    implementation = _gen_sim_dv_logs_db_impl,
-    cfg = opentitan_transition,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "platform": attr.string(default = OPENTITAN_PLATFORM),
@@ -649,6 +689,8 @@ gen_sim_dv_logs_db = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
+    cfg = opentitan_transition,
+    implementation = _gen_sim_dv_logs_db_impl,
 )
 
 def _assemble_flash_image_impl(ctx):
@@ -682,13 +724,16 @@ def _assemble_flash_image_impl(ctx):
     )]
 
 assemble_flash_image = rv_rule(
-    implementation = _assemble_flash_image_impl,
     attrs = {
-        "image_size": attr.int(default = 0, doc = "Size of the assembled image"),
+        "image_size": attr.int(
+            default = 0,
+            doc = "Size of the assembled image",
+        ),
         "output": attr.string(),
         "binaries": attr.label_keyed_string_dict(allow_empty = False),
     },
     toolchains = [LOCALTOOLS_TOOLCHAIN],
+    implementation = _assemble_flash_image_impl,
 )
 
 def opentitan_binary(
@@ -878,13 +923,13 @@ def _pick_correct_archive_for_device(ctx):
     return [cc_common.merge_cc_infos(cc_infos = cc_infos)]
 
 pick_correct_archive_for_device = rv_rule(
-    implementation = _pick_correct_archive_for_device,
     attrs = {
         "deps": attr.label_list(allow_files = True),
         "device": attr.string(),
     },
     fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
+    implementation = _pick_correct_archive_for_device,
 )
 
 def opentitan_multislot_flash_binary(

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -243,7 +243,6 @@ def _otbn_insn_count_range(ctx):
     return [DefaultInfo(files = depset([out]), runfiles = runfiles)]
 
 otbn_library = rv_rule(
-    implementation = _otbn_library,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "_cc_toolchain": attr.label(
@@ -257,11 +256,10 @@ otbn_library = rv_rule(
     },
     fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+    implementation = _otbn_library,
 )
 
 otbn_binary = rv_rule(
-    implementation = _otbn_binary,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [DefaultInfo]),
@@ -283,12 +281,10 @@ otbn_binary = rv_rule(
     },
     fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+    implementation = _otbn_binary,
 )
 
 otbn_sim_test = rv_rule(
-    implementation = _otbn_sim_test,
-    test = True,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [DefaultInfo]),
@@ -320,13 +316,12 @@ otbn_sim_test = rv_rule(
         ),
     },
     fragments = ["cpp"],
+    test = True,
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+    implementation = _otbn_sim_test,
 )
 
 otbn_consttime_test = rule(
-    implementation = _otbn_consttime_test_impl,
-    test = True,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [OutputGroupInfo]),
@@ -339,10 +334,11 @@ otbn_consttime_test = rule(
             cfg = "exec",
         ),
     },
+    test = True,
+    implementation = _otbn_consttime_test_impl,
 )
 
 otbn_insn_count_range = rule(
-    implementation = _otbn_insn_count_range,
     attrs = {
         "deps": attr.label_list(providers = [OutputGroupInfo]),
         "_counter": attr.label(
@@ -350,4 +346,5 @@ otbn_insn_count_range = rule(
             allow_single_file = True,
         ),
     },
+    implementation = _otbn_insn_count_range,
 )

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -47,7 +47,12 @@ def _clang_format_impl(ctx):
 
 clang_format_attrs = {
     "patterns": attr.string_list(
-        default = ["*.c", "*.h", "*.cc", "*.cpp"],
+        default = [
+            "*.c",
+            "*.h",
+            "*.cc",
+            "*.cpp",
+        ],
         doc = "Filename patterns for format checking",
     ),
     "exclude_patterns": attr.string_list(
@@ -55,7 +60,10 @@ clang_format_attrs = {
     ),
     "mode": attr.string(
         default = "diff",
-        values = ["diff", "fix"],
+        values = [
+            "diff",
+            "fix",
+        ],
         doc = "Execution mode: display diffs or fix formatting",
     ),
     "diff_command": attr.string(
@@ -80,15 +88,15 @@ clang_format_attrs = {
 }
 
 clang_format_check = rule(
-    implementation = _clang_format_impl,
     attrs = clang_format_attrs,
     executable = True,
+    implementation = _clang_format_impl,
 )
 
 _clang_format_test = rule(
-    implementation = _clang_format_impl,
     attrs = clang_format_attrs,
     test = True,
+    implementation = _clang_format_impl,
 )
 
 def clang_format_test(**kwargs):
@@ -274,13 +282,13 @@ def _make_clang_tidy_aspect(enable_fix):
             "_output_group_name": attr.string(default = "clang_tidy"),
             "_output_file_suffix": attr.string(default = "clang-tidy.out"),
         },
-        incompatible_use_toolchain_transition = True,
         fragments = ["cpp"],
         host_fragments = ["cpp"],
         toolchains = ["@rules_cc//cc:toolchain_type"],
     )
 
 clang_tidy_fix_aspect = _make_clang_tidy_aspect(True)
+
 clang_tidy_check_aspect = _make_clang_tidy_aspect(False)
 
 def _audit_sec_mmio_calls_run_action(ctx, cc_toolchain, cc_compile_ctx, generated_file, command_line, src):
@@ -311,7 +319,6 @@ def _audit_sec_mmio_calls_run_action(ctx, cc_toolchain, cc_compile_ctx, generate
     )
 
 audit_sec_mmio_calls_aspect = aspect(
-    implementation = lambda target, ctx: _cc_aspect_impl(target, ctx, _audit_sec_mmio_calls_run_action),
     attr_aspects = ["deps"],
     attrs = {
         "_audit_tool": attr.label(
@@ -322,10 +329,10 @@ audit_sec_mmio_calls_aspect = aspect(
         "_output_group_name": attr.string(default = "audit_sec_mmio"),
         "_output_file_suffix": attr.string(default = "clang-audit.out"),
     },
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
+    implementation = lambda target, ctx: _cc_aspect_impl(target, ctx, _audit_sec_mmio_calls_run_action),
 )
 
 def _clang_tidy_test_impl(ctx):
@@ -345,23 +352,23 @@ def _clang_tidy_test_impl(ctx):
     ]
 
 clang_tidy_rv_test = rv_rule(
-    implementation = _clang_tidy_test_impl,
     attrs = {
         "deps": attr.label_list(
             aspects = [clang_tidy_check_aspect],
         ),
     },
     test = True,
+    implementation = _clang_tidy_test_impl,
 )
 
 clang_tidy_test = rule(
-    implementation = _clang_tidy_test_impl,
     attrs = {
         "deps": attr.label_list(
             aspects = [clang_tidy_check_aspect],
         ),
     },
     test = True,
+    implementation = _clang_tidy_test_impl,
 )
 
 def _html_coverage_report_impl(ctx):
@@ -380,7 +387,6 @@ def _html_coverage_report_impl(ctx):
     )
 
 html_coverage_report = rule(
-    implementation = _html_coverage_report_impl,
     attrs = {
         "_runner": attr.label(
             default = "//rules/scripts:html_coverage_report.template.sh",
@@ -388,6 +394,7 @@ html_coverage_report = rule(
         ),
     },
     executable = True,
+    implementation = _html_coverage_report_impl,
 )
 
 HasModuleIdInfo = provider()
@@ -445,7 +452,6 @@ def _modid_check_aspect_impl(target, ctx):
     ]
 
 modid_check_aspect = aspect(
-    implementation = _modid_check_aspect_impl,
     # Propagate down all dependencies so we go through test suites and other
     # types of dependencies to reach the binaries.
     attr_aspects = ["*"],
@@ -470,6 +476,7 @@ modid_check_aspect = aspect(
             cfg = "exec",
         ),
     },
+    implementation = _modid_check_aspect_impl,
 )
 
 def _rustfmt_impl(ctx):
@@ -526,7 +533,7 @@ rustfmt_attrs = {
 }
 
 rustfmt_fix = rule(
-    implementation = _rustfmt_impl,
     attrs = rustfmt_attrs,
     executable = True,
+    implementation = _rustfmt_impl,
 )


### PR DESCRIPTION
Now that Bazel 7.0 has been released, it's time to remove this tech debt.

This has been a no-op since Bazel 5.0, I've been waiting to remove the code for two years, it's time.

Part of https://github.com/bazelbuild/bazel/issues/14127.