### PR TITLE
[sram_ctrl,test] Enable sram_ctrl_execution_test in prod locked state

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -103,6 +103,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_sram_ctrl_execution_main"]
+      bazel: ["//sw/device/tests:sram_ctrl_execution_test"]
     }
     {
       name: chip_sw_sram_lc_escalation

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3120,6 +3120,7 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -85,8 +85,19 @@ bool test_main(void) {
   // execution is unconditionally enabled for the main SRAM in the RMA life
   // cycle state.
   sram_ret_neg_test();
-  CHECK_DIF_OK(dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled));
-  sram_function_test();
+
+  // Try to enable SRAM execution.
+  dif_result_t exec_enabled =
+      dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled);
+
+  // If SRAM execution was not enabled, re-check that execution fails, else
+  // check the positive case.
+  if (exec_enabled == kDifLocked) {
+    sram_ret_neg_test();
+  } else {
+    CHECK_DIF_OK(exec_enabled);
+    sram_function_test();
+  }
 
   return true;
 }


### PR DESCRIPTION
This commit handles the case where SRAM execution cannot be enabled (because it's disabled through OTP, for example) by running the negative case again.

Resolves #19893 