### PR TITLE
[sival] ROM_EXT SiVal updates.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -458,6 +458,8 @@
       - [Test Plan](./sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson)
       - [Signoff Test Plan](./sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson)
       - [Shutdown Specification](./sw/device/silicon_creator/rom/doc/shutdown.md)
+    - [ROM\_EXT](./sw/device/silicon_creator/rom_ext/README.md)
+      - [ROM\_EXT for Silicon Validation](./sw/device/silicon_creator/rom_ext/doc/si_val.md)
     - [Manifest Format](./sw/device/silicon_creator/rom_ext/doc/manifest.md)
     - [Boot Log](./sw/device/silicon_creator/doc/boot_log.md)
   - [Top-Level Tests](./sw/device/tests/README.md)

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -699,10 +699,17 @@ void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
  * `flash_ctrl_creator_info_pages_lockdown()`.
  */
 static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
-    &kFlashCtrlInfoPageCreatorSecret,   &kFlashCtrlInfoPageOwnerSecret,
-    &kFlashCtrlInfoPageWaferAuthSecret, &kFlashCtrlInfoPageAttestationKeySeeds,
-    &kFlashCtrlInfoPageBootData0,       &kFlashCtrlInfoPageBootData1,
-    &kFlashCtrlInfoPageOwnerSlot0,      &kFlashCtrlInfoPageOwnerSlot1,
+    // Bank 0
+    &kFlashCtrlInfoPageFactoryId,
+    &kFlashCtrlInfoPageCreatorSecret,
+    &kFlashCtrlInfoPageOwnerSecret,
+    &kFlashCtrlInfoPageWaferAuthSecret,
+    &kFlashCtrlInfoPageAttestationKeySeeds,
+    // Bank 1
+    &kFlashCtrlInfoPageBootData0,
+    &kFlashCtrlInfoPageBootData1,
+    &kFlashCtrlInfoPageOwnerSlot0,
+    &kFlashCtrlInfoPageOwnerSlot1,
 };
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -165,7 +165,7 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * ```
  */
 enum {
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 18,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -682,7 +682,8 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 8> no_owner_access = {
+  std::array<const flash_ctrl_info_page_t *, 9> no_owner_access = {
+      &kFlashCtrlInfoPageFactoryId,
       &kFlashCtrlInfoPageCreatorSecret,
       &kFlashCtrlInfoPageOwnerSecret,
       &kFlashCtrlInfoPageWaferAuthSecret,

--- a/sw/device/silicon_creator/rom_ext/README.md
+++ b/sw/device/silicon_creator/rom_ext/README.md
@@ -1,0 +1,14 @@
+# ROM\_EXT
+
+The ROM\_EXT is the first boot mutable stage in the Secure Boot implementation,
+and starts executing after a successful signature verification performed by
+the ROM.
+
+The ROM\_EXT is in charge of verifying the first Silicon Owner mutable code
+partition, and locking down access to device critical assets before handing
+over execution to the next secure boot stage.
+
+## References
+
+* [Manifest Format](doc/manifest.md)
+* [ROM\_EXT for Silicon Validation](doc/si_val.md)

--- a/sw/device/silicon_creator/rom_ext/README.md
+++ b/sw/device/silicon_creator/rom_ext/README.md
@@ -1,6 +1,6 @@
 # ROM\_EXT
 
-The ROM\_EXT is the first boot mutable stage in the Secure Boot implementation,
+The ROM\_EXT is the first (mutable) boot stage in the Secure Boot implementation,
 and starts executing after a successful signature verification performed by
 the ROM.
 

--- a/sw/device/silicon_creator/rom_ext/doc/si_val.md
+++ b/sw/device/silicon_creator/rom_ext/doc/si_val.md
@@ -1,19 +1,22 @@
-# SiVal ROM\_EXT
+# SiVal `ROM_EXT`
 
 ## Lockdowns
 
-The following lockdowns are provided by the SiVal ROM\_EXT.
+The following lockdowns are provided by the SiVal `ROM_EXT`.
 
 ### AST
 
-TODO: Lockdown the AST.
+Access to the AST configuration registers is disabled by the ePMP
+configuration. The manufacturer may also configure the ROM to lockdown AST in
+the ROM stage by configuring the AST initialization sequence in OTP.
 
 ### ePMP
 
 The ePMP will allow access to the FLASH, to the MMIO region and to SRAM.
 
-An example of how the SiVal ROM\_EXT will configure the ePMP:
-```
+An example of how the SiVal `ROM_EXT` will configure the ePMP:
+
+```console
  0: 20010400 ----- ---- sz=00000000     ; OWNER code start.
  1: 20013d24   TOR LX-R sz=00003924     ; OWNER code end.
  2: 00008000 NAPOT L--R sz=00008000     ; OWNER data (if using remap window, else ROM data region)
@@ -37,21 +40,41 @@ mseccfg = 00000002                      ; RLB=0, MMWP=1, MML=0.
 
 - The OTP creator partition memory window is locked and is unreadable.
 - The OTP owner partition memory window is readable.
-- The OTP direct access interface is not available due to the ePMP lockout of the OTP register region.
+- The OTP direct access interface is not available due to the ePMP lockout of
+  the OTP register region.
 
 ### SRAM
 
-SRAM execution is forbidden.
-Both the ePMP and SRAM controller will forbid execution from SRAM.
+SRAM execution is forbidden to force all PROD SiVal configurations to enforce
+signature verification of programs loaded into the flash owner partitions.
 
-TODO: Re-evaluate this if needed.
+Both the ePMP and SRAM controller will forbid execution from SRAM. The SRAM
+controller configuration is locked by the `ROM_EXT`.
 
 ### FLASH
 
-The FLASH info pages designeded for `silicon_creator` use will be locked as no-access.
+The FLASH info pages designed for `silicon_creator` use are locked as
+no-access.
+
+Page ID                               | Bank | Page
+--------------------------------------|------|------
+kFlashCtrlInfoPageFactoryId           | 0    | 0
+kFlashCtrlInfoPageCreatorSecret       | 0    | 1
+kFlashCtrlInfoPageOwnerSecret         | 0    | 2
+kFlashCtrlInfoPageWaferAuthSecret     | 0    | 3
+kFlashCtrlInfoPageAttestationKeySeeds | 0    | 4
+kFlashCtrlInfoPageBootData0           | 1    | 0
+kFlashCtrlInfoPageBootData1           | 1    | 1
+kFlashCtrlInfoPageOwnerSlot0          | 1    | 2
+kFlashCtrlInfoPageOwnerSlot1          | 1    | 3
+
+The canonical info flash reference used by the ROM and the ROM\_EXT is available
+in the `sw/device/silicon_creator/lib/drivers/flash_ctrl.h` module.
 
 ### Key Manager
 
-The key manager will be moved to the final state so that no creator or intermediate stages may be accessed by owner code.
+The key manager will be moved to the final state so that no creator or
+intermediate stages may be accessed by owner code.
 
-TODO: Currently we stop at OwnerIntermediateKey.
+The end state of the key manager is `kKeymgrStateOwnerKey` for this
+configuration.


### PR DESCRIPTION
1. Update the info page lockdown configuration to include the `kFlashCtrlInfoPageFactoryId` page.
2. Updates the ROM_EXT SiVal documentation to include relevant details for this configuration. 