### PR TITLE
[dv,usbdev] Type fixes for xcelium testing

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -5,7 +5,7 @@
 interface usb20_block_if (
   input clk_i,
   input rst_ni,
-  output wire usb_vbus,
+  output logic usb_vbus,
   inout wire usb_p,
   inout wire usb_n
 );

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -59,8 +59,8 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     $cast(m_token_pkt, seq_item);
     m_token_pkt.print();
     // Modified each field of the packet to start with the Least Significant Bit (LSB)
-    m_token_pkt.m_pid_type = {<<4{m_token_pkt.m_pid_type}};
-    m_token_pkt.m_pid_type = {<<{m_token_pkt.m_pid_type}};
+    m_token_pkt.m_pid_type = pid_type_e'({<<4{m_token_pkt.m_pid_type}});
+    m_token_pkt.m_pid_type = pid_type_e'({<<{m_token_pkt.m_pid_type}});
     m_token_pkt.address = {<<{m_token_pkt.address}};
     m_token_pkt.endpoint = {<<{m_token_pkt.endpoint}};
     m_token_pkt.crc5 = {<<{m_token_pkt.crc5}};
@@ -90,8 +90,8 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     $cast(m_data_pkt, seq_item);
     m_data_pkt.print();
     // Modified each field of the packet to start with the Least Significant Bit (LSB)
-    m_data_pkt.m_pid_type = {<<4{m_data_pkt.m_pid_type}};
-    m_data_pkt.m_pid_type = {<<{m_data_pkt.m_pid_type}};
+    m_data_pkt.m_pid_type = pid_type_e'({<<4{m_data_pkt.m_pid_type}});
+    m_data_pkt.m_pid_type = pid_type_e'({<<{m_data_pkt.m_pid_type}});
     m_data_pkt.data = {<<8{m_data_pkt.data}};
     m_data_pkt.data = {<<{m_data_pkt.data}};
     m_data_pkt.crc16 = {<<{m_data_pkt.crc16}};
@@ -115,8 +115,8 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     bit driver_handshake_pkt[];
     bit comp_handshake_pkt[];
     $cast(m_handshake_pkt, seq_item);
-    m_handshake_pkt.m_pid_type = {<<4{m_handshake_pkt.m_pid_type}};
-    m_handshake_pkt.m_pid_type = {<<{m_handshake_pkt.m_pid_type}};
+    m_handshake_pkt.m_pid_type = pid_type_e'({<<4{m_handshake_pkt.m_pid_type}});
+    m_handshake_pkt.m_pid_type = pid_type_e'({<<{m_handshake_pkt.m_pid_type}});
     m_handshake_pkt.pack(driver_handshake_pkt);
     `uvm_info(`gfn, $sformatf("Driver Handshake_Packet = %p", driver_handshake_pkt), UVM_DEBUG)
     // To make complete packet need to attach SYNC at start of packet
@@ -287,6 +287,6 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
       received_pid[i] = decoded_received_pkt[i + 8];
     end
     received_pid = {<<4{received_pid}};
-    rsp_item.m_pid_type = received_pid;
+    rsp_item.m_pid_type = pid_type_e'(received_pid);
   endtask
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -86,7 +86,7 @@ class usb20_monitor extends dv_base_monitor #(
     sof_result = sof_p'(bit_destuffed);
 
     `uvm_info(`gfn, $sformatf("Final Sof Packet = %b", sof_result), UVM_DEBUG)
-    m_sof_pkt.m_pid_type = sof_result[9:2];
+    m_sof_pkt.m_pid_type = pid_type_e'(sof_result[9:2]);
     `uvm_info(`gfn, $sformatf("Sof Pid = %b", m_sof_pkt.m_pid_type), UVM_DEBUG)
     m_sof_pkt.framecnt = sof_result[20:10];
     `uvm_info(`gfn, $sformatf("Sof framecnt = %b", m_sof_pkt.framecnt), UVM_DEBUG)
@@ -122,7 +122,7 @@ class usb20_monitor extends dv_base_monitor #(
     token_result = token_p'(bit_destuffed);
 
     `uvm_info(`gfn, $sformatf("Final Token Packet = %b", token_result), UVM_DEBUG)
