### PR TITLE
[RV_DM] rv_dm_jtag_dmi_debug_disabled_vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -276,9 +276,8 @@
               originally written value.
             '''
       stage: V2
-      tests: [] // TODO(#15667)
+      tests: ["rv_dm_jtag_dmi_debug_disabled"]
     }
-
     {
       name: sba_debug_disabled
       desc: '''

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -43,6 +43,7 @@ filesets:
       - seq_lib/rv_dm_ndmreset_req_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_jtag_dmi_debug_disabled_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
+  task body();
+    uvm_reg_data_t rdata;
+    repeat ($urandom_range(1, 10)) begin
+    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value('h58743902));
+    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+    cfg.rv_dm_vif.lc_hw_debug_en<=lc_ctrl_pkg::Off;
+    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value('h11035662));
+    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
+    `DV_CHECK_EQ(rdata, jtag_dmi_ral.abstractdata[0].get_reset());
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+    cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+    cfg.rv_dm_vif.lc_hw_debug_en<=lc_ctrl_pkg::On;
+    cfg.clk_rst_vif.wait_clks(5);
+    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
+    `DV_CHECK_EQ('h58743902,rdata);
+   end
+
+  endtask : body
+endclass  : rv_dm_jtag_dmi_debug_disabled_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -21,3 +21,4 @@
 `include "rv_dm_ndmreset_req_vseq.sv"
 `include "rv_dm_jtag_dtm_idle_hint_vseq.sv"
 `include "rv_dm_jtag_dmi_dm_inactive_vseq.sv"
+`include "rv_dm_jtag_dmi_debug_disabled_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -240,6 +240,11 @@
       uvm_test_seq: rv_dm_jtag_dmi_dm_inactive_vseq
       reseed: 2
     }
+    {
+      name: rv_dm_jtag_dmi_debug_disabled
+      uvm_test_seq: rv_dm_jtag_dmi_debug_disabled_vseq
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This test verify that read/write operation on dmi register cannot be performed if pinmux_hw_debug_en is a non strict true value.