### PR TITLE
[top_earlgrey] Add flash_ctrl_write_clear_test to DV and SiVal environments

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -284,5 +284,29 @@
       si_stage: None
       tests: ["chip_sw_flash_crash_alert"]
     }
+    {
+      name: chip_sw_flash_ctrl_write_clear
+      desc: '''Verify the flash is able to process a second write to clear all bits
+            when ECC is enabled.
+
+            Configure memory protected entries to override the default flash configuration as follows:
+            1. ECC enabled, scrambling and high endurance disabled.
+            2. ECC and high endurance enabled, scrambling disabled.
+
+            Test the following sequence:
+            - Set one of the configuration options above.
+            - Erase target page.
+            - Write and verify intermediate value, different than all 1s or 0s.
+            - Write and verify all 0s.
+
+            The flash should not throw any errors on the second write.
+
+            Note: The hardware does not support this behavior when scrambling is enabled.
+            '''
+      stage: V2
+      si_stage: SV3
+      tests: ["chip_sw_flash_crash_alert"]
+      bazel: ["//sw/device/tests:flash_ctrl_write_clear_test"]
+    }
   ]
 }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1940,6 +1940,13 @@
       run_opts: ["+test_timeout_ns=8_000_000", "+bypass_alert_ready_to_end_check=1"]
     }
     {
+      name: chip_sw_flash_ctrl_write_clear
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests/sim_dv:flash_ctrl_write_clear_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+test_timeout_ns=8_000_000"]
+    }
+    {
       name: chip_padctrl_attributes
       build_mode: "pad_ctrl_test_mode"
       uvm_test_seq: chip_padctrl_attributes_vseq

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1652,6 +1652,29 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "flash_ctrl_write_clear_test",
+    srcs = ["flash_ctrl_write_clear_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+        },
+    ),
+    verilator = new_verilator_params(timeout = "long"),
+    deps = [
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "flash_ctrl_mem_protection_test",
     srcs = ["flash_ctrl_mem_protection_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/flash_ctrl_write_clear_test.c
+++ b/sw/device/tests/flash_ctrl_write_clear_test.c
@@ -86,9 +86,15 @@ static void flash_ctrl_write_clear_test(
       &flash, start_addr, kUnusedDataPartitionParam,
       kDifFlashCtrlPartitionTypeData));
 
-  const uint64_t kExpectedValue = 0xa5a5a5a594949494;
-  flash_word_write_verify(start_addr, kExpectedValue);
-  flash_word_write_verify(start_addr, /*expected_value*/ 0);
+  const uint64_t kExpectedValues[] = {
+      UINT64_MAX, UINT64_MAX - 1, 0, 0xa5a5a5a594949494, 0xaaaaaaaaaaaaaaaa,
+  };
+
+  for (size_t i = 0; i < ARRAYSIZE(kExpectedValues); ++i) {
+    flash_word_write_verify(start_addr + sizeof(uint64_t) * i,
+                            kExpectedValues[i]);
+    flash_word_write_verify(start_addr, /*expected_value=*/0);
+  }
 }
 
 bool test_main(void) {

--- a/sw/device/tests/flash_ctrl_write_clear_test.c
+++ b/sw/device/tests/flash_ctrl_write_clear_test.c
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/boot_stage.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+
+#include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// See chip_sw_flash_ctrl_write_clear in chip_flash_ctrl_testplan.hjson for
+// test description.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  // Some dif_flash_ctrl functions don't require the partition parameter when
+  // interacting with data partitions. This constant is added to improve
+  // readability.
+  kUnusedDataPartitionParam = 0,
+
+  // Number of bytes per page.
+  kFlashBytesPerPage = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+
+  // Number of pages allocated to the ROM_EXT. The same number of pages are
+  // allocated at the begining of each data bank.
+  kRomExtPageCount = CHIP_ROM_EXT_SIZE_MAX / kFlashBytesPerPage,
+
+  // The start page used by this test. Points to the start of the owner
+  // partition in bank 1, otherwise known as owner partition B.
+  kBank1StartPageNum = 256 + kRomExtPageCount,
+};
+
+// The `flash_word_verify()` function will need to be updated if this assertion
+// fails.
+static_assert(
+    FLASH_CTRL_PARAM_BYTES_PER_WORD == sizeof(uint64_t),
+    "This test expects the flash word to be sizeof(uint64_t) bytes long.");
+
+static dif_flash_ctrl_state_t flash;
+
+/**
+ * Write and verify `expected_value` at flash `address`.
+ *
+ * This function generates a test assertion on failure.
+ *
+ * @param address Flash address, uint32_t aligned.
+ * @param expected_value Value to write and verify.
+ */
+static void flash_word_write_verify(uintptr_t address,
+                                    uint64_t expected_value) {
+  size_t kWordSize = sizeof(uint64_t) / sizeof(uint32_t);
+  CHECK_STATUS_OK(flash_ctrl_testutils_write(
+      &flash, address, kUnusedDataPartitionParam, (uint32_t *)&expected_value,
+      kDifFlashCtrlPartitionTypeData, kWordSize));
+
+  uint64_t got_value;
+  CHECK_STATUS_OK(flash_ctrl_testutils_read(
+      &flash, address, kUnusedDataPartitionParam, (uint32_t *)&got_value,
+      kDifFlashCtrlPartitionTypeData, kWordSize,
+      /*delay=*/1));
+  CHECK(expected_value == got_value);
+}
+
+static void flash_ctrl_write_clear_test(
+    uint32_t mp_region_index,
+    dif_flash_ctrl_data_region_properties_t mp_properties) {
+  // Configure a memory protected region to implement the page configuration
+  // set in `mp_properties`.
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_properties(
+      &flash, mp_region_index, mp_properties));
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_enablement(
+      &flash, mp_region_index, kDifToggleEnabled));
+
+  uintptr_t start_addr = (uintptr_t)(mp_properties.base * kFlashBytesPerPage);
+  CHECK_STATUS_OK(flash_ctrl_testutils_erase_page(
+      &flash, start_addr, kUnusedDataPartitionParam,
+      kDifFlashCtrlPartitionTypeData));
+
+  const uint64_t kExpectedValue = 0xa5a5a5a594949494;
+  flash_word_write_verify(start_addr, kExpectedValue);
+  flash_word_write_verify(start_addr, /*expected_value*/ 0);
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  // The ROM_EXT configures the default region access. We can't modify the
+  // values after configured.
+  if (kBootStage != kBootStageOwner) {
+    CHECK_STATUS_OK(flash_ctrl_testutils_default_region_access(
+        &flash, /*rd_en=*/true, /*prog_en=*/true, /*erase_en=*/true,
+        /*scramble_en=*/false, /*ecc_en=*/false, /*high_endurance_en=*/false));
+  }
+
+  LOG_INFO("ECC enabled with high endurance disabled.");
+  flash_ctrl_write_clear_test(/*mp_region_index=*/0,
+                              (dif_flash_ctrl_data_region_properties_t){
+                                  .base = kBank1StartPageNum,
+                                  .size = 1,
+                                  .properties = {
+                                      .rd_en = kMultiBitBool4True,
+                                      .prog_en = kMultiBitBool4True,
+                                      .erase_en = kMultiBitBool4True,
+                                      .scramble_en = kMultiBitBool4False,
+                                      .ecc_en = kMultiBitBool4True,
+                                      .high_endurance_en = kMultiBitBool4False,
+                                  }});
+
+  LOG_INFO("ECC enabled with high endurance enabled.");
+  flash_ctrl_write_clear_test(/*mp_region_index=*/1,
+                              (dif_flash_ctrl_data_region_properties_t){
+                                  .base = kBank1StartPageNum + 1,
+                                  .size = 1,
+                                  .properties = {
+                                      .rd_en = kMultiBitBool4True,
+                                      .prog_en = kMultiBitBool4True,
+                                      .erase_en = kMultiBitBool4True,
+                                      .scramble_en = kMultiBitBool4False,
+                                      .ecc_en = kMultiBitBool4True,
+                                      .high_endurance_en = kMultiBitBool4True,
+                                  }});
+
+  return true;
+}


### PR DESCRIPTION
Adds test to verify 2nd write to clear (all 00s) requirement. The flash
ECC must map a 0 word value to a 0 encoding. This is an use case
requirement.
