### PR TITLE
[tlgen/xbar] Generalize `get_s1n_if_exist` to `get_socket_if_exist`

### DIFF
--- a/util/tlgen/xbar.dv.sv.tpl
+++ b/util/tlgen/xbar.dv.sv.tpl
@@ -138,7 +138,7 @@ module xbar_${xbar.name}_tb;
 <%
   clkname = "clk_" + host.clocks[0]
   rstname = "rst_" + host.clocks[0] + "_n"
-  num_dev = len(xbar.get_s1n_if_exist(host).ds)
+  num_dev = len(xbar.get_socket_if_exist(host).ds)
 
   addrs = list(map(xbar.get_addr, xbar.get_devices_from_host(host)))
 %>\

--- a/util/tlgen/xbar.py
+++ b/util/tlgen/xbar.py
@@ -63,30 +63,33 @@ class Xbar:
         """
         return self.get_downstream_device(node.ds[idx].ds)
 
-    def get_s1n_if_exist(self, node: Node) -> Node:
-        """ return SOCKET_1N if exists down from the node, if not return itself
+    def get_socket_if_exist(self, node):  # Node -> Node
+        """ return SOCKET_1N or SOCKET_M1 if exists down from the node, else
+            return itself
         """
         if isinstance(node, Device):
-            log.error("get_s1n_if_exist hits DEVICE type (unexpected)")
+            log.error("get_socket_if_exist hits DEVICE type (unexpected)")
             return node
         if isinstance(node, Socket1N):
             return node
-        return self.get_s1n_if_exist(node.ds[0].ds)
+        if isinstance(node, SocketM1):
+            return node
+        return self.get_socket_if_exist(node.ds[0].ds)
 
     def get_leaf_from_node(self, node: Node, idx: int) -> Node:
         """ get end device node from any node, idx is given to look down.
         """
-        num_dev = len(self.get_s1n_if_exist(node).ds)
+        num_dev = len(self.get_socket_if_exist(node).ds)
         if idx >= num_dev:
             log.error(
                 "given index is greater than number of devices under the node")
 
-        return self.get_leaf_from_s1n(self.get_s1n_if_exist(node), idx)
+        return self.get_leaf_from_s1n(self.get_socket_if_exist(node), idx)
 
     def get_devices_from_host(self, host: Node) -> List[Device]:
         devices = list(
             map(self.get_downstream_device_from_edge,
-                self.get_s1n_if_exist(host).ds))
+                self.get_socket_if_exist(host).ds))
 
         return devices
 


### PR DESCRIPTION
This cherry-picks https://github.com/lowRISC/opentitan/commit/7c0e4bd0b64dd15da08d059a6c82f1cb2e6d359f from `integrated_dev` and resolves merge conflicts (the code uses `isinstance(node, <type>)` now instead of a direct comparison).

Fixes https://github.com/lowRISC/opentitan/issues/2337

--------------------------------
This change is necessary for M-to-1 crossbars, in which multiple hosts are connected to a single device.  In that case, `get_s1n_if_exist` would return the device because no `socket_1n` exists between host and device.  For how this function is used, however, we want it to return the `socket_m1` between the multiple hosts and the one device.

Note that this function seems to be used 'only' in DV code (in `xbar.dv.sv.tpl`, which is modified in this commit).  I reran `tlgen` after this change (with the mailboxes instantiated, which happens in a later commit) and only found changes in one `xbar_env_pkg__params.sv`.