### PR TITLE
[aes, pre_sca] Enable masking evaluation of AES with PROLEAD

### DIFF
--- a/hw/ip/aes/pre_sca/prolead/README.md
+++ b/hw/ip/aes/pre_sca/prolead/README.md
@@ -1,0 +1,231 @@
+# AES Masking Evaluation Using PROLEAD
+
+This directory contains support files to evaluate the masking employed inside the AES cipher core together with the instantiated PRNG using the tool [PROLEAD - A Probing-Based Leakage Detection Tool for Hardware and Software](https://github.com/ChairImpSec/PROLEAD).
+For further details on the tool and its capabilities, refer to the paper [PROLEAD - A Probing-Based Hardware Leakage Detection Tool](https://eprint.iacr.org/2022/965).
+
+## Prerequisites
+
+Note that this flow is experimental.
+It has been developed using Yosys 0.36 (git sha1 8f07a0d84) and sv2v v0.0.11-28-g81d8225.
+The used PROLEAD version is from Oct 31, 2023 (7ed0f9f2).
+Other versions of these tools might not be compatible.
+
+1. Download the PROLEAD tool
+   ```sh
+   git clone git@github.com:ChairImpSec/PROLEAD.git
+   cd PROLEAD
+   git reset --hard 7ed0f9f2
+   ```
+
+   Install the PROLEAD requirements as documented in the [corresponding wiki page](https://github.com/ChairImpSec/PROLEAD/wiki/Installation#installation).
+
+   In the PROLEAD directory, run
+   ```sh
+   make release -j 16
+   ```
+   to build the tool.
+
+   The compiled binary can be found in the `release` directory.
+   Make sure to add it to your path.
+
+1. Generate a Verilog netlist
+
+   A netlist of the AES cipher core can be generated using the Yosys synthesis flow from the OpenTitan repository.
+   From the OpenTitan top level, run
+   ```sh
+   cd hw/ip/aes/pre_syn
+   ```
+   Set up the synthesis flow as described in the corresponding README.
+   Then, make sure to change the line in `syn_setup.sh`
+   ```sh
+   export LR_SYNTH_TOP_MODULE=aes
+   ```
+   to
+   ```sh
+   export LR_SYNTH_TOP_MODULE=aes_cipher_core
+   ```
+   to only synthesize the masked AES cipher core without the TL-UL and key sideload interfaces, unmasked datapath logic for the different block cipher modes of operation, and related control logic.
+
+   Then, run the synthesis
+   ```sh
+   ./syn_yosys.sh
+   ```
+
+## Evaluate the masking inside the AES cipher core together with the PRNG
+
+After downloading and building the PROLEAD tool, and synthesizing the AES cipher core, the masking together with the PRNG can finally be evaluated.
+
+1. Make sure to source the `build_consts.sh` script from the OpenTitan
+   repository
+   ```sh
+   source util/build_consts.sh
+   ```
+   in order to set up some shell variables.
+
+1. Enter the directory containing the PROLEAD support files for AES
+   ```sh
+   cd hw/ip/aes/pre_sca/prolead
+   ```
+
+1. Launch the PROLEAD tool to evaluate the netlist using the provided script
+   ```sh
+   ./evaluate.sh
+   ```
+   This should produce output similar to the one below:
+   ```sh
+   Start Hardware Leakage Evaluation
+
+   Library file:   library.lib
+   Library name:   NANG45
+   Design file:    opentitan/hw/ip/aes/pre_syn/syn_out/latest/generated/aes_cipher_core_netlist.v
+   Module name:    aes_cipher_core
+   Linker file:    linker.ld
+   Settings file:  aes_cipher_core_config.set
+   Result folder:  out/latest
+
+   Read library file...done!
+   Read design file..."aes_cipher_core"...done!
+   Make circuit depth...done!
+   Read settings file...done with 4 warnings!
+       Warning "remove_full_probing_sets" is not specified. Default "remove_full_probing_sets" = no is taken!
+       Warning "max_distance_multivariate" is not specified. Default "max_distance_multivariate" = 10 is taken!
+       Warning "no_of_probing_sets_per_step" is not specified. Default "no_of_probing_sets_per_step" = all is taken!
+       Warning "effect_size" is not specified. Default "effect_size" = 0.1 is taken!
+   Construct probes...done!
+   Prepare simulation memory...done!
+   Prepare shared data for 16 threads ...done!
+
+   Generate list of standard probes from 224 standard probe locations...12992 standard probes found...done!
+   Generate list of extended probes from 786 extended probe locations...943370 extended probes found...done!
+   Generate univariate probing sets...done (last step)! 12992 probing sets generated!
+   Extend all probing sets...done!
+   Remove duplicated probes in the sets...done!
+   Remove duplicated probing sets...done! 12992 probing sets remain!
+   ----------------------------------------------------------------------------------------------------------------------------------
+   | #Standard Probes | #Extended Probes | Security Order | Distance | #Entries in Report | #Probing Sets | Maximum #Probes per Set |
+   ----------------------------------------------------------------------------------------------------------------------------------
+   |            12992 |            45588 |              1 |       10 |                 10 |         12992 |                     127 |
+   ----------------------------------------------------------------------------------------------------------------------------------
+
+   Evaluate security under the robust probing model!
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | Elapsed Time | Required Ram | Processed Simulations |                                                                      Probing Set with highest Information Leakage | -log10(p) |  Status |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  112.107951s |  12.510552GB |       128000 / 161575 | ...gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[2] (37) |  3.620547 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  235.358985s |  12.510552GB |       256000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (17) |  5.025905 | LEAKAGE |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  358.192534s |  12.510552GB |       384000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[2].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[0] (12) |  3.363567 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  473.133173s |  12.510552GB |       512000 / 161585 | ...gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[2] (37) |  3.921945 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  590.334307s |  12.510552GB |       640000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[1] (12) |  4.717441 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  706.490746s |  12.510552GB |       768000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[0].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (57) |  3.492387 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   |  895.176681s |  12.510552GB |       896000 / 161585 |   ...gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.u_aes_dom_inverse_gf2p4.b_gamma_ss_d[1] (22) |  3.981567 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 1030.569630s |  12.510552GB |      1024000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (62) |  3.393895 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   ...
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 8518.762592s |  12.510552GB |      9088000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (41) |  3.017296 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 8639.829626s |  12.510552GB |      9216000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[2].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (41) |  3.018391 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 8758.906474s |  12.510552GB |      9344000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[5] (42) |  2.945251 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 8881.120705s |  12.510552GB |      9472000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[0].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[4] (46) |  2.996482 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 8998.628485s |  12.510552GB |      9600000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[7] (51) |  2.976931 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 9111.867212s |  12.510552GB |      9728000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.198678 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 9223.720210s |  12.510552GB |      9856000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.256948 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 9343.188344s |  12.510552GB |      9984000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.390740 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 9458.458347s |  12.510552GB |     10112000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.097989 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   | 9572.974702s |  12.510552GB |     10240000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.264392 |    OKAY |
+   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+   Evaluation done in 9573.98 seconds!
+   done!
+   ```
+   It may be that PROLEAD reports several `-log10(p)` values greater than the threshold value of 5.0 and thus reports to have found leakage.
+   However, as noted in the [PROLEAD wiki](https://github.com/ChairImpSec/PROLEAD/wiki/Results#interpretation), exceeding the 5.0 threshold is not a strict criterion for insecure designs.
+   It's recommended to continue the evaluation and to consider the course of the `-log10(p)` values as the number of simulations increase.
+   If the values do not grow in the further progression taking more simulations into account, the reported leakage probably occurred due to a false positive.
+   It's further recommended to consider at least 10 or 100 Mio simulations for hardware designs when evaluating in the normal or compact mode, respectively.
+
+   In this particular example, the evaluation is performed in normal mode and all `-log10(p)` values for more than 384sk simulations are below the threshold.
+   It can thus be assumed that the values above the threshold are false positives.
+
+   By default, the script will evaluate the AES cipher core including the PRNG.
+   But you can actually specify the top module to evaluate.
+   For example, to verify a single AES S-Box, first re-run the Yosys synthesis with
+   ```sh
+   export LR_SYNTH_TOP_MODULE=aes_sbox
+   ```
+   and then execute
+   ```sh
+   ./evaluate.sh aes_sbox
+   ```
+   Note that you need to create a dedicated PROLEAD config file for this.
+
+## Adapting and creating new configuration files
+
+When adapting and creating new configuration files, e.g., to evaluate the masked AES S-Box in isolation, it may be necessary to visually inspect wave dump files produced by PROLEAD to ensure the desired input values are applied with the correct timing.
+
+To this end, it's advisable to temporarily change the configuration as follows:
+```
+% total number of simulations (traces) in the tests, should be a factor of 64
+no_of_simulations
+64
+
+% number of simulations in each step, should be a factor of 64, and a divisor of no_of_simulations
+no_of_step_simulations
+64
+
+% number of simulations in each step that result files are written, should be a factor of 64, and
+% a divisor of no_of_simulations and should be a factor of no_of_step_simulations
+no_of_step_write_results
+64
+
+waveform_simulation % yes/no: whether VCD files of individual simulations are stored to disk (in
+                    % main directory) or not, can be useful for debugging the configuration
+yes
+```
+
+You can then run the evaluation using `evaluate.sh`.
+The waves are stored in per-simulation value change dump (VCD) files in the current directory.
+
+The VCDs can be opened using e.g. GTKWave.
+Based on this, you can tune the section of the configuration file applying the inputs during the initial clock cycles.
+This section typically starts with something like:
+```
+% number of clock cycles to initiate the run (start of encryption)
+no_of_initial_clock_cycles
+11
+```
+
+In addition, also the following settings found at the end of the configuration file may need to be changed:
+- `end_condition`
+- `end_wait_cycles`
+- `max_clock_cycle`
+- `no_of_outputs`
+- `no_of_test_clock_cycles`
+- `probes_exclude`
+- `probes_include`
+
+For details regarding these settings, check out the comments in the provided configuration file as well as the [PROLEAD wiki](https://github.com/ChairImpSec/PROLEAD/wiki).
+
+After finishing the tuning of the settings, don't forget to set the `waveform_simulation` setting back to `no`.
+Otherwise, PROLEAD might try to fill your disk with millions of VCDs.
+
+## Details of the provided support files
+
+- `aes_cipher_core_config.set`: PROLEAD configuration file for evaluating the AES cipher core including the PRNG.
+- `library.lib`: Library file containing the information required for simulating the evaluated netlist.
+                 The provided file contains a custom as well as the nangate45 library.
+                 Edit this file to add support for additional standard cell libraries.

--- a/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
+++ b/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
@@ -1,0 +1,356 @@
+% Copyright lowRISC contributors.
+% Copyright (c) 2022 ChairImpSec. All rights reserved.
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Redistribution and use in source and binary forms, with or without modification, are permitted
+% provided that the following conditions are met:
+%
+%   1. Redistributions of source code must retain the above copyright notice, this list of
+%      conditions and the following disclaimer.
+%   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+%      conditions and the following disclaimer in the documentation and/or other materials
+%      provided with the distribution.
+%   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+%      endorse or promote products derived from this software without specific prior written
+%      permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+% IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+% FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+% CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+% DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+% DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+% WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+% WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+% maximum number of threads *for parallel operation*
+max_no_of_threads
+16
+
+% total number of simulations (traces) in the tests, should be a factor of 64
+no_of_simulations
+10240000
+
+% number of simulations in each step, should be a factor of 64, and a divisor of no_of_simulations
+no_of_step_simulations
+128000
+
+% number of simulations in each step that result files are written, should be a factor of 64, and
+% a divisor of no_of_simulations and should be a factor of no_of_step_simulations
+no_of_step_write_results
+128000
+
+waveform_simulation % yes/no: whether VCD files of individual simulations are stored to disk (in
+                    % main directory) or not, can be useful for debugging the configuration
+no
+
+% maximum number of probes, i.e., order of test
+order_of_test
+1
+
+multivariate_test % no: only univariate test should be done, yes: univariate + multivariate
+no
+
+transitional_leakage % yes/no: whether transitional leakage should be considered in the tests
+no
+
+compact_distributions % yes/no: whether distributions (of probes) should be considered as compact.
+                      % it is recommended to use 'no' only for small circuits and low security
+                      % orders
+no
+
+minimize_probe_sets % yes/no: whether it should be tried to find equivalent probing sets.
+                    % it is recommended to use 'yes' only for small circuits and low security
+                    % orders
+no
+
+% number of groups to conduct the test, e.g., fixed vs. fixed, fixed vs. random, etc.
+no_of_groups
+2
+
+% The lowest 128 bits are used for the initial state shares. The upper 128 bits of share 0 are used
+% for prd_clearing_i. The latter bits are random but change only once per encryption (simulation),
+% i.e., we shouldn't use the `no_of_always_random_inputs` argument for that.
+256'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+256'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$00000000000000000000000000000000
+
+% name of the clock signal
+clock_signal_name
+clk_i
+
+% number of inputs which are fed randomly at every clock cycle
+no_of_always_random_inputs
+1
+
+[31:0] entropy_i
+
+% number of primary inputs during the initialization
+no_of_initial_inputs
+18
+
+% number of clock cycles to initiate the run (start of encryption)
+no_of_initial_clock_cycles
+11
+
+%1 - First clock cycle with inactive reset.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b011
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b0
+[2:0]       key_len_i           3'b000
+
+%2 - Reset the DUT.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b0
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b011
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b0
+[2:0]       key_len_i           3'b001
+
+%3 - Perform an initial reseed of the internal masking PRNG to put it into a random state.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b011
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%4 - De-assert in_valid_i. The DUT is busy reseeding the internal masking PRNG.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%5 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%6 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%7 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%8 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%9 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%10 - Start encryption in parallel with a reseed of the internal masking PRNG.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b011
+[2:0]       crypt_i             3'b011
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%11 - De-assert in_valid_i. The DUT is already busy performing the encryption.
+% De-asserting in_valid_i helps to avoid restarting the encryption after finishing in case the
+% simulation isn't stopped.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b011
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+% the condition to check to terminate the simulation (e.g., done signal is high) or a number of
+% clock cycles, e.g., ClockCycles 5.
+% Note: end_wait_cycles > 0 doesn't seem to work with signal values, otherwise we could use
+% something like [2:0] out_valid_o 3'b011
+end_condition
+ClockCycles 66
+
+% number of clock cycles to wait after the end_condition
+end_wait_cycles
+0
+
+% maximum number of clock cycles per run before checking the end_condition
+max_clock_cycle
+66
+
+no_of_outputs
+0
+
+% number of blocks to define clock cycles which should be covered in the tests
+no_of_test_clock_cycles
+1
+
+9-66  % The encryption starts at %10 and takes 56 clock cycles.
+
+% max number of entries in the report file with maximum leakage
+% 0 : do not generate the report file
+no_of_entries_in_report
+10
+
+% those wires which should be excluded for probing (all : to exclude them all, 0 : to exclude none,
+% e.g., 2 : to exclude two and name them)
+probes_exclude
+all
+
+% those wires which should be included for probing (all : to include them all, 0 : to include none,
+% e.g., 2 : to include two and name them)
+probes_include
+1
+
+{\u_aes_sub_bytes*}

--- a/hw/ip/aes/pre_sca/prolead/evaluate.sh
+++ b/hw/ip/aes/pre_sca/prolead/evaluate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Script for evaluating e.g. the masking implementation in combination with the PRNG inside the AES
+# cipher core using PROLEAD.
+
+set -e
+
+# Argument parsing
+if [[ "$#" -gt 0 ]]; then
+  TOP_MODULE=$1
+else
+  TOP_MODULE=aes_cipher_core
+fi
+if [[ "$#" -gt 1 ]]; then
+  NETLIST_DIR=$2
+else
+  NETLIST_DIR="${REPO_TOP}/hw/ip/aes/pre_syn/syn_out/latest/generated"
+fi
+
+# Create results directory.
+OUT_DIR_PREFIX="out/${TOP_MODULE}"
+OUT_DIR=$(date +"${OUT_DIR_PREFIX}_%Y_%m_%d_%H_%M_%S")
+mkdir -p ${OUT_DIR}
+rm -f out/latest
+ln -s "${OUT_DIR#out/}" out/latest
+
+# Launch the tool.
+PROLEAD -lf library.lib -ln NANG45 \
+        -mn ${TOP_MODULE} \
+        -df "${NETLIST_DIR}/${TOP_MODULE}_netlist.v" \
+        -cf "${TOP_MODULE}_config.set" \
+        -rf ${OUT_DIR} \
+        2>&1 | tee "${OUT_DIR}/log.txt"

--- a/hw/ip/aes/pre_sca/prolead/library.lib
+++ b/hw/ip/aes/pre_sca/prolead/library.lib
@@ -1,0 +1,428 @@
+% Copyright lowRISC contributors.
+% Copyright (c) 2022 ChairImpSec. All rights reserved.
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Redistribution and use in source and binary forms, with or without modification, are permitted
+% provided that the following conditions are met:
+%
+%   1. Redistributions of source code must retain the above copyright notice, this list of
+%      conditions and the following disclaimer.
+%   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+%      conditions and the following disclaimer in the documentation and/or other materials
+%      provided with the distribution.
+%   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+%      endorse or promote products derived from this software without specific prior written
+%      permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+% IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+% FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+% CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+% DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+% DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+% WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+% WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+%%%%%%  library file %%%%%%%
+% usage:
+%
+% Library
+% library_name
+%
+% Type of the cell: Gate/Reg
+%
+% # of its variants
+% variant names
+%
+% # of inputs
+% input names
+%
+% # of outputs
+% output names
+%
+% formula of each output. Possible terms in formula: not, nand, and, or, nor, xor, xnor.
+% Parentheses MUST be placed.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+Library
+custom
+
+Reg
+1 DFF
+2 C D
+1 Q
+((not C) and Q) or (C and D)
+
+Gate
+1 AND
+2 A B
+1 Y
+A and B
+
+Gate
+1 NAND
+2 A B
+1 Y
+not (A and B)
+
+Gate
+1 OR
+2 A B
+1 Y
+A or B
+
+Gate
+1 NOR
+2 A B
+1 Y
+not (A or B)
+
+Gate
+1 XOR
+2 A B
+1 Y
+A xor B
+
+Gate
+1 XNOR
+2 A B
+1 Y
+not (A xor B)
+
+Gate
+1 NOT
+1 A
+1 Y
+not A
+
+Gate
+1 MUX2
+3 S A B
+1 Q
+(S and B) or (A and (not S))
+
+Buffer
+2 BUFF BUF
+1 A
+1 Y
+not (not A)
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+Library
+NANG45
+
+Gate
+4
+INV_X1 INV_X2 INV_X4 INV_X8
+1
+A
+1
+ZN
+not A
+
+Gate
+3
+XNOR2_X1 XNOR2_X2 XNOR2_X4
+2
+A B
+1
+ZN
+not (A xor B)
+
+Gate
+3
+XOR2_X1 XOR2_X2 XOR2_X4
+2
+A B
+1
+Z
+A xor B
+
+Gate
+3
+AOI22_X1 AOI22_X2 AOI22_X4
+4
+A1 A2 B1 B2
+1
+ZN
+not ((A1 and A2) or (B1 and B2))
+
+Gate
+3
+MUX2_X1 MUX2_X2 MUX2_X4
+3
+A B S
+1
+Z
+(S and B) or (A and (not S))
+
+Gate
+3
+AND4_X1 AND4_X2 AND4_X4
+4
+A1 A2 A3 A4
+1
+ZN
+A1 and A2 and A3 and A4
+
+Gate
+3
+NOR2_X1 NOR2_X2 NOR2_X4
+2
+A1 A2
+1
+ZN
+not (A1 or A2)
+
+Gate
+3
+NAND2_X1 NAND2_X2 NAND2_X4
+2
+A1 A2
+1
+ZN
+not (A1 and A2)
+
+Gate
+3
+NAND3_X1 NAND3_X2 NAND3_X4
+3
+A1 A2 A3
+1
+ZN
+not (A1 and A2 and A3)
+
+Gate
+3
+NAND4_X1 NAND4_X2 NAND4_X4
+4
+A1 A2 A3 A4
+1
+ZN
+not (A1 and A2 and A3 and A4)
+
+Gate
+3
+OR2_X1 OR2_X2 OR2_X4
+2
+A1 A2
+1
+ZN
+A1 or A2
+
+Gate
+3
+NOR3_X1 NOR3_X2 NOR3_X4
+3
+A1 A2 A3
+1
+ZN
+not (A1 or A2 or A3)
+
+Gate
+3
+AOI211_X1 AOI211_X2 AOI211_X4
+4
+A B C1 C2
+1
+ZN
+not ((C1 and C2) or B or A)
+
+Gate
+3
+AOI221_X1 AOI221_X2 AOI221_X4
+5
+A B1 B2 C1 C2
+1
+ZN
+not ((C1 and C2) or A or (B1 and B2))
+
+Gate
+3
+OAI211_X1 OAI211_X2 OAI211_X4
+4
+A B C1 C2
+1
+ZN
+not ((C1 or C2) and A and B)
+
+Reg
+3
+DFF_X1 DFF_X2 DFF_X4
+2
+D CK
+2
+Q QN
+((not CK) and      Q ) or (CK and      D )
+((not CK) and (not Q)) or (CK and (not D))
+
+Reg
+3
+SDFF_X1 SDFF_X2 SDFF_X4
+4
+D SI SE CK
+2
+Q QN
+((not CK) and      Q ) or (CK and (((not SE) and      D ) or (SE and      SI )))
+((not CK) and (not Q)) or (CK and (((not SE) and (not D)) or (SE and (not SI))))
+
+Gate
+3
+OAI21_X1 OAI21_X2 OAI21_X4
+3
+A B1 B2
+1
+ZN
+not (A and (B1 or B2))
+
+Gate
+3
+AOI21_X1 AOI21_X2 AOI21_X4
+3
+A B1 B2
+1
+ZN
+not (A or (B1 and B2))
+
+Gate
+3
+OAI33_X1 OAI33_X2 OAI33_X4
+6
+A1 A2 A3 B1 B2 B3
+1
+ZN
+not ((A1 or A2 or A3) and (B1 or B2 or B3))
+
+Buffer
+7
+BUF_X1 BUF_X2 BUF_X4 BUF_X8
+CLKBUF_X1 CLKBUF_X2 CLKBUF_X4
+1
+A
+1
+Z
+not (not A)
+
+Gate
+3
+AND2_X1 AND2_X2 AND2_X4
+2
+A1 A2
+1
+ZN
+A1 and A2
+
+Gate
+3
+OAI22_X1 OAI22_X2 OAI22_X4
+4
+A1 A2 B1 B2
+1
+ZN
+not ((A1 or A2) and (B1 or B2))
+
+Gate
+3
+NOR4_X1 NOR4_X2 NOR4_X4
+4
+A1 A2 A3 A4
+1
+ZN
+not (A1 or A2 or A3 or A4)
+
+Gate
+3
+OAI221_X1 OAI221_X2 OAI221_X4
+5
+A B1 B2 C1 C2
+1
+ZN
+not ((C1 or C2) and A and (B1 or B2))
+
+Gate
+3
+AOI222_X1 AOI222_X2 AOI222_X4
+6
+A1 A2 B1 B2 C1 C2
+1
+ZN
+not (((A1 and A2) or (B1 and B2)) or (C1 and C2))
+
+Gate
+3
+OR3_X1 OR3_X2 OR3_X4
+3
+A1 A2 A3
+1
+ZN
+A1 or A2 or A3
+
+Gate
+3
+AND3_X1 AND3_X2 AND3_X4
+3
+A1 A2 A3
+1
+ZN
+A1 and A2 and A3
+
+Gate
+3
+OAI222_X1 OAI222_X2 OAI222_X4
+6
+A1 A2 B1 B2 C1 C2
+1
+ZN
+not (((A1 or A2) and (B1 or B2)) and (C1 or C2))
+
+Gate
+3
+OR4_X1 OR4_X2 OR4_X4
+4
+A1 A2 A3 A4
+1
+ZN
+A1 or A2 or A3 or A4
+
+%%%%%%%%%%%%%%%%%%%%%
+
+Gate
+3
+DLL_X1 DLL_X2 DLL_X4
+2
+D GN
+1
+Q
+not (not D)
+
+Reg
+3
+DFFR_X1 DFFR_X2 DFFR_X4
+3
+D CK RN
+2
+Q QN
+     RN and (((not CK) and      Q ) or (CK and      D ))
+(not RN) or (((not CK) and (not Q)) or (CK and (not D)))
+
+Reg
+3
+DFFS_X1 DFFS_X2 DFFS_X4
+3
+D CK SN
+2
+Q QN
+(not SN) or (((not CK) and      Q ) or (CK and      D ))
+     SN and (((not CK) and (not Q)) or (CK and (not D)))
+
+Reg
+3
+SDFFR_X1 SDFFR_X2 SDFFR_X4
+5
+D SI SE CK RN
+2
+Q QN
+     RN and (((not CK) and      Q ) or (CK and (((not SE) and      D ) or (SE and      SI ))))
+(not RN) or (((not CK) and (not Q)) or (CK and (((not SE) and (not D)) or (SE and (not SI)))))


### PR DESCRIPTION
This commit adds a couple of support files and a how to for evaluating the masking employed inside AES together with the instantiated PRNG using the PROLEAD tool.

The library file as well as the PROLEAD config file have been derived from files based on variants in the PROLEAD repository and kindly shared by @AeinRezaeiShahmirzadi.

This is related to lowRISC/OpenTitan#19091.