### PR TITLE
[keymgr_dpe/rtl] Fix assignment of creator root key shares from OTP

### DIFF
--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -265,8 +265,8 @@ module keymgr_dpe
   end
 
   hw_key_req_t root_key;
-  assign root_key.key = '{otp_key_i.creator_root_key_share0,
-                          otp_key_i.creator_root_key_share1};
+  assign root_key.key = '{otp_key_i.creator_root_key_share1,
+                          otp_key_i.creator_root_key_share0};
 
   prim_flop_2sync # (
     .Width(1)


### PR DESCRIPTION
The logic vector that holds the key is defined as "downto" over the shares, whereas the assignment prior to this commit assigned share 0 to the more significant bits and share 1 to the less significant bits. This is likely not a problem as the shares get XOR'ed (and XOR is commutative) but it is unnecessarily complicated to verify in DV.