### PR TITLE
[keymgr_dpe/rtl] Take max key version into account for root key

### DIFF
--- a/hw/ip/keymgr_dpe/doc/theory_of_operation.md
+++ b/hw/ip/keymgr_dpe/doc/theory_of_operation.md
@@ -123,7 +123,7 @@ Advancing a keymgr_dpe slot (also referred to as _deriving a child_) uses multip
 In particular, since there are multiple slots inside keymgr_dpe, source and destination parameters need to be passed to advance calls.
 
 The very first advance call only latches the OTP creator root key (UDS), therefore most of these registers are ignored during the first call.
-The only relevant registers (or register fields) during the first advance call are: `CONTROL_SHADOWED.OPERATION`, `CONTROL_SHADOWED.SLOT_DST_SEL` and `START`.
+The only relevant registers (or register fields) during the first advance call are: `CONTROL_SHADOWED.OPERATION`, `MAX_KEY_VER_SHADOWED`, `CONTROL_SHADOWED.SLOT_DST_SEL` and `START`.
 
 In particular, the destination slot for the UDS is chosen by SW, and there is no designated special slot for it.
 Moreover, since the destination slot for this first advance call has no parent, its `boot_stage` value is not incremented but initialized to `0`.

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_ctrl.sv
@@ -291,6 +291,7 @@ module keymgr_dpe_ctrl
         key_slots_d[slot_dst_sel_i].boot_stage = 0;
         key_slots_d[slot_dst_sel_i].key[0] ^= root_key_i.key[0];
         key_slots_d[slot_dst_sel_i].key[1] ^= root_key_i.key[1];
+        key_slots_d[slot_dst_sel_i].max_key_version = max_key_version_i;
         key_slots_d[slot_dst_sel_i].key_policy = DEFAULT_UDS_POLICY;
       end
 


### PR DESCRIPTION
Technically it's possible to generate output keys from the root key (i.e., the key with boot stage 0), so it is meaningful to allow SW to set the maximum key version when invoking the advance operation that loads the root key.  Prior to this commit, `keymgr_dpe` would ignore the `MAX_KEY_VER_SHADOWED` CSR for the root key and always set its maximum key version to zero -- that's now fixed.

I ran 10x the seeds of the current `keymgr_dpe_smoke` test with this change and get a nominal pass rate (99.6%) with no errors we haven't seen yet.

@neeraj-rv: as discussed yesterday.
@bobby-rivos: If you can test this without much extra work, could you please do so?


