### PR TITLE
[crypto] Pass buffers by value.

### DIFF
--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -168,37 +168,34 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  */
 static otcrypto_status_t generate(hardened_bool_t fips_check,
                                   otcrypto_const_byte_buf_t additional_input,
-                                  otcrypto_word32_buf_t *drbg_output) {
-  if (drbg_output == NULL) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  if (drbg_output->len == 0) {
+                                  otcrypto_word32_buf_t drbg_output) {
+  if (drbg_output.len == 0) {
     // Nothing to do.
     return OTCRYPTO_OK;
   }
   if ((additional_input.len != 0 && additional_input.data == NULL) ||
-      drbg_output->data == NULL) {
+      drbg_output.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   entropy_seed_material_t seed_material;
   seed_material_construct(additional_input, &seed_material);
-  HARDENED_TRY(entropy_csrng_generate(&seed_material, drbg_output->data,
-                                      drbg_output->len, fips_check));
+  HARDENED_TRY(entropy_csrng_generate(&seed_material, drbg_output.data,
+                                      drbg_output.len, fips_check));
 
   return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_drbg_generate(
     otcrypto_const_byte_buf_t additional_input,
-    otcrypto_word32_buf_t *drbg_output) {
+    otcrypto_word32_buf_t drbg_output) {
   return generate(/*fips_check=*/kHardenedBoolTrue, additional_input,
                   drbg_output);
 }
 
 otcrypto_status_t otcrypto_drbg_manual_generate(
     otcrypto_const_byte_buf_t additional_input,
-    otcrypto_word32_buf_t *drbg_output) {
+    otcrypto_word32_buf_t drbg_output) {
   return generate(/*fips_check=*/kHardenedBoolFalse, additional_input,
                   drbg_output);
 }

--- a/sw/device/lib/crypto/impl/kdf.c
+++ b/sw/device/lib/crypto/impl/kdf.c
@@ -216,7 +216,7 @@ otcrypto_status_t otcrypto_kdf_hkdf_extract(const otcrypto_blinded_key_t ikm,
   // Call HMAC(salt, IKM).
   uint32_t tag_data[digest_words];
   otcrypto_word32_buf_t tag = {.data = tag_data, .len = ARRAYSIZE(tag_data)};
-  HARDENED_TRY(otcrypto_hmac(&salt_key, unmasked_ikm, &tag));
+  HARDENED_TRY(otcrypto_hmac(&salt_key, unmasked_ikm, tag));
 
   // Construct the blinded keyblob for PRK (with an all-zero mask for now
   // because HMAC is unhardened anyway).
@@ -303,7 +303,7 @@ otcrypto_status_t otcrypto_kdf_hkdf_expand(const otcrypto_blinded_key_t prk,
         .data = t_data,
         .len = digest_words,
     };
-    HARDENED_TRY(otcrypto_hmac_final(&ctx, &t_words));
+    HARDENED_TRY(otcrypto_hmac_final(&ctx, t_words));
   }
 
   // Generate a mask (all-zero for now, since HMAC is unhardened anyway).

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -46,8 +46,8 @@ otcrypto_status_t otcrypto_symmetric_keygen(
 
   // Generate each share of the key independently.
   HARDENED_TRY(otcrypto_drbg_instantiate(perso_string));
-  HARDENED_TRY(otcrypto_drbg_generate(empty, &share0_buf));
-  HARDENED_TRY(otcrypto_drbg_generate(empty, &share1_buf));
+  HARDENED_TRY(otcrypto_drbg_generate(empty, share0_buf));
+  HARDENED_TRY(otcrypto_drbg_generate(empty, share1_buf));
 
   // Populate the checksum and return.
   key->checksum = integrity_blinded_checksum(key);
@@ -123,10 +123,10 @@ otcrypto_status_t otcrypto_import_blinded_key(
 }
 
 otcrypto_status_t otcrypto_export_blinded_key(
-    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t *key_share0,
-    otcrypto_word32_buf_t *key_share1) {
-  if (blinded_key.keyblob == NULL || key_share0 == NULL || key_share1 == NULL ||
-      key_share0->data == NULL || key_share1->data == NULL) {
+    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t key_share0,
+    otcrypto_word32_buf_t key_share1) {
+  if (blinded_key.keyblob == NULL || key_share0.data == NULL ||
+      key_share1.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -149,13 +149,13 @@ otcrypto_status_t otcrypto_export_blinded_key(
 
   // Check the lengths of the shares.
   size_t share_words = launder32(keyblob_share_num_words(blinded_key.config));
-  if (launder32(key_share0->len) != share_words ||
-      launder32(key_share1->len) != share_words) {
+  if (launder32(key_share0.len) != share_words ||
+      launder32(key_share1.len) != share_words) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(key_share0->len,
+  HARDENED_CHECK_EQ(key_share0.len,
                     keyblob_share_num_words(blinded_key.config));
-  HARDENED_CHECK_EQ(key_share1->len,
+  HARDENED_CHECK_EQ(key_share1.len,
                     keyblob_share_num_words(blinded_key.config));
 
   // Check the length of the keyblob.
@@ -172,7 +172,7 @@ otcrypto_status_t otcrypto_export_blinded_key(
   uint32_t *keyblob_share1;
   HARDENED_TRY(
       keyblob_to_shares(&blinded_key, &keyblob_share0, &keyblob_share1));
-  hardened_memcpy(key_share0->data, keyblob_share0, key_share0->len);
-  hardened_memcpy(key_share1->data, keyblob_share1, key_share1->len);
+  hardened_memcpy(key_share0.data, keyblob_share0, key_share0.len);
+  hardened_memcpy(key_share1.data, keyblob_share1, key_share1.len);
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -129,12 +129,12 @@ TEST(KeyTransport, BlindedKeyImportExport) {
   // Import the key into the blinded key struct.
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size(),
                     .data = share0.data(),
+                    .len = share0.size(),
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size(),
                     .data = share1.data(),
+                    .len = share1.size(),
                 },
                 &blinded_key)),
             true);
@@ -145,15 +145,15 @@ TEST(KeyTransport, BlindedKeyImportExport) {
 
   // Export the key again.
   otcrypto_word32_buf_t share0_buf = {
-      .len = share0.size(),
       .data = share0.data(),
+      .len = share0.size(),
   };
   otcrypto_word32_buf_t share1_buf = {
-      .len = share1.size(),
       .data = share1.data(),
+      .len = share1.size(),
   };
-  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, &share0_buf,
-                                                  &share1_buf)),
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, share0_buf,
+                                                  share1_buf)),
             true);
 
   // Unmask the result and compare to the unmasked key.
@@ -179,12 +179,12 @@ TEST(KeyTransport, BlindedKeyImportBadLengths) {
   // Set a bad length for share 0 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size() - 1,
                     .data = share0.data(),
+                    .len = share0.size() - 1,
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size(),
                     .data = share1.data(),
+                    .len = share1.size(),
                 },
                 &blinded_key)),
             false);
@@ -192,12 +192,12 @@ TEST(KeyTransport, BlindedKeyImportBadLengths) {
   // Set a bad length for share 1 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size(),
                     .data = share0.data(),
+                    .len = share0.size(),
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size() - 1,
                     .data = share1.data(),
+                    .len = share1.size() - 1,
                 },
                 &blinded_key)),
             false);
