### PR TITLE
[crypto] Use OTBN's checksum register in cryptolib.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -183,7 +183,9 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:random_order",
         "//sw/device/lib/crypto/impl:status",
     ],
 )

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -6,8 +6,10 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/random_order.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -114,42 +116,120 @@ static status_t otbn_assert_idle(void) {
 }
 
 /**
+ * Update a checksum value with a given IMEM or DMEM write.
+ *
+ * Calculates the checksum stream according to:
+ * https://opentitan.org/book/hw/ip/otbn/doc/theory_of_operation.html#memory-load-integrity
+ *
+ * This means each write is a 48b value, where the most significant two bytes
+ * indicate the location and the least significant four bytes are the 32-bit
+ * value that was written. Byte-writes or unaligned writes are not included in
+ * the checksum.
+ *
+ * The location bytes are formatted as follows (described from MSB->LSB):
+ * - The first bit (MSB) is 1 for IMEM, 0 for DMEM
+ * - The next 5b are zero
+ * - The next 10b are the word-index of the address in memory
+ *
+ * The 48b value is read by OTBN in little-endian order, so we accumulate it to
+ * the checksum with least significant bytes first.
+ *
+ * @param checksum Checksum value (updated in-place).
+ * @param is_imem Indicates whether the write is to IMEM.
+ * @param addr Address of the write.
+ * @param value Value to be written.
+ */
+static void update_checksum_for_write(uint32_t *checksum, bool is_imem,
+                                      uint32_t addr, uint32_t value) {
+  // Calculate prefix: is_imem || addr[11:2] || 00000
+  uint16_t prefix = is_imem ? 0x8000 : 0;
+  prefix |= (addr & 0x7ff) >> 2;
+  unsigned char *prefix_bytes = (unsigned char *)&prefix;
+
+  // The value and prefix are reversed here because of the little-endian
+  // ordering.
+  crc32_add32(checksum, value);
+  crc32_add8(checksum, prefix_bytes[0]);
+  crc32_add8(checksum, prefix_bytes[1]);
+}
+
+/**
  * Helper function for writing to OTBN's DMEM or IMEM.
  *
+ * Checks OTBN's CRC32 checksum register to ensure that the data was properly
+ * loaded.
+ *
+ * @param is_imem Boolean indicating whether the write is to IMEM.
  * @param dest_addr Destination address.
  * @param src Source buffer.
  * @param num_words Number of words to copy.
  */
