### PR TITLE
[spi_device] Add high-speed read pipeline to relax timing requirements

### DIFF
--- a/hw/ip/spi_device/README.md
+++ b/hw/ip/spi_device/README.md
@@ -24,6 +24,7 @@
   - HW control of SPI PADs' output enable based on command information list
   - SW configurable internal command process for Read Status, Read JEDEC ID, Read SFDP, and read access to the mailbox space
   - Targets 33MHz @ Quad read mode, fall backs to 25MHz
+  - Optional pipelined reads to decrease timing pressure for passthrough mode
 - Automated tracking of 3B/ 4B address mode in the flash and passthrough modes
 - 24 entries of command information slots
   - Configurable address/ dummy/ payload size per opcode

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -1077,6 +1077,48 @@
               `payload_swap_en` only works with write data and SingleIO mode. `payload_en` must be 4'b 0001 and `paylod_dir` to be PayloadIn.
               '''
           } // f: payload_swap_en
+          { bits: "23:22"
+            name: "read_pipeline_mode"
+            desc: '''Add 2-stage pipeline to read payload.
+
+              If `read_pipeline_mode` is not set to `zero_stages`, the read logic adds a 2-stage pipeline to the read data for this command.
+              This read pipeline enables higher throughput for certain read commands in passthrough mode.
+
+              `payload_dir` must be set to PayloadOut: `payload_pipeline_en` only works with read data.
+              It may be used with any IO mode, but general host compatibility is likely limited to Quad Read.
+              If this pipeline is used for passthrough, the internal SFDP should report 2 additional dummy cycles compared to the downstream flash.
+              SFDP read commands should be processed internally, and `dummy_size` should still reflect the downstream device's dummy cycle count.
+              '''
+            enum: [
+              { value: "0",
+                name: "zero_stages",
+                desc: '''Bypass the 2-stage read pipeline.
+
+                  This mode is for ordinary SPI flash operation.
+                  Passthrough read data flows combinatorially from input pads to output pads.
+                  '''
+              },
+              { value: "1"
+                name: "two_stages_half_cycle"
+                desc: '''2-stage read pipeline with half-cycle sampling.
+
+                  In this mode, the 2-stage read pipeline is enabled.
+                  Read data appears 2 cycles later than the `zero_stages` option.
+                  In addition, read data originating from the downstream flash is first sampled on the normal sampling edge for half-cycle sampling.
+                  '''
+              }
+              { value: "2"
+                name: "two_stages_full_cycle"
+                desc: '''2-stage read pipeline with full-cycle sampling.
+
+                  In this mode, the 2-stage read pipeline is enabled.
+                  Read data appears 2 cycles later than the `zero_stages` option.
+                  In addition, read data originating from the downstream flash is first sampled on the next launch edge.
+                  In other words, the internal pipeline performs full-cycle sampling of the downstream flash's response.
+                  '''
+              }
+            ]
+          } // f: payload_pipeline_en
           { bits: "24"
             name: "upload"
             desc: '''Set to 1 to upload the command.

--- a/hw/ip/spi_device/doc/programmers_guide.md
+++ b/hw/ip/spi_device/doc/programmers_guide.md
@@ -17,7 +17,7 @@ They are not used in this version of IP.
 ### Initialization
 
 The SW should enable the TPM submodule by writing 1 to the TPM_CFG.en CSR field.
-Other SPI_DEVICE features (Generic, Flash, Passthrough) CSRs do not affect the TPM feature.
+Other SPI_DEVICE features (Flash, Passthrough) CSRs do not affect the TPM feature.
 
 Update TPM_ACCESS_0, TPM_ACCESS_1 CSRs.
 The TPM submodule uses TPM_ACCESS_x.activeLocality to determine if the TPM_STS is returned to the host system.

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -1040,7 +1040,7 @@ byte.
 Command Info register.
 
 - Reset default: `0x7000`
-- Reset mask: `0x833fffff`
+- Reset mask: `0x83ffffff`
 
 ### Instances
 
