### PR TITLE
[crypto] Add OAEP padding for RSA.

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -19,6 +19,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('d', 'e', 'n')
 
+const entropy_seed_material_t kEntropyEmptySeed = {
+    .len = 0,
+    .data = {0},
+};
+
 enum {
   kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
   kBaseEntropySrc = TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR,

--- a/sw/device/lib/crypto/drivers/entropy.h
+++ b/sw/device/lib/crypto/drivers/entropy.h
@@ -52,6 +52,13 @@ typedef struct entropy_seed_material {
 } entropy_seed_material_t;
 
 /**
+ * Constant empty seed material for the entropy complex.
+ *
+ * This is convenient to have available for some implementations.
+ */
+extern const entropy_seed_material_t kEntropyEmptySeed;
+
+/**
  * Configures the entropy complex in continuous mode.
  *
  * The complex is configured in continuous mode with FIPS mode enabled. This is

--- a/sw/device/lib/crypto/impl/rsa/BUILD
+++ b/sw/device/lib/crypto/impl/rsa/BUILD
@@ -48,6 +48,7 @@ cc_library(
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
+        "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/crypto/impl/sha2:sha256",

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.h
@@ -112,6 +112,93 @@ status_t rsa_padding_pss_verify(const hash_digest_t *message_digest,
                                 size_t encoded_message_len,
                                 hardened_bool_t *result);
 
+/**
+ * Maximum message byte-length for OAEP padding.
+ *
+ * As per RFC 8017, the maximum message byte-length for OAEP is k - 2*hLen - 2,
+ * where k is the size of the RSA modulus in bytes and hLen is the digest
+ * length of the hash function used for padding. This function provides a
+ * simple convenience interface so that callers can check that buffers for
+ * decoded messages are long enough.
+ *
+ * Returns an error if the hash mode is not supported (i.e., a non-fixed-length
+ * hash function).
+ *
+ * @param hash_mode Hash function to use for OAEP.
+ * @param rsa_wordlen RSA modulus size in 32-bit words.
+ * @param[out] max_message_bytelen Maximum length of message in bytes.
+ * @return Result of the operation (OK or error).
+ */
+status_t rsa_padding_oaep_max_message_bytelen(const hash_mode_t hash_mode,
+                                              size_t rsa_wordlen,
+                                              size_t *max_message_bytelen);
+
+/**
+ * Encode the message with OAEP encoding (RFC 8017, section 7.1.1, steps 1-2).
+ *
+ * The caller must ensure that `encoded_message_len` 32-bit words are allocated
+ * in the output buffer.
+ *
+ * The maximum byte-length of the message (as per the RFC) is k - 2*hLen - 2,
+ * where k is the RSA size and hLen is the length of the hash digest. This
+ * function will return an error if the message is too long.
+ *
+ * The hash function must be a fixed-length (SHA-2 or SHA-3) hash function. The
+ * MGF will always be MGF1 with the same hash function.
+ *
+ * We encode the message in reversed byte-order from the RFC because OTBN
+ * interprets the message as a fully little-endian integer.
+ *
+ * @param hash_mode Hash function to use.
+ * @param message Message to encode.
+ * @param message_bytelen Message length in bytes.
+ * @param label Label for OAEP.
+ * @param label_bytelen Label length in bytes.
+ * @param encoded_message_len Intended encoded message length in 32-bit words.
+ * @param[out] encoded_message Encoded message.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t rsa_padding_oaep_encode(const hash_mode_t hash_mode,
+                                 const uint8_t *message, size_t message_bytelen,
+                                 const uint8_t *label, size_t label_bytelen,
+                                 size_t encoded_message_len,
+                                 uint32_t *encoded_message);
+
+/**
+ * Decode the OAEP-encoded message (RFC 8017, section 7.1.2, step 3).
+ *
+ * The maximum byte-length of the message (as per the RFC) is k - 2*hLen - 2,
+ * where k is the RSA size and hLen is the length of the hash digest. The
+ * caller must ensure there are at least this many bytes available for
+ * `message`; they can call `rsa_padding_oaep_max_message_bytelen` to get the
+ * exact value for a given hash mode and RSA size.
+ *
+ * The hash function must be a fixed-length (SHA-2 or SHA-3) hash function. The
+ * MGF will always be MGF1 with the same hash function.
+ *
+ * Note that this function expects the encoded message in reversed byte-order
+ * compared to the RFC, since OTBN is little-endian.
+ *
+ * Warning: modifies the encoded message in-place during comparison
+ * (specifically, reverses the byte-order).
+ *
+ * @param hash_mode Hash function to use.
+ * @param label Label for OAEP.
+ * @param label_bytelen Label length in bytes.
+ * @param encoded_message Encoded message.
+ * @param encoded_message_len Encoded message length in 32-bit words.
+ * @param[out] message Decoded message.
+ * @param[out] message_bytelen Length of the message in bytes.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t rsa_padding_oaep_decode(const hash_mode_t hash_mode,
+                                 const uint8_t *label, size_t label_bytelen,
+                                 uint32_t *encoded_message,
+                                 size_t encoded_message_len, uint8_t *message,
+                                 size_t *message_bytelen);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -18,14 +18,6 @@
 #define MODULE_ID MAKE_MODULE_ID('r', 's', 'v')
 
 /**
- * Constant empty seed material for the entropy complex.
- */
-static const entropy_seed_material_t kEntropyEmptySeed = {
-    .len = 0,
-    .data = {0},
-};
-
-/**
  * Ensure that the digest type matches the length and is supported.
  *
  * Accepts only SHA-2 and SHA-3 family hash functions (XOFs such as SHAKE are


### PR DESCRIPTION
This padding mode is used for RSA encryption and is defined in IETF RFC 8017.

I couldn't find any tests for OAEP specifically, but I implemented RSA encryption on top of this and got it passing tests. The encryption code and tests will be in a follow-up PR or two for size reasons.