### PR TITLE
[sival,testplan] Remove environment suffix from bazel tests

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -148,7 +148,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_rstmgr_alert_info"]
-      bazel: ["//sw/device/tests:rstmgr_alert_info_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:rstmgr_alert_info_test"]
     }
     {
       name: chip_sw_alert_handler_ping_timeout
@@ -163,7 +163,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_handler_ping_timeout"]
-      bazel: ["//sw/device/tests:alert_handler_ping_timeout_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:alert_handler_ping_timeout_test"]
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_alerts
@@ -208,7 +208,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_pings"]
-      bazel: ["//sw/device/tests:alert_handler_lpg_sleep_mode_pings_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:alert_handler_lpg_sleep_mode_pings_test"]
     }
     {
       name: chip_sw_alert_handler_lpg_clock_off
@@ -222,7 +222,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_handler_lpg_clkoff"]
-      bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test"]
     }
     {
       name: chip_sw_alert_handler_lpg_reset_toggle
@@ -236,7 +236,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
-      bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test"]
    }
    {
       name: chip_sw_alert_handler_reverse_ping_in_deep_sleep
@@ -294,7 +294,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_handler_reverse_ping_in_deep_sleep"]
-      bazel: ["//sw/device/tests:alert_handler_reverse_ping_in_deep_sleep_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:alert_handler_reverse_ping_in_deep_sleep_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
@@ -19,10 +19,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WAKEUP.INTERRUPT"]
       tests: ["chip_sw_aon_timer_irq"]
-      bazel: [
-        "//sw/device/tests:aon_timer_irq_test_fpga_cw310_test_rom",
-        "//sw/device/tests:aon_timer_irq_test_fpga_cw310_sival_rom_ext"
-      ]
+      bazel: ["//sw/device/tests:aon_timer_irq_test"]
     }
     {
       name: chip_sw_aon_timer_sleep_wakeup
@@ -44,10 +41,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WAKEUP.WAKEUP_CONFIG", "AON_TIMER.WAKEUP.WAKEUP_REQUEST"]
       tests: ["chip_sw_pwrmgr_smoketest"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_smoketest_fpga_cw310_test_rom"
-        "//sw/device/tests:pwrmgr_smoketest_fpga_cw310_sival_rom_ext"
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_smoketest"]
     }
     {
       name: chip_sw_aon_timer_wdog_bark_irq
@@ -62,10 +56,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WATCHDOG.INTERRUPT"]
       tests: ["chip_sw_aon_timer_irq"]
-      bazel: [
-        "//sw/device/tests:aon_timer_irq_test_fpga_cw310_test_rom",
-        "//sw/device/tests:aon_timer_irq_test_fpga_cw310_sival_rom_ext"
-      ]
+      bazel: ["//sw/device/tests:aon_timer_irq_test"]
     }
     {
       name: chip_sw_aon_timer_wdog_bite_reset
@@ -83,10 +74,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.BARK"]
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
-      bazel: [
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_cw310_test_rom",
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:aon_timer_wdog_bite_reset_test"]
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_bite_reset
@@ -104,10 +92,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.BARK"]
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
-      bazel: [
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_cw310_test_rom",
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:aon_timer_wdog_bite_reset_test"]
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_sleep_pause
@@ -127,10 +112,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.PAUSE"]
       tests: ["chip_sw_aon_timer_sleep_wdog_sleep_pause"]
-      bazel: [
-        "//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test_fpga_cw310_test_rom",
-        "//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test_fpga_cw310_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test"]
     }
     {
       name: chip_sw_aon_timer_wdog_lc_escalate
@@ -151,10 +133,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["AON_TIMER.WATCHDOG.DISABLE_BY_LC_CTRL"]
       tests: ["chip_sw_aon_timer_wdog_lc_escalate"]
-      bazel: [
-        "//sw/device/tests:aon_timer_wdog_lc_escalate_test_fpga_cw310_test_rom"
-        "//sw/device/tests:aon_timer_wdog_lc_escalate_test_fpga_cw310_sival_rom_ext"
-      ]
+      bazel: ["//sw/device/tests:aon_timer_wdog_lc_escalate_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -35,18 +35,10 @@
         "chip_sw_otbn_randomness",
       ]
       bazel: [
-        "//sw/device/tests:aes_idle_test_fpga_cw310_sival",
-        "//sw/device/tests:aes_idle_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:aes_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:hmac_enc_idle_test_fpga_cw310_sival",
-        "//sw/device/tests:hmac_enc_idle_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:hmac_enc_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:kmac_idle_test_fpga_cw310_sival",
-        "//sw/device/tests:kmac_idle_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:kmac_idle_test_fpga_cw310_test_rom",
-        "//sw/device/tests:otbn_randomness_test_fpga_cw310_sival",
-        "//sw/device/tests:otbn_randomness_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:otbn_randomness_test_fpga_cw310_test_rom",
+        "//sw/device/tests:aes_idle_test",
+        "//sw/device/tests:hmac_enc_idle_test",
+        "//sw/device/tests:kmac_idle_test",
+        "//sw/device/tests:otbn_randomness_test",
       ]
     }
     {
@@ -82,18 +74,10 @@
         "chip_sw_clkmgr_off_otbn_trans",
       ]
       bazel: [
-        "//sw/device/tests:clkmgr_off_aes_trans_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_off_aes_trans_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_off_aes_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_hmac_trans_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_off_hmac_trans_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_off_hmac_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_kmac_trans_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_off_kmac_trans_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_off_kmac_trans_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_off_otbn_trans_test_fpga_cw310_sival"
-        "//sw/device/tests:clkmgr_off_otbn_trans_test_fpga_cw310_sival_rom_ext"
-        "//sw/device/tests:clkmgr_off_otbn_trans_test_fpga_cw310_test_rom"
+        "//sw/device/tests:clkmgr_off_aes_trans_test",
+        "//sw/device/tests:clkmgr_off_hmac_trans_test",
+        "//sw/device/tests:clkmgr_off_kmac_trans_test",
+        "//sw/device/tests:clkmgr_off_otbn_trans_test",
       ]
     }
     {
@@ -120,11 +104,7 @@
         "CLKMGR.ENABLE.USB",
       ]
       tests: ["chip_sw_clkmgr_off_peri"]
-      bazel: [
-        "//sw/device/tests:clkmgr_off_peri_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_off_peri_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_off_peri_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:clkmgr_off_peri_test"]
     }
     {
       name: chip_sw_clkmgr_div
@@ -161,15 +141,9 @@
         "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",
       ]
       bazel: [
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_sival",
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_fpga_cw310_sival_rom",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test_fpga_cw310_test_rom",
+        "//sw/device/tests:ast_clk_outs_test",
+        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test",
+        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test",
       ]
     }
     {
@@ -211,12 +185,8 @@
         "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
       ]
       bazel: [
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_test_rom",
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_test_rom",
+        "//sw/device/tests:clkmgr_sleep_frequency_test",
+        "//sw/device/tests:clkmgr_reset_frequency_test",
       ]
     }
     {
@@ -270,11 +240,7 @@
         "CLKMGR.MEAS_CTRL.USB",
       ]
       tests: ["chip_sw_clkmgr_jitter_frequency"]
