### PR TITLE
[aes,rtl] Switch to Bivium-based masking PRNG implementation

### DIFF
--- a/hw/ip/aes/README.md
+++ b/hw/ip/aes/README.md
@@ -33,7 +33,7 @@ The AES unit supports the following features:
 - Support for AES-192 can be removed to save area, and is enabled/disabled using a compile-time Verilog parameter
 - First-order masking of the cipher core using domain-oriented masking (DOM) to deter side-channel analysis (SCA), can optionally be disabled using compile-time Verilog parameters (for more details see [Security Hardening](./doc/theory_of_operation.md#side-channel-analysis))
 - Latency per 16 byte data block of 12/14/16 clock cycles (unmasked implementation) and 56/66/72 clock cycles (DOM) in AES-128/192/256 mode
-- Automatic as well as software-initiated reseeding of internal pseudo-random number generators (PRNGs) with configurable reseeding rate resulting in max entropy consumption rates ranging from 286 Mbit/s to 0.035 Mbit/s (at 100 MHz).
+- Automatic as well as software-initiated reseeding of internal pseudo-random number generators (PRNGs) with configurable reseeding rate resulting in max entropy consumption rates ranging from 343 Mbit/s to 0.042 Mbit/s (at 100 MHz).
 - Countermeasures for deterring fault injection (FI) on the control path (for more details see [Security Hardening](./doc/theory_of_operation.md#fault-injection))
 - Register-based data and control interface
 - System key-manager interface for optional key sideload to not expose key material to the processor and other hosts attached to the system bus interconnect.

--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lfsr
       - lowrisc:prim:sparse_fsm
+      - lowrisc:prim:trivium
       - lowrisc:prim:util
       - lowrisc:ip:tlul
       - lowrisc:ip:lc_ctrl_pkg

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -131,7 +131,7 @@
       desc:    '''
         Default seed of the PRNG used for masking.
       '''
-      randcount: "160",
+      randcount: "288",
       randtype:  "data"
     },
     { name:    "RndCnstMaskingLfsrPerm",
@@ -731,21 +731,21 @@
             desc: '''
               3'b001: Reseed the masking PRNG once per block.
               Invalid input values, i.e., values with multiple bits set and value 3'b000 are mapped to PER_1 (3'b001).
-              This results in a max entropy consumption rate of ~286 Mbit/s.
+              This results in a max entropy consumption rate of ~343 Mbit/s.
             '''
           },
           { value: "2",
             name: "PER_64",
             desc: '''
               3'b010: Reseed the masking PRNG approximately once per every 64 blocks.
-              This results in a max entropy consumption rate of ~4.5 Mbit/s.
+              This results in a max entropy consumption rate of ~5.4 Mbit/s.
             '''
           },
           { value: "4",
             name: "PER_8K",
             desc: '''
               3'b100: Reseed the masking PRNG approximately once per every 8192 blocks.
-              This results in an max entropy consumption rate of ~0.035 Mbit/s.
+              This results in a max entropy consumption rate of ~0.042 Mbit/s.
             '''
           }
         ]

--- a/hw/ip/aes/doc/registers.md
+++ b/hw/ip/aes/doc/registers.md
@@ -287,9 +287,9 @@ Invalid input values, i.e., values with multiple bits set and value 3'b000 are m
 
 | Value   | Name   | Description                                                                                                                                                                                                             |
 |:--------|:-------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0x1     | PER_1  | 3'b001: Reseed the masking PRNG once per block. Invalid input values, i.e., values with multiple bits set and value 3'b000 are mapped to PER_1 (3'b001). This results in a max entropy consumption rate of ~286 Mbit/s. |
-| 0x2     | PER_64 | 3'b010: Reseed the masking PRNG approximately once per every 64 blocks. This results in a max entropy consumption rate of ~4.5 Mbit/s.                                                                                  |
-| 0x4     | PER_8K | 3'b100: Reseed the masking PRNG approximately once per every 8192 blocks. This results in an max entropy consumption rate of ~0.035 Mbit/s.                                                                             |
+| 0x1     | PER_1  | 3'b001: Reseed the masking PRNG once per block. Invalid input values, i.e., values with multiple bits set and value 3'b000 are mapped to PER_1 (3'b001). This results in a max entropy consumption rate of ~343 Mbit/s. |
+| 0x2     | PER_64 | 3'b010: Reseed the masking PRNG approximately once per every 64 blocks. This results in a max entropy consumption rate of ~5.4 Mbit/s.                                                                                  |
+| 0x4     | PER_8K | 3'b100: Reseed the masking PRNG approximately once per every 8192 blocks. This results in a max entropy consumption rate of ~0.042 Mbit/s.                                                                              |
 
 Other values are reserved.
 

--- a/hw/ip/aes/doc/theory_of_operation.md
+++ b/hw/ip/aes/doc/theory_of_operation.md
@@ -161,7 +161,7 @@ If the AES unit is busy and running in CBC or CTR mode, the AES unit itself upda
 
 The cipher core architecture of the AES unit is derived from the architecture proposed by Satoh et al.: ["A compact Rijndael Hardware Architecture with S-Box Optimization"](https://link.springer.com/chapter/10.1007%2F3-540-45682-1_15).
 The expected circuit area in a 110nm CMOS technology is in the order of 12 - 22 kGE (unmasked implementation, AES-128 only).
-The expected circuit area of the entire AES unit with masking enabled is around 110 kGE.
+The expected circuit area of the entire AES unit with masking enabled is around 112 kGE.
 
 For a description of the various sub modules, see the following sections.
 

--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -52,28 +52,18 @@ if (`EN_MASKING) begin : gen_prng_bind
     .rst_ni,
 
     .entropy_masking_req(entropy_masking_req),
+    .entropy_masking_ack(entropy_masking_ack),
 
     .entropy_i(edn_data),
-    .lfsr_q_0 (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.gen_lfsrs[0].u_lfsr_chunk.
-               lfsr_q),
-    .lfsr_q_1 (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.gen_lfsrs[1].u_lfsr_chunk.
-               lfsr_q),
-    .lfsr_q_2 (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.gen_lfsrs[2].u_lfsr_chunk.
-               lfsr_q),
-    .lfsr_q_3 (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.gen_lfsrs[3].u_lfsr_chunk.
-               lfsr_q),
-    .lfsr_q_4 (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.gen_lfsrs[4].u_lfsr_chunk.
-               lfsr_q),
+    .state_q  (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.u_prim_bivium.state_q),
 
-    .reseed_rate    (u_aes_core.prng_reseed_rate_q),
     .block_ctr_expr (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
                      u_aes_control_fsm.block_ctr_expr),
     .ctrl_state     (u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
                      u_aes_control_fsm.aes_ctrl_cs),
     .ctrl_state_next(u_aes_core.u_aes_control.gen_fsm[0].gen_fsm_p.u_aes_control_fsm_i.
                      u_aes_control_fsm.aes_ctrl_ns),
-    .alert_fatal    (u_aes_core.alert_fatal_o),
-    .seed_en        (u_aes_core.u_aes_cipher_core.gen_masks.u_aes_prng_masking.prng_seed_en)
+    .alert_fatal    (u_aes_core.alert_fatal_o)
   );
 end
 endmodule

--- a/hw/ip/aes/pre_sca/prolead/README.md
+++ b/hw/ip/aes/pre_sca/prolead/README.md
@@ -96,7 +96,7 @@ After downloading and building the PROLEAD tool, and synthesizing the AES cipher
    Prepare shared data for 16 threads ...done!
 
    Generate list of standard probes from 224 standard probe locations...12992 standard probes found...done!
-   Generate list of extended probes from 786 extended probe locations...943370 extended probes found...done!
+   Generate list of extended probes from 723 extended probe locations...962568 extended probes found...done!
    Generate univariate probing sets...done (last step)! 12992 probing sets generated!
    Extend all probing sets...done!
    Remove duplicated probes in the sets...done!
@@ -104,52 +104,38 @@ After downloading and building the PROLEAD tool, and synthesizing the AES cipher
    ----------------------------------------------------------------------------------------------------------------------------------
    | #Standard Probes | #Extended Probes | Security Order | Distance | #Entries in Report | #Probing Sets | Maximum #Probes per Set |
    ----------------------------------------------------------------------------------------------------------------------------------
-   |            12992 |            45588 |              1 |       10 |                 10 |         12992 |                     127 |
+   |            12992 |            41934 |              1 |       10 |                 10 |         12992 |                     152 |
    ----------------------------------------------------------------------------------------------------------------------------------
 
    Evaluate security under the robust probing model!
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | Elapsed Time | Required Ram | Processed Simulations |                                                                      Probing Set with highest Information Leakage | -log10(p) |  Status |
+   |  Elapsed Time | Required Ram | Processed Simulations |                                                                      Probing Set with highest Information Leakage | -log10(p) | Status |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  112.107951s |  12.510552GB |       128000 / 161575 | ...gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[2] (37) |  3.620547 |    OKAY |
+   |   331.772834s | 101.050288GB |               2000000 | \u_aes_sub_bytes.gen_sbox_j[2].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[0] (17) |  3.973875 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  235.358985s |  12.510552GB |       256000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (17) |  5.025905 | LEAKAGE |
+   |   663.508580s | 101.050288GB |               4000000 | \u_aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[5] (38) |  3.280448 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  358.192534s |  12.510552GB |       384000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[2].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[0] (12) |  3.363567 |    OKAY |
+   |   984.316709s | 101.050288GB |               6000000 | ...gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (38) |  3.934658 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  473.133173s |  12.510552GB |       512000 / 161585 | ...gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[2] (37) |  3.921945 |    OKAY |
+   |  1326.190893s | 101.050288GB |               8000000 | ...gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (38) |  4.786719 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  590.334307s |  12.510552GB |       640000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[1] (12) |  4.717441 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  706.490746s |  12.510552GB |       768000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[0].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (57) |  3.492387 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   |  895.176681s |  12.510552GB |       896000 / 161585 |   ...gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.u_aes_dom_inverse_gf2p4.b_gamma_ss_d[1] (22) |  3.981567 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 1030.569630s |  12.510552GB |      1024000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (62) |  3.393895 |    OKAY |
+   |  1662.860622s | 101.050288GB |              10000000 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[4] (37) |  3.379137 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    ...
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 8518.762592s |  12.510552GB |      9088000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (41) |  3.017296 |    OKAY |
+   | 16115.801588s | 101.050288GB |              90000000 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (17) |  3.505599 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 8639.829626s |  12.510552GB |      9216000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[2].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[6] (41) |  3.018391 |    OKAY |
+   | 16475.616037s | 101.050288GB |              92000000 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (17) |  3.886383 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 8758.906474s |  12.510552GB |      9344000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[5] (42) |  2.945251 |    OKAY |
+   | 16828.528801s | 101.050288GB |              94000000 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (17) |  3.938206 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 8881.120705s |  12.510552GB |      9472000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[0].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[4] (46) |  2.996482 |    OKAY |
+   | 17193.708467s | 101.050288GB |              96000000 | \u_aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[2] (17) |  3.841046 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 8998.628485s |  12.510552GB |      9600000 / 161585 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[2].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[7] (51) |  2.976931 |    OKAY |
+   | 17517.789999s | 101.050288GB |              98000000 | \u_aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[0].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[3] (67) |  3.761645 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 9111.867212s |  12.510552GB |      9728000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.198678 |    OKAY |
+   | 17863.879551s | 101.050288GB |             100000000 | \u_aes_sub_bytes.gen_sbox_j[3].gen_sbox_i[3].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.prd1_d[0] (37) |  3.780986 |   OKAY |
    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 9223.720210s |  12.510552GB |      9856000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.256948 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 9343.188344s |  12.510552GB |      9984000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.390740 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 9458.458347s |  12.510552GB |     10112000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.097989 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   | 9572.974702s |  12.510552GB |     10240000 / 161585 | ...gen_sbox_i[1].u_aes_sbox_ij.gen_sbox_masked.gen_sbox_dom.u_aes_sbox.u_aes_dom_inverse_gf2p8.b_y10_prd1[1] (57) |  3.264392 |    OKAY |
-   -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   Evaluation done in 9573.98 seconds!
+   Evaluation done in 17864.4 seconds!
    done!
    ```
    It may be that PROLEAD reports several `-log10(p)` values greater than the threshold value of 5.0 and thus reports to have found leakage.
@@ -158,8 +144,7 @@ After downloading and building the PROLEAD tool, and synthesizing the AES cipher
    If the values do not grow in the further progression taking more simulations into account, the reported leakage probably occurred due to a false positive.
    It's further recommended to consider at least 10 or 100 Mio simulations for hardware designs when evaluating in the normal or compact mode, respectively.
 
-   In this particular example, the evaluation is performed in normal mode and all `-log10(p)` values for more than 384sk simulations are below the threshold.
-   It can thus be assumed that the values above the threshold are false positives.
+   In this particular example, the evaluation is performed in compact mode and all `-log10(p)` values are below the threshold.
 
    By default, the script will evaluate the AES cipher core including the PRNG.
    But you can actually specify the top module to evaluate.

--- a/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
+++ b/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
@@ -29,16 +29,16 @@ max_no_of_threads
 
 % total number of simulations (traces) in the tests, should be a factor of 64
 no_of_simulations
-10240000
+100000000
 
 % number of simulations in each step, should be a factor of 64, and a divisor of no_of_simulations
 no_of_step_simulations
-128000
+2000000
 
 % number of simulations in each step that result files are written, should be a factor of 64, and
 % a divisor of no_of_simulations and should be a factor of no_of_step_simulations
 no_of_step_write_results
-128000
+2000000
 
 waveform_simulation % yes/no: whether VCD files of individual simulations are stored to disk (in
                     % main directory) or not, can be useful for debugging the configuration
@@ -57,7 +57,7 @@ no
 compact_distributions % yes/no: whether distributions (of probes) should be considered as compact.
                       % it is recommended to use 'no' only for small circuits and low security
                       % orders
-no
+yes
 
 minimize_probe_sets % yes/no: whether it should be tried to find equivalent probing sets.
                     % it is recommended to use 'yes' only for small circuits and low security

--- a/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
+++ b/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
@@ -90,7 +90,7 @@ no_of_initial_inputs
 
 % number of clock cycles to initiate the run (start of encryption)
 no_of_initial_clock_cycles
-11
+12
 
 %1 - First clock cycle with inactive reset.
             key_clear_i         1'b0
@@ -272,7 +272,27 @@ no_of_initial_clock_cycles
             prng_reseed_i       1'b1
 [2:0]       key_len_i           3'b001
 
-%10 - Start encryption in parallel with a reseed of the internal masking PRNG.
+%10 - Wait for initial reseed of the masking PRNG to finish.
+            key_clear_i         1'b0
+            data_out_clear_i    1'b0
+            alert_fatal_i       1'b0
+            force_masks_i       1'b0
+            entropy_ack_i       1'b1
+[2:0]       out_ready_i         3'b011
+            cfg_valid_i         1'b1
+[1:0]       op_i                2'b01
+[127:0]     state_init_i        group_in0[127:0]
+[255:128]   state_init_i        group_in1[127:0]
+[127:0]     prd_clearing_i      group_in0[255:128]
+[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni              1'b1
+[2:0]       in_valid_i          3'b100
+[2:0]       crypt_i             3'b100
+[2:0]       dec_key_gen_i       3'b100
+            prng_reseed_i       1'b1
+[2:0]       key_len_i           3'b001
+
+%11 - Start encryption.
             key_clear_i         1'b0
             data_out_clear_i    1'b0
             alert_fatal_i       1'b0
@@ -292,7 +312,7 @@ no_of_initial_clock_cycles
             prng_reseed_i       1'b1
 [2:0]       key_len_i           3'b001
 
-%11 - De-assert in_valid_i. The DUT is already busy performing the encryption.
+%12 - De-assert in_valid_i. The DUT is already busy performing the encryption.
 % De-asserting in_valid_i helps to avoid restarting the encryption after finishing in case the
 % simulation isn't stopped.
             key_clear_i         1'b0
@@ -319,7 +339,7 @@ no_of_initial_clock_cycles
 % Note: end_wait_cycles > 0 doesn't seem to work with signal values, otherwise we could use
 % something like [2:0] out_valid_o 3'b011
 end_condition
-ClockCycles 66
+ClockCycles 67
 
 % number of clock cycles to wait after the end_condition
 end_wait_cycles
@@ -327,7 +347,7 @@ end_wait_cycles
 
 % maximum number of clock cycles per run before checking the end_condition
 max_clock_cycle
-66
+67
 
 no_of_outputs
 0
@@ -336,7 +356,7 @@ no_of_outputs
 no_of_test_clock_cycles
 1
 
-9-66  % The encryption starts at %10 and takes 56 clock cycles.
+10-67  % The encryption starts at %11 and takes 56 clock cycles.
 
 % max number of entries in the report file with maximum leakage
 % 0 : do not generate the report file

--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -64,6 +64,7 @@ OT_DEP_SOURCES=(
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_lc_sync.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_sync_reqack_data.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_sync_reqack.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_trivium.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_packer_fifo.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_lfsr.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_flop_2sync.sv

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -306,7 +306,6 @@ module aes_cipher_core import aes_pkg::*;
     // - the PRD required by the key expand module (has 4 S-Boxes internally).
     aes_prng_masking #(
       .Width                ( WidthPRDMasking        ),
-      .ChunkSize            ( ChunkSizePRDMasking    ),
       .EntropyWidth         ( EntropyWidth           ),
       .SecAllowForcingMasks ( SecAllowForcingMasks   ),
       .SecSkipPRNGReseeding ( SecSkipPRNGReseeding   ),

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -32,8 +32,6 @@ parameter int unsigned WidthPRDData     = 16*WidthPRDSBox; // 16 S-Boxes for the
 parameter int unsigned WidthPRDKey      = 4*WidthPRDSBox;  // 4 S-Boxes for the key expand
 parameter int unsigned WidthPRDMasking  = WidthPRDData + WidthPRDKey;
 
-parameter int unsigned ChunkSizePRDMasking = WidthPRDMasking/5;
-
 // Clearing PRNG default LFSR seed and permutation
 // These LFSR parameters have been generated with
 // $ util/design/gen-lfsr-seed.py --width 64 --seed 31468618 --prefix "Clearing"
@@ -51,21 +49,27 @@ parameter clearing_lfsr_perm_t RndCnstClearingSharePermDefault = {
   256'h9736b95ac3f3b5205caf8dc536aad73605d393c8dd94476e830e97891d4828d0
 };
 
-// Masking PRNG default LFSR seed and permutation
-// We use a single seed that is split down into chunks internally.
+// Masking PRNG default state seed and output permutation
+// The output width is 160 bits (WidthPRDMasking = WidthPRDSBox * (16 + 4)).
 // These LFSR parameters have been generated with
 // $ util/design/gen-lfsr-seed.py --width 160 --seed 31468618 --prefix "Masking"
 parameter int MaskingLfsrWidth = 160; // = WidthPRDMasking = WidthPRDSBox * (16 + 4)
-typedef logic [MaskingLfsrWidth-1:0] masking_lfsr_seed_t;
 typedef logic [MaskingLfsrWidth-1:0][$clog2(MaskingLfsrWidth)-1:0] masking_lfsr_perm_t;
-parameter masking_lfsr_seed_t RndCnstMaskingLfsrSeedDefault =
-  160'hc132b5723c5a4cf4743b3c7c32d580f74f1713a;
 parameter masking_lfsr_perm_t RndCnstMaskingLfsrPermDefault = {
   256'h17261943423e4c5c03872194050c7e5f8497081d96666d406f4b606473303469,
   256'h8e7c721c8832471f59919e0b128f067b25622768462e554d8970815d490d7f44,
   256'h048c867d907a239b20220f6c79071a852d76485452189f14091b1e744e396737,
   256'h4f785b772b352f6550613c58130a8b104a3f28019c9a380233956b00563a512c,
   256'h808d419d63982a16995e0e3b57826a36718a9329452492533d83115a75316e15
+};
+// The state width is 177 bits (Bivium) but the primitive expects a 288-bit seed (Trivium).
+// These LFSR parameters have been generated with
+// $ util/design/gen-lfsr-seed.py --width 288 --seed 31468618 --prefix "Masking"
+parameter int MaskingPrngStateWidth = 288;
+typedef logic [MaskingPrngStateWidth-1:0] masking_lfsr_seed_t;
+parameter masking_lfsr_seed_t RndCnstMaskingLfsrSeedDefault = {
+  32'h758a4420,
+  256'h31e1c461_6ea343ec_153282a3_0c132b57_23c5a4cf_4743b3c7_c32d580f_74f1713a
 };
 
 typedef enum integer {

--- a/hw/ip/aes/rtl/aes_prng_masking.sv
+++ b/hw/ip/aes/rtl/aes_prng_masking.sv
@@ -4,29 +4,15 @@
 //
 // AES high-bandwidth pseudo-random number generator for masking
 //
-// This module uses multiple parallel LFSRs each one of them followed by an aligned permutation, a
-// non-linear layer (PRINCE S-Boxes) and another permutation layer spanning across all LFSRs to
-// generate pseudo-random data for masking the AES cipher core. The LFSRs can be reseeded using an
-// external interface.
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// IMPORTANT NOTE:                                                                               //
-//                                   DO NOT USE THIS BLINDLY!                                    //
-//                                                                                               //
-// This implementation has been experimentally evaluated with / optimized for the masked AES     //
-// cipher core using the S-Box implementation with first-order domain-oriented masking.          //
-// Other masking schemes and S-Box implementations might have different requirements on the PRNG //
-// in terms of uniformity and independence of the generated pseudo-random numbers. Upon changes  //
-// to these parts of the design, it is thus recommended to again perform experimental            //
-// evaluation. Use with care.                                                                    //
-///////////////////////////////////////////////////////////////////////////////////////////////////
+// This module uses a stream cipher primitive followed by a linear permutation layer to generate
+// pseudo-random data for masking the AES cipher core. The stream cipher primitive can be reseeded
+// using an external interface.
 
 `include "prim_assert.sv"
 
 module aes_prng_masking import aes_pkg::*;
 #(
-  parameter  int unsigned Width        = WidthPRDMasking,     // Must be divisble by ChunkSize and 8
-  parameter  int unsigned ChunkSize    = ChunkSizePRDMasking, // Width of the LFSR primitives
+  parameter  int unsigned Width        = WidthPRDMasking,
   parameter  int unsigned EntropyWidth = edn_pkg::ENDPOINT_BUS_WIDTH,
   parameter  bit          SecAllowForcingMasks  = 0, // Allow forcing masks to constant values using
                                                      // force_masks_i. Useful for SCA only.
@@ -35,8 +21,6 @@ module aes_prng_masking import aes_pkg::*;
                                                      // infrastructure required for PRNG reseeding.
                                                      // To enable SCA resistance evaluations, we
                                                      // need to skip reseeding requests.
-
-  localparam int unsigned NumChunks = Width/ChunkSize, // derived parameter
 
   parameter masking_lfsr_seed_t RndCnstLfsrSeed = RndCnstMaskingLfsrSeedDefault,
   parameter masking_lfsr_perm_t RndCnstLfsrPerm = RndCnstMaskingLfsrPermDefault
@@ -58,22 +42,21 @@ module aes_prng_masking import aes_pkg::*;
   input  logic [EntropyWidth-1:0] entropy_i
 );
 
-  logic                [NumChunks-1:0] prng_seed_en;
-  logic [NumChunks-1:0][ChunkSize-1:0] prng_seed;
-  logic                                prng_en;
-  logic [NumChunks-1:0][ChunkSize-1:0] prng_state, perm;
-  logic                    [Width-1:0] prng_b, perm_b;
-  logic                                phase_q;
+  logic             prng_seed_en;
+  logic             prng_seed_done;
+  logic [Width-1:0] prng_key;
+  logic             prng_err;
 
   /////////////
   // Control //
   /////////////
 
-  // The data requests are fed from the LFSRs. Reseed requests take precedence internally to the
-  // LFSRs. If there is an outstanding reseed request, the PRNG can keep updating and providing
-  // pseudo-random data (using the old seed). If the reseeding is taking place, the LFSRs will
-  // provide fresh pseudo-random data (the new seed) in the next cycle anyway. This means the
-  // PRNG is always ready to provide new pseudo-random data.
+  // The data requests are fed from a stream cipher primitive that is reseeded in chunks of
+  // EntropyWidth bits. Internally, the primitive generates the output based on the current state.
+  // If there is an outstanding reseed request, the PRNG can keep updating and providing
+  // pseudo-random data (using the current state of the primitive). When reseeding a chunk without
+  // requesting a PRNG update, the current output might change or not, depending on the Width and
+  // current chunk index.
 
   // In the current SCA setup, we don't have sufficient resources to implement the infrastructure
   // required for PRNG reseeding (CSRNG, EDN, etc.). Therefore, we skip any reseeding requests if
@@ -89,132 +72,65 @@ module aes_prng_masking import aes_pkg::*;
     assign unused_force_masks = force_masks_i;
   end
 
-  // PRNG control
-  assign prng_en = (SecAllowForcingMasks && force_masks_i) ? 1'b0 : data_update_i;
-
   // Create a lint error to reduce the risk of accidentally enabling this feature.
   `ASSERT_STATIC_LINT_ERROR(AesSecSkipPRNGReseedingNonDefault, SecSkipPRNGReseeding == 0)
 
-  // Width adaption for reseeding interface. We get EntropyWidth bits at a time.
-  if (ChunkSize == EntropyWidth) begin : gen_counter
-    // We can reseed chunk by chunk as we get fresh entropy. Need to keep track of which chunk to
-    // reseed next.
-    localparam int unsigned ChunkIdxWidth = prim_util_pkg::vbits(NumChunks);
-    logic [ChunkIdxWidth-1:0] chunk_idx_d, chunk_idx_q;
-    logic                     prng_reseed_done;
-
-    // Stop requesting entropy once every chunk got reseeded.
-    assign entropy_req_o = SecSkipPRNGReseeding ? 1'b0         : reseed_req_i;
-    assign reseed_ack_o  = SecSkipPRNGReseeding ? reseed_req_i : prng_reseed_done;
-
-    // Counter
-    assign prng_reseed_done =
-        (chunk_idx_q == ChunkIdxWidth'(NumChunks - 1)) & entropy_req_o & entropy_ack_i;
-    assign chunk_idx_d = prng_reseed_done ? '0                              :
-        entropy_req_o && entropy_ack_i    ? chunk_idx_q + ChunkIdxWidth'(1) : chunk_idx_q;
-
-    always_ff @(posedge clk_i or negedge rst_ni) begin : reg_chunk_idx
-      if (!rst_ni) begin
-        chunk_idx_q <= '0;
-      end else begin
-        chunk_idx_q <= chunk_idx_d;
-      end
-    end
-
-    // The entropy input is forwarded to all chunks, we just control the seed enable.
-    for (genvar c = 0; c < NumChunks; c++) begin : gen_seeds
-      assign prng_seed[c]    = entropy_i;
-      assign prng_seed_en[c] = (c == chunk_idx_q) ? entropy_req_o & entropy_ack_i : 1'b0;
-    end
-
-  end else begin : gen_packer
-    // Upsizing of entropy input to correct width for reseeding the full PRNG in one shot.
-    logic [Width-1:0] seed;
-    logic             seed_valid;
-
-    // Stop requesting entropy once the desired amount is available.
-    assign entropy_req_o = SecSkipPRNGReseeding ? 1'b0         : reseed_req_i & ~seed_valid;
-    assign reseed_ack_o  = SecSkipPRNGReseeding ? reseed_req_i : seed_valid;
-
-    prim_packer_fifo #(
-      .InW         ( EntropyWidth ),
-      .OutW        ( Width        ),
-      .ClearOnRead ( 1'b0         )
-    ) u_prim_packer_fifo (
-      .clk_i    ( clk_i         ),
-      .rst_ni   ( rst_ni        ),
-      .clr_i    ( 1'b0          ), // Not needed.
-      .wvalid_i ( entropy_ack_i ),
-      .wdata_i  ( entropy_i     ),
-      .wready_o (               ), // Not needed, we're always ready to sink data at this point.
-      .rvalid_o ( seed_valid    ),
-      .rdata_o  ( seed          ),
-      .rready_i ( 1'b1          ), // We're always ready to receive the packed output word.
-      .depth_o  (               )  // Not needed.
-    );
-
-    // Extract chunk seeds. All chunks get reseeded together.
-    for (genvar c = 0; c < NumChunks; c++) begin : gen_seeds
-      assign prng_seed[c]    = seed[c * ChunkSize +: ChunkSize];
-      assign prng_seed_en[c] = SecSkipPRNGReseeding ? 1'b0 : seed_valid;
-    end
+  if (SecSkipPRNGReseeding == 1) begin : gen_unused_prng_seed_done
+    logic unused_prng_seed_done;
+    assign unused_prng_seed_done = prng_seed_done;
   end
 
-  ///////////
-  // LFSRs //
-  ///////////
+  // Reseed interface handling
+  assign prng_seed_en = SecSkipPRNGReseeding ? 1'b0         : reseed_req_i;
+  assign reseed_ack_o = SecSkipPRNGReseeding ? reseed_req_i : prng_seed_done;
 
-  // We use multiple LFSR instances each having a width of ChunkSize.
-  for (genvar c = 0; c < NumChunks; c++) begin : gen_lfsrs
-    prim_lfsr #(
-      .LfsrType     ( "GAL_XOR"                                   ),
-      .LfsrDw       ( ChunkSize                                   ),
-      .StateOutDw   ( ChunkSize                                   ),
-      .DefaultSeed  ( RndCnstLfsrSeed[c * ChunkSize +: ChunkSize] ),
-      .StatePermEn  ( 1'b0                                        ),
-      .NonLinearOut ( 1'b1                                        )
-    ) u_lfsr_chunk (
-      .clk_i     ( clk_i           ),
-      .rst_ni    ( rst_ni          ),
-      .seed_en_i ( prng_seed_en[c] ),
-      .seed_i    ( prng_seed[c]    ),
-      .lfsr_en_i ( prng_en         ),
-      .entropy_i ( '0              ),
-      .state_o   ( prng_state[c]   )
-    );
-  end
+  ////////////////////////////////////
+  // Bivium Stream Cipher Primitive //
+  ////////////////////////////////////
+  prim_trivium #(
+   .BiviumVariant         (1),
+   .OutputWidth           (Width),
+   .StrictLockupProtection(!SecAllowForcingMasks),
+   .SeedType              (prim_trivium_pkg::SeedTypeStatePartial),
+   .PartialSeedWidth      (EntropyWidth),
+   .RndCnstTriviumLfsrSeed(RndCnstLfsrSeed)
+  ) u_prim_bivium (
+   .clk_i (clk_i),
+   .rst_ni(rst_ni),
 
-  // Add a permutation layer spanning across all LFSRs to break linear shift patterns.
-  assign prng_b = prng_state;
+   .en_i                (data_update_i),
+   .allow_lockup_i      (SecAllowForcingMasks & force_masks_i),
+   .seed_en_i           (prng_seed_en),
+   .seed_done_o         (prng_seed_done),
+   .seed_req_o          (entropy_req_o),
+   .seed_ack_i          (entropy_ack_i),
+   .seed_key_i          ('0), // Not used.
+   .seed_iv_i           ('0), // Not used.
+   .seed_state_full_i   ('0), // Not used.
+   .seed_state_partial_i(entropy_i),
+
+   .key_o(prng_key),
+   .err_o(prng_err)
+  );
+
+  // Add a permutation layer to obfuscate the output of stream cipher primitive.
   for (genvar b = 0; b < Width; b++) begin : gen_perm
-    assign perm_b[b] = prng_b[RndCnstLfsrPerm[b]];
+    assign data_o[b] = prng_key[RndCnstLfsrPerm[b]];
   end
-  assign perm = perm_b;
 
-  /////////////
-  // Outputs //
-  /////////////
-
-  // To achieve independence of input and output masks (the output mask of round X is the input
-  // mask of round X+1), we assign the scrambled chunks to the output data in alternating fashion.
-  assign data_o = phase_q ? {perm[0], perm[NumChunks-1:1]} : perm;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_phase
-    if (!rst_ni) begin
-      phase_q <= '0;
-    end else if (prng_en) begin
-      phase_q <= ~phase_q;
-    end
-  end
+  // At the moment, the PRNG error output is ignored. This signal is asserted only if the stream
+  // cipher primitive enters an all-zero state. Depending on the value of the SecAllowForcingMasks
+  // parameter, the primitive behaves differently:
+  // - If SecAllowForcingMasks == 0 or if SecAllowForcingMasks == 1 and force_masks_i == 0, the
+  //   primitive is automatically reset to the default value defined by a secret netlist constant.
+  // - If SecAllowForcingMasks == 1 and force_masks_i == 1, the primitive keeps the all-zero value.
+  //   This may be required to switch off the masking for evaluating the SCA resistance.
+  logic unused_prng_err;
+  assign unused_prng_err = prng_err;
 
   /////////////////
   // Asssertions //
   /////////////////
-
-  // Width must be divisible by ChunkSize
-  `ASSERT_INIT(AesPrngMaskingWidthByChunk, Width % ChunkSize == 0)
-  // Width must be divisible by 8
-  `ASSERT_INIT(AesPrngMaskingWidthBy8, Width % 8 == 0)
 
 // the code below is not meant to be synthesized,
 // but it is intended to be used in simulation and FPV

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1156,7 +1156,7 @@
           randcount: 40
           randtype: data
           name_top: RndCnstOtpCtrlLfsrSeed
-          default: 0xdd23f39863
+          default: 0x571eae0fc6
           randwidth: 40
         }
         {
@@ -1166,7 +1166,7 @@
           randcount: 40
           randtype: perm
           name_top: RndCnstOtpCtrlLfsrPerm
-          default: 0x1639502661994cf48d4401e17da38891678155c2940cc8028976cb7589c4
+          default: 0x46429e4882d35cd9e224c7ce04316384661a9823d66dd8140251c455c419
           randwidth: 240
         }
         {
@@ -1176,7 +1176,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtpCtrlScrmblKeyInit
-          default: 0x2efaa51f0de710c891d47ff7209f95d614848e38361cd9b7eb23d532c0ab44e1
+          default: 0x23d532c0ab44e1e92ccfebadad9193a3ee4ecd8c032462b3e18549cb1e70d5a8
           randwidth: 256
         }
       ]
@@ -1575,7 +1575,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0xe92ccfebadad9193a3ee4ecd8c032462
+          default: 0x3de6673d2c1c0a7b55176264e55c329c
           randwidth: 128
         }
         {
@@ -1585,7 +1585,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestDevRma
-          default: 0xb3e18549cb1e70d5a83de6673d2c1c0a
+          default: 0x8ae4725aeaf6728150127ac755d70063
           randwidth: 128
         }
         {
@@ -1595,7 +1595,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0x7b55176264e55c329c8ae4725aeaf672
+          default: 0x277642b5309a163990b966cd494444c3
           randwidth: 128
         }
         {
@@ -1605,7 +1605,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0x8150127ac755d70063277642b5309a163990b966cd494444c3bcdf8087b7facd65e9654cd85bc66d10208c4fb51b97bbf4d12c378ccfd6a5a5bf3032db51fa1eb92f6ce10e90f9c5c06f733dc911a321dd4c0ac2406d467215dab3f2b54a52e6728678af0718068e344d2eae4d73c8fa54de8aa4a4f258f3b2a145fd1950ae55
+          default: 0xbcdf8087b7facd65e9654cd85bc66d10208c4fb51b97bbf4d12c378ccfd6a5a5bf3032db51fa1eb92f6ce10e90f9c5c06f733dc911a321dd4c0ac2406d467215dab3f2b54a52e6728678af0718068e344d2eae4d73c8fa54de8aa4a4f258f3b2a145fd1950ae55d693e57968117e66dc634155e0f8150242862eb20eea9a1f75
           randwidth: 1024
         }
         {
@@ -2131,7 +2131,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0xd693e579
+          default: 0x44716551
           randwidth: 32
         }
         {
@@ -2141,7 +2141,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0x5dbf54f634c4afa998e470c258641e5239b63c4d
+          default: 0xe9f28b4f1248f60fb6b00dccb7bb9aa122cf08aa
           randwidth: 160
         }
       ]
@@ -4533,7 +4533,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0xc772795a358ec30f1bedd1af0ec9d9a9
+          default: 0x28363aaa0e93d45c423690ed05bd1e71
           randwidth: 128
         }
         {
@@ -4543,7 +4543,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0xcf36a2b130d32afe121af734f628363a
+          default: 0xf22d1095889fbd8a7b57fb1e11df367
           randwidth: 128
         }
         {
@@ -4553,7 +4553,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0xaa0e93d4
+          default: 0xc1c1ede3
           randwidth: 32
         }
         {
@@ -4563,7 +4563,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0xb4d22a55b8da8fdf1790665f1fe88170ee09190b
+          default: 0xef32502204a4eef4fc4a64b0730c36d6eae6c57e
           randwidth: 160
         }
         {
@@ -4743,7 +4743,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0xdebe60a22db6d398d4a21b73699e8082
+          default: 0xd0488805541166f1ec8ceb42692b089a
           randwidth: 128
         }
         {
@@ -4753,7 +4753,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0x434a1dcd0488805541166f1ec8ceb42
+          default: 0x6f99b1a7ac084224ade4612980d48e6c
           randwidth: 128
         }
         {
@@ -4763,7 +4763,7 @@
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
-          default: 0x692b089a6f99b1a7ac084224ade4612980d48e6c6493a50eedbac6a46b7a8a9b2c7aec92f39e49478c398c91db1841831b1f5c82a556096fff6175fc10f93979
+          default: 0x6493a50eedbac6a46b7a8a9b2c7aec92f39e49478c398c91db1841831b1f5c82a556096fff6175fc10f939792b444e521d4711e64066908adfd5918f8c563c92
           randwidth: 512
         }
         {
@@ -4773,7 +4773,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x2b444e52
+          default: 0x184f1c76
           randwidth: 32
         }
         {
@@ -4783,7 +4783,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0x596ad040db23bba7d2614fee755b198c99ee0903
+          default: 0xf1a4763625b576106958727fc5f61944eef20874
           randwidth: 160
         }
         {
@@ -5505,7 +5505,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x265c9cb3b2f1c44a
+          default: 0x8055b24b5f3b3ea7
           randwidth: 64
         }
         {
@@ -5515,7 +5515,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0xd3bc592488ae0cd2907447e3ae96b296ff27df01ff5ad63a45b53833d0263ce5f3b15e5e085d52dbea242e01814ea85c
+          default: 0x34693a24a552b718dd0b9d04bc342e81eec75887e1ff08a94da3dcc81627f5914eaf845b525de82f3b3632a5fe03cd66
           randwidth: 384
         }
         {
@@ -5525,18 +5525,18 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0xd33f4e8fc1287d2ebe0c62229f05de878cab602679355c5d9375b66d072a98aa6c681b8cd65ecb140fcf254bd344782d
+          default: 0x352c351eb2238ac0c93b4942bd9dcb5c07989ed90631d455531ea17d3e04168f2a833f8f5bfd9b41ccbb98aa79f5ab81
           randwidth: 384
         }
         {
           name: RndCnstMaskingLfsrSeed
           desc: Default seed of the PRNG used for masking.
           type: aes_pkg::masking_lfsr_seed_t
-          randcount: 160
+          randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xee55b032c07a29b920b7953e485f23ad102c6a0e
-          randwidth: 160
+          default: 0xe9f0ec4c712146a4ab60da8b656eabb0b3ef6e9b197ce582fc9b5965d697c23beafe8389
+          randwidth: 288
         }
         {
           name: RndCnstMaskingLfsrPerm
@@ -5545,7 +5545,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0xc6f87945305816a0d5d109b5c4d22350f7d34572c06679e483e4e80291a6b978d846d611d64957244137e31924a8a041c437f58232562908c5f69015427913841092d559c49705e328663029a1b3a9d42182b2033503f79082f75763d39730b287b369f0368780716148566374f24405b1f302a0e8e476c7a7496151e884b0a567745008f2693522e1151125a3c1789833b9959827c19986e658b604621714c
+          default: 0x1a6953018d0a1f407a46869e434a6366737179769406249b4458057b04650f3041707d0c345e0d6a67573b29276b23932261914b1d78971e873e2c351337959d4f25314d387f108192886e745b4e092d6d485582998f728a856c5c029c1b3a68642142185f8b208950840e082f629f478c392a0b28153683037c1907168e7e754c6f49803f60541c9833322b3d5d14567745009a269059522e961151125a3c17
           randwidth: 1280
         }
       ]
@@ -5771,7 +5771,7 @@
           randcount: 800
           randtype: data
           name_top: RndCnstKmacLfsrSeed
-          default: 0x165ee14a00ee9ff9382af33b479718558e6759764645aad1fb21c18124635e3d50a88f6808045627ac18f377d9071beca6f194ef96f3e535b58f2adad82b175fe9ea1c326a6610c1117744de61ccbfabd3e1fda667e04082478c14db070a6129bb2945b8
+          default: 0x4645aad1fb21c18124635e3d50a88f6808045627ac18f377d9071beca6f194ef96f3e535b58f2adad82b175fe9ea1c326a6610c1117744de61ccbfabd3e1fda667e04082478c14db070a6129bb2945b88dc6cfcf2ae02f47010cb666a5e22d3320f89caa
           randwidth: 800
         }
         {
@@ -5781,7 +5781,7 @@
           randcount: 800
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0xaa611a064c05044a68a00aab6b00646249809ded203004157d5bf189716117a78a4106046644366f9dd1514651b688819d2fb35d142706a868fc34b3adc7c3c5e12a8dc908e12363d12de51fdc2be4f9620c6af472036211a4e9558400c9c371857491439d5b6082bc740a2984b16ec7d39da3ad6e0be2f784195c6d9d6f25f30d925380a3fc9948d63756c35ad7b5c158c302d34977096b117f12a7aef02db9a15ee1a0d02444926d9077e0e3ba7fc769c7589cb8416554ec16597535278e17c61e5ea82faa2c098619a6b11a66cf3c041e7dafd4012c730bf96ed67e5710ceee940501d4ba465b40ade235d5ec0c38a54ed820157486c6c4ad76601515ec958f75f9f164cae92ead78018ba0b65b04e4c5a85d0bb875806a8c17352b9003faced8279a16071e726352318c14a0204806c509567acc5d479c3884314cb79edea0dca2e6dc22c3e286b05e1fd344660b8c9800c869e4688e2937691204ccb21a02f8b5461cb8f2391aa8c9761b8a1406a49a369284947a962653da6d0d076216931b60a5e996bc2e236d204eaba52ce44dd338d0ef3c9a603801180002bdba29e32389020c168440618be98c567c9ee794d27a35a3646eb9a09d8302f18951dc72f4832ea8818b4fd64b55d3bd904bc91c7a2270216a074b73a04881e2a2b1f40be9659c6558a660dc6b4d8247aee66c3191c2b8bf112298861c4fb6ad4773e443f0e3abf1f1361e105db67289b2e099f6ab85cb09d0a423ea8b4c4f8c5f0430d55a5fca13072284a79828bd4136080fb05c5bb65355c87311769671628dad9ccfe7201c0c6be8b85dc227e6963e6c8925421432855439d411d2252b04b430f88a2c446414b62d582cf27ea6361af572433826b34cc24a9bfba68e80c7e71d394055d89858252e4664623c0faa8ea72f03963a1c07df70a5fab7ed2294e6619796cecab94de84abf7907ba1e602406fa00fdc2908926eca959fc25d79a02125b0ba9270c696e91cdf7edf5869420d5488e929aeeac82c034f04631d44815be4299424c1942d4c351ae4ecb2b38022a20fc0aff22717a29265989d5fcf814db56346e041f20f507b1d0fb9e9989263c4d5a54436366541713e099839b1f845b109151e645a4152e3938058fe4d87efe8aec6525de7a53057db799ddd1d1ce8edf344c07bcc5a114cf0895bac83b06db868a865ce5716d842e29498a9b10a5a0f082616d4b5dc476a4ab2514564637bceb8102c85add7aac463dbd3369d9b92e7fa55a4921551ffad13d706523d1e31e23323a19a8ac5a7d8a40ec254e06b6c174c823a2146339983aaaa836155497245ce59207353cf5132691581a9d80c594a99a87725c43702304d6aebed385b67193f1184c3a5068dc16eb772d147e7220cb4a5ed9010bd2ae37
+          default: 0x7c29aa2531b1dc68bd06a85cca9414210ee2805f56079c3e3d516461f256b78f752d61c51404697cb8451192da2365d046641c94d92c6790c999b52426dd24249e986ea9c1f69fef11100b2216331a5b28a5c09df9a28bf8225e81d89b19ca72e686c6183fe03a5c7d0350502992340400ca783e5158a22a1a52b6b27cb7c8c8745ebc977c7710906980b5c520c252aa828da53c059a2007fb8cb3558ed30c9185c2a674d76e857048c5735ab49c4b081d1698c22c4682550d125d5961e16589cbea49789d9538dc68c167ac9891c595e155a9a8f6c2b52eaa7c0caba1009be12fa0ce7a5ae9c281e3b20c8098ca40d3ad8bd385c9bb43385168140755c4cb50ea30aef9981ee73c38b3293148155ae261b1002b5e6b5e665d52c465aa5fa659ccd266cae3a56fb4ded061972d97d1395eaed232ee3c622e6305c2a56210ff003c66bc3006c1a373cd90758b9aa48b0f8a1ae1801f8d11982e32609322bd912bec38dd77c813331e6a4be2d5185edbc9006a8c9a08896c5d1e5268da4a1251e9b697dbf3da740d076215871b611b059e762a836d204eaa4c70e44dd33b9cef3cad503801180002bec029e39389020c2004406189e724e5c762e804d281359ec46d81bddbb3017a8b11d01315c5ef37c5934fd64965e0bfd04c451c90a2e0216a074b73a04883a312b0e00bec359c65589950dc6b4d8246a2ef6e4b41c1e79f512298861c4fb6d147a7225944e3b963e6844db90417a19c9fad48412aaca1eb267b2908fabedc13e387f50c355f45a60aa2f022284ac6c28bf8136080f70eca742b1ae55721cc45d9d3b2f1f28dad9e8fe7201c0c5db7f23517704a15a5a1db22495086cca1550e750474894a806d9c6229b8911bf52d8d160b609fab4d86bd5c5c30d69e1c2c0fc4055d8b68c1609488199188f03eaf6b58bc0e58e88c1f7dc297eae8afca5399865e5b39d6ee37a12b21e41ee8eadc901be4c3f71342250bd6ac67f1275e6f08496c26ab9de9e5bb1637dfb7d61a508355223a4a6ceace0b00d3c118c7512056f90a650930650b530d46b93b2ca99008a883f0bc20899e691499662757f3e0536d58d1b8107c83d41ed043ef0a822498ef4569510d8d99505c4f82660e6c7e116c66454799169054bb24e0163f9361fc1e2bb3d49779e94c15f6de677747473a3b7cd1301efc1684533c2256eba0ec1b6e1a2a197395c5b610b8ac29498a9b10a5a0f082616ddb82bc711da92ad24515918def3ae040b216b35eab118f6f4cda766e4b9fe95692485547feb44f5c1948f478c788cc8e866a2b169f62903b095381adb05d3208e88518ce660eaaaa0d855525c917396481cd4f3d44c9a45606a76031652a66a1dc9710dc08c135abafb4e16d9c64fc6a130e941a3705baddcb451f
           randwidth: 8000
         }
         {
@@ -5791,7 +5791,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKmacLfsrFwdPerm
-          default: 0x3276e7c6778216cd53e2e58793a9a00e2b2293dd
+          default: 0x721afdfa782f01a3ae1da8659a12df62471ba846
           randwidth: 160
         }
         {
@@ -5801,7 +5801,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0x59e194dd143b9424f38ce83d5c589c9cfdb07476af86898b0446d8aee2bc57a00c7f4d480eab24fb1a49b4d672ff94b8
+          default: 0xf82671d835948217304a2bfa0239682ce7ed30d6ab769bb9609f734c59c7f322ac991de47b41b83f5408a955c113f6fb
           randwidth: 384
         }
       ]
@@ -5979,7 +5979,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0xd2696788a8735b27982f5007a24a125f876c9ca6ddeb52ac92f5600d2a41bc46
+          default: 0x465efe57aa3b59bd6b0a40216363420f041ed29a965b68faea3e59d4f2e2a0b4
           randwidth: 256
         }
         {
@@ -6015,7 +6015,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x5efe57aa3b59bd6b0a40216363420f04
+          default: 0x2eb9a8c3ab227b50766d2eaec89eb13b
           randwidth: 128
         }
         {
@@ -6025,7 +6025,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x1ed29a965b68faea
+          default: 0x7e9bf4ee4278413
           randwidth: 64
         }
       ]
@@ -6210,7 +6210,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x3e59d4f2e2a0b42e
+          default: 0x6d42c85e456f3b26
           randwidth: 64
         }
         {
@@ -6220,7 +6220,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x9ce4760a94fedacf600c64d0fde2259f906fe6805a52d63eb4568b71f115d0dc48494ef04eb27cab2db754788fb0aae
+          default: 0x67dff5779df3aea61ce14690b285a9171ea43910237cfc1b0a2c8682d101f870f6ed33523272882fc949bde9ae8555f4
           randwidth: 384
         }
         {
@@ -6230,7 +6230,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0x95a6c4ff0f42ef01f3d4575bac9cb50904e880db
+          default: 0x341c41f29adf4058a907f3ea297c295e18dbced9
           randwidth: 160
         }
         {
@@ -6240,7 +6240,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0xbe6e65c359480858c39611e658c97fb8d3e9cc0e7f8fa8725200c726c8f90ef5
+          default: 0x576ca8a8225c8e17053e44b68dd7822a6859f2cf52a55fd181b082d03c583756
           randwidth: 256
         }
         {
@@ -6250,7 +6250,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0xe2b74beee27cfa19ea576ca8a8225c8e17053e44b68dd7822a6859f2cf52a55f
+          default: 0xf11aa5b37f9544c4aa90eb97e1c0f8086f627a281c5681d6566641eecccc8887
           randwidth: 256
         }
         {
@@ -6260,7 +6260,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0xd181b082d03c583756f11aa5b37f9544c4aa90eb97e1c0f8086f627a281c5681
+          default: 0x6ad113c50ad1be4d94dce8fca54128a3860ae1d3493fbef6b9ba5dfe4463a461
           randwidth: 256
         }
         {
@@ -6270,7 +6270,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0xd6566641eecccc88876ad113c50ad1be4d94dce8fca54128a3860ae1d3493fbe
+          default: 0x5ef46762a794a8c2597e69fb259b961914cd75bbfd36ba48e780d27cd582540c
           randwidth: 256
         }
         {
@@ -6280,7 +6280,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0xf6b9ba5dfe4463a4615ef46762a794a8c2597e69fb259b961914cd75bbfd36ba
+          default: 0x7a68ff254edfd852829fecccabd4af9c9032da20bdaf59fe2ae209b8325d2c8c
           randwidth: 256
         }
         {
@@ -6290,7 +6290,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0x48e780d27cd582540c7a68ff254edfd852829fecccabd4af9c9032da20bdaf59
+          default: 0x35fc960679b106a87e59e6aeb1b5302d33401070251696fbb4ba169a6cd82fad
           randwidth: 256
         }
         {
@@ -6300,7 +6300,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0xfe2ae209b8325d2c8c35fc960679b106a87e59e6aeb1b5302d33401070251696
+          default: 0x46a0a5c04009bb934c7ef7b83b6e40610b4309fcb9dc54d4276137f9901d09a7
           randwidth: 256
         }
         {
@@ -6310,7 +6310,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0xfbb4ba169a6cd82fad46a0a5c04009bb934c7ef7b83b6e40610b4309fcb9dc54
+          default: 0x6aeaa19de5c579fd38bdf38f0c21d6a52226b6a4a7bdb05fe921615bf2ff9845
           randwidth: 256
         }
         {
@@ -6320,7 +6320,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOtbnSeed
-          default: 0xd4276137f9901d09a76aeaa19de5c579fd38bdf38f0c21d6a52226b6a4a7bdb0
+          default: 0x40f7d43ece76b4eb13363774ed2ed45545e927f6d9e4abac398d42c745eef646
           randwidth: 256
         }
         {
@@ -6330,7 +6330,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCdi
-          default: 0x5fe921615bf2ff984540f7d43ece76b4eb13363774ed2ed45545e927f6d9e4ab
+          default: 0xc1464dca86dafd7c7c71e6058ddfd871c51cacbaf4410f06dcc036fcd16fcde9
           randwidth: 256
         }
         {
@@ -6340,7 +6340,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0xac398d42c745eef646c1464dca86dafd7c7c71e6058ddfd871c51cacbaf4410f
+          default: 0x7d171891105dd895e3a1d0a19a16d6dbd8b20fc9e662e1e1b4982b3e8eff6389
           randwidth: 256
         }
       ]
@@ -6550,7 +6550,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0x6dcc036fcd16fcde97d171891105dd895e3a1d0a19a16d6dbd8b20fc9e662e1e1b4982b3e8eff63890dbeae926fd468
+          default: 0xdbeae926fd468a77efde3de5b4caf4776a247baba4c9908ed16bc5415ec16d28c53551312fcedcf2832a66ceacf8ed4
           randwidth: 384
         }
         {
@@ -6560,7 +6560,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0xa77efde3de5b4caf4776a247baba4c9908ed16bc5415ec16d28c53551312fcedcf2832a66ceacf8ed4d5b616177dd43b
+          default: 0xd5b616177dd43b56fa754e1f53ad658193b563d9bdc6d2aee84852f0cc7371ed3a6faa516c144b34c96dfabb6f6e7920
           randwidth: 384
         }
         {
@@ -7050,7 +7050,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x56fa754e1f53ad658193b563d9bdc6d2
+          default: 0x8a74f35c79f397c4e4c7e22b7581848a
           randwidth: 128
         }
         {
@@ -7060,7 +7060,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0xaee84852f0cc7371ed3a6faa516c144b
+          default: 0x90a1254b2276bec9fc1a7a5722a9aaca
           randwidth: 128
         }
         {
@@ -7070,7 +7070,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0x34c96dfa
+          default: 0x4db84a32
           randwidth: 32
         }
         {
@@ -7080,7 +7080,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x60fe032149a57a1c1c56dea70c965c5ba247f9b7
+          default: 0x7cb60455500e897a15a977bb93dbf1119835cf1c
           randwidth: 160
         }
         {
@@ -7251,7 +7251,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0x1a6435118b5f5f3f
+          default: 0xcc69a2147819b290
           randwidth: 64
         }
         {
@@ -7261,7 +7261,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0xd3b9313116b67192d856dd742d40e072
+          default: 0xa4bb0264347c0f91b0cec93c0129d85b
           randwidth: 128
         }
         {
@@ -7448,7 +7448,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0xe417ad9a
+          default: 0x95801dbe
           randwidth: 32
         }
         {
@@ -7458,7 +7458,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0x7443a428fe2de15c7d33b199c90dfda37790088b
+          default: 0x4093fa68a3c595c3dcd2ac19972e33e849b6bfc0
           randwidth: 160
         }
         {
@@ -7468,7 +7468,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0xdc260a79998eff5c710b67838adfb99a
+          default: 0x8e7026d0e5dce9e265a416a812231cfa
           randwidth: 128
         }
         {
@@ -7478,7 +7478,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0x5eca671672cf19bc
+          default: 0x76e3d982f8fdcec9
           randwidth: 64
         }
         {

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -59,3 +59,5 @@ waive -rules SAME_NAME_TYPE -location {spi_device.sv} -msg {'spi_device' is used
       -comment {This is acceptable, since these are used in different hierarchies.}
 waive -rules SAME_NAME_TYPE -location {tlul_socket_m1.sv} -msg {'M' is used as a parameter here, and as a reg at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
+waive -rules SAME_NAME_TYPE -location {prim_trivium.sv} -msg {'state_update' is used as a reg here, and as a function at} \
+      -comment {This is acceptable, since these are used in different hierarchies.}

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -18,17 +18,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter otp_ctrl_pkg::lfsr_seed_t RndCnstOtpCtrlLfsrSeed = {
-    40'hDD_23F39863
+    40'h57_1EAE0FC6
   };
 
   // Compile-time random permutation for LFSR output
   parameter otp_ctrl_pkg::lfsr_perm_t RndCnstOtpCtrlLfsrPerm = {
-    240'h1639_50266199_4CF48D44_01E17DA3_88916781_55C2940C_C8028976_CB7589C4
+    240'h4642_9E4882D3_5CD9E224_C7CE0431_6384661A_9823D66D_D8140251_C455C419
   };
 
   // Compile-time random permutation for scrambling key/nonce register reset value
   parameter otp_ctrl_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
-    256'h2EFAA51F_0DE710C8_91D47FF7_209F95D6_14848E38_361CD9B7_EB23D532_C0AB44E1
+    256'h23D532C0_AB44E1E9_2CCFEBAD_AD9193A3_EE4ECD8C_032462B3_E18549CB_1E70D5A8
   };
 
   ////////////////////////////////////////////
@@ -36,25 +36,25 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'hE92CCFEB_ADAD9193_A3EE4ECD_8C032462
+    128'h3DE6673D_2C1C0A7B_55176264_E55C329C
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestDevRma = {
-    128'hB3E18549_CB1E70D5_A83DE667_3D2C1C0A
+    128'h8AE4725A_EAF67281_50127AC7_55D70063
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'h7B551762_64E55C32_9C8AE472_5AEAF672
+    128'h277642B5_309A1639_90B966CD_494444C3
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
-    256'h8150127A_C755D700_63277642_B5309A16_3990B966_CD494444_C3BCDF80_87B7FACD,
-    256'h65E9654C_D85BC66D_10208C4F_B51B97BB_F4D12C37_8CCFD6A5_A5BF3032_DB51FA1E,
-    256'hB92F6CE1_0E90F9C5_C06F733D_C911A321_DD4C0AC2_406D4672_15DAB3F2_B54A52E6,
-    256'h728678AF_0718068E_344D2EAE_4D73C8FA_54DE8AA4_A4F258F3_B2A145FD_1950AE55
+    256'hBCDF8087_B7FACD65_E9654CD8_5BC66D10_208C4FB5_1B97BBF4_D12C378C_CFD6A5A5,
+    256'hBF3032DB_51FA1EB9_2F6CE10E_90F9C5C0_6F733DC9_11A321DD_4C0AC240_6D467215,
+    256'hDAB3F2B5_4A52E672_8678AF07_18068E34_4D2EAE4D_73C8FA54_DE8AA4A4_F258F3B2,
+    256'hA145FD19_50AE55D6_93E57968_117E66DC_634155E0_F8150242_862EB20E_EA9A1F75
   };
 
   ////////////////////////////////////////////
@@ -62,12 +62,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'hD693E579
+    32'h44716551
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h5DBF54F6_34C4AFA9_98E470C2_58641E52_39B63C4D
+    160'hE9F28B4F_1248F60F_B6B00DCC_B7BB9AA1_22CF08AA
   };
 
   ////////////////////////////////////////////
@@ -75,22 +75,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'hC772795A_358EC30F_1BEDD1AF_0EC9D9A9
+    128'h28363AAA_0E93D45C_423690ED_05BD1E71
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'hCF36A2B1_30D32AFE_121AF734_F628363A
+    128'h0F22D109_5889FBD8_A7B57FB1_E11DF367
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    32'hAA0E93D4
+    32'hC1C1EDE3
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    160'hB4D22A55_B8DA8FDF_1790665F_1FE88170_EE09190B
+    160'hEF325022_04A4EEF4_FC4A64B0_730C36D6_EAE6C57E
   };
 
   ////////////////////////////////////////////
@@ -98,28 +98,28 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'hDEBE60A2_2DB6D398_D4A21B73_699E8082
+    128'hD0488805_541166F1_EC8CEB42_692B089A
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'h0434A1DC_D0488805_541166F1_EC8CEB42
+    128'h6F99B1A7_AC084224_ADE46129_80D48E6C
   };
 
   // Compile-time random bits for default seeds
   parameter flash_ctrl_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
-    256'h692B089A_6F99B1A7_AC084224_ADE46129_80D48E6C_6493A50E_EDBAC6A4_6B7A8A9B,
-    256'h2C7AEC92_F39E4947_8C398C91_DB184183_1B1F5C82_A556096F_FF6175FC_10F93979
+    256'h6493A50E_EDBAC6A4_6B7A8A9B_2C7AEC92_F39E4947_8C398C91_DB184183_1B1F5C82,
+    256'hA556096F_FF6175FC_10F93979_2B444E52_1D4711E6_4066908A_DFD5918F_8C563C92
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h2B444E52
+    32'h184F1C76
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'h596AD040_DB23BBA7_D2614FEE_755B198C_99EE0903
+    160'hF1A47636_25B57610_6958727F_C5F61944_EEF20874
   };
 
   ////////////////////////////////////////////
@@ -127,33 +127,34 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h265C9CB3_B2F1C44A
+    64'h8055B24B_5F3B3EA7
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'hD3BC5924_88AE0CD2_907447E3_AE96B296,
-    256'hFF27DF01_FF5AD63A_45B53833_D0263CE5_F3B15E5E_085D52DB_EA242E01_814EA85C
+    128'h34693A24_A552B718_DD0B9D04_BC342E81,
+    256'hEEC75887_E1FF08A9_4DA3DCC8_1627F591_4EAF845B_525DE82F_3B3632A5_FE03CD66
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'hD33F4E8F_C1287D2E_BE0C6222_9F05DE87,
-    256'h8CAB6026_79355C5D_9375B66D_072A98AA_6C681B8C_D65ECB14_0FCF254B_D344782D
+    128'h352C351E_B2238AC0_C93B4942_BD9DCB5C,
+    256'h07989ED9_0631D455_531EA17D_3E04168F_2A833F8F_5BFD9B41_CCBB98AA_79F5AB81
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    160'hEE55B032_C07A29B9_20B7953E_485F23AD_102C6A0E
+    32'hE9F0EC4C,
+    256'h712146A4_AB60DA8B_656EABB0_B3EF6E9B_197CE582_FC9B5965_D697C23B_EAFE8389
   };
 
   // Permutation applied to the concatenated LFSRs of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h0C6F8794_5305816A_0D5D109B_5C4D2235_0F7D3457_2C06679E_483E4E80_291A6B97,
