### PR TITLE
[aes, doc] Clarify availability of sideload, change cryptolib link

### DIFF
--- a/hw/ip/aes/README.md
+++ b/hw/ip/aes/README.md
@@ -51,7 +51,7 @@ Galois/Counter Mode (GCM) can be implemented by leveraging [Ibex](../rv_core_ibe
 The AES unit is a cryptographic accelerator that accepts requests from the processor to encrypt or decrypt 16B blocks of data.
 It supports AES-128/192/256 in Electronic Codebook (ECB) mode, Cipher Block Chaining (CBC) mode, Cipher Feedback (CFB) mode (fixed data segment size of 128 bits, i.e., CFB-128), Output Feedback (OFB) mode and Counter (CTR) mode.
 For more information on these cipher modes, refer to [Recommendation for Block Cipher Modes of Operation](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf).
-Galois/Counter Mode (GCM) can be implemented using [Ibex](../rv_core_ibex/README.md) for the GHASH operation as demonstrated in [OpenTitan's library of cryptographic implementations](https://github.com/lowRISC/opentitan/tree/master/sw/device/lib/crypto).
+Galois/Counter Mode (GCM) can be implemented using [Ibex](../rv_core_ibex/README.md) for the GHASH operation as demonstrated in the [OpenTitan Cryptography Library](../../../doc/security/cryptolib/README.md).
 To improve the performance of GCM, instructions of the [RISC-V Bit-Manipulation Extension of Ibex](https://ibex-core.readthedocs.io/en/latest/03_reference/instruction_decode_execute.html#arithmetic-logic-unit-alu) can be leveraged.
 In particular, carry-less multiply instructions can help to speed up the GHASH operation.
 For details on GCM, refer to [Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf).
@@ -60,4 +60,4 @@ Other cipher modes might be added in future versions.
 The AES unit is attached to the chip interconnect bus as a peripheral module.
 Communication with the processor happens through a set of control and status registers (CSRs).
 This includes input/output data and key, as well as status and control information.
-Future versions of the AES unit might include a separate interface through which a possible system key manager can provide the key without exposing it to the processor or other hosts attached to the system bus interconnect.
+In addition, the AES unit includes a separate interface through which [Key Manager](../keymgr/README.md) can provide the key without exposing it to the processor or other hosts attached to the chip interconnect bus.


### PR DESCRIPTION
Thanks @m-temp for noticing the ambiguity regarding the key sideload interface.

As a drive by I also adjusted the link to the cryptolib which now as a real page in the documentation :-)