@@ -210,12 +210,12 @@ TEST(KeyTransport, BlindedKeyImportBadLengths) {
   };
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size(),
                     .data = share0.data(),
+                    .len = share0.size(),
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size(),
                     .data = share1.data(),
+                    .len = share1.size(),
                 },
                 &bad_blinded_key)),
             false);
@@ -238,33 +238,33 @@ TEST(KeyTransport, BlindedKeyExportBadLengths) {
   // Import the key.
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size(),
                     .data = share0.data(),
+                    .len = share0.size(),
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size(),
                     .data = share1.data(),
+                    .len = share1.size(),
                 },
                 &blinded_key)),
             true);
 
   otcrypto_word32_buf_t share_with_good_length = {
-      .len = share0.size(),
       .data = share0.data(),
+      .len = share0.size(),
   };
   otcrypto_word32_buf_t share_with_bad_length = {
-      .len = share1.size() - 1,
       .data = share1.data(),
+      .len = share1.size() - 1,
   };
 
   // Set a bad length for share 0 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
-                blinded_key, &share_with_bad_length, &share_with_good_length)),
+                blinded_key, share_with_bad_length, share_with_good_length)),
             false);
 
   // Set a bad length for share 1 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
-                blinded_key, &share_with_good_length, &share_with_bad_length)),
+                blinded_key, share_with_good_length, share_with_bad_length)),
             false);
 
   // Set a bad length for the keyblob and expect the export to fail.
@@ -275,7 +275,7 @@ TEST(KeyTransport, BlindedKeyExportBadLengths) {
   };
   EXPECT_EQ(
       status_ok(otcrypto_export_blinded_key(
-          bad_blinded_key, &share_with_good_length, &share_with_good_length)),
+          bad_blinded_key, share_with_good_length, share_with_good_length)),
       false);
 }
 
@@ -296,27 +296,27 @@ TEST(KeyTransport, BlindedKeyExportNotExportable) {
   // Import the key.
   EXPECT_EQ(status_ok(otcrypto_import_blinded_key(
                 (otcrypto_const_word32_buf_t){
-                    .len = share0.size(),
                     .data = share0.data(),
+                    .len = share0.size(),
                 },
                 (otcrypto_const_word32_buf_t){
-                    .len = share1.size(),
                     .data = share1.data(),
+                    .len = share1.size(),
                 },
                 &blinded_key)),
             true);
 
   // Expect key export to fail.
   otcrypto_word32_buf_t share0_buf = {
-      .len = share0.size(),
       .data = share0.data(),
+      .len = share0.size(),
   };
   otcrypto_word32_buf_t share1_buf = {
-      .len = share1.size(),
       .data = share1.data(),
+      .len = share1.size(),
   };
-  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, &share0_buf,
-                                                  &share1_buf)),
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, share0_buf,
+                                                  share1_buf)),
             false);
 }
 

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -193,7 +193,7 @@ otcrypto_status_t otcrypto_hmac_init(otcrypto_hmac_context_t *ctx,
             .len = key->config.key_length,
             .data = (unsigned char *)unmasked_key,
         },
-        &key_digest));
+        key_digest));
   }
 
   // Compute (K0 ^ ipad).
@@ -249,7 +249,7 @@ otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,
 
   // Finalize the computation of the inner hash = H(K0 ^ ipad || message) and
   // store it in `tag` temporarily.
-  HARDENED_TRY(otcrypto_hash_final(&ctx->inner, &digest_buf));
+  HARDENED_TRY(otcrypto_hash_final(&ctx->inner, digest_buf));
 
   // Finalize the computation of the outer hash
   //    = H(K0 ^ opad || H(K0 ^ ipad || message)).
@@ -258,5 +258,5 @@ otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,
       (otcrypto_const_byte_buf_t){.len = sizeof(uint32_t) * tag.len,
                                   .data = (unsigned char *)tag.data}));
 
