### PR TITLE
[sca] Fix trigger parsing

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/trigger_sca.c
@@ -27,7 +27,7 @@ status_t handle_trigger_sca_select_source(ujson_t *uj) {
   cryptotest_trigger_sca_source_t uj_trigger;
   TRY(ujson_deserialize_cryptotest_trigger_sca_source_t(uj, &uj_trigger));
 
-  sca_select_trigger_type((sca_trigger_type_t)uj_trigger.source);
+  sca_select_trigger_type(uj_trigger.source);
 
   return OK_STATUS(0);
 }

--- a/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h
@@ -20,7 +20,7 @@ extern "C" {
 UJSON_SERDE_ENUM(TriggerScaSubcommand, trigger_sca_subcommand_t, TRIGGERSCA_SUBCOMMAND);
 
 #define TRIGGER_SCA_SOURCE(field, string) \
-    field(source, uint8_t, TRIGGERSCA_CMD_MAX_SOURCE_BYTES)
+    field(source, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestTriggerScaSource, cryptotest_trigger_sca_source_t, TRIGGER_SCA_SOURCE);
 
 // clang-format on


### PR DESCRIPTION
This PR fixes a bug in how the trigger select is parsed. The ot-sca framework sends a 0 to select the HW or 1 to select the SW trigger. To parse this bit, we need to  dereference the pointer and read the value.