### PR TITLE
[provisioning] Sign ft programs with generic manifest.

### DIFF
--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//rules:const.bzl", "CONST")
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:opentitan.bzl",
     "RSA_ONLY_KEY_STRUCTS",
@@ -327,6 +328,13 @@ opentitan_test(
     ),
 )
 
+manifest(d = {
+    "name": "manifest",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:private"],
+})
+
 offline_presigning_artifacts(
     name = "presigning",
     testonly = True,
@@ -335,7 +343,7 @@ offline_presigning_artifacts(
         ":ft_personalize_2",
         ":ft_personalize_3",
     ],
-    manifest = "//sw/device/silicon_creator/rom_ext/sival:manifest_sival",
+    manifest = ":manifest",
     rsa_key = {
         "//sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_prod_0": "ealrgrey_a0_prod_0",
     },

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -22,7 +22,7 @@ manifest(d = {
     "address_translation": hex(CONST.HARDENED_FALSE),
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
-    "visibility": ["//visibility:public"],
+    "visibility": ["//visibility:private"],
 })
 
 # To test that the fake-signed SiVAL ROM_EXT can boot, you need a bitstream


### PR DESCRIPTION
Remove SKU restriction from the manifest used to sign the FT provisioning firmware. This is to allow the firmware to be used across all available EarlGrey SKUs.