### PR TITLE
[sca] Prepare KMAC for pen. tests on discrete

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -68,7 +68,10 @@ cc_library(
 cc_library(
     name = "kmac_sca",
     srcs = ["kmac_sca.c"],
-    hdrs = ["kmac_sca.h"],
+    hdrs = [
+        "kmac_sca.h",
+        "status.h",
+    ],
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",

--- a/sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #define KMACSCA_CMD_MAX_BATCH_DIGEST_BYTES 32
 #define KMACSCA_CMD_MAX_DATA_BYTES 16
+#define KMACSCA_CMD_MAX_FPGA_MODE_BYTES 1
 #define KMACSCA_CMD_MAX_KEY_BYTES 16
 #define KMACSCA_CMD_MAX_LFSR_BYTES 4
 #define KMACSCA_CMD_MAX_MSG_BYTES 16
@@ -34,6 +35,10 @@ UJSON_SERDE_STRUCT(CryptotestKmacScaKey, cryptotest_kmac_sca_key_t, KMAC_SCA_KEY
 #define KMAC_SCA_LFSR(field, string) \
     field(seed, uint8_t, KMACSCA_CMD_MAX_LFSR_BYTES)
 UJSON_SERDE_STRUCT(CryptotestKmacScaLfsr, cryptotest_kmac_sca_lfsr_t, KMAC_SCA_LFSR);
+
+#define KMAC_SCA_FPGA_MODE(field, string) \
+    field(fpga_mode, uint8_t, KMACSCA_CMD_MAX_FPGA_MODE_BYTES)
+UJSON_SERDE_STRUCT(CryptotestKmacScaFpgaMode, cryptotest_kmac_sca_fpga_mode_t, KMAC_SCA_FPGA_MODE);
 
 #define KMAC_SCA_DATA(field, string) \
     field(data, uint8_t, KMACSCA_CMD_MAX_DATA_BYTES)


### PR DESCRIPTION
Currently, the SCA code for KMAC uses features to improve SCA that are only available on the FPGA but not on discrete.

With this PR, the user can transmit a fpga_mode flag (c.f. #[269](https://github.com/lowRISC/ot-sca/pull/269)) allowing to specify which KMAC SCA version to use. For fpga_mode=1, the existing code is  used.
For fpga_mode=0 (i.e., discret chip), the SCA specific `sha3_ujson_absorb` function is replaced by calls to DIF:

- `dif_kmac_mode_kmac_start`
- `dif_kmac_absorb`

Moreover, the SCA specific `kmac_get_digest` function is replaced by:
- ` dif_kmac_squeeze`

By using the KMAC DIF functions, we now comply to the intended usage of KMAC.

Closes #20674 