### PR TITLE
[RV_DM] rv_dm_jtag_dtm_hard_reset_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -247,7 +247,7 @@
     }
     {
       name: rv_dm_jtag_dtm_hard_reset
-      uvm_test_seq: rrv_dm_jtag_dtm_hard_reset_vseq
+      uvm_test_seq: rv_dm_jtag_dtm_hard_reset_vseq
       reseed: 2
     }
   ]


### PR DESCRIPTION
This test verify that after performing the operation of hard reset the debug module still responds correctly. This test was failing in regression due to this mistake so i modified it.  