### PR TITLE
[sival,tests] Fix pwrmgr_random_sleep_all_wake_ups

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2590,7 +2590,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
     silicon = silicon_params(
@@ -2598,9 +2598,6 @@ opentitan_test(
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
-    ),
-    silicon_owner = silicon_params(
-        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",

--- a/sw/device/tests/pwrmgr_random_sleep_all_wake_ups.c
+++ b/sw/device/tests/pwrmgr_random_sleep_all_wake_ups.c
@@ -33,9 +33,8 @@
   5: sensor_ctrl
 
   #1 is excluded in non-DV because it forces an internal signal.
-  #5 is excluded because sensor_ctrl is not in the aon domain.
 
-  There are 10 cases to be tested. For each wake up this tests the normal and
+  There are 10 cases to be tested. For each wake up this tests normal and
   deep sleep in succession; for example, case 2 is adc_ctrl normal sleep and
   case 3 is adc_ctrl deep sleep.
 


### PR DESCRIPTION
This test expects sensor_ctrl to have a recoverable error at bit 0, but the AST triggers an additional alert for bit 5. We clear this additional bit and this test is working, but we added a TODO against #20798.
For each wakeup add checks that the CSR in the unit issuing the wakeup is also signalling a wakeup.