-    256'h8D846D61_1D649572_44137E31_924A8A04_1C437F58_23256290_8C5F6901_54279138,
-    256'h41092D55_9C49705E_32866302_9A1B3A9D_42182B20_33503F79_082F7576_3D39730B,
-    256'h287B369F_03687807_16148566_374F2440_5B1F302A_0E8E476C_7A749615_1E884B0A,
-    256'h56774500_8F269352_2E115112_5A3C1789_833B9959_827C1998_6E658B60_4621714C
+    256'h1A695301_8D0A1F40_7A46869E_434A6366_73717976_9406249B_4458057B_04650F30,
+    256'h41707D0C_345E0D6A_67573B29_276B2393_2261914B_1D78971E_873E2C35_1337959D,
+    256'h4F25314D_387F1081_92886E74_5B4E092D_6D485582_998F728A_856C5C02_9C1B3A68,
+    256'h64214218_5F8B2089_50840E08_2F629F47_8C392A0B_28153683_037C1907_168E7E75,
+    256'h4C6F4980_3F60541C_9833322B_3D5D1456_7745009A_26905952_2E961151_125A3C17
   };
 
   ////////////////////////////////////////////
@@ -161,57 +162,57 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random data for LFSR default seed
   parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
-    32'h165EE14A,
-    256'h00EE9FF9_382AF33B_47971855_8E675976_4645AAD1_FB21C181_24635E3D_50A88F68,
-    256'h08045627_AC18F377_D9071BEC_A6F194EF_96F3E535_B58F2ADA_D82B175F_E9EA1C32,
-    256'h6A6610C1_117744DE_61CCBFAB_D3E1FDA6_67E04082_478C14DB_070A6129_BB2945B8
+    32'h4645AAD1,
+    256'hFB21C181_24635E3D_50A88F68_08045627_AC18F377_D9071BEC_A6F194EF_96F3E535,
+    256'hB58F2ADA_D82B175F_E9EA1C32_6A6610C1_117744DE_61CCBFAB_D3E1FDA6_67E04082,
+    256'h478C14DB_070A6129_BB2945B8_8DC6CFCF_2AE02F47_010CB666_A5E22D33_20F89CAA
   };
 
   // Compile-time random permutation for LFSR output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    64'hAA611A06_4C05044A,
