### PR TITLE
[opentitantool] HyperDebug support for baud rate and break condition

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -164,6 +164,7 @@ rust_library(
         "src/transport/hyperdebug/servo_micro.rs",
         "src/transport/hyperdebug/spi.rs",
         "src/transport/hyperdebug/ti50.rs",
+        "src/transport/hyperdebug/uart.rs",
         "src/transport/ioexpander/mod.rs",
         "src/transport/ioexpander/sx1503.rs",
         "src/transport/mod.rs",

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -27,7 +27,7 @@ use crate::io::uart::Uart;
 use crate::transport::chip_whisperer::board::Board;
 use crate::transport::chip_whisperer::ChipWhisperer;
 use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
-use crate::transport::common::uart::{flock_serial, SerialPortExclusiveLock, SerialPortUart};
+use crate::transport::common::uart::{flock_serial, SerialPortExclusiveLock};
 use crate::transport::{
     Capabilities, Capability, Transport, TransportError, TransportInterfaceType, UpdateFirmware,
 };
@@ -41,13 +41,12 @@ pub mod i2c;
 pub mod servo_micro;
 pub mod spi;
 pub mod ti50;
+pub mod uart;
 
 pub use c2d2::C2d2Flavor;
 pub use dfu::HyperdebugDfu;
 pub use servo_micro::ServoMicroFlavor;
 pub use ti50::Ti50Flavor;
-
-const UART_BAUD: u32 = 115200;
 
 /// Implementation of the Transport trait for HyperDebug based on the
 /// Nucleo-L552ZE-Q.
@@ -55,7 +54,7 @@ pub struct Hyperdebug<T: Flavor> {
     spi_interface: BulkInterface,
     i2c_interface: Option<BulkInterface>,
     cmsis_interface: Option<BulkInterface>,
-    uart_ttys: HashMap<String, PathBuf>,
+    uart_interfaces: HashMap<String, UartInterface>,
     inner: Rc<Inner>,
     current_firmware_version: Option<String>,
     cmsis_google_capabilities: Cell<Option<u16>>,
@@ -103,6 +102,17 @@ pub struct BulkInterface {
     out_endpoint: u8,
 }
 
+pub struct UartInterface {
+    interface: u8,
+    tty: PathBuf,
+}
+
+impl UartInterface {
+    pub fn new(interface: u8, tty: PathBuf) -> Self {
+        Self { interface, tty }
+    }
+}
+
 impl<T: Flavor> Hyperdebug<T> {
     const USB_CLASS_VENDOR: u8 = 255;
     const USB_SUBCLASS_UART: u8 = 80;
@@ -141,7 +151,7 @@ impl<T: Flavor> Hyperdebug<T> {
         let mut spi_interface: Option<BulkInterface> = None;
         let mut i2c_interface: Option<BulkInterface> = None;
         let mut cmsis_interface: Option<BulkInterface> = None;
-        let mut uart_ttys: HashMap<String, PathBuf> = HashMap::new();
+        let mut uart_interfaces: HashMap<String, UartInterface> = HashMap::new();
 
         let config_desc = device.active_config_descriptor()?;
         let current_firmware_version = if let Some(idx) = config_desc.description_string_index() {
@@ -203,8 +213,11 @@ impl<T: Flavor> Hyperdebug<T> {
                         console_tty = Some(Self::find_tty(&interface_path)?);
                     } else {
                         // We found an UART forwarding USB interface.
-                        uart_ttys
-                            .insert(interface_name.to_string(), Self::find_tty(&interface_path)?);
+                        let uart = UartInterface {
+                            interface: interface.number(),
+                            tty: Self::find_tty(&interface_path)?,
+                        };
+                        uart_interfaces.insert(interface_name.to_string(), uart);
                     }
                     continue;
                 }
@@ -264,7 +277,7 @@ impl<T: Flavor> Hyperdebug<T> {
             })?,
             i2c_interface,
             cmsis_interface,
-            uart_ttys,
+            uart_interfaces,
             inner: Rc::new(Inner {
                 console_tty: console_tty.ok_or_else(|| {
                     TransportError::CommunicationError("Missing console interface".to_string())
@@ -636,19 +649,17 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
 
     // Create Uart instance, or return one from a cache of previously created instances.
     fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>> {
-        match self.uart_ttys.get(instance) {
-            Some(tty) => {
-                if let Some(instance) = self.inner.uarts.borrow().get(tty) {
+        match self.uart_interfaces.get(instance) {
+            Some(uart_interface) => {
+                if let Some(instance) = self.inner.uarts.borrow().get(&uart_interface.tty) {
                     return Ok(Rc::clone(instance));
                 }
-                let instance: Rc<dyn Uart> = Rc::new(SerialPortUart::open(
-                    tty.to_str().ok_or(TransportError::UnicodePathError)?,
-                    UART_BAUD,
-                )?);
+                let instance: Rc<dyn Uart> =
+                    Rc::new(uart::HyperdebugUart::open(&self.inner, uart_interface)?);
                 self.inner
                     .uarts
                     .borrow_mut()
-                    .insert(tty.clone(), Rc::clone(&instance));
+                    .insert(uart_interface.tty.clone(), Rc::clone(&instance));
                 Ok(instance)
             }
             _ => Err(TransportError::InvalidInstance(

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::UartInterface;
+use crate::io::nonblocking_help::NonblockingHelp;
+use crate::io::uart::Uart;
+use crate::transport::common::uart::SerialPortUart;
+use crate::transport::hyperdebug::Inner;
+use crate::transport::TransportError;
+use anyhow::Result;
+use rusb::{Direction, Recipient, RequestType};
+use std::rc::Rc;
+use std::time::Duration;
+
+const UART_BAUD: u32 = 115200;
+
+pub struct HyperdebugUart {
+    inner: Rc<Inner>,
+    usb_interface: u8,
+    serial_port: SerialPortUart,
+}
+
+#[allow(dead_code)]
+enum ControlRequest {
+    ReqParity = 0,
+    SetParity = 1,
+    ReqBaud = 2,
+    SetBaud = 3,
+    Break = 4,
+}
+
+impl HyperdebugUart {
+    pub fn open(inner: &Rc<Inner>, uart_interface: &UartInterface) -> Result<Self> {
+        Ok(Self {
+            inner: Rc::clone(inner),
+            usb_interface: uart_interface.interface,
+            serial_port: SerialPortUart::open(
+                uart_interface
+                    .tty
+                    .to_str()
+                    .ok_or(TransportError::UnicodePathError)?,
+                UART_BAUD,
+            )?,
+        })
+    }
+}
+
+impl Uart for HyperdebugUart {
+    fn get_baudrate(&self) -> Result<u32> {
+        let usb_handle = self.inner.usb_device.borrow();
+        let mut data = [0u8, 0u8];
+        usb_handle.read_control(
+            rusb::request_type(Direction::In, RequestType::Vendor, Recipient::Interface),
+            ControlRequest::ReqBaud as u8,
+            0,
+            self.usb_interface as u16,
+            &mut data,
+        )?;
+        Ok(u16::from_le_bytes(data) as u32 * 100)
+    }
+
+    fn set_baudrate(&self, baudrate: u32) -> Result<()> {
+        let usb_handle = self.inner.usb_device.borrow();
+        usb_handle.write_control(
+            rusb::request_type(Direction::Out, RequestType::Vendor, Recipient::Interface),
+            ControlRequest::SetBaud as u8,
+            ((baudrate + 50) / 100).try_into()?,
+            self.usb_interface as u16,
+            &[],
+        )?;
+        Ok(())
+    }
+
+    fn set_flow_control(&self, flow_control: bool) -> Result<()> {
+        self.serial_port.set_flow_control(flow_control)
+    }
+
+    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        self.serial_port.read(buf)
+    }
+
+    fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        self.serial_port.read_timeout(buf, timeout)
+    }
+
+    fn write(&self, buf: &[u8]) -> Result<()> {
+        self.serial_port.write(buf)
+    }
+
+    fn clear_rx_buffer(&self) -> Result<()> {
+        self.serial_port.clear_rx_buffer()
+    }
+
+    fn set_break(&self, enable: bool) -> Result<()> {
+        let usb_handle = self.inner.usb_device.borrow();
+        usb_handle.write_control(
+            rusb::request_type(Direction::Out, RequestType::Vendor, Recipient::Interface),
+            ControlRequest::Break as u8,
+            if enable { 0xFFFF } else { 0 },
+            self.usb_interface as u16,
+            &[],
+        )?;
+        Ok(())
+    }
+
+    fn supports_nonblocking_read(&self) -> Result<bool> {
+        self.serial_port.supports_nonblocking_read()
+    }
+
+    fn register_nonblocking_read(&self, registry: &mio::Registry, token: mio::Token) -> Result<()> {
+        self.serial_port.register_nonblocking_read(registry, token)
+    }
+
+    fn nonblocking_help(&self) -> Result<Rc<dyn NonblockingHelp>> {
+        self.serial_port.nonblocking_help()
+    }
+}

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240125_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "cabcd31873ba14f15b5d0a0b9ddbf510c7c6416c2f5d151aea01a0e91297c2a8",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240209_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "03c58b220828fc88c9a23ec1b6e93f210354687a5dccd9b957aaaf45f75f82f0",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
HyperDebug uses a non-standard bulk USB protocol for serial ports, and the Linux kernel has only a rudimentary driver, meaning that the usual system calls to set parity and baud rate or generate break conditions, do not work.

This PR adds code to opentitantool to be able to issue the USB control requests directly, instead of going to the Rust serial port library.

Relevant change to Hyperdebug firmware:
https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/5241764