### PR TITLE
[openocd,opentitanlib] Add earlgrey chip tapID

### DIFF
--- a/util/openocd/target/lowrisc-earlgrey-silicon.cfg
+++ b/util/openocd/target/lowrisc-earlgrey-silicon.cfg
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+if { [info exists CPUTAPID ] } {
+   set _CPUTAPID $CPUTAPID
+} else {
+   # Defined in `hw/top_earlgrey/rtl/jtag_id_pkg.sv`.
+   set _CPUTAPID 0x108c185b
+}
+
+source [find target/lowrisc-earlgrey.cfg]


### PR DESCRIPTION
The earlgrey chip has the TapID in this file and fixes errors in init.