### PR TITLE
[hw,rv_core_ibex,rtl] Increase upper bound for cycles to wait in IbexIcacheScrambleKeyRequestAfterFenceI_A

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -958,7 +958,7 @@ module rv_core_ibex
         u_core.u_ibex_core.id_stage_i.instr_valid_i
         && u_core.u_ibex_core.id_stage_i.decoder_i.opcode == ibex_pkg::OPCODE_MISC_MEM
         && u_core.u_ibex_core.id_stage_i.decoder_i.instr[14:12] == 3'b001 // FENCE.I
-        |-> ##[0:10] // upper bound is not exact, but it should not take more than a few cycles
+        |-> ##[0:20] // upper bound is not exact, but it should not take more than a few cycles
         icache_otp_key_o.req
     )
 


### PR DESCRIPTION
When OpenOCD issues a fence.i instruction as part of executing a program buffer through the DM the following assertion triggers:

```
[11-28 08:20:01] -I- xmsim: *E,ASRTST (/work/opentitan.integrated/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv,976): (time 10638803280 PS) Assertion top.u_rv_core_ibex.gen_icache_scramble_asserts.IbexIcacheScrambleKeyRequestAfterFenceI_A has failed (in 11 cycles)
[11-28 08:20:01] -I- UVM_ERROR ../../../opentitan.integrated/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv(976) @ 10638803280000: reporter [ASSERT FAILED] IbexIcacheScrambleKeyRequestAfterFenceI_A
```

I see upstream has increased this to 14 from 10 - https://github.com/lowRISC/opentitan/commit/4e615dedac018700ebd354920511b779e69e14e3 

We found that 14 wasn’t sufficient, but 20 works reliably.

