### PR TITLE
[sival,tests] Fix trivial mistakes

### DIFF
--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -48,7 +48,7 @@ static dif_alert_handler_t alert_handler;
  * the escalation.
  */
 enum {
-  kEscalationPhase0Micros = 100 * 1000,  // 10 ms
+  kEscalationPhase0Micros = 100 * 1000,  // 100 ms
   kEscalationPhase2Micros = 100,         // 100 us
   kIrqDeadlineMicros = 10,               // 10 us
   kWdogBarkMicros = 500,                 // 500 us

--- a/sw/device/tests/uart_tx_rx_test.c
+++ b/sw/device/tests/uart_tx_rx_test.c
@@ -121,7 +121,6 @@ static volatile uint32_t uart_irq_rx_watermartk_id;
 static volatile uint32_t uart_irq_tx_empty_id;
 static volatile uint32_t uart_irq_rx_overflow_id;
 static volatile uint32_t uart_irq_rx_frame_err_id;
-static volatile uint32_t uart_irq_rx_frame_err_id;
 static volatile uint32_t uart_irq_rx_break_err_id;
 static volatile uint32_t uart_irq_rx_timeout_id;
 static volatile uint32_t uart_irq_rx_parity_err_id;
@@ -150,7 +149,6 @@ void update_uart_base_addr_and_irq_id(void) {
       uart_irq_tx_empty_id = kTopEarlgreyPlicIrqIdUart0TxEmpty;
       uart_irq_rx_overflow_id = kTopEarlgreyPlicIrqIdUart0RxOverflow;
       uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart0RxFrameErr;
-      uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart0RxFrameErr;
       uart_irq_rx_break_err_id = kTopEarlgreyPlicIrqIdUart0RxBreakErr;
       uart_irq_rx_timeout_id = kTopEarlgreyPlicIrqIdUart0RxTimeout;
       uart_irq_rx_parity_err_id = kTopEarlgreyPlicIrqIdUart0RxParityErr;
@@ -162,7 +160,6 @@ void update_uart_base_addr_and_irq_id(void) {
       uart_irq_rx_watermartk_id = kTopEarlgreyPlicIrqIdUart1RxWatermark;
       uart_irq_tx_empty_id = kTopEarlgreyPlicIrqIdUart1TxEmpty;
       uart_irq_rx_overflow_id = kTopEarlgreyPlicIrqIdUart1RxOverflow;
-      uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart1RxFrameErr;
       uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart1RxFrameErr;
       uart_irq_rx_break_err_id = kTopEarlgreyPlicIrqIdUart1RxBreakErr;
       uart_irq_rx_timeout_id = kTopEarlgreyPlicIrqIdUart1RxTimeout;
@@ -176,7 +173,6 @@ void update_uart_base_addr_and_irq_id(void) {
       uart_irq_tx_empty_id = kTopEarlgreyPlicIrqIdUart2TxEmpty;
       uart_irq_rx_overflow_id = kTopEarlgreyPlicIrqIdUart2RxOverflow;
       uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart2RxFrameErr;
-      uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart2RxFrameErr;
       uart_irq_rx_break_err_id = kTopEarlgreyPlicIrqIdUart2RxBreakErr;
       uart_irq_rx_timeout_id = kTopEarlgreyPlicIrqIdUart2RxTimeout;
       uart_irq_rx_parity_err_id = kTopEarlgreyPlicIrqIdUart2RxParityErr;
@@ -188,7 +184,6 @@ void update_uart_base_addr_and_irq_id(void) {
       uart_irq_rx_watermartk_id = kTopEarlgreyPlicIrqIdUart3RxWatermark;
       uart_irq_tx_empty_id = kTopEarlgreyPlicIrqIdUart3TxEmpty;
       uart_irq_rx_overflow_id = kTopEarlgreyPlicIrqIdUart3RxOverflow;
-      uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart3RxFrameErr;
       uart_irq_rx_frame_err_id = kTopEarlgreyPlicIrqIdUart3RxFrameErr;
       uart_irq_rx_break_err_id = kTopEarlgreyPlicIrqIdUart3RxBreakErr;
       uart_irq_rx_timeout_id = kTopEarlgreyPlicIrqIdUart3RxTimeout;


### PR DESCRIPTION
Fix a comment, remove redundant assignments, and duplicate variable declarations.