### PR TITLE
Rework how bazel stamping work in the repository

### DIFF
--- a/rules/BUILD
+++ b/rules/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "OPENTITAN_PLATFORM")
+load("//rules:stamp.bzl", "stamp_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,6 @@ config_setting(
     name = "opentitan_platform",
     values = {"platforms": OPENTITAN_PLATFORM},
 )
+
+# See stamp.bzl for explanation.
+stamp_flag(name = "stamp_flag")

--- a/rules/stamp.bzl
+++ b/rules/stamp.bzl
@@ -1,0 +1,82 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Utilities to detect whether --stamp was specified on the command-line.
+# This relies on the workaround explained in
+# https://github.com/bazelbuild/bazel/issues/11164#issuecomment-617336309
+
+# Return a rule attribute to add a stamp parameters. This stamping parameter follows
+# the usual bazel convention:
+# - `stamp = 1` means that stamping information is available, even if stamping is
+#   is disabled on the command line (`--nostamp`).
+# - `stamp = 0` means that stamping information is not available, even if stamping is
+#   is enabled on the command line (`--stamp`).
+# - `stamp = -1` means that stamping is controlled by the command line `--stamp` or
+#   `--nostamp` flags.
+# See https://bazel.build/docs/user-manual#workspace-status for more information
+# on stamping.
+#
+# The first argument of that macro is the default value of the `stamp` attribute.
+# The second argument of that macro is the label of a stamp flag defined using `stamp_flag`.
+#
+# Use the `stamping_enabled` macro in the rule implementation to determine whether stamping
+# is enabled.
+def stamp_attr(default_value, stamp_flag):
+    return {
+        "stamp": attr.int(
+            doc = """Whether to provide access to stamping information to the rule.""",
+            default = default_value,
+            values = [-1, 0, 1],
+        ),
+        "_stamp_flag": attr.label(
+            default = stamp_flag,
+            providers = [StampFlag],
+        ),
+    }
+
+# See `stamp_flag`
+StampFlag = provider("Value of --stamp", fields = ["stamp_flag"])
+
+def _stamp_flag_impl(ctx):
+    return [StampFlag(stamp_flag = ctx.attr.value)]
+
+_stamp_flag = rule(
+    implementation = _stamp_flag_impl,
+    attrs = {
+        "value": attr.bool(
+            doc = "The value of the stamp flag",
+            mandatory = True,
+        ),
+    },
+    provides = [StampFlag],
+)
+
+# Define a stamping configuration flag to be used with `stamp_attr`.
+# This is convoluted because we cannot use select in default attributes of rules.
+# Hence we need define a rule just for the purpose of selecting its value using
+# a configuration setting.
+def stamp_flag(name):
+    native.config_setting(
+        name = name + "_config",
+        values = {"stamp": "1"},
+    )
+
+    _stamp_flag(
+        name = name,
+        value = select({
+            name + "_config": True,
+            "//conditions:default": False,
+        }),
+    )
+
+# Determine whether stamping is enabled, see `stamp_attr`.
+# Pass the rule context as argument.
+def stamping_enabled(ctx):
+    stamp_attr = ctx.attr.stamp
+    if stamp_attr == -1:
+        return ctx.attr._stamp_flag[StampFlag].stamp_flag
+    elif stamp_attr == 0:
+        return False
+    else:
+        return True

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -43,7 +43,7 @@ rust_binary(
         "stamp-env.txt",
     ],
     # stamping is necessary because opentitantool builds version.rs that needs it
-    stamp = 1,
+    stamp = -1,
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/ot_certs",

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -36,9 +36,6 @@ rust_binary(
         "src/command/version.rs",
         "src/main.rs",
     ],
