### PR TITLE
[sival/ibex] hyper310 env for sram exec test's sival targets

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4344,11 +4344,22 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
     ),
     exec_env = {
+        # This test is not compatible with the test_rom because the test_rom
+        # does not respect the exec_disabled OTP config word.
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
+        "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
         "//hw/top_earlgrey:silicon_creator": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":rv_core_ibex_isa_test": "sram_program",
+        },
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
+        tags = ["manual"],
+        test_cmd = "--elf={sram_program}",
+        test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
+    ),
     silicon = silicon_jtag_params(
         tags = ["manual"],
         test_cmd = "--elf={firmware}",
@@ -4518,12 +4529,22 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
     exec_env = {
+        # This test is not compatible with the test_rom because the test_rom
+        # does not respect the exec_disabled OTP config word.
         "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
+    hyper310 = hyper310_jtag_params(
+        binaries = {
+            ":rv_core_ibex_epmp_test": "sram_program",
+        },
+        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
+        tags = ["manual"],
+        test_cmd = "--elf={sram_program}",
+        test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+    ),
     silicon = silicon_jtag_params(
         binaries = {
             ":rv_core_ibex_mem_test": "sram_program",


### PR DESCRIPTION
The tests using SRAM exec need jtag access, so weren't running with the original config. Also removed test ROM targets, see comments.

Fixes: https://github.com/lowRISC/opentitan/issues/20033