### PR TITLE
[keymgr_dpe/rtl] Fix `invalid_max_boot_stage`

### DIFF
--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -600,7 +600,7 @@ module keymgr_dpe_ctrl
   assign invalid_allow_child = ~active_slot_policy.allow_child;
 
   logic invalid_max_boot_stage;
-  assign invalid_max_boot_stage = active_slot_boot_stage == DpeNumBootStages - 1;
+  assign invalid_max_boot_stage = active_slot_boot_stage >= DpeNumBootStages - 1;
 
   // Check source validity
   logic invalid_src_slot;


### PR DESCRIPTION
Boot stage can be at most one less than the number of supported boot stages (`DpeNumBootStages` synthesis parameter) for a successful Advance operation, and boot stage is invalid for all values *greater than* or equal to that maximum.

This inaccuracy in the RTL code did not lead to a problem in the current instantiation, where `DpeNumBootStages = 4` and thus `DpeNumBootStageWidth = 2`, where the width ensures that the value of boot stage cannot be greater than `DpeNumBootStages`.  But this does not hold generally and could cause problems if `DpeNumBootStages` is set to a different value in the future.