-static void otbn_write(uint32_t dest_addr, const uint32_t *src,
-                       size_t num_words) {
-  // TODO: replace 0 with a random index like the silicon_creator driver
-  // (requires an interface to Ibex's RND valid bit and data register).
-  size_t i = ((uint64_t)0 * (uint64_t)num_words) >> 32;
-  enum { kStep = 1 };
-  size_t iter_cnt = 0;
-  for (; launder32(iter_cnt) < num_words; ++iter_cnt) {
-    abs_mmio_write32(dest_addr + i * sizeof(uint32_t), src[i]);
-    i += kStep;
-    if (launder32(i) >= num_words) {
-      i -= num_words;
+OT_WARN_UNUSED_RESULT
+static status_t otbn_write(bool is_imem, uint32_t dest_addr,
+                           const uint32_t *src, size_t num_words) {
+  // Read the initial checksum value from OTBN.
+  uint32_t checksum = launder32(otbn_load_checksum_get());
+  HARDENED_CHECK_EQ(checksum, otbn_load_checksum_get());
+
+  // Invert the checksum to match the internal representation.
+  checksum ^= UINT32_MAX;
+
+  // Set up the iteration.
+  random_order_t iter;
+  random_order_init(&iter, num_words);
+
+  // Create a copy of the iterator to use for the checksum.
+  random_order_t iter_copy;
+  memcpy(&iter_copy, &iter, sizeof(iter));
+
+  // Calculate the expected checksum.
+  size_t i = 0;
+  for (; launder32(i) < random_order_len(&iter_copy); i++) {
+    size_t idx = random_order_advance(&iter_copy);
+    if (idx < num_words) {
+      uint32_t addr = dest_addr + idx * sizeof(uint32_t);
+      uint32_t value = src[idx];
+      update_checksum_for_write(&checksum, is_imem, addr, value);
     }
-    HARDENED_CHECK_LT(i, num_words);
   }
-  HARDENED_CHECK_EQ(iter_cnt, num_words);
+  HARDENED_CHECK_EQ(i, random_order_len(&iter_copy));
+  checksum = crc32_finish(&checksum);
+
+  // Perform the write.
+  i = 0;
+  for (; launder32(i) < random_order_len(&iter); i++) {
+    size_t idx = random_order_advance(&iter);
+    if (launder32(idx) < num_words) {
+      HARDENED_CHECK_LT(idx, num_words);
+      uint32_t addr = dest_addr + idx * sizeof(uint32_t);
+      uint32_t value = src[idx];
+      abs_mmio_write32(addr, value);
+    }
+  }
+  HARDENED_CHECK_EQ(i, random_order_len(&iter));
+
+  // Ensure the checksum updated the same way here and on OTBN.
+  if (launder32(checksum) != otbn_load_checksum_get()) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+  HARDENED_CHECK_EQ(checksum, otbn_load_checksum_get());
+
+  return OTCRYPTO_OK;
 }
 
+OT_WARN_UNUSED_RESULT
 static status_t otbn_imem_write(size_t num_words, const uint32_t *src,
                                 otbn_addr_t dest) {
   HARDENED_TRY(check_offset_len(dest, num_words, kOtbnIMemSizeBytes));
-  otbn_write(kBase + OTBN_IMEM_REG_OFFSET + dest, src, num_words);
-  return OTCRYPTO_OK;
+  return otbn_write(/*is_imem=*/true, kBase + OTBN_IMEM_REG_OFFSET + dest, src,
+                    num_words);
 }
 
 status_t otbn_dmem_write(size_t num_words, const uint32_t *src,
                          otbn_addr_t dest) {
   HARDENED_TRY(check_offset_len(dest, num_words, kOtbnDMemSizeBytes));
-  otbn_write(kBase + OTBN_DMEM_REG_OFFSET + dest, src, num_words);
-  return OTCRYPTO_OK;
+  return otbn_write(/*is_imem=*/false, kBase + OTBN_DMEM_REG_OFFSET + dest, src,
+                    num_words);
 }
 
 status_t otbn_dmem_set(size_t num_words, const uint32_t src, otbn_addr_t dest) {
@@ -228,6 +308,14 @@ uint32_t otbn_err_bits_get(void) {
   return abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
 }
 
+uint32_t otbn_load_checksum_get(void) {
+  return abs_mmio_read32(kBase + OTBN_LOAD_CHECKSUM_REG_OFFSET);
+}
+
+void otbn_load_checksum_reset(void) {
+  abs_mmio_write32(kBase + OTBN_LOAD_CHECKSUM_REG_OFFSET, 0);
+}
+
 uint32_t otbn_instruction_count_get(void) {
   return abs_mmio_read32(kBase + OTBN_INSN_CNT_REG_OFFSET);
 }
@@ -303,8 +391,10 @@ status_t otbn_load_app(const otbn_app_t app) {
   const size_t data_num_words =
       (size_t)(app.dmem_data_end - app.dmem_data_start);
 
+  // Wipe the memories and reset the checksum register.
   HARDENED_TRY(otbn_imem_sec_wipe());
   HARDENED_TRY(otbn_dmem_sec_wipe());
+  otbn_load_checksum_reset();
 
   // IMEM always starts at zero.
   otbn_addr_t imem_start_addr = 0;

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -193,6 +193,7 @@ typedef struct otbn_app {
  * @param dest The DMEM location to copy to.
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_dmem_write(size_t num_words, const uint32_t *src,
                          otbn_addr_t dest);
 
@@ -210,6 +211,7 @@ status_t otbn_dmem_write(size_t num_words, const uint32_t *src,
  * @param dest The DMEM location to set.
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_dmem_set(size_t num_words, const uint32_t src, otbn_addr_t dest);
 
 /**
@@ -226,6 +228,7 @@ status_t otbn_dmem_set(size_t num_words, const uint32_t src, otbn_addr_t dest);
  * @param[out] dest The main memory location to copy to.
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest);
 
 /**
@@ -235,6 +238,7 @@ status_t otbn_dmem_read(size_t num_words, otbn_addr_t src, uint32_t *dest);
  *
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_execute(void);
 
 /**
@@ -244,6 +248,7 @@ status_t otbn_execute(void);
  *
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_busy_wait_for_done(void);
 
 /**
@@ -270,6 +275,20 @@ uint32_t otbn_err_bits_get(void);
 uint32_t otbn_instruction_count_get(void);
 
 /**
+ * Get the checksum value of loaded data from OTBN.
+ *
+ * @return The contents of OTBN's LOAD_CHECKSUM register.
+ */
+uint32_t otbn_load_checksum_get(void);
+
+/**
+ * Reset the value of OTBN's LOAD_CHECKSUM register.
+ *
+ * Sets the checksum value to all-zero.
+ */
+void otbn_load_checksum_reset(void);
+
+/**
  * Wipe IMEM securely.
  *
  * This function returns an error if called when OTBN is not idle, and blocks
@@ -277,6 +296,7 @@ uint32_t otbn_instruction_count_get(void);
  *
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_imem_sec_wipe(void);
 
 /**
@@ -287,6 +307,7 @@ status_t otbn_imem_sec_wipe(void);
  *
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_dmem_sec_wipe(void);
 
 /**
@@ -300,6 +321,7 @@ status_t otbn_dmem_sec_wipe(void);
  * @param enable Enable or disable whether software errors are fatal.
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_set_ctrl_software_errs_fatal(bool enable);
 
 /**
@@ -314,6 +336,7 @@ status_t otbn_set_ctrl_software_errs_fatal(bool enable);
  * @param app The application to load into OTBN.
  * @return The result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t otbn_load_app(const otbn_app_t app);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/impl/sha2/sha256.c
+++ b/sw/device/lib/crypto/impl/sha2/sha256.c
@@ -109,7 +109,7 @@ static status_t process_block(sha256_otbn_ctx_t *ctx,
   otbn_addr_t dst = kOtbnVarSha256Msg + offset;
 
   // Copy the message block into DMEM.
-  otbn_dmem_write(kSha256MessageBlockWords, block->data, dst);
+  HARDENED_TRY(otbn_dmem_write(kSha256MessageBlockWords, block->data, dst));
   ctx->num_blocks += 1;
 
   // If we've reached the maximum number of message chunks for a single run,


### PR DESCRIPTION
Add a read of OTBN's checksum register as a lightweight write-and-read-back check. This is part of https://github.com/lowRISC/opentitan/issues/19173

I changed the iteration to use `random_order_t` from the base library instead of the more ad-hoc construction that was there earlier. `random_order_t` is currently a stub, but as it gets implemented this usage should be a good test case for it.

Some calls in the OTBN driver were missing `OT_WARN_IF_UNUSED_RESULT`; I fixed that while I was poking around in the driver.