### PR TITLE
[cryptotest] add wycheproof ecdh test vector parser/schema

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -104,3 +104,27 @@ genrule(
         "LongMsg",
     ] + extra_msg_types
 ]
+
+[
+    run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "//sw/vendor/wycheproof/testvectors:{}".format(src_name),
+            "//sw/host/cryptotest/testvectors/data/schemas:ecdh_schema.json",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--src",
+            "$(location //sw/vendor/wycheproof/testvectors:{})".format(src_name),
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:ecdh_schema.json)",
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ecdh_parser",
+    )
+    for src_name, cryptotest_name in [
+        ("ecdh_secp256r1_test.json", "wycheproof_ecdh_p256"),
+        ("ecdh_secp384r1_test.json", "wycheproof_ecdh_p384"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -15,6 +15,7 @@ filegroup(
 )
 
 exports_files([
+    "ecdh_schema.json",
     "hash_schema.json",
     "hmac_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdh_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdh_schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/ecdh_schema.json",
+  "title": "Cryptotest ECDH Key Derivation Test Vector",
+  "description": "A list of testvectors for ECDH Key Derivation testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID from test vector source -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be ecdh",
+        "type": "string",
+        "enum": ["ecdh"]
+      },
+      "operation": {
+        "description": "ECDH operation",
+        "type": "string",
+        "enum": ["derive"]
+      },
+      "curve": {
+        "description": "Curve type",
+        "type": "string",
+        "enum": ["p256", "p384"]
+      },
+      "d": {
+        "description": "Private key d",
+        "$ref": "#/$defs/byte_array"
+      },
+      "qx": {
+        "description": "Peer's public key x coordinate",
+        "$ref": "#/$defs/byte_array"
+      },
+      "qy": {
+        "description": "Peer's public key y coordinate",
+        "$ref": "#/$defs/byte_array"
+      },
+      "z": {
+	    "description": "Shared key Z",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Derivation result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -67,3 +67,13 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "wycheproof_ecdh_parser",
+    srcs = ["wycheproof_ecdh_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+        requirement("pycryptodome"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdh_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdh_parser.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import logging
+import sys
+
+from Crypto.PublicKey import ECC
+
+# Mapping from the curve names used by Wycheproof to those used by cryptotest
+EC_NAME_MAPPING = {
+    "secp256r1": "p256",
+    "secp384r1": "p384",
+}
+
+
+def parse_test_vectors(raw_data):
+    test_groups = raw_data["testGroups"]
+    test_vectors = list()
+    for group in test_groups:
+        # Parse tests within the group
+        for test in group["tests"]:
+            logging.debug(f"Parsing tcId {test['tcId']}")
+            # A few tests are flagged as "InvalidASN" but the public key DER
+            # string is nonetheless accepted by
+            # Crypto.PublicKey.ECC.import_key(), so we manually exclude these
+            # tests.
+            if "InvalidAsn" in test["flags"]:
+                logging.info(
+                    f"Skipped tcId {test['tcId']}: Tagged as Invalid ASN."
+                )
+                continue
+            test_vec = {
+                "vendor": "wycheproof",
+                "test_case_id": test['tcId'],
+                "algorithm": "ecdh",
+                "curve": EC_NAME_MAPPING[group["curve"]],
+                "d": list(bytes.fromhex(test["private"])),
+                "z": list(bytes.fromhex(test["shared"])),
+            }
+
+            # Parse ASN encoded public key
+            if group["encoding"] == "asn":
+                try:
+                    public_key = ECC.import_key(bytes.fromhex(test["public"]))
+                except ValueError as e:
+                    logging.info(
+                        f"Skipped tcId {test['tcId']}: ValueError when parsing DER sequence: {e}."
+                    )
+                    continue
+                if public_key.curve != EC_NAME_MAPPING[group["curve"]]:
+                    logging.info(
+                        f"Skipped tcId {test['tcId']}: Curve in DER did not match test vector."
+                    )
+                    continue
+                test_vec["qx"] = list(public_key.pointQ.x.to_bytes())
+                test_vec["qy"] = list(public_key.pointQ.y.to_bytes())
+            else:
+                logging.info(
+                    f"Skipped tcId {test['tcId']}: unsupported encoding '{group['encoding']}'."
+                )
+                continue
+
+            # Parse the expected result
+            if test["result"] == "valid":
+                test_vec["result"] = True
+            elif test["result"] == "invalid":
+                test_vec["result"] = False
+            elif test["result"] == "acceptable":
+                # Wycheproof flags valid tests using compressed public keys as
+                # "acceptable". We accept those tests, but reject others marked
+                # "acceptable" to err on the side of caution.
+                if "CompressedPoint" in test["flags"]:
+                    test_vec["result"] = True
+                else:
+                    test_vec["result"] = False
+            else:
+                raise RuntimeError(f"Unexpected result type {test['result']}")
+
+            test_vectors.append(test_vec)
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--src",
+        metavar="FILE",
+        type=argparse.FileType("r"),
+        help="Test vector input file to parse"
+    )
+    parser.add_argument(
+        "--dst",
+        metavar="FILE",
+        type=argparse.FileType("w"),
+        help="File to write parsed JSON test cases"
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(json.load(args.src))
+    args.src.close()
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds the ECDH wycheproof test vector parser for testing the cryptolib ECDH implementation. Like #20793 did for ECDSA, the JSON outputted by the test vector parser is intended to be used by the Rust driver in #20877 to submit tests to the device.

A few tests had to be manually excluded because `Crypto.Util.asn` failed to reject invalid DER OIDs. More annoyingly, the tests that failed have a different test case ID in the current upstream master wycheproof than in the one currently in `//sw/vendor`, so the comments (but not the logic) in the parser will be outdated if we update the vendored wycheproof or switch to a non-vendored fetch.