### PR TITLE
[top_darjeeling,dv] Fix `rel_path` of top-level IPs

### DIFF
--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -60,25 +60,25 @@
                name: alert_handler
                top_chip: top_darjeeling
                import_cfgs: ["{proj_root}/hw/{top_chip}/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson"]
-               rel_path: "{proj_root}/hw/{top_chip}/ip_autogen/alert_handler/dv/"
+               rel_path: "hw/{top_chip}/ip_autogen/alert_handler/dv"
              },
              {
                name: clkmgr
                top_chip: top_darjeeling
                import_cfgs: ["{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson"]
-               rel_path: "{proj_root}/hw/ip/clkmgr/dv/"
+               rel_path: "hw/ip/clkmgr/dv"
              },
              {
                name: pwrmgr
                top_chip: top_darjeeling
                import_cfgs: ["{proj_root}/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson"]
-               rel_path: "{proj_root}/hw/ip/pwrmgr/dv/"
+               rel_path: "hw/ip/pwrmgr/dv"
              },
              {
                name: rstmgr
                top_chip: top_darjeeling
                import_cfgs: ["{proj_root}/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson"]
-               rel_path: "{proj_root}/hw/ip/rstmgr/dv/"
+               rel_path: "hw/ip/rstmgr/dv"
              },
              "{proj_root}/hw/{top_chip}/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson",
              "{proj_root}/hw/{top_chip}/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",


### PR DESCRIPTION
The path used to publish the reports of top-level IPs for Darjeeling is currently wrong, as can be seen in the links of the [summary page][1]:
- ALERT_HANDLER: https://reports.opentitan.org/hw/top_darjeeling/ip_autogen/alert_handler/dv/latest/report.html
- CLKMGR: https://reports.opentitan.org/hw/ip/clkmgr/dv/latest/report.html
- PWRMGR: https://reports.opentitan.org/hw/ip/pwrmgr/dv/latest/report.html
- RSTMGR: https://reports.opentitan.org/hw/ip/rstmgr/dv/latest/report.html

All links miss the `integrated/` prefix after the domain name, so the link for `alert_handler` cannot be found and the links for `clkmgr` and `rstmgr` collide with the results for Earlgrey (`pwrmgr` does not collide because it lives under `hw/top_earlgrey/ip_autogen/pwrmgr` on `master`).

When printing the commands used to publish the results (invoking `dvsim` with `--verbose=debug`), we can see that the absolute path to the local source path is included in the remote path; for example: https://reports.opentitan.org/integrated//home/dev/src/hw/ip/clkmgr/dv//latest/report.html when `dvsim` is run inside an OpenTitan container (the local source path for the regression runner that publishes the results is likely different).

The reason for this is that `rel_path` for the top-level IPs in `hw/top_darjeeing/dv/top_darjeeling_sim_cfgs.hjson` includes `{proj_root}`, which resolves to an absolute path.

This commit fixes the problem by removing `{proj_root}` (and the trailing slash) from `rel_path` of Darjeeling's top-level IPs.

[1]: https://reports.opentitan.org/integrated/hw/top_darjeeling/dv/summary/latest/report.html