### PR TITLE
[otp_ctrl] Make DAI registers software-lockable

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -802,7 +802,7 @@ class cip_base_vseq #(
           csr_utils_pkg::wait_no_outstanding_access();
 
           // Manually lock lockable flds because we use tl_access() instead of csr_wr().
-          if (csrs[i].is_wen_reg()) csrs[i].lock_lockable_flds(`gmv(csrs[i]));
+          if (csrs[i].is_wen_reg()) csrs[i].lock_lockable_flds(`gmv(csrs[i]), UVM_PREDICT_WRITE);
         end
       end
     end

--- a/hw/ip/otp_ctrl/data/dif_otp_ctrl.c.tpl
+++ b/hw/ip/otp_ctrl/data/dif_otp_ctrl.c.tpl
@@ -92,6 +92,33 @@ dif_result_t dif_otp_ctrl_check_consistency(const dif_otp_ctrl_t *otp) {
   return kDifOk;
 }
 
+dif_result_t dif_otp_ctrl_lock_dai(const dif_otp_ctrl_t *otp) {
+  if (otp == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = bitfield_bit32_write(
+      0, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false);
+  mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+                      reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_otp_ctrl_dai_is_locked(const dif_otp_ctrl_t *otp,
+                                        bool *is_locked) {
+  if (otp == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(otp->base_addr,
+                                    OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
+  *is_locked = !bitfield_bit32_read(
+      reg, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT);
+
+  return kDifOk;
+}
+
 dif_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp) {
   if (otp == NULL) {
     return kDifBadArg;

--- a/hw/ip/otp_ctrl/data/dif_otp_ctrl.h.tpl
+++ b/hw/ip/otp_ctrl/data/dif_otp_ctrl.h.tpl
@@ -289,10 +289,38 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_check_consistency(const dif_otp_ctrl_t *otp);
 
 /**
+ * Locks out access to the direct access interface registers.
+ *
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
+ *
+ * @param otp An OTP handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_lock_dai(const dif_otp_ctrl_t *otp);
+
+/**
+ * Checks whether access to the direct access interface is locked.
+ *
+ * Note that besides locking the DAI out until the next reset using the
+ * dif_otp_ctrl_lock_dai function, the DAI is also temporarily locked by the
+ * HW itself when it is busy processing a DAI command. In such a case, the
+ * kDifOtpCtrlStatusCodeDaiIdle status bit will be set to 0 as well.
+ *
+ * @param otp An OTP handle.
+ * @param[out] is_locked Out-param for the locked state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_dai_is_locked(const dif_otp_ctrl_t *otp,
+                                        bool *is_locked);
+
+/**
  * Locks out `dif_otp_ctrl_configure()` function.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @return The result of the operation.
@@ -314,8 +342,8 @@ dif_result_t dif_otp_ctrl_config_is_locked(const dif_otp_ctrl_t *otp,
 /**
  * Locks out `dif_otp_ctrl_check_*()` functions.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @return The result of the operation.
@@ -344,8 +372,8 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  * `dif_otp_ctrl_dai_digest()`. In particular, the effects of this function will
  * not persist past a system reset.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @param partition The SW partition to lock.

--- a/hw/ip/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl
+++ b/hw/ip/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl
@@ -39,6 +39,39 @@ class OtpTest : public testing::Test, public MmioTest {
   dif_otp_ctrl_t otp_ = {.base_addr = dev().region()};
 };
 
+class DaiRegwenTest : public OtpTest {};
+
+TEST_F(DaiRegwenTest, LockDai) {
+  EXPECT_WRITE32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
+  EXPECT_DIF_OK(dif_otp_ctrl_lock_dai(&otp_));
+}
+
+TEST_F(DaiRegwenTest, IsDaiLocked) {
+  bool flag;
+
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_is_locked(&otp_, &flag));
+  EXPECT_FALSE(flag);
+
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_is_locked(&otp_, &flag));
+  EXPECT_TRUE(flag);
+}
+
+TEST_F(DaiRegwenTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_otp_ctrl_lock_dai(nullptr));
+
+  bool flag;
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_is_locked(nullptr, &flag));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_is_locked(&otp_, nullptr));
+}
+
 class ConfigTest : public OtpTest {};
 
 TEST_F(ConfigTest, Basic) {

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -1870,19 +1870,24 @@
         desc: '''
               Register write enable for all direct access interface registers.
               ''',
-        swaccess: "ro",
-        hwaccess: "hwo",
+        swaccess: "rw0c",
+        hwaccess: "hrw",
         hwext:    "true",
+        hwqe:     "true",
         tags: [ // OTP internal HW will set this enable register to 0 when OTP is not under IDLE
                 // state, so could not auto-predict its value
                 "excl:CsrNonInitTests:CsrExclCheck"],
         fields: [
           {
               bits:   "0",
-              desc: ''' This bit is hardware-managed and only readable by software.
-              The DAI sets this bit temporarily to 0 during an OTP operation such that
-              the corresponding address and data registers cannot be modified while
-              the operation is pending.
+              desc: '''
+              This bit controls whether the DAI registers can be written.
+              Write 0 to it in order to clear the bit.
+
+              Note that the hardware also modulates this bit and sets it to 0 temporarily
+              during an OTP operation such that the corresponding address and data registers
+              cannot be modified while an operation is pending. The !!DAI_IDLE status bit
+              will also be set to 0 in such a case.
               '''
               resval: 1,
           },

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -873,19 +873,24 @@ otp_size_as_uint32 = otp_size_as_bytes // 4
         desc: '''
               Register write enable for all direct access interface registers.
               ''',
-        swaccess: "ro",
-        hwaccess: "hwo",
+        swaccess: "rw0c",
+        hwaccess: "hrw",
         hwext:    "true",
+        hwqe:     "true",
         tags: [ // OTP internal HW will set this enable register to 0 when OTP is not under IDLE
                 // state, so could not auto-predict its value
                 "excl:CsrNonInitTests:CsrExclCheck"],
         fields: [
           {
               bits:   "0",
-              desc: ''' This bit is hardware-managed and only readable by software.
-              The DAI sets this bit temporarily to 0 during an OTP operation such that
-              the corresponding address and data registers cannot be modified while
-              the operation is pending.
+              desc: '''
+              This bit controls whether the DAI registers can be written.
+              Write 0 to it in order to clear the bit.
+
+              Note that the hardware also modulates this bit and sets it to 0 temporarily
+              during an OTP operation such that the corresponding address and data registers
+              cannot be modified while an operation is pending. The !!DAI_IDLE status bit
+              will also be set to 0 in such a case.
               '''
               resval: 1,
           },

--- a/hw/ip/otp_ctrl/data/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_scoreboard.sv.tpl
@@ -39,6 +39,10 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   // This bit is used for DAI interface to mark if the read access is valid.
   bit dai_read_valid;
 
+  // This captures the regwen state as configured by the SW side (i.e. without HW modulation
+  // with the idle signal overlaid).
+  bit direct_access_regwen_state = 1;
+
   // ICEBOX(#17798): currently scb will skip checking the readout value if the ECC error is
   // uncorrectable. Because if the error is uncorrectable, current scb does not track all the
   // backdoor injected values.
@@ -151,7 +155,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
           if (cfg.otp_ctrl_vif.under_error_states() == 0) begin
             // Dai access is unlocked because the power init is done
-            void'(ral.direct_access_regwen.predict(1));
+            void'(ral.direct_access_regwen.predict(direct_access_regwen_state));
 
             // Dai idle is set because the otp init is done
             exp_status[OtpDaiIdleIdx] = 1;
@@ -557,6 +561,10 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit         do_read_check = 1;
     uvm_reg     csr;
     dv_base_reg dv_reg;
+    string      csr_name;
+
+    `uvm_info(`gfn, $sformatf("sw state %d, reg state %d", direct_access_regwen_state,
+                             `gmv(ral.direct_access_regwen)), UVM_LOW);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -624,14 +632,18 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
+    csr_name = csr.get_name();
+
     if (addr_phase_write) begin
-      if (cfg.en_cov && cfg.otp_ctrl_vif.alert_reqs && csr.get_name == "direct_access_cmd") begin
+      if (cfg.en_cov && cfg.otp_ctrl_vif.alert_reqs && csr_name == "direct_access_cmd") begin
         cov.req_dai_access_after_alert_cg.sample(item.a_data);
       end
 
       // Skip predict if the register is locked by `direct_access_regwen`.
+      // An exception is the direct_access_regwen which may always be written.
       if (ral.direct_access_regwen.locks_reg_or_fld(dv_reg) &&
-          `gmv(ral.direct_access_regwen) == 0) return;
+          `gmv(ral.direct_access_regwen) == 0 &&
+          csr_name != "direct_access_regwen") return;
 
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
@@ -639,7 +651,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     // process the csr req
     // for write, update local variable and fifo at address phase
     // for read, update predication at address phase and compare at data phase
-    case (csr.get_name())
+    case (csr_name)
       // add individual case item for each csr
       "intr_state": begin
         if (data_phase_read) begin
@@ -904,7 +916,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
           if (under_dai_access && !cfg.otp_ctrl_vif.under_error_states()) begin
             if (item.d_data[OtpDaiIdleIdx]) begin
               under_dai_access = 0;
-              void'(ral.direct_access_regwen.predict(1));
+              void'(ral.direct_access_regwen.predict(direct_access_regwen_state));
               void'(ral.intr_state.otp_operation_done.predict(1));
             end
           end
@@ -940,6 +952,15 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
           end
         end
       end
+      "direct_access_regwen": begin
+        if (addr_phase_write) begin
+          // This locks the DAI until the next reset.
+          if (!item.a_data[0]) begin
+            direct_access_regwen_state = 0;
+            void'(ral.direct_access_regwen.predict(0));
+          end
+        end
+      end
       // For error codes, if lc_prog in progress, err_code might update anytime in DUT. Ignore
       // checking until req is acknowledged.
 
@@ -967,7 +988,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 <% part_name_snake = Name.from_snake_case(part["name"]).as_snake_case() %>\
       "${part_name_snake}_read_lock",
 % endfor
-      "direct_access_regwen",
       "direct_access_wdata_0",
       "direct_access_wdata_1",
       "direct_access_address",
@@ -1071,6 +1091,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       sram_fifos[i].flush();
     end
 
+    direct_access_regwen_state = 1;
     under_chk             = 0;
     under_dai_access      = 0;
     ignore_digest_chk     = 0;

--- a/hw/ip/otp_ctrl/doc/registers.md
+++ b/hw/ip/otp_ctrl/doc/registers.md
@@ -220,13 +220,22 @@ Register write enable for all direct access interface registers.
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "DIRECT_ACCESS_REGWEN", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 220}}
+{"reg": [{"name": "DIRECT_ACCESS_REGWEN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 220}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                 | Description                                                                                                                                                                                                                          |
-|:------:|:------:|:-------:|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:1  |        |         |                      | Reserved                                                                                                                                                                                                                             |
-|   0    |   ro   |   0x1   | DIRECT_ACCESS_REGWEN | This bit is hardware-managed and only readable by software. The DAI sets this bit temporarily to 0 during an OTP operation such that the corresponding address and data registers cannot be modified while the operation is pending. |
+|  Bits  |  Type  |  Reset  | Name                                                                |
+|:------:|:------:|:-------:|:--------------------------------------------------------------------|
+|  31:1  |        |         | Reserved                                                            |
+|   0    |  rw0c  |   0x1   | [DIRECT_ACCESS_REGWEN](#direct_access_regwen--direct_access_regwen) |
+
+### DIRECT_ACCESS_REGWEN . DIRECT_ACCESS_REGWEN
+This bit controls whether the DAI registers can be written.
+Write 0 to it in order to clear the bit.
+
+Note that the hardware also modulates this bit and sets it to 0 temporarily
+during an OTP operation such that the corresponding address and data registers
+cannot be modified while an operation is pending. The [`DAI_IDLE`](#dai_idle) status bit
+will also be set to 0 in such a case.
 
 ## DIRECT_ACCESS_CMD
 Command register for direct accesses.

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -228,7 +228,9 @@ module otp_ctrl_core_reg_top (
   logic err_code_9_re;
   logic [2:0] err_code_9_qs;
   logic direct_access_regwen_re;
+  logic direct_access_regwen_we;
   logic direct_access_regwen_qs;
+  logic direct_access_regwen_wd;
   logic direct_access_cmd_we;
   logic direct_access_cmd_rd_wd;
   logic direct_access_cmd_wr_wd;
@@ -965,19 +967,23 @@ module otp_ctrl_core_reg_top (
 
 
   // R[direct_access_regwen]: V(True)
+  logic direct_access_regwen_qe;
+  logic [0:0] direct_access_regwen_flds_we;
+  assign direct_access_regwen_qe = &direct_access_regwen_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_direct_access_regwen (
     .re     (direct_access_regwen_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (direct_access_regwen_we),
+    .wd     (direct_access_regwen_wd),
     .d      (hw2reg.direct_access_regwen.d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (direct_access_regwen_flds_we[0]),
+    .q      (reg2hw.direct_access_regwen.q),
     .ds     (),
     .qs     (direct_access_regwen_qs)
   );
+  assign reg2hw.direct_access_regwen.qe = direct_access_regwen_qe;
 
 
   // R[direct_access_cmd]: V(True)
@@ -1827,6 +1833,9 @@ module otp_ctrl_core_reg_top (
   assign err_code_8_re = addr_hit[13] & reg_re & !reg_error;
   assign err_code_9_re = addr_hit[14] & reg_re & !reg_error;
   assign direct_access_regwen_re = addr_hit[15] & reg_re & !reg_error;
+  assign direct_access_regwen_we = addr_hit[15] & reg_we & !reg_error;
+
+  assign direct_access_regwen_wd = reg_wdata[0];
   assign direct_access_cmd_we = addr_hit[16] & reg_we & !reg_error;
 
   assign direct_access_cmd_rd_wd = reg_wdata[0];
@@ -1907,7 +1916,7 @@ module otp_ctrl_core_reg_top (
     reg_we_check[12] = 1'b0;
     reg_we_check[13] = 1'b0;
     reg_we_check[14] = 1'b0;
-    reg_we_check[15] = 1'b0;
+    reg_we_check[15] = direct_access_regwen_we;
     reg_we_check[16] = direct_access_cmd_gated_we;
     reg_we_check[17] = direct_access_address_gated_we;
     reg_we_check[18] = direct_access_wdata_0_gated_we;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -245,6 +245,11 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
+    logic        q;
+    logic        qe;
+  } otp_ctrl_reg2hw_direct_access_regwen_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -409,10 +414,11 @@ package otp_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [201:200]
-    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [199:198]
-    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [197:194]
-    otp_ctrl_reg2hw_alert_test_reg_t alert_test; // [193:184]
+    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [203:202]
+    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [201:200]
+    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [199:196]
+    otp_ctrl_reg2hw_alert_test_reg_t alert_test; // [195:186]
+    otp_ctrl_reg2hw_direct_access_regwen_reg_t direct_access_regwen; // [185:184]
     otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [183:178]
     otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [177:167]
     otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [166:103]

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -85,6 +85,33 @@ dif_result_t dif_otp_ctrl_check_consistency(const dif_otp_ctrl_t *otp) {
   return kDifOk;
 }
 
+dif_result_t dif_otp_ctrl_lock_dai(const dif_otp_ctrl_t *otp) {
+  if (otp == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = bitfield_bit32_write(
+      0, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false);
+  mmio_region_write32(otp->base_addr, OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+                      reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_otp_ctrl_dai_is_locked(const dif_otp_ctrl_t *otp,
+                                        bool *is_locked) {
+  if (otp == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(otp->base_addr,
+                                    OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
+  *is_locked = !bitfield_bit32_read(
+      reg, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT);
+
+  return kDifOk;
+}
+
 dif_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp) {
   if (otp == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -358,10 +358,38 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_check_consistency(const dif_otp_ctrl_t *otp);
 
 /**
+ * Locks out access to the direct access interface registers.
+ *
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
+ *
+ * @param otp An OTP handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_lock_dai(const dif_otp_ctrl_t *otp);
+
+/**
+ * Checks whether access to the direct access interface is locked.
+ *
+ * Note that besides locking the DAI out until the next reset using the
+ * dif_otp_ctrl_lock_dai function, the DAI is also temporarily locked by the
+ * HW itself when it is busy processing a DAI command. In such a case, the
+ * kDifOtpCtrlStatusCodeDaiIdle status bit will be set to 0 as well.
+ *
+ * @param otp An OTP handle.
+ * @param[out] is_locked Out-param for the locked state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_dai_is_locked(const dif_otp_ctrl_t *otp,
+                                        bool *is_locked);
+
+/**
  * Locks out `dif_otp_ctrl_configure()` function.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @return The result of the operation.
@@ -383,8 +411,8 @@ dif_result_t dif_otp_ctrl_config_is_locked(const dif_otp_ctrl_t *otp,
 /**
  * Locks out `dif_otp_ctrl_check_*()` functions.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @return The result of the operation.
@@ -413,8 +441,8 @@ dif_result_t dif_otp_ctrl_check_trigger_is_locked(const dif_otp_ctrl_t *otp,
  * `dif_otp_ctrl_dai_digest()`. In particular, the effects of this function will
  * not persist past a system reset.
  *
- * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDifOtpCtrlOk`.
+ * This function is idempotent: calling it while functionality is locked will
+ * have no effect and return `kDifOk`.
  *
  * @param otp An OTP handle.
  * @param partition The SW partition to lock.

--- a/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
@@ -30,6 +30,39 @@ class OtpTest : public testing::Test, public MmioTest {
   dif_otp_ctrl_t otp_ = {.base_addr = dev().region()};
 };
 
+class DaiRegwenTest : public OtpTest {};
+
+TEST_F(DaiRegwenTest, LockDai) {
+  EXPECT_WRITE32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
+  EXPECT_DIF_OK(dif_otp_ctrl_lock_dai(&otp_));
+}
+
+TEST_F(DaiRegwenTest, IsDaiLocked) {
+  bool flag;
+
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_is_locked(&otp_, &flag));
+  EXPECT_FALSE(flag);
+
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
+  EXPECT_DIF_OK(dif_otp_ctrl_dai_is_locked(&otp_, &flag));
+  EXPECT_TRUE(flag);
+}
+
+TEST_F(DaiRegwenTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_otp_ctrl_lock_dai(nullptr));
+
+  bool flag;
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_is_locked(nullptr, &flag));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_dai_is_locked(&otp_, nullptr));
+}
+
 class ConfigTest : public OtpTest {};
 
 TEST_F(ConfigTest, Basic) {


### PR DESCRIPTION
So far only the hardware was able to modulate the DAI regwen. 
This updates the implementation so that the DAI can be permanently locked out via SW as well.

Fixes #20348

Note: this is WIP, the DV still needs to be updated for this.