### PR TITLE
[sival,tests] Enable clkmgr_off_otbn_trans_test in silicon

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -806,7 +806,7 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
     deps = ["clkmgr_off_trans_impl"],


### PR DESCRIPTION
The fpga_cw310_sival_rom_ext env is already part of EARLGREY_TEST_ENVS.