@@ -1075,25 +1075,25 @@ Command Info register.
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "opcode", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "addr_mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "addr_swap_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "mbyte_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "dummy_size", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "dummy_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "payload_en", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "payload_dir", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "payload_swap_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "upload", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "busy", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 5}, {"name": "valid", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 170}}
+{"reg": [{"name": "opcode", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "addr_mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "addr_swap_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "mbyte_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "dummy_size", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "dummy_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "payload_en", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "payload_dir", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "payload_swap_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "read_pipeline_mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "upload", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "busy", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 5}, {"name": "valid", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                                          |
-|:------:|:------:|:-------:|:----------------------------------------------|
-|   31   |   rw   |   0x0   | [valid](#cmd_info--valid)                     |
-| 30:26  |        |         | Reserved                                      |
-|   25   |   rw   |   0x0   | [busy](#cmd_info--busy)                       |
-|   24   |   rw   |   0x0   | [upload](#cmd_info--upload)                   |
-| 23:22  |        |         | Reserved                                      |
-|   21   |   rw   |   0x0   | [payload_swap_en](#cmd_info--payload_swap_en) |
-|   20   |   rw   |   0x0   | [payload_dir](#cmd_info--payload_dir)         |
-| 19:16  |   rw   |   0x0   | [payload_en](#cmd_info--payload_en)           |
-|   15   |   rw   |   0x0   | [dummy_en](#cmd_info--dummy_en)               |
-| 14:12  |   rw   |   0x7   | [dummy_size](#cmd_info--dummy_size)           |
-|   11   |   rw   |   0x0   | [mbyte_en](#cmd_info--mbyte_en)               |
-|   10   |   rw   |   0x0   | [addr_swap_en](#cmd_info--addr_swap_en)       |
-|  9:8   |   rw   |   0x0   | [addr_mode](#cmd_info--addr_mode)             |
-|  7:0   |   rw   |   0x0   | [opcode](#cmd_info--opcode)                   |
+|  Bits  |  Type  |  Reset  | Name                                                |
+|:------:|:------:|:-------:|:----------------------------------------------------|
+|   31   |   rw   |   0x0   | [valid](#cmd_info--valid)                           |
+| 30:26  |        |         | Reserved                                            |
+|   25   |   rw   |   0x0   | [busy](#cmd_info--busy)                             |
+|   24   |   rw   |   0x0   | [upload](#cmd_info--upload)                         |
+| 23:22  |   rw   |   0x0   | [read_pipeline_mode](#cmd_info--read_pipeline_mode) |
+|   21   |   rw   |   0x0   | [payload_swap_en](#cmd_info--payload_swap_en)       |
+|   20   |   rw   |   0x0   | [payload_dir](#cmd_info--payload_dir)               |
+| 19:16  |   rw   |   0x0   | [payload_en](#cmd_info--payload_en)                 |
+|   15   |   rw   |   0x0   | [dummy_en](#cmd_info--dummy_en)                     |
+| 14:12  |   rw   |   0x7   | [dummy_size](#cmd_info--dummy_size)                 |
+|   11   |   rw   |   0x0   | [mbyte_en](#cmd_info--mbyte_en)                     |
+|   10   |   rw   |   0x0   | [addr_swap_en](#cmd_info--addr_swap_en)             |
+|  9:8   |   rw   |   0x0   | [addr_mode](#cmd_info--addr_mode)                   |
+|  7:0   |   rw   |   0x0   | [opcode](#cmd_info--opcode)                         |
 
 ### CMD_INFO . valid
 Set to 1 if the config in the register is valid
@@ -1115,6 +1115,25 @@ defines the command address field size.
 The logic assumes the following SPI input stream as payload,
 which max size is 256B. If the command exceeds the maximum
 payload size 256B, the logic wraps the payload and overwrites.
+
+### CMD_INFO . read_pipeline_mode
+Add 2-stage pipeline to read payload.
+
+If `read_pipeline_mode` is not set to `zero_stages`, the read logic adds a 2-stage pipeline to the read data for this command.
+This read pipeline enables higher throughput for certain read commands in passthrough mode.
+
+`payload_dir` must be set to PayloadOut: `payload_pipeline_en` only works with read data.
+It may be used with any IO mode, but general host compatibility is likely limited to Quad Read.
+If this pipeline is used for passthrough, the internal SFDP should report 2 additional dummy cycles compared to the downstream flash.
+SFDP read commands should be processed internally, and `dummy_size` should still reflect the downstream device's dummy cycle count.
+
+| Value   | Name                  | Description                                                                                                                                                                                                                                                                                                                                                                       |
+|:--------|:----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x0     | zero_stages           | Bypass the 2-stage read pipeline. This mode is for ordinary SPI flash operation. Passthrough read data flows combinatorially from input pads to output pads.                                                                                                                                                                                                                      |
+| 0x1     | two_stages_half_cycle | 2-stage read pipeline with half-cycle sampling. In this mode, the 2-stage read pipeline is enabled. Read data appears 2 cycles later than the `zero_stages` option. In addition, read data originating from the downstream flash is first sampled on the normal sampling edge for half-cycle sampling.                                                                            |
+| 0x2     | two_stages_full_cycle | 2-stage read pipeline with full-cycle sampling. In this mode, the 2-stage read pipeline is enabled. Read data appears 2 cycles later than the `zero_stages` option. In addition, read data originating from the downstream flash is first sampled on the next launch edge. In other words, the internal pipeline performs full-cycle sampling of the downstream flash's response. |
+
+Other values are reserved.
 
 ### CMD_INFO . payload_swap_en
 Swap the first byte of the write payload.

--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -31,10 +31,6 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     cp_mode: coverpoint mode;
     cp_tpm_enabled: coverpoint tpm_enabled;
     cr_all: cross cp_mode, cp_tpm_enabled {
-      // FW mode can't run with TPM enabled
-      // but if we turn the mode on without realling sending transactions, it's fine.
-      ignore_bins invalid = binsof(cp_mode) intersect { GenericMode } &&
-                             binsof(cp_tpm_enabled) intersect { 1 };
     }
   endgroup
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -42,7 +42,7 @@ package spi_device_env_pkg;
   } tpm_cfg_mode_e;
 
   typedef enum {
-    GenericMode,
+    DisabledMode,
     FlashMode,
     PassthroughMode
   } device_mode_e;

--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -57,6 +57,9 @@ module spi_cmdparse
   input cfg_intercept_en_jedec_i,
   input cfg_intercept_en_sfdp_i,
 
+  // CFG: Additional 2-stage pipeline for read payloads
+  output logic cmd_read_pipeline_sel_o,
+
   // Output assumed
   output logic intercept_status_o,
   output logic intercept_jedec_o,
@@ -221,6 +224,7 @@ module spi_cmdparse
       cmd_info_q <= '{
         payload_dir: payload_dir_e'(PayloadIn),
         addr_mode: addr_mode_e'(0),
+        read_pipeline_mode: read_pipeline_mode_e'(0),
         default: '0
       };
       cmd_info_idx_q <= '0;
@@ -234,6 +238,7 @@ module spi_cmdparse
     cmd_info_d = '{
       payload_dir: payload_dir_e'(PayloadIn),
       addr_mode: addr_mode_e'(0),
+      read_pipeline_mode: read_pipeline_mode_e'(0),
       default: '0
     };
     cmd_info_idx_d = '0;
@@ -263,6 +268,7 @@ module spi_cmdparse
     cmd_only_info_o = '{
       payload_dir: payload_dir_e'(PayloadIn),
       addr_mode: addr_mode_e'(0),
+      read_pipeline_mode: read_pipeline_mode_e'(0),
       default: '0
     };
     cmd_only_info_idx_o = '0;
@@ -289,6 +295,10 @@ module spi_cmdparse
       if (opcode_readsfdp)   intercept_sfdp_o   <= 1'b 1;
     end
   end
+
+  // CFG: Added 2-stage pipeline for read payloads
+  assign cmd_read_pipeline_sel_o = (cmd_info_q.read_pipeline_mode == RdPipeTwoStageHalfCycle) ||
+                                   (cmd_info_q.read_pipeline_mode == RdPipeTwoStageFullCycle);
 
   ///////////////////
   // State Machine //

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -953,7 +953,7 @@ module spi_device
       cio_sd_en_o = {2'b 00, tpm_miso_en, 1'b 0};
 
     end else begin : spi_out_flash_passthrough
-      // SPI Generic, Flash, Passthrough modes
+      // SPI Flash, Passthrough modes
       unique case (spi_mode)
         FlashMode: begin
           cio_sd_o    = internal_sd;

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -255,6 +255,9 @@ package spi_device_reg_pkg;
       logic        q;
     } upload;
     struct packed {
+      logic [1:0]  q;
+    } read_pipeline_mode;
+    struct packed {
       logic        q;
     } payload_swap_en;
     struct packed {
@@ -560,27 +563,27 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1516:1511]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1510:1505]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1504:1493]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1492:1491]
-    spi_device_reg2hw_control_reg_t control; // [1490:1488]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1487:1483]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1482:1479]
-    spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1478:1477]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1476:1450]
-    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1449:1434]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1433:1410]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1409:1400]
-    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1399:1368]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1367:1353]
-    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1352:1320]
-    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1319:1064]
-    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1063:1032]
-    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [1031:1000]
-    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [999:968]
-    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [967:936]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [935:336]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1564:1559]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1558:1553]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1552:1541]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1540:1539]
+    spi_device_reg2hw_control_reg_t control; // [1538:1536]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1535:1531]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1530:1527]
+    spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1526:1525]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1524:1498]
+    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1497:1482]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1481:1458]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1457:1448]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1447:1416]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1415:1401]
+    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1400:1368]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1367:1112]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1111:1080]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [1079:1048]
+    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [1047:1016]
+    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [1015:984]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [983:336]
     spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [335:327]
     spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [326:318]
     spi_device_reg2hw_cmd_info_wren_reg_t cmd_info_wren; // [317:309]

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -830,6 +830,8 @@ module spi_device_reg_top (
   logic cmd_info_0_payload_dir_0_wd;
   logic cmd_info_0_payload_swap_en_0_qs;
   logic cmd_info_0_payload_swap_en_0_wd;
+  logic [1:0] cmd_info_0_read_pipeline_mode_0_qs;
+  logic [1:0] cmd_info_0_read_pipeline_mode_0_wd;
   logic cmd_info_0_upload_0_qs;
   logic cmd_info_0_upload_0_wd;
   logic cmd_info_0_busy_0_qs;
@@ -855,6 +857,8 @@ module spi_device_reg_top (
   logic cmd_info_1_payload_dir_1_wd;
   logic cmd_info_1_payload_swap_en_1_qs;
   logic cmd_info_1_payload_swap_en_1_wd;
+  logic [1:0] cmd_info_1_read_pipeline_mode_1_qs;
+  logic [1:0] cmd_info_1_read_pipeline_mode_1_wd;
   logic cmd_info_1_upload_1_qs;
   logic cmd_info_1_upload_1_wd;
   logic cmd_info_1_busy_1_qs;
@@ -880,6 +884,8 @@ module spi_device_reg_top (
   logic cmd_info_2_payload_dir_2_wd;
   logic cmd_info_2_payload_swap_en_2_qs;
   logic cmd_info_2_payload_swap_en_2_wd;
+  logic [1:0] cmd_info_2_read_pipeline_mode_2_qs;
+  logic [1:0] cmd_info_2_read_pipeline_mode_2_wd;
   logic cmd_info_2_upload_2_qs;
   logic cmd_info_2_upload_2_wd;
   logic cmd_info_2_busy_2_qs;
@@ -905,6 +911,8 @@ module spi_device_reg_top (
   logic cmd_info_3_payload_dir_3_wd;
   logic cmd_info_3_payload_swap_en_3_qs;
   logic cmd_info_3_payload_swap_en_3_wd;
+  logic [1:0] cmd_info_3_read_pipeline_mode_3_qs;
+  logic [1:0] cmd_info_3_read_pipeline_mode_3_wd;
   logic cmd_info_3_upload_3_qs;
   logic cmd_info_3_upload_3_wd;
   logic cmd_info_3_busy_3_qs;
@@ -930,6 +938,8 @@ module spi_device_reg_top (
   logic cmd_info_4_payload_dir_4_wd;
   logic cmd_info_4_payload_swap_en_4_qs;
   logic cmd_info_4_payload_swap_en_4_wd;
+  logic [1:0] cmd_info_4_read_pipeline_mode_4_qs;
+  logic [1:0] cmd_info_4_read_pipeline_mode_4_wd;
   logic cmd_info_4_upload_4_qs;
   logic cmd_info_4_upload_4_wd;
   logic cmd_info_4_busy_4_qs;
@@ -955,6 +965,8 @@ module spi_device_reg_top (
   logic cmd_info_5_payload_dir_5_wd;
   logic cmd_info_5_payload_swap_en_5_qs;
   logic cmd_info_5_payload_swap_en_5_wd;
+  logic [1:0] cmd_info_5_read_pipeline_mode_5_qs;
+  logic [1:0] cmd_info_5_read_pipeline_mode_5_wd;
   logic cmd_info_5_upload_5_qs;
   logic cmd_info_5_upload_5_wd;
   logic cmd_info_5_busy_5_qs;
@@ -980,6 +992,8 @@ module spi_device_reg_top (
   logic cmd_info_6_payload_dir_6_wd;
   logic cmd_info_6_payload_swap_en_6_qs;
   logic cmd_info_6_payload_swap_en_6_wd;
+  logic [1:0] cmd_info_6_read_pipeline_mode_6_qs;
+  logic [1:0] cmd_info_6_read_pipeline_mode_6_wd;
   logic cmd_info_6_upload_6_qs;
   logic cmd_info_6_upload_6_wd;
   logic cmd_info_6_busy_6_qs;
@@ -1005,6 +1019,8 @@ module spi_device_reg_top (
   logic cmd_info_7_payload_dir_7_wd;
   logic cmd_info_7_payload_swap_en_7_qs;
   logic cmd_info_7_payload_swap_en_7_wd;
+  logic [1:0] cmd_info_7_read_pipeline_mode_7_qs;
+  logic [1:0] cmd_info_7_read_pipeline_mode_7_wd;
   logic cmd_info_7_upload_7_qs;
   logic cmd_info_7_upload_7_wd;
   logic cmd_info_7_busy_7_qs;
@@ -1030,6 +1046,8 @@ module spi_device_reg_top (
   logic cmd_info_8_payload_dir_8_wd;
   logic cmd_info_8_payload_swap_en_8_qs;
   logic cmd_info_8_payload_swap_en_8_wd;
+  logic [1:0] cmd_info_8_read_pipeline_mode_8_qs;
+  logic [1:0] cmd_info_8_read_pipeline_mode_8_wd;
   logic cmd_info_8_upload_8_qs;
   logic cmd_info_8_upload_8_wd;
   logic cmd_info_8_busy_8_qs;
@@ -1055,6 +1073,8 @@ module spi_device_reg_top (
   logic cmd_info_9_payload_dir_9_wd;
   logic cmd_info_9_payload_swap_en_9_qs;
   logic cmd_info_9_payload_swap_en_9_wd;
+  logic [1:0] cmd_info_9_read_pipeline_mode_9_qs;
+  logic [1:0] cmd_info_9_read_pipeline_mode_9_wd;
   logic cmd_info_9_upload_9_qs;
   logic cmd_info_9_upload_9_wd;
   logic cmd_info_9_busy_9_qs;
@@ -1080,6 +1100,8 @@ module spi_device_reg_top (
   logic cmd_info_10_payload_dir_10_wd;
   logic cmd_info_10_payload_swap_en_10_qs;
   logic cmd_info_10_payload_swap_en_10_wd;
+  logic [1:0] cmd_info_10_read_pipeline_mode_10_qs;
+  logic [1:0] cmd_info_10_read_pipeline_mode_10_wd;
   logic cmd_info_10_upload_10_qs;
   logic cmd_info_10_upload_10_wd;
   logic cmd_info_10_busy_10_qs;
@@ -1105,6 +1127,8 @@ module spi_device_reg_top (
   logic cmd_info_11_payload_dir_11_wd;
   logic cmd_info_11_payload_swap_en_11_qs;
   logic cmd_info_11_payload_swap_en_11_wd;
+  logic [1:0] cmd_info_11_read_pipeline_mode_11_qs;
+  logic [1:0] cmd_info_11_read_pipeline_mode_11_wd;
   logic cmd_info_11_upload_11_qs;
   logic cmd_info_11_upload_11_wd;
   logic cmd_info_11_busy_11_qs;
@@ -1130,6 +1154,8 @@ module spi_device_reg_top (
   logic cmd_info_12_payload_dir_12_wd;
   logic cmd_info_12_payload_swap_en_12_qs;
   logic cmd_info_12_payload_swap_en_12_wd;
+  logic [1:0] cmd_info_12_read_pipeline_mode_12_qs;
+  logic [1:0] cmd_info_12_read_pipeline_mode_12_wd;
   logic cmd_info_12_upload_12_qs;
   logic cmd_info_12_upload_12_wd;
   logic cmd_info_12_busy_12_qs;
@@ -1155,6 +1181,8 @@ module spi_device_reg_top (
   logic cmd_info_13_payload_dir_13_wd;
   logic cmd_info_13_payload_swap_en_13_qs;
   logic cmd_info_13_payload_swap_en_13_wd;
+  logic [1:0] cmd_info_13_read_pipeline_mode_13_qs;
+  logic [1:0] cmd_info_13_read_pipeline_mode_13_wd;
   logic cmd_info_13_upload_13_qs;
   logic cmd_info_13_upload_13_wd;
   logic cmd_info_13_busy_13_qs;
@@ -1180,6 +1208,8 @@ module spi_device_reg_top (
   logic cmd_info_14_payload_dir_14_wd;
   logic cmd_info_14_payload_swap_en_14_qs;
   logic cmd_info_14_payload_swap_en_14_wd;
+  logic [1:0] cmd_info_14_read_pipeline_mode_14_qs;
+  logic [1:0] cmd_info_14_read_pipeline_mode_14_wd;
   logic cmd_info_14_upload_14_qs;
   logic cmd_info_14_upload_14_wd;
   logic cmd_info_14_busy_14_qs;
@@ -1205,6 +1235,8 @@ module spi_device_reg_top (
   logic cmd_info_15_payload_dir_15_wd;
   logic cmd_info_15_payload_swap_en_15_qs;
   logic cmd_info_15_payload_swap_en_15_wd;
+  logic [1:0] cmd_info_15_read_pipeline_mode_15_qs;
+  logic [1:0] cmd_info_15_read_pipeline_mode_15_wd;
   logic cmd_info_15_upload_15_qs;
   logic cmd_info_15_upload_15_wd;
   logic cmd_info_15_busy_15_qs;
@@ -1230,6 +1262,8 @@ module spi_device_reg_top (
   logic cmd_info_16_payload_dir_16_wd;
   logic cmd_info_16_payload_swap_en_16_qs;
   logic cmd_info_16_payload_swap_en_16_wd;
+  logic [1:0] cmd_info_16_read_pipeline_mode_16_qs;
+  logic [1:0] cmd_info_16_read_pipeline_mode_16_wd;
   logic cmd_info_16_upload_16_qs;
   logic cmd_info_16_upload_16_wd;
   logic cmd_info_16_busy_16_qs;
@@ -1255,6 +1289,8 @@ module spi_device_reg_top (
   logic cmd_info_17_payload_dir_17_wd;
   logic cmd_info_17_payload_swap_en_17_qs;
   logic cmd_info_17_payload_swap_en_17_wd;
+  logic [1:0] cmd_info_17_read_pipeline_mode_17_qs;
+  logic [1:0] cmd_info_17_read_pipeline_mode_17_wd;
   logic cmd_info_17_upload_17_qs;
   logic cmd_info_17_upload_17_wd;
   logic cmd_info_17_busy_17_qs;
@@ -1280,6 +1316,8 @@ module spi_device_reg_top (
   logic cmd_info_18_payload_dir_18_wd;
   logic cmd_info_18_payload_swap_en_18_qs;
   logic cmd_info_18_payload_swap_en_18_wd;
+  logic [1:0] cmd_info_18_read_pipeline_mode_18_qs;
+  logic [1:0] cmd_info_18_read_pipeline_mode_18_wd;
   logic cmd_info_18_upload_18_qs;
   logic cmd_info_18_upload_18_wd;
   logic cmd_info_18_busy_18_qs;
@@ -1305,6 +1343,8 @@ module spi_device_reg_top (
   logic cmd_info_19_payload_dir_19_wd;
   logic cmd_info_19_payload_swap_en_19_qs;
   logic cmd_info_19_payload_swap_en_19_wd;
+  logic [1:0] cmd_info_19_read_pipeline_mode_19_qs;
+  logic [1:0] cmd_info_19_read_pipeline_mode_19_wd;
   logic cmd_info_19_upload_19_qs;
   logic cmd_info_19_upload_19_wd;
   logic cmd_info_19_busy_19_qs;
@@ -1330,6 +1370,8 @@ module spi_device_reg_top (
   logic cmd_info_20_payload_dir_20_wd;
   logic cmd_info_20_payload_swap_en_20_qs;
   logic cmd_info_20_payload_swap_en_20_wd;
+  logic [1:0] cmd_info_20_read_pipeline_mode_20_qs;
+  logic [1:0] cmd_info_20_read_pipeline_mode_20_wd;
   logic cmd_info_20_upload_20_qs;
   logic cmd_info_20_upload_20_wd;
   logic cmd_info_20_busy_20_qs;
@@ -1355,6 +1397,8 @@ module spi_device_reg_top (
   logic cmd_info_21_payload_dir_21_wd;
   logic cmd_info_21_payload_swap_en_21_qs;
   logic cmd_info_21_payload_swap_en_21_wd;
+  logic [1:0] cmd_info_21_read_pipeline_mode_21_qs;
+  logic [1:0] cmd_info_21_read_pipeline_mode_21_wd;
   logic cmd_info_21_upload_21_qs;
   logic cmd_info_21_upload_21_wd;
   logic cmd_info_21_busy_21_qs;
@@ -1380,6 +1424,8 @@ module spi_device_reg_top (
   logic cmd_info_22_payload_dir_22_wd;
   logic cmd_info_22_payload_swap_en_22_qs;
   logic cmd_info_22_payload_swap_en_22_wd;
+  logic [1:0] cmd_info_22_read_pipeline_mode_22_qs;
+  logic [1:0] cmd_info_22_read_pipeline_mode_22_wd;
   logic cmd_info_22_upload_22_qs;
   logic cmd_info_22_upload_22_wd;
   logic cmd_info_22_busy_22_qs;
@@ -1405,6 +1451,8 @@ module spi_device_reg_top (
   logic cmd_info_23_payload_dir_23_wd;
   logic cmd_info_23_payload_swap_en_23_qs;
   logic cmd_info_23_payload_swap_en_23_wd;
+  logic [1:0] cmd_info_23_read_pipeline_mode_23_qs;
+  logic [1:0] cmd_info_23_read_pipeline_mode_23_wd;
   logic cmd_info_23_upload_23_qs;
   logic cmd_info_23_upload_23_wd;
   logic cmd_info_23_busy_23_qs;
@@ -10089,6 +10137,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_payload_swap_en_0_qs)
   );
 
+  //   F[read_pipeline_mode_0]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_0_read_pipeline_mode_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_0_we),
+    .wd     (cmd_info_0_read_pipeline_mode_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[0].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_0_read_pipeline_mode_0_qs)
+  );
+
   //   F[upload_0]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -10414,6 +10489,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_1_payload_swap_en_1_qs)
+  );
+
+  //   F[read_pipeline_mode_1]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_1_read_pipeline_mode_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_1_we),
+    .wd     (cmd_info_1_read_pipeline_mode_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[1].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_1_read_pipeline_mode_1_qs)
   );
 
   //   F[upload_1]: 24:24
@@ -10743,6 +10845,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_payload_swap_en_2_qs)
   );
 
+  //   F[read_pipeline_mode_2]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_2_read_pipeline_mode_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_2_we),
+    .wd     (cmd_info_2_read_pipeline_mode_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[2].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_2_read_pipeline_mode_2_qs)
+  );
+
   //   F[upload_2]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -11068,6 +11197,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_3_payload_swap_en_3_qs)
+  );
+
+  //   F[read_pipeline_mode_3]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_3_read_pipeline_mode_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_3_we),
+    .wd     (cmd_info_3_read_pipeline_mode_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[3].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_3_read_pipeline_mode_3_qs)
   );
 
   //   F[upload_3]: 24:24
@@ -11397,6 +11553,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_payload_swap_en_4_qs)
   );
 
+  //   F[read_pipeline_mode_4]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_4_read_pipeline_mode_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_4_we),
+    .wd     (cmd_info_4_read_pipeline_mode_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[4].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_4_read_pipeline_mode_4_qs)
+  );
+
   //   F[upload_4]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -11722,6 +11905,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_5_payload_swap_en_5_qs)
+  );
+
+  //   F[read_pipeline_mode_5]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_5_read_pipeline_mode_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_5_we),
+    .wd     (cmd_info_5_read_pipeline_mode_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[5].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_5_read_pipeline_mode_5_qs)
   );
 
   //   F[upload_5]: 24:24
@@ -12051,6 +12261,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_payload_swap_en_6_qs)
   );
 
+  //   F[read_pipeline_mode_6]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_6_read_pipeline_mode_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_6_we),
+    .wd     (cmd_info_6_read_pipeline_mode_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[6].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_6_read_pipeline_mode_6_qs)
+  );
+
   //   F[upload_6]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -12376,6 +12613,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_7_payload_swap_en_7_qs)
+  );
+
+  //   F[read_pipeline_mode_7]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_7_read_pipeline_mode_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_7_we),
+    .wd     (cmd_info_7_read_pipeline_mode_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[7].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_7_read_pipeline_mode_7_qs)
   );
 
   //   F[upload_7]: 24:24
@@ -12705,6 +12969,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_payload_swap_en_8_qs)
   );
 
+  //   F[read_pipeline_mode_8]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_8_read_pipeline_mode_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_8_we),
+    .wd     (cmd_info_8_read_pipeline_mode_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[8].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_8_read_pipeline_mode_8_qs)
+  );
+
   //   F[upload_8]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -13030,6 +13321,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_9_payload_swap_en_9_qs)
+  );
+
+  //   F[read_pipeline_mode_9]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_9_read_pipeline_mode_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_9_we),
+    .wd     (cmd_info_9_read_pipeline_mode_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[9].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_9_read_pipeline_mode_9_qs)
   );
 
   //   F[upload_9]: 24:24
