### PR TITLE
[rtl,sensor_ctrl] Fix CDC bug

### DIFF
--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
@@ -202,7 +202,6 @@ module sensor_ctrl
 
     // only recoverable alerts ack
     assign event_clr[i] = recov_event[i] & reg2hw.recov_alert[i].q;
-
   end
 
   // handle internal alert events, currently only have fatals
@@ -296,8 +295,8 @@ module sensor_ctrl
     .Width(1),
     .ResetValue('0)
   ) u_wake_sync (
-    .clk_i,
-    .rst_ni,
+    .clk_i(clk_aon_i),
+    .rst_ni(rst_aon_ni),
     .d_i(async_wake),
     .q_o(unstable_wake_req)
   );


### PR DESCRIPTION
This has 2 commits in this order:
- Hold the incoming alert from AST until pwrmgr is back in active state in the `chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up` sim_dv test, or the wake_info won't be captured.
- Fix a CDC bug in sensor_ctrl RTL.

Fixes #20614