-    256'h68A00AAB_6B006462_49809DED_20300415_7D5BF189_716117A7_8A410604_6644366F,
-    256'h9DD15146_51B68881_9D2FB35D_142706A8_68FC34B3_ADC7C3C5_E12A8DC9_08E12363,
-    256'hD12DE51F_DC2BE4F9_620C6AF4_72036211_A4E95584_00C9C371_85749143_9D5B6082,
-    256'hBC740A29_84B16EC7_D39DA3AD_6E0BE2F7_84195C6D_9D6F25F3_0D925380_A3FC9948,
-    256'hD63756C3_5AD7B5C1_58C302D3_4977096B_117F12A7_AEF02DB9_A15EE1A0_D0244492,
-    256'h6D9077E0_E3BA7FC7_69C7589C_B8416554_EC165975_35278E17_C61E5EA8_2FAA2C09,
-    256'h8619A6B1_1A66CF3C_041E7DAF_D4012C73_0BF96ED6_7E5710CE_EE940501_D4BA465B,
-    256'h40ADE235_D5EC0C38_A54ED820_157486C6_C4AD7660_1515EC95_8F75F9F1_64CAE92E,
-    256'hAD78018B_A0B65B04_E4C5A85D_0BB87580_6A8C1735_2B9003FA_CED8279A_16071E72,
-    256'h6352318C_14A02048_06C50956_7ACC5D47_9C388431_4CB79EDE_A0DCA2E6_DC22C3E2,
-    256'h86B05E1F_D344660B_8C9800C8_69E4688E_29376912_04CCB21A_02F8B546_1CB8F239,
-    256'h1AA8C976_1B8A1406_A49A3692_84947A96_2653DA6D_0D076216_931B60A5_E996BC2E,
-    256'h236D204E_ABA52CE4_4DD338D0_EF3C9A60_38011800_02BDBA29_E3238902_0C168440,
-    256'h618BE98C_567C9EE7_94D27A35_A3646EB9_A09D8302_F18951DC_72F4832E_A8818B4F,
-    256'hD64B55D3_BD904BC9_1C7A2270_216A074B_73A04881_E2A2B1F4_0BE9659C_6558A660,
-    256'hDC6B4D82_47AEE66C_3191C2B8_BF112298_861C4FB6_AD4773E4_43F0E3AB_F1F1361E,
-    256'h105DB672_89B2E099_F6AB85CB_09D0A423_EA8B4C4F_8C5F0430_D55A5FCA_13072284,
-    256'hA79828BD_4136080F_B05C5BB6_5355C873_11769671_628DAD9C_CFE7201C_0C6BE8B8,
-    256'h5DC227E6_963E6C89_25421432_855439D4_11D2252B_04B430F8_8A2C4464_14B62D58,
-    256'h2CF27EA6_361AF572_433826B3_4CC24A9B_FBA68E80_C7E71D39_4055D898_58252E46,
-    256'h64623C0F_AA8EA72F_03963A1C_07DF70A5_FAB7ED22_94E66197_96CECAB9_4DE84ABF,
-    256'h7907BA1E_602406FA_00FDC290_8926ECA9_59FC25D7_9A02125B_0BA9270C_696E91CD,
-    256'hF7EDF586_9420D548_8E929AEE_AC82C034_F04631D4_4815BE42_99424C19_42D4C351,
-    256'hAE4ECB2B_38022A20_FC0AFF22_717A2926_5989D5FC_F814DB56_346E041F_20F507B1,
-    256'hD0FB9E99_89263C4D_5A544363_66541713_E099839B_1F845B10_9151E645_A4152E39,
-    256'h38058FE4_D87EFE8A_EC6525DE_7A53057D_B799DDD1_D1CE8EDF_344C07BC_C5A114CF,
-    256'h0895BAC8_3B06DB86_8A865CE5_716D842E_29498A9B_10A5A0F0_82616D4B_5DC476A4,
-    256'hAB251456_4637BCEB_8102C85A_DD7AAC46_3DBD3369_D9B92E7F_A55A4921_551FFAD1,
-    256'h3D706523_D1E31E23_323A19A8_AC5A7D8A_40EC254E_06B6C174_C823A214_6339983A,
-    256'hAAA83615_5497245C_E5920735_3CF51326_91581A9D_80C594A9_9A87725C_43702304,
-    256'hD6AEBED3_85B67193_F1184C3A_5068DC16_EB772D14_7E7220CB_4A5ED901_0BD2AE37
+    64'h7C29AA25_31B1DC68,
+    256'hBD06A85C_CA941421_0EE2805F_56079C3E_3D516461_F256B78F_752D61C5_1404697C,
+    256'hB8451192_DA2365D0_46641C94_D92C6790_C999B524_26DD2424_9E986EA9_C1F69FEF,
+    256'h11100B22_16331A5B_28A5C09D_F9A28BF8_225E81D8_9B19CA72_E686C618_3FE03A5C,
+    256'h7D035050_29923404_00CA783E_5158A22A_1A52B6B2_7CB7C8C8_745EBC97_7C771090,
+    256'h6980B5C5_20C252AA_828DA53C_059A2007_FB8CB355_8ED30C91_85C2A674_D76E8570,
+    256'h48C5735A_B49C4B08_1D1698C2_2C468255_0D125D59_61E16589_CBEA4978_9D9538DC,
+    256'h68C167AC_9891C595_E155A9A8_F6C2B52E_AA7C0CAB_A1009BE1_2FA0CE7A_5AE9C281,
+    256'hE3B20C80_98CA40D3_AD8BD385_C9BB4338_51681407_55C4CB50_EA30AEF9_981EE73C,
+    256'h38B32931_48155AE2_61B1002B_5E6B5E66_5D52C465_AA5FA659_CCD266CA_E3A56FB4,
+    256'hDED06197_2D97D139_5EAED232_EE3C622E_6305C2A5_6210FF00_3C66BC30_06C1A373,
+    256'hCD90758B_9AA48B0F_8A1AE180_1F8D1198_2E326093_22BD912B_EC38DD77_C813331E,
+    256'h6A4BE2D5_185EDBC9_006A8C9A_08896C5D_1E5268DA_4A1251E9_B697DBF3_DA740D07,
+    256'h6215871B_611B059E_762A836D_204EAA4C_70E44DD3_3B9CEF3C_AD503801_180002BE,
+    256'hC029E393_89020C20_04406189_E724E5C7_62E804D2_81359EC4_6D81BDDB_B3017A8B,
+    256'h11D01315_C5EF37C5_934FD649_65E0BFD0_4C451C90_A2E0216A_074B73A0_4883A312,
+    256'hB0E00BEC_359C6558_9950DC6B_4D8246A2_EF6E4B41_C1E79F51_2298861C_4FB6D147,
+    256'hA7225944_E3B963E6_844DB904_17A19C9F_AD48412A_ACA1EB26_7B2908FA_BEDC13E3,
+    256'h87F50C35_5F45A60A_A2F02228_4AC6C28B_F8136080_F70ECA74_2B1AE557_21CC45D9,
+    256'hD3B2F1F2_8DAD9E8F_E7201C0C_5DB7F235_17704A15_A5A1DB22_495086CC_A1550E75,
+    256'h0474894A_806D9C62_29B8911B_F52D8D16_0B609FAB_4D86BD5C_5C30D69E_1C2C0FC4,
+    256'h055D8B68_C1609488_199188F0_3EAF6B58_BC0E58E8_8C1F7DC2_97EAE8AF_CA539986,
+    256'h5E5B39D6_EE37A12B_21E41EE8_EADC901B_E4C3F713_42250BD6_AC67F127_5E6F0849,
+    256'h6C26AB9D_E9E5BB16_37DFB7D6_1A508355_223A4A6C_EACE0B00_D3C118C7_512056F9,
+    256'h0A650930_650B530D_46B93B2C_A99008A8_83F0BC20_899E6914_99662757_F3E0536D,
+    256'h58D1B810_7C83D41E_D043EF0A_822498EF_4569510D_8D99505C_4F82660E_6C7E116C,
+    256'h66454799_169054BB_24E0163F_9361FC1E_2BB3D497_79E94C15_F6DE6777_47473A3B,
+    256'h7CD1301E_FC168453_3C2256EB_A0EC1B6E_1A2A1973_95C5B610_B8AC2949_8A9B10A5,
+    256'hA0F08261_6DDB82BC_711DA92A_D2451591_8DEF3AE0_40B216B3_5EAB118F_6F4CDA76,
+    256'h6E4B9FE9_56924855_47FEB44F_5C1948F4_78C788CC_8E866A2B_169F6290_3B095381,
+    256'hADB05D32_08E88518_CE660EAA_AA0D8555_25C91739_6481CD4F_3D44C9A4_5606A760,
+    256'h31652A66_A1DC9710_DC08C135_ABAFB4E1_6D9C64FC_6A130E94_1A3705BA_DDCB451F
   };
 
   // Compile-time random permutation for forwarding LFSR state
   parameter kmac_pkg::lfsr_fwd_perm_t RndCnstKmacLfsrFwdPerm = {
-    160'h3276E7C6_778216CD_53E2E587_93A9A00E_2B2293DD
+    160'h721AFDFA_782F01A3_AE1DA865_9A12DF62_471BA846
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'h59E194DD_143B9424_F38CE83D_5C589C9C,
-    256'hFDB07476_AF86898B_0446D8AE_E2BC57A0_0C7F4D48_0EAB24FB_1A49B4D6_72FF94B8
+    128'hF82671D8_35948217_304A2BFA_0239682C,
+    256'hE7ED30D6_AB769BB9_609F734C_59C7F322_AC991DE4_7B41B83F_5408A955_C113F6FB
   };
 
   ////////////////////////////////////////////
