### PR TITLE
[sival/otbn] Added bazel target for testplans covered by randomness.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -40,6 +40,7 @@
       si_stage: SV3
       tests: ["chip_sw_otbn_ecdsa_op_irq",
               "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
+      bazel: ["//sw/device/tests:otbn_ecdsa_op_irq_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "OTBN.ISA"

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -58,6 +58,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "OTBN.RANDOM"
@@ -72,6 +73,7 @@
       stage: V2
       si_stage: SV3
       tests:  ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: [
         "OTBN.RANDOM"
@@ -95,6 +97,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
       features: []
     }


### PR DESCRIPTION
Covers: https://github.com/lowRISC/opentitan/issues/20118, https://github.com/lowRISC/opentitan/issues/20117, https://github.com/lowRISC/opentitan/issues/20116 & https://github.com/lowRISC/opentitan/issues/20115

```
//sw/device/tests:otbn_randomness_test_fpga_cw310_rom_with_fake_keys (cached) PASSED in 19.1s
//sw/device/tests:otbn_randomness_test_fpga_cw310_sival         (cached) PASSED in 19.7s
//sw/device/tests:otbn_randomness_test_fpga_cw310_sival_rom_ext (cached) PASSED in 18.0s
//sw/device/tests:otbn_randomness_test_fpga_cw310_test_rom      (cached) PASSED in 18.7s
//sw/device/tests:otbn_ecdsa_op_irq_test_fpga_cw310_test_rom    (cached) PASSED in 18.9s
//sw/device/tests:otbn_ecdsa_op_irq_test_fpga_cw310_rom_with_fake_keys   PASSED in 19.3s
//sw/device/tests:otbn_ecdsa_op_irq_test_fpga_cw310_sival_rom_ext        PASSED in 19.7s
```