-      bazel: [
-        "//sw/device/tests:clkmgr_jitter_frequency_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_jitter_frequency_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_jitter_frequency_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:clkmgr_jitter_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_extended_range
@@ -342,11 +308,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_ast_clk_outputs"]
-      bazel: [
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_sival",
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:ast_clk_outs_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:ast_clk_outs_test"]
     }
     {
       name: chip_sw_clkmgr_sleep_frequency
@@ -374,11 +336,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_clkmgr_sleep_frequency"]
-      bazel: [
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_sleep_frequency_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:clkmgr_sleep_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_reset_frequency
@@ -402,11 +360,7 @@
         "CLKMGR.MEAS_CTRL.RECOV_ERR",
       ]
       tests: ["chip_sw_clkmgr_reset_frequency"]
-      bazel: [
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_sival",
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:clkmgr_reset_frequency_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:clkmgr_reset_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_escalation_reset
@@ -443,11 +397,7 @@
       ]
       features: ["CLKMGR.ALERT_HANDLER.CLOCK_STATUS"]
       tests: ["chip_sw_alert_handler_lpg_clkoff"]
-      bazel: [
-        "//sw/device/tests:alert_handler_lpg_clkoff_test_fpga_cw310_sival",
-        "//sw/device/tests:alert_handler_lpg_clkoff_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:alert_handler_lpg_clkoff_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -25,7 +25,7 @@
       features: ["I2C.MODE.HOST", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
       si_stage: SV2
-      bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test_cw310_test_rom"]
+      bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test"]
       tests: ["chip_sw_i2c_host_tx_rx",
               "chip_sw_i2c_host_tx_rx_idx1",
               "chip_sw_i2c_host_tx_rx_idx2"]
@@ -49,7 +49,7 @@
       features: ["I2C.MODE.TARGET", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
       si_stage: SV2
-      bazel: ["//sw/device/tests:i2c_target_test_cw310_test_rom"]
+      bazel: ["//sw/device/tests:i2c_target_test"]
       tests: ["chip_sw_i2c_device_tx_rx"]
     }
     {
@@ -138,7 +138,7 @@
       stage: V3
       si_stage: SV3
       tests: []
-      bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test_cw310_test_rom"]
+      bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test"]
     }
     {
       name: chip_sw_i2c_repeatedstart

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -139,7 +139,7 @@
       stage: V2
       si_stage: SV2
       tests: []
-      bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test_fpga_cw310_sival"]
+      bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "OTBN.KEYMGR",

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -68,11 +68,7 @@
         "PWRMGR.LOW_POWER.WAKE_INFO"
       ]
       tests: ["chip_sw_pwrmgr_random_sleep_all_wake_ups"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_random_sleep_all_wake_ups_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_random_sleep_all_wake_ups_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_random_sleep_all_wake_ups_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_wake_ups"]
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
@@ -114,12 +110,7 @@
         "PWRMGR.RESET.POR_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_deep_sleep_por_reset"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_deep_sleep_por_reset_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_deep_sleep_por_reset_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_deep_sleep_por_reset_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_deep_sleep_por_reset_test_silicon_owner_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_deep_sleep_por_reset_test"]
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_por_reset
@@ -142,12 +133,7 @@
         "PWRMGR.RESET.POR_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_sleep_por_reset"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_normal_sleep_por_reset_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_normal_sleep_por_reset_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_normal_sleep_por_reset_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_normal_sleep_por_reset_test_silicon_owner_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_normal_sleep_por_reset_test"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
@@ -198,10 +184,8 @@
         "chip_sw_pwrmgr_deep_sleep_all_reset_reqs",
       ]
       bazel: [
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_sival",
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_deep_sleep_all_reset_reqs_test_fpga_cw310_test_rom",
+        "//sw/device/tests:aon_timer_wdog_bite_reset_test",
+        "//sw/device/tests:pwrmgr_deep_sleep_all_reset_reqs_test",
       ]
     }
     {
@@ -246,7 +230,7 @@
         "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_normal_sleep_all_reset_reqs"]
-      bazel: ["//sw/device/tests:pwrmgr_normal_sleep_all_reset_reqs_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_normal_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_wdog_reset
@@ -271,11 +255,7 @@
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_wdog_reset"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_aon_power_glitch_reset
@@ -398,7 +378,7 @@
         "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_random_sleep_all_reset_reqs"]
-      bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test_fpga_cw310_test_rom"]
+      bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_sysrst_ctrl_reset
@@ -420,9 +400,7 @@
         "chip_sw_pwrmgr_sysrst_ctrl_reset",
         "chip_sw_pwrmgr_all_reset_reqs",
       ]
-      bazel: [
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req
@@ -451,12 +429,7 @@
       ]
       features: ["PWRMGR.LOW_POWER.ENTRY"]
       tests: ["chip_sw_pwrmgr_sleep_disabled"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_sleep_disabled_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_sleep_disabled_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_sleep_disabled_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_sleep_disabled_test_silicon_owner_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_sleep_disabled_test"]
     }
     {
       name: chip_sw_pwrmgr_usb_clk_disabled_when_active
@@ -476,12 +449,7 @@
       ]
       features: ["PWRMGR.CLOCK_CONTROL.USB_WHEN_ACTIVE"]
       tests: ["chip_sw_pwrmgr_usb_clk_disabled_when_active"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test_silicon_owner_sival_rom_ext",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test"]
     }
     {
       name: chip_sw_all_resets
@@ -512,11 +480,7 @@
         "PWRMGR.RESET.POR_REQUEST",
       ]
       tests: ["chip_sw_pwrmgr_all_reset_reqs"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_escalation_reset

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -46,15 +46,9 @@
         "chip_sw_pwrmgr_wdog_reset",
       ]
       bazel: [
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_sival_rom",
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_test_rom",
+        "//sw/device/tests:pwrmgr_all_reset_reqs_test",
+        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test",
+        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs",
       ]
     }
     {
@@ -88,9 +82,7 @@
         "RSTMGR.RESET_INFO.CLEAR",
       ]
       tests: ["chip_rv_dm_ndm_reset_req"]