@@ -219,17 +220,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'hD2696788_A8735B27_982F5007_A24A125F_876C9CA6_DDEB52AC_92F5600D_2A41BC46
+    256'h465EFE57_AA3B59BD_6B0A4021_6363420F_041ED29A_965B68FA_EA3E59D4_F2E2A0B4
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h5EFE57AA_3B59BD6B_0A402163_63420F04
+    128'h2EB9A8C3_AB227B50_766D2EAE_C89EB13B
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h1ED29A96_5B68FAEA
+    64'h07E9BF4E_E4278413
   };
 
   ////////////////////////////////////////////
@@ -237,73 +238,73 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h3E59D4F2_E2A0B42E
+    64'h6D42C85E_456F3B26
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h09CE4760_A94FEDAC_F600C64D_0FDE2259,
-    256'hF906FE68_05A52D63_EB4568B7_1F115D0D_C48494EF_04EB27CA_B2DB7547_88FB0AAE
+    128'h67DFF577_9DF3AEA6_1CE14690_B285A917,
+    256'h1EA43910_237CFC1B_0A2C8682_D101F870_F6ED3352_3272882F_C949BDE9_AE8555F4
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'h95A6C4FF_0F42EF01_F3D4575B_AC9CB509_04E880DB
+    160'h341C41F2_9ADF4058_A907F3EA_297C295E_18DBCED9
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'hBE6E65C3_59480858_C39611E6_58C97FB8_D3E9CC0E_7F8FA872_5200C726_C8F90EF5
+    256'h576CA8A8_225C8E17_053E44B6_8DD7822A_6859F2CF_52A55FD1_81B082D0_3C583756
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'hE2B74BEE_E27CFA19_EA576CA8_A8225C8E_17053E44_B68DD782_2A6859F2_CF52A55F
+    256'hF11AA5B3_7F9544C4_AA90EB97_E1C0F808_6F627A28_1C5681D6_566641EE_CCCC8887
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'hD181B082_D03C5837_56F11AA5_B37F9544_C4AA90EB_97E1C0F8_086F627A_281C5681
+    256'h6AD113C5_0AD1BE4D_94DCE8FC_A54128A3_860AE1D3_493FBEF6_B9BA5DFE_4463A461
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'hD6566641_EECCCC88_876AD113_C50AD1BE_4D94DCE8_FCA54128_A3860AE1_D3493FBE
+    256'h5EF46762_A794A8C2_597E69FB_259B9619_14CD75BB_FD36BA48_E780D27C_D582540C
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'hF6B9BA5D_FE4463A4_615EF467_62A794A8_C2597E69_FB259B96_1914CD75_BBFD36BA
+    256'h7A68FF25_4EDFD852_829FECCC_ABD4AF9C_9032DA20_BDAF59FE_2AE209B8_325D2C8C
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'h48E780D2_7CD58254_0C7A68FF_254EDFD8_52829FEC_CCABD4AF_9C9032DA_20BDAF59
+    256'h35FC9606_79B106A8_7E59E6AE_B1B5302D_33401070_251696FB_B4BA169A_6CD82FAD
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'hFE2AE209_B8325D2C_8C35FC96_0679B106_A87E59E6_AEB1B530_2D334010_70251696
+    256'h46A0A5C0_4009BB93_4C7EF7B8_3B6E4061_0B4309FC_B9DC54D4_276137F9_901D09A7
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'hFBB4BA16_9A6CD82F_AD46A0A5_C04009BB_934C7EF7_B83B6E40_610B4309_FCB9DC54
+    256'h6AEAA19D_E5C579FD_38BDF38F_0C21D6A5_2226B6A4_A7BDB05F_E921615B_F2FF9845
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
-    256'hD4276137_F9901D09_A76AEAA1_9DE5C579_FD38BDF3_8F0C21D6_A52226B6_A4A7BDB0
+    256'h40F7D43E_CE76B4EB_13363774_ED2ED455_45E927F6_D9E4ABAC_398D42C7_45EEF646
   };
 
   // Compile-time random bits for generation seed when no CDI is selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrCdi = {
