### PR TITLE
[keymgr_dpe] Ignore invalid operations

### DIFF
--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -731,6 +731,12 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
                   $sformatf("process_tl_access: unrecognized state in the start case"))
               end
             endcase
+            if (get_invalid_op()) begin
+              set_exp_alert(.alert_name("recov_operation_err"));
+              current_op_status = keymgr_pkg::OpDoneFail;
+              void'(ral.intr_state.predict(.value(1'b1)));
+              void'(ral.err_code.invalid_op.predict(.value(1'b1)));
+            end
           end // start
         end else if (addr_phase_read) begin
           // start drops when op is done.

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -244,7 +244,7 @@ module keymgr_dpe_ctrl
   assign active_slot_boot_stage = active_key_slot_o.boot_stage;
   assign active_slot_policy     = active_key_slot_o.key_policy;
 
-  assign data_valid_o = op_ack & gen_key_op;
+  assign data_valid_o = op_ack & gen_key_op & ~invalid_op;
   assign wipe_key_o = update_sel == SlotQuickWipeAll;
 
   logic destination_slot_valid;
@@ -558,6 +558,7 @@ module keymgr_dpe_ctrl
     .adv_req_i(adv_req),
     .gen_req_i(gen_req),
     .erase_req_i(erase_req),
+    .invalid_op_i(invalid_op),
     .op_ack_o(op_ack),
     .op_busy_o(op_busy),
     .op_update_o(op_update),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_op_state_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_op_state_ctrl.sv
@@ -18,6 +18,8 @@ module keymgr_dpe_op_state_ctrl
   input gen_req_i,
   input erase_req_i,
 
+  input invalid_op_i,
+
   // `op_ack_o` signals to the top module that the requested operation is completed
   output logic op_ack_o,
   output logic op_busy_o,
@@ -60,12 +62,18 @@ module keymgr_dpe_op_state_ctrl
 
     unique case (state_q)
       StIdle: begin
-        if (adv_req_i) begin
-          state_d = StAdv;
-        end else if (gen_req_i) begin
-          state_d = StWait;
-        end else if (erase_req_i) begin
-          state_d = StErase;
+        if (invalid_op_i) begin
+          // If the incoming operation is invalid, acknowledge it and don't proceed with this FSM.
+          // This is *not* an FSM error (which is reserved for illegal states).
+          op_ack_o = 1'b1;
+        end else begin
+          if (adv_req_i) begin
+            state_d = StAdv;
+          end else if (gen_req_i) begin
+            state_d = StWait;
+          end else if (erase_req_i) begin
+            state_d = StErase;
+          end
         end
       end
 


### PR DESCRIPTION
As reported in lowRISC/opentitan-integrated#687, `keymgr_dpe` runs KMAC even for invalid operations (e.g., for a Generate from an invalid key slot).  This commit changes `keymgr_dpe` to not run KMAC for invalid operations, thereby resolving lowRISC/opentitan-integrated#687.

This PR supersedes https://github.com/lowRISC/opentitan-integrated/pull/684.