@@ -13359,6 +13677,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_payload_swap_en_10_qs)
   );
 
+  //   F[read_pipeline_mode_10]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_10_read_pipeline_mode_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_10_we),
+    .wd     (cmd_info_10_read_pipeline_mode_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[10].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_10_read_pipeline_mode_10_qs)
+  );
+
   //   F[upload_10]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -13684,6 +14029,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_11_payload_swap_en_11_qs)
+  );
+
+  //   F[read_pipeline_mode_11]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_11_read_pipeline_mode_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_11_we),
+    .wd     (cmd_info_11_read_pipeline_mode_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[11].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_11_read_pipeline_mode_11_qs)
   );
 
   //   F[upload_11]: 24:24
@@ -14013,6 +14385,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_payload_swap_en_12_qs)
   );
 
+  //   F[read_pipeline_mode_12]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_12_read_pipeline_mode_12 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_12_we),
+    .wd     (cmd_info_12_read_pipeline_mode_12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[12].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_12_read_pipeline_mode_12_qs)
+  );
+
   //   F[upload_12]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -14338,6 +14737,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_13_payload_swap_en_13_qs)
+  );
+
+  //   F[read_pipeline_mode_13]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_13_read_pipeline_mode_13 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_13_we),
+    .wd     (cmd_info_13_read_pipeline_mode_13_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[13].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_13_read_pipeline_mode_13_qs)
   );
 
   //   F[upload_13]: 24:24