-    256'h5FE92161_5BF2FF98_4540F7D4_3ECE76B4_EB133637_74ED2ED4_5545E927_F6D9E4AB
+    256'hC1464DCA_86DAFD7C_7C71E605_8DDFD871_C51CACBA_F4410F06_DCC036FC_D16FCDE9
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'hAC398D42_C745EEF6_46C1464D_CA86DAFD_7C7C71E6_058DDFD8_71C51CAC_BAF4410F
+    256'h7D171891_105DD895_E3A1D0A1_9A16D6DB_D8B20FC9_E662E1E1_B4982B3E_8EFF6389
   };
 
   ////////////////////////////////////////////
@@ -311,14 +312,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'h06DCC036_FCD16FCD_E97D1718_91105DD8,
-    256'h95E3A1D0_A19A16D6_DBD8B20F_C9E662E1_E1B4982B_3E8EFF63_890DBEAE_926FD468
+    128'h0DBEAE92_6FD468A7_7EFDE3DE_5B4CAF47,
+    256'h76A247BA_BA4C9908_ED16BC54_15EC16D2_8C535513_12FCEDCF_2832A66C_EACF8ED4
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'hA77EFDE3_DE5B4CAF_4776A247_BABA4C99,
-    256'h08ED16BC_5415EC16_D28C5355_1312FCED_CF2832A6_6CEACF8E_D4D5B616_177DD43B
+    128'hD5B61617_7DD43B56_FA754E1F_53AD6581,
+    256'h93B563D9_BDC6D2AE_E84852F0_CC7371ED_3A6FAA51_6C144B34_C96DFABB_6F6E7920
   };
 
   ////////////////////////////////////////////
