### PR TITLE
[rv_dm,dv] Remove TODOs when setting reset values in env cfgs

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -63,8 +63,8 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
     jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
     jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
-    jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);  // TODO: verify this!
-    jtag_dmi_ral.hartinfo.nscratch.set_reset(2);  // TODO: verify this!
+    jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);
+    jtag_dmi_ral.hartinfo.nscratch.set_reset(2);
     jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
     jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
     jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -243,8 +243,8 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
       `uvm_info(`gfn, "Fixing reset values in jtag_dmi_ral", UVM_LOW)
       jtag_dmi_ral.hartinfo.dataaddr.set_reset(dm::DataAddr);
       jtag_dmi_ral.hartinfo.datasize.set_reset(dm::DataCount);
-      jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);  // TODO: verify this!
-      jtag_dmi_ral.hartinfo.nscratch.set_reset(2);  // TODO: verify this!
+      jtag_dmi_ral.hartinfo.dataaccess.set_reset(1);
+      jtag_dmi_ral.hartinfo.nscratch.set_reset(2);
       jtag_dmi_ral.abstractcs.datacount.set_reset(dm::DataCount);
       jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
       jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.


### PR DESCRIPTION
The TODOs were reminding us to verify that the numbers are right. They are! The values are stored in the hartinfo array in rv_dm.sv, which gets initialised with DebugHartInfo (defined a few lines earlier). This has reset values that match the DV code.