-  return otcrypto_hash_final(&ctx->outer, &digest_buf);
+  return otcrypto_hash_final(&ctx->outer, digest_buf);
 }

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -289,10 +289,10 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_rsa_sign(
-    const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
-    otcrypto_rsa_padding_t padding_mode, otcrypto_word32_buf_t signature) {
+otcrypto_status_t otcrypto_rsa_sign(const otcrypto_blinded_key_t *private_key,
+                                    const otcrypto_hash_digest_t message_digest,
+                                    otcrypto_rsa_padding_t padding_mode,
+                                    otcrypto_word32_buf_t signature) {
   HARDENED_TRY(
       otcrypto_rsa_sign_async_start(private_key, message_digest, padding_mode));
   return otcrypto_rsa_sign_async_finalize(signature);
@@ -300,7 +300,7 @@ otcrypto_status_t otcrypto_rsa_sign(
 
 otcrypto_status_t otcrypto_rsa_verify(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode, otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result) {
   HARDENED_TRY(otcrypto_rsa_verify_async_start(public_key, signature));
@@ -612,11 +612,11 @@ static status_t key_mode_padding_check(otcrypto_key_mode_t key_mode,
 
 otcrypto_status_t otcrypto_rsa_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode) {
   // Check for NULL pointers.
-  if (message_digest == NULL || message_digest->data == NULL ||
-      private_key == NULL || private_key->keyblob == NULL) {
+  if (message_digest.data == NULL || private_key == NULL ||
+      private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -751,11 +751,10 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
 }
 
 otcrypto_status_t otcrypto_rsa_verify_async_finalize(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode, hardened_bool_t *verification_result) {
   // Check for NULL pointers.
-  if (message_digest == NULL || message_digest->data == NULL ||
-      verification_result == NULL) {
+  if (message_digest.data == NULL || verification_result == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 

--- a/sw/device/lib/crypto/impl/rsa/rsa_padding.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_padding.h
@@ -33,7 +33,7 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 status_t rsa_padding_pkcs1v15_encode(
-    const otcrypto_hash_digest_t *message_digest, size_t encoded_message_len,
+    const otcrypto_hash_digest_t message_digest, size_t encoded_message_len,
     uint32_t *encoded_message);
 
 /**
@@ -56,7 +56,7 @@ status_t rsa_padding_pkcs1v15_encode(
  */
 OT_WARN_UNUSED_RESULT
 status_t rsa_padding_pkcs1v15_verify(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const uint32_t *encoded_message, const size_t encoded_message_len,
     hardened_bool_t *result);
 
@@ -77,7 +77,7 @@ status_t rsa_padding_pkcs1v15_verify(
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_padding_pss_encode(const otcrypto_hash_digest_t *message_digest,
+status_t rsa_padding_pss_encode(const otcrypto_hash_digest_t message_digest,
                                 const uint32_t *salt, size_t salt_len,
                                 size_t encoded_message_len,
                                 uint32_t *encoded_message);
@@ -107,7 +107,7 @@ status_t rsa_padding_pss_encode(const otcrypto_hash_digest_t *message_digest,
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t rsa_padding_pss_verify(const otcrypto_hash_digest_t *message_digest,
+status_t rsa_padding_pss_verify(const otcrypto_hash_digest_t message_digest,
                                 uint32_t *encoded_message,
                                 size_t encoded_message_len,
                                 hardened_bool_t *result);

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.c
@@ -28,9 +28,9 @@
  * @return Result of the operation (OK or BAD_ARGS).
  */
 OT_WARN_UNUSED_RESULT
-static status_t digest_check(const otcrypto_hash_digest_t *digest) {
+static status_t digest_check(const otcrypto_hash_digest_t digest) {
   size_t num_words = 0;
-  switch (digest->mode) {
+  switch (digest.mode) {
     case kOtcryptoHashModeSha3_224:
       num_words = 224 / 32;
       break;
@@ -54,7 +54,7 @@ static status_t digest_check(const otcrypto_hash_digest_t *digest) {
   }
   HARDENED_CHECK_GT(num_words, 0);
 
-  if (num_words != digest->len) {
+  if (num_words != digest.len) {
     return OTCRYPTO_BAD_ARGS;
   }
   return OTCRYPTO_OK;
@@ -70,7 +70,7 @@ static status_t digest_check(const otcrypto_hash_digest_t *digest) {
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-static status_t message_encode(const otcrypto_hash_digest_t *message_digest,
+static status_t message_encode(const otcrypto_hash_digest_t message_digest,
                                const rsa_signature_padding_t padding_mode,
                                size_t encoded_message_len,
                                uint32_t *encoded_message) {
@@ -83,7 +83,7 @@ static status_t message_encode(const otcrypto_hash_digest_t *message_digest,
                                          encoded_message);
     case kRsaSignaturePaddingPss: {
       // Generate a random salt value whose length matches the digest length.
-      uint32_t salt[message_digest->len];
+      uint32_t salt[message_digest.len];
       HARDENED_TRY(entropy_complex_check());
       HARDENED_TRY(entropy_csrng_uninstantiate());
       HARDENED_TRY(entropy_csrng_instantiate(
@@ -123,7 +123,7 @@ static status_t message_encode(const otcrypto_hash_digest_t *message_digest,
  */
 OT_WARN_UNUSED_RESULT
 static status_t encoded_message_verify(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode, uint32_t *encoded_message,
     const size_t encoded_message_len, hardened_bool_t *result) {
   // Check that the digest length is OK.
@@ -148,7 +148,7 @@ static status_t encoded_message_verify(
 
 status_t rsa_signature_generate_2048_start(
     const rsa_2048_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode) {
   // Encode the message.
   rsa_2048_int_t encoded_message;
@@ -173,7 +173,7 @@ status_t rsa_signature_verify_2048_start(
 }
 
 status_t rsa_signature_verify_finalize(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode,
     hardened_bool_t *verification_result) {
   // Wait for OTBN to complete and get the size for the last RSA operation.
@@ -216,7 +216,7 @@ status_t rsa_signature_verify_finalize(
 
 status_t rsa_signature_generate_3072_start(
     const rsa_3072_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode) {
   // Encode the message.
   rsa_3072_int_t encoded_message;
@@ -242,7 +242,7 @@ status_t rsa_signature_verify_3072_start(
 
 status_t rsa_signature_generate_4096_start(
     const rsa_4096_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode) {
   // Encode the message.
   rsa_4096_int_t encoded_message;

--- a/sw/device/lib/crypto/impl/rsa/rsa_signature.h
+++ b/sw/device/lib/crypto/impl/rsa/rsa_signature.h
@@ -55,7 +55,7 @@ typedef enum rsa_signature_padding {
 OT_WARN_UNUSED_RESULT
 status_t rsa_signature_generate_2048_start(
     const rsa_2048_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode);
 
 /**
@@ -102,7 +102,7 @@ status_t rsa_signature_verify_2048_start(
  */
 OT_WARN_UNUSED_RESULT
 status_t rsa_signature_verify_finalize(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode,
     hardened_bool_t *verification_result);
 
@@ -121,7 +121,7 @@ status_t rsa_signature_verify_finalize(
 OT_WARN_UNUSED_RESULT
 status_t rsa_signature_generate_3072_start(
     const rsa_3072_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode);
 
 /**
@@ -164,7 +164,7 @@ status_t rsa_signature_verify_3072_start(
 OT_WARN_UNUSED_RESULT
 status_t rsa_signature_generate_4096_start(
     const rsa_4096_private_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const rsa_signature_padding_t padding_mode);
 
 /**

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -165,8 +165,8 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(const otcrypto_blinded_key_t *key,
                                            otcrypto_const_word32_buf_t iv,
                                            otcrypto_const_byte_buf_t aad,
                                            otcrypto_aes_gcm_tag_len_t tag_len,
-                                           otcrypto_byte_buf_t *ciphertext,
-                                           otcrypto_word32_buf_t *auth_tag);
+                                           otcrypto_byte_buf_t ciphertext,
+                                           otcrypto_word32_buf_t auth_tag);
 
 /**
  * Performs the AES-GCM authenticated decryption operation.
@@ -199,7 +199,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
     const otcrypto_blinded_key_t *key, otcrypto_const_byte_buf_t ciphertext,
     otcrypto_const_word32_buf_t iv, otcrypto_const_byte_buf_t aad,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_const_word32_buf_t auth_tag,
-    otcrypto_byte_buf_t *plaintext, hardened_bool_t *success);
+    otcrypto_byte_buf_t plaintext, hardened_bool_t *success);
 
 /**
  * Initializes the AES-GCM authenticated encryption operation.
@@ -318,8 +318,8 @@ otcrypto_status_t otcrypto_aes_gcm_update_encrypted_data(
  */
 otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
     otcrypto_aes_gcm_context_t *ctx, otcrypto_aes_gcm_tag_len_t tag_len,
-    otcrypto_byte_buf_t *ciphertext, size_t *ciphertext_bytes_written,
-    otcrypto_word32_buf_t *auth_tag);
+    otcrypto_byte_buf_t ciphertext, size_t *ciphertext_bytes_written,
+    otcrypto_word32_buf_t auth_tag);
 
 /**
  * Finishes the AES-GCM authenticated decryption operation.
@@ -346,7 +346,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_final(
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt_final(
     otcrypto_aes_gcm_context_t *ctx, otcrypto_const_word32_buf_t auth_tag,
-    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t *plaintext,
+    otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_byte_buf_t plaintext,
     size_t *plaintext_bytes_written, hardened_bool_t *success);
 
 /**
@@ -379,7 +379,7 @@ otcrypto_status_t otcrypto_aes_kwp_wrapped_len(
  */
 otcrypto_status_t otcrypto_aes_kwp_wrap(
     const otcrypto_blinded_key_t *key_to_wrap,
-    const otcrypto_blinded_key_t *key_kek, otcrypto_word32_buf_t *wrapped_key);
+    const otcrypto_blinded_key_t *key_kek, otcrypto_word32_buf_t wrapped_key);
 
 /**
  * Performs the cryptographic key unwrapping operation.

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -81,10 +81,10 @@ typedef enum otcrypto_status_value {
  * crypto library will throw an error if `len` doesn't match expectations.
  */
 typedef struct otcrypto_byte_buf {
-  // Length of the data in bytes.
-  size_t len;
   // Pointer to the data.
   uint8_t *data;
+  // Length of the data in bytes.
+  size_t len;
 } otcrypto_byte_buf_t;
 
 /**
@@ -96,10 +96,10 @@ typedef struct otcrypto_byte_buf {
  * otcrypto_byte_buf_t` would still allow data to change.
  */
 typedef struct otcrypto_const_byte_buf {
-  // Length of the data in bytes.
-  const size_t len;
   // Pointer to the data.
   const uint8_t *const data;
+  // Length of the data in bytes.
+  const size_t len;
 } otcrypto_const_byte_buf_t;
 
 /**
@@ -110,10 +110,10 @@ typedef struct otcrypto_const_byte_buf {
  * crypto library will throw an error if `len` doesn't match expectations.
  */
 typedef struct otcrypto_word32_buf {
-  // Length of the data in words.
-  size_t len;
   // Pointer to the data.
   uint32_t *data;
+  // Length of the data in words.
+  size_t len;
 } otcrypto_word32_buf_t;
 
 /**
@@ -125,10 +125,10 @@ typedef struct otcrypto_word32_buf {
  * otcrypto_word32_buf_t` would still allow data to change.
  */
 typedef struct otcrypto_const_word32_buf {
-  // Length of the data in words.
-  const size_t len;
   // Pointer to the data.
   const uint32_t *const data;
+  // Length of the data in words.
+  const size_t len;
 } otcrypto_const_word32_buf_t;
 
 /**
@@ -445,10 +445,10 @@ typedef enum otcrypto_hash_mode {
 typedef struct otcrypto_hash_digest {
   // Digest type.
   otcrypto_hash_mode_t mode;
-  // Digest length in 32-bit words.
-  size_t len;
   // Digest data.
   uint32_t *data;
+  // Digest length in 32-bit words.
+  size_t len;
 } otcrypto_hash_digest_t;
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -96,7 +96,7 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  */
 otcrypto_status_t otcrypto_drbg_generate(
     otcrypto_const_byte_buf_t additional_input,
-    otcrypto_word32_buf_t *drbg_output);
+    otcrypto_word32_buf_t drbg_output);
 
 /**
  * DRBG function for generating random bits.
@@ -118,7 +118,7 @@ otcrypto_status_t otcrypto_drbg_generate(
  */
 otcrypto_status_t otcrypto_drbg_manual_generate(
     otcrypto_const_byte_buf_t additional_input,
-    otcrypto_word32_buf_t *drbg_output);
+    otcrypto_word32_buf_t drbg_output);
 
 /**
  * Uninstantiates DRBG and clears the context.

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -131,7 +131,7 @@ otcrypto_status_t otcrypto_ecdsa_keygen(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_sign(
     const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const otcrypto_ecc_curve_t *elliptic_curve,
     otcrypto_word32_buf_t signature);
 
@@ -159,7 +159,7 @@ otcrypto_status_t otcrypto_ecdsa_sign(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_verify(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_const_word32_buf_t signature,
     const otcrypto_ecc_curve_t *elliptic_curve,
     hardened_bool_t *verification_result);
@@ -372,7 +372,7 @@ otcrypto_status_t otcrypto_ecdsa_keygen_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     const otcrypto_ecc_curve_t *elliptic_curve);
 
 /**
@@ -412,7 +412,7 @@ otcrypto_status_t otcrypto_ecdsa_sign_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ecdsa_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_const_word32_buf_t signature,
     const otcrypto_ecc_curve_t *elliptic_curve);
 

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -48,7 +48,7 @@ typedef struct otcrypto_hash_context {
  * @return Result of the hash operation.
  */
 otcrypto_status_t otcrypto_hash(otcrypto_const_byte_buf_t input_message,
-                                otcrypto_hash_digest_t *digest);
+                                otcrypto_hash_digest_t digest);
 
 /**
  * Performs the SHAKE extendable output function (XOF) on input data.
@@ -63,7 +63,7 @@ otcrypto_status_t otcrypto_hash(otcrypto_const_byte_buf_t input_message,
  * @return Result of the xof operation.
  */
 otcrypto_status_t otcrypto_xof_shake(otcrypto_const_byte_buf_t input_message,
-                                     otcrypto_hash_digest_t *digest);
+                                     otcrypto_hash_digest_t digest);
 
 /**
  * Performs the CSHAKE extendable output function (XOF) on input data.
@@ -88,7 +88,7 @@ otcrypto_status_t otcrypto_xof_cshake(
     otcrypto_const_byte_buf_t input_message,
     otcrypto_const_byte_buf_t function_name_string,
     otcrypto_const_byte_buf_t customization_string,
-    otcrypto_hash_digest_t *digest);
+    otcrypto_hash_digest_t digest);
 
 /**
  * Performs the INIT operation for a cryptographic hash function.
@@ -143,7 +143,7 @@ otcrypto_status_t otcrypto_hash_update(otcrypto_hash_context_t *const ctx,
  * @return Result of the hash final operation.
  */
 otcrypto_status_t otcrypto_hash_final(otcrypto_hash_context_t *const ctx,
-                                      otcrypto_hash_digest_t *digest);
+                                      otcrypto_hash_digest_t digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -113,8 +113,8 @@ otcrypto_status_t otcrypto_import_blinded_key(
  * @return Result of the blinded key export operation.
  */
 otcrypto_status_t otcrypto_export_blinded_key(
-    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t *key_share0,
-    otcrypto_word32_buf_t *key_share1);
+    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t key_share0,
+    otcrypto_word32_buf_t key_share1);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -61,7 +61,7 @@ typedef struct otcrypto_hmac_context {
  */
 otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
                                 otcrypto_const_byte_buf_t input_message,
-                                otcrypto_word32_buf_t *tag);
+                                otcrypto_word32_buf_t tag);
 
 /**
  * Performs the KMAC function on the input data.
@@ -90,7 +90,7 @@ otcrypto_status_t otcrypto_kmac(const otcrypto_blinded_key_t *key,
                                 otcrypto_kmac_mode_t kmac_mode,
                                 otcrypto_const_byte_buf_t customization_string,
                                 size_t required_output_len,
-                                otcrypto_word32_buf_t *tag);
+                                otcrypto_word32_buf_t tag);
 
 /**
  * Performs the INIT operation for HMAC.
@@ -143,7 +143,7 @@ otcrypto_status_t otcrypto_hmac_update(otcrypto_hmac_context_t *const ctx,
  * @return Result of the HMAC final operation.
  */
 otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,
-                                      otcrypto_word32_buf_t *tag);
+                                      otcrypto_word32_buf_t tag);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -174,10 +174,10 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
  * @param[out] signature Pointer to the generated signature struct.
  * @return The result of the RSA signature generation.
  */
-otcrypto_status_t otcrypto_rsa_sign(
-    const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
-    otcrypto_rsa_padding_t padding_mode, otcrypto_word32_buf_t signature);
+otcrypto_status_t otcrypto_rsa_sign(const otcrypto_blinded_key_t *private_key,
+                                    const otcrypto_hash_digest_t message_digest,
+                                    otcrypto_rsa_padding_t padding_mode,
+                                    otcrypto_word32_buf_t signature);
 
 /**
  * Verifies the authenticity of the input signature.
@@ -195,7 +195,7 @@ otcrypto_status_t otcrypto_rsa_sign(
  */
 otcrypto_status_t otcrypto_rsa_verify(
     const otcrypto_unblinded_key_t *public_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode, otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result);
 
@@ -344,7 +344,7 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
  */
 otcrypto_status_t otcrypto_rsa_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode);
 
 /**
@@ -385,7 +385,7 @@ otcrypto_status_t otcrypto_rsa_verify_async_start(
  * @return Result of async RSA verify finalize operation.
  */
 otcrypto_status_t otcrypto_rsa_verify_async_finalize(
-    const otcrypto_hash_digest_t *message_digest,
+    const otcrypto_hash_digest_t message_digest,
     otcrypto_rsa_padding_t padding_mode, hardened_bool_t *verification_result);
 
 /**

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -177,7 +177,7 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor(
 otcrypto_status_t otcrypto_rsa_sign(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t *message_digest,
-    otcrypto_rsa_padding_t padding_mode, otcrypto_word32_buf_t *signature);
+    otcrypto_rsa_padding_t padding_mode, otcrypto_word32_buf_t signature);
 
 /**
  * Verifies the authenticity of the input signature.
@@ -233,7 +233,7 @@ otcrypto_status_t otcrypto_rsa_verify(
 otcrypto_status_t otcrypto_rsa_encrypt(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t message,
-    otcrypto_const_byte_buf_t label, otcrypto_word32_buf_t *ciphertext);
+    otcrypto_const_byte_buf_t label, otcrypto_word32_buf_t ciphertext);
 
 /**
  * Decrypts a message with RSA.
@@ -269,7 +269,7 @@ otcrypto_status_t otcrypto_rsa_decrypt(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_mode_t hash_mode,
     otcrypto_const_word32_buf_t ciphertext, otcrypto_const_byte_buf_t label,
-    otcrypto_byte_buf_t *plaintext);
+    otcrypto_byte_buf_t plaintext);
 /**
  * Starts the asynchronous RSA key generation function.
  *
@@ -356,7 +356,7 @@ otcrypto_status_t otcrypto_rsa_sign_async_start(
  * @return Result of async RSA sign finalize operation.
  */
 otcrypto_status_t otcrypto_rsa_sign_async_finalize(
-    otcrypto_word32_buf_t *signature);
+    otcrypto_word32_buf_t signature);
 
 /**
  * Starts the asynchronous signature verification function.
@@ -417,7 +417,7 @@ otcrypto_status_t otcrypto_rsa_encrypt_async_start(
  * @return The result of the RSA encryption operation.
  */
 otcrypto_status_t otcrypto_rsa_encrypt_async_finalize(
-    otcrypto_word32_buf_t *ciphertext);
+    otcrypto_word32_buf_t ciphertext);
 
 /**
  * Starts the asynchronous decryption function.
@@ -446,7 +446,7 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
  */
 otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
     const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t label,
-    otcrypto_byte_buf_t *plaintext);
+    otcrypto_byte_buf_t plaintext);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -249,9 +249,8 @@ otcrypto_status_t otcrypto_rsa_encrypt(
  * of the hash function digest. If the plaintext buffer is not long enough,
  * this function will return an error.
  *
- * If the plaintext buffer is longer than necessary, this function will change
- * the `len` field in `plaintext` to match the actual plaintext length. At this
- * point, excess memory at the end of the buffer may be safely freed.
+ * Decryption recovers the original length of the plaintext buffer and will
+ * return its value in `plaintext_bytelen`.
  *
  * Note: RSA encryption is included for compatibility with legacy interfaces,
  * and is typically not recommended for modern applications because it is
@@ -263,13 +262,14 @@ otcrypto_status_t otcrypto_rsa_encrypt(
  * @param ciphertext Ciphertext to decrypt.
  * @param label Label for OAEP encoding.
  * @param[out] plaintext Buffer for the decrypted message.
+ * @param[out] plaintext_bytelen Recovered byte-length of plaintext.
  * @return Result of the RSA decryption operation.
  */
 otcrypto_status_t otcrypto_rsa_decrypt(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_mode_t hash_mode,
     otcrypto_const_word32_buf_t ciphertext, otcrypto_const_byte_buf_t label,
-    otcrypto_byte_buf_t plaintext);
+    otcrypto_byte_buf_t plaintext, size_t *plaintext_bytelen);
 /**
  * Starts the asynchronous RSA key generation function.
  *
@@ -442,11 +442,12 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_start(
  * @param hash_mode Hash function to use for OAEP encoding.
  * @param label Label for OAEP encoding.
  * @param[out] plaintext Buffer for the decrypted message.
+ * @param[out] plaintext_bytelen Recovered byte-length of plaintext.
  * @return Result of the RSA decryption finalize operation.
  */
 otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
     const otcrypto_hash_mode_t hash_mode, otcrypto_const_byte_buf_t label,
-    otcrypto_byte_buf_t plaintext);
+    otcrypto_byte_buf_t plaintext, size_t *plaintext_bytelen);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -101,8 +101,7 @@ static status_t lock_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       .len = ARRAYSIZE(digest),
       .data = digest,
   };
-  TRY(manuf_util_hash_otp_partition(otp_ctrl, partition,
-                                    &otp_partition_digest));
+  TRY(manuf_util_hash_otp_partition(otp_ctrl, partition, otp_partition_digest));
 
   // Get the least significant 64 bits of the digest. We will use this as the
   // digest to lock the OTP partition. The complete digest will be used in the

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -54,7 +54,7 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
   };
 
   TRY(otcrypto_xof_cshake(input, function_name_string, customization_string,
-                          &output));
+                          output));
   memcpy(hashed_token, token_data, sizeof(token_data));
 
   return OK_STATUS();
@@ -62,13 +62,13 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
 
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                        dif_otp_ctrl_partition_t partition,
-                                       otcrypto_word32_buf_t *output) {
-  if (otp_ctrl == NULL || output == NULL || output->len != kSha256DigestWords) {
+                                       otcrypto_word32_buf_t output) {
+  if (otp_ctrl == NULL || output.len != kSha256DigestWords) {
     return INVALID_ARGUMENT();
   }
   otcrypto_hash_digest_t digest = {
-      .data = output->data,
-      .len = output->len,
+      .data = output.data,
+      .len = output.len,
       .mode = kOtcryptoHashModeSha256,
   };
 
@@ -84,7 +84,7 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
           .data = (unsigned char *)vendor_test_32bit_array,
           .len = OTP_CTRL_PARAM_VENDOR_TEST_SIZE,
       };
-      TRY(otcrypto_hash(input, &digest));
+      TRY(otcrypto_hash(input, digest));
     } break;
     case kDifOtpCtrlPartitionCreatorSwCfg: {
       otcrypto_const_byte_buf_t input = {
@@ -92,7 +92,7 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                     OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET),
           .len = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE,
       };
-      TRY(otcrypto_hash(input, &digest));
+      TRY(otcrypto_hash(input, digest));
     } break;
     case kDifOtpCtrlPartitionOwnerSwCfg: {
       otcrypto_const_byte_buf_t input = {
@@ -101,7 +101,7 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                     OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE),
           .len = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE,
       };
-      TRY(otcrypto_hash(input, &digest));
+      TRY(otcrypto_hash(input, digest));
     } break;
     default:
       return INVALID_ARGUMENT();

--- a/sw/device/silicon_creator/manuf/lib/util.h
+++ b/sw/device/silicon_creator/manuf/lib/util.h
@@ -52,6 +52,6 @@ status_t manuf_util_hash_lc_transition_token(const uint32_t *raw_token,
 OT_WARN_UNUSED_RESULT
 status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                        dif_otp_ctrl_partition_t partition,
-                                       otcrypto_word32_buf_t *hash);
+                                       otcrypto_word32_buf_t hash);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_UTIL_H_

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -192,14 +192,14 @@ status_t aes_gcm_testutils_encrypt(const aes_gcm_test_t *test, bool streaming,
         .data = actual_ciphertext.data + ciphertext_bytes_written,
         .len = test->plaintext_len - ciphertext_bytes_written,
     };
-    TRY(otcrypto_aes_gcm_encrypt_final(&ctx, tag_len, &final_ciphertext,
-                                       &ciphertext_bytes_written, &actual_tag));
+    TRY(otcrypto_aes_gcm_encrypt_final(&ctx, tag_len, final_ciphertext,
+                                       &ciphertext_bytes_written, actual_tag));
     *cycles = profile_end(t_start);
   } else {
     // Call encrypt() with a cycle count timing profile.
     uint64_t t_start = profile_start();
     otcrypto_status_t err = otcrypto_aes_gcm_encrypt(
-        &key, plaintext, iv, aad, tag_len, &actual_ciphertext, &actual_tag);
+        &key, plaintext, iv, aad, tag_len, actual_ciphertext, actual_tag);
     *cycles = profile_end(t_start);
 
     // Check for errors.
@@ -290,7 +290,7 @@ status_t aes_gcm_testutils_decrypt(const aes_gcm_test_t *test,
         .len = actual_plaintext.len - plaintext_bytes_written,
     };
     size_t final_plaintext_bytes_written;
-    TRY(otcrypto_aes_gcm_decrypt_final(&ctx, tag, tag_len, &final_plaintext,
+    TRY(otcrypto_aes_gcm_decrypt_final(&ctx, tag, tag_len, final_plaintext,
                                        &final_plaintext_bytes_written,
                                        tag_valid));
     *cycles = profile_end(t_start);
@@ -299,7 +299,7 @@ status_t aes_gcm_testutils_decrypt(const aes_gcm_test_t *test,
     icache_invalidate();
     uint64_t t_start = profile_start();
     otcrypto_status_t err = otcrypto_aes_gcm_decrypt(
-        &key, ciphertext, iv, aad, tag_len, tag, &actual_plaintext, tag_valid);
+        &key, ciphertext, iv, aad, tag_len, tag, actual_plaintext, tag_valid);
     *cycles = profile_end(t_start);
     icache_invalidate();
 

--- a/sw/device/tests/crypto/aes_kwp_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_functest.c
@@ -39,7 +39,7 @@ static status_t run_wrap_unwrap(const otcrypto_blinded_key_t *key_to_wrap,
       .data = wrapped_key_data,
       .len = ARRAYSIZE(wrapped_key_data),
   };
-  TRY(otcrypto_aes_kwp_wrap(key_to_wrap, key_kek, &wrapped_key));
+  TRY(otcrypto_aes_kwp_wrap(key_to_wrap, key_kek, wrapped_key));
 
   // Unwrap the key.
   hardened_bool_t success;

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -49,7 +49,7 @@ static status_t run_wrap_unwrap(const otcrypto_blinded_key_t *key_to_wrap,
       .data = wrapped_key_data,
       .len = ARRAYSIZE(wrapped_key_data),
   };
-  TRY(otcrypto_aes_kwp_wrap(key_to_wrap, key_kek, &wrapped_key));
+  TRY(otcrypto_aes_kwp_wrap(key_to_wrap, key_kek, wrapped_key));
 
   // Unwrap the key.
   hardened_bool_t success;

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -49,10 +49,10 @@ static status_t kat_test(void) {
   // Generate output twice.
   LOG_INFO("Generating...");
   TRY(otcrypto_drbg_manual_generate(/*additional_input=*/kEmptyBuffer,
-                                    &actual_output));
+                                    actual_output));
   LOG_INFO("Generating again...");
   TRY(otcrypto_drbg_manual_generate(/*additional_input=*/kEmptyBuffer,
-                                    &actual_output));
+                                    actual_output));
 
   // Compare second result to expected output.
   TRY_CHECK_ARRAYS_EQ(kExpOutput, actual_output_words, ARRAYSIZE(kExpOutput));
@@ -71,7 +71,7 @@ static status_t random_test(void) {
       .data = output_data,
       .len = ARRAYSIZE(output_data),
   };
-  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer, &output));
+  TRY(otcrypto_drbg_generate(/*additional_input=*/kEmptyBuffer, output));
 
   // Run a basic randomness-quality check on the output.
   return randomness_quality_monobit_test(

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -73,7 +73,7 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(msg, &msg_digest));
+  TRY(otcrypto_hash(msg, msg_digest));
 
   // Allocate space for the signature.
   uint32_t sig[kP256SignatureWords] = {0};
@@ -81,13 +81,13 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   // Generate a signature for the message.
   LOG_INFO("Signing...");
   CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, &msg_digest, &kCurveP256,
+      &private_key, msg_digest, &kCurveP256,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   CHECK_STATUS_OK(otcrypto_ecdsa_verify(
-      &public_key, &msg_digest,
+      &public_key, msg_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
       &kCurveP256, verification_result));
 

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -84,7 +84,7 @@ status_t sign_then_verify_test(void) {
       .len = ARRAYSIZE(message_digest_data),
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(message, &message_digest));
+  TRY(otcrypto_hash(message, message_digest));
 
   // Allocate space for the signature.
   uint32_t sig[kP256SignatureWords] = {0};
@@ -92,14 +92,14 @@ status_t sign_then_verify_test(void) {
   // Generate a signature for the message.
   LOG_INFO("Signing...");
   CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, &message_digest, &kCurveP256,
+      &private_key, message_digest, &kCurveP256,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   hardened_bool_t verification_result;
   CHECK_STATUS_OK(otcrypto_ecdsa_verify(
-      &public_key, &message_digest,
+      &public_key, message_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
       &kCurveP256, &verification_result));
 

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -79,7 +79,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .len = ARRAYSIZE(act_tag),
   };
 
-  TRY(otcrypto_hmac(&blinded_key, msg, &tag_buf));
+  TRY(otcrypto_hmac(&blinded_key, msg, tag_buf));
   TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -84,7 +84,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .len = ARRAYSIZE(act_tag),
   };
 
-  TRY(otcrypto_hmac(&blinded_key, msg, &tag_buf));
+  TRY(otcrypto_hmac(&blinded_key, msg, tag_buf));
   TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -87,7 +87,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
       .len = ARRAYSIZE(act_tag),
   };
 
-  TRY(otcrypto_hmac(&blinded_key, msg, &tag_buf));
+  TRY(otcrypto_hmac(&blinded_key, msg, tag_buf));
   TRY_CHECK_ARRAYS_EQ(act_tag, exp_tag, kTagLenWords);
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -157,7 +157,7 @@ static status_t run_test_vector(void) {
       TRY(otcrypto_kmac(&current_test_vector->key,
                         current_test_vector->input_msg, mode,
                         current_test_vector->cust_str,
-                        current_test_vector->digest.len, &tag_buf));
+                        current_test_vector->digest.len, tag_buf));
       break;
     }
     default: {

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -130,7 +130,7 @@ static status_t run_test_vector(void) {
     case kKmacTestOperationShake: {
       TRY(get_shake_mode(current_test_vector->security_strength,
                          &digest_buf.mode));
-      TRY(otcrypto_xof_shake(current_test_vector->input_msg, &digest_buf));
+      TRY(otcrypto_xof_shake(current_test_vector->input_msg, digest_buf));
       break;
     }
     case kKmacTestOperationCshake: {
@@ -138,13 +138,13 @@ static status_t run_test_vector(void) {
                           &digest_buf.mode));
       TRY(otcrypto_xof_cshake(current_test_vector->input_msg,
                               current_test_vector->func_name,
-                              current_test_vector->cust_str, &digest_buf));
+                              current_test_vector->cust_str, digest_buf));
       break;
     }
     case kKmacTestOperationSha3: {
       TRY(get_sha3_mode(current_test_vector->security_strength,
                         &digest_buf.mode));
-      TRY(otcrypto_hash(current_test_vector->input_msg, &digest_buf));
+      TRY(otcrypto_hash(current_test_vector->input_msg, digest_buf));
       break;
     }
     case kKmacTestOperationKmac: {

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -193,11 +193,8 @@ static status_t run_rsa_2048_decrypt(const uint8_t *label, size_t label_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_decrypt(&private_key, kTestHashMode, ciphertext_buf,
-                           label_buf, plaintext_buf));
+                           label_buf, plaintext_buf, msg_len));
   profile_end_and_print(t_start, "RSA-2048 decryption");
-
-  // Write the actual plaintext length to `msg_len`.
-  *msg_len = plaintext_buf.len;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -124,7 +124,7 @@ static status_t run_rsa_2048_encrypt(const uint8_t *msg, size_t msg_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_encrypt(&public_key, kTestHashMode, msg_buf, label_buf,
-                           &ciphertext_buf));
+                           ciphertext_buf));
   profile_end_and_print(t_start, "RSA-2048 encryption");
 
   return OK_STATUS();
