### PR TITLE
[RV_DM]rv_dm_scoreboard

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -186,10 +186,15 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
                                 item.sprint(uvm_default_line_printer)), UVM_HIGH)
       if (sba_tl_access_q.size() > 0) begin
         compare_sba_access(item, sba_tl_access_q.pop_front());
+      end else if (cfg.rv_dm_vif.lc_hw_debug_en==lc_ctrl_pkg::Off) begin
+        `uvm_info(`gfn, $sformatf("Received predicted SBA access but lc_hw_debug_en is set to",
+                                  "not strict true value, so no transaction was seen on",
+                                  "SBA TL host interface.:\n%0s",
+                                  item.sprint(uvm_default_line_printer)), UVM_HIGH)
       end else begin
         `uvm_error(`gfn, $sformatf({"Received predicted SBA access but no transaction was seen on ",
                                     "the SBA TL host interface: %0s"},
-                                   item.sprint(uvm_default_line_printer)))
+                                    item.sprint(uvm_default_line_printer)))
       end
     end
   endtask


### PR DESCRIPTION
This commit contains a change in line of code that is passing criteria for our 'rv_dm_sba_debug_disabled_vseq'. Our test condition is that no transaction was seen on TL SBA interface when 'lc_hw_debug_en' is Off.So that's why we add this line in scoreboard.