### PR TITLE
[hw,mbx,rtl] Clear interrupts when acknowledging an abort

### DIFF
--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -203,6 +203,8 @@ module mbx
     .doe_async_msg_en_o                  ( doe_async_msg_en                   ),
     .doe_async_msg_set_i                 ( doe_async_msg_set                  ),
     .doe_async_msg_clear_i               ( doe_async_msg_clear                ),
+    // Abort clearing from the host
+    .sysif_abort_ack_i                   ( hostif_control_abort_clear         ),
     // Access to the control register
     .sysif_control_abort_set_o           ( sysif_control_abort_set            ),
     .sysif_control_go_set_o              ( sysif_control_go_set               ),


### PR DESCRIPTION
Previously, acknowledging an abort left all interrupts to the host side being active, as well as the interrupt to the SOC.

This PR utilizes the `hostif_control_abort_clear` signal to clear all pending interrupts to Ibex and clears the interrupt register to the SOC.

Since there is currently no proper DV environment in place, I verified that manually using the existing smoke sequence with the following flow:
1. Start a transfer from the SOC (Generates ready IRQ)
2. Let Host write an error
3. Soc Writes Abort (Generates Abort IRQ)
4. Ibex acknowledges the abort

![Screenshot 2024-01-19 at 11 56 01](https://github.com/lowRISC/opentitan/assets/278301/30d4a9a9-f43e-440d-95c8-f9eeb368153f)

