### PR TITLE
[cryptolib] KDF API changes

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -142,10 +142,6 @@ Data structures for key types and modes help the cryptolib recognize and prevent
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h otcrypto_hash_mode }}
 {{#header-snippet sw/device/lib/crypto/include/datatypes.h otcrypto_hash_digest }}
 
-#### Key derivation data structures
-
-{{#header-snippet sw/device/lib/crypto/include/kdf.h otcrypto_kdf_type }}
-
 #### Message authentication data structures
 
 {{#header-snippet sw/device/lib/crypto/include/mac.h otcrypto_kmac_mode }}
@@ -477,7 +473,9 @@ To learn more about PRFs, various key derivation mechanisms and security conside
 
 #### KDF-CTR
 
-{{#header-snippet sw/device/lib/crypto/include/kdf.h otcrypto_kdf_ctr }}
+{{#header-snippet sw/device/lib/crypto/include/kdf.h otcrypto_kdf_hmac_ctr }}
+{{#header-snippet sw/device/lib/crypto/include/kdf.h otcrypto_kdf_kmac }}
+
 
 #### HKDF
 

--- a/sw/device/lib/crypto/impl/kdf.c
+++ b/sw/device/lib/crypto/impl/kdf.c
@@ -14,12 +14,21 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('k', 'd', 'f')
 
-otcrypto_status_t otcrypto_kdf_ctr(const otcrypto_blinded_key_t ikm,
-                                   otcrypto_kdf_type_t kdf_mode,
-                                   otcrypto_key_mode_t key_mode,
-                                   size_t required_bit_len,
-                                   otcrypto_blinded_key_t keying_material) {
-  // TODO: Implement HMAC-KDF-CTR and KMAC-KDF-CTR.
+otcrypto_status_t otcrypto_kdf_hmac_ctr(
+    const otcrypto_blinded_key_t key_derivation_key,
+    const otcrypto_const_byte_buf_t kdf_label,
+    const otcrypto_const_byte_buf_t kdf_context, size_t required_byte_len,
+    otcrypto_blinded_key_t *keying_material) {
+  // TODO: Implement HMAC-KDF-CTR.
+  return OTCRYPTO_NOT_IMPLEMENTED;
+}
+
+otcrypto_status_t otcrypto_kdf_kmac(
+    const otcrypto_blinded_key_t key_derivation_key,
+    otcrypto_kmac_mode_t kmac_mode, const otcrypto_const_byte_buf_t kdf_label,
+    const otcrypto_const_byte_buf_t kdf_context, size_t required_byte_len,
+    otcrypto_blinded_key_t *keying_material) {
+  // TODO: Implement KMAC-KDF.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -254,9 +254,11 @@ typedef enum otcrypto_ecc_key_mode {
  */
 typedef enum otcrypto_kdf_key_mode {
   // Mode KDF-CTR with HMAC as PRF.
-  kOtcryptoKdfKeyModeCtrHmac = 0x127,
-  // Mode KDF-CTR with KMAC as PRF.
-  kOtcryptoKdfKeyModeCtrKmac = 0x3dd,
+  kOtcryptoKdfKeyModeCtrHmac = 0x12f,
+  // Mode KDF-KMAC with KMAC128 as PRF.
+  kOtcryptoKdfKeyModeKmac128 = 0xe5e,
+  // Mode KDF-KMAC with KMAC256 as PRF.
+  kOtcryptoKdfKeyModeKmac256 = 0x353,
 } otcrypto_kdf_key_mode_t;
 
 /**
@@ -320,9 +322,12 @@ typedef enum otcrypto_key_mode {
   // Key is intended for KDF-CTR with HMAC as PRF.
   kOtcryptoKeyModeKdfCtrHmac =
       kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeCtrHmac,
-  // Key is intended for KDF-CTR with KMAC as PRF.
-  kOtcryptoKeyModeKdfCtrKmac =
-      kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeCtrKmac,
+  // Key is intended for KDF with KMAC128 as PRF.
+  kOtcryptoKeyModeKdfKmac128 =
+      kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeKmac128,
+  // Key is intended for KDF with KMAC256 as PRF.
+  kOtcryptoKeyModeKdfKmac256 =
+      kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeKmac256,
 } otcrypto_key_mode_t;
 
 /**


### PR DESCRIPTION
NIST SP 800-108r1 defines multiple iteration modes for given PRF \in {KMAC, HMAC, CMAC}. Our current plan is to support:

- counter mode with HMAC
- (no-mode) with KMAC, since KMAC can process produce arbitrary-size outputs

This PR modifies the API so that these two are separate functions. _Label_ and _Context_ inputs are also added to API.