### PR TITLE
[opentitantool] Introduce JSON config for teacup shield

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -1,0 +1,417 @@
+{
+  "includes": ["/__builtin__/opentitan.json"],
+  "interface": "hyperdebug",
+  "pins": [
+    {
+      "name": "RESET",
+      "mode": "OpenDrain",
+      "pull_mode": "PullUp",
+      "alias_of": "CN10_29"
+    },
+    {
+      "name": "DFT_STRAP0",
+      "mode": "Alternate",
+      "alias_of": "IOC3"
+    },
+    {
+      "name": "DFT_STRAP1",
+      "mode": "Alternate",
+      "alias_of": "IOC4"
+    },
+    {
+      "name": "IOA0",
+      "alias_of": "CN8_6"
+    },
+    {
+      "name": "IOA1",
+      "alias_of": "CN8_8"
+    },
+    {
+      "name": "IOA2",
+      "alias_of": "CN9_29"
+    },
+    {
+      "name": "IOA3",
+      "alias_of": "CN7_18"
+    },
+    {
+      "name": "IOA4",
+      "alias_of": "CN8_10"
+    },
+    {
+      "name": "IOA5",
+      "alias_of": "CN8_12"
+    },
+    {
+      "name": "IOA6",
+      "alias_of": "CN7_20"
+    },
+    {
+      "name": "IOA7",
+      "alias_of": "CN7_4"
+    },
+    {
+      "name": "IOA8",
+      "alias_of": "CN7_2"
+    },
+    {
+      "name": "IOB0",
+      "alias_of": "CN9_25"
+    },
+    {
+      "name": "IOB1",
+      "alias_of": "CN9_8"
+    },
+    {
+      "name": "IOB2",
+      "alias_of": "CN9_10"
+    },
+    {
+      "name": "IOB3",
+      "alias_of": "CN9_27"
+    },
+    {
+      "name": "IOB4",
+      "alias_of": "CN10_14"
+    },
+    {
+      "name": "IOB5",
+      "alias_of": "CN10_16"
+    },
+    {
+      "name": "IOB6",
+      "alias_of": "CN9_5"
+    },
+    {
+      "name": "IOB7",
+      "alias_of": "CN8_4"
+    },
+    {
+      "name": "IOB8",
+      "alias_of": "CN9_2"
+    },
+    {
+      "name": "IOB9",
+      "alias_of": "CN9_11"
+    },
+    {
+      "name": "IOB10",
+      "alias_of": "CN9_9"
+    },
+    {
+      "name": "IOB11",
+      "alias_of": "CN9_19"
+    },
+    {
+      "name": "IOB12",
+      "alias_of": "CN9_21"
+    },
+    {
+      "name": "IOC0",
+      "alias_of": "CN9_13"
+    },
+    {
+      "name": "IOC1",
+      "alias_of": "CN9_15"
+    },
+    {
+      "name": "IOC2",
+      "alias_of": "CN9_17"
+    },
+    {
+      "name": "IOC3",
+      "alias_of": "CN9_6"
+    },
+    {
+      "name": "IOC4",
+      "alias_of": "CN9_4"
+    },
+    {
+      "name": "IOC5",
+      "alias_of": "CN8_14"
+    },
+    {
+      "name": "IOC6",
+      "alias_of": "CN10_7"
+    },
+    {
+      "name": "IOC7",
+      "alias_of": "CN10_18"
+    },
+    {
+      "name": "IOC8",
+      "alias_of": "CN8_16"
+    },
+    {
+      "name": "IOC9",
+      "alias_of": "CN10_31"
+    },
+    {
+      "name": "IOC10",
+      "alias_of": "CN10_33"
+    },
+    {
+      "name": "IOC11",
+      "alias_of": "CN10_2"
+    },
+    {
+      "name": "IOC12",
+      "alias_of": "CN10_4"
+    },
+    {
+      "name": "IOR0",
+      "alias_of": "CN7_7"
+    },
+    {
+      "name": "IOR1",
+      "alias_of": "CN7_5"
+    },
+    {
+      "name": "IOR2",
+      "alias_of": "CN7_3"
+    },
+    {
+      "name": "IOR3",
+      "alias_of": "CN7_1"
+    },
+    {
+      "name": "IOR4",
+      "alias_of": "CN7_16"
+    },
+    {
+      "name": "IOR5",
+      "alias_of": "CN9_14"
+    },
+    {
+      "name": "IOR6",
+      "alias_of": "CN9_16"
+    },
+    {
+      "name": "IOR7",
+      "alias_of": "CN9_18"
+    },
+    {
+      "name": "IOR8",
+      "alias_of": "CN9_20"
+    },
+    {
+      "name": "IOR9",
+      "alias_of": "CN9_22"
+    },
+    {
+      "name": "IOR10",
+      "alias_of": "CN9_24"
+    },
+    {
+      "name": "IOR11",
+      "alias_of": "CN9_26"
+    },
+    {
+      "name": "IOR12",
+      "alias_of": "CN9_28"
+    },
+    {
+      "name": "IOR13",
+      "alias_of": "CN9_30"
+    },
+    {
+      "name": "CC1",
+      "alias_of": "CN7_9"
+    },
+    {
+      "name": "CC2",
+      "alias_of": "CN7_10"
+    },
+    {
+      "name": "SPI_DEV_SCK",
+      "mode": "Alternate",
+      "alias_of": "CN10_24"
+    },
+    {
+      "name": "SPI_DEV_D0",
+      "mode": "Alternate",
+      "alias_of": "CN10_23"
+    },
+    {
+      "name": "SPI_DEV_D1",
+      "mode": "Alternate",
+      "alias_of": "CN10_10"
+    },
+    {
+      "name": "SPI1_SCK",
+      "mode": "Input",
+      "alias_of": "CN7_15"
+    },
+    {
+      "name": "SPI1_MOSI",
+      "mode": "Input",
+      "alias_of": "CN7_14"
+    },
+    {
+      "name": "SPI1_MISO",
+      "mode": "Input",
+      "alias_of": "CN7_12"
+    },
+    {
+      "name": "SPI1_CSB",
+      "mode": "Input",
+      "pull_mode": "PullUp",
+      "alias_of": "IOA7"
+    },
+    {
+      "name": "CC1",
+      "mode": "AnalogOutput",
+      "volts": 0.0
+      "alias_of": "CN7_9"
+    },
+    {
+      "name": "CC2",
+      "mode": "AnalogOutput",
+      "volts": 0.0
+      "alias_of": "CN7_10"
+    },
+    {
+      "name": "SW_STRAP0_WEAK",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "CN7_11"
+    },
+    {
+      "name": "SW_STRAP1_WEAK",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "CN10_34"
+    },
+    {
+      "name": "SW_STRAP2_WEAK",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None",
+      "alias_of": "CN10_20"
+    },
+    {
+      // Controls if CS signal from OT QSPI device is propagated to onboard SPI
+      // flash chip.
+      "name": "SPI1_CS_BUF_EN",
+      "mode": "PushPull",
+      "level": true,
+      "alias_of": "CN9_7" // Same as "CN10_21"
+    },
+    {
+      // Controls how HyperDebug SPI1 is routed, when low SPI1 interposes on the
+      // SPI communication between OT and the onboard flash chip, when high SPI1
+      // is connected together with HyperDebug QSPI, which is useful for TPM
+      // communication.
+      "name": "SPI_MUX_SEL",
+      "mode": "PushPull",
+      "level": true,
+      "alias_of": "CN10_11"
+    },
+    {
+      // Controls whether VBUS_SENSE signal is externally driven on OT pin IOC7.
+      "name": "VBUS_SENSE_EN",
+      "mode": "PushPull",
+      "level": false,
+      "alias_of": "CN8_2"
+    },
+    {
+      "name": "VBUS_SENSE",
+      "mode": "Input",
+      "alias_of": "CN10_18"
+    }
+  ],
+  "spi": [
+    {
+      "name": "TPM",
+      "bits_per_sec": 250000,
+      "chip_select": "IOA7",
+      "alias_of": "SPI1"
+    },
+    {
+      "name": "BOOTSTRAP",
+      "bits_per_sec": 8000000,
+      "chip_select": "CN10_6",
+      "alias_of": "QSPI"
+    }
+  ],
+  "i2c": [
+    {
+      "name": "DEFAULT",
+      "alias_of": "I2C1"
+    },
+    {
+      "name": "TPM",
+      "bits_per_sec": 100000,
+      "address": 0x50,
+      "alias_of": "I2C1"
+    },
+    {
+      "name": "LED",
+      "bits_per_sec": 100000,
+      "address": 0x34,
+      "alias_of": "I2C3"
+    },
+    {
+      "name": "PWR_SENSE_1",
+      "bits_per_sec": 100000,
+      "address": 0x10,
+      "alias_of": "I2C4"
+    },
+    {
+      "name": "PWR_SENSE_2",
+      "bits_per_sec": 100000,
+      "address": 0x11,
+      "alias_of": "I2C4"
+    }
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "alias_of": "UART2"
+    }
+  ],
+  "strappings": [
+    {
+      "name": "PRERESET_DFT_DISABLE",
+      "pins": [
+        {
+          "name": "DFT_STRAP0",
+          "mode": "PushPull",
+          "level": false
+        },
+        {
+          "name": "DFT_STRAP1",
+          "mode": "PushPull",
+          "level": false
+        }
+      ]
+    },
+    {
+      "name": "SPI_TPM",
+      "pins": [
+	{
+	  "name": "SPI_MUX_SEL",
+	  "level": true,
+	},
+        {
+          "name": "SPI1_SCK",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI1_MOSI",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI1_MISO",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI1_CSB",
+          "mode": "PushPull"
+        }
+      ]
+    }
+  ],
+}

--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -71,6 +71,7 @@ static BUILTINS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         "/__builtin__/hyperdebug_chipwhisperer.json" => include_str!("hyperdebug_chipwhisperer.json"),
         "/__builtin__/hyperdebug_cw310.json" => include_str!("hyperdebug_cw310.json"),
         "/__builtin__/hyperdebug_cw340.json" => include_str!("hyperdebug_cw340.json"),
+        "/__builtin__/hyperdebug_teacup.json" => include_str!("hyperdebug_teacup.json"),
         "/__builtin__/opentitan_ultradebug.json" => include_str!("opentitan_ultradebug.json"),
         "/__builtin__/opentitan_verilator.json" => include_str!("opentitan_verilator.json"),
     }


### PR DESCRIPTION
The HyperDebug "shield" has a number of MUX'es, buffers and other ICs (current sensors), which can be controlled through some signals in addition to what is used when e.g. simulating OpenTitan on an FPGA.

This PR introduces a new `hyperdebug_teacup.json` file, to be used with `--interface=hyperdebug` (not `hyper310`).  Both this file and existing FPGA-specific files refer to a common `opentitan.json`.