@@ -326,22 +327,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h56FA754E_1F53AD65_8193B563_D9BDC6D2
+    128'h8A74F35C_79F397C4_E4C7E22B_7581848A
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'hAEE84852_F0CC7371_ED3A6FAA_516C144B
+    128'h90A1254B_2276BEC9_FC1A7A57_22A9AACA
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'h34C96DFA
+    32'h4DB84A32
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h60FE0321_49A57A1C_1C56DEA7_0C965C5B_A247F9B7
+    160'h7CB60455_500E897A_15A977BB_93DBF111_9835CF1C
   };
 
   ////////////////////////////////////////////
@@ -349,12 +350,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h1A643511_8B5F5F3F
+    64'hCC69A214_7819B290
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'hD3B93131_16B67192_D856DD74_2D40E072
+    128'hA4BB0264_347C0F91_B0CEC93C_0129D85B
   };
 
   ////////////////////////////////////////////
@@ -362,22 +363,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'hE417AD9A
+    32'h95801DBE
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'h7443A428_FE2DE15C_7D33B199_C90DFDA3_7790088B
+    160'h4093FA68_A3C595C3_DCD2AC19_972E33E8_49B6BFC0
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'hDC260A79_998EFF5C_710B6783_8ADFB99A
+    128'h8E7026D0_E5DCE9E2_65A416A8_12231CFA
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'h5ECA6716_72CF19BC
+    64'h76E3D982_F8FDCEC9
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -49,14 +49,11 @@ enum {
   kEdnSeedMaterialLen = 12,
 };
 
