### PR TITLE
[bazel] enable specifing alternative OpenSSL paths

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,12 @@
 
 workspace(name = "lowrisc_opentitan")
 
+# Bazel skylib library
+load("//third_party/skylib:repos.bzl", "bazel_skylib_repos")
+bazel_skylib_repos()
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 # CRT is the Compiler Repository Toolkit.  It contains the configuration for
 # the windows compiler.
 load("//third_party/crt:repos.bzl", "crt_repos")
@@ -148,10 +154,6 @@ nonhermetic_repo(name = "nonhermetic")
 # Binary firmware image for HyperDebug
 load("//third_party/hyperdebug:repos.bzl", "hyperdebug_repos")
 hyperdebug_repos()
-
-# Bazel skylib library
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-bazel_skylib_workspace()
 
 register_toolchains(
     "//rules/opentitan:localtools",

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
-
 """Rules for generating OTP images.
 
 OTP image generation begins with producing one or more (H)JSON files that
@@ -38,9 +36,9 @@ list of dicts, each of the form {"name": key, "value": value}, which is the
 format expected by the image generation tool.
 """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
-load("//rules:host.bzl", "host_tools_transition")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 load("//rules:const.bzl", "CONST", "hex")
 
 def get_otp_images():

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -1,12 +1,22 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_vendor")
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_rust//bindgen:bindgen.bzl", "rust_bindgen_toolchain")
+load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_vendor")
+
+package(default_visibility = ["//visibility:public"])
 
 config_setting(
     name = "specify_bindgen_libstdcxx",
     values = {"define": "SPECIFY_BINDGEN_LIBSTDCXX=true"},
+)
+
+string_flag(
+    name = "openssl_pkg_config_path",
+    build_setting_default = "",
+    make_variable = "OPENSSL_PKG_CONFIG_PATH",
 )
 
 rust_bindgen_toolchain(
@@ -55,6 +65,13 @@ crates_vendor(
                     ],
                 )
             """,
+        )],
+        "openssl-sys": [crate.annotation(
+            build_script_env = {
+                "PKG_CONFIG_PATH": "$(OPENSSL_PKG_CONFIG_PATH)",
+                "OPENSSL_STATIC": "1",
+            },
+            build_script_toolchains = ["@//third_party/rust:openssl_pkg_config_path"],
         )],
         "pqcrypto-internals": [crate.annotation(
             additive_build_file_content = """

--- a/third_party/rust/crates/BUILD.openssl-sys-0.9.95.bazel
+++ b/third_party/rust/crates/BUILD.openssl-sys-0.9.95.bazel
@@ -83,6 +83,10 @@ rust_library(
 cargo_build_script(
     name = "openssl-sys_build_script",
     srcs = glob(["**/*.rs"]),
+    build_script_env = {
+        "OPENSSL_STATIC": "1",
+        "PKG_CONFIG_PATH": "$(OPENSSL_PKG_CONFIG_PATH)",
+    },
     crate_name = "build_script_main",
     crate_root = "build/main.rs",
     data = glob(
@@ -108,6 +112,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
+    toolchains = ["@//third_party/rust:openssl_pkg_config_path"],
     version = "0.9.95",
     visibility = ["//visibility:private"],
     deps = [

--- a/third_party/skylib/BUILD.bazel
+++ b/third_party/skylib/BUILD.bazel
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/skylib/repos.bzl
+++ b/third_party/skylib/repos.bzl
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def bazel_skylib_repos(local = None):
+    if local:
+        native.local_repository(
+            name = "bazel_skylib",
+            path = local,
+        )
+    else:
+        maybe(
+            http_archive,
+            name = "bazel_skylib",
+            sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+            urls = [
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+            ],
+        )


### PR DESCRIPTION
This adds a Bazel string flag build setting to enable specifing an alternative location for OpenSSL (via piping through an augmented PKG_CONFIG_PATH envar to the rust openssl-sys crate build script) so that opentitantool can be built on CentOS7 machines, which have much older native versions of OpenSSL. OpenSSL is required in order to generate OpenTitan attestation certs.