-      bazel: [
-        "//sw/device/tests:rv_dm_ndm_reset_req",
-      ],
+      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
     }
     {
       name: chip_sw_rstmgr_cpu_info
@@ -118,11 +110,7 @@
         "RSTMGR.CPU_INFO.ENABLE",
       ]
       tests: ["chip_sw_rstmgr_cpu_info"]
-      bazel: [
-        "//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_sival",
-        "//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
     }
     {
       name: chip_sw_rstmgr_sw_req_reset
@@ -149,12 +137,8 @@
       features: ["RSTMGR.SW_RST.CHIP_RESET"]
       tests: ["chip_sw_rstmgr_sw_req"]
       bazel: [
-        "//sw/device/tests:rstmgr_sw_req_test_fpga_cw310_sival",
-        "//sw/device/tests:rstmgr_sw_req_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:rstmgr_sw_req_test_fpga_cw310_test_rom",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_test_rom",
+        "//sw/device/tests:rstmgr_sw_req_test",
+        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs",
       ]
     }
     {
@@ -235,11 +219,7 @@
         "RSTMGR.SW_RST.SPI_DEVICE_REQUEST",
       ]
       tests: ["chip_sw_rstmgr_sw_rst"]
-      bazel: [
-        "//sw/device/tests:rstmgr_sw_rst_ctrl_test_fpga_cw310_sival",
-        "//sw/device/tests:rstmgr_sw_rst_ctrl_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:rstmgr_sw_rst_ctrl_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test"]
     }
     {
       name: chip_sw_rstmgr_escalation_reset
@@ -269,11 +249,7 @@
         "RSTMGR.ALERT_INFO.CAPTURE",
       ]
       tests: ["chip_sw_all_escalation_resets"]
