### PR TITLE
[RV_DM]rv_dm_jtag_dtm_hard_reset_vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -152,7 +152,7 @@
             - Read the target DMI register to verify the write did not succeed.
             '''
       stage: V2
-      tests: [] // TODO(#15670)
+      tests: ["rv_dm_jtag_dtm_hard_reset"]
     }
     {
       name: jtag_dtm_idle_hint

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -44,6 +44,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_jtag_dtm_hard_reset_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_jtag_dtm_hard_reset_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
+  task body();
+    uvm_reg_data_t wdata;
+    uvm_reg_data_t rdata1;
+    uvm_reg_data_t rdata2;
+    repeat ($urandom_range(1, 10)) begin
+      wdata = $urandom_range(0,31);
+      csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(wdata));
+      csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(wdata));
+      csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata1));
+      csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata2));
+      `DV_CHECK_EQ(wdata,rdata1);
+      `DV_CHECK_EQ(wdata,rdata2);
+      csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmihardreset), .value(1));
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+      csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata1));
+      csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata2));
+      `DV_CHECK_EQ(wdata,rdata1);
+      `DV_CHECK_EQ(wdata,rdata2);
+    end
+  endtask : body
+endclass : rv_dm_jtag_dtm_hard_reset_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -22,3 +22,4 @@
 `include "rv_dm_jtag_dtm_idle_hint_vseq.sv"
 `include "rv_dm_jtag_dmi_dm_inactive_vseq.sv"
 `include "rv_dm_jtag_dmi_debug_disabled_vseq.sv"
+`include "rv_dm_jtag_dtm_hard_reset_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -245,6 +245,11 @@
       uvm_test_seq: rv_dm_jtag_dmi_debug_disabled_vseq
       reseed: 2
     }
+    {
+      name: rv_dm_jtag_dtm_hard_reset
+      uvm_test_seq: rv_dm_jtag_dtm_hard_reset_vseq
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This test verify that after performing the operation of hard-reset the debug module still responds correctly. This test was failing in regression so i modified it.