### PR TITLE
[spi_device,dv] Remove Generic-mode-only vseqs from `stress_all` test

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_stress_all_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_stress_all_vseq.sv
@@ -16,13 +16,7 @@ class spi_device_stress_all_vseq extends spi_device_base_vseq;
 
   task body();
     int num_flash_tpm_seq;
-    string seq_names[$] = {"spi_device_txrx_vseq",
-                           "spi_device_fifo_full_vseq",
-                           "spi_device_fifo_underflow_overflow_vseq",
-                           "spi_device_extreme_fifo_size_vseq",
-                           "spi_device_dummy_item_extra_dly_vseq",
-                           "spi_device_intr_vseq",
-                           "spi_device_perf_vseq",
+    string seq_names[$] = {
                            "spi_device_csb_read_vseq",
                            "spi_device_common_vseq" // for intr_test
                           };


### PR DESCRIPTION
We have disabled Generic / Firmware mode for `spi_device` in 02c15bb1728b689a0e670e15e0d520258ce9c2ac.  In that commit, we also disabled the tests that work only in that mode.  However, `spi_device_stress_all_vseq` still runs vseqs from tests that got disabled in the aforementioned commit.

This commit removes those vseqs from `spi_device_stress_all_vseq`.

This should resolve lowRISC/opentitan-integrated#607, though I would wait with closing that issue until we have confirmed its resolution through nightly regression results.