### PR TITLE
[sival,rstmgr] Adjust rstmgr_alert_info_test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -65,7 +65,7 @@
             after reset seems suitable. The `spi_host` IPs receive multiple resets so they will
             need special consideration.
 
-            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
+            SiVal: CPU and debug must be enabled, so it only works in TEST_UNLOCKED, DEV, and RMA.
             The rv_dm is an important tool for SiVal, so the stage is set to SV2.
             '''
       stage: V2
@@ -73,8 +73,6 @@
       lc_states: [
         "TEST_UNLOCKED",
         "DEV",
-        "PROD",
-        "PROD_END",
         "RMA",
       ]
       features: [
@@ -153,8 +151,7 @@
             Refer to `chip_sw_rstmgr_*sys_reset_info`.
 
             SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
-            This can be an important diagnostic tool, so setting it to SV2.
-            This test already runs in CW310.
+            This can be an important diagnostic tool, so setting it to SV3.
             '''
       stage: V2
       si_stage: SV3
@@ -170,12 +167,7 @@
         "RSTMGR.ALERT_INFO.ENABLE",
       ]
       tests: ["chip_sw_rstmgr_alert_info"]
-      bazel: [
-# TODO(lowrisc/opentitan#20589): Enable these _sival tests when the bug is fixed
-#        "//sw/device/tests:rstmgr_alert_info_test_fpga_cw310_sival",
-#        "//sw/device/tests:rstmgr_alert_info_test_fpga_cw310_sival_rom_ext",
-        "//sw/device/tests:rstmgr_alert_info_test_fpga_cw310_test_rom",
-      ]
+      bazel: ["//sw/device/tests:rstmgr_alert_info_test"]
     }
     {
       name: chip_sw_rstmgr_sw_rst

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -335,3 +335,26 @@ status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
   } while (new_data == prior_data);
   return OK_STATUS();
 }
+
+status_t flash_ctrl_testutils_show_faults(
+    const dif_flash_ctrl_state_t *flash_ctrl) {
+  dif_flash_ctrl_faults_t faults = {.memory_properties_error = false};
+  CHECK_DIF_OK(dif_flash_ctrl_get_faults(flash_ctrl, &faults));
+#define LOG_IF_FIELD_SET(_struct, _field)             \
+  if (_struct._field != 0) {                          \
+    LOG_INFO("Flash_ctrl fault status has " #_field); \
+  }
+
+  LOG_IF_FIELD_SET(faults, memory_properties_error);
+  LOG_IF_FIELD_SET(faults, read_error);
+  LOG_IF_FIELD_SET(faults, prog_window_error);
+  LOG_IF_FIELD_SET(faults, prog_type_error);
+  LOG_IF_FIELD_SET(faults, host_gnt_error);
+  LOG_IF_FIELD_SET(faults, register_integrity_error);
+  LOG_IF_FIELD_SET(faults, phy_integrity_error);
+  LOG_IF_FIELD_SET(faults, lifecycle_manager_error);
+  LOG_IF_FIELD_SET(faults, shadow_storage_error);
+#undef LOG_IF_FIELD_SET
+
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -267,4 +267,13 @@ status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
                                                    uint8_t prior_data,
                                                    size_t timeout_usec);
 
+/**
+ * Write to log any faults set in the status register.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ */
+OT_WARN_UNUSED_RESULT
+status_t flash_ctrl_testutils_show_faults(
+    const dif_flash_ctrl_state_t *flash_state);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3585,6 +3585,7 @@ opentitan_test(
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -3605,6 +3606,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:keymgr_testutils",
         "//sw/device/lib/testing:ret_sram_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",


### PR DESCRIPTION
A minor cleanup of the test to expect an otp_ctrl error if not
in rom_ext. There is still an unexpected flash_ctrl read error
for cw310 upon entry to test_main, so it is pending from rom_ext.

Add utility to log the bits set in flash_ctrl fault status.

The issue https://github.com/lowRISC/opentitan/issues/20589 has an explanation of this test's failures.