### PR TITLE
Post si SKU updates

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/prodc/BUILD
@@ -77,8 +77,8 @@ otp_json(
                 "CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE": otp_hex(0x0),
                 # Disable use of entropy for countermeasures. See the definition
                 # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_TRUE),
-                "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_TRUE),
+                "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_FALSE),
+                "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_FALSE),
                 "CREATOR_SW_CFG_RET_RAM_RESET_MASK": otp_hex(0x0),
                 "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.PRODC),
                 # ROM execution is enabled if this item is set to a non-zero
@@ -334,7 +334,6 @@ cc_library(
 otp_image(
     name = "otp_img_test_unlocked0_manuf_empty",
     src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
-    visibility = ["//visibility:private"],
 )
 
 # `MANUF_INITIALIZED` configuration. This configuration will be generally used

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -199,6 +199,7 @@ filegroup(
     name = "sram_ft_individualize_all",
     testonly = True,
     srcs = [
+        ":sram_ft_individualize_prodc",
         ":sram_ft_individualize_sival",
         ":sram_ft_individualize_sival_bringup",
     ],

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -945,7 +945,7 @@ impl TransportWrapper {
         log::info!("Deasserting the reset signal");
         self.pin_strapping("RESET")?.remove()?;
         if self.disable_dft_on_reset.get() {
-            std::thread::sleep(Duration::from_millis(5));
+            std::thread::sleep(Duration::from_millis(10));
             // We remove the DFT strapping after waiting some time, as the DFT straps should have been
             // sampled by then and we can resume our desired pin configuration.
             self.pin_strapping("PRERESET_DFT_DISABLE")?.remove()?;

--- a/sw/host/opentitanlib/src/test_utils/lc.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc.rs
@@ -16,10 +16,15 @@ pub fn read_lc_state(
     reset_delay: Duration,
 ) -> Result<DifLcCtrlState> {
     transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+
+    // Apply bootstrap pin to be able to connect to JTAG when ROM execution is
+    // enabled.
+    transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
     transport.reset_target(reset_delay, true)?;
     let mut jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
     let raw_lc_state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     jtag.disconnect()?;
     transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;
+    transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     DifLcCtrlState::from_redundant_encoding(raw_lc_state)
 }

--- a/sw/host/provisioning/orchestrator/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/orchestrator.py
@@ -145,7 +145,7 @@ def main():
                         required=True)
     parser.add_argument("--sku",
                         help="SKU",
-                        choices=["sival", "sival_bringup"],
+                        choices=["prodc", "sival", "sival_bringup"],
                         required=True)
     parser.add_argument("--fpga_test",
                         action="store_true",


### PR DESCRIPTION
1. Add `prodc` to provisioning scripts.
2. Update `prodc` OTP config to match the `sival_bringup` configuration.
3. Force `rom_bootstrap` pins before connecting to life-cycle tap during provisioning.
4. Increase the DFT strap apply time to 10ms to account for slower parts.