### PR TITLE
[crypto] Implement symmetric blinded key import/export.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -71,15 +71,17 @@ Word buffers can be safely interpreted as byte streams by the caller; the bytes 
 ### Key data structures
 
 Keys receive extra protection from the cryptolib.
-Public keys are represented in plain, "unblinded" form, but have a checksum to protect their integrity.
+Public keys are represented in plain, "unblinded" form, but include a checksum to protect them against accidental corruption.
 The checksum is implementation-specific and may change over time.
-Therefore, the caller should not compute the checksum themselves; use the key import/export functions to construct unblinded keys.
+The caller should use algorithm-specific routines to construct unblinded keys; see e.g. the ECC and RSA sections for details.
 
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_unblinded_key }}
 
-Secret keys are _blinded_ (also called "masked"), meaning that keys are represented by at least two "shares" the same size as the key.
+Secret keys are "blinded", meaning that keys are represented by at least two "shares" the same size as the key.
+Blinded keys are also sometimes referred to as "masked".
 This helps protect against e.g. power side-channel attacks, because the code will never handle a bit of the "real" key, only the independent shares.
 The exact blinding method and internal representation of blinded key data is opaque to the caller and subject to change in future library versions.
+Lke unblinded keys, they include a checksum.
 Callers should use key import/export functions to generate, construct, and interpret blinded keys.
 
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h crypto_blinded_key }}

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -17,11 +17,12 @@ namespace {
 using ::testing::ElementsAreArray;
 
 // Key configuration for testing (128-bit AES-CTR hardware-backed key).
-constexpr crypto_key_config_t kConfigCtr128 = {
+constexpr crypto_key_config_t kConfigHwBackedAesCtr128 = {
     .version = kCryptoLibVersion1,
     .key_mode = kKeyModeAesCtr,
     .key_length = 128 / 8,
     .hw_backed = kHardenedBoolTrue,
+    .exportable = kHardenedBoolFalse,
     .security_level = kSecurityLevelLow,
 };
 
@@ -31,10 +32,31 @@ constexpr crypto_key_config_t kConfigRsaInvalid = {
     .key_mode = kKeyModeRsaSignPkcs,
     .key_length = 2048 / 8,
     .hw_backed = kHardenedBoolTrue,
+    .exportable = kHardenedBoolFalse,
     .security_level = kSecurityLevelLow,
 };
 
-TEST(Keyblob, HwBackedKeyToDiversificationData) {
+// Key configuration for testing (128-bit AES-CTR exportable key).
+constexpr crypto_key_config_t kConfigExportableAesCtr128 = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeAesCtr,
+    .key_length = 128 / 8,
+    .hw_backed = kHardenedBoolFalse,
+    .exportable = kHardenedBoolTrue,
+    .security_level = kSecurityLevelLow,
+};
+
+// Key configuration for testing (128-bit AES-CTR non-exportable key).
+constexpr crypto_key_config_t kConfigNonExportableAesCtr128 = {
+    .version = kCryptoLibVersion1,
+    .key_mode = kKeyModeAesCtr,
+    .key_length = 128 / 8,
+    .hw_backed = kHardenedBoolFalse,
+    .exportable = kHardenedBoolFalse,
+    .security_level = kSecurityLevelLow,
+};
+
+TEST(KeyTransport, HwBackedKeyToDiversificationData) {
   uint32_t test_version = 0xf0f1f2f3;
   std::array<uint32_t, 7> test_salt = {0x01234567, 0x89abcdef, 0x00010203,
                                        0x04050607, 0x08090a0b, 0x0c0d0e0f,
@@ -43,7 +65,7 @@ TEST(Keyblob, HwBackedKeyToDiversificationData) {
   // Create a key handle from the test data.
   uint32_t keyblob[32] = {0};
   crypto_blinded_key_t key = {
-      .config = kConfigCtr128,
+      .config = kConfigHwBackedAesCtr128,
       .keyblob_length = 32,
       .keyblob = keyblob,
   };
@@ -62,10 +84,10 @@ TEST(Keyblob, HwBackedKeyToDiversificationData) {
     EXPECT_EQ(diversification.salt[i], test_salt[i]);
   }
   EXPECT_EQ(diversification.salt[kKeymgrSaltNumWords - 1],
-            kConfigCtr128.key_mode);
+            kConfigHwBackedAesCtr128.key_mode);
 }
 
-TEST(Keyblob, HwBackedRsaKeyFails) {
+TEST(KeyTransport, HwBackedRsaKeyFails) {
   uint32_t test_version = 0xf0f1f2f3;
   std::array<uint32_t, 7> test_salt = {0x01234567, 0x89abcdef, 0x00010203,
                                        0x04050607, 0x08090a0b, 0x0c0d0e0f,
@@ -83,6 +105,219 @@ TEST(Keyblob, HwBackedRsaKeyFails) {
   EXPECT_EQ(
       status_ok(otcrypto_hw_backed_key(test_version, test_salt.data(), &key)),
       false);
+}
+
+TEST(KeyTransport, BlindedKeyImportExport) {
+  std::array<uint32_t, 4> share0 = {0x00010203, 0x04050607, 0x08090a0b,
+                                    0x0c0d0e0f};
+  std::array<uint32_t, 4> share1 = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb,
+                                    0xfcfdfeff};
+
+  // Determine the unmasked value of the key.
+  std::array<uint32_t, 4> unmasked_key;
+  for (size_t i = 0; i < unmasked_key.size(); i++) {
+    unmasked_key[i] = share0[i] ^ share1[i];
+  }
+
+  uint32_t keyblob[share0.size() * 2];
+  crypto_blinded_key_t blinded_key = {
+      .config = kConfigExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Import the key into the blinded key struct.
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size(),
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size(),
+                    .data = share1.data(),
+                },
+                &blinded_key)),
+            true);
+
+  // Zero the original inputs (they should now be safe to free).
+  memset(share0.data(), 0, sizeof(share0));
+  memset(share1.data(), 0, sizeof(share1));
+
+  // Export the key again.
+  crypto_word32_buf_t share0_buf = {
+      .len = share0.size(),
+      .data = share0.data(),
+  };
+  crypto_word32_buf_t share1_buf = {
+      .len = share1.size(),
+      .data = share1.data(),
+  };
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, &share0_buf,
+                                                  &share1_buf)),
+            true);
+
+  // Unmask the result and compare to the unmasked key.
+  for (size_t i = 0; i < unmasked_key.size(); i++) {
+    EXPECT_EQ(unmasked_key[i], share0[i] ^ share1[i]);
+  }
+}
+
+TEST(KeyTransport, BlindedKeyImportBadLengths) {
+  std::array<uint32_t, 4> share0 = {0x00010203, 0x04050607, 0x08090a0b,
+                                    0x0c0d0e0f};
+  std::array<uint32_t, 4> share1 = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb,
+                                    0xfcfdfeff};
+
+  // Create destination struct.
+  uint32_t keyblob[share0.size() * 2];
+  crypto_blinded_key_t blinded_key = {
+      .config = kConfigExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Set a bad length for share 0 and expect the import to fail.
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size() - 1,
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size(),
+                    .data = share1.data(),
+                },
+                &blinded_key)),
+            false);
+
+  // Set a bad length for share 1 and expect the import to fail.
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size(),
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size() - 1,
+                    .data = share1.data(),
+                },
+                &blinded_key)),
+            false);
+
+  // Set a bad length for the keyblob and expect the import to fail.
+  crypto_blinded_key_t bad_blinded_key = {
+      .config = kConfigExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob) - 1,
+      .keyblob = keyblob,
+  };
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size(),
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size(),
+                    .data = share1.data(),
+                },
+                &bad_blinded_key)),
+            false);
+}
+
+TEST(KeyTransport, BlindedKeyExportBadLengths) {
+  std::array<uint32_t, 4> share0 = {0x00010203, 0x04050607, 0x08090a0b,
+                                    0x0c0d0e0f};
+  std::array<uint32_t, 4> share1 = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb,
+                                    0xfcfdfeff};
+
+  // Create destination struct.
+  uint32_t keyblob[share0.size() * 2];
+  crypto_blinded_key_t blinded_key = {
+      .config = kConfigExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Import the key.
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size(),
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size(),
+                    .data = share1.data(),
+                },
+                &blinded_key)),
+            true);
+
+  crypto_word32_buf_t share_with_good_length = {
+      .len = share0.size(),
+      .data = share0.data(),
+  };
+  crypto_word32_buf_t share_with_bad_length = {
+      .len = share1.size() - 1,
+      .data = share1.data(),
+  };
+
+  // Set a bad length for share 0 and expect the import to fail.
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
+                blinded_key, &share_with_bad_length, &share_with_good_length)),
+            false);
+
+  // Set a bad length for share 1 and expect the import to fail.
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
+                blinded_key, &share_with_good_length, &share_with_bad_length)),
+            false);
+
+  // Set a bad length for the keyblob and expect the export to fail.
+  crypto_blinded_key_t bad_blinded_key = {
+      .config = kConfigExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob) - 1,
+      .keyblob = keyblob,
+  };
+  EXPECT_EQ(
+      status_ok(otcrypto_export_blinded_key(
+          bad_blinded_key, &share_with_good_length, &share_with_good_length)),
+      false);
+}
+
+TEST(KeyTransport, BlindedKeyExportNotExportable) {
+  std::array<uint32_t, 4> share0 = {0x00010203, 0x04050607, 0x08090a0b,
+                                    0x0c0d0e0f};
+  std::array<uint32_t, 4> share1 = {0xf0f1f2f3, 0xf4f5f6f7, 0xf8f9fafb,
+                                    0xfcfdfeff};
+
+  // Create destination struct.
+  uint32_t keyblob[share0.size() * 2];
+  crypto_blinded_key_t blinded_key = {
+      .config = kConfigNonExportableAesCtr128,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Import the key.
+  EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
+                (crypto_const_word32_buf_t){
+                    .len = share0.size(),
+                    .data = share0.data(),
+                },
+                (crypto_const_word32_buf_t){
+                    .len = share1.size(),
+                    .data = share1.data(),
+                },
+                &blinded_key)),
+            true);
+
+  // Expect key export to fail.
+  crypto_word32_buf_t share0_buf = {
+      .len = share0.size(),
+      .data = share0.data(),
+  };
+  crypto_word32_buf_t share1_buf = {
+      .len = share1.size(),
+      .data = share1.data(),
+  };
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, &share0_buf,
+                                                  &share1_buf)),
+            false);
 }
 
 }  // namespace

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -24,7 +24,8 @@ extern "C" {
  *
  * Use this only for symmetric algorithms (e.g. AES, HMAC, KMAC). Asymmetric
  * algorithms (e.g. ECDSA, RSA) have their own specialized key-generation
- * routines.
+ * routines. Cannot be used for hardware-backed keys; use
+ * `otcrypto_hw_backed_key` instead to generate these.
  *
  * The caller should allocate space for the keyblob and populate the blinded
  * key struct with the length of the keyblob, the pointer to the keyblob
@@ -34,14 +35,8 @@ extern "C" {
  * will return an error if the keyblob length does not match expectations based
  * on the key mode and configuration.
  *
- * For hardware-backed keys, the keyblob length should always be 256 bits and
- * the caller should populate the key blob with their desired key version and
- * salt value. The first 32 bits of the key blob are interpreted in
- * little-endian form as the version, and the remaining 224 bits are
- * concatenated with the one-word key mode to become the salt.
- *
- * For non-hardware-backed keys, the keyblob should be twice the length of the
- * key, and the caller only needs to allocate the keyblob, not populate it.
+ * The keyblob should be twice the length of the key. The caller only needs to
+ * allocate the keyblob, not populate it.
  *
  * The personalization string may empty, and may be up to 48 bytes long; any
  * longer will result in an error. It is passed as an extra seed input to the
@@ -80,39 +75,19 @@ crypto_status_t otcrypto_hw_backed_key(uint32_t version, const uint32_t salt[7],
                                        crypto_blinded_key_t *key);
 
 /**
- * Imports a user provided key to an unblinded key struct.
- *
- * This API takes as input a plain key from the user and writes it to the
- * `unblinded_key.key`.
- *
- * The caller should populate the `unblinded_key.key_mode` and allocate
- * space for the key. The value in the `checksum` field of the unblinded
- * key struct will be populated by the key generation function.
- *
- * @param plain_key Pointer to the user defined plain key.
- * @param[out] unblinded_key Generated unblinded key struct.
- * @return Result of the unblinded key import operation.
- */
-crypto_status_t otcrypto_import_unblinded_key(
-    const crypto_const_word32_buf_t plain_key,
-    crypto_unblinded_key_t *unblinded_key);
-
-/**
- * Imports a user provided masked key in shares, to a blinded key struct.
- *
- * This API takes as input a masked key from the user in two shares, and masks
- * it using an implementation specific masking with `n` shares writing the
- * output to the `blinded_key.keyblob`.
+ * Creates a blinded key struct from masked key material.
  *
  * The caller should allocate and partially populate the blinded key struct,
  * including populating the key configuration and allocating space for the
- * keyblob. For non-hardware-backed keys, the keyblob should be twice the
- * length of the user key. For hardware-backed keys, the user should call the
- * `otcrypto_hw_backed_key` function instead. The value in the `checksum` field
- * of the blinded key struct will be populated by the key generation function.
+ * keyblob. The keyblob should be twice the length of the user key.
+ * Hardware-backed and asymmetric (ECC or RSA) keys cannot be imported this
+ * way. For asymmetric keys, use algorithm-specific key construction methods.
  *
- * @param key_share0 Pointer to the 1st share of the user provided key.
- * @param key_share1 Pointer to the 2nd share of the user provided key.
+ * This function will copy the data from the shares into the keyblob; it is
+ * safe to free `key_share0` and `key_share1` after this call.
+ *
+ * @param key_share0 First share of the user provided key.
+ * @param key_share1 Second share of the user provided key.
  * @param[out] blinded_key Generated blinded key struct.
  * @return Result of the blinded key import operation.
  */
@@ -122,23 +97,18 @@ crypto_status_t otcrypto_import_blinded_key(
     crypto_blinded_key_t *blinded_key);
 
 /**
- * Exports an unblinded key to the user provided key buffer.
- *
- * @param unblinded_key Unblinded key struct to be exported.
- * @param[out] plain_key Pointer to the user provided key buffer.
- * @return Result of the unblinded key export operation.
- */
-crypto_status_t otcrypto_export_unblinded_key(
-    const crypto_unblinded_key_t unblinded_key, crypto_word32_buf_t *plain_key);
-
-/**
  * Exports a blinded key to the user provided key buffer, in shares.
  *
+ * This function will copy data from the keyblob into the shares; after the
+ * call, it is safe to free the blinded key and the data pointed to by
+ * `blinded_key.keyblob`.
+ *
+ * Hardware-backed, non-exportable, and asymmetric (ECC or RSA) keys cannot be
+ * exported this way. For asymmetric keys, use an algorithm-specific funtion.
+ *
  * @param blinded_key Blinded key struct to be exported.
- * @param[out] key_share0 Pointer to the 1st share of the user provided key
- * buffer.
- * @param[out] key_share1 Pointer to the 2nd share of the user provided key
- * buffer.
+ * @param[out] key_share0 First share of the blinded key.
+ * @param[out] key_share1 Second share of the blinded key.
  * @return Result of the blinded key export operation.
  */
 crypto_status_t otcrypto_export_blinded_key(


### PR DESCRIPTION
- Implements blinded key import/export for symmetric keys.
- Removes unblinded key import/export routines.

I ended up adjusting the API a little bit here because when I gave it some thought, I think that it makes sense for ECC and RSA keys to use algorithm-specific import/export routines than generic ones, especially now that the internal structure of these keys is not exposed via the API. ECC and RSA (the only contexts in which we have unblinded keys) use different masking schemes than symmetric keys that can be very specific to the algorithm in use, so conceptually it makes more sense to me to group the code there. Custom routines already exist for importing RSA private and public keys; we still need to add export functions for RSA and import/export for ECC, which I'm tracking in this issue: https://github.com/lowRISC/opentitan/issues/20762

Related: https://github.com/lowRISC/opentitan/issues/19549