### PR TITLE
[keymgr_dpe] Fix not updating of sideload keys on invalid operation (RTL) and issues in smoke test

### DIFF
--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -1443,6 +1443,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     for (int slot = 0; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
       `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid,
                    current_internal_key[slot].valid)
+      if (current_internal_key[slot].valid) begin
+        `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot],
+                     current_internal_key[slot])
+      end
     end
     if (compare_internal_key_slot)
       `uvm_error(`gfn,

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -1440,6 +1440,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     // post test checks - ensure that all local fifos and queues are empty
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(kmac_app_item, req_fifo)
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(kmac_app_item, rsp_fifo)
+    for (int slot = 0; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
+      `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid,
+                   current_internal_key[slot].valid)
+    end
     if (compare_internal_key_slot)
       `uvm_error(`gfn,
         $sformatf("outstanding compare_internal_key_slot left unchecked %0d",

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -285,7 +285,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
       end
       // Should occur when a valid OpDpeGenSwOut is issued in the StWorkDpeAvailable state
       UpdateSwOut: begin
-        if (!get_fault_err) begin
+        if (!get_fault_err && !get_invalid_op()) begin
           bit [keymgr_pkg::Shares-1:0][DIGEST_SHARE_WORD_NUM-1:0][TL_DW-1:0] sw_share_output;
           // digest is 384 bits wide while SW output is only 256, need to truncate it
           sw_share_output = {item.rsp_digest_share1[keymgr_pkg::KeyWidth-1:0],
@@ -306,7 +306,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
         keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
             `gmv(ral.control_shadowed.dest_sel));
 
-        if (dest != keymgr_pkg::None && !get_fault_err()) begin
+        if (dest != keymgr_pkg::None && !get_fault_err() && !get_invalid_op()) begin
           cfg.keymgr_dpe_vif.update_sideload_key(key_shares, current_state, dest);
           `uvm_info(`gfn, $sformatf("Update sideload key 0x%0h for %s", key_shares, dest.name),
                     UVM_MEDIUM)

--- a/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
+++ b/hw/ip/keymgr_dpe/dv/env/seq_lib/keymgr_dpe_smoke_vseq.sv
@@ -64,11 +64,6 @@ class keymgr_dpe_smoke_vseq extends keymgr_dpe_base_vseq;
             iter, src_slot ,dst_slot), UVM_HIGH)
         keymgr_dpe_operations(.advance_state(1), .num_gen_op($urandom_range(1,4)), .clr_output(1));
       end
-
-      // check to make sure all key slots are valid
-      for (int slot = 0; slot < keymgr_dpe_pkg::DpeNumSlots; slot++) begin
-        `DV_CHECK_EQ(cfg.keymgr_dpe_vif.internal_key_slots[slot].valid, 1)
-      end
   endtask : body
 
 endclass : keymgr_dpe_smoke_vseq

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -244,7 +244,7 @@ module keymgr_dpe_ctrl
   assign active_slot_boot_stage = active_key_slot_o.boot_stage;
   assign active_slot_policy     = active_key_slot_o.key_policy;
 
-  assign data_valid_o = op_ack & gen_key_op;
+  assign data_valid_o = op_ack & gen_key_op & ~invalid_op;
   assign wipe_key_o = update_sel == SlotQuickWipeAll;
 
   logic destination_slot_valid;


### PR DESCRIPTION
Together, these fixes now mean that `keymgr_dpe`'s smoke test passes 100% (even with `-rx 10`, i.e., for 500 reseeds). Please see the commit messages for details.