### PR TITLE
[mbx,dv] Add testcase to exercise mailbox inbox oob checks

### DIFF
--- a/hw/ip/mbx/dv/env/mbx_env.core
+++ b/hw/ip/mbx/dv/env/mbx_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/mbx_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/mbx_vseq_list.sv: {is_include_file: true}
       - seq_lib/mbx_stress_vseq.sv: {is_include_file: true}
+      - seq_lib/mbx_imbx_oob_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/mbx/dv/env/mbx_seq_item.sv
+++ b/hw/ip/mbx/dv/env/mbx_seq_item.sv
@@ -44,6 +44,9 @@ class mbx_seq_item extends uvm_sequence_item;
     (ibmbx_limit_addr < 32'h4000_0000);
 
     (ibmbx_limit_addr >= ibmbx_base_addr);
+  }
+
+  constraint imbx_addr_range_lock_limit_c {
     // Ensure that the allocated address range is large enough for all valid messages because
     // otherwise we run the risk of making all subsequent response messages artificially small
     // because the address range has been locked.

--- a/hw/ip/mbx/dv/env/seq_lib/mbx_imbx_oob_vseq.sv
+++ b/hw/ip/mbx/dv/env/seq_lib/mbx_imbx_oob_vseq.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Add extra constraints to the mbx_config to ensure we generate messages
+// which exceed the size of the imbx.
+// This should trigger a HW-based check when the imbx attempts to write
+// outside the configured address range, raising the 'Error' condition.
+
+class mbx_imbx_oob_vseq extends mbx_stress_vseq;
+
+  `uvm_object_utils(mbx_imbx_oob_vseq)
+  `uvm_object_new
+
+  function void randomize_mbx_config();
+    // Disabling this constraint allows the solver to randomize to an otherwise-invalid
+    // config of imbx size + response_dwords that elicits the out-of-bounds error.
+    mbx_config.imbx_addr_range_lock_limit_c.constraint_mode(0);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(mbx_config,
+      // imbx_size is inclusive of limit address, hence +1
+      ((ibmbx_limit_addr - ibmbx_base_addr) / 4) + 1 < request_dwords;
+    )
+    `uvm_info(`gfn,
+              $sformatf("imbx_size_dwords = %0d, request_dwords = %0d",
+                        ((mbx_config.ibmbx_limit_addr - mbx_config.ibmbx_base_addr) / 4) + 1,
+                        mbx_config.request_dwords),
+              UVM_MEDIUM)
+    p_expect_error = 1'b1;
+  endfunction
+
+endclass : mbx_imbx_oob_vseq

--- a/hw/ip/mbx/dv/env/seq_lib/mbx_stress_vseq.sv
+++ b/hw/ip/mbx/dv/env/seq_lib/mbx_stress_vseq.sv
@@ -12,9 +12,15 @@ class mbx_stress_vseq extends mbx_base_vseq;
   constraint num_txns_c { num_txns inside {[2:12]}; }
 
   // Whether to produce these stimuli to stress the DUT.
-  bit aborts_en = 1'b1;  // Aborts from the SoC side.
-  bit errors_en = 1'b1;  // Errors from the Core side.
-  bit panics_en = 1'b1;  // FW-initiated reset/Abort clear from the Core side.
+  rand bit aborts_en;  // Aborts from the SoC side.
+  rand bit errors_en;  // Errors from the Core side.
+  rand bit panics_en;  // FW-initiated reset/Abort clear from the Core side.
+
+  constraint stressors_en_c {
+    aborts_en dist {0:/75, 1:/25};
+    errors_en dist {0:/75, 1:/25};
+    panics_en dist {0:/75, 1:/25};
+  }
 
   // TODO: decide how often errors and aborts should be generated; sequences shall probably want
   // to override the behavior, but we shall also want some kind of sensible default. Perhaps
@@ -70,10 +76,9 @@ class mbx_stress_vseq extends mbx_base_vseq;
   virtual task body();
     `uvm_info(get_full_name(), "body -- stress test -- Start", UVM_DEBUG)
 
-    // Decide which stimuli to present to the DUT.
-    aborts_en = ($urandom_range(0,100) > 75);
-    errors_en = ($urandom_range(0,100) > 75);
-    panics_en = ($urandom_range(0,100) > 75);
+    `uvm_info(`gfn, $sformatf("aborts_en = %0b", aborts_en), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("errors_en = %0b", errors_en), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("panics_en = %0b", panics_en), UVM_LOW)
 
     super.body();
     `uvm_info(get_full_name(), "body -- stress test -- End", UVM_DEBUG)

--- a/hw/ip/mbx/dv/env/seq_lib/mbx_vseq_list.sv
+++ b/hw/ip/mbx/dv/env/seq_lib/mbx_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "mbx_common_vseq.sv"
 `include "mbx_smoke_vseq.sv"
 `include "mbx_stress_vseq.sv"
+`include "mbx_imbx_oob_vseq.sv"

--- a/hw/ip/mbx/dv/mbx_sim_cfg.hjson
+++ b/hw/ip/mbx/dv/mbx_sim_cfg.hjson
@@ -82,6 +82,10 @@
       uvm_test_seq: mbx_stress_vseq
       run_opts: ["+zero_delays=1"]
     }
+    {
+      name: mbx_imbx_oob
+      uvm_test_seq: mbx_imbx_oob_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
> ~Don't merge until after https://github.com/lowRISC/opentitan/pull/20538 has been merged. This PR should remain a draft until that is the case~.

Builds on top of https://github.com/lowRISC/opentitan/pull/20538 ~(this PR for-now contains the changes from that PR, so ignore all but the final commit for reviewing in the meantime. Will be rebased away.)~

Configure the mailbox transaction to exceed the size of the buffer for the request message, then check that the 'Error' condition has been raised come the end of the transaction. This test currently inherits from "mbx_stress", so can still randomly activate stressors (abort, error_req, panic) during each transaction.

Closes lowRISC/opentitan-integrated#573