### PR TITLE
[cryptolib] Add Ibex drivers for P-384 ECDH and ECDSA on OTBN

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -52,7 +52,9 @@ cc_library(
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/drivers:hmac",
         "//sw/device/lib/crypto/impl/ecc:ecdh_p256",
+        "//sw/device/lib/crypto/impl/ecc:ecdh_p384",
         "//sw/device/lib/crypto/impl/ecc:ecdsa_p256",
+        "//sw/device/lib/crypto/impl/ecc:ecdsa_p384",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -43,3 +43,96 @@ cc_library(
         "//sw/device/lib/crypto/impl:status",
     ],
 )
+
+cc_library(
+    name = "ecdh_p384",
+    srcs = ["ecdh_p384.c"],
+    hdrs = ["ecdh_p384.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p384_common",
+        ":p384_curve_point_valid",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p384_ecdh",
+    ],
+)
+
+cc_library(
+    name = "ecdsa_p384",
+    hdrs = ["ecdsa_p384.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":ecdsa_p384_keygen",
+        ":ecdsa_p384_sign",
+        ":ecdsa_p384_verify",
+    ],
+)
+
+cc_library(
+    name = "ecdsa_p384_keygen",
+    srcs = ["ecdsa_p384_keygen.c"],
+    hdrs = ["ecdsa_p384_keygen.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p384_common",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p384_ecdsa_keygen",
+    ],
+)
+
+cc_library(
+    name = "ecdsa_p384_sign",
+    srcs = ["ecdsa_p384_sign.c"],
+    hdrs = ["ecdsa_p384_sign.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p384_common",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p384_ecdsa_sign",
+    ],
+)
+
+cc_library(
+    name = "ecdsa_p384_verify",
+    srcs = ["ecdsa_p384_verify.c"],
+    hdrs = ["ecdsa_p384_verify.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p384_common",
+        ":p384_curve_point_valid",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p384_ecdsa_verify",
+    ],
+)
+
+cc_library(
+    name = "p384_common",
+    srcs = ["p384_common.c"],
+    hdrs = ["p384_common.h"],
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:status",
+    ],
+)
+
+cc_library(
+    name = "p384_curve_point_valid",
+    srcs = ["p384_curve_point_valid.c"],
+    hdrs = ["p384_curve_point_valid.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":p384_common",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:p384_curve_point_valid",
+    ],
+)

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
@@ -1,0 +1,174 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ecdh_p384.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '3', 'x')
+
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);          // The OTBN ECDSH/P-384 app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, mode);    // ECDH application mode.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, dptr_x);  // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, dptr_y);  // The public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
+                         x);  // The pointer to public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
+                         y);  // The pointer to public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(
+    p384_ecdh,
+    dptr_d0);  // The pointer to private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(
+    p384_ecdh,
+    dptr_d1);  // The pointer to private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
+                         d0);  // The private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
+                         d1);  // The private key scalar d (share 1).
+
+static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p384_ecdh);
+static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p384_ecdh, mode);
+static const otbn_addr_t kOtbnVarEcdhDptrX =
+    OTBN_ADDR_T_INIT(p384_ecdh, dptr_x);
+static const otbn_addr_t kOtbnVarEcdhDptrY =
+    OTBN_ADDR_T_INIT(p384_ecdh, dptr_y);
+static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p384_ecdh, x);
+static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p384_ecdh, y);
+static const otbn_addr_t kOtbnVarEcdhDptrD0 =
+    OTBN_ADDR_T_INIT(p384_ecdh, dptr_d0);
+static const otbn_addr_t kOtbnVarEcdhDptrD1 =
+    OTBN_ADDR_T_INIT(p384_ecdh, dptr_d1);
+static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p384_ecdh, d0);
+static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p384_ecdh, d1);
+
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEcdhModeWords = 1,
+  /*
+   * Mode to generate a new random keypair.
+   */
+  kOtbnEcdhModeKeypairRandom = 0x3f1,
+  /*
+   * Mode to generate a new shared key.
+   */
+  kOtbnEcdhModeSharedKey = 0x5ec,
+  // TODO: kOtbnEcdhModeKeypairFromSeed = 0x29f;
+  // TODO: kOtbnEcdhModeSharedKeyFromSeed = 0x74b;
+};
+
+/**
+ * Makes a single dptr in the P384 library point to where its value is stored.
+ */
+static void setup_data_pointer(const otbn_addr_t dptr,
+                               const otbn_addr_t value) {
+  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
+}
+
+/**
+ * Sets up all data pointers used by the P384 library to point to DMEM.
+ *
+ * The ECDH P384 OTBN library makes use of "named" data pointers as part of
+ * its calling convention, which are exposed as symbol starting with `dptr_`.
+ * The DMEM locations these pointers refer to is not mandated by the P384
+ * calling convention; the values can be placed anywhere in OTBN DMEM.
+ *
+ * This function makes the data pointers refer to the pre-allocated DMEM
+ * regions to store the actual values.
+ */
+static void setup_data_pointers(void) {
+  setup_data_pointer(kOtbnVarEcdhDptrX, kOtbnVarEcdhX);
+  setup_data_pointer(kOtbnVarEcdhDptrY, kOtbnVarEcdhY);
+  setup_data_pointer(kOtbnVarEcdhDptrD0, kOtbnVarEcdhD0);
+  setup_data_pointer(kOtbnVarEcdhDptrD1, kOtbnVarEcdhD1);
+}
+
+status_t ecdh_p384_keypair_start(void) {
+  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Set mode so start() will jump into keygen.
+  uint32_t mode = kOtbnEcdhModeKeypairRandom;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdh_p384_keypair_finalize(p384_masked_scalar_t *private_key,
+                                    p384_point_t *public_key) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the masked private key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarEcdhD0,
+                              private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarEcdhD1,
+                              private_key->share1));
+
+  // Read the public key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarEcdhX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarEcdhY, public_key->y));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}
+
+status_t ecdh_p384_shared_key_start(const p384_masked_scalar_t *private_key,
+                                    const p384_point_t *public_key) {
+  // Check if public key is valid
+  HARDENED_TRY(p384_curve_point_validate_start(public_key));
+  HARDENED_TRY(p384_curve_point_validate_finalize());
+
+  // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Set mode so start() will jump into shared-key generation.
+  uint32_t mode = kOtbnEcdhModeSharedKey;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
+
+  // Set the private key shares.
+  HARDENED_TRY(
+      p384_masked_scalar_write(private_key, kOtbnVarEcdhD0, kOtbnVarEcdhD1));
+
+  // Set the public key x coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->x, kOtbnVarEcdhX));
+
+  // Set the public key y coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->y, kOtbnVarEcdhY));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdh_p384_shared_key_finalize(ecdh_p384_shared_key_t *shared_key) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the shares of the key from OTBN dmem (at vars x and y).
+  HARDENED_TRY(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarEcdhX, shared_key->share0));
+  HARDENED_TRY(
+      otbn_dmem_read(kP384CoordWords, kOtbnVarEcdhY, shared_key->share1));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p384.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p384.h
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P384_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P384_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A type that holds a blinded ECDH shared secret key.
+ *
+ * The key is boolean-masked (XOR of the two shares).
+ */
+typedef struct ecdh_p384_shared_key {
+  uint32_t share0[kP384CoordWords];
+  uint32_t share1[kP384CoordWords];
+} ecdh_p384_shared_key_t;
+
+/**
+ * Start an async ECDH/P-384 keypair generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdh_p384_keypair_start(void);
+
+/**
+ * Finish an async ECDH/P-384 keypair generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] private_key Generated private key.
+ * @param[out] public_key Generated public key.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdh_p384_keypair_finalize(p384_masked_scalar_t *private_key,
+                                    p384_point_t *public_key);
+
+/**
+ * Start an async ECDH/P-384 shared key generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param private_key Private key (d).
+ * @param public_key Public key (Q).
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdh_p384_shared_key_start(const p384_masked_scalar_t *private_key,
+                                    const p384_point_t *public_key);
+
+/**
+ * Finish an async ECDH/P-384 shared key generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle. May be used after either
+ * `ecdh_p384_shared_key_start` or `ecdh_p384_sideload_shared_key_start`; the
+ * operation is the same.
+ *
+ * @param[out] shared_key Shared secret key (x-coordinate of d*Q).
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdh_p384_shared_key_finalize(ecdh_p384_shared_key_t *shared_key);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDH_P384_H_

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384.h
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_H_
+
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.h"
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h"
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.h"
+
+/**
+ * @file
+ * @brief Unified header file that includes all P-384 ECDSA operations.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_H_

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
@@ -1,0 +1,142 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '3', 'k')
+
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_k0);  // Pointer to k0.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_k1);  // Pointer to k1.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_d0);  // Pointer to d0.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_d1);  // Pointer to d1.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, k0);  // Random scalar first share.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, k1);  // Random scalar second share.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d0);  // Private key first share.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d1);  // Private key second share.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen,
+                         dptr_x);  // pointer to x-coordinate (dptr_x)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen,
+                         dptr_y);  // pointer to y-coordinate (dptr_y)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, x);  // x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, y);  // y-coordinate.
+
+static const otbn_app_t kOtbnAppEcdsaKeygen =
+    OTBN_APP_T_INIT(p384_ecdsa_keygen);
+static const otbn_addr_t kOtbnVarEcdsaDptrX =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_x);
+static const otbn_addr_t kOtbnVarEcdsaDptrY =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_y);
+static const otbn_addr_t kOtbnVarEcdsaX =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, x);
+static const otbn_addr_t kOtbnVarEcdsaY =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, y);
+static const otbn_addr_t kOtbnVarEcdsaDptrK0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_k0);
+static const otbn_addr_t kOtbnVarEcdsaDptrK1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_k1);
+static const otbn_addr_t kOtbnVarEcdsaDptrD0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_d0);
+static const otbn_addr_t kOtbnVarEcdsaDptrD1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_d1);
+static const otbn_addr_t kOtbnVarEcdsaK0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, k0);
+static const otbn_addr_t kOtbnVarEcdsaK1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, k1);
+static const otbn_addr_t kOtbnVarEcdsaD0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, d0);
+static const otbn_addr_t kOtbnVarEcdsaD1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, d1);
+
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEcdsaModeWords = 1,
+  /*
+   * Mode to generate a new random keypair.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeKeygen = 0x3d4,
+  /*
+   * Mode to generate a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeSign = 0x15b,
+  /*
+   * Mode to verify a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeVerify = 0x727,
+};
+
+/**
+ * Makes a single dptr in the P384 library point to where its value is stored.
+ */
+static void setup_data_pointer(const otbn_addr_t dptr,
+                               const otbn_addr_t value) {
+  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
+}
+
+/**
+ * Sets up all data pointers used by the P384 library to point to DMEM.
+ *
+ * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
+ * its calling convention, which are exposed as symbol starting with `dptr_`.
+ * The DMEM locations these pointers refer to is not mandated by the P384
+ * calling convention; the values can be placed anywhere in OTBN DMEM.
+ *
+ * This function makes the data pointers refer to the pre-allocated DMEM
+ * regions to store the actual values.
+ */
+static void setup_data_pointers(void) {
+  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
+  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
+  setup_data_pointer(kOtbnVarEcdsaDptrK0, kOtbnVarEcdsaK0);
+  setup_data_pointer(kOtbnVarEcdsaDptrK1, kOtbnVarEcdsaK1);
+  setup_data_pointer(kOtbnVarEcdsaDptrD0, kOtbnVarEcdsaD0);
+  setup_data_pointer(kOtbnVarEcdsaDptrD1, kOtbnVarEcdsaD1);
+}
+
+status_t ecdsa_p384_keygen_start(void) {
+  // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaKeygen));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdsa_p384_keygen_finalize(p384_masked_scalar_t *private_key,
+                                    p384_point_t *public_key) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the masked private key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarEcdsaD0,
+                              private_key->share0));
+  HARDENED_TRY(otbn_dmem_read(kP384MaskedScalarShareWords, kOtbnVarEcdsaD1,
+                              private_key->share1));
+
+  // Read the public key from OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarEcdsaX, public_key->x));
+  HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarEcdsaY, public_key->y));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.h
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_KEYGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_KEYGEN_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Start an async ECDSA/P-384 keypair generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_keygen_start(void);
+
+/**
+ * Finish an async ECDSA/P-384 keypair generation operation on OTBN.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] private_key Generated private key.
+ * @param[out] public_key Generated public key.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_keygen_finalize(p384_masked_scalar_t *private_key,
+                                    p384_point_t *public_key);
+
+#ifdef __cplusplus
+}
+"C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_KEYGEN_H_

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '3', 's')
+
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sign);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
+                         dptr_x);  // pointer to x-coordinate (dptr_x)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
+                         dptr_y);  // pointer to y-coordinate (dptr_y)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_k0);  // pointer to k0 (dptr_k0)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_k1);  // pointer to k1 (dptr_k1)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_d0);  // pointer to d0 (dptr_d0)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_d1);  // pointer to d1 (dptr_d1)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
+                         dptr_msg);                 // pointer to msg (dptr_msg)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_r);  // pointer to R (dptr_r)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_s);  // pointer to S (dptr_s)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, x);       // x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, y);       // y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, k0);      // random scalar first share
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, k1);   // random scalar second share
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d0);   // private key first share
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d1);   // private key second share
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, msg);  // hash message to sign/verify
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, r);    // r part of signature
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, s);    // s part of signature
+
+static const otbn_app_t kOtbnAppEcdsaSign = OTBN_APP_T_INIT(p384_ecdsa_sign);
+static const otbn_addr_t kOtbnVarEcdsaDptrX =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_x);
+static const otbn_addr_t kOtbnVarEcdsaDptrY =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_y);
+static const otbn_addr_t kOtbnVarEcdsaDptrK0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_k0);
+static const otbn_addr_t kOtbnVarEcdsaDptrK1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_k1);
+static const otbn_addr_t kOtbnVarEcdsaDptrD0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_d0);
+static const otbn_addr_t kOtbnVarEcdsaDptrD1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_d1);
+static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_msg);
+static const otbn_addr_t kOtbnVarEcdsaDptrR =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_r);
+static const otbn_addr_t kOtbnVarEcdsaDptrS =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_s);
+static const otbn_addr_t kOtbnVarEcdsaX = OTBN_ADDR_T_INIT(p384_ecdsa_sign, x);
+static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p384_ecdsa_sign, y);
+static const otbn_addr_t kOtbnVarEcdsaK0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, k0);
+static const otbn_addr_t kOtbnVarEcdsaK1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, k1);
+static const otbn_addr_t kOtbnVarEcdsaD0 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, d0);
+static const otbn_addr_t kOtbnVarEcdsaD1 =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, d1);
+static const otbn_addr_t kOtbnVarEcdsaMsg =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, msg);
+otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
+otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
+
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEcdsaModeWords = 1,
+  /*
+   * Mode to generate a new random keypair.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeKeygen = 0x3d4,
+  /*
+   * Mode to generate a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeSign = 0x15b,
+  /*
+   * Mode to verify a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeVerify = 0x727,
+};
+
+/**
+ * Makes a single dptr in the P384 library point to where its value is stored.
+ */
+static void setup_data_pointer(const otbn_addr_t dptr,
+                               const otbn_addr_t value) {
+  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
+}
+
+/**
+ * Sets up all data pointers used by the P384 library to point to DMEM.
+ *
+ * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
+ * its calling convention, which are exposed as symbol starting with `dptr_`.
+ * The DMEM locations these pointers refer to is not mandated by the P384
+ * calling convention; the values can be placed anywhere in OTBN DMEM.
+ *
+ * This function makes the data pointers refer to the pre-allocated DMEM
+ * regions to store the actual values.
+ */
+static void setup_data_pointers(void) {
+  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
+  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
+  setup_data_pointer(kOtbnVarEcdsaDptrK0, kOtbnVarEcdsaK0);
+  setup_data_pointer(kOtbnVarEcdsaDptrK1, kOtbnVarEcdsaK1);
+  setup_data_pointer(kOtbnVarEcdsaDptrD0, kOtbnVarEcdsaD0);
+  setup_data_pointer(kOtbnVarEcdsaDptrD1, kOtbnVarEcdsaD1);
+  setup_data_pointer(kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg);
+  setup_data_pointer(kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR);
+  setup_data_pointer(kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS);
+}
+
+status_t ecdsa_p384_sign_start(const uint32_t digest[kP384ScalarWords],
+                               const p384_masked_scalar_t *private_key) {
+  // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaSign));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Set the message digest.
+  HARDENED_TRY(set_message_digest(digest, kOtbnVarEcdsaMsg));
+
+  // Set the private key shares.
+  HARDENED_TRY(
+      p384_masked_scalar_write(private_key, kOtbnVarEcdsaD0, kOtbnVarEcdsaD1));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdsa_p384_sign_finalize(ecdsa_p384_signature_t *result) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read signature R out of OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarEcdsaR, result->r));
+
+  // Read signature S out of OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarEcdsaS, result->s));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_SIGN_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_SIGN_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern otbn_addr_t kOtbnVarEcdsaR;
+extern otbn_addr_t kOtbnVarEcdsaS;
+
+/**
+ * Start an async ECDSA/P-384 signature generation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param digest Digest of the message to sign.
+ * @param private_key Secret key to sign the message with.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_sign_start(const uint32_t digest[kP384ScalarWords],
+                               const p384_masked_scalar_t *private_key);
+
+/**
+ * Finish an async ECDSA/P-384 signature generation operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p384_sign` for details.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] result Buffer in which to store the generated signature.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_sign_finalize(ecdsa_p384_signature_t *result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_SIGN_H_

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
@@ -1,0 +1,164 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '3', 'v')
+
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_verify);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         dptr_x);  // pointer to x-coordinate (dptr_x)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         dptr_y);  // pointer to y-coordinate (dptr_y)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         dptr_rnd);  // pointer to rnd (dptr_rnd)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         dptr_msg);  // pointer to msg (dptr_msg)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, dptr_r);  // pointer to R (dptr_r)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, dptr_s);  // pointer to S (dptr_s)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, x);  // Public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, y);  // Public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         rnd);  // result of verify (x1 coordinate)
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
+                         msg);                   // hash message to sign/verify
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, r);  // r part of signature
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, s);  // s part of signature
+
+static const otbn_app_t kOtbnAppEcdsaVerify =
+    OTBN_APP_T_INIT(p384_ecdsa_verify);
+static const otbn_addr_t kOtbnVarEcdsaDptrX =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_x);
+static const otbn_addr_t kOtbnVarEcdsaDptrY =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_y);
+static const otbn_addr_t kOtbnVarEcdsaDptrRnd =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_rnd);
+static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_msg);
+static const otbn_addr_t kOtbnVarEcdsaDptrR =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_r);
+static const otbn_addr_t kOtbnVarEcdsaDptrS =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_s);
+static const otbn_addr_t kOtbnVarEcdsaX =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, x);
+static const otbn_addr_t kOtbnVarEcdsaY =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, y);
+static const otbn_addr_t kOtbnVarEcdsaMsg =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, msg);
+static const otbn_addr_t kOtbnVarEcdsaR =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, r);
+static const otbn_addr_t kOtbnVarEcdsaS =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, s);
+static const otbn_addr_t kOtbnVarEcdsaRnd =
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, rnd);
+
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEcdsaModeWords = 1,
+  /*
+   * Mode to generate a new random keypair.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeKeygen = 0x3d4,
+  /*
+   * Mode to generate a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeSign = 0x15b,
+  /*
+   * Mode to verify a signature.
+   *
+   * Value taken from `p384_ecdsa.s`.
+   */
+  kOtbnEcdsaModeVerify = 0x727,
+};
+
+/**
+ * Makes a single dptr in the P384 library point to where its value is stored.
+ */
+static void setup_data_pointer(const otbn_addr_t dptr,
+                               const otbn_addr_t value) {
+  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
+}
+
+/**
+ * Sets up all data pointers used by the P384 library to point to DMEM.
+ *
+ * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
+ * its calling convention, which are exposed as symbol starting with `dptr_`.
+ * The DMEM locations these pointers refer to is not mandated by the P384
+ * calling convention; the values can be placed anywhere in OTBN DMEM.
+ *
+ * This function makes the data pointers refer to the pre-allocated DMEM
+ * regions to store the actual values.
+ */
+static void setup_data_pointers(void) {
+  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
+  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
+  setup_data_pointer(kOtbnVarEcdsaDptrRnd, kOtbnVarEcdsaRnd);
+  setup_data_pointer(kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg);
+  setup_data_pointer(kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR);
+  setup_data_pointer(kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS);
+}
+
+status_t ecdsa_p384_verify_start(const ecdsa_p384_signature_t *signature,
+                                 const uint32_t digest[kP384ScalarWords],
+                                 const p384_point_t *public_key) {
+  // Check if public key is valid
+  HARDENED_TRY(p384_curve_point_validate_start(public_key));
+  HARDENED_TRY(p384_curve_point_validate_finalize());
+
+  // Load the ECDSA/P-384 app
+  HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaVerify));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Set the message digest.
+  HARDENED_TRY(set_message_digest(digest, kOtbnVarEcdsaMsg));
+
+  // Set the signature R.
+  HARDENED_TRY(otbn_dmem_write(kP384ScalarWords, signature->r, kOtbnVarEcdsaR));
+
+  // Set the signature S.
+  HARDENED_TRY(otbn_dmem_write(kP384ScalarWords, signature->s, kOtbnVarEcdsaS));
+
+  // Set the public key x coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->x, kOtbnVarEcdsaX));
+
+  // Set the public key y coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->y, kOtbnVarEcdsaY));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ecdsa_p384_verify_finalize(const ecdsa_p384_signature_t *signature,
+                                    hardened_bool_t *result) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read x_r (recovered R) out of OTBN dmem.
+  uint32_t rnd[kP384ScalarWords];
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarEcdsaRnd, rnd));
+
+  *result = hardened_memeq(rnd, signature->r, kP384ScalarWords);
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.h
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_VERIFY_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_VERIFY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Start an async ECDSA/P-384 signature verification operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p384_verify` for details.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param signature Signature to be verified.
+ * @param digest Digest of the message to check the signature against.
+ * @param public_key Key to check the signature against.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_verify_start(const ecdsa_p384_signature_t *signature,
+                                 const uint32_t digest[kP384ScalarWords],
+                                 const p384_point_t *public_key);
+
+/**
+ * Finish an async ECDSA/P-384 signature verification operation on OTBN.
+ *
+ * See the documentation of `ecdsa_p384_verify` for details.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * If the signature is valid, writes `kHardenedBoolTrue` to `result`;
+ * otherwise, writes `kHardenedBoolFalse`.
+ *
+ * Note: the caller must check the `result` buffer in order to determine if a
+ * signature passed verification. If a signature is invalid, but nothing goes
+ * wrong during computation (e.g. hardware errors, failed preconditions), the
+ * status will be OK but `result` will be `kHardenedBoolFalse`.
+ *
+ * @param signature Signature to be verified.
+ * @param[out] result Output buffer (true if signature is valid, false
+ * otherwise)
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ecdsa_p384_verify_finalize(const ecdsa_p384_signature_t *signature,
+                                    hardened_bool_t *result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ECDSA_P384_VERIFY_H_

--- a/sw/device/lib/crypto/impl/ecc/p384_common.c
+++ b/sw/device/lib/crypto/impl/ecc/p384_common.c
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+enum {
+  /**
+   * Number of extra padding words needed for masked scalar shares.
+   *
+   * Where W is the word size and S is the share size, the padding needed is:
+   *   (W - (S % W)) % W
+   *
+   * The extra outer "% W" ensures that the padding is 0 if (S % W) is 0.
+   */
+  kMaskedScalarPaddingWords =
+      (kOtbnWideWordNumWords -
+       (kP384MaskedScalarShareWords % kOtbnWideWordNumWords)) %
+      kOtbnWideWordNumWords,
+};
+
+status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
+                                  const otbn_addr_t share0_addr,
+                                  const otbn_addr_t share1_addr) {
+  HARDENED_TRY(
+      otbn_dmem_write(kP384MaskedScalarShareWords, src->share0, share0_addr));
+  HARDENED_TRY(
+      otbn_dmem_write(kP384MaskedScalarShareWords, src->share1, share1_addr));
+
+  // Write trailing 0s so that OTBN's 384-bit read of the second share does not
+  // cause an error.
+  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                             share0_addr + kP384MaskedScalarShareBytes));
+  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                             share1_addr + kP384MaskedScalarShareBytes));
+
+  return OTCRYPTO_OK;
+}
+
+status_t set_message_digest(const uint32_t digest[kP384ScalarWords],
+                            const otbn_addr_t kOtbnVarEcdsaMsg) {
+  // Set the message digest. We swap all the bytes so that OTBN can interpret
+  // the digest as a little-endian integer, which is a more natural fit for the
+  // architecture than the big-endian form requested by the specification (FIPS
+  // 186-5, section B.2.1).
+  uint32_t digest_little_endian[kP384ScalarWords];
+  size_t i = 0;
+  for (; launder32(i) < kP384ScalarWords; i++) {
+    digest_little_endian[i] =
+        __builtin_bswap32(digest[kP384ScalarWords - 1 - i]);
+  }
+  HARDENED_CHECK_EQ(i, kP384ScalarWords);
+  return otbn_dmem_write(kP384ScalarWords, digest_little_endian,
+                         kOtbnVarEcdsaMsg);
+}

--- a/sw/device/lib/crypto/impl/ecc/p384_common.h
+++ b/sw/device/lib/crypto/impl/ecc/p384_common.h
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_COMMON_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_COMMON_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * Length of a P-384 curve point coordinate in bits (modulo p).
+   */
+  kP384CoordBits = 384,
+  /**
+   * Length of a P-384 curve point coordinate in bytes.
+   */
+  kP384CoordBytes = kP384CoordBits / 8,
+  /**
+   * Length of a P-384 curve point coordinate in words.
+   */
+  kP384CoordWords = kP384CoordBytes / sizeof(uint32_t),
+  /**
+   * Length of an element in the P-384 scalar field (modulo the curve order n).
+   */
+  kP384ScalarBits = 384,
+  /**
+   * Length of a secret scalar share in bytes.
+   */
+  kP384ScalarBytes = kP384ScalarBits / 8,
+  /**
+   * Length of secret scalar share in words.
+   */
+  kP384ScalarWords = kP384ScalarBytes / sizeof(uint32_t),
+  /**
+   * Length of a masked secret scalar share.
+   *
+   * This implementation uses extra redundant bits for side-channel protection.
+   */
+  kP384MaskedScalarShareBits = kP384ScalarBits + 64,
+  /**
+   * Length of a masked secret scalar share in bytes.
+   */
+  kP384MaskedScalarShareBytes = kP384MaskedScalarShareBits / 8,
+  /**
+   * Length of masked secret scalar share in words.
+   */
+  kP384MaskedScalarShareWords = kP384MaskedScalarShareBytes / sizeof(uint32_t),
+};
+
+/**
+ * A type that holds a masked value from the P-384 scalar field.
+ *
+ * This struct is used to represent secret keys, which are integers modulo n.
+ * The key d is represented in two 320-bit shares, d0 and d1, such that d = (d0
+ * + d1) mod n. Mathematically, d0 and d1 could also be reduced modulo n, but
+ * the extra bits provide side-channel protection.
+ */
+typedef struct p384_masked_scalar {
+  /**
+   * First share of the secret scalar.
+   */
+  uint32_t share0[kP384MaskedScalarShareWords];
+  /**
+   * Second share of the secret scalar.
+   */
+  uint32_t share1[kP384MaskedScalarShareWords];
+} p384_masked_scalar_t;
+
+/**
+ * A type that holds a P-384 curve point.
+ */
+typedef struct p384_point {
+  /**
+   * Affine x-coordinate.
+   */
+  uint32_t x[kP384CoordWords];
+  /**
+   * Affine y-coordinate.
+   */
+  uint32_t y[kP384CoordWords];
+} p384_point_t;
+
+/**
+ * A type that holds an ECDSA/P-384 signature.
+ *
+ * The signature consists of two integers r and s, computed modulo n.
+ */
+typedef struct ecdsa_p384_signature_t {
+  uint32_t r[kP384ScalarWords];
+  uint32_t s[kP384ScalarWords];
+} ecdsa_p384_signature_t;
+
+/**
+ * Write a masked P-384 scalar to OTBN's data memory.
+ *
+ * OTBN actually requires that 512 bits be written, even though only 320 are
+ * used; the others are ignored but must be set to avoid an error when OTBN
+ * attempts to read uninitialized memory.
+ *
+ * @param src Masked scalar to write.
+ * @param share0_addr DMEM address of the first share.
+ * @param share1_addr DMEM address of the second share.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
+                                  const otbn_addr_t share0_addr,
+                                  const otbn_addr_t share1_addr);
+
+/**
+ * Set the message digest for signature generation or verification.
+ *
+ * OTBN requires the digest in little-endian form, so this routine flips the
+ * bytes.
+ *
+ * @param digest Digest to set (big-endian).
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t set_message_digest(const uint32_t digest[kP384ScalarWords],
+                            const otbn_addr_t kOtbnVarEcdsaMsg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_COMMON_H_

--- a/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
+++ b/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('p', '3', 'c')
+
+OTBN_DECLARE_APP_SYMBOLS(
+    p384_curve_point_valid);  // The OTBN Curve Point Valid Check app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         dptr_x);  // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         dptr_y);  // The public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         x);  // The pointer to public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         y);  // The pointer to public key y-coordinate.
+
+static const otbn_app_t kOtbnAppCpv = OTBN_APP_T_INIT(p384_curve_point_valid);
+static const otbn_addr_t kOtbnVarCpvDptrX =
+    OTBN_ADDR_T_INIT(p384_curve_point_valid, dptr_x);
+static const otbn_addr_t kOtbnVarCpvDptrY =
+    OTBN_ADDR_T_INIT(p384_curve_point_valid, dptr_y);
+static const otbn_addr_t kOtbnVarCpvX =
+    OTBN_ADDR_T_INIT(p384_curve_point_valid, x);
+static const otbn_addr_t kOtbnVarCpvY =
+    OTBN_ADDR_T_INIT(p384_curve_point_valid, y);
+
+/**
+ * Makes a single dptr in the P384 library point to where its value is stored.
+ */
+static void setup_data_pointer(const otbn_addr_t dptr,
+                               const otbn_addr_t value) {
+  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
+}
+
+/**
+ * Sets up all data pointers used by the P384 library to point to DMEM.
+ *
+ * The Curve Point Valid P384 OTBN library makes use of "named" data pointers
+ * as part of its calling convention, which are exposed as symbol starting
+ * with `dptr_`. The DMEM locations these pointers refer to is not mandated
+ * by the P384 calling convention; the values can be placed anywhere in OTBN
+ * DMEM.
+ *
+ * This function makes the data pointers refer to the pre-allocated DMEM
+ * regions to store the actual values.
+ */
+static void setup_data_pointers(void) {
+  setup_data_pointer(kOtbnVarCpvDptrX, kOtbnVarCpvX);
+  setup_data_pointer(kOtbnVarCpvDptrY, kOtbnVarCpvY);
+}
+
+status_t p384_curve_point_validate_start(const p384_point_t *public_key) {
+  // Load the P-384 Curve Point Valid app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppCpv));
+
+  // Set up the data pointers
+  setup_data_pointers();
+
+  // Set the public key x coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->x, kOtbnVarCpvX));
+
+  // Set the public key y coordinate.
+  HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->y, kOtbnVarCpvY));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t p384_curve_point_validate_finalize(void) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h
+++ b/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_CURVE_POINT_VALID_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_CURVE_POINT_VALID_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/ecc/p384_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Start a P-384 public key (curve point) validation operation on OTBN.
+ *
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ * Returns an `ILLEGAL_INSN` error if public key (curve point) is invalid.
+ *
+ * @param public_key Public key (Q).
+ * @return Result of the operation (OK or error).
+ */
+status_t p384_curve_point_validate_start(const p384_point_t *public_key);
+
+/**
+ * Finish a P-384 public key (curve point) validation operation on OTBN.
+ *
+ * Blocks until OTBN is idle. To be used after `p384_curve_point_validate`.
+ *
+ * @return Result of the operation (OK or error).
+ */
+status_t p384_curve_point_validate_finalize(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_P384_CURVE_POINT_VALID_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -215,6 +215,22 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "ecdh_p384_functest",
+    srcs = ["ecdh_p384_functest.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = verilator_params(
+        timeout = "eternal",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "ecdh_p256_sideload_functest",
     srcs = ["ecdh_p256_sideload_functest.c"],
     broken = cw310_params(tags = ["broken"]),
@@ -243,7 +259,38 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p256_functest",
     srcs = ["ecdsa_p256_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = {
+        # Test is too large for ROM, so excluding rom_with_fake_keys.
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
+    name = "ecdsa_p384_functest",
+    srcs = ["ecdsa_p384_functest.c"],
+    exec_env = {
+        # Test is too large for ROM, so excluding rom_with_fake_keys.
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /* Number of 32-bit words in a P-384 public key. */
+  kP384PublicKeyWords = 768 / 32,
+  /* Number of 32-bit words in a P-384 signature. */
+  kP384SignatureWords = 768 / 32,
+  /* Number of bytes in a P-384 private key. */
+  kP384PrivateKeyBytes = 384 / 8,
+  /* Number of bytes in an ECDH/P-384 shared key. */
+  kP384SharedKeyBytes = 384 / 8,
+  /* Number of 32-bit words in an ECDH/P-384 shared key. */
+  kP384SharedKeyWords = kP384SharedKeyBytes / sizeof(uint32_t),
+};
+
+static const otcrypto_ecc_curve_t kCurveP384 = {
+    .curve_type = kOtcryptoEccCurveTypeNistP384,
+    .domain_parameter = NULL,
+};
+
+// Configuration for the private key.
+static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEcdh,
+    .key_length = kP384PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+// Configuration for the ECDH shared (symmetric) key. This configuration
+// specifies an AES key, but any symmetric mode that supports 384-bit keys is
+// OK here.
+static const otcrypto_key_config_t kEcdhSharedKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeAesCtr,
+    .key_length = kP384SharedKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+status_t key_exchange_test(void) {
+  // Allocate space for two private keys.
+  uint32_t keyblobA[keyblob_num_words(kEcdhPrivateKeyConfig)];
+  otcrypto_blinded_key_t private_keyA = {
+      .config = kEcdhPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblobA),
+      .keyblob = keyblobA,
+      .checksum = 0,
+  };
+  uint32_t keyblobB[keyblob_num_words(kEcdhPrivateKeyConfig)];
+  otcrypto_blinded_key_t private_keyB = {
+      .config = kEcdhPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblobB),
+      .keyblob = keyblobB,
+      .checksum = 0,
+  };
+
+  // Allocate space for two public keys.
+  uint32_t pkA[kP384PublicKeyWords] = {0};
+  uint32_t pkB[kP384PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_keyA = {
+      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_length = sizeof(pkA),
+      .key = pkA,
+  };
+  otcrypto_unblinded_key_t public_keyB = {
+      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_length = sizeof(pkB),
+      .key = pkB,
+  };
+
+  // Generate a keypair.
+  LOG_INFO("Generating keypair A...");
+  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyA, &public_keyA));
+
+  // Generate a second keypair.
+  LOG_INFO("Generating keypair B...");
+  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyB, &public_keyB));
+
+  // Sanity check; public keys should be different from each other.
+  CHECK_ARRAYS_NE(pkA, pkB, ARRAYSIZE(pkA));
+  // Sanity check; private keys should be different from each other.
+  CHECK_ARRAYS_NE(keyblobA, keyblobB, ARRAYSIZE(keyblobA));
+
+  // Allocate space for two shared keys.
+  uint32_t shared_keyblobA[keyblob_num_words(kEcdhSharedKeyConfig)];
+  otcrypto_blinded_key_t shared_keyA = {
+      .config = kEcdhSharedKeyConfig,
+      .keyblob_length = sizeof(shared_keyblobA),
+      .keyblob = shared_keyblobA,
+      .checksum = 0,
+  };
+  uint32_t shared_keyblobB[keyblob_num_words(kEcdhSharedKeyConfig)];
+  otcrypto_blinded_key_t shared_keyB = {
+      .config = kEcdhSharedKeyConfig,
+      .keyblob_length = sizeof(shared_keyblobB),
+      .keyblob = shared_keyblobB,
+      .checksum = 0,
+  };
+
+  // Compute the shared secret from A's side of the computation (using A's
+  // private key and B's public key).
+  LOG_INFO("Generating shared secret (A)...");
+  TRY(otcrypto_ecdh(&private_keyA, &public_keyB, &kCurveP384, &shared_keyA));
+
+  // Compute the shared secret from B's side of the computation (using B's
+  // private key and A's public key).
+  LOG_INFO("Generating shared secret (B)...");
+  TRY(otcrypto_ecdh(&private_keyB, &public_keyA, &kCurveP384, &shared_keyB));
+
+  // Get pointers to individual shares of both shared keys.
+  uint32_t *keyA0;
+  uint32_t *keyA1;
+  TRY(keyblob_to_shares(&shared_keyA, &keyA0, &keyA1));
+  uint32_t *keyB0;
+  uint32_t *keyB1;
+  TRY(keyblob_to_shares(&shared_keyB, &keyB0, &keyB1));
+
+  // Unmask the keys and check that they match.
+  uint32_t keyA[kP384SharedKeyWords];
+  uint32_t keyB[kP384SharedKeyWords];
+  for (size_t i = 0; i < ARRAYSIZE(keyA); i++) {
+    keyA[i] = keyA0[i] ^ keyA1[i];
+    keyB[i] = keyB0[i] ^ keyB1[i];
+  }
+  CHECK_ARRAYS_EQ(keyA, keyB, ARRAYSIZE(keyA));
+
+  return OTCRYPTO_OK;
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  status_t err = key_exchange_test();
+  if (!status_ok(err)) {
+    // If there was an error, print the OTBN error bits and instruction count.
+    LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+    LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
+    // Print the error.
+    CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  return true;
+}

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -1,0 +1,120 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+enum {
+  /* Number of 32-bit words in a SHA384 digest. */
+  kSha384DigestWords = 384 / 32,
+  /* Number of 32-bit words in a P-384 public key. */
+  kP384PublicKeyWords = 768 / 32,
+  /* Number of 32-bit words in a P-384 signature. */
+  kP384SignatureWords = 768 / 32,
+  /* Number of bytes in a P-384 private key. */
+  kP384PrivateKeyBytes = 384 / 8,
+};
+
+// Message
+static const char kMessage[] = "test message";
+
+static const otcrypto_ecc_curve_t kCurveP384 = {
+    .curve_type = kOtcryptoEccCurveTypeNistP384,
+    .domain_parameter = NULL,
+};
+
+static const otcrypto_key_config_t kPrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_length = kP384PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+status_t sign_then_verify_test(hardened_bool_t *verification_result) {
+  // Allocate space for a masked private key.
+  uint32_t keyblob[keyblob_num_words(kPrivateKeyConfig)];
+  otcrypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Allocate space for a public key.
+  uint32_t pk[kP384PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEcdsa,
+      .key_length = sizeof(pk),
+      .key = pk,
+  };
+
+  // Generate a keypair.
+  LOG_INFO("Generating keypair...");
+  CHECK_STATUS_OK(
+      otcrypto_ecdsa_keygen(&kCurveP384, &private_key, &public_key));
+
+  // Hash the message.
+  otcrypto_const_byte_buf_t msg = {
+      .len = sizeof(kMessage) - 1,
+      .data = (unsigned char *)&kMessage,
+  };
+  uint32_t msg_digest_data[kSha384DigestWords];
+  otcrypto_hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+      .mode = kOtcryptoHashModeSha384,
+  };
+  TRY(otcrypto_hash(msg, msg_digest));
+
+  // Allocate space for the signature.
+  uint32_t sig[kP384SignatureWords] = {0};
+
+  // Generate a signature for the message.
+  LOG_INFO("Signing...");
+  CHECK_STATUS_OK(otcrypto_ecdsa_sign(
+      &private_key, msg_digest, &kCurveP384,
+      (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
+
+  // Verify the signature.
+  LOG_INFO("Verifying...");
+  CHECK_STATUS_OK(otcrypto_ecdsa_verify(
+      &public_key, msg_digest,
+      (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
+      &kCurveP384, verification_result));
+
+  return OTCRYPTO_OK;
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  hardened_bool_t verificationResult;
+  status_t err = sign_then_verify_test(&verificationResult);
+  if (!status_ok(err)) {
+    // If there was an error, print the OTBN error bits and instruction count.
+    LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+    LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
+    // Print the error.
+    CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  // Signature verification is expected to succeed.
+  if (verificationResult != kHardenedBoolTrue) {
+    LOG_ERROR("Signature failed to pass verification!");
+    return false;
+  }
+
+  return true;
+}

--- a/sw/otbn/crypto/p384_ecdh.s
+++ b/sw/otbn/crypto/p384_ecdh.s
@@ -114,21 +114,23 @@ keypair_random:
  */
 shared_key:
     /* Generate arithmetically masked shared key d*Q.
-       dmem[x] <= (d*Q).x - m_x mod p
-       dmem[y] <= m_x */
+       dmem[x] <= (d*Q).x - m mod p
+       dmem[y] <= m */
   jal       x1, p384_scalar_mult
 
   /* Arithmetic-to-boolean conversion*/
 
   /* load result to WDRs for a2b conversion.
-     [w12,w11] <= dmem[p1_x] = x_m
-     [w19,w18] <= dmem[p1_y] = m */
+     [w12,w11] <= dmem[x] = x_m
+     [w19,w18] <= dmem[y] = m */
   li        x2, 11
-  la        x3, x
+  la        x3, dptr_x
+  lw        x3, 0(x3)
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
   li        x2, 18
-  la        x3, y
+  la        x3, dptr_y
+  lw        x3, 0(x3)
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -141,10 +143,13 @@ shared_key:
 
   jal       x1, p384_arithmetic_to_boolean_mod
 
-  /* dmem[x] <= w20 = x' */
-  li        x3, 20
-  la        x4, x
-  bn.sid    x3, 0(x4)
+  /* Store arithmetically masked key to DMEM
+     dmem[x] <= [w21,w20] = x_m' */
+  li        x2, 20
+  la        x3, dptr_x
+  lw        x3, 0(x3)
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2++, 32(x3)
 
   ecall
 
@@ -191,6 +196,7 @@ y:
 .globl dptr_d0
 .balign 4
 dptr_d0:
+dptr_k0:
   .zero 4
 
 /* pointer to d1 (dptr_d1) */
@@ -198,6 +204,7 @@ dptr_d0:
 .globl dptr_d1
 .balign 4
 dptr_d1:
+dptr_k1:
   .zero 4
 
 .globl d0

--- a/sw/otbn/crypto/p384_ecdsa_keygen.s
+++ b/sw/otbn/crypto/p384_ecdsa_keygen.s
@@ -37,7 +37,8 @@ start:
  * @param[out] dmem[d0]: 1st private key share d0
  * @param[out] dmem[d1]: 2nd private key share d1
  * @param[out]  dmem[x]: Public key x-coordinate
- * @param[out]  dmem[y]: Public key y-coordinate
+ * @param[out]  dmem[y]: Public key y-coordinate]
+
  */
 random_keygen:
   /* Generate secret key d in shares.
@@ -96,6 +97,30 @@ d0:
 .globl d1
 .balign 32
 d1:
+  .zero 64
+
+/* pointer to x-coordinate (dptr_x) */
+.globl dptr_x
+.balign 4
+dptr_x:
+  .zero 4
+
+/* pointer to y-coordinate (dptr_y) */
+.globl dptr_y
+.balign 4
+dptr_y:
+  .zero 4
+
+/* x-coordinate. */
+.globl x
+.balign 32
+x:
+  .zero 64
+
+/* y-coordinate. */
+.globl y
+.balign 32
+y:
   .zero 64
 
 /* 704 bytes of scratchpad memory

--- a/sw/otbn/crypto/p384_ecdsa_sign.s
+++ b/sw/otbn/crypto/p384_ecdsa_sign.s
@@ -125,6 +125,20 @@ k0:
 k1:
   .zero 64
 
+/* r part of signature */
+.globl r
+.balign 32
+r:
+  .zero 64
+
+/* s part of signature */
+.globl s
+.balign 32
+s:
+  .zero 64
+
+.data
+
 /* private key first share */
 .globl d0
 .balign 32
@@ -141,18 +155,6 @@ d1:
 .globl msg
 .balign 32
 msg:
-  .zero 64
-
-/* r part of signature */
-.globl r
-.balign 32
-r:
-  .zero 64
-
-/* s part of signature */
-.globl s
-.balign 32
-s:
   .zero 64
 
 /* 704 bytes of scratchpad memory

--- a/sw/otbn/crypto/p384_ecdsa_verify.s
+++ b/sw/otbn/crypto/p384_ecdsa_verify.s
@@ -86,6 +86,14 @@ dptr_r:
 dptr_s:
   .zero 4
 
+/* result of verify (x1 coordinate) */
+.globl rnd
+.balign 32
+rnd:
+  .zero 64
+
+.data
+
 /* Public key x-coordinate. */
 .globl x
 .balign 32
@@ -96,12 +104,6 @@ x:
 .globl y
 .balign 32
 y:
-  .zero 64
-
-/* result of verify (x1 coordinate) */
-.globl rnd
-.balign 32
-rnd:
   .zero 64
 
 /* hash message to sign/verify */

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -47,44 +47,44 @@ p384_sign:
   /* init all-zero reg */
   bn.xor    w31, w31, w31
 
-  /* set dmem pointer to domain parameter b */
+  /* get dmem pointer of domain parameter b */
   la        x28, p384_b
 
-  /* set dmem pointer to base point x-coordinate */
+  /* get dmem pointer of base point x-coordinate */
   la        x20, p384_gx
 
-  /* set dmem pointer to base point y-coordinate */
+  /* get dmem pointer of base point y-coordinate */
   la        x21, p384_gy
 
-  /* set dmem pointer to 1st scalar share k0 */
+  /* get dmem pointer of 1st scalar share k0 */
   la        x17, dptr_k0
   lw        x17, 0(x17)
 
-  /* set dmem pointer to 2nd scalar share k1 */
+  /* get dmem pointer of 2nd scalar share k1 */
   la        x19, dptr_k1
   lw        x19, 0(x19)
 
-  /* set dmem pointer to 1st private key share d0 */
+  /* get dmem pointer of 1st private key share d0 */
   la        x4, dptr_d0
   lw        x4, 0(x4)
 
-  /* set dmem pointer to 2nd private key share d1 */
+  /* get dmem pointer of 2nd private key share d1 */
   la        x5, dptr_d1
   lw        x5, 0(x5)
 
-  /* set dmem pointer to message msg */
+  /* get dmem pointer of message msg */
   la        x6, dptr_msg
   lw        x6, 0(x6)
 
-  /* set dmem pointer to signature r */
+  /* get dmem pointer of signature r */
   la        x14, dptr_r
   lw        x14, 0(x14)
 
-  /* set dmem pointer to signature s */
+  /* get dmem pointer of signature s */
   la        x15, dptr_s
   lw        x15, 0(x15)
 
-  /* set dmem pointer to scratchpad */
+  /* get dmem pointer of scratchpad */
   la        x30, scratchpad
 
   /* load domain parameter p (modulus)
@@ -103,11 +103,11 @@ p384_sign:
 
   /* scalar multiplication with base point and
      conversion of projective coordinates to affine space
-     [w28:w25] <= (x_1, y_1) = (k*alpha) * G */
+     [w28:w25] <= (R_x, R_y) = k * G */
   jal       x1, scalar_mult_int_p384
   jal       x1, proj_to_affine_p384
 
-  /* store r of signature in dmem: dmem[dptr_r] <= r = [w26,w25] */
+  /* store r of signature in dmem: dmem[dptr_r] <= r = R_x = [w26,w25] */
   li        x2, 25
   bn.sid    x2++, 0(x14)
   bn.sid    x2++, 32(x14)


### PR DESCRIPTION
This PR 

- adds Ibex driver code for P-384 ECC on OTBN. 
  -> In case of ECDSA the code is split up into individual files for keygen, sign, and verify. This is because each function is a separate OTBN application. But still, everything is put together in a single ecdsa_p384 file, which then is used by the top level ecc driver file.
  -> Similar, curve point validation is put into an own driver file, as it also is a separate OTBN application. It is executed before ECDH shared key generation and ECDSA signature verification, to check if the public key is valid (= is a curve point).

- adds the corresponding functests for P-384 ECDH and ECDSA.
- fixes some memory issues in the P-384 top level OTBN binaries, which we discovered during development.