### PR TITLE
[boards] reorganize LED SiVal board driver code into lib

### DIFF
--- a/sw/device/examples/teacup_demos/BUILD
+++ b/sw/device/examples/teacup_demos/BUILD
@@ -18,8 +18,8 @@ opentitan_test(
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/boards/teacup_v1_3_0:leds",
         "//sw/device/lib/dif:i2c",
-        "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:i2c_testutils",

--- a/sw/device/examples/teacup_demos/teacup_leds_demo.c
+++ b/sw/device/examples/teacup_demos/teacup_leds_demo.c
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/boards/teacup_v1_3_0/leds.h"
 #include "sw/device/lib/dif/dif_i2c.h"
-#include "sw/device/lib/dif/dif_spi_host.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/i2c_testutils.h"
@@ -21,99 +21,36 @@ static dif_i2c_t i2c;
 static dif_pinmux_t pinmux;
 
 /**
- * Teacup RGB LEDs.
- */
-typedef enum teacup_led {
-  kTeacupLedDs5 = 0,
-  kTeacupLedDs9 = 1,
-  kTeacupLedDs10 = 2,
-  kTeacupLedDs11 = 3,
-} teacup_led_t;
-
-/**
- * LED RGB color value.
- */
-typedef struct rgb_color {
-  uint8_t r;
-  uint8_t g;
-  uint8_t b;
-} rgb_color_t;
-
-/**
  * Defined Constants.
  */
 enum {
-  // Teacup LED Controller
-  kDeviceAddr = 0x34,
-
-  // Teacup LED Controller Registers
-  kControlRegAddr = 0x00,
-  kUpdateRegAddr = 0x49,
-  kLedChannel0ScalingRegAddr = 0x4D,
-  kGlobalCurrentControlRegAddr = 0x6E,
-
-  // LED DS5
-  // Blue
-  kPwmReg0LowAddr = 0x07,
-  // Red
-  kPwmReg1LowAddr = 0x09,
-  // Green
-  kPwmReg2LowAddr = 0x0B,
-
-  // LED DS9
-  // Blue
-  kPwmReg3LowAddr = 0x0D,
-  // Red
-  kPwmReg4LowAddr = 0x0F,
-  // Green
-  kPwmReg5LowAddr = 0x11,
-
-  // LED DS10
-  // Blue
-  kPwmReg6LowAddr = 0x13,
-  // Red
-  kPwmReg7LowAddr = 0x15,
-  // Green
-  kPwmReg8LowAddr = 0x17,
-
-  // LED DS11
-  // Blue
-  kPwmReg9LowAddr = 0x19,
-  // Red
-  kPwmReg10LowAddr = 0x1B,
-  // Green
-  kPwmReg11LowAddr = 0x1D,
-
-  // Other
-  kTotalNumLedsOnBoard = 4,
-  kNumLedCycles = 100,
-  kNumColorsInCycle = 4,
+  kLedNumCycles = 100,
+  kLedNumColorsInCycle = 4,
   kLedCyclePauseMilliseconds = 200,
   kLedBrightnessLowPercent = 5,
   kLedBrightnessHighPercent = 40,
   kLedBrightnessStepPercent = 5,
-  kDefaultTimeoutMicros = 1000,
 };
 
-static const rgb_color_t kColorBlue = {
+static const led_rgb_color_t kLedColorBlue = {
     .r = 0x33,
     .g = 0x69,
     .b = 0xE8,
 };
 
-static const rgb_color_t kColorRed = {
+static const led_rgb_color_t kLedColorRed = {
     .r = 0xD5,
     .g = 0x0F,
     .b = 0x25,
 };
 
-static const rgb_color_t kColorYellow = {
+static const led_rgb_color_t kLedColorYellow = {
     .r = 0xEE,
     .g = 0xB2,
     .b = 0x11,
 };
 
-static const rgb_color_t kColorGreen = {
+static const led_rgb_color_t kLedColorGreen = {
     .r = 0x00,
     .g = 0x99,
     .b = 0x25,
@@ -138,138 +75,17 @@ static status_t peripheral_init(void) {
   return OK_STATUS();
 }
 
-static status_t read_led_ctrl_reg(uint8_t reg_addr, uint8_t *data_out) {
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/1, &reg_addr,
-                          /*skip_stop=*/false));
-  TRY(i2c_testutils_read(&i2c, kDeviceAddr, /*byte_count=*/1, data_out,
-                         kDefaultTimeoutMicros));
-  return OK_STATUS();
-}
-
-static status_t set_led_ctrl_color(teacup_led_t led, const rgb_color_t *color) {
-  // Get register addresses for desired LED.
-  uint8_t b_pwm_low_reg;
-  uint8_t r_pwm_low_reg;
-  uint8_t g_pwm_low_reg;
-  switch (led) {
-    case kTeacupLedDs5:
-      b_pwm_low_reg = kPwmReg0LowAddr;
-      r_pwm_low_reg = kPwmReg1LowAddr;
-      g_pwm_low_reg = kPwmReg2LowAddr;
-      break;
-    case kTeacupLedDs9:
-      b_pwm_low_reg = kPwmReg3LowAddr;
-      r_pwm_low_reg = kPwmReg4LowAddr;
-      g_pwm_low_reg = kPwmReg5LowAddr;
-      break;
-    case kTeacupLedDs10:
-      b_pwm_low_reg = kPwmReg6LowAddr;
-      r_pwm_low_reg = kPwmReg7LowAddr;
-      g_pwm_low_reg = kPwmReg8LowAddr;
-      break;
-    case kTeacupLedDs11:
-      b_pwm_low_reg = kPwmReg9LowAddr;
-      r_pwm_low_reg = kPwmReg10LowAddr;
-      g_pwm_low_reg = kPwmReg11LowAddr;
-      break;
-    default:
-      return INTERNAL();
-  }
-
-  // Set PWM duty cycle for each color channel of the specified LED.
-  // Blue
-  uint8_t blue_data[2] = {b_pwm_low_reg, color->b};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(blue_data),
-                          blue_data,
-                          /*skip_stop=*/false));
-  // Red
-  uint8_t red_data[2] = {r_pwm_low_reg, color->r};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(red_data),
-                          red_data,
-                          /*skip_stop=*/false));
-  // Green
-  uint8_t green_data[2] = {g_pwm_low_reg, color->g};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(green_data),
-                          green_data,
-                          /*skip_stop=*/false));
-
-  // Activate PWM configurations.
-  uint8_t data[2] = {kUpdateRegAddr, 0};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
-
-  return OK_STATUS();
-}
-
-static status_t config_i2c_led_controller(void) {
+static status_t configure_led_i2c_controller(void) {
   TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedFastPlus));
