### PR TITLE
[dma,dv] Randomly select between OT-internal and CTN target memory

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -137,6 +137,13 @@ SECTIONS {
   } > ottf_flash
 
   /**
+   * Section for data that is stored in the CTN RAM outside of top_darjeeling
+   */
+  .ctn_data : ALIGN(4) {
+    KEEP(*(.ctn_data))
+  } > ottf_flash
+
+  /**
    * Critical static data that is accessible by both the ROM and the ROM
    * extension.
    */


### PR DESCRIPTION
This PR changes the second DMA transfer to randomly target the OT-internal or the CTN memory. The second transfer does not use inline hashing, thus we can test all transfer widths, which are selected randomly.

To place an array in the CTN memory, a new `.ctn_data` section was added to the linker script.

This PR build upon the changes from https://github.com/lowRISC/opentitan/pull/20899