### PR TITLE
[Sival, spi dev] Flash mode test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -23,10 +23,9 @@
         "SPI_DEVICE.MODE.FLASH_EMULATION.COMMANDS",
         "SPI_DEVICE.MODE.FLASH_EMULATION.READ_COMMAND_PROCESSOR",
         "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
-        "SPI_DEVICE.HW.LAST_READ_ADDR",
       ]
-      tests: ["chip_sw_uart_tx_rx_bootstrap"]
-      bazel: []
+      tests: ["rom_e2e_smoke"]
+      bazel: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke"]
     }
     {
       name: chip_sw_spi_device_pass_through
@@ -38,6 +37,7 @@
             - Send random flash commands over the SPI device interface (chip IOs) from the
               testbench.
             - Verify the flash commands which pass through spi_host0 are received on chip IOs.
+            - Verify the LAST_READ_ADDR.
             - Verify that only the payloads that are not filtered show up on the SPI host interface
               at chip IOs.
             - Verify spi_host1 doesn't send out any data from spi_device.
@@ -58,6 +58,7 @@
         "SPI_DEVICE.MODE.PASSTHROUGH",
         "SPI_DEVICE.HW.LANES",
         "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
+        "SPI_DEVICE.HW.LAST_READ_ADDR",
       ]
       tests: ["chip_sw_spi_device_pass_through"]
       bazel: []

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
     "//rules:opentitan_test.bzl",
     "cw310_params",
     "dv_params",
@@ -44,6 +48,7 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "opentitan_binary",
     "opentitan_test",
     "rsa_key_by_name",
@@ -317,11 +322,16 @@ opentitan_test(
     dv = new_dv_params(
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+    ),
     verilator = new_verilator_params(
         timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -3,10 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules/opentitan:defs.bzl",
-    "opentitan_binary",
-)
-load(
     "//rules:opentitan_test.bzl",
     "cw310_params",
     "dv_params",
@@ -52,6 +48,8 @@ load(
     "opentitan_test",
     "rsa_key_by_name",
     new_cw310_params = "cw310_params",
+    new_dv_params = "dv_params",
+    new_verilator_params = "verilator_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -313,25 +311,25 @@ opentitan_functest(
     ],
 )
 
-opentitan_functest(
+opentitan_test(
     name = "rom_e2e_smoke",
-    cw310 = cw310_params(
-        bitstream = "//hw/bitstream:rom_with_fake_keys",
-    ),
-    dv = dv_params(
+    srcs = ["empty_test.c"],
+    dv = new_dv_params(
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
     ),
-    key_struct = RSA_ONLY_KEY_STRUCTS[0],
-    ot_flash_binary = ":empty_test_slot_a",
-    targets = [
-        "cw310_rom_with_fake_keys",
-        "verilator",
-        "dv",
-    ],
-    verilator = verilator_params(
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    verilator = new_verilator_params(
         timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
     ),
+    deps = [
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
 )
 
 opentitan_functest(

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -65,6 +65,7 @@ test_suite(
 test_suite(
     name = "sv3_tests",
     tests = [
+        "//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke",
         "//sw/device/tests:aes_entropy_test",
         "//sw/device/tests:aes_idle_test",
         "//sw/device/tests:alert_handler_lpg_clkoff_test",


### PR DESCRIPTION
Link `chip_sw_spi_device_flash_mode` to `//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke`.