### PR TITLE
[cryptotest] ed25519 wycheproof test vector parser

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -93,6 +93,24 @@ run_binary(
     ]
 ]
 
+run_binary(
+    name = "wycheproof_ed25519_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json",
+        "@wycheproof//testvectors_v1:ed25519_test.json",
+    ],
+    outs = [":wycheproof_ed25519.json"],
+    args = [
+        "--src",
+        "$(location @wycheproof//testvectors_v1:ed25519_test.json)",
+        "--dst",
+        "$(location :wycheproof_ed25519.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
+)
+
 [
     run_binary(
         name = "nist_cavp_{}_{}_{}_json".format(

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -19,6 +19,7 @@ exports_files([
     "aes_gcm_schema.json",
     "drbg_schema.json",
     "ecdh_schema.json",
+    "ed25519_schema.json",
     "hash_schema.json",
     "hmac_schema.json",
     "kmac_schema.json",

--- a/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json",
+  "title": "Cryptotest Ed25519 Signature Verification Test Vector",
+  "description": "A list of testvectors for Ed25519 Signature Verification testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "algorithm": {
+        "description": "Should be ed25519",
+        "type": "string",
+        "enum": ["ed25519"]
+      },
+      "operation": {
+        "description": "Ed25519 operation",
+        "type": "string",
+        "enum": ["verify"]
+      },
+      "message": {
+        "description": "Message to be verified",
+        "$ref": "#/$defs/byte_array"
+      },
+      "public_key": {
+        "description": "Public key to use for verification",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "Signature to verify",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Verification result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -148,3 +148,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "wycheproof_ed25519_parser",
+    srcs = ["wycheproof_ed25519_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import logging
+import sys
+
+
+def parse_test_vectors(raw_data):
+    test_groups = raw_data["testGroups"]
+    test_vectors = list()
+    for group in test_groups:
+        # Parse the key for the group
+        key = group["publicKey"]
+        if key["curve"] != "edwards25519":
+            logging.info(f"Skipped test group: Unsupported curve type '{key['curve']}'")
+            continue
+
+        # Parse tests within the group
+        for test in group["tests"]:
+            logging.debug(f"Parsing tcId {test['tcId']}")
+            test_vec = {
+                "algorithm": "ed25519",
+                "operation": "verify",
+                "message": list(bytes.fromhex(test["msg"])),
+                "public_key": list(bytes.fromhex(key["pk"])),
+                "signature": list(bytes.fromhex(test["sig"])),
+            }
+
+            # Parse the expected result
+            if test["result"] == "valid":
+                test_vec["result"] = True
+            elif test["result"] == "invalid":
+                test_vec["result"] = False
+            elif test["result"] == "acceptable":
+                # Err on the side of caution and reject "acceptable" signatures
+                test_vec["result"] = False
+            else:
+                raise RuntimeError(f"Unexpected result type {test['result']}")
+
+            test_vectors.append(test_vec)
+
+        return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--src',
+        metavar='FILE',
+        type=argparse.FileType('r'),
+        help='Read test vectors from this JSON file.'
+    )
+    parser.add_argument(
+        '--dst',
+        metavar='FILE',
+        type=argparse.FileType('w'),
+        help='Write output to this file.'
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Testvector schema file"
+    )
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(json.load(args.src))
+    args.src.close()
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This PR adds a python parser for the [ed25519 wycheproof test vectors](https://github.com/google/wycheproof/blob/master/testvectors_v1/ed25519_test.json).

Unlike [the analogous script](https://github.com/lowRISC/opentitan/pull/20793) for ECDSA, this script does not require any deconstructing of ASN.1 DER sequences, because the ed25519 vectors provide the key in a raw format, and cryptolib accepts ed25519 public keys and signatures in raw binary format, as opposed to an (x, y) curve point. The actual decoding of the point is done internally by cryptolib using the OTBN (see https://github.com/lowRISC/opentitan/pull/14218).

The cryptolib implementation of Ed25519 is currently a TODO, so a test harness using these vectors is currently TBD.