-// CSRNG needs to constantly output these bits to EDN. The AES masking PRNG
-// consists of five 32-bit LFSRs each followed by a linear permutation and a
-// non-linear layer and ultimately a secret permutation spanning all five
-// LFSRs. Only if the non-linear layers of all five LFSRs output an all-zero
-// vector, the PRNG output is zero as well.
-//
+// CSRNG needs to constantly output these bits to EDN. If reseeded to an all-
+// zero value the AES masking PRNG will output an all-zero vector. It will
+// further keep this value if the CTRL_AUX_SHADOWED.FORCE_MASKS bit is set.
 const uint32_t kAesMaskingPrngZeroOutputSeed[kCsrngBlockLen] = {
-    0xff00ffff, 0xff00ffff, 0xff00ffff, 0xff00ffff};
+    0x00000000, 0x000000000, 0x00000000, 0x00000000};
 
 // Seed material for instantiate command. The CTR_DRBG construction
 // implemented by CSRNG produces
@@ -64,36 +61,36 @@ const uint32_t kAesMaskingPrngZeroOutputSeed[kCsrngBlockLen] = {
 // key = 00 01 02 03 04 05 06 07 - 08 09 0a 0b 0c 0d 0e 0f
 //       10 11 12 13 14 15 16 17 - 18 19 1a 1b 1c 1d 1e 1f
 //
-//   V = 8d 97 b4 1b c2 0a cb bb - 81 06 d3 91 85 46 67 f8
+//   V = 6d 9f 08 eb 2a 2e 27 7a - b4 89 84 cf f1 ab 9a 09
 //
 // from this seed material upon instantiate. The key is arbitrarily chosen.
 // Encrypting V using this key then gives the required
 // kAesMaskingPrngZeroOutputSeed above.
 const uint32_t kEdnSeedMaterialInstantiate[kEdnSeedMaterialLen] = {
-    0xf0405279, 0x50a4261f, 0xf5ace1cf, 0xfff7b7d1, 0xa6ee8307, 0x1f57dfc8,
+    0x84adaf86, 0x652b7141, 0x1d880d0e, 0x1fff0b21, 0xa6ee8307, 0x1f57dfc8,
     0x59757d79, 0xdeb6522e, 0xc8c67d84, 0xa16abefa, 0xc34030be, 0x530e88f8};
 
 // V and key after instantiate.
-const uint32_t kCsrngVInstantiate[kCsrngBlockLen] = {0x854667f7, 0x8106d391,
-                                                     0xc20acbbb, 0x8d97b41b};
+const uint32_t kCsrngVInstantiate[kCsrngBlockLen] = {0xf1ab9a08, 0xb48984cf,
+                                                     0x2a2e277a, 0x6d9f08eb};
 const uint32_t kCsrngKeyInstantiate[kCsrngKeyLen] = {
     0x1c1d1e1f, 0x18191a1b, 0x14151617, 0x10111213,
     0x0c0d0e0f, 0x08090a0b, 0x04050607, 0x00010203};
 
 // V and key after generate.
-const uint32_t kCsrngVGenerate[kCsrngBlockLen] = {0x1569e491, 0xe854f642,
-                                                  0xe931a570, 0x60939074};
+const uint32_t kCsrngVGenerate[kCsrngBlockLen] = {0x654600bd, 0xf0c32787,
+                                                  0x3eb52114, 0x8a1e0dce};
 const uint32_t kCsrngKeyGenerate[kCsrngKeyLen] = {
-    0xfdab6b68, 0x31920240, 0x32a48b64, 0xda4189d7,
-    0xf49b7a55, 0x3d86fe43, 0xf4eaeab1, 0x8fae023a};
+    0xff6589b5, 0x4bb8e5f9, 0x62847098, 0x1e9f9cd1,
+    0x3c005fbd, 0x9a1b6e70, 0xe30eb080, 0x71dea927};
 
 // Seed material for reseed command. After one generate, this seed material
 // will bring the key and V of CSRNG back to the state after instantiate.
 // I.e., one can again run one generate to produce the seed required for AES
 // (see kAesMaskingPrngZeroOutputSeed).
 const uint32_t kEdnSeedMaterialReseed[kEdnSeedMaterialLen] = {
-    0x5f6fb665, 0x21ca8e3f, 0x5ba3dba1, 0x2c10a9ec, 0x03b8cd4b, 0x8264aaea,
-    0x371e6305, 0x8fb186e1, 0xf622bc3e, 0x98e5d247, 0x73040c38, 0x6596739e};
+    0x96994362, 0x7ef8f0b9, 0x5b5332dc, 0xd0df9b12, 0x96dfbaa9, 0xac0b5af7,
+    0xec2504be, 0xb00fb68c, 0xf37e0a7f, 0x88172eec, 0x4e4b5f58, 0xfec120c0};
 
 status_t aes_testutils_masking_prng_zero_output_seed(void) {
   const dif_csrng_t csrng = {


### PR DESCRIPTION
While the LFSR-based masking PRNG seems to be able to produce randomness of sufficient quality for the masking implementation in the AES cipher core (as indicated both by our FPGA-based side-channel analysis and by the PROLEAD tool) it may be vulnerable to brute-forcing attacks on the LFSR states.

Therefore, this PR replaces the LFSR-based masking PRNG implementation inside AES with an implementation based on an unrolled Bivium stream cipher primitive as suggested in the paper:
    
    Cassiers, "Randomness Generation for Secure Hardware Masking - Unrolled
    Trivium to the Rescue" available at https://eprint.iacr.org/2023/1134
    
Thanks to bigger individual state chunks - the smallest non-linear feedback shift register (NFSR) has a width of 84 bits - brute-forcing attacks are rendered infeasible. The overall PRNG state width increases from 160 to 177 bits, meaning the randomness consumption for reseeding increases by one 32-bit word per reseed. Thanks to the strong diffusion properties of Bivium, fresh entropy received from EDN can still be injected directly into the PRNG without additional buffering. From an area perspective, the overall AES area increases slightly (+1.81 kGE or +1.1% based on Yosys + nangate45).

This is related to lowRISC/OpenTitan#19091.

The SCA properties of the changes have been evaluated both using PROLEAD and our FPGA-based evaluation framework (using the Englishbreakfast top-level on the CW305 board). All experiments look good.

The first commit prepares the Bivium/Trivium primitive to allow disabling the lockup protection at run time which is more suitable for the optional masking off feature of AES. The second commit contains the actual RTL integration, DV changes, top-level changes due to different seed constants etc. The third commit contains changes to avoid the memory consumption of PROLEAD going much beyond 100 GB during evaluation.