### PR TITLE
[test] Enable uart_tx_rx_test for fpga sival environments

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -152,6 +152,24 @@ fpga_cw310(
     """,
 )
 
+fpga_cw310(
+    name = "fpga_hyper310_rom_ext",
+    testonly = True,
+    base = ":fpga_hyper310_rom_with_fake_keys",
+    exec_env = "fpga_hyper310_rom_ext",
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+    manifest = "//sw/device/silicon_owner:manifest_standard",
+    otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@0 {firmware}@0x10000",
+    },
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
+)
+
 # FPGA configuration used to emulate silicon targets. This rule can be used by
 # targets that require executing at the `rom_ext` stage level in flash, as well
 # as SRAM programs. Use the `fpga_cw310_sival_rom_ext` execution environment to
@@ -178,7 +196,7 @@ fpga_cw310(
 fpga_cw310(
     name = "fpga_cw310_sival_rom_ext",
     testonly = True,
-    base = ":fpga_cw310_rom_ext",
+    base = ":fpga_hyper310_rom_ext",
     exec_env = "fpga_cw310_sival_rom_ext",
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3999,10 +3999,8 @@ opentitan_binary(
             test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
         ),
         exec_env = {
-            # TODO: this test currently fails on FPGA.
-            # "//hw/top_earlgrey:fpga_cw310_sival": None,
-            # "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            # "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_earlgrey:sim_dv": None,
         },


### PR DESCRIPTION
They pass locally. Also, remove the cw310_test_rom environment from the list, as it doesn't support this test.

Note that this PR depends on https://github.com/lowRISC/opentitan/pull/20696 to bring the fpga_cw310_sival_rom_ext config over to hyper310.