-    compile_data = [
-        "//util:full_version.txt",
-    ],
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -410,10 +410,17 @@ impl CommandDispatch for GpioMonitoringVcd {
         let version = super::version::VersionResponse::default();
         writeln!(
             &mut file,
-            "   opentitantool {} {} {}",
-            version.version,
-            if version.clean { "clean" } else { "modified" },
-            version.timestamp,
+            "   opentitantool {} {}",
+            version.version.unwrap_or("<unknown>".into()),
+            if let Some(clean) = version.clean {
+                if clean {
+                    "clean"
+                } else {
+                    "modified"
+                }
+            } else {
+                "<unknown>"
+            }
         )?;
         writeln!(&mut file, "$end")?;
         match clock_nature {

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -15,19 +15,29 @@ pub struct Version {}
 
 #[derive(Debug, serde::Serialize)]
 pub struct VersionResponse {
-    pub version: String,
-    pub revision: String,
-    pub clean: bool,
-    pub timestamp: i64,
+    pub version: Option<String>,
+    pub revision: Option<String>,
+    pub clean: Option<bool>,
+}
+
+fn parse_variable(content: &str) -> Option<String> {
+    // If stamping is disabled, the variable substition in stamp-env.txt
+    // will not happen and the content of the environment variable will be
+    // `{NAME_OF_VARIABLE}`. If we detect that this is the case, we return
+    // None, otherwise we return the content.
+    if content.starts_with('{') {
+        None
+    } else {
+        Some(content.to_string())
+    }
 }
 
 impl Default for VersionResponse {
     fn default() -> Self {
         VersionResponse {
-            version: std::env!("BUILD_GIT_VERSION").to_string(),
-            revision: std::env!("BUILD_SCM_REVISION").to_string(),
-            clean: std::env!("BUILD_SCM_STATUS") == "clean",
-            timestamp: std::env!("BUILD_TIMESTAMP").parse::<i64>().unwrap(),
+            version: parse_variable(std::env!("BUILD_GIT_VERSION")),
+            revision: parse_variable(std::env!("BUILD_SCM_REVISION")),
+            clean: parse_variable(std::env!("BUILD_SCM_STATUS")).map(|x| x == "clean"),
         }
     }
 }

--- a/util/BUILD
+++ b/util/BUILD
@@ -9,27 +9,6 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
 
-genrule(
-    name = "ot_version_file",
-    outs = ["ot_version.txt"],
-    cmd = """awk '/BUILD_GIT_VERSION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
-    stamp = 1,  # this provides volatile-status.txt
-)
-
-genrule(
-    name = "full_version_file",
-    outs = ["full_version.txt"],
-    cmd = """cp -f bazel-out/volatile-status.txt $@""",
-    stamp = 1,  # this provides volatile-status.txt
-)
-
-genrule(
-    name = "scm_revision_file",
-    outs = ["scm_revision.txt"],
-    cmd = """awk '/BUILD_SCM_REVISION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
-    stamp = 1,  # this provides volatile-status.txt
-)
-
 py_binary(
     name = "otbn_build",
     srcs = ["otbn_build.py"],

--- a/util/reggen/gen_tock.py
+++ b/util/reggen/gen_tock.py
@@ -384,8 +384,6 @@ def gen_tock(block: IpBlock, outfile: TextIO, src_file: Optional[str],
     fieldstr = fieldout.getvalue()
     fieldout.close()
 
-    tm = int(version_stamp.get('BUILD_TIMESTAMP', 0))
-    dt = datetime.utcfromtimestamp(tm) if tm else datetime.utcnow()
     # Opensource council has approved dual-licensing the generated files under
     # both Apache and MIT licenses.
     # Since these generated files are meant to be imported into the Tock
@@ -395,17 +393,20 @@ def gen_tock(block: IpBlock, outfile: TextIO, src_file: Optional[str],
         "// Licensed under the Apache License, Version 2.0 or the MIT License.\n"
     )
     genout(outfile, "// SPDX-License-Identifier: Apache-2.0 OR MIT\n")
-    genout(outfile, "// Copyright lowRISC contributors {}.\n", dt.year)
+    genout(outfile, "// Copyright lowRISC contributors.\n")
     genout(outfile, '\n')
     genout(outfile, '// Generated register constants for {}.\n', block.name)
 
-    genout(outfile, '// Built for {}\n',
-           version_stamp.get('BUILD_GIT_VERSION', '<unknown>'))
-    genout(outfile, '// https://github.com/lowRISC/opentitan/tree/{}\n',
-           version_stamp.get('BUILD_SCM_REVISION', '<unknown>'))
-    genout(outfile, '// Tree status: {}\n',
-           version_stamp.get('BUILD_SCM_STATUS', '<unknown>'))
-    genout(outfile, '// Build date: {}\n\n', dt.isoformat())
+    if 'BUILD_GIT_VERSION' in version_stamp:
+        genout(outfile, '// Built for {}\n', version_stamp['BUILD_GIT_VERSION'])
+    if 'BUILD_SCM_REVISION' in version_stamp:
+        genout(outfile, '// https://github.com/lowRISC/opentitan/tree/{}\n', version_stamp['BUILD_SCM_REVISION'])
+    if 'BUILD_SCM_STATUS' in version_stamp:
+        genout(outfile, '// Tree status: {}\n', version_stamp['BUILD_SCM_STATUS'])
+    if 'BUILD_TIMESTAMP' in version_stamp:
+        tm = int(version_stamp['BUILD_TIMESTAMP'])
+        dt = datetime.utcfromtimestamp(tm)
+        genout(outfile, '// Build date: {}\n\n', dt.isoformat())
 
     if src_file:
         genout(outfile, '// Original reference file: {}\n', src_file)

--- a/util/reggen/gen_tock.py
+++ b/util/reggen/gen_tock.py
@@ -10,14 +10,15 @@ import logging as log
 import sys
 import textwrap
 import warnings
-from datetime import datetime
-from typing import Any, Dict, Optional, Set, TextIO
+from typing import Any, Optional, Set, TextIO
 
 from reggen.ip_block import IpBlock
 from reggen.multi_register import MultiRegister
 from reggen.params import LocalParam
 from reggen.register import Register
 from reggen.window import Window
+
+from version_file import VersionInformation
 
 REG_VISIBILITY = 'pub(crate)'
 FIELD_VISIBILITY = 'pub(crate)'
@@ -327,7 +328,7 @@ def gen_const_interrupts(fieldout: TextIO, block: IpBlock, component: str,
 
 def gen_tock(block: IpBlock, outfile: TextIO, src_file: Optional[str],
              src_lic: Optional[str], src_copy: str,
-             version_stamp: Dict[str, str]) -> int:
+             version: VersionInformation) -> int:
     rnames = block.get_rnames()
 
     paramout = io.StringIO()
@@ -397,16 +398,12 @@ def gen_tock(block: IpBlock, outfile: TextIO, src_file: Optional[str],
     genout(outfile, '\n')
     genout(outfile, '// Generated register constants for {}.\n', block.name)
 
-    if 'BUILD_GIT_VERSION' in version_stamp:
-        genout(outfile, '// Built for {}\n', version_stamp['BUILD_GIT_VERSION'])
-    if 'BUILD_SCM_REVISION' in version_stamp:
-        genout(outfile, '// https://github.com/lowRISC/opentitan/tree/{}\n', version_stamp['BUILD_SCM_REVISION'])
-    if 'BUILD_SCM_STATUS' in version_stamp:
-        genout(outfile, '// Tree status: {}\n', version_stamp['BUILD_SCM_STATUS'])
-    if 'BUILD_TIMESTAMP' in version_stamp:
-        tm = int(version_stamp['BUILD_TIMESTAMP'])
-        dt = datetime.utcfromtimestamp(tm)
-        genout(outfile, '// Build date: {}\n\n', dt.isoformat())
+    if version.scm_version() is not None:
+        genout(outfile, '// Built for {}\n', version.scm_version())
+    if version.scm_revision() is not None:
+        genout(outfile, '// https://github.com/lowRISC/opentitan/tree/{}\n', version.scm_revision())
+    if version.scm_status() is not None:
+        genout(outfile, '// Tree status: {}\n', version.scm_status())
 
     if src_file:
         genout(outfile, '// Original reference file: {}\n', src_file)

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -229,7 +229,7 @@ def main():
             sys.exit(1)
 
     # Extract version stamp from file
-    version_stamp = version_file.parse_version_file(args.version_stamp)
+    version_stamp = version_file.VersionInformation(args.version_stamp)
 
     if fmt == 'doc':
         with outfile:

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -18,6 +18,8 @@ from reggen import (
 from reggen.countermeasure import CounterMeasure
 from reggen.ip_block import IpBlock
 
+import version_file
+
 DESC = """regtool, generate register info from Hjson source"""
 
 USAGE = '''
@@ -226,12 +228,8 @@ def main():
                     fmt))
             sys.exit(1)
 
-    version_stamp = {}
-    if args.version_stamp is not None:
-        with open(args.version_stamp, 'rt') as f:
-            for line in f:
-                k, v = line.strip().split(' ', 1)
-                version_stamp[k] = v
+    # Extract version stamp from file
+    version_stamp = version_file.parse_version_file(args.version_stamp)
 
     if fmt == 'doc':
         with outfile:

--- a/util/rom_chip_info.py
+++ b/util/rom_chip_info.py
@@ -52,7 +52,8 @@ def read_version_file(version_info_path) -> int:
     if the revision cannot be found.
     """
 
-    version = version_info.get('BUILD_SCM_REVISION', "8badF00d")
+    version_info = version_file.VersionInformation(version_info_path)
+    version = version_info.scm_revision("")
     return int(version, base=16)
 
 
@@ -84,7 +85,7 @@ def main():
     args = parser.parse_args()
 
     # Extract version stamp from file
-    version = read_version_file(version_file.parse_version_file(args.ot_version_file))
+    version = read_version_file(args.ot_version_file)
     log.info("Version: %x" % (version, ))
 
     generated_source = generate_chip_info_c_source(version)

--- a/util/rom_chip_info.py
+++ b/util/rom_chip_info.py
@@ -8,6 +8,8 @@ import argparse
 import logging as log
 from pathlib import Path
 
+import version_file
+
 
 def generate_chip_info_c_source(scm_revision: int) -> str:
     """Return the contents of a C source file that defines `kChipInfo`.
@@ -43,11 +45,14 @@ const chip_info_t kChipInfo = {{
 """
 
 
-def read_version_file(path: Path) -> int:
-    """Interprets the contents of `path` as a big-endian hex literal."""
+def read_version_file(version_info_path) -> int:
+    """
+    Search for the scm revision variable and interprets
+    the contents as a big-endian hex literal. Return an error
+    if the revision cannot be found.
+    """
 
-    with open(path, "rt") as f:
-        version = f.read().strip()
+    version = version_info.get('BUILD_SCM_REVISION', "8badF00d")
     return int(version, base=16)
 
 
@@ -73,13 +78,13 @@ def main():
                         type=Path,
                         help='Output Directory')
     parser.add_argument('--ot_version_file',
-                        required=True,
                         type=Path,
                         help='Path to a file with the OpenTitan Version')
 
     args = parser.parse_args()
 
-    version = read_version_file(args.ot_version_file)
+    # Extract version stamp from file
+    version = read_version_file(version_file.parse_version_file(args.ot_version_file))
     log.info("Version: %x" % (version, ))
 
     generated_source = generate_chip_info_c_source(version)

--- a/util/rom_chip_info_test.py
+++ b/util/rom_chip_info_test.py
@@ -78,8 +78,8 @@ const chip_info_t kChipInfo = {
 
 
 class TestFileOperations(unittest.TestCase):
-    @patch('rom_chip_info.open',
-           mock_open(read_data=f'{EXAMPLE_SHA1_DIGEST:x}'))
+    @patch('version_file.open',
+           mock_open(read_data=f'BUILD_SCM_REVISION {EXAMPLE_SHA1_DIGEST:x}'))
     def test_read_version_file(self):
         """Reading a properly-formatted version file produces the expected int.
         """
@@ -87,7 +87,7 @@ class TestFileOperations(unittest.TestCase):
             pathlib.Path("fake/path/version.txt"))
         self.assertEqual(version, EXAMPLE_SHA1_DIGEST)
 
-    @patch("rom_chip_info.open", mock_open(read_data=''))
+    @patch("version_file.open", mock_open(read_data=''))
     def test_read_version_file_empty(self):
         """Reading an empty version file raises an exception.
         """
@@ -95,7 +95,7 @@ class TestFileOperations(unittest.TestCase):
             rom_chip_info.read_version_file(
                 pathlib.Path("fake/path/version.txt"))
 
-    @patch("rom_chip_info.open", mock_open(read_data='xyz'))
+    @patch("version_file.open", mock_open(read_data='BUILD_SCM_REVISION xyz'))
     def test_read_version_file_invalid_hex(self):
         """Reading an invalid version file raises an exception.
         """

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1127,7 +1127,7 @@ def main():
         raise SystemExit(sys.exc_info()[1])
 
     # Extract version stamp from file
-    version_stamp = version_file.parse_version_file(args.version_stamp)
+    version_stamp = version_file.VersionInformation(args.version_stamp)
 
     # Initialize RNG for compile-time netlist constants.
     # If specified, override the seed for random netlist constant computation.

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional, Tuple
 
 import hjson
 import tlgen
+import version_file
 from design.lib.common import expand_seed
 from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
                    IpTemplate, TemplateRenderError)
@@ -1126,17 +1127,7 @@ def main():
         raise SystemExit(sys.exc_info()[1])
 
     # Extract version stamp from file
-    version_stamp = {}
-    if args.version_stamp is not None:
-        try:
-            with open(args.version_stamp, 'rt') as f:
-                log.info("version stamp path: {}", args.version_stamp)
-                for line in f:
-                    k, v = line.strip().split(' ', 1)
-                    version_stamp[k] = v
-                    log.info("{} {}", k, v)
-        except ValueError:
-            raise SystemExit(sys.exc_info()[1])
+    version_stamp = version_file.parse_version_file(args.version_stamp)
 
     # Initialize RNG for compile-time netlist constants.
     # If specified, override the seed for random netlist constant computation.

--- a/util/version_file.py
+++ b/util/version_file.py
@@ -4,22 +4,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
+from typing import Union
 
 
-def parse_version_file(path):
-    """
-    Parse a bazel version file and return a dictionary of the values.
-    If `path` is None, an empty dictionary is returned.
-    If an error occurs during parsing, an exception is raised.
-    """
-    if path is None:
-        return {}
-    version_stamp = {}
-    try:
-        with open(path, 'rt') as f:
-            for line in f:
-                k, v = line.strip().split(' ', 1)
-                version_stamp[k] = v
-    except ValueError:
-        raise SystemExit(sys.exc_info()[1])
-    return version_stamp
+class VersionInformation():
+    def __init__(self, path: str):
+        """
+        Parse a bazel version file and store a dictionary of the values.
+        If `path` is None, an empty dictionary will be created.
+        If an error occurs during parsing, an exception is raised.
+        """
+        self.version_stamp = {}
+        if path is None:
+            return
+        try:
+            with open(path, 'rt') as f:
+                for line in f:
+                    k, v = line.strip().split(' ', 1)
+                    self.version_stamp[k] = v
+        except ValueError:
+            raise SystemExit(sys.exc_info()[1])
+
+    def scm_version(self, default: Union[str, None] = None) -> Union[str, None]:
+        return self.version_stamp.get('BUILD_GIT_VERSION', default)
+
+    def scm_revision(self, default: Union[str, None] = None) -> Union[str, None]:
+        return self.version_stamp.get('BUILD_SCM_REVISION', default)
+
+    def scm_status(self, default: Union[str, None] = None) -> Union[str, None]:
+        return self.version_stamp.get('BUILD_SCM_STATUS', default)

--- a/util/version_file.py
+++ b/util/version_file.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+
+def parse_version_file(path):
+    """
+    Parse a bazel version file and return a dictionary of the values.
+    If `path` is None, an empty dictionary is returned.
+    If an error occurs during parsing, an exception is raised.
+    """
+    if path is None:
+        return {}
+    version_stamp = {}
+    try:
+        with open(path, 'rt') as f:
+            for line in f:
+                k, v = line.strip().split(' ', 1)
+                version_stamp[k] = v
+    except ValueError:
+        raise SystemExit(sys.exc_info()[1])
+    return version_stamp


### PR DESCRIPTION
This PR reworks completely how stamping works in the repository:
- It introduces `stamp.bzl` which is a module to handle stamping. Notably, it allows rules to add `stamp` parameters
that behaves like the usual bazel conversion (0 means no stamping, 1 is always stamping, -1 follows the command line).
- It fixes several python tool and bazel rule to use this module so that they only stamp if required to do so.
- It removes some targets that were always stamping and have now become useless

**What does this change do:**
With this PR, there are two main changes:
- Certain headers generated by reggen (`autogen_hjson_header`, the tock files) do not contain stamping information anymore **by default**. If one requires stamping, see below.
- The topgen code has been updated but it is not called direcly by bazel (it is called by make) so the default behaviour remains the same and this does not affect bazel caching anyway.
- Opentitantool is not stamped anymore **by default** so the `version` command will print:
```
{
  version: null,
  revision: null,
  clean: null
}
```
The build timestamp is removed also since it adds no useful information.

**Open question:**
The `chip_info` section of the ROM still includes the git sha **by default**. We could change this behaviour by setting `stamp = -1` in the definition of `autogen_chip_info_src` but the `rom_chip_info.py` script will error out because it always exactly a valid SHA to embed. This is problematic though because it will prevent proper caching of the ROM and the tests. I think we should not stamp by default but I see at least two options to do that:
- make the `rom_chip_info.py` script use a default value if none is provided: this is easy but implicit/hidden and easy to forget, I am not a fan of this idea.
- modify the stamping code so that we explicitely pass a default version file when stamping is disabled and we store a default value of the sha in the ROM when stamping is disabled. This produces the same effect but with the added benefit that this is a lot more explicit. I envision something like this:
```python
autogen_chip_info_src = rule(
    implementation = _chip_info_src,
    attrs = {
        "_tool": attr.label(
            default = "//util:rom_chip_info",
            executable = True,
            cfg = "exec",
        ),
    } | stamp_attr(-1, "//rules:stamp_flag", "//path/to/default/version/file/for/rom_chip_info"),
```

**Summary**
I believe thoses changes are acceptable since by default (i.e. in CI or locally), embedding this information does not really make sense. However, when doing a release, we definitely want to have this information. We need to make sure that various release flows add the `--stamp` parameters to recover the previous behaviour. Alternatively, we could make stamping the default and add `--nostamp` in CI.
