### PR TITLE
[sival,uart] Add uart_tx_rx_test as target for two points

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -21,6 +21,7 @@
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx"]
       tags: ["gls"]
+      bazel: ["//sw/device/tests:uart_tx_rx_test"]
     }
     {
       name: chip_sw_uart_rx_overflow
@@ -37,6 +38,7 @@
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
               "chip_sw_uart_tx_rx_idx3"]
+      bazel: ["//sw/device/tests:uart_tx_rx_test"]
     }
     {
       name: chip_sw_uart_rand_baudrate
@@ -147,7 +149,8 @@
       stage: V3
       si_stage: SV3
       features: ["UART.FIFO_INTERRUPTS"]
-      tests: []
+      tests: ["chip_sw_uart_tx_rx"]
+      bazel: ["//sw/device/tests:uart_tx_rx_test"]
     },
 
   ]


### PR DESCRIPTION
The `uart_rx_overflow` and `uart_watermarks` test points are both covered by the existing `uart_tx_rx_test` target.

Resolves #19871 and resolves #19872.