-
-  // Set control register to 0x0 to enable:
-  // - Software shutdown mode (keep LEDs off until explicitly turned on)
-  // - 8-bit (PWM resolution)
-  // - 16MHz (max oscillator clock frequency)
-  uint8_t data[2] = {kControlRegAddr, 0};
-  uint8_t reg_val = 0;
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
-  TRY(read_led_ctrl_reg(kControlRegAddr, &reg_val));
-  LOG_INFO("Control Reg = 0x%02x", reg_val);
-
-  // Set global current control to ~30%.
-  data[0] = kGlobalCurrentControlRegAddr;
-  data[1] = (uint8_t)((float)0xFF * (float)kLedBrightnessLowPercent / 100.0);
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
-  TRY(read_led_ctrl_reg(kGlobalCurrentControlRegAddr, &reg_val));
-  LOG_INFO("Global Current Control Reg = 0x%02x", reg_val);
-
-  // Set each PWM channel's current control to 100%.
-  data[0] = kLedChannel0ScalingRegAddr;
-  data[1] = 0xFF;
-  for (size_t i = 0; i < 12; ++i) {
-    TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data),
-                            data,
-                            /*skip_stop=*/false));
-    TRY(read_led_ctrl_reg(data[0], &reg_val));
-    LOG_INFO("LED Channel %d Scaling Reg = 0x%02x", i, reg_val);
-    data[0]++;
-  }
-
-  return OK_STATUS();
-}
-
-static status_t set_global_led_brightness(uint8_t brightness) {
-  uint8_t data[2] = {kGlobalCurrentControlRegAddr, brightness};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
-  return OK_STATUS();
-}
-
-static status_t turn_off_leds(void) {
-  LOG_INFO("Turning off LEDs via software shutdown bit ...");
-  uint8_t ctrl_reg_val = 0;
-  TRY(read_led_ctrl_reg(kControlRegAddr, &ctrl_reg_val));
-  uint8_t data[2] = {kControlRegAddr, ctrl_reg_val & ~0x1};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
-  return OK_STATUS();
-}
-
-static status_t turn_on_leds(void) {
-  LOG_INFO("Turning on LEDs via software shutdown bit ...");
-  uint8_t ctrl_reg_val = 0;
-  TRY(read_led_ctrl_reg(kControlRegAddr, &ctrl_reg_val));
-  uint8_t data[2] = {kControlRegAddr, ctrl_reg_val | 0x1};
-  TRY(i2c_testutils_write(&i2c, kDeviceAddr, /*byte_count=*/sizeof(data), data,
-                          /*skip_stop=*/false));
+  TRY(leds_i2c_controller_configure(&i2c));
   return OK_STATUS();
 }
 
 bool test_main(void) {
   CHECK_STATUS_OK(peripheral_init());
-  CHECK_STATUS_OK(config_i2c_led_controller());
-  CHECK_STATUS_OK(turn_on_leds());
+  CHECK_STATUS_OK(configure_led_i2c_controller());
+  CHECK_STATUS_OK(leds_turn_all_on(&i2c));
 
   // Brightness levels and colors.
   uint8_t brightness_start =
@@ -279,20 +95,20 @@ bool test_main(void) {
   uint8_t brightness_step =
       (uint8_t)((float)0xFF * (float)kLedBrightnessStepPercent / 100.0);
   uint8_t curr_brightness = brightness_start;
-  const rgb_color_t kColorCycle[kNumColorsInCycle] = {
-      kColorBlue,
-      kColorRed,
-      kColorYellow,
-      kColorGreen,
+  const led_rgb_color_t kColorCycle[kLedNumColorsInCycle] = {
+      kLedColorBlue,
+      kLedColorRed,
+      kLedColorYellow,
+      kLedColorGreen,
   };
 
   // Cycle through brightness levels and colors.
-  for (size_t i = 0; i < kNumLedCycles; ++i) {
-    for (size_t j = 0; j < kNumColorsInCycle; ++j) {
+  for (size_t i = 0; i < kLedNumCycles; ++i) {
+    for (size_t j = 0; j < kLedNumColorsInCycle; ++j) {
       CHECK_STATUS_OK(
-          set_led_ctrl_color((i + j) % kTotalNumLedsOnBoard, &kColorCycle[j]));
+          leds_set_color(&i2c, (i + j) % kNumTeacupLeds, kColorCycle[j]));
     }
-    CHECK_STATUS_OK(set_global_led_brightness(curr_brightness));
+    CHECK_STATUS_OK(leds_set_all_brightness(&i2c, curr_brightness));
     curr_brightness += brightness_step;
     if (curr_brightness >= brightness_end ||
         curr_brightness <= brightness_start) {
@@ -301,7 +117,7 @@ bool test_main(void) {
     busy_spin_micros(kLedCyclePauseMilliseconds * 1000);
   }
 
-  CHECK_STATUS_OK(turn_off_leds());
+  CHECK_STATUS_OK(leds_turn_all_off(&i2c));
 
   return true;
 }

--- a/sw/device/lib/boards/teacup_v1_3_0/BUILD
+++ b/sw/device/lib/boards/teacup_v1_3_0/BUILD
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "leds",
+    srcs = ["leds.c"],
+    hdrs = ["leds.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:i2c_testutils",
+    ],
+)

--- a/sw/device/lib/boards/teacup_v1_3_0/leds.c
+++ b/sw/device/lib/boards/teacup_v1_3_0/leds.c
@@ -1,0 +1,145 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/boards/teacup_v1_3_0/leds.h"
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/i2c_testutils.h"
+
+static const size_t kDefaultI2cReadTimeoutMicros = 1000;
+
+status_t leds_read_ctrl_reg(const dif_i2c_t *i2c, uint8_t reg_addr,
+                            uint8_t *data_out) {
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/1, &reg_addr,
+                          /*skip_stop=*/false));
+  TRY(i2c_testutils_read(i2c, kLedsDriverI2cAddr, /*byte_count=*/1, data_out,
+                         kDefaultI2cReadTimeoutMicros));
+  return OK_STATUS();
+}
+
+status_t leds_set_color(const dif_i2c_t *i2c, teacup_led_t led,
+                        led_rgb_color_t color) {
+  // Get register addresses for desired LED.
+  uint8_t b_pwm_low_reg;
+  uint8_t r_pwm_low_reg;
+  uint8_t g_pwm_low_reg;
+  switch (led) {
+    case kTeacupLedDs5:
+      b_pwm_low_reg = kLedBlue0LowRegAddr;
+      r_pwm_low_reg = kLedRed0LowRegAddr;
+      g_pwm_low_reg = kLedGreen0LowRegAddr;
+      break;
+    case kTeacupLedDs9:
+      b_pwm_low_reg = kLedBlue1LowRegAddr;
+      r_pwm_low_reg = kLedRed1LowRegAddr;
+      g_pwm_low_reg = kLedGreen1LowRegAddr;
+      break;
+    case kTeacupLedDs10:
+      b_pwm_low_reg = kLedBlue2LowRegAddr;
+      r_pwm_low_reg = kLedRed2LowRegAddr;
+      g_pwm_low_reg = kLedGreen2LowRegAddr;
+      break;
+    case kTeacupLedDs11:
+      b_pwm_low_reg = kLedBlue3LowRegAddr;
+      r_pwm_low_reg = kLedRed3LowRegAddr;
+      g_pwm_low_reg = kLedGreen3LowRegAddr;
+      break;
+    default:
+      return INTERNAL();
+  }
+
+  // Set PWM duty cycle for each color channel of the specified LED.
+  // Blue
+  uint8_t blue_data[2] = {b_pwm_low_reg, color.b};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr,
+                          /*byte_count=*/sizeof(blue_data), blue_data,
+                          /*skip_stop=*/false));
+  // Red
+  uint8_t red_data[2] = {r_pwm_low_reg, color.r};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr,
+                          /*byte_count=*/sizeof(red_data), red_data,
+                          /*skip_stop=*/false));
+  // Green
+  uint8_t green_data[2] = {g_pwm_low_reg, color.g};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr,
+                          /*byte_count=*/sizeof(green_data), green_data,
+                          /*skip_stop=*/false));
+
+  // Activate PWM configurations.
+  uint8_t data[2] = {kLedUpdateRegAddr, 0};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+
+  return OK_STATUS();
+}
+
+status_t leds_set_all_brightness(const dif_i2c_t *i2c, uint8_t brightness) {
+  uint8_t data[2] = {kLedGlobalCurrentControlRegAddr, brightness};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+  return OK_STATUS();
+}
+
+status_t leds_i2c_controller_configure(const dif_i2c_t *i2c) {
+  // Set control register to 0x0 to enable:
+  // - Software shutdown mode (keep LEDs off until explicitly turned on)
+  // - 8-bit (PWM resolution)
+  // - 16MHz (max oscillator clock frequency)
+  uint8_t data[2] = {kLedsControlRegAddr, 0};
+  uint8_t reg_val = 0;
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+  TRY(leds_read_ctrl_reg(i2c, kLedsControlRegAddr, &reg_val));
+  LOG_INFO("Control Reg = 0x%02x", reg_val);
+
+  // Set global current control to ~30%.
+  data[0] = kLedGlobalCurrentControlRegAddr;
+  data[1] = (uint8_t)((float)0xFF * 30.0 / 100.0);
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+  TRY(leds_read_ctrl_reg(i2c, kLedGlobalCurrentControlRegAddr, &reg_val));
+  LOG_INFO("Global Current Control Reg = 0x%02x", reg_val);
+
+  // Set each PWM channel's current control to 100%.
+  data[0] = kLedChannel0ScalingRegAddr;
+  data[1] = 0xFF;
+  for (size_t i = 0; i < 12; ++i) {
+    TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr,
+                            /*byte_count=*/sizeof(data), data,
+                            /*skip_stop=*/false));
+    TRY(leds_read_ctrl_reg(i2c, data[0], &reg_val));
+    LOG_INFO("LED Channel %d Scaling Reg = 0x%02x", i, reg_val);
+    data[0]++;
+  }
+
+  return OK_STATUS();
+}
+
+status_t leds_turn_all_off(const dif_i2c_t *i2c) {
+  LOG_INFO("Turning off LEDs via software shutdown bit ...");
+  uint8_t ctrl_reg_val = 0;
+  TRY(leds_read_ctrl_reg(i2c, kLedsControlRegAddr, &ctrl_reg_val));
+  uint8_t data[2] = {kLedsControlRegAddr, ctrl_reg_val & ~0x1};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+  return OK_STATUS();
+}
+
+status_t leds_turn_all_on(const dif_i2c_t *i2c) {
+  LOG_INFO("Turning on LEDs via software shutdown bit ...");
+  uint8_t ctrl_reg_val = 0;
+  TRY(leds_read_ctrl_reg(i2c, kLedsControlRegAddr, &ctrl_reg_val));
+  uint8_t data[2] = {kLedsControlRegAddr, ctrl_reg_val | 0x1};
+  TRY(i2c_testutils_write(i2c, kLedsDriverI2cAddr, /*byte_count=*/sizeof(data),
+                          data,
+                          /*skip_stop=*/false));
+  return OK_STATUS();
+}