@@ -14667,6 +15093,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_payload_swap_en_14_qs)
   );
 
+  //   F[read_pipeline_mode_14]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_14_read_pipeline_mode_14 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_14_we),
+    .wd     (cmd_info_14_read_pipeline_mode_14_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[14].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_14_read_pipeline_mode_14_qs)
+  );
+
   //   F[upload_14]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -14992,6 +15445,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_15_payload_swap_en_15_qs)
+  );
+
+  //   F[read_pipeline_mode_15]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_15_read_pipeline_mode_15 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_15_we),
+    .wd     (cmd_info_15_read_pipeline_mode_15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[15].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_15_read_pipeline_mode_15_qs)
   );
 
   //   F[upload_15]: 24:24
@@ -15321,6 +15801,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_payload_swap_en_16_qs)
   );
 
+  //   F[read_pipeline_mode_16]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_16_read_pipeline_mode_16 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_16_we),
+    .wd     (cmd_info_16_read_pipeline_mode_16_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[16].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_16_read_pipeline_mode_16_qs)
+  );
+
   //   F[upload_16]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -15646,6 +16153,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_17_payload_swap_en_17_qs)
+  );
+
+  //   F[read_pipeline_mode_17]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_17_read_pipeline_mode_17 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_17_we),
+    .wd     (cmd_info_17_read_pipeline_mode_17_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[17].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_17_read_pipeline_mode_17_qs)
   );
 
   //   F[upload_17]: 24:24