-      bazel: [
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs"]
     }
     {
       name: chip_sw_rstmgr_alert_handler_reset_enables
@@ -297,11 +273,7 @@
       ]
       features: ["RSTMGR.ALERT_HANDLER.RESET_STATUS"]
       tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
-      bazel: [
-        "//sw/device/tests:alert_handler_lpg_reset_toggle_test_fpga_cw310_sival",
-        "//sw/device/tests:alert_handler_lpg_reset_toggle_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:alert_handler_lpg_reset_toggle_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -21,7 +21,7 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_sw_rv_core_ibex_nmi_irq"]
-      bazel: ["//sw/device/tests:rv_core_ibex_nmi_irq_test_fpga_cw310_rom_with_fake_keys"]
+      bazel: ["//sw/device/tests:rv_core_ibex_nmi_irq_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "RV_CORE_IBEX.CPU.INTERRUPTS"
@@ -47,7 +47,7 @@
       features: [
         "RV_CORE_IBEX.RND"
       ]
-      bazel: ["//sw/device/tests:rv_core_ibex_rnd_test_fpga_cw310_sival"]
+      bazel: ["//sw/device/tests:rv_core_ibex_rnd_test"]
     }
     {
       name: chip_sw_rv_core_ibex_address_translation
@@ -69,7 +69,7 @@
       features: [
         "RV_CORE_IBEX.ADDRESS_TRANSLATION"
       ]
-      bazel: ["//sw/device/tests:rv_core_ibex_address_translation_test_fpga_cw310_rom_with_fake_keys"]
+      bazel: ["//sw/device/tests:rv_core_ibex_address_translation_test"]
     }
     {
       name: chip_sw_rv_core_ibex_icache_scrambled_access
@@ -91,7 +91,7 @@
       features: [
         "RV_CORE_IBEX.CPU.ICACHE"
       ]
-      bazel: ["//sw/device/tests:rv_core_ibex_icache_invalidate_test_fpga_cw310_rom_with_fake_keys"]
+      bazel: ["//sw/device/tests:rv_core_ibex_icache_invalidate_test"]
     }
     {
        name: chip_sw_rv_core_ibex_fault_dump
@@ -105,7 +105,7 @@
        stage: V2
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
-       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_rom_with_fake_keys"]
+       bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"
@@ -123,7 +123,7 @@
        stage: V2
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
-       bazel: ["//sw/device/tests:rstmgr_cpu_info_test_fpga_cw310_sival"]
+       bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"
@@ -166,7 +166,7 @@
        stage: V2
        si_stage: SV1
        tests: []
-       bazel: ["//sw/device/tests:rv_core_ibex_epmp_test_functest_fpga_cw310_sival"]
+       bazel: ["//sw/device/tests:rv_core_ibex_epmp_test_functest"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
        features: [
          "RV_CORE_IBEX.CPU.EPMP"
@@ -206,7 +206,7 @@
          "RV_CORE_IBEX.CPU.ICACHE",
          "RV_CORE_IBEX.CPU.MEMORY"
        ]
-       bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest_fpga_cw310_sival"]
+       bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest"]
     }
     {
      name: chip_sw_rv_core_ibex_lockstep_glitch

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -96,9 +96,7 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_rv_dm_ndm_reset_req"]
-      bazel: [
-        "//sw/device/tests:rv_dm_ndm_reset_req",
-      ],
+      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
       host_support: "true"
       features: [
@@ -185,9 +183,7 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_tap_straps_rma"]
-      bazel: [
-        "//sw/device/tests:rv_dm_jtag_tap_sel",
-      ],
+      bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
       host_support: "true"
       features: [
@@ -240,9 +236,7 @@
       stage: V2
       si_stage: SV3
       tests: []
-      bazel: [
-        "//sw/device/tests:rv_dm_jtag",
-      ],
+      bazel: ["//sw/device/tests:rv_dm_jtag"],
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
       host_support: "true"
       features: [

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -19,7 +19,7 @@
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER"]
       tests: ["chip_sw_rv_timer_irq"]
-      bazel: ["//sw/device/tests:rv_timer_smoketest_fpga_cw310_sival_rom_ext"]
+      bazel: ["//sw/device/tests:rv_timer_smoketest"]
     }
     {
       name: tick_configuration
@@ -38,7 +38,7 @@
       lc_states: ["DEV", "PROD", "RMA"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE"]
       tests: ["chip_sw_rv_timer_systick_test"]
-      bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_sival_rom_ext"]
+      bazel: ["//sw/device/tests:rv_timer_systick_test"]
     }
     {
       name: counter_wrap
@@ -58,7 +58,7 @@
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER", "RV_TIMER.RISCV_CSRS_INTEGRATION"]
       tests: ["chip_sw_rv_timer_systick_test"]
-      bazel: ["//sw/device/tests:rv_timer_systick_test_fpga_cw310_sival_rom_ext"]
+      bazel: ["//sw/device/tests:rv_timer_systick_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -39,7 +39,7 @@
         "SPI_DEVICE.MODE.GENERIC.DPSRAM_TXF_RXF",
       ]
       tests: ["chip_sw_spi_device_tx_rx"]
-      bazel: ["//sw/device/tests:spi_device_smoketest_cw310_sival"]
+      bazel: ["//sw/device/tests:spi_device_smoketest"]
     }
     {
       name: chip_sw_spi_device_flash_mode

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -30,8 +30,8 @@
       si_stage: SV2
       tests: ["chip_sw_spi_host_tx_rx"]
       bazel: [
-        "//sw/device/tests:spi_host_winbond_flash_test_fpga_cw310_rom_with_fake_keys",
-        "//sw/device/tests/pmod:spi_host_macronix_flash_test_fpga_cw310_sival"
+        "//sw/device/tests:spi_host_winbond_flash_test",
+        "//sw/device/tests/pmod:spi_host_macronix_flash_test"
       ]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -55,12 +55,8 @@
         "chip_sw_sleep_sram_ret_contents_scramble",
       ]
       bazel: [
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_sival",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test_fpga_cw310_rom_test",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_sival",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test_fpga_cw310_rom_test",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test",
+        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test",
       ]
     }
     {


### PR DESCRIPTION
This changes the test plans to comply with the guidelines.