### PR TITLE
[rom_ext] Improve error reporting for bad images

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -11,6 +11,7 @@ _SEL_LIFE_CYCLE_STATE = (1 << 10)
 
 def _manifest_impl(ctx):
     mf = {}
+    mf_version = {}
 
     # All the easy parameters are simple assignments
     if ctx.attr.signature:
@@ -37,6 +38,13 @@ def _manifest_impl(ctx):
         mf["code_end"] = ctx.attr.code_end
     if ctx.attr.entry_point:
         mf["entry_point"] = ctx.attr.entry_point
+
+    if ctx.attr.manifest_version_major:
+        mf_version["major"] = ctx.attr.manifest_version_major
+    if ctx.attr.manifest_version_minor:
+        mf_version["minor"] = ctx.attr.manifest_version_minor
+    if mf_version:
+        mf["manifest_version"] = mf_version
 
     # Address Translation is a bool, but encoded as an int so we can have
     # a special value mean "unset" and so we can set to non-standard values
@@ -140,6 +148,8 @@ _manifest = rule(
         "life_cycle_state": attr.string(doc = "Usage constraint for life cycle status as a 0x-prefixed hex-encoded string"),
         "address_translation": attr.string(doc = "Whether this image uses address translation as a 0x-prefixed hex-encoded string"),
         "identifier": attr.string(doc = "Manifest identifier as a 0x-prefixed hex-encoded string"),
+        "manifest_version_major": attr.string(doc = "Manifest major version as a 0x-prefixed hex-encoded string"),
+        "manifest_version_minor": attr.string(doc = "Manifest minor version as a 0x-prefixed hex-encoded string"),
         "length": attr.string(doc = "Length of this image as a 0x-prefixed hex-encoded string"),
         "version_major": attr.string(doc = "Image major version as a 0x-prefixed hex-encoded string"),
         "version_minor": attr.string(doc = "Image minor version as a 0x-prefixed hex-encoded string"),

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -9,6 +9,8 @@ load(
     "cw310_params",
     "opentitan_test",
 )
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -61,6 +63,36 @@ _POSITIONS = {
 test_suite(
     name = "positions",
     tests = ["position_{}".format(name) for name in _POSITIONS],
+)
+
+manifest(d = {
+    "name": "bad_manifest",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.OWNER),
+    "manifest_version_major": "0",
+    "manifest_version_minor": "0",
+    "visibility": ["//visibility:public"],
+})
+
+opentitan_test(
+    name = "bad_manifest_test",
+    srcs = ["boot_test.c"],
+    cw310 = cw310_params(
+        exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
+        # Because our bad manifest has an invalid manifest version, we should
+        # expect kErrorManifestBadVersionMajor from the ROM_EXT.
+        exit_success = "BFV:054d410d",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    manifest = ":bad_manifest",
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
 )
 
 _KEYS = {

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -46,7 +46,7 @@ opentitan_binary(
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/rom_ext",
-        "//sw/device/silicon_creator/rom_ext/keys/fake",
+        "//sw/device/silicon_creator/rom_ext/prodc/keys",
     ],
 )
 
@@ -66,7 +66,7 @@ opentitan_binary(
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/rom_ext",
-        "//sw/device/silicon_creator/rom_ext/keys/fake",
+        "//sw/device/silicon_creator/rom_ext/prodc/keys",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -46,7 +46,7 @@ opentitan_binary(
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/rom_ext",
-        "//sw/device/silicon_creator/rom_ext/keys/fake",
+        "//sw/device/silicon_creator/rom_ext/sival/keys",
     ],
 )
 
@@ -66,7 +66,7 @@ opentitan_binary(
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/rom_ext",
-        "//sw/device/silicon_creator/rom_ext/keys/fake",
+        "//sw/device/silicon_creator/rom_ext/sival/keys",
     ],
 )
 


### PR DESCRIPTION
Trying to boot a bad image often results in
`kErrorBootPolicyBadIdentifier` rather than the true error code for the bad image.  This is because the ROM_EXT tries the non-primary slot which is often empty and the "bad identifier" error is appropriate for an empty slot.

1. Determine if the error is "bad identify" for the non-primary slot and prefer the primary slot error message in that case.
2. Link the customer signing keys into the "fake signed" ROM_EXT targets to facilitate creating ROM_EXTs for FPGAs or DEV parts.