### PR TITLE
[doc,reset] Fix references to reset behavior

### DIFF
--- a/hw/ip/lc_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/lc_ctrl/doc/theory_of_operation.md
@@ -149,8 +149,6 @@ When HW_DEBUG_EN is OFF, the TAP should not be able to perform its normal debug 
 #### CPU_EN
 
 CPU_EN controls whether code execution is allowed.
-This is implemented as part of the processor's reset controls.
-In OpenTitan's [reset topology](../../rstmgr/README.md), it is not possible to reset only the processor by itself, so this reset control extends to a large population of the OpenTitan peripherals.
 
 This ensures that during specific states (RAW, TEST_LOCKED, SCRAP, INVALID) it is not possible for the processor to execute code that breaks the device out of a non-functional state.
 

--- a/hw/ip/rv_dm/doc/interfaces.md
+++ b/hw/ip/rv_dm/doc/interfaces.md
@@ -60,8 +60,7 @@ Note that in order to support the non-debug module (NDM) reset functionality, th
 
 The first one comes directly from the life cycle controller and is a "live" value, decoded from the current life cycle state.
 The second one is a latched version coming from the [strap sampling and TAP selection logic inside the pinmux](../../pinmux/doc/theory_of_operation.md#strap-sampling-and-tap-isolation).
-In addition to the power, reset and clock managers, the `rv_dm` and the TAP selection logic in the pinmux are the only parts of the system that do not get reset when an NDM reset is triggered (see also [reset manager documentation](../../rstmgr/doc/theory_of_operation.md#system-reset-tree)).
-The latched variant of the signal allows to keep the JTAG side of the debug module operational while the rest of the system (including the life cycle controller) undergoes a reset cycle.
+When NDM reset is triggered the life cycle controller is reset, but the debug module is not, so the latched variant of the signal allows the JTAG side of the debug module to remain operational.
 
 ## JTAG
 


### PR DESCRIPTION
- Don't mention the reset topology in the lc_ctrl theory of operation doc's description of CPU_EN since lc_cpu_en_o is independent of reset, and rv_core_ibex gets a separate fetch_en input from pwrmgr that determines whether the cpu is effectively enabled.
- Fix the life cycle control description in the rv_dm interfaces doc: all it needs to say is that NDM reset will not reset rv_dm but will reset lc_ctrl. The prior text is inaccurate.

Fixes #20700