### PR TITLE
[cleanup] Fix a typo in the earlgrey key nickname

### DIFF
--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -345,7 +345,7 @@ offline_presigning_artifacts(
     ],
     manifest = ":manifest",
     rsa_key = {
-        "//sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_prod_0": "ealrgrey_a0_prod_0",
+        "//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_prod_0",
     },
     tags = ["manual"],
 )


### PR DESCRIPTION
The key nickname was written as `ealrgrey` (L and R transposed).  Correct it to `earlgrey`.