### PR TITLE
[bazel] Make pip wheels install reproducible

### DIFF
--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -46,6 +46,10 @@ def _pip_wheel_impl(rctx):
     rctx.report_progress("Installing the Python wheel package")
     result = rctx.execute(
         args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
         timeout = rctx.attr.timeout,
         quiet = rctx.attr.quiet,
     )
@@ -66,6 +70,10 @@ def _pip_wheel_impl(rctx):
     rctx.report_progress("Pre-building Python wheels")
     result = rctx.execute(
         args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
         timeout = rctx.attr.timeout,
         quiet = rctx.attr.quiet,
     )
@@ -81,6 +89,10 @@ def _pip_wheel_impl(rctx):
     rctx.report_progress("Generating sanitzed requirements file")
     result = rctx.execute(
         args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
         timeout = rctx.attr.timeout,
         quiet = rctx.attr.quiet,
         working_directory = "./",


### PR DESCRIPTION
When installing python packages using pip, we use a custom script that invokes python directly. By default, python will timestamp bytecode files hence making the builds non-reproducible which is bad for CI. Python also uses a random seed for hash. This commit sets two environment variables when running pip that force python to use a deterministic seed and to use a fixed timestamp instead of the current time.

Note: we should probably get rid of our custom fork of rules python and our custom pip install script. This would be a bigger change that can be done at a later stage.