### PR TITLE
[dv,dma] Introduce an adapter between System bus and TL-UL agent

### DIFF
--- a/hw/ip/dma/dv/env/dma_env.core
+++ b/hw/ip/dma/dv/env/dma_env.core
@@ -13,6 +13,7 @@ filesets:
     files:
       - dma_env_pkg.sv
       - dma_if.sv
+      - dma_sys_tl_if.sv
       - dma_handshake_mode_fifo.sv: {is_include_file: true}
       - dma_env_cfg.sv: {is_include_file: true}
       - dma_env_cov.sv: {is_include_file: true}

--- a/hw/ip/dma/dv/env/dma_env.sv
+++ b/hw/ip/dma/dv/env/dma_env.sv
@@ -30,9 +30,17 @@ class dma_env extends cip_base_env #(
     cfg.tl_agent_dma_ctn_cfg.synchronise_ports = 1'b1;
     cfg.tl_agent_dma_sys_cfg.synchronise_ports  = 1'b1;
 
+    // The SoC System bus does not have a TL-style 'ready' signal on the address channel.
+    cfg.tl_agent_dma_sys_cfg.a_ready_delay_min = 0;
+    cfg.tl_agent_dma_sys_cfg.a_ready_delay_max = 0;
+
     // Get dma interface
     if (!uvm_config_db#(dma_vif)::get(this, "", "dma_vif", cfg.dma_vif)) begin
       `uvm_fatal(`gfn, "failed to get dma_vif from uvm_config_db")
+    end
+    // Get SoC System bus <-> TL-UL adapter interface
+    if (!uvm_config_db#(dma_sys_tl_vif)::get(this, "", "dma_sys_tl_vif", cfg.dma_sys_tl_vif)) begin
+      `uvm_fatal(`gfn, "failed to get dma_sys_tl_vif from uvm_config_db")
     end
 
     // Host agent

--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -8,8 +8,9 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
   tl_agent_cfg tl_agent_dma_ctn_cfg;
   tl_agent_cfg tl_agent_dma_sys_cfg;
 
-  // Interface
+  // Interfaces
   dma_vif               dma_vif;
+  dma_sys_tl_vif        dma_sys_tl_vif;
   virtual clk_rst_if    clk_rst_vif;
 
   // Scoreboard

--- a/hw/ip/dma/dv/env/dma_env_cfg.sv
+++ b/hw/ip/dma/dv/env/dma_env_cfg.sv
@@ -18,6 +18,12 @@ class dma_env_cfg extends cip_base_env_cfg #(.RAL_T(dma_reg_block));
   // Variable to indicate if any memory checks are in progress
   bit mem_check_in_progress;
 
+  // Waive full testing of the SoC System bus within block level DV?
+  bit dma_dv_waive_system_bus;
+  // Note: Currently we have only a 32-bit TL-UL model of the SoC System bus when full testing of
+  // the System bus has been explicitly waived.
+  logic [31:0] soc_system_hi_addr;
+
   // Names of interfaces used in DMA block
   // These variables are used to store names of FIFO that are used
   // in scoreboard and environment

--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -49,7 +49,7 @@ package dma_env_pkg;
 
   // types
   typedef virtual dma_if dma_vif;
-  //typedef virtual clk_if clk_rst_vif;
+  typedef virtual dma_sys_tl_if dma_sys_tl_vif;
   typedef class dma_scoreboard;
 
   // DMAC data direction in hardware handshake mode

--- a/hw/ip/dma/dv/env/dma_if.sv
+++ b/hw/ip/dma/dv/env/dma_if.sv
@@ -21,9 +21,4 @@ task automatic init();
   handshake_i <= '0;
 endtask : init
 
-// Drive Handshake
-task automatic drive(input int pos = 0);
-  handshake_i[pos] <= 1'b1;
-endtask : drive
-
 endinterface

