### PR TITLE
[sival,plic] Fix plic_all_irqs_test_10 and enable for silicon

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -24,6 +24,11 @@
         "chip_plic_all_irqs_10",
         "chip_plic_all_irqs_20",
       ]
+      bazel: [
+        "//sw/device/tests/autogen:plic_all_irqs_test_0",
+        "//sw/device/tests/autogen:plic_all_irqs_test_10",
+        "//sw/device/tests/autogen:plic_all_irqs_test_20",
+      ]
     }
     {
       name: chip_sw_plic_sw_irq

--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -10,10 +10,72 @@
 load(
     "//rules/opentitan:defs.bzl",
     "opentitan_test",
+    "silicon_params",
     "verilator_params",
 )
 
+package(default_visibility = ["//visibility:public"])
+
 # IP Integration Tests
+opentitan_test(
+    name = "plic_all_irqs_test_0".format(min),
+    srcs = ["plic_all_irqs_test.c"],
+    copts = [
+        "-DTEST_MIN_IRQ_PERIPHERAL=0",
+        "-DTEST_MAX_IRQ_PERIPHERAL=10",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    silicon_owner = silicon_params(
+        # TODO(lowrisc/opentitan#20747): Enable silicon_owner when fixed.
+        tags = ["broken"],
+    ),
+    verilator = verilator_params(
+        timeout = "eternal",
+        tags = ["flaky"],
+        # often times out in 3600s on 4 cores
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:adc_ctrl",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pattgen",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 [
     opentitan_test(
         name = "plic_all_irqs_test_{}".format(min),
@@ -26,6 +88,7 @@ load(
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
         },
@@ -36,6 +99,7 @@ load(
         ),
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/arch:boot_stage",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:adc_ctrl",
             "//sw/device/lib/dif:alert_handler",
@@ -67,7 +131,7 @@ load(
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for min in range(0, 23, 10)
+    for min in range(10, 23, 10)
 ]
 
 test_suite(

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -48,6 +48,8 @@ test_suite(
         "//sw/device/tests:uart1_tx_rx_test",
         "//sw/device/tests:uart2_tx_rx_test",
         "//sw/device/tests:uart_smoketest",
+        "//sw/device/tests/autogen:plic_all_irqs_test_10",
+        "//sw/device/tests/autogen:plic_all_irqs_test_20",
     ],
 )
 


### PR DESCRIPTION
- Disable otp_ctrl CSR accesses in Owner boot stage since they are made illegal by rom_ext. This makes plic_all_irqs_test_10 pass, so enable it for silicon_owner_sival_rom_ext.
- The plic_all_irqs_test_10 test was already passing, so it is also enabled for silicon_owner_sival_rom_ext.
- Split the plic_all_irqs_test_0 test in the autogen BUILD file to mark it as broken for silicon_owner_sival_rom_ext.
- Add plic_all_irqs_test_10 and 20 to the sival sv2_tests suite.