### PR TITLE
[hmac,syn] Add cfg and constraints to support HMAC synthesis

### DIFF
--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -52,7 +52,6 @@ parameters:
     datatype: bool
     paramtype: vlogdefine
 
-
 targets:
   default: &default_target
     filesets:
@@ -72,3 +71,12 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
+
+  syn:
+    <<: *default_target
+    # TODO: set default to DC once
+    # this option is available
+    # olofk/edalize#89
+    default_tool: icarus
+    parameters:
+      - SYNTHESIS=true

--- a/hw/ip/hmac/syn/constraints.sdc
+++ b/hw/ip/hmac/syn/constraints.sdc
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic constraints file for simple synthesis flow
+
+# note that we do not fix hold timing in this flow
+set SETUP_CLOCK_UNCERTAINTY 0.5
+
+#####################
+# main clock        #
+#####################
+set MAIN_CLK_PIN clk_i
+set MAIN_RST_PIN rst_ni
+# set main clock to 125 MHz
+set MAIN_TCK  8.0
+set_ideal_network ${MAIN_CLK_PIN}
+set_ideal_network ${MAIN_RST_PIN}
+set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${MAIN_CLK_PIN}
+
+# other timing constraint in ns
+set IN_DEL    1.0
+set OUT_DEL   1.0
+set DELAY     ${MAIN_TCK}
+
+create_clock ${MAIN_CLK_PIN} -period ${MAIN_TCK}
+
+# in to out
+set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
+# in to reg / reg to out
+set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${MAIN_CLK_PIN}}] -clock ${MAIN_CLK_PIN}
+set_output_delay ${OUT_DEL}  [all_outputs] -clock ${MAIN_CLK_PIN}
+
+#####################
+# I/O drive/load    #
+#####################
+
+# attach load and drivers to IOs to get a more realistic estimate
+set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin ${DRIVING_CELL_PIN} [all_inputs]
+set_load [load_of ${LOAD_CELL_LIB}/${LOAD_CELL}/${LOAD_CELL_PIN}] [all_outputs]
+
+# set a nonzero critical range to be able to spot the violating paths better
+# in the report
+set_critical_range 0.5 ${DUT}
+
+#####################
+# Size Only Cells   #
+#####################
+
+set_size_only -all_instances [get_cells -h *u_size_only*] true

--- a/hw/ip/hmac/syn/hmac_syn_cfg.hjson
+++ b/hw/ip/hmac/syn/hmac_syn_cfg.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Top level dut name (sv module).
+  name: hmac
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:ip:{name}:0.1
+
+  import_cfgs: [// Project wide common synthesis config file
+                "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
+
+  // Timing constraints for this module
+  sdc_file: "{proj_root}/hw/ip/{name}/syn/constraints.sdc"
+
+  // This is not needed for this module
+  foundry_sdc_file: ""
+}


### PR DESCRIPTION
This PR adds the synthesis configuration files and modifies the core to support test synthesis for area estimates in kGE.