### PR TITLE
[pinmux,doc] Clarify that pad attributes apply to tap straps.

### DIFF
--- a/hw/ip/pinmux/doc/theory_of_operation.md
+++ b/hw/ip/pinmux/doc/theory_of_operation.md
@@ -138,6 +138,9 @@ TAP strap 1 | TAP strap 0  | Life Cycle State         | Selected TAP
 
 Note that the tool-inserted DFT controller may assert the `dft_hold_tap_sel_i` during a test (e.g. boundary scan) in which case the `pinmux` will temporarily pause sampling of the TAP selection straps.
 
+It should be noted that the TAP straps are muxed with MIOs and that the pad attributes will take effect even in life cycles states that
+continuously sample the straps. As a result, pad attributes can interfere or even disable tap selection entirely in those life cycle states.
+
 Also, it should be noted that the pad attributes of all JTAG IOs will be gated to all-zero temporarily, while the JTAG is enabled (this does not affect the values in the CSRs).
 This is to ensure that any functional attributes like inversion or pull-ups / pull-downs do not interfere with the JTAG while it is in use.
 


### PR DESCRIPTION
The goal of this PR is to clarify the fact that the TAP straps are muxed with MIOs and pad attributes apply, even in LC states that continuously sample (such as RMA). This means that one can potentially disable debugging in RMA (intentionally or by mistake) by configuring those pins as output for example. I think this is an important point to keep in mind since debugging in RMA can be valuable, and in fact one could say it's the whole point of the RMA state.

Let me know if you think the text is clear/accurate.