@@ -193,7 +193,7 @@ static status_t run_rsa_2048_decrypt(const uint8_t *label, size_t label_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_decrypt(&private_key, kTestHashMode, ciphertext_buf,
-                           label_buf, &plaintext_buf));
+                           label_buf, plaintext_buf));
   profile_end_and_print(t_start, "RSA-2048 decryption");
 
   // Write the actual plaintext length to `msg_len`.

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -112,7 +112,7 @@ status_t keygen_then_sign_test(void) {
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
   TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
-                        &sig_buf));
+                        sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -97,7 +97,7 @@ status_t keygen_then_sign_test(void) {
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   uint32_t sig[kRsa2048NumWords];
   otcrypto_word32_buf_t sig_buf = {
@@ -111,7 +111,7 @@ status_t keygen_then_sign_test(void) {
 
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                         sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
@@ -120,7 +120,7 @@ status_t keygen_then_sign_test(void) {
   // p and q, incorrect d), then this is likely to fail.
   LOG_INFO("Starting signature verification...");
   hardened_bool_t verification_result;
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                           const_sig_buf, &verification_result));
   LOG_INFO("Signature verification complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -160,14 +160,14 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_word32_buf_t sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();
@@ -226,14 +226,14 @@ static status_t run_rsa_2048_verify(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_const_word32_buf_t sig_buf = {
       .data = sig,
       .len = kRsa2048NumWords,
   };
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, padding_mode, sig_buf,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, sig_buf,
                           verification_result));
   profile_end_and_print(t_start, "RSA verify");
 

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -167,7 +167,7 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
       .len = kRsa2048NumWords,
   };
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, &sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();

--- a/sw/device/tests/crypto/rsa_3072_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_encryption_functest.c
@@ -145,7 +145,7 @@ static status_t run_rsa_3072_encrypt(const uint8_t *msg, size_t msg_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_encrypt(&public_key, kTestHashMode, msg_buf, label_buf,
-                           &ciphertext_buf));
+                           ciphertext_buf));
   profile_end_and_print(t_start, "RSA-3072 encryption");
 
   return OK_STATUS();