--- a/sw/device/lib/boards/teacup_v1_3_0/leds.h
+++ b/sw/device/lib/boards/teacup_v1_3_0/leds.h
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BOARDS_TEACUP_V1_3_0_LEDS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BOARDS_TEACUP_V1_3_0_LEDS_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_i2c.h"
+
+/**
+ * Defined Constants.
+ */
+enum {
+  // Teacup LED Controller
+  kLedsDriverI2cAddr = 0x34,
+
+  // Teacup LED Controller Registers
+  kLedsControlRegAddr = 0x00,
+  kLedUpdateRegAddr = 0x49,
+  kLedChannel0ScalingRegAddr = 0x4D,
+  kLedGlobalCurrentControlRegAddr = 0x6E,
+
+  // LED DS5
+  kLedBlue0LowRegAddr = 0x07,
+  kLedRed0LowRegAddr = 0x09,
+  kLedGreen0LowRegAddr = 0x0B,
+
+  // LED DS9
+  kLedBlue1LowRegAddr = 0x0D,
+  kLedRed1LowRegAddr = 0x0F,
+  kLedGreen1LowRegAddr = 0x11,
+
+  // LED DS10
+  kLedBlue2LowRegAddr = 0x13,
+  kLedRed2LowRegAddr = 0x15,
+  kLedGreen2LowRegAddr = 0x17,
+
+  // LED DS11
+  kLedBlue3LowRegAddr = 0x19,
+  kLedRed3LowRegAddr = 0x1B,
+  kLedGreen3LowRegAddr = 0x1D,
+
+  // Other
+  kNumTeacupLeds = 4,
+};
+
+/**
+ * Teacup RGB LEDs.
+ */
+typedef enum teacup_led {
+  kTeacupLedDs5 = 0,
+  kTeacupLedDs9 = 1,
+  kTeacupLedDs10 = 2,
+  kTeacupLedDs11 = 3,
+} teacup_led_t;
+
+/**
+ * LED RGB color value.
+ */
+typedef struct led_rgb_color {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} led_rgb_color_t;
+
+/**
+ * Reads the teacup LED controller's control register.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ * @param reg_addr Address of the I2C LED controller to read.
+ * @param[out] data_out Data read from the I2C LED controller.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_read_ctrl_reg(const dif_i2c_t *i2c, uint8_t reg_addr,
+                            uint8_t *data_out);
+
+/**
+ * Sets the color for a specific teacup LED.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ * @param led The teacup LED to configure.
+ * @param color The color to set the LED to.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_set_color(const dif_i2c_t *i2c, teacup_led_t led,
+                        led_rgb_color_t color);
+
+/**
+ * Sets the brightness (global current control) of all LEDs on the teacup board.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ * @param brightness The brightness value, in [0, 255], to set the LED to.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_set_all_brightness(const dif_i2c_t *i2c, uint8_t brightness);
+
+/**
+ * Configures the I2C LED controller on the teacup board.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_i2c_controller_configure(const dif_i2c_t *i2c);
+
+/**
+ * Turns all LEDs off, on the teacup board.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_turn_all_off(const dif_i2c_t *i2c);
+
+/**
+ * Turns all LEDs on, on the teacup board.
+ *
+ * @param i2c I2C handle to communicate with the I2C LED controller.
+ */
+OT_WARN_UNUSED_RESULT
+status_t leds_turn_all_on(const dif_i2c_t *i2c);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BOARDS_TEACUP_V1_3_0_LEDS_H_


### PR DESCRIPTION
This refactors the SiVal board LED driver code into a separate library that is useable by other code.