### PR TITLE
[test] Use ram_ctn memory instead of aliased ottf_flash

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -141,7 +141,7 @@ SECTIONS {
    */
   .ctn_data : ALIGN(4) {
     KEEP(*(.ctn_data))
-  } > ottf_flash
+  } > ram_ctn
 
   /**
    * Critical static data that is accessible by both the ROM and the ROM


### PR DESCRIPTION
This was missing on the last PR