-    m_token_pkt.m_pid_type = token_result[26:19];
+    m_token_pkt.m_pid_type = pid_type_e'(token_result[26:19]);
     `uvm_info(`gfn, $sformatf("Token Pid = %b", m_token_pkt.m_pid_type), UVM_DEBUG)
     m_token_pkt.address = token_result[18:12];
     `uvm_info(`gfn, $sformatf("Token Address = %b", m_token_pkt.address), UVM_DEBUG)
@@ -163,7 +163,7 @@ class usb20_monitor extends dv_base_monitor #(
     for (int i = 0; i < 8; i++) begin
       data_pid[i] = bit_destuffed[i + 8];
     end
-    m_data_pkt.m_pid_type = data_pid;
+    m_data_pkt.m_pid_type = pid_type_e'(data_pid);
     `uvm_info(`gfn, $sformatf("Data Pid = %b", m_data_pkt.m_pid_type), UVM_DEBUG)
     // Data_in_bits
     for (int i = 0 ; i < bit_destuffed.size() - 35; i++) begin
@@ -211,9 +211,9 @@ class usb20_monitor extends dv_base_monitor #(
     handshake_result = handshake_p'(bit_destuffed);
 
     `uvm_info(`gfn, $sformatf("Final Handshake Packet = %b", handshake_result), UVM_DEBUG)
-    m_handshake_pkt.m_pid_type = handshake_result[10:3];
-    m_handshake_pkt.m_pid_type = {<<4{m_handshake_pkt.m_pid_type}};
-    m_handshake_pkt.m_pid_type = {<<{m_handshake_pkt.m_pid_type}};
+    m_handshake_pkt.m_pid_type = pid_type_e'(handshake_result[10:3]);
+    m_handshake_pkt.m_pid_type = pid_type_e'({<<4{m_handshake_pkt.m_pid_type}});
+    m_handshake_pkt.m_pid_type = pid_type_e'({<<{m_handshake_pkt.m_pid_type}});
     `uvm_info(`gfn, $sformatf("Handshake Pid = %b", m_handshake_pkt.m_pid_type), UVM_DEBUG)
     analysis_port.write(m_handshake_pkt);
   endtask

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -48,7 +48,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     csr_update(ral.avbuffer);
   endtask
 
-  task call_token_sequence(input string pkt_type, input string pid_type);
+  task call_token_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
     RSP rsp_item;
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
     m_token_pkt.m_pkt_type = pkt_type;
@@ -58,20 +58,20 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
       m_usb20_item = m_token_pkt;
       start_item(m_token_pkt);
       finish_item(m_token_pkt);
-      if (pid_type == "PidTypeInToken") begin
+      if (pid_type == PidTypeInToken) begin
         get_response(rsp_item);
         $cast(rsp_itm, rsp_item);
         get_response_from_device(rsp_itm, PidTypeData1);
       end
   endtask
 
-  task call_data_sequence(input string pkt_type, input string pid_type);
+  task call_data_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
     RSP rsp_item;
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pkt_type = pkt_type;
     m_data_pkt.m_pid_type = pid_type;
-    m_data_pkt.m_bmRT = 8'h80;
-    m_data_pkt.m_bR = 8'h06;
+    m_data_pkt.m_bmRT = bmRequestType3;
+    m_data_pkt.m_bR = bRequestGET_DESCRIPTOR;
     assert(m_data_pkt.randomize());
     m_usb20_item = m_data_pkt;
     m_data_pkt.set_payload (m_data_pkt.m_bmRT, m_data_pkt.m_bR,8'h00, 8'h01, 8'h00, 8'h00,
@@ -83,7 +83,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     get_response_from_device(rsp_itm, PidTypeAck);
   endtask
 
-  task get_response_from_device(usb20_item rsp_itm, input string pid_type);
+  task get_response_from_device(usb20_item rsp_itm, input pid_type_e pid_type);
     `uvm_create_on(m_handshake_pkt, p_sequencer.usb20_sequencer_h)
     m_handshake_pkt.m_pid_type = pid_type;
     m_usb20_item = m_handshake_pkt;


### PR DESCRIPTION
This PR makes minimal changes to the recently-introduced usbdev_smoke test to achieve the same behavior whichever simulation tool is used.

Introduce type casts required for strong typing with xcelium.
Use enum types not strings within usdbev_smoke_vseq; attempting to use run-time strings to identify the different enumeration values does not work, and unfortunately does not result in a build error because the strings are treated as open arrays of bytes and subject to bit-streaming casts.