### PR TITLE
[sival,test_suite] Remove plic_all_irqs tests from suite

### DIFF
--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -61,8 +61,6 @@ test_suite(
         "//sw/device/tests:uart1_tx_rx_test",
         "//sw/device/tests:uart2_tx_rx_test",
         "//sw/device/tests:uart_smoketest",
-        "//sw/device/tests/autogen:plic_all_irqs_test_10",
-        "//sw/device/tests/autogen:plic_all_irqs_test_20",
         "//sw/device/tests/pmod:i2c_host_eeprom_test",
     ],
 )


### PR DESCRIPTION
Some of these tests don't exist in englishbreakfast since there are less irqs, so the englishbreakfst buid breaks unless they are removed.

Use the plic_all_irqs_test test_suite in sw/device/tests/autogen to run them instead.