### PR TITLE
[RV_DM] rv_dm_sba_debug_disabled_vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -294,7 +294,7 @@
             - Verify via assertion checks, no transactions were seen on the SBA TL interface.
             '''
       stage: V2
-      tests: [] // TODO(#15668)
+      tests: ["rv_dm_sba_debug_disabled"]
     }
     {
       name: ndmreset_req

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -45,6 +45,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_sba_debug_disabled_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_debug_disabled_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_sba_debug_disabled_vseq extends rv_dm_sba_tl_access_vseq;
+  `uvm_object_utils(rv_dm_sba_debug_disabled_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
+  task sba_access();
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1));
+    req = sba_access_item::type_id::create("req");
+    randomize_req(req);
+    cfg.debugger.sba_access(req);
+  endtask
+
+  task body();
+    repeat ($urandom_range(1, 10)) begin
+      sba_access();
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+      cfg.rv_dm_vif.lc_hw_debug_en = get_rand_lc_tx_val(.t_weight(0), .f_weight(1),
+                                                        .other_weight(4));
+      sba_access();
+      `DV_CHECK_EQ(req.is_err, SbaErrNone)
+    end
+  endtask : body
+endclass  : rv_dm_sba_debug_disabled_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -23,3 +23,4 @@
 `include "rv_dm_jtag_dmi_dm_inactive_vseq.sv"
 `include "rv_dm_jtag_dmi_debug_disabled_vseq.sv"
 `include "rv_dm_jtag_dtm_hard_reset_vseq.sv"
+`include "rv_dm_sba_debug_disabled_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -250,6 +250,11 @@
       uvm_test_seq: rv_dm_jtag_dtm_hard_reset_vseq
       reseed: 2
     }
+    {
+      name: rv_dm_sba_debug_disabled
+      uvm_test_seq: rv_dm_sba_debug_disabled_vseq
+      reseed: 2
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
The test ensures that the SBA interface is disabled when 'lc_hw_debug_en' is not set to true, ensuring no SBA TL accesses occur. This commit contains only test sequence as suggested to separate it from scoreboard.