### PR TITLE
[opt_ctrl,dv] Fix types in otp_ctrl_scoreboard.sv

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -866,11 +866,11 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         end
 
         if (addr_phase_write && `gmv(ral.check_trigger_regwen) && item.a_data inside {[1:3]}) begin
-          bit [TL_DW-1] check_timout = `gmv(ral.check_timeout) == 0 ? '1 : `gmv(ral.check_timeout);
+          int unsigned check_timeout = `gmv(ral.check_timeout);
           exp_status[OtpCheckPendingIdx] = 1;
           under_chk = 1;
-          if (check_timout <= CHK_TIMEOUT_CYC) begin
-            set_exp_alert("fatal_check_error", 1, `gmv(ral.check_timeout));
+          if (check_timeout > 0 && check_timeout <= CHK_TIMEOUT_CYC) begin
+            set_exp_alert("fatal_check_error", 1, check_timeout);
             predict_err(OtpTimeoutErrIdx);
           end else begin
             if (get_field_val(ral.check_trigger.consistency, item.a_data)) begin
@@ -878,7 +878,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 if (cfg.ecc_chk_err[i] == OtpEccCorrErr) begin
                   predict_err(i, OtpMacroEccCorrError);
                 end else if (cfg.ecc_chk_err[i] == OtpEccUncorrErr) begin
-                  set_exp_alert("fatal_macro_error", 1, check_timout);
+                  set_exp_alert("fatal_macro_error", 1, check_timeout);
                   predict_err(i, OtpMacroEccUncorrError);
                 end
               end


### PR DESCRIPTION
This fixes a silly typo in the definition of a "check_timout" variable. In particular, simulators like Xcelium don't allow a variable to be declared like "bit [123] foo". The correct syntax would be packed dimensions like "bit [123:0] foo".

However, there's a reasonably obvious simpler fix, so I switched things to just using an integer. In the original code, a value of 0 was overridden with '1 (which was 2**32 with this type). Leaving it as zero (which already means "no timeout" for set_exp_alert) seems to work perfectly well.

As a minor nit, I also changed the variable name. Timeout now contains an "e"!