### PR TITLE
[sival,flash_ctrl] complete flash_ctrl sival

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -18,6 +18,7 @@
               different seed values.
 
             - This test needs to execute as a boot rom image.
+            - In sival, this will be covered by manuf_ft_provision_rma_token_and_personalization.
             '''
       features: ["FLASH_CTRL.INIT.SCRAMBLING_KEYS", "FLASH_CTRL.INIT.ROOT_SEEDS",
                  "FLASH_CTRL.INFO.CREATOR_PARTITION", "FLASH_CTRL.INFO.OWNER_PARTITION"]
@@ -38,6 +39,7 @@
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_access",
               "chip_sw_flash_ctrl_access_jitter_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
     }
     {
       name: chip_sw_flash_ctrl_ops
@@ -52,6 +54,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_ops", "chip_sw_flash_ctrl_ops_jitter_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
     }
     {
       name: chip_sw_flash_memory_protection
@@ -66,7 +69,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
-      tests: []
+      tests: ["chip_sw_flash_ctrl_mem_protection"]
+      bazel: ["//sw/device/tests:flash_ctrl_mem_protection_test"]
     }
     {
       name: chip_sw_flash_rma_unlocked
@@ -121,6 +125,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_idle_low_power"]
+      bazel: ["//sw/device/tests:flash_ctrl_idle_low_power_test"]
     }
     {
       name: chip_sw_flash_keymgr_seeds
@@ -148,6 +153,9 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states",
+              "//sw/device/tests:flash_ctrl_info_access_lc_states_personalized"]
+
     }
     {
       name: chip_sw_flash_creator_seed_wipe_on_rma
@@ -158,6 +166,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_rma_unlocked"]
+      bazel: ["//sw/device/tests:flash_ctrl_rma_test"]
     }
     {
       name: chip_sw_flash_lc_owner_seed_sw_rw_en
@@ -172,6 +181,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_rd_en
@@ -186,6 +196,7 @@
       si_stage: SV3
       lc_states: ["PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_wr_en
@@ -200,6 +211,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
       name: chip_sw_flash_lc_seed_hw_rd_en
@@ -209,6 +221,7 @@
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the flash ctrl
               does (or does not) read the creator and owner partitions to fetch the seeds for the
               keymgr.
+            - In sival, this will be covered by manuf_ft_provision_rma_token_and_personalization.
             '''
       features: ["FLASH_CTRL.INIT.ROOT_SEEDS"]
       stage: V2
@@ -230,8 +243,7 @@
             '''
       features: ["FLASH_CTRL.ESCALATION"]
       stage: V2
-      si_stage: SV3
-      lc_states: []
+      si_stage: None
       tests: ["chip_sw_all_escalation_resets"]
     }
     {
@@ -255,8 +267,9 @@
             - This sets the test for closed source where the flash access timing matters.
             '''
       stage: V2
-      si_stage: None
+      si_stage: SV3
       tests: ["chip_sw_flash_ctrl_clock_freqs"]