@@ -15975,6 +16509,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_payload_swap_en_18_qs)
   );
 
+  //   F[read_pipeline_mode_18]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_18_read_pipeline_mode_18 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_18_we),
+    .wd     (cmd_info_18_read_pipeline_mode_18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[18].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_18_read_pipeline_mode_18_qs)
+  );
+
   //   F[upload_18]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -16300,6 +16861,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_19_payload_swap_en_19_qs)
+  );
+
+  //   F[read_pipeline_mode_19]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_19_read_pipeline_mode_19 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_19_we),
+    .wd     (cmd_info_19_read_pipeline_mode_19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[19].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_19_read_pipeline_mode_19_qs)
   );
 
   //   F[upload_19]: 24:24
@@ -16629,6 +17217,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_payload_swap_en_20_qs)
   );
 
+  //   F[read_pipeline_mode_20]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_20_read_pipeline_mode_20 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_20_we),
+    .wd     (cmd_info_20_read_pipeline_mode_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[20].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_20_read_pipeline_mode_20_qs)
+  );
+
   //   F[upload_20]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -16954,6 +17569,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_21_payload_swap_en_21_qs)
+  );
+
+  //   F[read_pipeline_mode_21]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_21_read_pipeline_mode_21 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_21_we),
+    .wd     (cmd_info_21_read_pipeline_mode_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[21].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_21_read_pipeline_mode_21_qs)
   );
 
   //   F[upload_21]: 24:24
@@ -17283,6 +17925,33 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_payload_swap_en_22_qs)
   );
 
+  //   F[read_pipeline_mode_22]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_22_read_pipeline_mode_22 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_22_we),
+    .wd     (cmd_info_22_read_pipeline_mode_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[22].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_22_read_pipeline_mode_22_qs)
+  );
+
   //   F[upload_22]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -17608,6 +18277,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_23_payload_swap_en_23_qs)
+  );
+
+  //   F[read_pipeline_mode_23]: 23:22
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_cmd_info_23_read_pipeline_mode_23 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_23_we),
+    .wd     (cmd_info_23_read_pipeline_mode_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[23].read_pipeline_mode.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (cmd_info_23_read_pipeline_mode_23_qs)
   );
 
   //   F[upload_23]: 24:24
