### PR TITLE
[rtl,pwrmgr] Fix escalation timeout persistence

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
@@ -21,6 +21,7 @@ class pwrmgr_escalation_timeout_vseq extends pwrmgr_base_vseq;
                   UVM_MEDIUM)
         cfg.esc_clk_rst_vif.stop_clk();
         cfg.clk_rst_vif.wait_clks(stop_cycles);
+        `uvm_info(`gfn, "Restarting escalation clock", UVM_MEDIUM)
         cfg.esc_clk_rst_vif.start_clk();
         cfg.esc_clk_rst_vif.wait_clks(4000);
       end

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_escalation_timeout_vseq.sv
@@ -21,6 +21,7 @@ class pwrmgr_escalation_timeout_vseq extends pwrmgr_base_vseq;
                   UVM_MEDIUM)
         cfg.esc_clk_rst_vif.stop_clk();
         cfg.clk_rst_vif.wait_clks(stop_cycles);
+        `uvm_info(`gfn, "Restarting escalation clock", UVM_MEDIUM)
         cfg.esc_clk_rst_vif.start_clk();
         cfg.esc_clk_rst_vif.wait_clks(4000);
       end


### PR DESCRIPTION
The escalation timeout needs to persist until reset. The timeout is detected by clk_i, but the timeout is used to drive a flop clocked by clk_lc. This change adds a synchronizer from clk_i to clk_lc, and a clk_lc flop reset by rst_lc_n. The output of this flop is used to set the fault_status and as a reset request.

Fixes #20516