### PR TITLE
[crypto] Create a unified header file for the cryptolib.

### DIFF
--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "OPENTITAN_PLATFORM", "opentitan_binary")
+
+# Top-level cryptolib target.
+cc_library(
+    name = "otcrypto",
+    hdrs = [
+        "otcrypto.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/crypto/impl:aes",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/crypto/impl:ecc",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/impl:kdf",
+        "//sw/device/lib/crypto/impl:key_transport",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/crypto/impl:rsa",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+    alwayslink = True,
+)

--- a/sw/device/lib/crypto/otcrypto.h
+++ b/sw/device/lib/crypto/otcrypto.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTCRYPTO_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTCRYPTO_H_
+
+#include "sw/device/lib/crypto/include/aes.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/drbg.h"
+#include "sw/device/lib/crypto/include/ecc.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/crypto/include/kdf.h"
+#include "sw/device/lib/crypto/include/key_transport.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/crypto/include/rsa.h"
+
+/**
+ * @file
+ * @brief Unified header file that includes the full crypto library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTCRYPTO_H_


### PR DESCRIPTION
This will hide the internal structure and allow callers to import only one thing.