### PR TITLE
[verible-lint] Pin version of verible instead of following latest

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Run Verible linter action
         uses: chipsalliance/verible-linter-action@main
         with:
+          verible_version: "v0.0-3430-g060bde0f"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reviewdog_reporter: 'github-pr-check'
           suggest_fixes: 'false'


### PR DESCRIPTION
The verible github actions look for an Ubuntu-specific tarball in the releases, but these stopped being built. Use the latest release for which that tarball is available.