+      bazel: ["//sw/device/tests:flash_ctrl_clock_freqs_test"]
     }
     {
       name: chip_sw_flash_ctrl_escalation_reset

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1469,7 +1469,7 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
     silicon = silicon_params(tags = ["broken"]),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1660,11 +1660,9 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
-            "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1433,15 +1433,11 @@ opentitan_test(
     srcs = ["flash_ctrl_idle_low_power_test.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },
-    silicon_owner = silicon_params(
-        tags = ["broken"],
-    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1472,7 +1472,6 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -1608,12 +1607,13 @@ opentitan_test(
     name = "flash_ctrl_clock_freqs_test",
     srcs = ["flash_ctrl_clock_freqs_test.c"],
     # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+    # update: verilator pass
     cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
     silicon = silicon_params(tags = ["broken"]),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1469,6 +1469,7 @@ opentitan_test(
         },
     ),
     deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
@@ -1602,9 +1603,6 @@ test_suite(
 opentitan_test(
     name = "flash_ctrl_clock_freqs_test",
     srcs = ["flash_ctrl_clock_freqs_test.c"],
-    # TODO(#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-    # update: verilator pass
-    cw310 = new_cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
@@ -1612,9 +1610,10 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:flash_ctrl",

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_clkmgr.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -140,10 +141,12 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
 
   for (int i = 0; i < kNumLoops; ++i) {
-    do_info_partition_test(kFlashInfoPageIdCreatorSecret);
-    do_info_partition_test(kFlashInfoPageIdOwnerSecret);
-    do_info_partition_test(kFlashInfoPageIdIsoPart);
-    do_data_partition_test(kFlashDataBank0);
+    if (kBootStage != kBootStageOwner) {
+      do_info_partition_test(kFlashInfoPageIdCreatorSecret);
+      do_info_partition_test(kFlashInfoPageIdOwnerSecret);
+      do_info_partition_test(kFlashInfoPageIdIsoPart);
+      do_data_partition_test(kFlashDataBank0);
+    }
     do_data_partition_test(kFlashDataBank1);
   }
 

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -160,7 +159,7 @@ bool test_main(void) {
     uint32_t bite_th = kAONBiteTh;
 
     // Update bark and bite threshold in case of silicon test
-    if (kBootStage == kBootStageOwner) {
+    if (kDeviceType == kDeviceSilicon) {
       bark_th = 4000;
       bite_th = 4 * bark_th;
     }

--- a/sw/device/tests/flash_ctrl_mem_protection_test.c
+++ b/sw/device/tests/flash_ctrl_mem_protection_test.c
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
@@ -199,7 +198,7 @@ bool test_main(void) {
   // Set up default access for data partitions.
   // In silicon, rom_ext will set default region access.
   // After that, it cannot be updated.
-  if (kBootStage != kBootStageOwner) {
+  if (kDeviceType != kDeviceSilicon) {
     CHECK_STATUS_OK(flash_ctrl_testutils_default_region_access(
         &flash, /*rd_en=*/true, /*prog_en=*/true, /*erase_en=*/true,
         /*scramble_en=*/false, /*ecc_en=*/false, /*high_endurance_en=*/false));

--- a/sw/device/tests/flash_ctrl_mem_protection_test.c
+++ b/sw/device/tests/flash_ctrl_mem_protection_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
@@ -196,10 +197,13 @@ bool test_main(void) {
       &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
 
   // Set up default access for data partitions.
-  CHECK_STATUS_OK(flash_ctrl_testutils_default_region_access(
-      &flash, /*rd_en=*/true, /*prog_en=*/true, /*erase_en=*/true,
-      /*scramble_en=*/false, /*ecc_en=*/false, /*high_endurance_en=*/false));
-
+  // In silicon, rom_ext will set default region access.
+  // After that, it cannot be updated.
+  if (kBootStage != kBootStageOwner) {
+    CHECK_STATUS_OK(flash_ctrl_testutils_default_region_access(
+        &flash, /*rd_en=*/true, /*prog_en=*/true, /*erase_en=*/true,
+        /*scramble_en=*/false, /*ecc_en=*/false, /*high_endurance_en=*/false));
+  }
   // Program starts from kRegion[2], kRegion[1], and kRegion[0] in order.
   for (int i = 2; i >= 0; i--) {
     CHECK_DIF_OK(dif_flash_ctrl_set_data_region_properties(

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -384,7 +383,7 @@ bool test_main(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  if (kBootStage != kBootStageOwner) {
+  if (kDeviceType != kDeviceSilicon) {
     do_info_partition_test(kFlashInfoPageIdCreatorSecret, kRandomData1);
     do_info_partition_test(kFlashInfoPageIdOwnerSecret, kRandomData2);
     do_info_partition_test(kFlashInfoPageIdIsoPart, kRandomData3);

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -383,10 +384,12 @@ bool test_main(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  do_info_partition_test(kFlashInfoPageIdCreatorSecret, kRandomData1);
-  do_info_partition_test(kFlashInfoPageIdOwnerSecret, kRandomData2);
-  do_info_partition_test(kFlashInfoPageIdIsoPart, kRandomData3);
-  do_bank0_data_partition_test();
+  if (kBootStage != kBootStageOwner) {
+    do_info_partition_test(kFlashInfoPageIdCreatorSecret, kRandomData1);
+    do_info_partition_test(kFlashInfoPageIdOwnerSecret, kRandomData2);
+    do_info_partition_test(kFlashInfoPageIdIsoPart, kRandomData3);
+    do_bank0_data_partition_test();
+  }
   do_bank1_data_partition_test();
 
   return true;


### PR DESCRIPTION
- Porting selective tests(see commits below for detail)
  - flash_ctrl_test.c
  - flash_ctrl_ops_test.c
  - flash_ctrl_clock_freqs_test.c
  - flash_ctrl_idle_low_power_test.c
  - flash_ctrl_mem_protection_test.c
- Update testplan with bazel target
- address issue #12486 