### PR TITLE
[rv_dm,dv] Add comments to rv_dm_jtag_dmi_debug_disabled_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -15,23 +15,61 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
     scanmode == prim_mubi_pkg::MuBi4False;
   }
 
-  task body();
-    uvm_reg_data_t rdata;
-    repeat ($urandom_range(1, 10)) begin
-    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value('h58743902));
-    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    cfg.rv_dm_vif.lc_hw_debug_en<=lc_ctrl_pkg::Off;
-    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value('h11035662));
-    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, jtag_dmi_ral.abstractdata[0].get_reset());
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
-    cfg.rv_dm_vif.lc_hw_debug_en<=lc_ctrl_pkg::On;
-    cfg.clk_rst_vif.wait_clks(5);
-    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    `DV_CHECK_EQ('h58743902,rdata);
-   end
+  task automatic write_abstractdata(uvm_reg_data_t value);
+    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(value));
+  endtask
 
+  task automatic read_abstractdata(uvm_reg_data_t expected_value);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
+    `DV_CHECK_EQ(rdata, expected_value);
+  endtask
+
+  // Possibly wait a short time.
+  //
+  // The probability of a zero wait is intentionally reasonably large, because this is likely to be
+  // the timing that's most likely to trigger errors.
+  task maybe_delay();
+    if ($urandom_range(1, 0)) begin
+      cfg.clk_rst_vif.wait_clks($urandom_range(20, 1));
+    end
+  endtask
+
+  task body();
+    repeat ($urandom_range(1, 10)) begin
+      bit [31:0] value0, value1;
+      std::randomize(value0);
+      std::randomize(value1);
+
+      // Write value0 to abstractdata[0], then read it back, checking the value has arrived as
+      // expected.
+      write_abstractdata(value0);
+      read_abstractdata(value0);
+
+      // Possibly wait a bit
+      maybe_delay();
+
+      // Set lc_hw_debug_en to Off.
+      cfg.rv_dm_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
+
+      // Write a different value to abstractdata[0] than read it back. The write should be ignored
+      // and the register should read as its reset value (because the debug block is disabled).
+      write_abstractdata(value1);
+      read_abstractdata(jtag_dmi_ral.abstractdata[0].get_reset());
+
+      // Possibly wait a bit
+      maybe_delay();
+
+      // Issue a JTAG reset through trst_n and switch lc_hw_debug_en to On.
+      cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+      cfg.rv_dm_vif.lc_hw_debug_en = lc_ctrl_pkg::On;
+
+      // Wait a clock edge to make sure the LC signal has an effect
+      cfg.clk_rst_vif.wait_clks(1);
+
+      // Read the contents of abstractdata[0] and check they are what we set at the start.
+      read_abstractdata(value0);
+    end
   endtask : body
+
 endclass  : rv_dm_jtag_dmi_debug_disabled_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -49,8 +49,13 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
       // Possibly wait a bit
       maybe_delay();
 
-      // Set lc_hw_debug_en to Off.
-      cfg.rv_dm_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
+      // Set lc_hw_debug_en to some value other than On.
+      begin
+        lc_ctrl_pkg::lc_tx_t lc_hw_debug_en;
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lc_hw_debug_en,
+                                           lc_hw_debug_en != lc_ctrl_pkg::On;)
+        cfg.rv_dm_vif.lc_hw_debug_en = lc_hw_debug_en;
+      end
 
       // Write a different value to abstractdata[0] than read it back. The write should be ignored
       // and the register should read as its reset value (because the debug block is disabled).


### PR DESCRIPTION
The vseq was a reasonably magic bunch of instructions and it wasn't particularly clear to me what it was supposed to be doing. This commit adds comments about what's going on (and why we expect particular values).

I've also slightly strengthened the test:

 - Randomise the arbitrary data instead of hard-coding something.

 - Read back abstractdata values and check they change in the expected way.

 - Make the timing waits a bit more general.

Note that the wait code was previously broken because it was calling $urandom_range with backwards arguments. The wait would always have been for zero cycles.