### PR TITLE
[test,uart] Fix uart_tx_rx_test on FPGAs by using another UART as the OTTF console

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -327,9 +327,9 @@
                  // Format SW image names (which are Bazel labels concatenated with an index
                  // and/or flags, see below) into output file names separated by commas to feed into
                  // +sw_images plusarg. For example, if the input list of SW images is
-                 // ["//sw/device/tests:uart0_tx_rx_test:1",
+                 // ["//sw/device/tests:uart_tx_rx_test:1",
                  //  "//sw/device/lib/testing/test_rom:test_rom:0"], then the output of this eval_cmd
-                 // will be: "uart0_tx_rx_test:1,test_rom:0".
+                 // will be: "uart_tx_rx_test:1,test_rom:0".
                  '''+sw_images={eval_cmd} \
                  reformatted_sw_images=; \
                  for image in {sw_images}; do \
@@ -525,7 +525,7 @@
     {
       name: chip_sw_uart_tx_rx
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
       reseed: 5
@@ -533,7 +533,7 @@
     {
       name: chip_sw_uart_tx_rx_idx1
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=1", "+calibrate_usb_clk=1"]
       reseed: 5
@@ -541,7 +541,7 @@
     {
       name: chip_sw_uart_tx_rx_idx2
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=2", "+calibrate_usb_clk=1"]
       reseed: 5
@@ -549,7 +549,7 @@
     {
       name: chip_sw_uart_tx_rx_idx3
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=3", "+calibrate_usb_clk=1"]
       reseed: 5
@@ -557,7 +557,7 @@
     {
       name: chip_sw_uart_tx_rx_bootstrap
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1",
                  "+test_timeout_ns=80_000_000"]
@@ -633,7 +633,7 @@
     {
       name: chip_sw_uart_rand_baudrate
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1"]
       run_timeout_mins: 120
@@ -642,7 +642,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000",
                  "+chip_clock_source=ChipClockSourceExternal96Mhz", "+calibrate_usb_clk=1"]
@@ -652,7 +652,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq_low_speed
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["//sw/device/tests:uart0_tx_rx_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+calibrate_usb_clk=1",
                  "+chip_clock_source=ChipClockSourceExternal48Mhz"]

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -40,7 +40,7 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_uart_smoke_vseq;
     super.cpu_init();
     sw_symbol_backdoor_overwrite("kUartTxData", exp_uart_tx_data);
     sw_symbol_backdoor_overwrite("kExpUartRxData", uart_rx_data);
-    sw_symbol_backdoor_overwrite("kUartIdx", uart_idx_data);
+    sw_symbol_backdoor_overwrite("kUartIdxDv", uart_idx_data);
   endtask
 
   virtual task body();

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -73,27 +73,8 @@ void ottf_console_init(void) {
         CHECK(kOttfTestConfig.console.type == kOttfConsoleUart);
         base_addr = TOP_EARLGREY_UART0_BASE_ADDR;
       }
-      CHECK_DIF_OK(
-          dif_uart_init(mmio_region_from_addr(base_addr), &ottf_console_uart));
-      CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
-      CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
-            "kClockFreqPeripheralHz must fit in uint32_t");
-      CHECK_DIF_OK(dif_uart_configure(
-          &ottf_console_uart,
-          (dif_uart_config_t){
-              .baudrate = (uint32_t)kUartBaudrate,
-              .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
-              .parity_enable = kDifToggleDisabled,
-              .parity = kDifUartParityEven,
-              .tx_enable = kDifToggleEnabled,
-              .rx_enable = kDifToggleEnabled,
-          }));
-      base_uart_stdout(&ottf_console_uart);
 
-      // Initialize/Configure console flow control (if requested).
-      if (kOttfTestConfig.enable_uart_flow_control) {
-        ottf_console_flow_control_enable();
-      }
+      ottf_console_configure_uart(base_addr);
       break;
     case (kOttfConsoleSpiDevice):
       CHECK_DIF_OK(dif_spi_device_init_handle(
@@ -122,6 +103,29 @@ void ottf_console_init(void) {
     default:
       CHECK(false, "unsupported OTTF console interface.");
       break;
+  }
+}
+
+void ottf_console_configure_uart(uintptr_t base_addr) {
+  CHECK_DIF_OK(
+      dif_uart_init(mmio_region_from_addr(base_addr), &ottf_console_uart));
+  CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK_DIF_OK(dif_uart_configure(
+      &ottf_console_uart, (dif_uart_config_t){
+                              .baudrate = (uint32_t)kUartBaudrate,
+                              .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                              .parity_enable = kDifToggleDisabled,
+                              .parity = kDifUartParityEven,
+                              .tx_enable = kDifToggleEnabled,
+                              .rx_enable = kDifToggleEnabled,
+                          }));
+  base_uart_stdout(&ottf_console_uart);
+
+  // Initialize/Configure console flow control (if requested).
+  if (kOttfTestConfig.enable_uart_flow_control) {
+    ottf_console_flow_control_enable();
   }
 }
 

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -41,6 +41,13 @@ void *ottf_console_get(void);
 void ottf_console_init(void);
 
 /**
+ * Configures the given UART to be used by the OTTF console.
+ *
+ * @param base_addr The base address of the UART to use.
+ */
+void ottf_console_configure_uart(uintptr_t base_addr);
+
+/**
  * Manage flow control by inspecting the OTTF console device's receive FIFO.
  *
  * @param uart A UART handle.

--- a/sw/device/lib/testing/uart_testutils.c
+++ b/sw/device/lib/testing/uart_testutils.c
@@ -61,7 +61,6 @@ static const pinmux_testutils_mio_pin_t
                      .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
                      .insel = kTopEarlgreyPinmuxInselIoc3,
                  },
-             // FIXME: select the other available pins.
              [UartPinmuxChannelDut] =
                  {
                      .mio_out = kTopEarlgreyPinmuxMioOutIob5,
@@ -74,7 +73,6 @@ static const pinmux_testutils_mio_pin_t
                     .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
                     .insel = kTopEarlgreyPinmuxInselIoc3,
                 },
-            // FIXME: select the other available pins.
             [UartPinmuxChannelDut] = {
                 .mio_out = kTopEarlgreyPinmuxMioOutIob5,
                 .insel = kTopEarlgreyPinmuxInselIob4,

--- a/sw/device/lib/testing/uart_testutils.c
+++ b/sw/device/lib/testing/uart_testutils.c
@@ -53,85 +53,77 @@ static const pinmux_testutils_peripheral_pin_t kUartPinmuxPins[] = {
  * This is used to connect UART instances to mio pins based on the platform.
  */
 static const pinmux_testutils_mio_pin_t
-    kUartPlatformPins[UartPinmuxPlatformIdCount][4] = {
+    kUartPlatformPins[UartPinmuxPlatformIdCount][UartPinmuxChannelCount] = {
         // Hyper310 bitstream.
         [UartPinmuxPlatformIdHyper310] =
-            {// UART0.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART1.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART2.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART3.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             }},
+            {[UartPinmuxChannelConsole] =
+                 {
+                     .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                     .insel = kTopEarlgreyPinmuxInselIoc3,
+                 },
+             // FIXME: select the other available pins.
+             [UartPinmuxChannelDut] =
+                 {
+                     .mio_out = kTopEarlgreyPinmuxMioOutIob5,
+                     .insel = kTopEarlgreyPinmuxInselIob4,
+                 }},
         // Silicon.
-        [UartPinmuxPlatformIdSilicon] =
-            {// UART0.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART1.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART2.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             },
-             // UART3.
-             {
-                 .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                 .insel = kTopEarlgreyPinmuxInselIoc3,
-             }},
-        // DV.
-        [UartPinmuxPlatformIdDvsim] = {
-            // UART0.
-            {
-                .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
-                .insel = kTopEarlgreyPinmuxInselIoc3,
-            },
-            // UART1.
-            {
+        [UartPinmuxPlatformIdSilicon] = {
+            [UartPinmuxChannelConsole] =
+                {
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+                    .insel = kTopEarlgreyPinmuxInselIoc3,
+                },
+            // FIXME: select the other available pins.
+            [UartPinmuxChannelDut] = {
                 .mio_out = kTopEarlgreyPinmuxMioOutIob5,
                 .insel = kTopEarlgreyPinmuxInselIob4,
-            },
-            // UART2.
-            {
-                .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
-                .insel = kTopEarlgreyPinmuxInselIoa4,
-            },
-            // UART3.
-            {
-                .mio_out = kTopEarlgreyPinmuxMioOutIoa1,
-                .insel = kTopEarlgreyPinmuxInselIoa0,
             }}};
+
+/**
+ * The DV platform is handled separately at the moment: all four UARTs have
+ * their own channels that they map to rather than using one channel for the
+ * console and second for the DUT.
+ */
+static const pinmux_testutils_mio_pin_t kUartDvPins[4] = {
+    // UART0.
+    {
+        .mio_out = kTopEarlgreyPinmuxMioOutIoc4,
+        .insel = kTopEarlgreyPinmuxInselIoc3,
+    },
+    // UART1.
+    {
+        .mio_out = kTopEarlgreyPinmuxMioOutIob5,
+        .insel = kTopEarlgreyPinmuxInselIob4,
+    },
+    // UART2.
+    {
+        .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
+        .insel = kTopEarlgreyPinmuxInselIoa4,
+    },
+    // UART3.
+    {
+        .mio_out = kTopEarlgreyPinmuxMioOutIoa1,
+        .insel = kTopEarlgreyPinmuxInselIoa0,
+    }};
 
 status_t uart_testutils_select_pinmux(const dif_pinmux_t *pinmux,
                                       uint8_t uart_id,
-                                      uart_pinmux_platform_id_t platform) {
+                                      uart_pinmux_platform_id_t platform,
+                                      uart_pinmux_channel_t channel) {
   TRY_CHECK(platform < UartPinmuxPlatformIdCount &&
+                channel < UartPinmuxChannelCount &&
                 uart_id < ARRAYSIZE(kUartPinmuxPins),
             "Index out of bounds");
 
+  pinmux_testutils_mio_pin_t mio_pin =
+      platform == UartPinmuxPlatformIdDvsim
+          ? kUartDvPins[uart_id]
+          : kUartPlatformPins[platform][channel];
+
   TRY(dif_pinmux_input_select(pinmux, kUartPinmuxPins[uart_id].peripheral_in,
-                              kUartPlatformPins[platform][uart_id].insel));
-  TRY(dif_pinmux_output_select(pinmux,
-                               kUartPlatformPins[platform][uart_id].mio_out,
+                              mio_pin.insel));
+  TRY(dif_pinmux_output_select(pinmux, mio_pin.mio_out,
                                kUartPinmuxPins[uart_id].outsel));
 
   return OK_STATUS();

--- a/sw/device/lib/testing/uart_testutils.h
+++ b/sw/device/lib/testing/uart_testutils.h
@@ -22,6 +22,15 @@ typedef enum uart_pinmux_platform_id {
 } uart_pinmux_platform_id_t;
 
 /**
+ * Define the available external channels that a UART could be connected to.
+ */
+typedef enum uart_pinmux_channel {
+  UartPinmuxChannelConsole,
+  UartPinmuxChannelDut,
+  UartPinmuxChannelCount,
+} uart_pinmux_channel_t;
+
+/**
  * Connect the uart pins to mio pins via pinmux based on the platform the test
  * is running.
  *
@@ -33,7 +42,8 @@ typedef enum uart_pinmux_platform_id {
 OT_WARN_UNUSED_RESULT
 status_t uart_testutils_select_pinmux(const dif_pinmux_t *pinmux,
                                       uint8_t kUartIdx,
-                                      uart_pinmux_platform_id_t platform);
+                                      uart_pinmux_platform_id_t platform,
+                                      uart_pinmux_channel_t channel);
 
 /**
  * Disconnect the uart input pins from mio pads and wire it to zero.
@@ -45,4 +55,5 @@ status_t uart_testutils_select_pinmux(const dif_pinmux_t *pinmux,
 OT_WARN_UNUSED_RESULT
 status_t uart_testutils_detach_pinmux(const dif_pinmux_t *pinmux,
                                       uint8_t uart_id);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_UART_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4447,60 +4447,56 @@ opentitan_binary(
     ],
 )
 
-[
-    opentitan_test(
-        name = "uart{}_tx_rx_test".format(uart_idx),
-        srcs = ["uart_tx_rx_test.c"],
-        copts = ["-DUART_IDX={}".format(uart_idx)],
-        cw310 = new_cw310_params(
-            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
-            test_cmd = " ".join([
-                "--bitstream=\"{bitstream}\"",
-                "--bootstrap=\"{firmware}\"",
-                "--firmware-elf=\"{firmware:elf}\"",
-            ]),
-            test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
-        ),
-        exec_env = {
-            # TODO: this test currently fails on FPGA.
-            # "//hw/top_earlgrey:fpga_cw310_sival": None,
-            # "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            # "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:sim_dv": None,
-        },
-        silicon = silicon_params(
-            test_cmd = " ".join([
-                "--bootstrap=\"{firmware}\"",
-                "--firmware-elf=\"{firmware:elf}\"",
-            ]),
-            test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
-        ),
-        silicon_owner = silicon_params(
-            tags = ["broken"],
-        ),
-        deps = [
-            "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
-            "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
-            "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-            "//sw/device/lib/base:mmio",
-            "//sw/device/lib/dif:clkmgr",
-            "//sw/device/lib/dif:lc_ctrl",
-            "//sw/device/lib/dif:rv_plic",
-            "//sw/device/lib/dif:uart",
-            "//sw/device/lib/runtime:hart",
-            "//sw/device/lib/runtime:irq",
-            "//sw/device/lib/runtime:log",
-            "//sw/device/lib/testing:clkmgr_testutils",
-            "//sw/device/lib/testing:uart_testutils",
-            "//sw/device/lib/testing/test_framework:ottf_main",
-        ],
-    )
-    for uart_idx in range(0, 4, 1)
-]
+opentitan_test(
+    name = "uart_tx_rx_test",
+    srcs = ["uart_tx_rx_test.c"],
+    cw310 = new_cw310_params(
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
+        test_cmd = " ".join([
+            "--bitstream=\"{bitstream}\"",
+            "--bootstrap=\"{firmware}\"",
+            "--firmware-elf=\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:sim_dv": None,
+    },
+    silicon = silicon_params(
+        test_cmd = " ".join([
+            "--bootstrap=\"{firmware}\"",
+            "--firmware-elf=\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
+    ),
+    silicon_owner = silicon_params(
+        tags = ["broken"],
+    ),
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+        "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing:uart_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_console",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
+    ],
+)
 
 opentitan_test(
     name = "rv_core_ibex_mem_test_functest",

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -57,10 +57,8 @@ test_suite(
         "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test",
         "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test",
         "//sw/device/tests:sram_ctrl_smoketest",
-        "//sw/device/tests:uart0_tx_rx_test",
-        "//sw/device/tests:uart1_tx_rx_test",
-        "//sw/device/tests:uart2_tx_rx_test",
         "//sw/device/tests:uart_smoketest",
+        "//sw/device/tests:uart_tx_rx_test",
         "//sw/device/tests/pmod:i2c_host_eeprom_test",
     ],
 )

--- a/sw/device/tests/uart_tx_rx_test.c
+++ b/sw/device/tests/uart_tx_rx_test.c
@@ -525,7 +525,8 @@ bool test_main(void) {
   }
 
   // Attach the UART under test.
-  CHECK_STATUS_OK(uart_testutils_select_pinmux(&pinmux, kUartIdx, platform_id));
+  CHECK_STATUS_OK(uart_testutils_select_pinmux(&pinmux, kUartIdx, platform_id,
+                                               UartPinmuxChannelDut));
 
   if (kUseExtClk) {
     config_external_clock(&clkmgr);

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
@@ -246,6 +246,10 @@
     {
       "name": "console",
       "alias_of": "UART2"
+    },
+    {
+      "name": "dut",
+      "alias_of": "UART3"
     }
   ],
   "strappings": [

--- a/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+++ b/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
@@ -51,6 +51,10 @@
     {
       "name": "console",
       "alias_of": "0"
+    },
+    {
+      "name": "dut",
+      "alias_of": "1"
     }
   ]
 }


### PR DESCRIPTION
This test previously used the SPI device as its OTTF console to avoid having to use a UART (which would have been under test). This PR refactors the test to use one UART0 for the console unless it's under test, in which case we switch to UART1.

To make this work, the `uart_testutils_select_pinmux` function has been simplified to only support two output channels / interfaces: one for the console and another for DUT (device under test). This reflects the two TTYs that are available when using HyperDebug or the chipwhisperer. All of the DV simulations use a separate channel for each of the four UARTs and I didn't want to mess with that, so I've left DV alone.

Now that we can properly use the OTTF console both directions, the `kUartIdx` variable is configured using ujson commands. This allowed the four variants of the test (`uart[0-3]_tx_rx_test`) to be merged back into a single binary. Apologies for the noise that this creates in the diffs here, it was hard to extract to another commit.

I ran this locally 100 times to check for flakiness and it seemed okay:

```console
[jw opentitan]$ bazel test --test_output=streamed --nocache_test_results --runs_per_test=100 //sw/device/tests:uart_tx_rx_test_fpga_cw310_sival

[...]

INFO: Elapsed time: 587.165s, Critical Path: 6.03s
INFO: 101 processes: 200 local.
INFO: Build completed successfully, 101 total actions
//sw/device/tests:uart_tx_rx_test_fpga_cw310_sival                       PASSED in 5.9s
  Stats over 100 runs: max = 5.9s, min = 5.8s, avg = 5.8s, dev = 0.0s
```