@@ -214,11 +214,8 @@ static status_t run_rsa_3072_decrypt(const uint8_t *label, size_t label_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_decrypt(&private_key, kTestHashMode, ciphertext_buf,
-                           label_buf, &plaintext_buf));
+                           label_buf, plaintext_buf, msg_len));
   profile_end_and_print(t_start, "RSA-3072 decryption");
-
-  // Write the actual plaintext length to `msg_len`.
-  *msg_len = plaintext_buf.len;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -114,7 +114,7 @@ status_t keygen_then_sign_test(void) {
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
   TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
-                        &sig_buf));
+                        sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -99,7 +99,7 @@ status_t keygen_then_sign_test(void) {
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   uint32_t sig[kRsa3072NumWords];
   otcrypto_word32_buf_t sig_buf = {
@@ -113,7 +113,7 @@ status_t keygen_then_sign_test(void) {
 
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                         sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
@@ -122,7 +122,7 @@ status_t keygen_then_sign_test(void) {
   // p and q, incorrect d), then this is likely to fail.
   LOG_INFO("Starting signature verification...");
   hardened_bool_t verification_result;
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                           const_sig_buf, &verification_result));
   LOG_INFO("Signature verification complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -194,7 +194,7 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, &sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -186,7 +186,7 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_word32_buf_t sig_buf = {
       .data = sig,
@@ -194,7 +194,7 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();
@@ -253,7 +253,7 @@ static status_t run_rsa_3072_verify(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_const_word32_buf_t sig_buf = {
       .data = sig,
@@ -261,7 +261,7 @@ static status_t run_rsa_3072_verify(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, padding_mode, sig_buf,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, sig_buf,
                           verification_result));
   profile_end_and_print(t_start, "RSA verify");
 

--- a/sw/device/tests/crypto/rsa_4096_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_encryption_functest.c
@@ -165,7 +165,7 @@ static status_t run_rsa_4096_encrypt(const uint8_t *msg, size_t msg_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_encrypt(&public_key, kTestHashMode, msg_buf, label_buf,
-                           &ciphertext_buf));
+                           ciphertext_buf));
   profile_end_and_print(t_start, "RSA-4096 encryption");
 
   return OK_STATUS();
@@ -234,11 +234,8 @@ static status_t run_rsa_4096_decrypt(const uint8_t *label, size_t label_len,
   };
   uint64_t t_start = profile_start();
   TRY(otcrypto_rsa_decrypt(&private_key, kTestHashMode, ciphertext_buf,
-                           label_buf, &plaintext_buf));
+                           label_buf, plaintext_buf, msg_len));
   profile_end_and_print(t_start, "RSA-4096 decryption");
