### PR TITLE
[rom_ext] Update the ROM_EXT ePMP configuration

### DIFF
--- a/sw/device/silicon_creator/lib/epmp_state.h
+++ b/sw/device/silicon_creator/lib/epmp_state.h
@@ -42,16 +42,36 @@ enum {
  *    W  |  1
  *    X  |  2
  *
- * Combinations not exposed by this enum should not be used. The 'unlocked'
- * zero value should only be used for entries that are configured as OFF.
+ * NOTE: Because the chip is configured with MMWP=1 and MML=0, the ePMP bit
+ * patterns can sometimes have counterintuitive meanings.
+ *
+ * NOTE: After setting MML=1, the meanings of some of the bit patterns will
+ * change.  See section 2.2 of the "PMP Enhancements for memory access and
+ * execution prevention on Machine mode (Smepmp)" document
+ * (https://github.com/riscv/riscv-tee/blob/main/Smepmp/Smepmp.pdf).
  */
 typedef enum epmp_perm {
   kEpmpPermUnlocked = 0,
+  /** M mode: no access. U mode: no access. */
   kEpmpPermLockedNoAccess = EPMP_CFG_L,
+
+  /** M mode: read only. U mode: no access. */
   kEpmpPermLockedReadOnly = EPMP_CFG_LR,
+
+  /** M mode: read/write. U mode: no access. */
   kEpmpPermLockedReadWrite = EPMP_CFG_LRW,
+
+  /** M mode: read/execute. U mode: no access. */
   kEpmpPermLockedReadExecute = EPMP_CFG_LRX,
+
+  /** M mode: read/execute. U mode: read/execute. */
   kEpmpPermLockedReadWriteExecute = EPMP_CFG_LRWX,
+
+  /** M mode: read/write/execute. U mode: read only. */
+  kEpmpPermReadOnly = EPMP_CFG_R,
+
+  /** M mode: read/write/execute. U mode: read/execute. */
+  kEpmpPermReadExecute = EPMP_CFG_R | EPMP_CFG_X,
 } epmp_perm_t;
 
 /**

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:epmp_state",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/doc/si_val.md
+++ b/sw/device/silicon_creator/rom_ext/doc/si_val.md
@@ -17,24 +17,33 @@ The ePMP will allow access to the FLASH, to the MMIO region and to SRAM.
 An example of how the SiVal `ROM_EXT` will configure the ePMP:
 
 ```console
- 0: 20010400 ----- ---- sz=00000000     ; OWNER code start.
- 1: 20013d24   TOR LX-R sz=00003924     ; OWNER code end.
- 2: 00008000 NAPOT L--R sz=00008000     ; OWNER data (if using remap window, else ROM data region)
- 3: 20000400 ----- ---- sz=00000000     ; ROM_EXT code start.
- 4: 20004fe8   TOR LX-R sz=00004be8     ; ROM_EXT code end.
- 5: 20000000 NAPOT L--R sz=00100000     ; FLASH data (1 MB).
- 6: 40130000 NAPOT L--- sz=00001000     ; OTP MMIO lockout.
- 7: 40480000 NAPOT L--- sz=00000400     ; AST MMIO lockout.
+ 0: 40130000 NAPOT L--- sz=00001000     ; OTP MMIO lockout.
+ 1: 40480000 NAPOT L--- sz=00000400     ; AST MMIO lockout.
+ 2: 20010400 ----- ---- sz=00000000     ; OWNER code start.
+ 3: 20013cac   TOR -X-R sz=000038ac     ; OWNER code end.
+ 4: 00000000 ----- ---- sz=00000000     ; OWNER data (if using remap window, else unused).
+ 5: 00000000 ----- ---- sz=00000000
+ 6: 00000000 ----- ---- sz=00000000
+ 7: 00000000 ----- ---- sz=00000000
  8: 00000000 ----- ---- sz=00000000
  9: 00000000 ----- ---- sz=00000000
-10: 00000000 ----- ---- sz=00000000
-11: 40000000 NAPOT L-WR sz=10000000     ; MMIO region.
-12: 00000000 ----- ---- sz=00000000
+10: 20000400 ----- ---- sz=00000000     ; ROM_EXT code start.
+11: 20005bc8   TOR -X-R sz=000057c8     ; ROM_EXT code end.
+12: 20000000 NAPOT L--R sz=00100000     ; FLASH data (1 MB).
 13: 00010000 NAPOT LXWR sz=00001000     ; RvDM region (not PROD, RMA/DEV only).
-14: 1001c000   NA4 L--- sz=00000004     ; Stack guard.
+14: 40000000 NAPOT L-WR sz=10000000     ; MMIO region.
 15: 10000000 NAPOT L-WR sz=00020000     ; RAM region.
 mseccfg = 00000002                      ; RLB=0, MMWP=1, MML=0.
 ```
+
+In this configuration, the owner stage can re-arrange ePMP entries
+2-11 as needed.  Applications that require machine/user mode isolation can set
+the MML bit after arranging the ePMP to the preferred configuration.
+
+NOTE: if the ROM\_EXT stage is booted in the virtual slot, then ePMP entries
+9/10/11 will be used to map the virtual window's code/data segments.  Since
+these entries are unlocked _and_ since the ROM\_EXT is no longer requred
+after owner code boots, these entries can be reclaimed for owner use.
 
 ### OTP
 

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -64,14 +64,6 @@ opentitan_test(
 opentitan_test(
     name = "epmp_rlb_lockdown",
     srcs = ["epmp_rlb_lockdown.c"],
-    cw310 = cw310_params(
-        exit_failure = "(PASS|FAIL|BFV|FAULT).*\r\n",
-        # Make sure the test program failed to modify the ePMP.
-        exit_success = (
-            "6: 40130000 NAPOT L--- sz=00001000\r\n" +
-            "7: 40480000 NAPOT L--- sz=00000400\r\n"
-        ),
-    ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
     },

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/epmp_rlb_lockdown.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/epmp_rlb_lockdown.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 
@@ -13,13 +14,16 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  // Try to overwrite ePMP entry 6 (ie: the otp lockout) by clearing its config
+  // Try to overwrite ePMP entry 0 (ie: the otp lockout) by clearing its config
   // bits.
-  CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff << 16);
-  CSR_WRITE(CSR_REG_PMPADDR6, 0);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, 0xff);
+  CSR_WRITE(CSR_REG_PMPADDR0, 0);
 
-  // The test rule in the BUILD file will look for the expected configuration
-  // for ePMP entry 10.
-  dbg_print_epmp();
+  // Read back ePMP entry 0 and make sure it hasn't changed to zero.
+  uint32_t pmpcfg0, pmpaddr0;
+  CSR_READ(CSR_REG_PMPCFG0, &pmpcfg0);
+  CSR_READ(CSR_REG_PMPADDR0, &pmpaddr0);
+  CHECK((pmpcfg0 & 0xFF) != 0);
+  CHECK(pmpaddr0 != 0);
   return true;
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_epmp.h
@@ -37,70 +37,44 @@ extern "C" {
 // stage.
 
 /**
- * Unlocks the provided first Silicon Owner stage region with read-execute
- * permissions.
+ * Clear an ePMP entry.
  *
- * The provided ePMP state is also updated to reflect the changes made to the
- * hardware configuration.
+ * Sets the PMPADDR and PMPCFG entries to zero.
  *
- * @param state The ePMP state to update.
- * @param image Region for executable sections in the silicon Owner image.
+ * @param entry The ePMP entry to clear.
  */
-void rom_ext_epmp_unlock_owner_stage_rx(epmp_region_t image);
+void rom_ext_epmp_clear(uint8_t entry);
 
 /**
- * Unlocks the provided first silicon owner region with read-only permissions.
+ * Configures an ePMP entry for a NAPOT or NA4 region.
  *
- * The provided ePMP state is also updated to reflect the changes made to the
- * hardware configuration.
- * The image size must be a power of 2 as this function uses NAPOT
- * (Naturally-Aligned-Power-Of-Two) addressing mode.
+ * The region start must have an alignment consistend with the region size.  The
+ * region size must be a power of two.  If either of these conditions is not
+ * met, this function will fault.
  *
- * @param state The ePMP state to update.
- * @param region Region in the silicon Owner image to receive read-only
- * permission.
+ * From a configuration perspective, an NA4 region is just a special case of a
+ * NAPOT region.
+ *
+ * @param entry The ePMP entry to configure.
+ * @param region The address region to configure.
+ * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_unlock_owner_stage_r(epmp_region_t region);
+void rom_ext_epmp_set_napot(uint8_t entry, epmp_region_t region,
+                            epmp_perm_t perm);
 
 /**
- * Adjusts the ePMP MMIO region from a TOR region to a NAPOT region.
+ * Configures an ePMP entry for a TOR region.
  *
- * The earlgrey MMIO region is 0x4000_0000 to 0x5000_0000.  We adjust
- * this to a NAPOT region to free up an ePMP entry for other use.
- */
-void rom_ext_epmp_mmio_adjust(void);
-
-/**
- * Lock out access to the OTP DAI interface.
+ * The region start and end may be abitrary addresses.  The start will be
+ * rounded down to a 4-byte address.  The end will be rounded up to a 4-byte
+ * address.
  *
- * The OTP controller doesn't have a per-boot software lock-out capability.
- * In order to forbid accidental OTP programming during the bring-up process,
- * we use the ePMP to forbid access to the OTP register space.
+ * @param entry The ePMP entry to configure.
+ * @param region The address region to configure.
+ * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_otp_dai_lockout(void);
-
-/**
- * Lock out access to the AST registers.
- *
- * The AST peripheral contains all of the low-level analog configuration
- * registers (sensors, clock trimming, etc).  After ROM_EXT completes,
- * the ePMP will forbid access to the AST register space.
- */
-void rom_ext_epmp_ast_lockout(void);
-
-/**
- * Clear the ROM mapping from the ePMP.
- *
- * The ROM memory mapping is no longer needed once the ROM_EXT starts.
- */
-void rom_ext_epmp_clear_rom_region(void);
-
-/**
- * Perform final cleanups to the ePMP configuration before owner handoff.
- *
- * Unlock the ROM_EXT code segments so they can be ovewritten by the next stage.
- */
-void rom_ext_epmp_final_cleanup(void);
+void rom_ext_epmp_set_tor(uint8_t entry, epmp_region_t region,
+                          epmp_perm_t perm);
 
 /**
  * Clear the rule-locking-bypass (RLB) bit.


### PR DESCRIPTION
To provide owner applications with a more flexible memory protection configuration, I have re-arranged the ePMP settings.

Notably:
- The lockouts are moved to regions 0 & 1 to have the highest priority.
- The full FLASH/MMIO/RAM windows have been moved to the end to allow finer grained controls to be applied in the middle entries.
- The ROM_EXT region is moved and unlocked so owners can reclaim the ROM_EXT entries for their own use.
- The owner code regions are left unlocked so owners can select their own preferred arrangement.

We jump to owner code with MML=0, allowing the owner to reconfigure the unlocked entries.  The owner should set MML=1 if they need machine/user mode isolation.