### PR TITLE
[opentitantool] Correct manifest checks

### DIFF
--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -102,8 +102,8 @@ impl Image {
         let manifest = self.borrow_manifest()?;
         let len = self.data.bytes.len() as u32;
 
-        ensure!(manifest.signed_region_end < len);
-        ensure!(manifest.length < len);
+        ensure!(manifest.signed_region_end <= len);
+        ensure!(manifest.length <= len);
         ensure!(manifest.code_start < len);
         ensure!(manifest.code_end < len);
         ensure!(manifest.entry_point < len);


### PR DESCRIPTION
The manifest check should allow both `manifest.signed_region_end` and `length` to be equal to the length of the binary.