--- a/hw/ip/dma/dv/env/dma_sys_tl_if.sv
+++ b/hw/ip/dma/dv/env/dma_sys_tl_if.sv
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "dv_macros.svh"
+`include "prim_assert.sv"
+
+interface dma_sys_tl_if
+  import dma_pkg::*;
+  import tlul_pkg::*;
+#(
+  // Number of address bits used by the TL-UL agent.
+  parameter int unsigned TLAddrWidth = 32
+)
+(
+  input   clk_i,
+  input   rst_ni
+);
+  // Base address of TL-UL agent (4GiB aligned for TLAddrWidth == 32; bottom 32 bits are unused.)
+  logic [SYS_ADDR_WIDTH-1:0] base_addr;
+
+  // Compute 'a_size' value for single word read/write on TL-UL.
+  localparam int unsigned WordSize = $clog2(SYS_DATA_BYTEWIDTH);
+
+  // Set the base address of the window mapping the TL-UL agent into the 64-bit address space.
+  // Presently the agent is restricted to 32-bit addressing, so we map it to a 4GiB-aligned base
+  // address, and check the upper 32 bits on each read/write access.
+  function static void set_base_addr(logic [SYS_ADDR_WIDTH-1:0] base);
+    // Note that when the adapter is not expected to be encountering traffic, the base address is
+    // invalidated using all Xs.
+    `DV_CHECK_FATAL(base === {SYS_ADDR_WIDTH{1'bX}} || base[31:0] === 0,
+                    "Valid TL Agent base address must be 32-bit aligned", "dma_sys_tl_if");
+    base_addr = base;
+  endfunction
+
+  // SoC System Bus host connection
+  sys_req_t sys_h2d;
+  sys_rsp_t sys_d2h;
+
+  // TL-UL device connection
+  tl_h2d_t tl_h2d;
+  tl_d2h_t tl_d2h;
+
+  // Arbitration of write and read requests
+  tl_a_op_e                   h2d_opcode;
+  logic [63:0]                h2d_address;
+  logic [top_pkg::TL_DBW-1:0] h2d_mask;
+  always_comb begin
+    h2d_opcode  = Get;
+    h2d_address = 'b0;
+    h2d_mask    = 'b0;
+
+    // Writes take predecence over reads.
+    //
+    // Not expected to handle simultaneous write and read requests with the current DMA
+    // implementation and the behavior in this case has not been publicly specified.
+    if (sys_h2d.vld_vec[SysCmdWrite]) begin
+      // Write request
+      h2d_opcode  = &sys_h2d.write_be ? PutFullData : PutPartialData;
+      h2d_address = sys_h2d.iova_vec[SysCmdWrite];
+      h2d_mask    = sys_h2d.write_be;
+    end else if (sys_h2d.vld_vec[SysCmdRead]) begin
+      // Read request
+      h2d_address = sys_h2d.iova_vec[SysCmdRead];
+      h2d_mask    = {SYS_DATA_BYTEWIDTH{1'b1}};
+    end
+  end
+
+  // Check that the upper address bits (not visibile to the TL-UL agent) are driven to the correct
+  // values by the host.
+  // Address mismatches are reported immediately to the host and the request is not forwarded to
+  // the TL-UL agent.
+  wire addr_matches = (h2d_address >> TLAddrWidth) === (base_addr >> TLAddrWidth);
+  wire h2d_a_valid  = addr_matches & |sys_h2d.vld_vec;
+  // Writes take predecence over reads.
+  wire write_mismatch =  sys_h2d.vld_vec[SysCmdWrite] & !addr_matches;
+  wire read_mismatch  = !sys_h2d.vld_vec[SysCmdWrite] & sys_h2d.vld_vec[SysCmdRead] &
+                        !addr_matches;
+
+  assign tl_h2d = '{
+    // Host->device address channel
+    a_valid:   h2d_a_valid,
+    a_opcode:  h2d_opcode,
+    a_param:   3'b0,
+    a_size:    top_pkg::TL_SZW'(WordSize),
+    a_mask:    h2d_mask,
+    a_source:  'b0,
+    a_address: h2d_address[TLAddrWidth-1:0],
+    // Host->device write data
+    a_data:    sys_h2d.write_data,
+    a_user:    'b0,
+    // Ready to receive read data
+    d_ready:   1'b1
+  };
+
+  always_comb begin
+    sys_d2h = 'b0;
+    // Read granted immediately, but host must wait for read response.
+    sys_d2h.grant_vec[SysCmdRead]  = 1'b1;
+    // Write does not receive a response; grant write only when TL-UL agent responds.
+    sys_d2h.grant_vec[SysCmdWrite] = tl_d2h.d_valid & (tl_d2h.d_opcode == AccessAck)
+                                   | write_mismatch;
+    // Read response
+    // Note: read errors are signaled by the simultaneous assertion of `read_data_vld` and
+    //       `error_vld.`
+    sys_d2h.read_data_vld          = (tl_d2h.d_valid & (tl_d2h.d_opcode == AccessAckData))
+                                   | read_mismatch;
+    sys_d2h.read_data              = tl_d2h.d_data;
+    sys_d2h.error_vld              = (tl_d2h.d_valid & (tl_d2h.d_opcode == AccessAckData) &
+                                      tl_d2h.d_error)
+                                   | read_mismatch;
+  end
+
+`ifdef INC_ASSERT
+  // Not expected to handle simultaneous write and read requests with the current DMA implementation
+  // and the behavior in this case has not been publicly specified.
+  `ASSERT_NEVER(DisjointReadAndWrite_A, sys_h2d.vld_vec[SysCmdWrite] & sys_h2d.vld_vec[SysCmdRead]);
+`else
+  // Not currently required; combinational logic only
+  logic unused_clk = clk_i;
+  logic unused_rst_n = rst_ni;
+`endif
+endinterface

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -295,6 +295,8 @@ class dma_generic_vseq extends dma_base_vseq;
           `uvm_fatal(`gfn, $sformatf("FATAL: Unexpected/unrecognised completion status 0x%0x",
                                      int'(status)))
         end
+        // Clear 'memory limit' interrupt to prevent it interfering with subsequent transfers.
+        clear_interrupts(1 << DMA_MEM_LIMIT);
 
         // Now that we've finished all DUT accesses for his iteration...
         stop_device();


### PR DESCRIPTION
This PR introduces changes to the DMA block level DV environment to support some testing of the SoC System bus when full testing has been expressly waived. It introduces a simple adapter between DMAC and a TL-UL agent/memory that responds to a 4GiB address window within the 64-bit address space, plus additional constraints to make this usable.

Note that this is based upon understanding of the behavior of the SoC System bus that has to some extent been gleaned from observations of the DMA controller itself, so it should not be regarded as complete. It does, however, offer:

- An increased chance of catching any regressions in the DMA controller logic.
- Testing of 64-bit addressing logic within the DMA controller and the DV environment (SoC System bus is the only bus with a 64-bit address space).
- Improved coverage statistics in the DMA DV and a reduced need for gross exclusions.
- Variable response timing and the reporting of Read errors on the bus (Write errors cannot be returned for this bus).

Note that although the existing test sequences that have thus far been tried against this PR have passed, ~~testing is not yet complete, and in particular~~ this work will need rebasing on top of PR #20657 because of a few common changes/conflicts.