-
-  // Write the actual plaintext length to `msg_len`.
-  *msg_len = plaintext_buf.len;
 
   return OK_STATUS();
 }

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -114,7 +114,7 @@ status_t keygen_then_sign_test(void) {
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
   TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
-                        &sig_buf));
+                        sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
 

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -99,7 +99,7 @@ status_t keygen_then_sign_test(void) {
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   uint32_t sig[kRsa4096NumWords];
   otcrypto_word32_buf_t sig_buf = {
@@ -113,7 +113,7 @@ status_t keygen_then_sign_test(void) {
 
   // Generate a signature.
   LOG_INFO("Starting signature generation...");
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                         sig_buf));
   LOG_INFO("Signature generation complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());
@@ -122,7 +122,7 @@ status_t keygen_then_sign_test(void) {
   // p and q, incorrect d), then this is likely to fail.
   LOG_INFO("Starting signature verification...");
   hardened_bool_t verification_result;
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, kOtcryptoRsaPaddingPkcs,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, kOtcryptoRsaPaddingPkcs,
                           const_sig_buf, &verification_result));
   LOG_INFO("Signature verification complete.");
   LOG_INFO("OTBN instruction count: %u", otbn_instruction_count_get());

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -223,7 +223,7 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, &sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -215,7 +215,7 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_word32_buf_t sig_buf = {
       .data = sig,
@@ -223,7 +223,7 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_sign(&private_key, &msg_digest, padding_mode, sig_buf));
+  TRY(otcrypto_rsa_sign(&private_key, msg_digest, padding_mode, sig_buf));
   profile_end_and_print(t_start, "RSA signature generation");
 
   return OK_STATUS();
@@ -282,7 +282,7 @@ static status_t run_rsa_4096_verify(const uint8_t *msg, size_t msg_len,
       .len = ARRAYSIZE(msg_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(msg_buf, &msg_digest));
+  TRY(otcrypto_hash(msg_buf, msg_digest));
 
   otcrypto_const_word32_buf_t sig_buf = {
       .data = sig,
@@ -290,7 +290,7 @@ static status_t run_rsa_4096_verify(const uint8_t *msg, size_t msg_len,
   };
 
   uint64_t t_start = profile_start();
-  TRY(otcrypto_rsa_verify(&public_key, &msg_digest, padding_mode, sig_buf,
+  TRY(otcrypto_rsa_verify(&public_key, msg_digest, padding_mode, sig_buf,
                           verification_result));
   profile_end_and_print(t_start, "RSA verify");
 

--- a/sw/device/tests/crypto/sha256_functest.c
+++ b/sw/device/tests/crypto/sha256_functest.c
@@ -62,7 +62,7 @@ static status_t run_test(otcrypto_const_byte_buf_t msg,
       .len = kHmacDigestNumWords,
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash(msg, &digest_buf));
+  TRY(otcrypto_hash(msg, digest_buf));
   TRY_CHECK_ARRAYS_EQ(act_digest, exp_digest, kHmacDigestNumWords);
   return OK_STATUS();
 }
@@ -125,7 +125,7 @@ static status_t one_update_streaming_test(void) {
       .len = digest_num_words,
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash_final(&ctx, &digest_buf));
+  TRY(otcrypto_hash_final(&ctx, digest_buf));
   TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kExactBlockExpDigest,
                       sizeof(kExactBlockExpDigest));
   return OK_STATUS();
@@ -161,7 +161,7 @@ static status_t multiple_update_streaming_test(void) {
       .len = digest_num_words,
       .mode = kOtcryptoHashModeSha256,
   };
-  TRY(otcrypto_hash_final(&ctx, &digest_buf));
+  TRY(otcrypto_hash_final(&ctx, digest_buf));
   TRY_CHECK_ARRAYS_EQ((unsigned char *)act_digest, kTwoBlockExpDigest,
                       sizeof(kTwoBlockExpDigest));
   return OK_STATUS();

--- a/sw/device/tests/crypto/sha384_functest.c
+++ b/sw/device/tests/crypto/sha384_functest.c
@@ -65,7 +65,7 @@ status_t sha384_test(const unsigned char *msg, const size_t msg_len,
       .len = ARRAYSIZE(actual_digest_data),
       .mode = kOtcryptoHashModeSha384,
   };
-  TRY(otcrypto_hash(input_message, &actual_digest));
+  TRY(otcrypto_hash(input_message, actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
@@ -102,7 +102,7 @@ status_t sha384_streaming_test(const unsigned char *msg, size_t msg_len,
       .len = ARRAYSIZE(actual_digest_data),
       .mode = kOtcryptoHashModeSha384,
   };
-  TRY(otcrypto_hash_final(&ctx, &actual_digest));
+  TRY(otcrypto_hash_final(&ctx, actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,

--- a/sw/device/tests/crypto/sha512_functest.c
+++ b/sw/device/tests/crypto/sha512_functest.c
@@ -58,7 +58,7 @@ status_t sha512_test(const unsigned char *msg, const size_t msg_len,
       .data = actual_digest_data,
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash(input_message, &actual_digest));
+  TRY(otcrypto_hash(input_message, actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,
@@ -95,7 +95,7 @@ status_t sha512_streaming_test(const unsigned char *msg, size_t msg_len,
       .len = ARRAYSIZE(actual_digest_data),
       .mode = kOtcryptoHashModeSha512,
   };
-  TRY(otcrypto_hash_final(&ctx, &actual_digest));
+  TRY(otcrypto_hash_final(&ctx, actual_digest));
 
   // Check that the expected and actual digests match.
   TRY_CHECK_ARRAYS_EQ((unsigned char *)actual_digest_data, expected_digest,


### PR DESCRIPTION
Since word/byte buffers are structs containing only a pointer and a length, there is no need to make them pointers when they are return values, and this makes the API more ergonomic and easier to call from Rust (since you can just pass a slice directly). I also fixed the order of `data` and `len` in the buffer types for Rust compatibility in the second commit. The third commit applies the same change to hash digest structs (which look a lot like word buffers except they remember the hash mode used to construct them).