### PR TITLE
[opentitantool] HyperDebug firmware with bugfixes

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20231221_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "f58e79737ced25fa8252cd6414a8ef11a336b308e2816e78e2f1759017812520",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240112_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "71942c4aabbc93fe3ec49c631009a30028f07658b36c803b40ffb348b915abef",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Update the version of the pre-built firmware for HyperDebug shipped with opentitantool.  This should resolve problems with HyperDebug dropping characters if the USB host computer fails to poll for a few milliseconds, while OT is producing data at maximum speed.

Also, bugs in corner cases of GPIO monitoring have been addressed.