@@ -19473,6 +20169,8 @@ module spi_device_reg_top (
 
   assign cmd_info_0_payload_swap_en_0_wd = reg_wdata[21];
 
+  assign cmd_info_0_read_pipeline_mode_0_wd = reg_wdata[23:22];
+
   assign cmd_info_0_upload_0_wd = reg_wdata[24];
 
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
@@ -19497,6 +20195,8 @@ module spi_device_reg_top (
   assign cmd_info_1_payload_dir_1_wd = reg_wdata[20];
 
   assign cmd_info_1_payload_swap_en_1_wd = reg_wdata[21];
+
+  assign cmd_info_1_read_pipeline_mode_1_wd = reg_wdata[23:22];
 
   assign cmd_info_1_upload_1_wd = reg_wdata[24];
 
@@ -19523,6 +20223,8 @@ module spi_device_reg_top (
 
   assign cmd_info_2_payload_swap_en_2_wd = reg_wdata[21];
 
+  assign cmd_info_2_read_pipeline_mode_2_wd = reg_wdata[23:22];
+
   assign cmd_info_2_upload_2_wd = reg_wdata[24];
 
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
@@ -19547,6 +20249,8 @@ module spi_device_reg_top (
   assign cmd_info_3_payload_dir_3_wd = reg_wdata[20];
 
   assign cmd_info_3_payload_swap_en_3_wd = reg_wdata[21];
+
+  assign cmd_info_3_read_pipeline_mode_3_wd = reg_wdata[23:22];
 
   assign cmd_info_3_upload_3_wd = reg_wdata[24];
 
@@ -19573,6 +20277,8 @@ module spi_device_reg_top (
 
   assign cmd_info_4_payload_swap_en_4_wd = reg_wdata[21];
 
+  assign cmd_info_4_read_pipeline_mode_4_wd = reg_wdata[23:22];
+
   assign cmd_info_4_upload_4_wd = reg_wdata[24];
 
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
@@ -19597,6 +20303,8 @@ module spi_device_reg_top (
   assign cmd_info_5_payload_dir_5_wd = reg_wdata[20];
 
   assign cmd_info_5_payload_swap_en_5_wd = reg_wdata[21];
+
+  assign cmd_info_5_read_pipeline_mode_5_wd = reg_wdata[23:22];
 
   assign cmd_info_5_upload_5_wd = reg_wdata[24];
 
@@ -19623,6 +20331,8 @@ module spi_device_reg_top (
 
   assign cmd_info_6_payload_swap_en_6_wd = reg_wdata[21];
 
+  assign cmd_info_6_read_pipeline_mode_6_wd = reg_wdata[23:22];
+
   assign cmd_info_6_upload_6_wd = reg_wdata[24];
 
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
@@ -19647,6 +20357,8 @@ module spi_device_reg_top (
   assign cmd_info_7_payload_dir_7_wd = reg_wdata[20];
 
   assign cmd_info_7_payload_swap_en_7_wd = reg_wdata[21];
+
+  assign cmd_info_7_read_pipeline_mode_7_wd = reg_wdata[23:22];
 
   assign cmd_info_7_upload_7_wd = reg_wdata[24];
 
@@ -19673,6 +20385,8 @@ module spi_device_reg_top (
 
   assign cmd_info_8_payload_swap_en_8_wd = reg_wdata[21];
 
+  assign cmd_info_8_read_pipeline_mode_8_wd = reg_wdata[23:22];
+
   assign cmd_info_8_upload_8_wd = reg_wdata[24];
 
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
@@ -19697,6 +20411,8 @@ module spi_device_reg_top (
   assign cmd_info_9_payload_dir_9_wd = reg_wdata[20];
 
   assign cmd_info_9_payload_swap_en_9_wd = reg_wdata[21];
+
+  assign cmd_info_9_read_pipeline_mode_9_wd = reg_wdata[23:22];
 
   assign cmd_info_9_upload_9_wd = reg_wdata[24];
 
@@ -19723,6 +20439,8 @@ module spi_device_reg_top (
 
   assign cmd_info_10_payload_swap_en_10_wd = reg_wdata[21];
 
+  assign cmd_info_10_read_pipeline_mode_10_wd = reg_wdata[23:22];
+
   assign cmd_info_10_upload_10_wd = reg_wdata[24];
 
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
@@ -19747,6 +20465,8 @@ module spi_device_reg_top (
   assign cmd_info_11_payload_dir_11_wd = reg_wdata[20];
 
   assign cmd_info_11_payload_swap_en_11_wd = reg_wdata[21];
+
+  assign cmd_info_11_read_pipeline_mode_11_wd = reg_wdata[23:22];
 
   assign cmd_info_11_upload_11_wd = reg_wdata[24];
 
@@ -19773,6 +20493,8 @@ module spi_device_reg_top (
 
   assign cmd_info_12_payload_swap_en_12_wd = reg_wdata[21];
 
+  assign cmd_info_12_read_pipeline_mode_12_wd = reg_wdata[23:22];
+
   assign cmd_info_12_upload_12_wd = reg_wdata[24];
 
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
@@ -19797,6 +20519,8 @@ module spi_device_reg_top (
   assign cmd_info_13_payload_dir_13_wd = reg_wdata[20];
 
   assign cmd_info_13_payload_swap_en_13_wd = reg_wdata[21];
+
+  assign cmd_info_13_read_pipeline_mode_13_wd = reg_wdata[23:22];
 
   assign cmd_info_13_upload_13_wd = reg_wdata[24];
 
@@ -19823,6 +20547,8 @@ module spi_device_reg_top (
 
   assign cmd_info_14_payload_swap_en_14_wd = reg_wdata[21];
 
+  assign cmd_info_14_read_pipeline_mode_14_wd = reg_wdata[23:22];
+
   assign cmd_info_14_upload_14_wd = reg_wdata[24];
 
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
@@ -19847,6 +20573,8 @@ module spi_device_reg_top (
   assign cmd_info_15_payload_dir_15_wd = reg_wdata[20];
 
   assign cmd_info_15_payload_swap_en_15_wd = reg_wdata[21];
+
+  assign cmd_info_15_read_pipeline_mode_15_wd = reg_wdata[23:22];
 
   assign cmd_info_15_upload_15_wd = reg_wdata[24];
 
@@ -19873,6 +20601,8 @@ module spi_device_reg_top (
 
   assign cmd_info_16_payload_swap_en_16_wd = reg_wdata[21];
 
+  assign cmd_info_16_read_pipeline_mode_16_wd = reg_wdata[23:22];
+
   assign cmd_info_16_upload_16_wd = reg_wdata[24];
 
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
@@ -19897,6 +20627,8 @@ module spi_device_reg_top (
   assign cmd_info_17_payload_dir_17_wd = reg_wdata[20];
 
   assign cmd_info_17_payload_swap_en_17_wd = reg_wdata[21];
+
+  assign cmd_info_17_read_pipeline_mode_17_wd = reg_wdata[23:22];
 
   assign cmd_info_17_upload_17_wd = reg_wdata[24];
 
@@ -19923,6 +20655,8 @@ module spi_device_reg_top (
 
   assign cmd_info_18_payload_swap_en_18_wd = reg_wdata[21];
 
+  assign cmd_info_18_read_pipeline_mode_18_wd = reg_wdata[23:22];
+
   assign cmd_info_18_upload_18_wd = reg_wdata[24];
 
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
@@ -19947,6 +20681,8 @@ module spi_device_reg_top (
   assign cmd_info_19_payload_dir_19_wd = reg_wdata[20];
 
   assign cmd_info_19_payload_swap_en_19_wd = reg_wdata[21];
+
+  assign cmd_info_19_read_pipeline_mode_19_wd = reg_wdata[23:22];
 
   assign cmd_info_19_upload_19_wd = reg_wdata[24];
 
@@ -19973,6 +20709,8 @@ module spi_device_reg_top (
 
   assign cmd_info_20_payload_swap_en_20_wd = reg_wdata[21];
 
+  assign cmd_info_20_read_pipeline_mode_20_wd = reg_wdata[23:22];
+
   assign cmd_info_20_upload_20_wd = reg_wdata[24];
 
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
@@ -19997,6 +20735,8 @@ module spi_device_reg_top (
   assign cmd_info_21_payload_dir_21_wd = reg_wdata[20];
 
   assign cmd_info_21_payload_swap_en_21_wd = reg_wdata[21];
+
+  assign cmd_info_21_read_pipeline_mode_21_wd = reg_wdata[23:22];
 
   assign cmd_info_21_upload_21_wd = reg_wdata[24];
 
@@ -20023,6 +20763,8 @@ module spi_device_reg_top (
 
   assign cmd_info_22_payload_swap_en_22_wd = reg_wdata[21];
 
+  assign cmd_info_22_read_pipeline_mode_22_wd = reg_wdata[23:22];
+
   assign cmd_info_22_upload_22_wd = reg_wdata[24];
 
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
@@ -20047,6 +20789,8 @@ module spi_device_reg_top (
   assign cmd_info_23_payload_dir_23_wd = reg_wdata[20];
 
   assign cmd_info_23_payload_swap_en_23_wd = reg_wdata[21];
+
+  assign cmd_info_23_read_pipeline_mode_23_wd = reg_wdata[23:22];
 
   assign cmd_info_23_upload_23_wd = reg_wdata[24];
 
@@ -20626,6 +21370,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_0_payload_en_0_qs;
         reg_rdata_next[20] = cmd_info_0_payload_dir_0_qs;
         reg_rdata_next[21] = cmd_info_0_payload_swap_en_0_qs;
+        reg_rdata_next[23:22] = cmd_info_0_read_pipeline_mode_0_qs;
         reg_rdata_next[24] = cmd_info_0_upload_0_qs;
         reg_rdata_next[25] = cmd_info_0_busy_0_qs;
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
@@ -20641,6 +21386,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_1_payload_en_1_qs;
         reg_rdata_next[20] = cmd_info_1_payload_dir_1_qs;
         reg_rdata_next[21] = cmd_info_1_payload_swap_en_1_qs;
+        reg_rdata_next[23:22] = cmd_info_1_read_pipeline_mode_1_qs;
         reg_rdata_next[24] = cmd_info_1_upload_1_qs;
         reg_rdata_next[25] = cmd_info_1_busy_1_qs;
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
@@ -20656,6 +21402,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_2_payload_en_2_qs;
         reg_rdata_next[20] = cmd_info_2_payload_dir_2_qs;
         reg_rdata_next[21] = cmd_info_2_payload_swap_en_2_qs;
+        reg_rdata_next[23:22] = cmd_info_2_read_pipeline_mode_2_qs;
         reg_rdata_next[24] = cmd_info_2_upload_2_qs;
         reg_rdata_next[25] = cmd_info_2_busy_2_qs;
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
@@ -20671,6 +21418,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_3_payload_en_3_qs;
         reg_rdata_next[20] = cmd_info_3_payload_dir_3_qs;
         reg_rdata_next[21] = cmd_info_3_payload_swap_en_3_qs;
+        reg_rdata_next[23:22] = cmd_info_3_read_pipeline_mode_3_qs;
         reg_rdata_next[24] = cmd_info_3_upload_3_qs;
         reg_rdata_next[25] = cmd_info_3_busy_3_qs;
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
@@ -20686,6 +21434,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_4_payload_en_4_qs;
         reg_rdata_next[20] = cmd_info_4_payload_dir_4_qs;
         reg_rdata_next[21] = cmd_info_4_payload_swap_en_4_qs;
+        reg_rdata_next[23:22] = cmd_info_4_read_pipeline_mode_4_qs;
         reg_rdata_next[24] = cmd_info_4_upload_4_qs;
         reg_rdata_next[25] = cmd_info_4_busy_4_qs;
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
@@ -20701,6 +21450,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_5_payload_en_5_qs;
         reg_rdata_next[20] = cmd_info_5_payload_dir_5_qs;
         reg_rdata_next[21] = cmd_info_5_payload_swap_en_5_qs;
+        reg_rdata_next[23:22] = cmd_info_5_read_pipeline_mode_5_qs;
         reg_rdata_next[24] = cmd_info_5_upload_5_qs;
         reg_rdata_next[25] = cmd_info_5_busy_5_qs;
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
@@ -20716,6 +21466,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_6_payload_en_6_qs;
         reg_rdata_next[20] = cmd_info_6_payload_dir_6_qs;
         reg_rdata_next[21] = cmd_info_6_payload_swap_en_6_qs;
+        reg_rdata_next[23:22] = cmd_info_6_read_pipeline_mode_6_qs;
         reg_rdata_next[24] = cmd_info_6_upload_6_qs;
         reg_rdata_next[25] = cmd_info_6_busy_6_qs;
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
@@ -20731,6 +21482,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_7_payload_en_7_qs;
         reg_rdata_next[20] = cmd_info_7_payload_dir_7_qs;
         reg_rdata_next[21] = cmd_info_7_payload_swap_en_7_qs;
+        reg_rdata_next[23:22] = cmd_info_7_read_pipeline_mode_7_qs;
         reg_rdata_next[24] = cmd_info_7_upload_7_qs;
         reg_rdata_next[25] = cmd_info_7_busy_7_qs;
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
@@ -20746,6 +21498,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_8_payload_en_8_qs;
         reg_rdata_next[20] = cmd_info_8_payload_dir_8_qs;
         reg_rdata_next[21] = cmd_info_8_payload_swap_en_8_qs;
+        reg_rdata_next[23:22] = cmd_info_8_read_pipeline_mode_8_qs;
         reg_rdata_next[24] = cmd_info_8_upload_8_qs;
         reg_rdata_next[25] = cmd_info_8_busy_8_qs;
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
@@ -20761,6 +21514,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_9_payload_en_9_qs;
         reg_rdata_next[20] = cmd_info_9_payload_dir_9_qs;
         reg_rdata_next[21] = cmd_info_9_payload_swap_en_9_qs;
+        reg_rdata_next[23:22] = cmd_info_9_read_pipeline_mode_9_qs;
         reg_rdata_next[24] = cmd_info_9_upload_9_qs;
         reg_rdata_next[25] = cmd_info_9_busy_9_qs;
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
@@ -20776,6 +21530,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_10_payload_en_10_qs;
         reg_rdata_next[20] = cmd_info_10_payload_dir_10_qs;
         reg_rdata_next[21] = cmd_info_10_payload_swap_en_10_qs;
+        reg_rdata_next[23:22] = cmd_info_10_read_pipeline_mode_10_qs;
         reg_rdata_next[24] = cmd_info_10_upload_10_qs;
         reg_rdata_next[25] = cmd_info_10_busy_10_qs;
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
@@ -20791,6 +21546,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_11_payload_en_11_qs;
         reg_rdata_next[20] = cmd_info_11_payload_dir_11_qs;
         reg_rdata_next[21] = cmd_info_11_payload_swap_en_11_qs;
+        reg_rdata_next[23:22] = cmd_info_11_read_pipeline_mode_11_qs;
         reg_rdata_next[24] = cmd_info_11_upload_11_qs;
         reg_rdata_next[25] = cmd_info_11_busy_11_qs;
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
@@ -20806,6 +21562,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_12_payload_en_12_qs;
         reg_rdata_next[20] = cmd_info_12_payload_dir_12_qs;
         reg_rdata_next[21] = cmd_info_12_payload_swap_en_12_qs;
+        reg_rdata_next[23:22] = cmd_info_12_read_pipeline_mode_12_qs;
         reg_rdata_next[24] = cmd_info_12_upload_12_qs;
         reg_rdata_next[25] = cmd_info_12_busy_12_qs;
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
@@ -20821,6 +21578,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_13_payload_en_13_qs;
         reg_rdata_next[20] = cmd_info_13_payload_dir_13_qs;
         reg_rdata_next[21] = cmd_info_13_payload_swap_en_13_qs;
+        reg_rdata_next[23:22] = cmd_info_13_read_pipeline_mode_13_qs;
         reg_rdata_next[24] = cmd_info_13_upload_13_qs;
         reg_rdata_next[25] = cmd_info_13_busy_13_qs;
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
@@ -20836,6 +21594,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_14_payload_en_14_qs;
         reg_rdata_next[20] = cmd_info_14_payload_dir_14_qs;
         reg_rdata_next[21] = cmd_info_14_payload_swap_en_14_qs;
+        reg_rdata_next[23:22] = cmd_info_14_read_pipeline_mode_14_qs;
         reg_rdata_next[24] = cmd_info_14_upload_14_qs;
         reg_rdata_next[25] = cmd_info_14_busy_14_qs;
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
@@ -20851,6 +21610,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_15_payload_en_15_qs;
         reg_rdata_next[20] = cmd_info_15_payload_dir_15_qs;
         reg_rdata_next[21] = cmd_info_15_payload_swap_en_15_qs;
+        reg_rdata_next[23:22] = cmd_info_15_read_pipeline_mode_15_qs;
         reg_rdata_next[24] = cmd_info_15_upload_15_qs;
         reg_rdata_next[25] = cmd_info_15_busy_15_qs;
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
@@ -20866,6 +21626,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_16_payload_en_16_qs;
         reg_rdata_next[20] = cmd_info_16_payload_dir_16_qs;
         reg_rdata_next[21] = cmd_info_16_payload_swap_en_16_qs;
+        reg_rdata_next[23:22] = cmd_info_16_read_pipeline_mode_16_qs;
         reg_rdata_next[24] = cmd_info_16_upload_16_qs;
         reg_rdata_next[25] = cmd_info_16_busy_16_qs;
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
@@ -20881,6 +21642,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_17_payload_en_17_qs;
         reg_rdata_next[20] = cmd_info_17_payload_dir_17_qs;
         reg_rdata_next[21] = cmd_info_17_payload_swap_en_17_qs;
+        reg_rdata_next[23:22] = cmd_info_17_read_pipeline_mode_17_qs;
         reg_rdata_next[24] = cmd_info_17_upload_17_qs;
         reg_rdata_next[25] = cmd_info_17_busy_17_qs;
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
@@ -20896,6 +21658,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_18_payload_en_18_qs;
         reg_rdata_next[20] = cmd_info_18_payload_dir_18_qs;
         reg_rdata_next[21] = cmd_info_18_payload_swap_en_18_qs;
+        reg_rdata_next[23:22] = cmd_info_18_read_pipeline_mode_18_qs;
         reg_rdata_next[24] = cmd_info_18_upload_18_qs;
         reg_rdata_next[25] = cmd_info_18_busy_18_qs;
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
@@ -20911,6 +21674,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_19_payload_en_19_qs;
         reg_rdata_next[20] = cmd_info_19_payload_dir_19_qs;
         reg_rdata_next[21] = cmd_info_19_payload_swap_en_19_qs;
+        reg_rdata_next[23:22] = cmd_info_19_read_pipeline_mode_19_qs;
         reg_rdata_next[24] = cmd_info_19_upload_19_qs;
         reg_rdata_next[25] = cmd_info_19_busy_19_qs;
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
@@ -20926,6 +21690,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_20_payload_en_20_qs;
         reg_rdata_next[20] = cmd_info_20_payload_dir_20_qs;
         reg_rdata_next[21] = cmd_info_20_payload_swap_en_20_qs;
+        reg_rdata_next[23:22] = cmd_info_20_read_pipeline_mode_20_qs;
         reg_rdata_next[24] = cmd_info_20_upload_20_qs;
         reg_rdata_next[25] = cmd_info_20_busy_20_qs;
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
@@ -20941,6 +21706,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_21_payload_en_21_qs;
         reg_rdata_next[20] = cmd_info_21_payload_dir_21_qs;
         reg_rdata_next[21] = cmd_info_21_payload_swap_en_21_qs;
+        reg_rdata_next[23:22] = cmd_info_21_read_pipeline_mode_21_qs;
         reg_rdata_next[24] = cmd_info_21_upload_21_qs;
         reg_rdata_next[25] = cmd_info_21_busy_21_qs;
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
@@ -20956,6 +21722,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_22_payload_en_22_qs;
         reg_rdata_next[20] = cmd_info_22_payload_dir_22_qs;
         reg_rdata_next[21] = cmd_info_22_payload_swap_en_22_qs;
+        reg_rdata_next[23:22] = cmd_info_22_read_pipeline_mode_22_qs;
         reg_rdata_next[24] = cmd_info_22_upload_22_qs;
         reg_rdata_next[25] = cmd_info_22_busy_22_qs;
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
@@ -20971,6 +21738,7 @@ module spi_device_reg_top (
         reg_rdata_next[19:16] = cmd_info_23_payload_en_23_qs;
         reg_rdata_next[20] = cmd_info_23_payload_dir_23_qs;
         reg_rdata_next[21] = cmd_info_23_payload_swap_en_23_qs;
+        reg_rdata_next[23:22] = cmd_info_23_read_pipeline_mode_23_qs;
         reg_rdata_next[24] = cmd_info_23_upload_23_qs;
         reg_rdata_next[25] = cmd_info_23_busy_23_qs;
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;

--- a/hw/ip/spi_device/rtl/spi_p2s.sv
+++ b/hw/ip/spi_device/rtl/spi_p2s.sv
@@ -22,7 +22,7 @@ module spi_p2s
 
   // Configuration
   // If CPHA=1, then the first byte should be delayed.
-  // But this does not matter in SPI Flash. Only applicable to Generic mode
+  // But this does not matter in SPI Flash.
   input cpha_i,
 
   // Control
@@ -54,8 +54,7 @@ module spi_p2s
   io_mode_e io_mode;
 
   // in Mode3, the logic skips first clock edge to move to next bit.
-  // This is not necessary for Flash / Passthrough mode. But Generic mode
-  // sends the data through TX line right after reset
+  // This is not necessary for Flash / Passthrough mode.
   logic first_beat, last_beat;
 
   count_t cnt;

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -191,6 +191,7 @@ module spi_readcmd
     cmd_info_i.opcode,          // Does not need to check opcode. (fixed slot)
     cmd_info_i.payload_dir,     // Always output mode
     cmd_info_i.payload_swap_en, // Used in passthrough mode only
+    cmd_info_i.read_pipeline_mode,
     cmd_info_i.upload,
     cmd_info_i.busy
     };

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -220,6 +220,7 @@ module spid_upload
     cmd_only_info_i.payload_dir,
     cmd_only_info_i.payload_en,
     cmd_only_info_i.payload_swap_en,
+    cmd_only_info_i.read_pipeline_mode,
     cmd_only_info_i.upload
   };
 

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -345,6 +345,24 @@ dif_result_t dif_spi_device_set_flash_command_slot(
         return kDifBadArg;
     }
 
+    uint32_t read_pipeline_mode;
+    switch (command_info.read_pipeline_mode) {
+      case kDifSpiDeviceReadPipelineModeZeroStages:
+        read_pipeline_mode =
+            SPI_DEVICE_CMD_INFO_0_READ_PIPELINE_MODE_0_VALUE_ZERO_STAGES;
+        break;
+      case kDifSpiDeviceReadPipelineModeTwoStagesHalfCycle:
+        read_pipeline_mode =
+            SPI_DEVICE_CMD_INFO_0_READ_PIPELINE_MODE_0_VALUE_TWO_STAGES_HALF_CYCLE;
+        break;
+      case kDifSpiDeviceReadPipelineModeTwoStagesFullCycle:
+        read_pipeline_mode =
+            SPI_DEVICE_CMD_INFO_0_READ_PIPELINE_MODE_0_VALUE_TWO_STAGES_FULL_CYCLE;
+        break;
+      default:
+        return kDifBadArg;
+    }
+
     // Check for invalid argument combinations.
     if (command_info.payload_swap_enable &&
         (command_info.payload_dir_to_host ||
@@ -379,6 +397,9 @@ dif_result_t dif_spi_device_set_flash_command_slot(
     reg_val = bitfield_bit32_write(reg_val,
                                    SPI_DEVICE_CMD_INFO_0_PAYLOAD_SWAP_EN_0_BIT,
                                    command_info.payload_swap_enable);
+    reg_val = bitfield_field32_write(
+        reg_val, SPI_DEVICE_CMD_INFO_0_READ_PIPELINE_MODE_0_FIELD,
+        read_pipeline_mode);
     reg_val = bitfield_bit32_write(reg_val, SPI_DEVICE_CMD_INFO_0_UPLOAD_0_BIT,
                                    command_info.upload);
     reg_val = bitfield_bit32_write(reg_val, SPI_DEVICE_CMD_INFO_0_BUSY_0_BIT,

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -354,6 +354,22 @@ typedef enum dif_spi_device_payload_io {
   kDifSpiDevicePayloadIoInvalid = 0x10,
 } dif_spi_device_payload_io_t;
 
+typedef enum dif_spi_device_read_pipeline_mode {
+  /** No additional flash payload read pipeline stages. */
+  kDifSpiDeviceReadPipelineModeZeroStages = 0,
+  /**
+   * Add 2-stage pipeline to command read output. Perform half-cycle sampling on
+   * the incoming data.
+   */
+  kDifSpiDeviceReadPipelineModeTwoStagesHalfCycle,
+  /**
+   * Add 2-stage pipeline to command read output. Perform full-cycle sampling on
+   * the incoming data.
+   */
+  kDifSpiDeviceReadPipelineModeTwoStagesFullCycle,
+  kDifSpiDeviceReadPipelineModeCount,
+} dif_spi_device_read_pipeline_mode_t;
+
 typedef struct dif_spi_device_flash_command {
   /** The opcode for this command. */
   uint8_t opcode;
@@ -379,6 +395,8 @@ typedef struct dif_spi_device_flash_command {
   bool payload_dir_to_host;
   /** Whether to swap up to the first 32 bits of the payload. */
   bool payload_swap_enable;
+  /** The read payload pipeline mode to use for this command. */
+  dif_spi_device_read_pipeline_mode_t read_pipeline_mode;
   /** Whether to upload the command to the payload FIFO. */
   bool upload;
   /** Whether to set the busy bit in the status register. */

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -292,6 +292,42 @@ status_t spi_device_testutils_configure_passthrough(
   return OK_STATUS();
 }
 
+status_t spi_device_testutils_configure_read_pipeline(
+    dif_spi_device_handle_t *spi_device,
+    dif_spi_device_read_pipeline_mode_t dual_mode,
+    dif_spi_device_read_pipeline_mode_t quad_mode) {
+  if (spi_device == NULL || dual_mode >= kDifSpiDeviceReadPipelineModeCount ||
+      quad_mode >= kDifSpiDeviceReadPipelineModeCount) {
+    return INVALID_ARGUMENT();
+  }
+
+  const dif_spi_device_flash_command_t dual_read_cmd = {
+      // Slot 7: ReadDual
+      .opcode = kSpiDeviceFlashOpReadDual,
+      .address_type = kDifSpiDeviceFlashAddrCfg,
+      .passthrough_swap_address = true,
+      .dummy_cycles = 8,
+      .payload_io_type = kDifSpiDevicePayloadIoDual,
+      .payload_dir_to_host = true,
+      .read_pipeline_mode = dual_mode,
+  };
+  const dif_spi_device_flash_command_t quad_read_cmd = {
+      // Slot 8: ReadQuad
+      .opcode = kSpiDeviceFlashOpReadQuad,
+      .address_type = kDifSpiDeviceFlashAddrCfg,
+      .passthrough_swap_address = true,
+      .dummy_cycles = 8,
+      .payload_io_type = kDifSpiDevicePayloadIoQuad,
+      .payload_dir_to_host = true,
+      .read_pipeline_mode = quad_mode,
+  };
+  TRY(dif_spi_device_set_flash_command_slot(spi_device, /*slot=*/7,
+                                            kDifToggleEnabled, dual_read_cmd));
+  TRY(dif_spi_device_set_flash_command_slot(spi_device, /*slot=*/8,
+                                            kDifToggleEnabled, quad_read_cmd));
+  return OK_STATUS();
+}
+
 status_t spi_device_testutils_wait_for_upload(dif_spi_device_handle_t *spid,
                                               upload_info_t *info) {
   // Wait for a SPI transaction cause an upload.

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -97,6 +97,22 @@ status_t spi_device_testutils_configure_passthrough(
     bool upload_write_commands);
 
 /**
+ * Configure the read pipeline setting of the read command slots.
+ *
+ * Note that these settings can be overwritten by any other function that writes
+ * the command slots. As such, this configuration should come after any function
+ * calls that would affect dual read and quad read commands.
+ *
+ * @param spi_device A spi_device DIF handle.
+ * @param dual_mode Desired read pipeline mode for the dual read command.
+ * @param quad_mode Desired read pipeline mode for the quad read command.
+ */
+status_t spi_device_testutils_configure_read_pipeline(
+    dif_spi_device_handle_t *spi_device,
+    dif_spi_device_read_pipeline_mode_t dual_mode,
+    dif_spi_device_read_pipeline_mode_t quad_mode);
+
+/**
  * Wait for a spi command upload.
  *
  * Upon detecting a spi command upload, the `info` block will be populated

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3859,19 +3859,27 @@ opentitan_test(
     name = "spi_passthru_test",
     srcs = ["spi_passthru_test.c"],
     cw310 = new_cw310_params(
-        # TODO: This test will need hyperdebug once we start using multi-lane
-        # SPI modes.
-        # interface = "hyper310",
-        # tags = ["manual"],
         test_cmd = """
             --bitstream={bitstream}
             --bootstrap="{firmware}"
+            "{firmware:elf}"
         """,
         test_harness = "//sw/host/tests/chip/spi_passthru",
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": "hyper310",
     },
+    hyper310 = new_cw310_params(
+        tags = ["manual"],  # TODO: QE bit handling
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap="{firmware}"
+            "{firmware:elf}"
+        """,
+        test_harness = "//sw/host/tests/chip/spi_passthru",
+    ),
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:gpio",
@@ -3882,6 +3890,7 @@ opentitan_test(
         "//sw/device/lib/testing/json:spi_passthru",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
     ],
 )
 

--- a/sw/host/tests/chip/spi_passthru/BUILD
+++ b/sw/host/tests/chip/spi_passthru/BUILD
@@ -17,6 +17,7 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:object",
         "@crate_index//:serde_json",
     ],
 )


### PR DESCRIPTION
Add a 2-stage pipeline to break up the combinatorial path for passthrough reads, particularly for quad output reads.

For selected commands in the CMD_INFO tables, this pipeline samples the read data from the downstream SPI flash and latches it in spi_device, then shifts it out to the host 2 cycles later. To use it, the user would read the number of dummy cycles required for the downstream SPI flash, configure the CMD_INFO table for the same number as the downstream SPI flash, then add 2 more cycles and advertise the higher value in an intercepted SFDP read.

On quad output reads, the host thinks there are N+2 dummy cycles (which it learned from the SFDP tables advertised by spi_device), and the downstream SPI device will shift out one additional byte (which will be harmlessly dropped).

Constraints for this specific mode will need to be added in a subsequent PR.

Resolves https://github.com/lowRISC/opentitan/issues/11718