### PR TITLE
[rv_dm,dv] Remove a TODO in rv_dm_env.core

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -13,7 +13,8 @@ filesets:
       - lowrisc:dv:jtag_agent
       - lowrisc:dv:jtag_dmi_agent
       - lowrisc:opentitan:bus_params_pkg
-      # TODO: we only depend on dm_pkg, which should be separated into its own core file.
+      # Note: This core pulls in an rv_dm implementation. We actually
+      # just need the package (dm_pkg.sv) for DV here.
       - pulp-platform:riscv-dbg:0.1
     files:
       - rv_dm_env_pkg.sv


### PR DESCRIPTION
The TODO was added a long time ago because the environment doesn't actually need the whole of an rv_dm implementation. But the core file on which we depend is just a "grab the vendored rv_dm repository". It's probably not really worth putting in engineering effort to chop it up: I don't think we'll ever want to "vendor just some of the repository".

Drop the TODO message.