### PR TITLE
[sival,alert_test] Enable alert_test for sival_rom_ext

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -23,6 +23,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_alert_test"]
+      bazel: ["//sw/device/tests/autogen:alert_test"]
     }
     {
       name: chip_sw_alert_handler_escalations

--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -148,13 +148,16 @@ opentitan_test(
     srcs = ["alert_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:adc_ctrl",

--- a/sw/device/tests/autogen/alert_test.c
+++ b/sw/device/tests/autogen/alert_test.c
@@ -8,6 +8,7 @@
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 // util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 // -o hw/top_earlgrey
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_adc_ctrl.h"
 #include "sw/device/lib/dif/dif_aes.h"
@@ -550,19 +551,22 @@ static void trigger_alert_test(void) {
         &alert_handler, exp_alert));
   }
 
-  // Write otp_ctrl's alert_test reg and check alert_cause.
-  for (dif_otp_ctrl_alert_t i = 0; i < 5; ++i) {
-    CHECK_DIF_OK(dif_otp_ctrl_alert_force(&otp_ctrl, kDifOtpCtrlAlertFatalMacroError + i));
+  // TODO(lowrisc/opentitan#20348): Enable otp_ctrl when this is fixed.
+  if (kBootStage != kBootStageOwner) {
+    // Write otp_ctrl's alert_test reg and check alert_cause.
+    for (dif_otp_ctrl_alert_t i = 0; i < 5; ++i) {
+      CHECK_DIF_OK(dif_otp_ctrl_alert_force(&otp_ctrl, kDifOtpCtrlAlertFatalMacroError + i));
 
-    // Verify that alert handler received it.
-    exp_alert = kTopEarlgreyAlertIdOtpCtrlFatalMacroError + i;
-    CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
-        &alert_handler, exp_alert, &is_cause));
-    CHECK(is_cause, "Expect alert %d!", exp_alert);
+      // Verify that alert handler received it.
+      exp_alert = kTopEarlgreyAlertIdOtpCtrlFatalMacroError + i;
+      CHECK_DIF_OK(dif_alert_handler_alert_is_cause(
+          &alert_handler, exp_alert, &is_cause));
+      CHECK(is_cause, "Expect alert %d!", exp_alert);
 
-    // Clear alert cause register
-    CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
-        &alert_handler, exp_alert));
+      // Clear alert cause register
+      CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(
+          &alert_handler, exp_alert));
+    }
   }
 
   // Write pattgen's alert_test reg and check alert_cause.

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -144,5 +144,6 @@ test_suite(
         "//sw/device/tests:sram_ctrl_memset_test",
         "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test",
         "//sw/device/tests:sram_ctrl_subword_access_test",
+        "//sw/device/tests/autogen:alert_test",
     ],
 )

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -108,13 +108,16 @@ opentitan_test(
     srcs = ["alert_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
 % for n in sorted(alert_peripheral_names + ["alert_handler"]):


### PR DESCRIPTION
Skip otp_ctrl for rom_ext since otp_ctrl CSR accesses are disabled.
This is because all otp accesses are blocked via ePMP. We expect a
more granular approach to locking OTP access, in issue https://github.com/lowRISC/opentitan/issues/20348.
The code has a TODO for changes once that issue is addressed.
