### PR TITLE
[opentitanlib] Add serial break support to the console

### DIFF
--- a/sw/host/opentitanlib/src/io/console.rs
+++ b/sw/host/opentitanlib/src/io/console.rs
@@ -32,6 +32,10 @@ pub trait ConsoleDevice {
         Err(ConsoleError::UnsupportedError("console_write() not implemented.".into()).into())
     }
 
+    fn set_break(&self, _enable: bool) -> Result<()> {
+        Err(ConsoleError::GenericError("break unsupported".into()).into())
+    }
+
     /// Query if nonblocking mio mode is supported.
     fn supports_nonblocking_read(&self) -> Result<bool> {
         Ok(false)

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -15,6 +15,7 @@ use super::nonblocking_help::{NoNonblockingHelp, NonblockingHelp};
 use crate::app::TransportWrapper;
 use crate::impl_serializable_error;
 use crate::io::console::ConsoleDevice;
+use crate::transport::TransportError;
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
 pub struct UartParams {
@@ -92,6 +93,10 @@ pub trait Uart {
         Ok(())
     }
 
+    fn set_break(&self, _enable: bool) -> Result<()> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
     /// Query if nonblocking mio mode is supported.
     fn supports_nonblocking_read(&self) -> Result<bool> {
         Ok(false)
@@ -126,6 +131,10 @@ impl<'a> ConsoleDevice for dyn Uart + 'a {
 
     fn console_write(&self, buf: &[u8]) -> Result<()> {
         self.write(buf)
+    }
+
+    fn set_break(&self, enable: bool) -> Result<()> {
+        <Self as Uart>::set_break(self, enable)
     }
 
     fn supports_nonblocking_read(&self) -> Result<bool> {

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -190,6 +190,16 @@ impl Uart for SerialPortUart {
         Ok(())
     }
 
+    fn set_break(&self, enable: bool) -> Result<()> {
+        let port = self.port.borrow_mut();
+        if enable {
+            port.set_break()?;
+        } else {
+            port.clear_break()?;
+        }
+        Ok(())
+    }
+
     /// Clears the UART RX buffer.
     fn clear_rx_buffer(&self) -> Result<()> {
         self.rxbuf.borrow_mut().clear();

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -97,8 +97,8 @@ impl CommandDispatch for Console {
                 uart.write(send.as_bytes())?;
             }
             if !self.non_interactive {
-                eprintln!("Starting interactive console");
-                eprintln!("[CTRL+C] to exit.\n");
+                eprint!("Starting interactive console\r\n");
+                eprint!("[CTRL+C] to exit.\r\n\r\n");
             }
             console.interact(&*uart, stdin.as_mut().map(|x| x as _), Some(&mut stdout))?
         };


### PR DESCRIPTION
1. Add serial break support to the opentitanlib Uart trait and serial console.
2. Fix the "Starting interactive console" greeting.
