### PR TITLE
[opentitantool] Allow changing which pins to use for JTAG

### DIFF
--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -183,6 +183,15 @@ pub struct Bootstrap {
     pub image_path: PathBuf,
 }
 
+/// Some transports allow dynamically changing which pins are used for JTAG.
+pub struct SetJtagPins {
+    pub tclk: Option<Rc<dyn GpioPin>>,
+    pub tms: Option<Rc<dyn GpioPin>>,
+    pub tdi: Option<Rc<dyn GpioPin>>,
+    pub tdo: Option<Rc<dyn GpioPin>>,
+    pub trst: Option<Rc<dyn GpioPin>>,
+}
+
 pub trait ProgressIndicator {
     // Begins a new stage, indicating "size" of this stage in bytes.  `name` can be the empty
     // string, for instance if the operation has only a single stage.


### PR DESCRIPTION
HyperDebug by default does JTAG on five particular pins.  However, as it is all bit-banging with no true hardware support, it is able to use almost any combination of pins.

This PR introduces a transport-specific command to "move" the JTAG functionality to a different set of pins.

Usage:
`opentitantool --interface=hyperdebug transport set-jtag-pins <TCLK> <TMS> <TDI> <TDO> <TRSTn>`
