### PR TITLE
[sival] Document silicon execution environments.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -473,6 +473,7 @@
   - [OpenTitan Certificate Generator](./sw/host/ot_certs/README.md)
   - [Hardware Security Module (HSM) tool](./sw/host/hsmtool/README.md)
     - [Requirements](./sw/host/hsmtool/doc/requirements.md)
+    - [Signing Guide](./signing/README.md)
   - [OpenTitanLib](./sw/host/opentitanlib/README.md)
   - [OpenTitanSession](./sw/host/opentitansession/README.md)
   - [OpenTitanTool](./sw/host/opentitantool/README.md)

--- a/signing/README.md
+++ b/signing/README.md
@@ -1,4 +1,4 @@
-# Signing
+# Signing Guide
 
 ## Configuration of NitroKeys
 
@@ -13,9 +13,11 @@ the private key material for the named keyset.
 
 For example, a configuration for `//sw/device/silicon_creator/rom/keys/real/rsa:keyset`
 might look like the following:
-```
-# Locate this file in $HOME/.config/hsmtool/profiles.json and set the file
-# mode to 700.
+
+>Locate this file in $HOME/.config/hsmtool/profiles.json and set the file
+mode to 700.
+
+```json
 {
   "earlgrey_a0": {
     "token": "earlgrey_a0_000",
@@ -33,15 +35,17 @@ the keyset by telling bazel that you want to use a token.
 In the example below, we instruct bazel to use a NitroKey as the token
 and to sign with the key specified by the `rsa_key` attribute of the target
 (or the target's `exec_env`).
-```
-$ bazel build --//signing:token=//signing/tokens:nitrokey //label-of-target
+
+```console
+bazel build --//signing:token=//signing/tokens:nitrokey //label-of-target
 ```
 
 To sign with an alternate key, you can override the key label via the
 keyset in question.  For `silicon_creator` code, the keyset is
 `//sw/device/silicon_creator/rom/keys/real/rsa:keyset`.
-```
-$ bazel build \
+
+```console
+bazel build \
     --//signing:token=//signing/tokens:nitrokey \
     --//sw/device/silicon_creator/rom/keys/real/rsa:keyset=earlgrey_a0_dev_0 \
     //label-of-target
@@ -54,8 +58,11 @@ cloud-kms service.
 
 You need an hsmtool profile that maps to the cloud-kms token.  Add an entry
 to your profiles confiuration file:
-```
-# $HOME/.config/hsmtool/profiles.json.
+
+>Locate this file in $HOME/.config/hsmtool/profiles.json and set the file
+mode to 700.
+
+```console
 {
   "earlgrey_z0_sival": {
     "token": "ot-earlgrey-z0-sival",
@@ -66,7 +73,8 @@ to your profiles confiuration file:
 
 In order to sign with the cloud-kms key, you need to authenticate to Google
 cloud using your opentitan.org account.
-```
+
+```console
 # Install the Google cloud CLI if you don't already have it.
 sudo apt install -y google-cloud-cli
 
@@ -78,13 +86,13 @@ gcloud config set project otkms-407107
 
 # Application default authentication
 gcloud auth application-default login
-
 ```
 
 Once authenticated to Google cloud, you can build and sign SiVAL tests
 by requesting the `cloud_kms` token:
-```
-$ bazel build --//signing:token=//signing/tokens:cloud_kms //label-of-target
+
+```console
+bazel build --//signing:token=//signing/tokens:cloud_kms //label-of-target
 ```
 
 ## Demo of offline signing
@@ -99,13 +107,15 @@ and emits signed artifacts.
 Generating the pre-signing artifacts builds the requested targets and
 updates the manifest and public key.  Then, SHA256 digests are computed
 for each binary.
-```
+
+```console
 bazel build //siging/examples:digests
 ```
 
 The bazel `offline_presigning_artifacts` rule updates the binary with
 a supplied manifest and public key:
-```
+
+```console
 opentitantool \
    image manifest update \
    --manifest=<manifest file> \
@@ -116,7 +126,8 @@ opentitantool \
 
 Having updated the manifest and public key, the rule then generates
 the SHA256 digest to be signed:
-```
+
+```console
 opentitantool \
    image digest \
    --bin=<sha256 digest> \
@@ -129,14 +140,15 @@ Normally, in this step, the pre-signing artifacts would be taken to the
 secure facility and a signing ceremony would be performed to create the
 detached signatures.
 
-```
+```console
 bazel build //siging/examples:fake
 ```
 
 The bazel `offline_fake_sign` rule performs the same RSA signing
 operation as the HSM would perform, but public test keys are used
 instead of the real keys:
-```
+
+```console
 opentitantool \
    rsa sign \
    --input=<sha256 digest> \
@@ -149,7 +161,7 @@ opentitantool \
 Normally, in this step, the signatures created in the signing ceremony
 would be copied into the target directory.
 
-```
+```console
 cp -f bazel-bin/signing/examples/*.sig signing/examples/signatures/
 ```
 
@@ -158,14 +170,15 @@ cp -f bazel-bin/signing/examples/*.sig signing/examples/signatures/
 The detached signatures are attached to the pre-signing binaries and
 final signed binaries are produced.
 
-```
+```console
 bazel build //signing/examples:signed
 ```
 
 The bazel `offline_signature_attach` rule takes the signed digests and
 attaches them to the pre-signed binaries, thus producing signed binaries
 that can be verified by the ROM.
-```
+
+```console
 opentitantool \
    image manifest update \
    --signature-file=<signed digest> \
@@ -175,7 +188,7 @@ opentitantool \
 
 ### Inspect the signed artifacts (optional)
 
-```
+```console
 cd $REPO_TOP
 bazel run //sw/host/opentitantool -- \
    image manifest show \

--- a/sw/device/tests/doc/sival/README.md
+++ b/sw/device/tests/doc/sival/README.md
@@ -165,11 +165,12 @@ The following command runs the `SV1` test suite on `fpga_cw310_sival` and
 `fpga_cw310_sival_rom_ext` execution environments.
 
 ```console
-bazel test   --define DISABLE_VERILATOR_BUILD=true   \
-    --test_tag_filters=cw310_sival,cw310_sival_rom_ext   \
-    --test_output=streamed   \
+bazel test   --define DISABLE_VERILATOR_BUILD=true      \
+    --build_tag_filters=cw310_sival,cw310_sival_rom_ext \
+    --test_tag_filters=cw310_sival,cw310_sival_rom_ext  \
+    --test_output=streamed          \
     --define bitstream=gcp_splice   \
-    --cache_test_results=no \
+    --cache_test_results=no         \
     //sw/device/tests/sival:sv1_tests
 ```
 
@@ -180,15 +181,15 @@ execution environment. The binaries are signed with the `earlgrey_a0_dev_0`
 key using the `nitrokey` signing token configuration.
 
 ```console
-bazel test --define DISABLE_VERILATOR_BUILD=true   \
-    --//signing:token=//signing/tokens:nitrokey \
+bazel test --define DISABLE_VERILATOR_BUILD=true \
+    --//signing:token=//signing/tokens:nitrokey  \
     --//sw/device/silicon_creator/rom/keys/real/rsa:keyset=earlgrey_a0_dev_0 \
     --build_tag_filters=silicon_creator \
-    --test_tag_filters=silicon_creator \
-    --test_output=streamed   \
-    --define bitstream=gcp_splice   \
-    --cache_test_results=no \
-    --local_test_jobs 1 \
+    --test_tag_filters=silicon_creator  \
+    --test_output=streamed              \
+    --define bitstream=gcp_splice       \
+    --cache_test_results=no             \
+    --local_test_jobs 1                 \
     //sw/device/tests/sival:sv2_tests
 ```
 
@@ -199,21 +200,23 @@ The following command runs the `SV2` test suite using the
 using the `cloud_kms` signing token configuration.
 
 ```console
-bazel test --define DISABLE_VERILATOR_BUILD=true   \
-    --//signing:token=//signing/tokens:cloud_kms \
+bazel test --define DISABLE_VERILATOR_BUILD=true    \
+    --//signing:token=//signing/tokens:cloud_kms    \
     --build_tag_filters=silicon_owner_sival_rom_ext \
-    --test_tag_filters=silicon_owner_sival_rom_ext \
-    --test_output=streamed   \
+    --test_tag_filters=silicon_owner_sival_rom_ext  \
+    --test_output=streamed          \
     --define bitstream=gcp_splice   \
-    --cache_test_results=no \
-    --local_test_jobs 1 \
+    --cache_test_results=no         \
+    --local_test_jobs 1             \
     //sw/device/tests/sival:sv2_tests
 ```
 
 ## Read More
 
-*  [SiVal Developer Guide](./devguide.md)
-*  [On-Device Test Framework](../../../lib/testing/test_framework/README.md)
 *  [Build & Test Rules](../../../../../rules/opentitan/README.md)
-*  [OTP Build and Test Infrastructure](../../../../../hw/ip/otp_ctrl/data/README.md)
 *  [FPGA Bitstreams](../../../../../hw/bitstream/README.md)
+*  [On-Device Test Framework](../../../lib/testing/test_framework/README.md)
+*  [OTP Build and Test Infrastructure](../../../../../hw/ip/otp_ctrl/data/README.md)
+*  [ROM\_EXT for Silicon Validation](../../../silicon_creator/rom_ext/doc/si_val.md)
+*  [Signing Guide](../../../../../signing/README.md)
+*  [SiVal Developer Guide](./devguide.md)

--- a/sw/device/tests/doc/sival/devguide.md
+++ b/sw/device/tests/doc/sival/devguide.md
@@ -194,5 +194,51 @@ Configuration:
 ### `:fpga_cw310_sival_rom_ext`
 
 FPGA configuration used to emulate silicon targets containing a `rom_ext`
-stage.This is the recommended option for test cases that implemented to run in
+stage. This is the recommended option for test cases that implemented to run in
 `prod` or `prod_end` life cycle states.
+
+## Silicon Targets
+
+`//hw/top_earlgrey/BUILD` defines targets for silicon execution. The following
+sections describe the targets in more detail.
+
+### `:silicon_creator`
+
+This execution environment can be used by targets that require execution at the
+`rom_ext` stage level as well as SRAM programs. Use the
+`silicon_owner_sival_rom_ext` execution environment to target silicon
+configurations where the test must be loaded by a `rom_ext`.
+
+This execution environment is restricted to devices in one of the following
+life cycle stages:
+
+* `test_unlocked{1..7}`
+* `dev`
+* `rma`
+
+This is because PROD signing keys are restricted to offline signing, and by
+policy PROD keys are only targeted for production environments.
+
+> This execution environment requires a physical signing token. See
+[NitroKey](../../../../../signing/README.md#configuration-of-nitrokeys) token
+configuration for more details.
+
+> See [instructions](./README.md#silicon-creator) on how to run the SiVal test
+suites with this execution environment.
+
+### `:silicon_owner_sival_rom_ext`
+
+This execution environment is used to execute on silicon targets containing a
+`rom_ext` stage. This is the recommended option for test cases that implemented
+to run in `prod` or `prod_end` life cycle states.
+
+> This execution environment requires access to the OpenTitan Cloud KMS
+service. See
+[CloudKMS](../../../../../signing/README.md#configuration-for-silicon_owner-sival-signing)
+for more details.
+
+> See [instructions](./README.md#silicon-owner) on how to run the SiVal test
+suites with this execution environment.
+
+> See [ROM\_EXT for SiVal](../../../silicon_creator/rom_ext/doc/si_val.md) for
+more details on the ROM\_EXT configuration.


### PR DESCRIPTION
This commit describes how to use the silicon execution environments and adds cross references to other SiVal relevant documentation.

Only review the last commit. Other commits are part of #20694.