### PR TITLE
[otbn] Slightly weaken some loop stack assertions

### DIFF
--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -314,6 +314,12 @@ module otbn_loop_controller
   assign prefetch_loop_end_addr_o  = next_loop_addr_info.loop_end;
   assign prefetch_loop_jump_addr_o = next_loop_addr_info.loop_start;
 
-  `ASSERT(NoLoopStackPushAndPop, !(loop_stack_push_req && loop_stack_pop))
-  `ASSERT(NoLoopWriteIfCounterDec, current_loop_counter_dec |-> !loop_stack_write)
+  // Check that an instruction that tries to cause a stack push and pop at the same time will be
+  // reported as a SW error.
+  `ASSERT(NoLoopStackPushAndPop, loop_stack_push_req && loop_stack_pop |-> sw_err_o)
+
+  // The stack counter shouldn't get decremented at the same time as we write to the top of the loop
+  // stack. This can only happen on a combined push and pop, which will cause a SW error (so the
+  // contents of the stack will no longer matter any more).
+  `ASSERT(NoLoopWriteIfCounterDec, current_loop_counter_dec |-> (!loop_stack_write | sw_err_o))
 endmodule


### PR DESCRIPTION
The existing assertions got triggered if a loop body ended with another loop like this:

    ...
    loopi 1, 1
    loopi 1, 123
    ...

Here, the outer loop contains the second loopi as its only instruction. When that instruction runs, we're completing the only iteration of the outer loop (and popping from the loop stack) at the same time as we start an inner loop (and pushing to the loop stack).

This isn't allowed!

The hardware correctly kills the program and signals a SW error. This commit weakens the assertions so that they allow a simultaneous push and pop, so long as it causes an error.

Closes #20792.